### PR TITLE
Allow to define more than one subgroup level in shader material

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -601,9 +601,6 @@ void ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const
 		const ShaderLanguage::ShaderNode::Uniform &uniform = uniforms[uniform_name];
 
 		String group = uniform.group;
-		if (!uniform.subgroup.is_empty()) {
-			group += "::" + uniform.subgroup;
-		}
 
 		if (group != last_group) {
 			PropertyInfo pi;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -249,16 +249,10 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 		List<PropertyInfo> list;
 		shader->get_shader_uniform_list(&list, true);
 
-		HashMap<String, HashMap<String, List<PropertyInfo>>> groups;
-		LocalVector<Pair<String, LocalVector<String>>> vgroups;
-		{
-			HashMap<String, List<PropertyInfo>> none_subgroup;
-			none_subgroup.insert("<None>", List<PropertyInfo>());
-			groups.insert("<None>", none_subgroup);
-		}
+		HashMap<String, List<PropertyInfo>> groups;
+		LocalVector<String> vgroups;
 
 		String last_group = "<None>";
-		String last_subgroup = "<None>";
 
 		bool is_none_group_undefined = true;
 		bool is_none_group = true;
@@ -266,13 +260,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 		for (const PropertyInfo &pi : list) {
 			if (pi.usage == PROPERTY_USAGE_GROUP) {
 				if (!pi.name.is_empty()) {
-					Vector<String> vgroup = pi.name.split("::");
-					last_group = vgroup[0];
-					if (vgroup.size() > 1) {
-						last_subgroup = vgroup[1];
-					} else {
-						last_subgroup = "<None>";
-					}
+					last_group = pi.name;
 					is_none_group = false;
 
 					if (!groups.has(last_group)) {
@@ -281,36 +269,14 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 						info.name = last_group.capitalize();
 						info.hint_string = "shader_parameter/";
 
-						List<PropertyInfo> none_subgroup;
-						none_subgroup.push_back(info);
+						List<PropertyInfo> props;
+						props.push_back(info);
 
-						HashMap<String, List<PropertyInfo>> subgroup_map;
-						subgroup_map.insert("<None>", none_subgroup);
-
-						groups.insert(last_group, subgroup_map);
-						vgroups.push_back(Pair<String, LocalVector<String>>(last_group, { "<None>" }));
-					}
-
-					if (!groups[last_group].has(last_subgroup)) {
-						PropertyInfo info;
-						info.usage = PROPERTY_USAGE_SUBGROUP;
-						info.name = last_subgroup.capitalize();
-						info.hint_string = "shader_parameter/";
-
-						List<PropertyInfo> subgroup;
-						subgroup.push_back(info);
-
-						groups[last_group].insert(last_subgroup, subgroup);
-						for (Pair<String, LocalVector<String>> &group : vgroups) {
-							if (group.first == last_group) {
-								group.second.push_back(last_subgroup);
-								break;
-							}
-						}
+						groups.insert(last_group, props);
+						vgroups.push_back(last_group);
 					}
 				} else {
 					last_group = "<None>";
-					last_subgroup = "<None>";
 					is_none_group = true;
 				}
 				continue; // Pass group.
@@ -323,9 +289,12 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				info.usage = PROPERTY_USAGE_GROUP;
 				info.name = "Shader Parameters";
 				info.hint_string = "shader_parameter/";
-				groups["<None>"]["<None>"].push_back(info);
 
-				vgroups.push_back(Pair<String, LocalVector<String>>("<None>", { "<None>" }));
+				List<PropertyInfo> props;
+				props.push_back(info);
+
+				groups.insert("<None>", props);
+				vgroups.push_back("<None>");
 			}
 
 			const bool is_uniform_cached = param_cache.has(pi.name);
@@ -376,16 +345,13 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				remap_cache.insert(info.name, pi.name);
 				RS::get_singleton()->material_set_param(_get_material(), pi.name, default_value);
 			}
-			groups[last_group][last_subgroup].push_back(info);
+			groups[last_group].push_back(info);
 		}
 
-		for (const Pair<String, LocalVector<String>> &group_pair : vgroups) {
-			String group = group_pair.first;
-			for (const String &subgroup : group_pair.second) {
-				List<PropertyInfo> &prop_infos = groups[group][subgroup];
-				for (const PropertyInfo &item : prop_infos) {
-					p_list->push_back(item);
-				}
+		for (const String &group : vgroups) {
+			List<PropertyInfo> &prop_infos = groups[group];
+			for (const PropertyInfo &item : prop_infos) {
+				p_list->push_back(item);
 			}
 		}
 	}

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -214,9 +214,6 @@ void MaterialStorage::get_shader_parameter_list(RID p_shader, List<PropertyInfo>
 		const ShaderLanguage::ShaderNode::Uniform &uniform = shader->uniforms[uniform_name];
 
 		String group = uniform.group;
-		if (!uniform.subgroup.is_empty()) {
-			group += "::" + uniform.subgroup;
-		}
 
 		if (group != last_group) {
 			PropertyInfo pi;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -609,9 +609,6 @@ void MaterialStorage::ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_
 		const ShaderLanguage::ShaderNode::Uniform &uniform = uniforms[uniform_name];
 
 		String group = uniform.group;
-		if (!uniform.subgroup.is_empty()) {
-			group += "::" + uniform.subgroup;
-		}
 
 		if (group != last_group) {
 			PropertyInfo pi;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1316,7 +1316,6 @@ void ShaderLanguage::clear() {
 	last_name = StringName();
 	last_type = IDENTIFIER_MAX;
 	current_uniform_group_name = "";
-	current_uniform_subgroup_name = "";
 	current_uniform_hint = ShaderNode::Uniform::HINT_NONE;
 	current_uniform_filter = FILTER_DEFAULT;
 	current_uniform_repeat = REPEAT_DEFAULT;
@@ -9767,7 +9766,6 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					uniform.precision = precision;
 					uniform.array_size = array_size;
 					uniform.group = current_uniform_group_name;
-					uniform.subgroup = current_uniform_subgroup_name;
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
@@ -10301,22 +10299,22 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				tk = _get_token();
 				if (tk.type == TK_IDENTIFIER) {
 					current_uniform_group_name = tk.text;
-					current_uniform_subgroup_name = "";
+
 					tk = _get_token();
-					if (tk.type == TK_PERIOD) {
+					while (tk.type == TK_PERIOD) {
 						tk = _get_token();
+
 						if (tk.type == TK_IDENTIFIER) {
-							current_uniform_subgroup_name = tk.text;
-							tk = _get_token();
-							if (tk.type != TK_SEMICOLON) {
-								_set_expected_error(";");
-								return ERR_PARSE_ERROR;
-							}
+							current_uniform_group_name += "/" + tk.text;
 						} else {
 							_set_error(RTR("Expected an uniform subgroup identifier."));
 							return ERR_PARSE_ERROR;
 						}
-					} else if (tk.type != TK_SEMICOLON) {
+
+						tk = _get_token();
+					}
+
+					if (tk.type != TK_SEMICOLON) {
 						_set_expected_error(";", ".");
 						return ERR_PARSE_ERROR;
 					}
@@ -10333,7 +10331,6 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						return ERR_PARSE_ERROR;
 					} else {
 						current_uniform_group_name = "";
-						current_uniform_subgroup_name = "";
 					}
 				}
 			} break;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -711,7 +711,6 @@ public:
 			PackedStringArray hint_enum_names;
 			int instance_index = 0;
 			String group;
-			String subgroup;
 
 			_FORCE_INLINE_ bool is_texture() const {
 				// Order is assigned to -1 for texture uniforms.
@@ -1063,7 +1062,6 @@ private:
 	bool is_shader_inc = false;
 
 	String current_uniform_group_name;
-	String current_uniform_subgroup_name;
 
 	VaryingFunctionNames varying_function_names;
 	uint32_t base_varying_index = 0;


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/14609

<img width="2810" height="1381" alt="изображение" src="https://github.com/user-attachments/assets/71e3efd5-1d08-42cc-961d-5982ed0b07de" />

Test code:

```gdshader
shader_type canvas_item;

group_uniforms Foo.test.Cool;
uniform float t; 

group_uniforms Foo.test;
uniform float aa;

group_uniforms Foo;
uniform vec3 v;

group_uniforms;
uniform vec3 vv;

group_uniforms Foo2;
uniform vec3 v2;

group_uniforms Foo.test.Cool;
uniform float v3; 

group_uniforms;
uniform vec3 vv4;

void fragment() {
}
```