### PR TITLE
Change `display/window/hdr/request_hdr_output` project setting to be a basic setting.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1740,7 +1740,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_width_override", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"), 0); // 8K resolution
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_height_override", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"), 0); // 8K resolution
 
-	GLOBAL_DEF("display/window/hdr/request_hdr_output", false);
+	GLOBAL_DEF_BASIC("display/window/hdr/request_hdr_output", false);
 
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	GLOBAL_DEF("animation/warnings/check_invalid_skeleton_modifier_node_paths", true);


### PR DESCRIPTION
### What problem(s) does this PR solve?

- It is difficult for users to find the `display/window/hdr/request_hdr_output` project setting because it is hidden by default as an advanced project setting.

### What is the rationale for the approach used in this PR?

I believe it was an oversight to introduce this project setting as an advanced setting, especially given `rendering/viewport/hdr_2d` is a basic setting. Also, there has been a massive amount of work to ensure that this feature is extremely safe and easy to use correctly; it is not an advanced feature.

### Was AI used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

No.