### PR TITLE
Fix null material RID crash in ShaderMaterial property list

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -374,7 +374,9 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				Variant default_value = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), pi.name);
 				param_cache.insert(pi.name, default_value);
 				remap_cache.insert(info.name, pi.name);
-				RS::get_singleton()->material_set_param(_get_material(), pi.name, default_value);
+				if (_get_material().is_valid()) {
+					RS::get_singleton()->material_set_param(_get_material(), pi.name, default_value);
+				}
 			}
 			groups[last_group][last_subgroup].push_back(info);
 		}


### PR DESCRIPTION
Fixes #118344.

The `material_set_param` call added in #110287 in `ShaderMaterial::_get_property_list()` does not check if the material RID is valid before use. When `local_to_scene` is enabled, the material RID is not yet initialized during property list generation, causing a null material error.

This adds a validity check matching the pattern used by every other `material_set_param` call site in the same file. The default value is still cached in `param_cache`, so it gets applied when `_check_material_rid()` lazily creates the material.