### PR TITLE
[.Net] Emit warning on common user patterns that may prevent ALC unloading

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0001.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0001.cs
@@ -1,0 +1,37 @@
+using System;
+using Godot;
+
+// Positive: [Tool] class subscribing to external static event triggers GDU0001
+[Tool]
+public class ToolClassWithStaticEvent
+{
+    public void Subscribe()
+    {
+        {|GDU0001:Console.CancelKeyPress += OnCancel|};
+    }
+
+    private void OnCancel(object sender, ConsoleCancelEventArgs e) { }
+}
+
+// Negative: non-Tool class subscribing to external static event should NOT trigger
+public class NonToolClassWithStaticEvent
+{
+    public void Subscribe()
+    {
+        Console.CancelKeyPress += OnCancel;
+    }
+
+    private void OnCancel(object sender, ConsoleCancelEventArgs e) { }
+}
+
+// Negative: [Tool] class unsubscribing (-=) should NOT trigger
+[Tool]
+public class ToolClassUnsubscribing
+{
+    public void Unsubscribe()
+    {
+        Console.CancelKeyPress -= OnCancel;
+    }
+
+    private void OnCancel(object sender, ConsoleCancelEventArgs e) { }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0002.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0002.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Runtime.InteropServices;
+using Godot;
+
+// Positive: [Tool] class calling GCHandle.Alloc (default = Normal) triggers GDU0002
+[Tool]
+public class ToolClassWithGCHandle
+{
+    public void AllocHandle()
+    {
+        var obj = new object();
+        var handle = {|GDU0002:GCHandle.Alloc(obj)|};
+    }
+
+    public void AllocPinnedHandle()
+    {
+        var data = new byte[10];
+        var handle = {|GDU0002:GCHandle.Alloc(data, GCHandleType.Pinned)|};
+    }
+}
+
+// Negative: Weak GCHandles do NOT create strong roots — should NOT trigger
+[Tool]
+public class ToolClassWithWeakGCHandle
+{
+    public void AllocWeakHandle()
+    {
+        var obj = new object();
+        var handle = GCHandle.Alloc(obj, GCHandleType.Weak);
+    }
+
+    public void AllocWeakTrackResurrectionHandle()
+    {
+        var obj = new object();
+        var handle = GCHandle.Alloc(obj, GCHandleType.WeakTrackResurrection);
+    }
+}
+
+// Negative: non-Tool class calling GCHandle.Alloc should NOT trigger
+public class NonToolClassWithGCHandle
+{
+    public void AllocHandle()
+    {
+        var obj = new object();
+        var handle = GCHandle.Alloc(obj);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0003.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0003.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using Godot;
+
+// Positive: [Tool] class calling ThreadPool.RegisterWaitForSingleObject triggers GDU0003
+[Tool]
+public class ToolClassWithRegisterWait
+{
+    public void Register()
+    {
+        var waitHandle = new ManualResetEvent(false);
+        {|GDU0003:ThreadPool.RegisterWaitForSingleObject(waitHandle, Callback, null, -1, true)|};
+    }
+
+    private void Callback(object state, bool timedOut) { }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithRegisterWait
+{
+    public void Register()
+    {
+        var waitHandle = new ManualResetEvent(false);
+        ThreadPool.RegisterWaitForSingleObject(waitHandle, Callback, null, -1, true);
+    }
+
+    private void Callback(object state, bool timedOut) { }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0005.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0005.cs
@@ -1,0 +1,40 @@
+using Godot;
+
+// Stubs for Newtonsoft.Json (not available in test reference assemblies)
+namespace Newtonsoft.Json
+{
+    public static class JsonConvert
+    {
+        public static string SerializeObject(object value) => "";
+        public static T DeserializeObject<T>(string value) => default;
+    }
+}
+
+public class MyData
+{
+    public int Value { get; set; }
+}
+
+// Positive: [Tool] class calling JsonConvert.SerializeObject triggers GDU0005
+[Tool]
+public class ToolClassWithNewtonsoft
+{
+    public void Serialize()
+    {
+        var json = {|GDU0005:Newtonsoft.Json.JsonConvert.SerializeObject(new MyData())|};
+    }
+
+    public void Deserialize()
+    {
+        var obj = {|GDU0005:Newtonsoft.Json.JsonConvert.DeserializeObject<MyData>("{}")|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithNewtonsoft
+{
+    public void Serialize()
+    {
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(new MyData());
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0006.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0006.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel;
+using Godot;
+
+// Positive: [Tool] class calling TypeDescriptor methods with a user-defined type triggers GDU0006
+[Tool]
+public class ToolClassWithTypeDescriptor
+{
+    public void ModifyTypeDescriptor()
+    {
+        {|GDU0006:TypeDescriptor.Refresh(typeof(ToolClassWithTypeDescriptor))|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithTypeDescriptor
+{
+    public void ModifyTypeDescriptor()
+    {
+        TypeDescriptor.Refresh(typeof(NonToolClassWithTypeDescriptor));
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0007.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0007.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using Godot;
+
+// Positive: [Tool] class creating a Thread triggers GDU0007
+[Tool]
+public class ToolClassWithThread
+{
+    public void CreateThread()
+    {
+        var thread = {|GDU0007:new Thread(() => { })|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithThread
+{
+    public void CreateThread()
+    {
+        var thread = new Thread(() => { });
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0008.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0008.cs
@@ -1,0 +1,32 @@
+using Godot;
+
+// Positive: [Tool] class creating System.Threading.Timer triggers GDU0008
+[Tool]
+public class ToolClassWithThreadingTimer
+{
+    public void CreateTimer()
+    {
+        var timer = {|GDU0008:new System.Threading.Timer(_ => { }, null, 0, 1000)|};
+    }
+}
+
+// Positive (conservative): [Tool] class creating System.Timers.Timer triggers GDU0008
+// because it is typically followed by Elapsed += handler from the collectible assembly.
+// This is a known conservative heuristic; suppress if no collectible callback is attached.
+[Tool]
+public class ToolClassWithTimersTimer
+{
+    public void CreateTimer()
+    {
+        var timer = {|GDU0008:new System.Timers.Timer(1000)|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithTimer
+{
+    public void CreateTimer()
+    {
+        var timer = new System.Threading.Timer(_ => { }, null, 0, 1000);
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0009.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0009.cs
@@ -1,0 +1,27 @@
+using System.Text;
+using Godot;
+
+public class MyEncodingProvider : EncodingProvider
+{
+    public override Encoding GetEncoding(int codepage) => null;
+    public override Encoding GetEncoding(string name) => null;
+}
+
+// Positive: [Tool] class calling Encoding.RegisterProvider with a user-defined provider triggers GDU0009
+[Tool]
+public class ToolClassWithEncodingProvider
+{
+    public void Register()
+    {
+        {|GDU0009:Encoding.RegisterProvider(new MyEncodingProvider())|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithEncodingProvider
+{
+    public void Register()
+    {
+        Encoding.RegisterProvider(new MyEncodingProvider());
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0010.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0010.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Godot;
+
+// Positive: [Tool] class calling Task.Run triggers GDU0010
+[Tool]
+public class ToolClassWithTaskRun
+{
+    public void RunTask()
+    {
+        {|GDU0010:Task.Run(() => { })|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithTaskRun
+{
+    public void RunTask()
+    {
+        Task.Run(() => { });
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0011.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Unloadability.GDU0011.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using Godot;
+
+// Positive: [Tool] class calling ThreadPool.QueueUserWorkItem triggers GDU0011
+[Tool]
+public class ToolClassWithQueueUserWorkItem
+{
+    public void QueueWork()
+    {
+        {|GDU0011:ThreadPool.QueueUserWorkItem(_ => { })|};
+    }
+}
+
+// Negative: non-Tool class should NOT trigger
+public class NonToolClassWithQueueUserWorkItem
+{
+    public void QueueWork()
+    {
+        ThreadPool.QueueUserWorkItem(_ => { });
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/UnloadabilityAnalyzerTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/UnloadabilityAnalyzerTests.cs
@@ -1,0 +1,67 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class UnloadabilityAnalyzerTests
+{
+    [Fact]
+    public async Task SubscriptionToExternalStaticEventTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0001.cs");
+    }
+
+    [Fact]
+    public async Task GCHandleAllocTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0002.cs");
+    }
+
+    [Fact]
+    public async Task ThreadPoolRegisterWaitForSingleObjectTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0003.cs");
+    }
+
+    [Fact]
+    public async Task NewtonsoftJsonSerializationTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0005.cs");
+    }
+
+    [Fact]
+    public async Task TypeDescriptorModificationTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0006.cs");
+    }
+
+    [Fact]
+    public async Task ThreadCreationTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0007.cs");
+    }
+
+    [Fact]
+    public async Task TimerCreationTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0008.cs");
+    }
+
+    [Fact]
+    public async Task EncodingRegisterProviderTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0009.cs");
+    }
+
+    [Fact]
+    public async Task TaskRunTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0010.cs");
+    }
+
+    [Fact]
+    public async Task ThreadPoolQueueUserWorkItemTest()
+    {
+        await CSharpAnalyzerVerifier<UnloadabilityAnalyzer>.Verify("Unloadability.GDU0011.cs");
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,14 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GDU0001 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0002 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0003 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0005 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0006 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0007 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0008 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0009 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0010 | Unloadability | Warning | UnloadabilityAnalyzer
+GDU0011 | Unloadability | Warning | UnloadabilityAnalyzer

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -226,5 +226,107 @@ namespace Godot.SourceGenerators
                 isEnabledByDefault: true,
                 "The class must not be generic. Make the class non-generic, or remove the '[GlobalClass]' attribute.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0402"));
+
+        // Unloadability Diagnostics (GDU)
+
+        public static readonly DiagnosticDescriptor GDU0001_SubscriptionToExternalStaticEventRule =
+            new DiagnosticDescriptor(id: "GDU0001",
+                title: "Subscription to external static event prevents unloading",
+                messageFormat: "Subscribing to static event '{0}.{1}' prevents assembly hot-reload; unsubscribe before the assembly unloads",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "Static events on framework or engine types (e.g. Console, AppDomain) keep a reference to your delegate. Unsubscribe before the AssemblyLoadContext unloads, for example in an AssemblyLoadContext.Unloading callback.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0001"));
+
+        public static readonly DiagnosticDescriptor GDU0002_GCHandleAllocRule =
+            new DiagnosticDescriptor(id: "GDU0002",
+                title: "GCHandle.Alloc prevents unloading",
+                messageFormat: "GCHandle.Alloc creates a GC root that prevents assembly hot-reload; free the handle before the assembly unloads",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "Normal and Pinned GCHandles create strong GC roots. Call GCHandle.Free before the AssemblyLoadContext unloads. Suppress this warning if you are sure the handle will be freed in time.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0002"));
+
+        public static readonly DiagnosticDescriptor GDU0003_ThreadPoolRegisterWaitForSingleObjectRule =
+            new DiagnosticDescriptor(id: "GDU0003",
+                title: "RegisterWaitForSingleObject prevents unloading",
+                messageFormat: "ThreadPool.RegisterWaitForSingleObject prevents assembly hot-reload while the wait is registered",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "The registered wait handle holds a reference to your callback. Call RegisteredWaitHandle.Unregister before the AssemblyLoadContext unloads.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0003"));
+
+        public static readonly DiagnosticDescriptor GDU0005_NewtonsoftJsonSerializationRule =
+            new DiagnosticDescriptor(id: "GDU0005",
+                title: "Newtonsoft.Json serialization may prevent unloading",
+                messageFormat: "Newtonsoft.Json serialization may cache type metadata and prevent assembly hot-reload",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "Newtonsoft.Json caches type metadata internally, which can root the assembly. This warning flags any serialization call in a [Tool] type. Suppress if you only serialize types from non-collectible assemblies.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0005"));
+
+        public static readonly DiagnosticDescriptor GDU0006_TypeDescriptorModificationRule =
+            new DiagnosticDescriptor(id: "GDU0006",
+                title: "TypeDescriptor modification may prevent unloading",
+                messageFormat: "TypeDescriptor.{0} may register type metadata globally and prevent assembly hot-reload",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "TypeDescriptor stores type metadata in global caches that are never cleared. This warning flags any TypeDescriptor call in a [Tool] type. Suppress if you only register types from non-collectible assemblies.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0006"));
+
+        public static readonly DiagnosticDescriptor GDU0007_ThreadCreationRule =
+            new DiagnosticDescriptor(id: "GDU0007",
+                title: "Thread creation prevents unloading",
+                messageFormat: "Creating a Thread prevents assembly hot-reload while the thread is running",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "A running thread keeps the assembly loaded. Make sure the thread exits before the AssemblyLoadContext unloads. Suppress if you are sure the thread will finish in time.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0007"));
+
+        public static readonly DiagnosticDescriptor GDU0008_TimerCreationRule =
+            new DiagnosticDescriptor(id: "GDU0008",
+                title: "Timer creation may prevent unloading",
+                messageFormat: "Creating a Timer may prevent assembly hot-reload; dispose the timer before the assembly unloads",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "Timers hold references to callback delegates that keep the assembly loaded. Dispose the timer before the AssemblyLoadContext unloads. Suppress if the timer uses no callbacks from this assembly.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0008"));
+
+        public static readonly DiagnosticDescriptor GDU0009_EncodingRegisterProviderRule =
+            new DiagnosticDescriptor(id: "GDU0009",
+                title: "Encoding.RegisterProvider may prevent unloading",
+                messageFormat: "Encoding.RegisterProvider may prevent assembly hot-reload; registered providers cannot be removed",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "Registered encoding providers are stored in a global list that is never cleared. This warning flags any RegisterProvider call in a [Tool] type. Suppress if the provider is from a non-collectible assembly (e.g. a framework-provided provider).",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0009"));
+
+        public static readonly DiagnosticDescriptor GDU0010_TaskRunRule =
+            new DiagnosticDescriptor(id: "GDU0010",
+                title: "Task.Run prevents unloading",
+                messageFormat: "Task.Run prevents assembly hot-reload while the task is running",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "A running task keeps the assembly loaded. Make sure the task completes or is cancelled before the AssemblyLoadContext unloads. Suppress if you are sure the task will finish in time.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0010"));
+
+        public static readonly DiagnosticDescriptor GDU0011_ThreadPoolQueueUserWorkItemRule =
+            new DiagnosticDescriptor(id: "GDU0011",
+                title: "ThreadPool.QueueUserWorkItem prevents unloading",
+                messageFormat: "ThreadPool.QueueUserWorkItem prevents assembly hot-reload while the work item is running",
+                category: "Unloadability",
+                DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                "A running work item keeps the assembly loaded. Make sure it completes before the AssemblyLoadContext unloads. Suppress if you are sure it will finish in time.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GDU0011"));
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/UnloadabilityAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/UnloadabilityAnalyzer.cs
@@ -1,0 +1,175 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Godot.SourceGenerators
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnloadabilityAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(
+                Common.GDU0001_SubscriptionToExternalStaticEventRule,
+                Common.GDU0002_GCHandleAllocRule,
+                Common.GDU0003_ThreadPoolRegisterWaitForSingleObjectRule,
+                Common.GDU0005_NewtonsoftJsonSerializationRule,
+                Common.GDU0006_TypeDescriptorModificationRule,
+                Common.GDU0007_ThreadCreationRule,
+                Common.GDU0008_TimerCreationRule,
+                Common.GDU0009_EncodingRegisterProviderRule,
+                Common.GDU0010_TaskRunRule,
+                Common.GDU0011_ThreadPoolQueueUserWorkItemRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterOperationAction(AnalyzeEventAssignment, OperationKind.EventAssignment);
+            context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+            context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
+        }
+
+        private static bool IsInToolType(ISymbol symbol)
+        {
+            var type = symbol as INamedTypeSymbol ?? symbol.ContainingType;
+            while (type != null)
+            {
+                if (type.GetAttributes().Any(a =>
+                        a.AttributeClass?.ToDisplayString() == GodotClasses.ToolAttr))
+                    return true;
+                type = type.ContainingType;
+            }
+            return false;
+        }
+
+        private static bool IsRootAlcAssembly(IAssemblySymbol assembly)
+        {
+            var name = assembly?.Name;
+            if (name == null) return false;
+
+            return name == "mscorlib"
+                   || name == "netstandard"
+                   || name == "System"
+                   || name.StartsWith("System.")
+                   || name.StartsWith("Microsoft.")
+                   || name == "GodotSharp"
+                   || name == "GodotSharpEditor"
+                   || name.StartsWith("Godot.");
+        }
+
+        private static bool IsWeakGCHandleAlloc(IInvocationOperation operation)
+        {
+            var method = operation.TargetMethod;
+            if (method.Parameters.Length != 2)
+                return false;
+
+            var typeArg = operation.Arguments[1].Value;
+            if (!typeArg.ConstantValue.HasValue)
+                return false;
+
+            // GCHandleType.Weak = 0, GCHandleType.WeakTrackResurrection = 1
+            return typeArg.ConstantValue.Value is int handleType && (handleType == 0 || handleType == 1);
+        }
+
+        private static void AnalyzeEventAssignment(OperationAnalysisContext context)
+        {
+            if (!IsInToolType(context.ContainingSymbol))
+                return;
+
+            var operation = (IEventAssignmentOperation)context.Operation;
+
+            if (!operation.Adds)
+                return;
+
+            if (!(operation.EventReference is IEventReferenceOperation eventRef))
+                return;
+
+            var eventSymbol = eventRef.Event;
+
+            if (!eventSymbol.IsStatic)
+                return;
+
+            if (SymbolEqualityComparer.Default.Equals(
+                    eventSymbol.ContainingAssembly, context.Compilation.Assembly))
+                return;
+
+            if (!IsRootAlcAssembly(eventSymbol.ContainingAssembly))
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Common.GDU0001_SubscriptionToExternalStaticEventRule,
+                operation.Syntax.GetLocation(),
+                eventSymbol.ContainingType?.ToDisplayString(),
+                eventSymbol.Name));
+        }
+
+        private static void AnalyzeInvocation(OperationAnalysisContext context)
+        {
+            if (!IsInToolType(context.ContainingSymbol))
+                return;
+
+            var operation = (IInvocationOperation)context.Operation;
+            var method = operation.TargetMethod;
+            var containingType = method.ContainingType?.ToDisplayString();
+
+            if (containingType == null)
+                return;
+
+            DiagnosticDescriptor? descriptor = null;
+
+            if (containingType == "System.Runtime.InteropServices.GCHandle" && method.Name == "Alloc"
+                && !IsWeakGCHandleAlloc(operation))
+                descriptor = Common.GDU0002_GCHandleAllocRule;
+            else if (containingType == "System.Threading.ThreadPool" && method.Name == "RegisterWaitForSingleObject")
+                descriptor = Common.GDU0003_ThreadPoolRegisterWaitForSingleObjectRule;
+            else if ((containingType == "Newtonsoft.Json.JsonConvert"
+                      && (method.Name == "SerializeObject" || method.Name == "DeserializeObject"))
+                     || (containingType == "Newtonsoft.Json.JsonSerializer"
+                         && (method.Name == "Serialize" || method.Name == "Deserialize")))
+                descriptor = Common.GDU0005_NewtonsoftJsonSerializationRule;
+            else if (containingType == "System.ComponentModel.TypeDescriptor"
+                     && (method.Name == "AddAttributes" || method.Name == "AddProvider"
+                         || method.Name == "AddProviderTransparent" || method.Name == "Refresh"))
+                descriptor = Common.GDU0006_TypeDescriptorModificationRule;
+            else if (containingType == "System.Text.Encoding" && method.Name == "RegisterProvider")
+                descriptor = Common.GDU0009_EncodingRegisterProviderRule;
+            else if (containingType == "System.Threading.Tasks.Task" && method.Name == "Run")
+                descriptor = Common.GDU0010_TaskRunRule;
+            else if (containingType == "System.Threading.ThreadPool" && method.Name == "QueueUserWorkItem")
+                descriptor = Common.GDU0011_ThreadPoolQueueUserWorkItemRule;
+
+            if (descriptor != null)
+            {
+                var diagnostic = descriptor.Id == "GDU0006"
+                    ? Diagnostic.Create(descriptor, operation.Syntax.GetLocation(), method.Name)
+                    : Diagnostic.Create(descriptor, operation.Syntax.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        private static void AnalyzeObjectCreation(OperationAnalysisContext context)
+        {
+            if (!IsInToolType(context.ContainingSymbol))
+                return;
+
+            var operation = (IObjectCreationOperation)context.Operation;
+            var createdType = operation.Type?.ToDisplayString();
+
+            if (createdType == "System.Threading.Thread")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Common.GDU0007_ThreadCreationRule,
+                    operation.Syntax.GetLocation()));
+            }
+            else if (createdType == "System.Threading.Timer" || createdType == "System.Timers.Timer")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Common.GDU0008_TimerCreationRule,
+                    operation.Syntax.GetLocation()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Partially implemented:
- godotengine/godot-proposals#11819

Related:
- https://github.com/godotengine/godot/issues/78513

This is the `Analyzer` part of the proposal. The approaches for helping developers against the ALC unloading failures are:

1. An analyzer that flags certain use cases that prevent ALC from being unloaded, steering the developer away from writing ALC-incompatible code. (You are here)
2. At the framework level, implement well-known community cleanup workarounds on very frequently used BCL classes, enabling commonly used BCL functions that are frequently encountered when doing Tools development. (Not yet implemented, maybe implemented by another community member)

```csharp
// e.g., System.Text.Json
void ClearJsonSerializerCache()
{
    var assembly = typeof(JsonSerializerOptions).Assembly;
    var updateHandlerType = assembly.GetType("System.Text.Json.JsonSerializerOptionsUpdateHandler");
    var clearCacheMethod = updateHandlerType?.GetMethod("ClearCache", BindingFlags.Static | BindingFlags.Public);
    clearCacheMethod?.Invoke(null, new object[] { null! });
}
```

3. **Leak** the not unloadable ALC and reload everything to a new ALC, **bypass\*** the issue by leaking memory, making the C# functions of the editor stay up even if unloading has failed. (Not yet implemented, maybe implemented by another community member)
4. Auto-reboot the Editor when ALC leaks reach certain amounts, resolves the memory leak when lots of ALCs are stacking inside the memory. Maybe even surpasses number 3 if we can persist the current change assets & scene state very quickly, restart the project, and entirely fix #78513. (Not yet implemented, maybe implemented by another community member)

The inspiration of # 1 and # 3 entirely comes from this [two-line discussion](https://discussions.unity.com/t/path-to-coreclr-2026-upgrade-guide/1714279/7), and the **documentation** of [the Tool that Unity builds for helping their users on migrating to Modern .Net](https://docs.unity3d.com/Packages/com.unity.project-auditor@1.1/manual/domain-reloading-issues.html), the author of this PR read 0 line of the Unity's implmentation, and are very certain that the analyzer in this PR have minimum overlaps wit the Unity's implmentation (as we don't host the running game within the Editor, so we don't need all of the static variable resetting attribute shenanegins).

> > What happens when an assembly can’t be unloaded? What are the possible issues? Will there be two instances of types in that assembly: one from the newly loaded assembly and one from the one that couldn’t be unloaded? Will a newly instantiated object correctly use the new assembly?
> 
> Yes. We’re planning to report to the user after a suitable time that an AssemblyLoadContext has leaked.

AI Disclosure:

The Analyzer was developed by `Opus 4.6` as the orchestrator, with `GPT 5.4` serving as a subagent under the author’s supervision. The cases the analyzer targets to prevent ALC unloading have been rigorously validated using [isolated MRP projects](https://github.com/Delsin-Yu/GodotSharp-Unloadability-Analyzer/tree/main/ValidationProjects) to ensure accuracy. The analyzer has been adapted for use in `Godot.SourceGenerators.csproj` by `Opus 4.6`, along with corresponding test suites. Additionally, the author manually modified some diagnostic warning messages to enhance clarity for general developers. A fresh instance of `GPT 5.4` is also activated as an independent reviewer of the exact files modified in this PR to minimize inaccuracies.