### PR TITLE
Add `hide_titles` and `hide_icons` properties to `TabBar` & `TabContainer`

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -258,6 +258,12 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="hide_icons" type="bool" setter="set_hide_icons" getter="is_hiding_icons" default="false">
+			If [code]true[/code], the icons of the tabs will be hidden.
+		</member>
+		<member name="hide_titles" type="bool" setter="set_hide_titles" getter="is_hiding_titles" default="false">
+			If [code]true[/code], the titles of the tabs will be hidden.
+		</member>
 		<member name="max_tab_width" type="int" setter="set_max_tab_width" getter="get_max_tab_width" default="0">
 			Sets the maximum width which all tabs should be limited to. Unlimited if set to [code]0[/code].
 		</member>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -223,6 +223,12 @@
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
+		<member name="hide_tabs_icons" type="bool" setter="set_hide_tabs_icons" getter="is_hiding_tabs_icons" default="false">
+			If [code]true[/code], the icons of the tabs will be hidden.
+		</member>
+		<member name="hide_tabs_titles" type="bool" setter="set_hide_tabs_titles" getter="is_hiding_tabs_titles" default="false">
+			If [code]true[/code], the titles of the tabs will be hidden.
+		</member>
 		<member name="switch_on_drag_hover" type="bool" setter="set_switch_on_drag_hover" getter="get_switch_on_drag_hover" default="true">
 			If [code]true[/code], hovering over a tab while dragging something will switch to that tab. Does not have effect when hovering another tab to rearrange.
 		</member>

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -81,16 +81,18 @@ Size2 TabBar::get_minimum_size() const {
 		}
 		ms.width += style->get_minimum_size().width;
 
-		if (tabs[i].icon.is_valid()) {
+		if (tabs[i].icon.is_valid() && !hide_icons) {
 			const Size2 icon_size = _get_tab_icon_size(i);
 			ms.height = MAX(ms.height, icon_size.height + y_margin);
 			ms.width += icon_size.width + theme_cache.h_separation;
 		}
 
-		if (!tabs[i].text.is_empty()) {
+		if (!tabs[i].text.is_empty() && !hide_titles) {
 			ms.width += tabs[i].size_text + theme_cache.h_separation;
 		}
-		ms.height = MAX(ms.height, tabs[i].text_buf->get_size().y + y_margin);
+		if (!hide_titles) {
+			ms.height = MAX(ms.height, tabs[i].text_buf->get_size().y + y_margin);
+		}
 
 		bool close_visible = cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current);
 
@@ -687,7 +689,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 	// Draw the icon.
 	Ref<Texture2D> icon = tabs[p_index].icon;
-	if (icon.is_valid()) {
+	if (icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(p_index);
 		const Point2 icon_pos = Point2i(rtl ? p_x - icon_size.width : p_x, p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon_size.height) / 2);
 		icon->draw_rect(ci, Rect2(icon_pos, icon_size), false, p_icon_color);
@@ -696,7 +698,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 	}
 
 	// Draw the text.
-	if (!tabs[p_index].text.is_empty()) {
+	if (!tabs[p_index].text.is_empty() && !hide_titles) {
 		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
 				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
 
@@ -1492,7 +1494,7 @@ Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_poin
 
 	HBoxContainer *drag_preview = memnew(HBoxContainer);
 
-	if (tabs[tab_over].icon.is_valid()) {
+	if (tabs[tab_over].icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(tab_over);
 
 		TextureRect *tf = memnew(TextureRect);
@@ -1739,6 +1741,36 @@ void TabBar::set_tab_style_v_flip(bool p_tab_style_v_flip) {
 	tab_style_v_flip = p_tab_style_v_flip;
 }
 
+void TabBar::set_hide_titles(bool p_hide_titles) {
+	if (hide_titles == p_hide_titles) {
+		return;
+	}
+	hide_titles = p_hide_titles;
+
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool TabBar::is_hiding_titles() const {
+	return hide_titles;
+}
+
+void TabBar::set_hide_icons(bool p_hide_icons) {
+	if (hide_icons == p_hide_icons) {
+		return;
+	}
+	hide_icons = p_hide_icons;
+
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool TabBar::is_hiding_icons() const {
+	return hide_icons;
+}
+
 void TabBar::move_tab(int p_from, int p_to) {
 	if (p_from == p_to) {
 		return;
@@ -1796,12 +1828,12 @@ int TabBar::get_tab_width(int p_idx) const {
 	}
 	int x = style->get_minimum_size().width;
 
-	if (tabs[p_idx].icon.is_valid()) {
+	if (tabs[p_idx].icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(p_idx);
 		x += icon_size.width + theme_cache.h_separation;
 	}
 
-	if (!tabs[p_idx].text.is_empty()) {
+	if (!tabs[p_idx].text.is_empty() && !hide_titles) {
 		x += tabs[p_idx].size_text + theme_cache.h_separation;
 	}
 
@@ -2137,6 +2169,10 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_select_with_rmb"), &TabBar::get_select_with_rmb);
 	ClassDB::bind_method(D_METHOD("set_deselect_enabled", "enabled"), &TabBar::set_deselect_enabled);
 	ClassDB::bind_method(D_METHOD("get_deselect_enabled"), &TabBar::get_deselect_enabled);
+	ClassDB::bind_method(D_METHOD("set_hide_titles", "hide_titles"), &TabBar::set_hide_titles);
+	ClassDB::bind_method(D_METHOD("is_hiding_titles"), &TabBar::is_hiding_titles);
+	ClassDB::bind_method(D_METHOD("set_hide_icons", "hide_icons"), &TabBar::set_hide_icons);
+	ClassDB::bind_method(D_METHOD("is_hiding_icons"), &TabBar::is_hiding_icons);
 	ClassDB::bind_method(D_METHOD("clear_tabs"), &TabBar::clear_tabs);
 
 	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
@@ -2161,6 +2197,8 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_to_selected"), "set_scroll_to_selected", "get_scroll_to_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_with_rmb"), "set_select_with_rmb", "get_select_with_rmb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_titles"), "set_hide_titles", "is_hiding_titles");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_icons"), "set_hide_icons", "is_hiding_icons");
 
 	ADD_ARRAY_COUNT("Tabs", "tab_count", "set_tab_count", "get_tab_count", "tab_");
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -106,6 +106,8 @@ private:
 	int offset = 0;
 	int max_drawn_tab = 0;
 	int highlight_arrow = -1;
+	bool hide_titles = false;
+	bool hide_icons = false;
 	bool buttons_visible = false;
 	bool missing_right = false;
 	Vector<Tab> tabs;
@@ -274,6 +276,12 @@ public:
 	bool get_clip_tabs() const;
 
 	void set_tab_style_v_flip(bool p_tab_style_v_flip);
+
+	void set_hide_titles(bool p_hide_titles);
+	bool is_hiding_titles() const;
+
+	void set_hide_icons(bool p_hide_icons);
+	bool is_hiding_icons() const;
 
 	void move_tab(int p_from, int p_to);
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1126,6 +1126,22 @@ Popup *TabContainer::get_popup() const {
 	return nullptr;
 }
 
+void TabContainer::set_hide_tabs_titles(bool p_hide) {
+	tab_bar->set_hide_titles(p_hide);
+}
+
+bool TabContainer::is_hiding_tabs_titles() const {
+	return tab_bar->is_hiding_titles();
+}
+
+void TabContainer::set_hide_tabs_icons(bool p_hide) {
+	tab_bar->set_hide_icons(p_hide);
+}
+
+bool TabContainer::is_hiding_tabs_icons() const {
+	return tab_bar->is_hiding_icons();
+}
+
 void TabContainer::set_switch_on_drag_hover(bool p_enabled) {
 	tab_bar->set_switch_on_drag_hover(p_enabled);
 }
@@ -1208,6 +1224,10 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_metadata", "tab_idx"), &TabContainer::get_tab_metadata);
 	ClassDB::bind_method(D_METHOD("set_tab_button_icon", "tab_idx", "icon"), &TabContainer::set_tab_button_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_button_icon", "tab_idx"), &TabContainer::get_tab_button_icon);
+	ClassDB::bind_method(D_METHOD("set_hide_tabs_titles", "hide"), &TabContainer::set_hide_tabs_titles);
+	ClassDB::bind_method(D_METHOD("is_hiding_tabs_titles"), &TabContainer::is_hiding_tabs_titles);
+	ClassDB::bind_method(D_METHOD("set_hide_tabs_icons", "hide"), &TabContainer::set_hide_tabs_icons);
+	ClassDB::bind_method(D_METHOD("is_hiding_tabs_icons"), &TabContainer::is_hiding_tabs_icons);
 
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabContainer::get_tab_idx_at_point);
 	ClassDB::bind_method(D_METHOD("get_tab_idx_from_control", "control"), &TabContainer::get_tab_idx_from_control);
@@ -1246,6 +1266,8 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hidden_tabs_for_min_size"), "set_use_hidden_tabs_for_min_size", "get_use_hidden_tabs_for_min_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_tab_focus_mode", "get_tab_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_tabs_titles"), "set_hide_tabs_titles", "is_hiding_tabs_titles");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_tabs_icons"), "set_hide_tabs_icons", "is_hiding_tabs_icons");
 
 	ADD_CLASS_DEPENDENCY("TabBar");
 	ADD_CLASS_DEPENDENCY("Button");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -236,6 +236,12 @@ public:
 	void set_popup(Node *p_popup);
 	Popup *get_popup() const;
 
+	void set_hide_tabs_titles(bool p_hide_text);
+	bool is_hiding_tabs_titles() const;
+
+	void set_hide_tabs_icons(bool p_hide_icons);
+	bool is_hiding_tabs_icons() const;
+
 	void move_tab_from_tab_container(TabContainer *p_from, int p_from_index, int p_to_index = -1);
 
 	void set_switch_on_drag_hover(bool p_enabled);


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/14636

This PR adds two new toggles to `TabBar` (& `TabContainer`):
1. `hide_titles` (& `hide_tabs_titles`): Hides the titles on all tabs from displaying
2. `hide_icons` (& `hide_tabs_icons`): Hides the icons on all tabs from displaying

Below is a summary table (uses a mockup of the editor title bar)

| -- | Horizontal |
| -- | -- |
| show both (default) | <img width="417" height="71" alt="image" src="https://github.com/user-attachments/assets/6f0989be-d471-4adb-8cff-85dd8c9ee246" /> |
| hide titles | <img width="195" height="59" alt="image" src="https://github.com/user-attachments/assets/ee6a0db8-9aee-40a6-bf6a-ec15d823b803" /> |
| hide icons | <img width="308" height="59" alt="image" src="https://github.com/user-attachments/assets/eb4a421c-3f8c-4681-8118-cb89a86ad658" /> |



