### PR TITLE
Split inspector property sections into tabs

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -60,6 +60,11 @@
 				Emitted when the object being edited by the inspector has changed.
 			</description>
 		</signal>
+		<signal name="inspector_tabs_updated">
+			<description>
+				Emitted when the inspector tabs are updated. This can happen when the edited object changes or when the user changes the inspector tab settings in EditorSettings.
+			</description>
+		</signal>
 		<signal name="object_id_selected">
 			<param index="0" name="id" type="int" />
 			<description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1166,6 +1166,27 @@
 		<member name="interface/inspector/show_low_level_opentype_features" type="bool" setter="" getter="">
 			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
 		</member>
+		<member name="interface/inspector/tabs/horizontal_tab_style" type="int" setter="" getter="">
+			The tab style of horizontal tabs in the inspector.
+		</member>
+		<member name="interface/inspector/tabs/merge_abstract_class_tabs" type="bool" setter="" getter="">
+			If [code]true[/code], tabs of abstract classes in the inspector will be merged with their first non-abstract subclass.
+		</member>
+		<member name="interface/inspector/tabs/tab_layout" type="int" setter="" getter="">
+			The orientation of the tab bar in the inspector.
+		</member>
+		<member name="interface/inspector/tabs/tab_property_mode" type="int" setter="" getter="">
+			Controls how tab switching works in the inspector.
+		</member>
+		<member name="interface/inspector/tabs/use_inspector_tabs" type="bool" setter="" getter="">
+			If [code]true[/code], the inspector uses tabs to separate properties of different classes.
+		</member>
+		<member name="interface/inspector/tabs/vertical_tab_side" type="int" setter="" getter="">
+			The side of the inspector to display vertical tabs on.
+		</member>
+		<member name="interface/inspector/tabs/vertical_tab_style" type="int" setter="" getter="">
+			The tab style of vertical tabs in the inspector.
+		</member>
 		<member name="interface/multi_window/enable" type="bool" setter="" getter="">
 			If [code]true[/code], multiple window support in editor is enabled. The following panels can become dedicated windows (i.e. made floating): Docks, Script editor, Shader editor, and Game Workspace.
 			[b]Note:[/b] When [member interface/editor/display/single_window_mode] is [code]true[/code], the multi window support is always disabled.

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -258,6 +258,12 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="hide_icons" type="bool" setter="set_hide_icons" getter="is_hide_icons" default="false">
+			If [code]true[/code], the icons of the tabs will be hidden.
+		</member>
+		<member name="hide_text" type="bool" setter="set_hide_text" getter="is_hide_text" default="false">
+			If [code]true[/code], the text of the tabs will be hidden.
+		</member>
 		<member name="max_tab_width" type="int" setter="set_max_tab_width" getter="get_max_tab_width" default="0">
 			Sets the maximum width which all tabs should be limited to. Unlimited if set to [code]0[/code].
 		</member>

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TabBar" inherits="Control" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A control that provides a horizontal bar with tabs.
+		A control that provides a bar with tabs.
 	</brief_description>
 	<description>
-		A control that provides a horizontal bar with tabs. Similar to [TabContainer] but is only in charge of drawing tabs, not interacting with children.
+		A control that provides a bar with tabs. Similar to [TabContainer] but is only in charge of drawing tabs, not interacting with children.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -301,6 +301,9 @@
 		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
 			[TabBar]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].
 			Setting this to [code]-1[/code] will disable rearranging between [TabBar]s.
+		</member>
+		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" default="false">
+			If [code]true[/code], the [TabBar] will arrange its tabs vertically, rather than horizontally.
 		</member>
 	</members>
 	<signals>

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -506,6 +506,7 @@ void InspectorDock::_notification(int p_what) {
 
 				bool disable_folding = EDITOR_GET("interface/inspector/disable_folding");
 				inspector->set_use_folding(!disable_folding);
+				_update_tab_bar_layout();
 			}
 		} break;
 	}
@@ -697,6 +698,126 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 	stored_properties.clear();
 }
 
+// Inspector tab bar.
+
+void InspectorDock::_on_inspector_tab_selected(int p_tab) {
+	if (tab_bar_updating) {
+		return;
+	}
+	inspector->set_current_inspector_tab(p_tab);
+}
+
+void InspectorDock::_update_inspector_tab_bar() {
+	tab_bar_updating = true;
+
+	bool tabs_enabled = inspector->are_inspector_tabs_enabled();
+	int tab_count = inspector->get_inspector_tab_count();
+	bool search_active = !search->get_text().is_empty();
+
+	// Hide tab bar when tabs are disabled, no tabs, or search is active.
+	if (!tabs_enabled || tab_count == 0 || search_active) {
+		tab_bar_container->hide();
+		tab_bar_updating = false;
+		return;
+	}
+
+	int tab_style = inspector->get_tab_style();
+	switch (tab_style) {
+		case EditorInspector::TAB_STYLE_TEXT_ONLY: {
+			inspector_tab_bar->set_hide_text(false);
+			inspector_tab_bar->set_hide_icons(true);
+		} break;
+		case EditorInspector::TAB_STYLE_ICON_ONLY: {
+			inspector_tab_bar->set_hide_text(true);
+			inspector_tab_bar->set_hide_icons(false);
+		} break;
+		case EditorInspector::TAB_STYLE_TEXT_AND_ICON: {
+			inspector_tab_bar->set_hide_text(false);
+			inspector_tab_bar->set_hide_icons(false);
+		} break;
+	}
+
+	// Rebuild tab bar.
+	inspector_tab_bar->clear_tabs();
+	for (int i = 0; i < tab_count; i++) {
+		String name = inspector->get_inspector_tab_name(i);
+		Ref<Texture2D> icon = inspector->get_inspector_tab_icon(i);
+		inspector_tab_bar->add_tab(name, icon);
+		inspector_tab_bar->set_tab_tooltip(i, name);
+	}
+
+	int current_tab = inspector->get_current_inspector_tab();
+	if (current_tab >= 0 && current_tab < tab_count) {
+		inspector_tab_bar->set_current_tab(current_tab);
+	}
+
+	_update_tab_bar_layout();
+	tab_bar_container->show();
+
+	tab_bar_updating = false;
+}
+
+void InspectorDock::_update_tab_bar_layout() {
+	if (!inspector_tab_bar || inspector_tab_bar->get_tab_count() == 0) {
+		return;
+	}
+
+	int tab_layout = inspector->get_tab_layout();
+	bool is_vertical = (tab_layout == 1);
+
+	inspector_tab_bar->set_vertical(is_vertical);
+
+	// Propagate TabBar minimum size to the container.
+	Size2 tab_min = inspector_tab_bar->get_minimum_size();
+
+	if (is_vertical) {
+		// Vertical mode: tab bar on the side.
+		inspector_with_tabs->set_vertical(false); // HBoxContainer-like.
+		tab_bar_container->set_h_size_flags(Control::SIZE_FILL);
+		tab_bar_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tab_bar_container->set_custom_minimum_size(Size2(tab_min.x, 0));
+
+		// Determine if this dock is currently on the right side of the editor.
+		bool dock_is_on_right = true;
+		if (inspector->is_inside_tree()) {
+			float inspector_center_x = inspector->get_global_position().x + inspector->get_size().x / 2.0;
+			float viewport_center_x = inspector->get_viewport_rect().size.x / 2.0;
+			dock_is_on_right = (inspector_center_x >= viewport_center_x);
+		}
+
+		bool right_side = true;
+		switch (inspector->get_vertical_tab_side()) {
+			case EditorInspector::TAB_VERTICAL_SIDE_LEFT: {
+				right_side = false;
+			} break;
+			case EditorInspector::TAB_VERTICAL_SIDE_RIGHT: {
+				right_side = true;
+			} break;
+			case EditorInspector::TAB_VERTICAL_SIDE_INSIDE: {
+				right_side = !dock_is_on_right;
+			} break;
+			case EditorInspector::TAB_VERTICAL_SIDE_OUTSIDE:
+			default: {
+				right_side = dock_is_on_right;
+			} break;
+		}
+
+		// Ensure tab bar container is on the correct side.
+		if (right_side) {
+			inspector_with_tabs->move_child(tab_bar_container, -1); // Right side.
+		} else {
+			inspector_with_tabs->move_child(tab_bar_container, 0); // Left side.
+		}
+	} else {
+		// Horizontal mode: tab bar on top.
+		inspector_with_tabs->set_vertical(true); // VBoxContainer-like.
+		tab_bar_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		tab_bar_container->set_v_size_flags(Control::SIZE_FILL);
+		inspector_with_tabs->move_child(tab_bar_container, 0); // Top.
+		tab_bar_container->set_custom_minimum_size(Size2(0, tab_min.y));
+	}
+}
+
 void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -874,13 +995,34 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	load_resource_dialog->set_current_dir("res://");
 	load_resource_dialog->connect("file_selected", callable_mp(this, &InspectorDock::_resource_file_selected));
 
+	// Inspector tab bar and inspector area.
+	inspector_with_tabs = memnew(BoxContainer);
+	inspector_with_tabs->set_vertical(true);
+	main_vb->add_child(inspector_with_tabs);
+	inspector_with_tabs->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	tab_bar_container = memnew(Control);
+	tab_bar_container->set_clip_contents(true);
+	inspector_with_tabs->add_child(tab_bar_container);
+	tab_bar_container->hide();
+	tab_bar_container->connect(SceneStringName(resized), callable_mp(this, &InspectorDock::_update_tab_bar_layout));
+
+	inspector_tab_bar = memnew(TabBar);
+	inspector_tab_bar->set_tab_close_display_policy(TabBar::CLOSE_BUTTON_SHOW_NEVER);
+	inspector_tab_bar->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	tab_bar_container->add_child(inspector_tab_bar);
+	inspector_tab_bar->connect("tab_selected", callable_mp(this, &InspectorDock::_on_inspector_tab_selected));
+	inspector_tab_bar->connect("minimum_size_changed", callable_mp(this, &InspectorDock::_update_tab_bar_layout));
+
 	MarginContainer *mc = memnew(MarginContainer);
-	main_vb->add_child(mc);
+	inspector_with_tabs->add_child(mc);
 	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	inspector = memnew(EditorInspector);
 	mc->add_child(inspector);
+	inspector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_autoclear(true);
 	inspector->set_show_categories(true, true);
 	inspector->set_use_doc_hints(true);
@@ -895,6 +1037,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_use_filter(true);
 
 	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
+	inspector->connect("inspector_tabs_updated", callable_mp(this, &InspectorDock::_update_inspector_tab_bar));
 
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &InspectorDock::_files_moved));
 

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -34,10 +34,12 @@
 #include "editor/editor_data.h"
 #include "editor/gui/create_dialog.h"
 #include "editor/inspector/editor_inspector.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/tab_bar.h"
 #include "scene/gui/tree.h"
 
 class EditorFileDialog;
@@ -92,6 +94,16 @@ class InspectorDock : public EditorDock {
 	Button *open_docs_button = nullptr;
 	MenuButton *object_menu = nullptr;
 	EditorObjectSelector *object_selector = nullptr;
+
+	// Inspector tab bar.
+	TabBar *inspector_tab_bar = nullptr;
+	Control *tab_bar_container = nullptr;
+	BoxContainer *inspector_with_tabs = nullptr;
+	bool tab_bar_updating = false;
+
+	void _on_inspector_tab_selected(int p_tab);
+	void _update_inspector_tab_bar();
+	void _update_tab_bar_layout();
 
 	bool info_is_warning = false; // Display in yellow and use warning icon if true.
 	Button *info = nullptr;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5127,6 +5127,12 @@ void EditorInspector::update_tree() {
 		EditorNode::get_singleton()->hide_unused_editors();
 	}
 
+	// Collect and apply inspector tabs.
+	_collect_inspector_tabs();
+	_apply_tab_filter();
+	set_current_inspector_tab(0);
+	emit_signal("inspector_tabs_updated");
+
 	if (root_inspector_was_following_focus) {
 		get_root_inspector()->set_follow_focus(true);
 	}
@@ -5218,6 +5224,11 @@ void EditorInspector::edit(Object *p_object) {
 		_update_current_favorites();
 
 		update_tree();
+	} else {
+		inspector_tabs.clear();
+		current_inspector_tab = 0;
+		current_tab_class_name = String();
+		emit_signal("inspector_tabs_updated");
 	}
 
 	// Keep it available until the end so it works with both main and sub inspectors.
@@ -5962,6 +5973,16 @@ void EditorInspector::_notification(int p_what) {
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
+			// Initialize inspector tab settings.
+			if (is_main_editor_inspector() && EditorSettings::get_singleton()) {
+				use_inspector_tabs = EDITOR_GET("interface/inspector/tabs/use_inspector_tabs");
+				tab_property_mode = EDITOR_GET("interface/inspector/tabs/tab_property_mode");
+				horizontal_tab_style = EDITOR_GET("interface/inspector/tabs/horizontal_tab_style");
+				vertical_tab_style = EDITOR_GET("interface/inspector/tabs/vertical_tab_style");
+				vertical_tab_side = EDITOR_GET("interface/inspector/tabs/vertical_tab_side");
+				tab_layout = EDITOR_GET("interface/inspector/tabs/tab_layout");
+				merge_abstract_class_tabs = EDITOR_GET("interface/inspector/tabs/merge_abstract_class_tabs");
+			}
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
@@ -6040,6 +6061,17 @@ void EditorInspector::_notification(int p_what) {
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/inspector")) {
 				update_tree_pending = true;
+
+				// Update inspector tab settings.
+				if (is_main_editor_inspector()) {
+					use_inspector_tabs = EDITOR_GET("interface/inspector/tabs/use_inspector_tabs");
+					tab_property_mode = EDITOR_GET("interface/inspector/tabs/tab_property_mode");
+					horizontal_tab_style = EDITOR_GET("interface/inspector/tabs/horizontal_tab_style");
+					vertical_tab_style = EDITOR_GET("interface/inspector/tabs/vertical_tab_style");
+					vertical_tab_side = EDITOR_GET("interface/inspector/tabs/vertical_tab_side");
+					tab_layout = EDITOR_GET("interface/inspector/tabs/tab_layout");
+					merge_abstract_class_tabs = EDITOR_GET("interface/inspector/tabs/merge_abstract_class_tabs");
+				}
 			}
 		} break;
 	}
@@ -6061,6 +6093,13 @@ void EditorInspector::_vscroll_changed(double p_offset) {
 	if (object) {
 		scroll_cache[object->get_instance_id()] = p_offset;
 	}
+
+	if (ignore_scroll_tab_sync) {
+		ignore_scroll_tab_sync = false;
+		return;
+	}
+
+	_update_tab_from_scroll();
 }
 
 void EditorInspector::set_property_prefix(const String &p_prefix) {
@@ -6158,6 +6197,241 @@ EditorInspector *EditorInspector::_get_control_parent_inspector(Control *p_contr
 	return nullptr;
 }
 
+// Inspector tabs.
+
+void EditorInspector::_collect_inspector_tabs() {
+	inspector_tabs.clear();
+
+	if (!use_inspector_tabs || !is_main_editor_inspector()) {
+		return;
+	}
+
+	bool first_category = true;
+
+	for (int i = 0; i < main_vbox->get_child_count(); i++) {
+		EditorInspectorCategory *category = Object::cast_to<EditorInspectorCategory>(main_vbox->get_child(i));
+		if (!category || category->is_favorite) {
+			continue;
+		}
+
+		// Skip custom categories (from @export_category).
+		if (category->info.hint_string.is_empty()) {
+			continue;
+		}
+
+		String class_name = category->info.name;
+
+		// Check if this should be merged with previous tab (abstract class).
+		if (merge_abstract_class_tabs && !first_category) {
+			if (ClassDB::class_exists(class_name) && !ClassDB::can_instantiate(class_name)) {
+				continue;
+			}
+		}
+		first_category = false;
+
+		InspectorTab tab;
+		tab.class_name = class_name;
+		tab.label = category->label;
+		tab.icon = category->icon;
+		inspector_tabs.push_back(tab);
+	}
+
+	// Restore current tab by class name.
+	int restored_tab = 0;
+	if (!current_tab_class_name.is_empty()) {
+		for (int i = 0; i < (int)inspector_tabs.size(); i++) {
+			if (inspector_tabs[i].class_name == current_tab_class_name) {
+				restored_tab = i;
+				break;
+			}
+		}
+	}
+	current_inspector_tab = CLAMP(restored_tab, 0, MAX((int)inspector_tabs.size() - 1, 0));
+	if (!inspector_tabs.is_empty()) {
+		current_tab_class_name = inspector_tabs[current_inspector_tab].class_name;
+	}
+}
+
+void EditorInspector::_apply_tab_filter() {
+	if (!use_inspector_tabs || inspector_tabs.is_empty() || !is_main_editor_inspector()) {
+		return;
+	}
+
+	// Don't filter when searching.
+	String filter = search_box ? search_box->get_text() : "";
+	if (!filter.is_empty()) {
+		return;
+	}
+
+	if (tab_property_mode != TAB_PROPERTY_MODE_TABBED) {
+		return;
+	}
+
+	// Tabbed mode - show only the current tab's content.
+	int tab_idx = -1;
+	bool first_standard_category = true;
+
+	for (int i = 0; i < main_vbox->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(main_vbox->get_child(i));
+		if (!child) {
+			continue;
+		}
+
+		EditorInspectorCategory *category = Object::cast_to<EditorInspectorCategory>(child);
+		if (category && !category->is_favorite && !category->info.hint_string.is_empty()) {
+			String class_name = category->info.name;
+			bool is_new_tab = true;
+
+			if (merge_abstract_class_tabs && !first_standard_category) {
+				if (ClassDB::class_exists(class_name) && !ClassDB::can_instantiate(class_name)) {
+					is_new_tab = false;
+				}
+			}
+			first_standard_category = false;
+
+			if (is_new_tab) {
+				tab_idx++;
+			}
+		} else if (tab_idx == -1 && !category) {
+			// Content before the first standard category - assign to first tab.
+			tab_idx = 0;
+		}
+
+		child->set_visible(tab_idx == current_inspector_tab);
+	}
+}
+
+void EditorInspector::_update_tab_from_scroll() {
+	if (!use_inspector_tabs || tab_property_mode != TAB_PROPERTY_MODE_JUMP_SCROLL || inspector_tabs.is_empty()) {
+		return;
+	}
+
+	float scroll_value = get_v_scroll_bar()->get_value();
+	int tab_idx = -1;
+	int best_tab = 0;
+	bool first_standard_category = true;
+
+	if (scroll_value <= 1) {
+		if (current_inspector_tab != 0) {
+			current_inspector_tab = 0;
+			if (!inspector_tabs.is_empty()) {
+				current_tab_class_name = inspector_tabs[0].class_name;
+			}
+			emit_signal("inspector_tabs_updated");
+		}
+		return;
+	}
+
+	for (int i = 0; i < main_vbox->get_child_count(); i++) {
+		EditorInspectorCategory *category = Object::cast_to<EditorInspectorCategory>(main_vbox->get_child(i));
+		if (!category || category->is_favorite || category->info.hint_string.is_empty()) {
+			continue;
+		}
+
+		String class_name = category->info.name;
+		bool is_new_tab = true;
+		if (merge_abstract_class_tabs && !first_standard_category) {
+			if (ClassDB::class_exists(class_name) && !ClassDB::can_instantiate(class_name)) {
+				is_new_tab = false;
+			}
+		}
+		first_standard_category = false;
+
+		if (is_new_tab) {
+			tab_idx++;
+		}
+
+		// Keep the active tab in sync with the top edge of the viewport.
+		float category_global_y = category->get_global_position().y;
+		float inspector_global_y = get_global_position().y;
+		float relative_y = category_global_y - inspector_global_y;
+
+		if (relative_y <= 0.0) {
+			best_tab = tab_idx;
+		} else {
+			break;
+		}
+	}
+
+	if (best_tab != current_inspector_tab && best_tab >= 0 && best_tab < (int)inspector_tabs.size()) {
+		current_inspector_tab = best_tab;
+		current_tab_class_name = inspector_tabs[best_tab].class_name;
+		emit_signal("inspector_tabs_updated");
+	}
+}
+
+int EditorInspector::get_inspector_tab_count() const {
+	return (int)inspector_tabs.size();
+}
+
+String EditorInspector::get_inspector_tab_name(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, (int)inspector_tabs.size(), String());
+	return inspector_tabs[p_idx].label;
+}
+
+Ref<Texture2D> EditorInspector::get_inspector_tab_icon(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, (int)inspector_tabs.size(), Ref<Texture2D>());
+	return inspector_tabs[p_idx].icon;
+}
+
+int EditorInspector::get_current_inspector_tab() const {
+	return current_inspector_tab;
+}
+
+void EditorInspector::set_current_inspector_tab(int p_tab) {
+	if (p_tab < 0 || p_tab >= (int)inspector_tabs.size()) {
+		return;
+	}
+	if (current_inspector_tab == p_tab) {
+		return;
+	}
+
+	current_inspector_tab = p_tab;
+	current_tab_class_name = inspector_tabs[p_tab].class_name;
+
+	if (tab_property_mode == TAB_PROPERTY_MODE_TABBED) {
+		_apply_tab_filter();
+	} else {
+		emit_signal("inspector_tabs_updated");
+		scroll_to_inspector_tab(p_tab);
+	}
+}
+
+void EditorInspector::scroll_to_inspector_tab(int p_tab) {
+	int tab_idx = -1;
+	bool first_standard_category = true;
+
+	for (int i = 0; i < main_vbox->get_child_count(); i++) {
+		EditorInspectorCategory *category = Object::cast_to<EditorInspectorCategory>(main_vbox->get_child(i));
+		if (!category || category->is_favorite || category->info.hint_string.is_empty()) {
+			continue;
+		}
+
+		String class_name = category->info.name;
+		bool is_new_tab = true;
+		if (merge_abstract_class_tabs && !first_standard_category) {
+			if (ClassDB::class_exists(class_name) && !ClassDB::can_instantiate(class_name)) {
+				is_new_tab = false;
+			}
+		}
+		first_standard_category = false;
+
+		if (is_new_tab) {
+			tab_idx++;
+		}
+
+		if (tab_idx == p_tab) {
+			// Align the target category with the top of the inspector viewport as much as possible.
+			float current_scroll = get_v_scroll_bar()->get_value();
+			float relative_y = category->get_global_position().y - get_global_position().y;
+			float target_scroll = CLAMP(current_scroll + relative_y, get_v_scroll_bar()->get_min(), get_v_scroll_bar()->get_max());
+			ignore_scroll_tab_sync = !Math::is_equal_approx(target_scroll, current_scroll);
+			get_v_scroll_bar()->set_value(target_scroll);
+			break;
+		}
+	}
+}
+
 void EditorInspector::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit", "object"), &EditorInspector::edit);
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
@@ -6175,6 +6449,7 @@ void EditorInspector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("property_toggled", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::BOOL, "checked")));
 	ADD_SIGNAL(MethodInfo("edited_object_changed"));
 	ADD_SIGNAL(MethodInfo("restart_requested"));
+	ADD_SIGNAL(MethodInfo("inspector_tabs_updated"));
 }
 
 EditorInspector::EditorInspector() {

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -747,6 +747,24 @@ public:
 		PropertyClipboard() {}
 	};
 
+	enum TabPropertyMode {
+		TAB_PROPERTY_MODE_TABBED,
+		TAB_PROPERTY_MODE_JUMP_SCROLL,
+	};
+
+	enum TabStyle {
+		TAB_STYLE_TEXT_ONLY,
+		TAB_STYLE_ICON_ONLY,
+		TAB_STYLE_TEXT_AND_ICON,
+	};
+
+	enum TabVerticalSide {
+		TAB_VERTICAL_SIDE_LEFT,
+		TAB_VERTICAL_SIDE_RIGHT,
+		TAB_VERTICAL_SIDE_INSIDE,
+		TAB_VERTICAL_SIDE_OUTSIDE,
+	};
+
 private:
 	enum {
 		MAX_PLUGINS = 1024
@@ -798,6 +816,29 @@ private:
 	bool autoclear = false;
 	bool use_folding = false;
 	int changing;
+
+	// Inspector tabs.
+	struct InspectorTab {
+		String class_name;
+		String label;
+		Ref<Texture2D> icon;
+	};
+
+	bool use_inspector_tabs = false;
+	int tab_property_mode = TAB_PROPERTY_MODE_TABBED;
+	int horizontal_tab_style = TAB_STYLE_TEXT_AND_ICON;
+	int vertical_tab_style = TAB_STYLE_ICON_ONLY;
+	int vertical_tab_side = TAB_VERTICAL_SIDE_OUTSIDE;
+	int tab_layout = 0; // 0 = Horizontal, 1 = Vertical.
+	bool merge_abstract_class_tabs = true;
+	int current_inspector_tab = 0;
+	String current_tab_class_name;
+	LocalVector<InspectorTab> inspector_tabs;
+	bool ignore_scroll_tab_sync = false;
+
+	void _collect_inspector_tabs();
+	void _apply_tab_filter();
+	void _update_tab_from_scroll();
 	bool update_all_pending = false;
 	bool read_only = false;
 	bool keying = false;
@@ -958,6 +999,18 @@ public:
 	void set_use_deletable_properties(bool p_enabled);
 
 	void set_restrict_to_basic_settings(bool p_restrict);
+
+	// Inspector tabs.
+	int get_inspector_tab_count() const;
+	String get_inspector_tab_name(int p_idx) const;
+	Ref<Texture2D> get_inspector_tab_icon(int p_idx) const;
+	int get_current_inspector_tab() const;
+	void set_current_inspector_tab(int p_tab);
+	void scroll_to_inspector_tab(int p_tab);
+	bool are_inspector_tabs_enabled() const { return use_inspector_tabs; }
+	int get_tab_layout() const { return tab_layout; }
+	int get_tab_style() const { return (tab_layout == 1) ? vertical_tab_style : horizontal_tab_style; }
+	int get_vertical_tab_side() const { return vertical_tab_side; }
 
 	EditorInspector();
 };

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -600,6 +600,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle") // `SHAPE_NONE` is 4.
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/color_picker_show_intensity", true, "");
 
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/tabs/use_inspector_tabs", true, "")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/tabs/tab_layout", 0, "Horizontal,Vertical")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/tabs/horizontal_tab_style", 2, "Text Only,Icon Only,Text and Icon")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/tabs/vertical_tab_style", 1, "Text Only,Icon Only,Text and Icon")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/tabs/vertical_tab_side", 0, "Left,Right,Inside,Outside")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/tabs/tab_property_mode", 0, "Tabbed, Jump Scroll")
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/tabs/merge_abstract_class_tabs", true, "")
+
 	// Theme
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_ENUM, "interface/theme/follow_system_theme", false, "")
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/style", "Modern", "Modern,Classic")

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -50,8 +50,9 @@ static inline Color _select_color(const Color &p_override_color, const Color &p_
 Size2 TabBar::get_minimum_size() const {
 	Size2 ms;
 	Size2 combined_max = get_combined_maximum_size();
-	int computed_max_width = 0;
-	bool stop_adding = combined_max.width < 0;
+	int computed_max_extent = 0;
+	float max_limit = vertical ? combined_max.height : combined_max.width;
+	bool stop_adding = max_limit < 0;
 
 	int buttons_size = get_tab_count() > 1 ? theme_cache.decrement_icon->get_width() + theme_cache.increment_icon->get_width() : 0;
 
@@ -61,13 +62,18 @@ Size2 TabBar::get_minimum_size() const {
 
 	int y_margin = MAX(MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_hovered_style->get_minimum_size().height), theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
 	int max_tab_width = 0;
+	int clip_max_extent = 0;
+	int visible_count = 0;
 
 	for (int i = 0; i < tabs.size(); i++) {
 		if (tabs[i].hidden) {
 			continue;
 		}
 
-		int ofs = ms.width;
+		visible_count++;
+
+		int tab_w = 0;
+		int tab_h = 0;
 
 		Ref<StyleBox> style;
 		if (tabs[i].disabled) {
@@ -79,18 +85,18 @@ Size2 TabBar::get_minimum_size() const {
 		} else {
 			style = theme_cache.tab_unselected_style;
 		}
-		ms.width += style->get_minimum_size().width;
+		tab_w += style->get_minimum_size().width;
 
 		if (tabs[i].icon.is_valid()) {
 			const Size2 icon_size = _get_tab_icon_size(i);
-			ms.height = MAX(ms.height, icon_size.height + y_margin);
-			ms.width += icon_size.width + theme_cache.h_separation;
+			tab_h = MAX(tab_h, (int)icon_size.height + y_margin);
+			tab_w += icon_size.width + theme_cache.h_separation;
 		}
 
 		if (!tabs[i].text.is_empty()) {
-			ms.width += tabs[i].size_text + theme_cache.h_separation;
+			tab_w += tabs[i].size_text + theme_cache.h_separation;
 		}
-		ms.height = MAX(ms.height, tabs[i].text_buf->get_size().y + y_margin);
+		tab_h = MAX(tab_h, (int)tabs[i].text_buf->get_size().y + y_margin);
 
 		bool close_visible = cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current);
 
@@ -98,48 +104,79 @@ Size2 TabBar::get_minimum_size() const {
 			Ref<Texture2D> rb = tabs[i].right_button;
 
 			if (close_visible) {
-				ms.width += theme_cache.button_hl_style->get_minimum_size().width + rb->get_width();
+				tab_w += theme_cache.button_hl_style->get_minimum_size().width + rb->get_width();
 			} else {
-				ms.width += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + rb->get_width() + theme_cache.h_separation;
+				tab_w += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + rb->get_width() + theme_cache.h_separation;
 			}
 
-			ms.height = MAX(ms.height, rb->get_height() + y_margin);
+			tab_h = MAX(tab_h, rb->get_height() + y_margin);
 		}
 
 		if (close_visible) {
-			ms.width += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + theme_cache.close_icon->get_width() + theme_cache.h_separation;
+			tab_w += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + theme_cache.close_icon->get_width() + theme_cache.h_separation;
 
-			ms.height = MAX(ms.height, theme_cache.close_icon->get_height() + y_margin);
+			tab_h = MAX(tab_h, theme_cache.close_icon->get_height() + y_margin);
 		}
 
-		if (ms.width - ofs > style->get_minimum_size().width) {
-			ms.width -= theme_cache.h_separation;
+		if (tab_w > style->get_minimum_size().width) {
+			tab_w -= theme_cache.h_separation;
 		}
 
-		if (i < tabs.size() - 1) {
-			ms.width += theme_cache.tab_separation;
-		}
+		ms.height = MAX(ms.height, tab_h);
+		max_tab_width = MAX(max_tab_width, tab_w);
 
-		if (!stop_adding) {
-			int buttons_eff_size = clip_tabs ? (i != tabs.size() - 1 ? buttons_size : 0) : 0;
-			if (computed_max_width + ms.width - ofs + buttons_eff_size >= combined_max.width) {
-				stop_adding = true;
-			} else {
-				computed_max_width += ms.width - ofs;
+		if (vertical) { /* Vertical */
+			int tab_total_h = tab_h + (i < tabs.size() - 1 ? (int)theme_cache.tab_separation : 0);
+			clip_max_extent = MAX(clip_max_extent, tab_total_h);
+
+			if (!stop_adding) {
+				int buttons_eff_size = clip_tabs ? (i != tabs.size() - 1 ? buttons_size : 0) : 0;
+				if (computed_max_extent + tab_total_h + buttons_eff_size >= max_limit) {
+					stop_adding = true;
+				} else {
+					computed_max_extent += tab_total_h;
+				}
+			}
+		} else { /* Horizontal */
+			ms.width += tab_w;
+
+			if (i < tabs.size() - 1) {
+				ms.width += theme_cache.tab_separation;
+			}
+
+			int tab_total_w = tab_w + (i < tabs.size() - 1 ? (int)theme_cache.tab_separation : 0);
+			clip_max_extent = MAX(clip_max_extent, tab_total_w);
+
+			if (!stop_adding) {
+				int buttons_eff_size = clip_tabs ? (i != tabs.size() - 1 ? buttons_size : 0) : 0;
+				if (computed_max_extent + tab_total_w + buttons_eff_size >= max_limit) {
+					stop_adding = true;
+				} else {
+					computed_max_extent += tab_total_w;
+				}
 			}
 		}
+	}
 
-		if (ms.width - ofs > max_tab_width) {
-			max_tab_width = ms.width - ofs;
+	if (vertical) { /* Vertical */
+		ms.width = max_tab_width;
+		ms.height = visible_count * ms.height + MAX(0, visible_count - 1) * (int)theme_cache.tab_separation;
+
+		if (clip_tabs) {
+			ms.height = clip_max_extent + buttons_size;
 		}
-	}
 
-	if (clip_tabs) {
-		ms.width = max_tab_width + buttons_size;
-	}
+		if (combined_max.height >= 0) {
+			ms.height = stop_adding ? combined_max.height : MIN(computed_max_extent, combined_max.height);
+		}
+	} else { /* Horizontal */
+		if (clip_tabs) {
+			ms.width = clip_max_extent + buttons_size;
+		}
 
-	if (combined_max.width >= 0) {
-		ms.width = stop_adding ? combined_max.width : MIN(computed_max_width, combined_max.width);
+		if (combined_max.width >= 0) {
+			ms.width = stop_adding ? combined_max.width : MIN(computed_max_extent, combined_max.width);
+		}
 	}
 
 	return ms;
@@ -154,7 +191,23 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 		Point2 pos = mm->get_position();
 
 		if (buttons_visible) {
-			if (is_layout_rtl()) {
+			if (vertical) {
+				int limit_minus_buttons = get_size().height - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+				if (pos.y > limit_minus_buttons + theme_cache.decrement_icon->get_width()) {
+					if (highlight_arrow != 1) {
+						highlight_arrow = 1;
+						queue_redraw();
+					}
+				} else if (pos.y > limit_minus_buttons) {
+					if (highlight_arrow != 0) {
+						highlight_arrow = 0;
+						queue_redraw();
+					}
+				} else if (highlight_arrow != -1) {
+					highlight_arrow = -1;
+					queue_redraw();
+				}
+			} else if (is_layout_rtl()) {
 				if (pos.x < theme_cache.decrement_icon->get_width()) {
 					if (highlight_arrow != 1) {
 						highlight_arrow = 1;
@@ -252,7 +305,24 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			bool selecting = mb->get_button_index() == MouseButton::LEFT || (select_with_rmb && mb->get_button_index() == MouseButton::RIGHT);
 
 			if (buttons_visible && selecting) {
-				if (is_layout_rtl()) {
+				if (vertical) {
+					int limit = get_size().height - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+					if (pos.y > limit + theme_cache.decrement_icon->get_width()) {
+						if (missing_right) {
+							offset++;
+							_update_cache();
+							queue_redraw();
+						}
+						return;
+					} else if (pos.y > limit) {
+						if (offset > 0) {
+							offset--;
+							_update_cache();
+							queue_redraw();
+						}
+						return;
+					}
+				} else if (is_layout_rtl()) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
@@ -573,7 +643,8 @@ void TabBar::_notification(int p_what) {
 						icn_col = theme_cache.icon_unselected_color;
 					}
 
-					_draw_tab(sb, fnt_col, icn_col, i, rtl ? (size.width - tabs[i].ofs_cache - tabs[i].size_cache) : tabs[i].ofs_cache, false);
+					float tab_ofs = vertical ? tabs[i].ofs_cache : (rtl ? (size.width - tabs[i].ofs_cache - tabs[i].size_cache) : tabs[i].ofs_cache);
+					_draw_tab(sb, fnt_col, icn_col, i, tab_ofs, false);
 				}
 			}
 
@@ -582,35 +653,57 @@ void TabBar::_notification(int p_what) {
 				Ref<StyleBox> sb = tabs[current].disabled ? theme_cache.tab_disabled_style : theme_cache.tab_selected_style;
 				Color col = _select_color(tabs[current].font_color_overrides[DrawMode::DRAW_PRESSED], theme_cache.font_selected_color);
 
-				_draw_tab(sb, col, theme_cache.icon_selected_color, current, rtl ? (size.width - tabs[current].ofs_cache - tabs[current].size_cache) : tabs[current].ofs_cache, has_focus(true));
+				float tab_ofs = vertical ? tabs[current].ofs_cache : (rtl ? (size.width - tabs[current].ofs_cache - tabs[current].size_cache) : tabs[current].ofs_cache);
+				_draw_tab(sb, col, theme_cache.icon_selected_color, current, tab_ofs, has_focus(true));
 			}
 
 			if (buttons_visible) {
-				int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
+				if (vertical) { /* VERTICAL */
+					int limit_minus_buttons_y = size.height - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
-				if (rtl) {
-					if (missing_right) {
-						draw_texture(highlight_arrow == 1 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(0, vofs));
-					} else {
-						draw_texture(theme_cache.decrement_icon, Point2(0, vofs), Color(1, 1, 1, 0.5));
-					}
+					Ref<Texture2D> dec_icon = (offset > 0) ? (highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon) : theme_cache.decrement_icon;
+					Ref<Texture2D> inc_icon = missing_right ? (highlight_arrow == 1 ? theme_cache.increment_hl_icon : theme_cache.increment_icon) : theme_cache.increment_icon;
 
-					if (offset > 0) {
-						draw_texture(highlight_arrow == 0 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs));
-					} else {
-						draw_texture(theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
-					}
-				} else {
-					if (offset > 0) {
-						draw_texture(highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs));
-					} else {
-						draw_texture(theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
-					}
+					Color dec_modulate = (offset > 0) ? Color(1, 1, 1, 1) : Color(1, 1, 1, 0.5);
+					Color inc_modulate = missing_right ? Color(1, 1, 1, 1) : Color(1, 1, 1, 0.5);
 
-					if (missing_right) {
-						draw_texture(highlight_arrow == 1 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs));
+					float dec_x = (size.width - dec_icon->get_height()) / 2.0f;
+					float inc_x = (size.width - inc_icon->get_height()) / 2.0f;
+
+					draw_set_transform(Point2(dec_x + dec_icon->get_height(), limit_minus_buttons_y), 1.5707964f, Size2(1, 1));
+					draw_texture(dec_icon, Point2(), dec_modulate);
+					draw_set_transform(Point2(), 0.0, Size2(1, 1));
+
+					draw_set_transform(Point2(inc_x + inc_icon->get_height(), limit_minus_buttons_y + theme_cache.decrement_icon->get_width()), 1.5707964f, Size2(1, 1));
+					draw_texture(inc_icon, Point2(), inc_modulate);
+					draw_set_transform(Point2(), 0.0, Size2(1, 1));
+				} else { /* HORIZONTAL */
+					int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
+
+					if (rtl) {
+						if (missing_right) {
+							draw_texture(highlight_arrow == 1 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(0, vofs));
+						} else {
+							draw_texture(theme_cache.decrement_icon, Point2(0, vofs), Color(1, 1, 1, 0.5));
+						}
+
+						if (offset > 0) {
+							draw_texture(highlight_arrow == 0 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs));
+						} else {
+							draw_texture(theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
+						}
 					} else {
-						draw_texture(theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
+						if (offset > 0) {
+							draw_texture(highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs));
+						} else {
+							draw_texture(theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
+						}
+
+						if (missing_right) {
+							draw_texture(highlight_arrow == 1 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs));
+						} else {
+							draw_texture(theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
+						}
 					}
 				}
 			}
@@ -664,13 +757,24 @@ void TabBar::_draw_tab_drop(RID p_canvas_item) {
 	theme_cache.drop_mark_icon->draw(p_canvas_item, Point2(x - theme_cache.drop_mark_icon->get_width() / 2, (size.height - theme_cache.drop_mark_icon->get_height()) / 2), theme_cache.drop_mark_color);
 }
 
-void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, const Color &p_icon_color, int p_index, float p_x, bool p_focus) {
+void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, const Color &p_icon_color, int p_index, float p_offset, bool p_focus) {
 	RID ci = get_canvas_item();
 	bool rtl = is_layout_rtl();
 
-	Rect2 sb_rect = Rect2(p_x, 0, tabs[p_index].size_cache, get_size().height);
+	Rect2 sb_rect;
+	float y_base = 0;
+
+	if (vertical) {
+		y_base = p_offset;
+		sb_rect = Rect2(0, p_offset, get_size().width, tabs[p_index].size_cache);
+		// Set p_offset for horizontal content layout within the tab.
+		p_offset = rtl ? get_size().width - p_tab_style->get_margin(SIDE_RIGHT) : p_tab_style->get_margin(SIDE_LEFT);
+	} else {
+		sb_rect = Rect2(p_offset, 0, tabs[p_index].size_cache, get_size().height);
+	}
+
 	if (tab_style_v_flip) {
-		draw_set_transform(Point2(0.0, p_tab_style->get_draw_rect(sb_rect).size.y), 0.0, Size2(1.0, -1.0));
+		draw_set_transform(Point2(0.0, y_base + p_tab_style->get_draw_rect(sb_rect).size.y), 0.0, Size2(1.0, -1.0));
 	}
 	p_tab_style->draw(ci, sb_rect);
 	if (tab_style_v_flip) {
@@ -681,7 +785,9 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 		focus_style->draw(ci, sb_rect);
 	}
 
-	p_x += rtl ? tabs[p_index].size_cache - p_tab_style->get_margin(SIDE_LEFT) : p_tab_style->get_margin(SIDE_LEFT);
+	if (!vertical) {
+		p_offset += rtl ? tabs[p_index].size_cache - p_tab_style->get_margin(SIDE_LEFT) : p_tab_style->get_margin(SIDE_LEFT);
+	}
 
 	Size2i sb_ms = p_tab_style->get_minimum_size();
 
@@ -689,23 +795,23 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 	Ref<Texture2D> icon = tabs[p_index].icon;
 	if (icon.is_valid()) {
 		const Size2 icon_size = _get_tab_icon_size(p_index);
-		const Point2 icon_pos = Point2i(rtl ? p_x - icon_size.width : p_x, p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon_size.height) / 2);
+		const Point2 icon_pos = Point2i(rtl ? p_offset - icon_size.width : p_offset, y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon_size.height) / 2);
 		icon->draw_rect(ci, Rect2(icon_pos, icon_size), false, p_icon_color);
 
-		p_x = rtl ? p_x - icon_size.width - theme_cache.h_separation : p_x + icon_size.width + theme_cache.h_separation;
+		p_offset = rtl ? p_offset - icon_size.width - theme_cache.h_separation : p_offset + icon_size.width + theme_cache.h_separation;
 	}
 
 	// Draw the text.
 	if (!tabs[p_index].text.is_empty()) {
-		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
-				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
+		Point2i text_pos = Point2i(rtl ? p_offset - tabs[p_index].size_text : p_offset,
+				y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
 
 		if (theme_cache.outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 			tabs[p_index].text_buf->draw_outline(ci, text_pos, theme_cache.outline_size, theme_cache.font_outline_color);
 		}
 		tabs[p_index].text_buf->draw(ci, text_pos, p_font_color);
 
-		p_x = rtl ? p_x - tabs[p_index].size_text - theme_cache.h_separation : p_x + tabs[p_index].size_text + theme_cache.h_separation;
+		p_offset = rtl ? p_offset - tabs[p_index].size_text - theme_cache.h_separation : p_offset + tabs[p_index].size_text + theme_cache.h_separation;
 	}
 
 	// Draw and calculate rect of the right button.
@@ -715,8 +821,8 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 		Rect2 rb_rect;
 		rb_rect.size = style->get_minimum_size() + rb->get_size();
-		rb_rect.position.x = rtl ? p_x - rb_rect.size.width : p_x;
-		rb_rect.position.y = p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - (rb_rect.size.y)) / 2;
+		rb_rect.position.x = rtl ? p_offset - rb_rect.size.width : p_offset;
+		rb_rect.position.y = y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - (rb_rect.size.y)) / 2;
 
 		tabs.write[p_index].rb_rect = rb_rect;
 
@@ -730,7 +836,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 		rb->draw(ci, Point2i(rb_rect.position.x + style->get_margin(SIDE_LEFT), rb_rect.position.y + style->get_margin(SIDE_TOP)));
 
-		p_x = rtl ? rb_rect.position.x : rb_rect.position.x + rb_rect.size.width;
+		p_offset = rtl ? rb_rect.position.x : rb_rect.position.x + rb_rect.size.width;
 	} else {
 		tabs.write[p_index].rb_rect = Rect2();
 	}
@@ -742,8 +848,8 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 		Rect2 cb_rect;
 		cb_rect.size = style->get_minimum_size() + cb->get_size();
-		cb_rect.position.x = rtl ? p_x - cb_rect.size.width : p_x;
-		cb_rect.position.y = p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - (cb_rect.size.y)) / 2;
+		cb_rect.position.x = rtl ? p_offset - cb_rect.size.width : p_offset;
+		cb_rect.position.y = y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - (cb_rect.size.y)) / 2;
 
 		tabs.write[p_index].cb_rect = cb_rect;
 
@@ -1223,93 +1329,147 @@ void TabBar::_update_cache(bool p_update_hover) {
 		return;
 	}
 
-	Size2 combined_max = get_combined_maximum_size();
-	int combined_max_width = combined_max.width >= 0 ? int(combined_max.width) - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width() : INT_MAX;
-	int effective_max_width = max_width > 0 ? MIN(max_width, combined_max_width) : combined_max_width;
-
-	int limit = combined_max.width > 0 ? combined_max.width : get_size().width;
-	int limit_minus_buttons = limit - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
-
-	int w = 0;
-
-	max_drawn_tab = tabs.size() - 1;
+	// Update text buffers. For vertical, also compute uniform tab height.
+	int y_margin = MAX(MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_hovered_style->get_minimum_size().height), theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
+	int uniform_height = y_margin;
 
 	for (int i = 0; i < tabs.size(); i++) {
 		tabs.write[i].text_buf->set_width(-1);
 		tabs.write[i].size_text = Math::ceil(tabs[i].text_buf->get_size().x);
-		tabs.write[i].size_cache = get_tab_width(i);
 		tabs.write[i].accessibility_item_dirty = true;
 
-		tabs.write[i].truncated = effective_max_width > 0 && effective_max_width < INT_MAX && tabs[i].size_cache > effective_max_width;
-		if (tabs[i].truncated) {
-			int size_textless = tabs[i].size_cache - tabs[i].size_text;
-			int mw = MAX(size_textless, effective_max_width);
-
-			tabs.write[i].size_text = MAX(mw - size_textless, 1);
-			tabs.write[i].text_buf->set_width(tabs[i].size_text);
-			tabs.write[i].size_cache = size_textless + tabs[i].size_text;
-		}
-
-		if (i < offset || i > max_drawn_tab) {
-			tabs.write[i].ofs_cache = 0;
-			continue;
-		}
-
-		tabs.write[i].ofs_cache = w;
-
-		if (tabs[i].hidden) {
-			continue;
-		}
-
-		w += tabs[i].size_cache;
-
-		// Check if all tabs would fit inside the area.
-		if (clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons))) {
-			tabs.write[i].ofs_cache = 0;
-
-			w -= tabs[i].size_cache;
-			w -= theme_cache.tab_separation;
-
-			max_drawn_tab = i - 1;
-
-			while (w > limit_minus_buttons && max_drawn_tab > offset) {
-				tabs.write[max_drawn_tab].ofs_cache = 0;
-
-				if (!tabs[max_drawn_tab].hidden) {
-					w -= tabs[max_drawn_tab].size_cache;
-					w -= theme_cache.tab_separation;
-				}
-
-				max_drawn_tab--;
+		if (vertical && !tabs[i].hidden) {
+			int content_h = 0;
+			if (tabs[i].icon.is_valid()) {
+				content_h = MAX(content_h, (int)_get_tab_icon_size(i).height);
 			}
-		} else if (i < tabs.size() - 1) {
-			// Only add the tab separation if this isn't the last tab drawn.
-			w += theme_cache.tab_separation;
+			if (!tabs[i].text.is_empty()) {
+				content_h = MAX(content_h, (int)tabs[i].text_buf->get_size().y);
+			}
+			uniform_height = MAX(uniform_height, content_h + y_margin);
+		}
+	}
+
+	Size2 combined_max = get_combined_maximum_size();
+	int buttons_size = theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width();
+	int combined_max_axis = vertical ? (combined_max.height >= 0 ? int(combined_max.height) - buttons_size : INT_MAX) : (combined_max.width >= 0 ? int(combined_max.width) - buttons_size : INT_MAX);
+	int effective_max_width = max_width > 0 ? MIN(max_width, combined_max_axis) : combined_max_axis;
+
+	int limit = vertical ? (combined_max.height > 0 ? combined_max.height : get_size().height) : (combined_max.width > 0 ? combined_max.width : get_size().width);
+	int limit_minus_buttons = limit - buttons_size;
+
+	int w = 0;
+	max_drawn_tab = tabs.size() - 1;
+
+	for (int i = 0; i < tabs.size(); i++) {
+		if (vertical) {
+			tabs.write[i].size_cache = uniform_height;
+
+			if (i < offset || i > max_drawn_tab) {
+				tabs.write[i].ofs_cache = 0;
+				continue;
+			}
+
+			tabs.write[i].ofs_cache = w;
+
+			if (tabs[i].hidden) {
+				continue;
+			}
+
+			w += tabs[i].size_cache;
+
+			// Check if all tabs would fit inside the area.
+			if (clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons))) {
+				tabs.write[i].ofs_cache = 0;
+
+				w -= tabs[i].size_cache;
+				w -= theme_cache.tab_separation;
+
+				max_drawn_tab = i - 1;
+
+				while (w > limit_minus_buttons && max_drawn_tab > offset) {
+					tabs.write[max_drawn_tab].ofs_cache = 0;
+
+					if (!tabs[max_drawn_tab].hidden) {
+						w -= tabs[max_drawn_tab].size_cache;
+						w -= theme_cache.tab_separation;
+					}
+
+					max_drawn_tab--;
+				}
+			} else if (i < tabs.size() - 1) {
+				// Only add the tab separation if this isn't the last tab drawn.
+				w += theme_cache.tab_separation;
+			}
+		} else {
+			tabs.write[i].size_cache = get_tab_width(i);
+
+			tabs.write[i].truncated = effective_max_width > 0 && effective_max_width < INT_MAX && tabs[i].size_cache > effective_max_width;
+			if (tabs[i].truncated) {
+				int size_textless = tabs[i].size_cache - tabs[i].size_text;
+				int mw = MAX(size_textless, effective_max_width);
+
+				tabs.write[i].size_text = MAX(mw - size_textless, 1);
+				tabs.write[i].text_buf->set_width(tabs[i].size_text);
+				tabs.write[i].size_cache = size_textless + tabs[i].size_text;
+			}
+
+			if (i < offset || i > max_drawn_tab) {
+				tabs.write[i].ofs_cache = 0;
+				continue;
+			}
+
+			tabs.write[i].ofs_cache = w;
+
+			if (tabs[i].hidden) {
+				continue;
+			}
+
+			w += tabs[i].size_cache;
+
+			// Check if all tabs would fit inside the area.
+			if (clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons))) {
+				tabs.write[i].ofs_cache = 0;
+
+				w -= tabs[i].size_cache;
+				w -= theme_cache.tab_separation;
+
+				max_drawn_tab = i - 1;
+
+				while (w > limit_minus_buttons && max_drawn_tab > offset) {
+					tabs.write[max_drawn_tab].ofs_cache = 0;
+
+					if (!tabs[max_drawn_tab].hidden) {
+						w -= tabs[max_drawn_tab].size_cache;
+						w -= theme_cache.tab_separation;
+					}
+
+					max_drawn_tab--;
+				}
+			} else if (i < tabs.size() - 1) {
+				// Only add the tab separation if this isn't the last tab drawn.
+				w += theme_cache.tab_separation;
+			}
 		}
 	}
 
 	missing_right = max_drawn_tab < tabs.size() - 1;
 	buttons_visible = offset > 0 || missing_right;
 
-	if (tab_alignment == ALIGNMENT_LEFT) {
-		if (p_update_hover) {
-			_update_hover();
+	if (!vertical && tab_alignment != ALIGNMENT_LEFT) {
+		if (tab_alignment == ALIGNMENT_CENTER) {
+			w = ((buttons_visible ? limit_minus_buttons : limit) - w) / 2;
+		} else if (tab_alignment == ALIGNMENT_RIGHT) {
+			w = (buttons_visible ? limit_minus_buttons : limit) - w;
 		}
-		return;
-	}
 
-	if (tab_alignment == ALIGNMENT_CENTER) {
-		w = ((buttons_visible ? limit_minus_buttons : limit) - w) / 2;
-	} else if (tab_alignment == ALIGNMENT_RIGHT) {
-		w = (buttons_visible ? limit_minus_buttons : limit) - w;
-	}
+		for (int i = offset; i <= max_drawn_tab; i++) {
+			if (!tabs[i].hidden) {
+				tabs.write[i].ofs_cache = w;
 
-	for (int i = offset; i <= max_drawn_tab; i++) {
-		if (!tabs[i].hidden) {
-			tabs.write[i].ofs_cache = w;
-
-			w += tabs[i].size_cache;
-			w += theme_cache.tab_separation;
+				w += tabs[i].size_cache;
+				w += theme_cache.tab_separation;
+			}
 		}
 	}
 
@@ -1678,12 +1838,14 @@ int TabBar::get_closest_tab_idx_to_point(const Point2 &p_point) const {
 	int closest_tab = get_tab_idx_at_point(p_point);
 	float closest_distance = FLT_MAX;
 
-	// Search along the x-axis since the TabBar is horizontal.
+	// Search along the appropriate axis.
 	if (closest_tab == -1) {
 		for (int i = offset; i <= max_drawn_tab; i++) {
 			if (!tabs[i].hidden) {
-				float center = get_tab_rect(i).get_center().x;
-				float distance = Math::abs(center - p_point.x);
+				Rect2 rect = get_tab_rect(i);
+				float center = vertical ? rect.get_center().y : rect.get_center().x;
+				float point = vertical ? p_point.y : p_point.x;
+				float distance = Math::abs(center - point);
 				if (distance < closest_distance) {
 					closest_distance = distance;
 					closest_tab = i;
@@ -1737,6 +1899,20 @@ bool TabBar::get_clip_tabs() const {
 
 void TabBar::set_tab_style_v_flip(bool p_tab_style_v_flip) {
 	tab_style_v_flip = p_tab_style_v_flip;
+}
+
+void TabBar::set_vertical(bool p_vertical) {
+	if (vertical == p_vertical) {
+		return;
+	}
+	vertical = p_vertical;
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool TabBar::is_vertical() const {
+	return vertical;
 }
 
 void TabBar::move_tab(int p_from, int p_to) {
@@ -1857,8 +2033,8 @@ void TabBar::_ensure_no_over_offset() {
 		return;
 	}
 
-	int limit_with_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
-	int limit_with_no_button = get_size().width;
+	int limit_with_buttons = vertical ? (get_size().height - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width()) : (get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width());
+	int limit_with_no_button = vertical ? get_size().height : get_size().width;
 	int offset_with_buttons = offset;
 	int offset_with_no_button = offset;
 
@@ -1918,7 +2094,7 @@ void TabBar::ensure_tab_visible(int p_idx) {
 		return;
 	}
 
-	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+	int limit_minus_buttons = vertical ? (get_size().height - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width()) : (get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width());
 
 	int total_w = tabs[max_drawn_tab].ofs_cache - tabs[offset].ofs_cache;
 	for (int i = max_drawn_tab; i <= p_idx; i++) {
@@ -1953,7 +2129,9 @@ void TabBar::ensure_tab_visible(int p_idx) {
 Rect2 TabBar::get_tab_rect(int p_tab) const {
 	ERR_FAIL_INDEX_V(p_tab, tabs.size(), Rect2());
 
-	if (is_layout_rtl()) {
+	if (vertical) {
+		return Rect2(0, tabs[p_tab].ofs_cache, get_size().width, tabs[p_tab].size_cache);
+	} else if (is_layout_rtl()) {
 		return Rect2(get_size().width - tabs[p_tab].ofs_cache - tabs[p_tab].size_cache, 0, tabs[p_tab].size_cache, get_size().height);
 	} else {
 		return Rect2(tabs[p_tab].ofs_cache, 0, tabs[p_tab].size_cache, get_size().height);
@@ -2137,6 +2315,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_select_with_rmb"), &TabBar::get_select_with_rmb);
 	ClassDB::bind_method(D_METHOD("set_deselect_enabled", "enabled"), &TabBar::set_deselect_enabled);
 	ClassDB::bind_method(D_METHOD("get_deselect_enabled"), &TabBar::get_deselect_enabled);
+	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &TabBar::set_vertical);
+	ClassDB::bind_method(D_METHOD("is_vertical"), &TabBar::is_vertical);
 	ClassDB::bind_method(D_METHOD("clear_tabs"), &TabBar::clear_tabs);
 
 	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
@@ -2161,6 +2341,7 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_to_selected"), "set_scroll_to_selected", "get_scroll_to_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_with_rmb"), "set_select_with_rmb", "get_select_with_rmb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
 
 	ADD_ARRAY_COUNT("Tabs", "tab_count", "set_tab_count", "get_tab_count", "tab_");
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -87,16 +87,18 @@ Size2 TabBar::get_minimum_size() const {
 		}
 		tab_w += style->get_minimum_size().width;
 
-		if (tabs[i].icon.is_valid()) {
+		if (tabs[i].icon.is_valid() && !hide_icons) {
 			const Size2 icon_size = _get_tab_icon_size(i);
 			tab_h = MAX(tab_h, (int)icon_size.height + y_margin);
 			tab_w += icon_size.width + theme_cache.h_separation;
 		}
 
-		if (!tabs[i].text.is_empty()) {
+		if (!tabs[i].text.is_empty() && !hide_text) {
 			tab_w += tabs[i].size_text + theme_cache.h_separation;
 		}
-		tab_h = MAX(tab_h, (int)tabs[i].text_buf->get_size().y + y_margin);
+		if (!hide_text) {
+			tab_h = MAX(tab_h, (int)tabs[i].text_buf->get_size().y + y_margin);
+		}
 
 		bool close_visible = cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current);
 
@@ -793,7 +795,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 
 	// Draw the icon.
 	Ref<Texture2D> icon = tabs[p_index].icon;
-	if (icon.is_valid()) {
+	if (icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(p_index);
 		const Point2 icon_pos = Point2i(rtl ? p_offset - icon_size.width : p_offset, y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon_size.height) / 2);
 		icon->draw_rect(ci, Rect2(icon_pos, icon_size), false, p_icon_color);
@@ -802,7 +804,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, const Color &p_font_color, co
 	}
 
 	// Draw the text.
-	if (!tabs[p_index].text.is_empty()) {
+	if (!tabs[p_index].text.is_empty() && !hide_text) {
 		Point2i text_pos = Point2i(rtl ? p_offset - tabs[p_index].size_text : p_offset,
 				y_base + p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
 
@@ -1335,15 +1337,15 @@ void TabBar::_update_cache(bool p_update_hover) {
 
 	for (int i = 0; i < tabs.size(); i++) {
 		tabs.write[i].text_buf->set_width(-1);
-		tabs.write[i].size_text = Math::ceil(tabs[i].text_buf->get_size().x);
+		tabs.write[i].size_text = hide_text ? 0 : Math::ceil(tabs[i].text_buf->get_size().x);
 		tabs.write[i].accessibility_item_dirty = true;
 
 		if (vertical && !tabs[i].hidden) {
 			int content_h = 0;
-			if (tabs[i].icon.is_valid()) {
+			if (tabs[i].icon.is_valid() && !hide_icons) {
 				content_h = MAX(content_h, (int)_get_tab_icon_size(i).height);
 			}
-			if (!tabs[i].text.is_empty()) {
+			if (!tabs[i].text.is_empty() && !hide_text) {
 				content_h = MAX(content_h, (int)tabs[i].text_buf->get_size().y);
 			}
 			uniform_height = MAX(uniform_height, content_h + y_margin);
@@ -1652,7 +1654,7 @@ Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_poin
 
 	HBoxContainer *drag_preview = memnew(HBoxContainer);
 
-	if (tabs[tab_over].icon.is_valid()) {
+	if (tabs[tab_over].icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(tab_over);
 
 		TextureRect *tf = memnew(TextureRect);
@@ -1906,6 +1908,7 @@ void TabBar::set_vertical(bool p_vertical) {
 		return;
 	}
 	vertical = p_vertical;
+
 	_update_cache();
 	queue_redraw();
 	update_minimum_size();
@@ -1913,6 +1916,36 @@ void TabBar::set_vertical(bool p_vertical) {
 
 bool TabBar::is_vertical() const {
 	return vertical;
+}
+
+void TabBar::set_hide_text(bool p_hide_text) {
+	if (hide_text == p_hide_text) {
+		return;
+	}
+	hide_text = p_hide_text;
+
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool TabBar::is_hide_text() const {
+	return hide_text;
+}
+
+void TabBar::set_hide_icons(bool p_hide_icons) {
+	if (hide_icons == p_hide_icons) {
+		return;
+	}
+	hide_icons = p_hide_icons;
+
+	_update_cache();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool TabBar::is_hide_icons() const {
+	return hide_icons;
 }
 
 void TabBar::move_tab(int p_from, int p_to) {
@@ -1972,12 +2005,12 @@ int TabBar::get_tab_width(int p_idx) const {
 	}
 	int x = style->get_minimum_size().width;
 
-	if (tabs[p_idx].icon.is_valid()) {
+	if (tabs[p_idx].icon.is_valid() && !hide_icons) {
 		const Size2 icon_size = _get_tab_icon_size(p_idx);
 		x += icon_size.width + theme_cache.h_separation;
 	}
 
-	if (!tabs[p_idx].text.is_empty()) {
+	if (!tabs[p_idx].text.is_empty() && !hide_text) {
 		x += tabs[p_idx].size_text + theme_cache.h_separation;
 	}
 
@@ -2317,6 +2350,10 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_deselect_enabled"), &TabBar::get_deselect_enabled);
 	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &TabBar::set_vertical);
 	ClassDB::bind_method(D_METHOD("is_vertical"), &TabBar::is_vertical);
+	ClassDB::bind_method(D_METHOD("set_hide_text", "hide_text"), &TabBar::set_hide_text);
+	ClassDB::bind_method(D_METHOD("is_hide_text"), &TabBar::is_hide_text);
+	ClassDB::bind_method(D_METHOD("set_hide_icons", "hide_icons"), &TabBar::set_hide_icons);
+	ClassDB::bind_method(D_METHOD("is_hide_icons"), &TabBar::is_hide_icons);
 	ClassDB::bind_method(D_METHOD("clear_tabs"), &TabBar::clear_tabs);
 
 	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
@@ -2342,6 +2379,8 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_with_rmb"), "set_select_with_rmb", "get_select_with_rmb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_text"), "set_hide_text", "is_hide_text");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_icons"), "set_hide_icons", "is_hide_icons");
 
 	ADD_ARRAY_COUNT("Tabs", "tab_count", "set_tab_count", "get_tab_count", "tab_");
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -106,6 +106,8 @@ private:
 	int offset = 0;
 	int max_drawn_tab = 0;
 	int highlight_arrow = -1;
+	bool hide_text = false;
+	bool hide_icons = false;
 	bool buttons_visible = false;
 	bool missing_right = false;
 	Vector<Tab> tabs;
@@ -278,6 +280,12 @@ public:
 
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
+
+	void set_hide_text(bool p_hide_text);
+	bool is_hide_text() const;
+
+	void set_hide_icons(bool p_hide_icons);
+	bool is_hide_icons() const;
 
 	void move_tab(int p_from, int p_to);
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -113,6 +113,7 @@ private:
 	int previous = -1;
 	AlignmentMode tab_alignment = ALIGNMENT_LEFT;
 	bool clip_tabs = true;
+	bool vertical = false;
 	int rb_hover = -1;
 	bool rb_pressing = false;
 	bool tab_style_v_flip = false;
@@ -274,6 +275,9 @@ public:
 	bool get_clip_tabs() const;
 
 	void set_tab_style_v_flip(bool p_tab_style_v_flip);
+
+	void set_vertical(bool p_vertical);
+	bool is_vertical() const;
 
 	void move_tab(int p_from, int p_to);
 


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/12270
* Includes #118358
  * Includes a modified version thereof, which has a technical placeholder. [See comment](https://github.com/godotengine/godot/pull/118359#issuecomment-4223655672). 
* Requires #116485

This PR implements our 2nd most requested usability feature: editor inspector tabs.

The tabs come with a lot of configurability through the editor settings in the `interface/inspector/tabs/` subcategory:
* Can be disabled via `use_inspector_tabs`
* Can be switched between horizontal and vertical via `tab_layout`
* Can show text only/icon only/both via `horizontal_tab_style` and `vertical_tab_style` (split due to different layouts looking better with different modes)
* In vertical layout, they can be on the right/left of the inspector dock tab (static), or on the inside/outside of the inspector dock tab (dynamic) via `vertical_tab_side`
* They can be used either as a list and clicking on the tabs scrolls automatically, or used as fully separate tabs via `tab_property_mode`
* Abstract classes can be merged into the first non-abstract class that inherits them via `merge_abstract_class_tabs`

<sub> Note: All property names subject to change </sub>

Here are some snippets:

Horizontal with both text and icon (default):
<img width="545" height="121" alt="image" src="https://github.com/user-attachments/assets/6082e8c8-fc1b-483e-af91-8a2681087bdd" />

Vertical with icon only (vertical default):
<img width="541" height="190" alt="image" src="https://github.com/user-attachments/assets/1b95b3d1-dba2-4472-b34f-d025eeb3de25" />

Tabbed mode:

https://github.com/user-attachments/assets/03843de7-5e79-403a-8f29-f12bcf356941

Jump Scroll mode:

https://github.com/user-attachments/assets/beb5fa18-c84b-413e-b64f-fb472299244d

*AI Disclaimer: I used AI to help me figure some of the implementation. Verified it all.*