### PR TITLE
Prevent branding in Project Manager from being affected by icon saturation

### DIFF
--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -111,6 +111,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	saturation_exceptions.insert("DefaultProjectIcon");
 	saturation_exceptions.insert("Godot");
 	saturation_exceptions.insert("Logo");
+	saturation_exceptions.insert("TitleBarLogo");
 
 	// Accent color conversion map.
 	// It is used on some icons (checkbox, radio, toggle, etc.), regardless of the dark


### PR DESCRIPTION
Adds an exception to prevent icon saturation altering the coloured branding in the Project Manager.

Before, and after.

<img width="522" height="125" alt="saturation" src="https://github.com/user-attachments/assets/f97f92f9-c37b-4f5c-aae1-e83d461608c5" />

