### PR TITLE
Switch NoiseTexture2D/3D from using Threads to WorkerThreadPool

### DIFF
--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -48,8 +48,9 @@ NoiseTexture2D::~NoiseTexture2D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free_rid(texture);
 	}
-	if (noise_thread.is_started()) {
-		noise_thread.wait_to_finish();
+	if (current_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		regen_queued = false;
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(current_task_id);
 	}
 }
 
@@ -131,17 +132,19 @@ void NoiseTexture2D::_set_texture_image(const Ref<Image> &p_image) {
 }
 
 void NoiseTexture2D::_thread_done(const Ref<Image> &p_image) {
+	if (current_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(current_task_id);
+		current_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	}
 	_set_texture_image(p_image);
-	noise_thread.wait_to_finish();
 	if (regen_queued) {
-		noise_thread.start(_thread_function, this);
+		current_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &NoiseTexture2D::_thread_function), false, "Noise Texture 2D Image generation");
 		regen_queued = false;
 	}
 }
 
-void NoiseTexture2D::_thread_function(void *p_ud) {
-	NoiseTexture2D *tex = static_cast<NoiseTexture2D *>(p_ud);
-	callable_mp(tex, &NoiseTexture2D::_thread_done).call_deferred(tex->_generate_texture());
+void NoiseTexture2D::_thread_function() {
+	callable_mp(this, &NoiseTexture2D::_thread_done).call_deferred(_generate_texture());
 }
 
 void NoiseTexture2D::_queue_update() {
@@ -208,8 +211,8 @@ void NoiseTexture2D::_update_texture() {
 		first_time = false;
 	}
 	if (use_thread) {
-		if (!noise_thread.is_started()) {
-			noise_thread.start(_thread_function, this);
+		if (current_task_id == WorkerThreadPool::INVALID_TASK_ID) {
+			current_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &NoiseTexture2D::_thread_function), false, "Noise Texture 2D Image generation");
 			regen_queued = false;
 		} else {
 			regen_queued = true;

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -33,6 +33,7 @@
 #include "noise.h"
 
 #include "core/object/ref_counted.h"
+#include "core/object/worker_thread_pool.h"
 #include "scene/resources/gradient.h"
 #include "scene/resources/texture.h"
 
@@ -42,7 +43,7 @@ class NoiseTexture2D : public Texture2D {
 private:
 	Ref<Image> image;
 
-	Thread noise_thread;
+	WorkerThreadPool::TaskID current_task_id = WorkerThreadPool::INVALID_TASK_ID;
 
 	bool first_time = true;
 	bool update_queued = false;
@@ -65,7 +66,7 @@ private:
 	Ref<Noise> noise;
 
 	void _thread_done(const Ref<Image> &p_image);
-	static void _thread_function(void *p_ud);
+	void _thread_function();
 
 	void _queue_update();
 	Ref<Image> _generate_texture();

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -48,8 +48,9 @@ NoiseTexture3D::~NoiseTexture3D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free_rid(texture);
 	}
-	if (noise_thread.is_started()) {
-		noise_thread.wait_to_finish();
+	if (current_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		regen_queued = false;
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(current_task_id);
 	}
 }
 
@@ -120,17 +121,19 @@ void NoiseTexture3D::_set_texture_data(const TypedArray<Image> &p_data) {
 }
 
 void NoiseTexture3D::_thread_done(const TypedArray<Image> &p_data) {
+	if (current_task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(current_task_id);
+		current_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	}
 	_set_texture_data(p_data);
-	noise_thread.wait_to_finish();
 	if (regen_queued) {
-		noise_thread.start(_thread_function, this);
+		current_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &NoiseTexture3D::_thread_function), false, "Noise Texture 3D Image generation");
 		regen_queued = false;
 	}
 }
 
-void NoiseTexture3D::_thread_function(void *p_ud) {
-	NoiseTexture3D *tex = static_cast<NoiseTexture3D *>(p_ud);
-	callable_mp(tex, &NoiseTexture3D::_thread_done).call_deferred(tex->_generate_texture());
+void NoiseTexture3D::_thread_function() {
+	callable_mp(this, &NoiseTexture3D::_thread_done).call_deferred(_generate_texture());
 }
 
 void NoiseTexture3D::_queue_update() {
@@ -203,8 +206,8 @@ void NoiseTexture3D::_update_texture() {
 		first_time = false;
 	}
 	if (use_thread) {
-		if (!noise_thread.is_started()) {
-			noise_thread.start(_thread_function, this);
+		if (current_task_id == WorkerThreadPool::INVALID_TASK_ID) {
+			current_task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &NoiseTexture3D::_thread_function), false, "Noise Texture 3D Image generation");
 			regen_queued = false;
 		} else {
 			regen_queued = true;

--- a/modules/noise/noise_texture_3d.h
+++ b/modules/noise/noise_texture_3d.h
@@ -33,6 +33,7 @@
 #include "noise.h"
 
 #include "core/object/ref_counted.h"
+#include "core/object/worker_thread_pool.h"
 #include "scene/resources/gradient.h"
 #include "scene/resources/texture.h"
 
@@ -40,8 +41,7 @@ class NoiseTexture3D : public Texture3D {
 	GDCLASS(NoiseTexture3D, Texture3D);
 
 private:
-	Thread noise_thread;
-
+	WorkerThreadPool::TaskID current_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool first_time = true;
 	bool update_queued = false;
 	bool regen_queued = false;
@@ -63,7 +63,7 @@ private:
 	Image::Format format = Image::FORMAT_L8;
 
 	void _thread_done(const TypedArray<Image> &p_data);
-	static void _thread_function(void *p_ud);
+	void _thread_function();
 
 	void _queue_update();
 	TypedArray<Image> _generate_texture();


### PR DESCRIPTION
### Summary
NoiseTexture2D and 3D spawn a thread for each texture generation, use it to generate the texture and then drop the thread again. This kind of behavior is perfect for the WorkerThreadPool, but the NoiseTextures predate the creation of the WorkerThreadPool, so the NoiseTextures seem to not have been updated, yet. 

This PR simply exchanges all the Thread functionality with WorkerThreadPool functions.

### Testing
I only tested it in our prototype where the problem manifested itself: we used a lot of noise textures in one scene, resulting in more than 40 threads being created when that scene was loaded asynchronously, which would even lead to OS stuttering (audio running in different applications dropping out!). I added profiling markers to the noise generation functions and could see all the threads being created in tracy. After the switch to the WorkerThreadPool the threads were nice and tidy again and the noise generation was even faster, because the overhead of all the threads being created was gone.

### Issue fixes
I looked for issues that could be fixed by this PR, but only found one old comment wondering about the excessive thread creation in the NoiseTexture: https://github.com/godotengine/godot/issues/26520#issuecomment-469032819 