### PR TITLE
Revert "Fix uniforms break particle shaders after conversion from a `ParticleProcessMaterial`"

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -374,7 +374,6 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				Variant default_value = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), pi.name);
 				param_cache.insert(pi.name, default_value);
 				remap_cache.insert(info.name, pi.name);
-				RS::get_singleton()->material_set_param(_get_material(), pi.name, default_value);
 			}
 			groups[last_group][last_subgroup].push_back(info);
 		}


### PR DESCRIPTION
- Reverts #110287.
- Supersedes #118356.
- Fixes #118344.
- Fixes #118360.
- Reopens #101456.