### PR TITLE
Add playback get for separate interactive clips

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1023,6 +1023,11 @@ int AudioStreamPlaybackInteractive::get_current_clip_index() const {
 	return playback_current;
 }
 
+Ref<AudioStreamPlayback> AudioStreamPlaybackInteractive::get_clip_playback(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, stream->get_clip_count(), nullptr);
+	return states[p_index].playback;
+}
+
 int AudioStreamPlaybackInteractive::get_loop_count() const {
 	return 0; // Looping not supported
 }
@@ -1039,4 +1044,5 @@ void AudioStreamPlaybackInteractive::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("switch_to_clip_by_name", "clip_name"), &AudioStreamPlaybackInteractive::switch_to_clip_by_name);
 	ClassDB::bind_method(D_METHOD("switch_to_clip", "clip_index"), &AudioStreamPlaybackInteractive::switch_to_clip);
 	ClassDB::bind_method(D_METHOD("get_current_clip_index"), &AudioStreamPlaybackInteractive::get_current_clip_index);
+	ClassDB::bind_method(D_METHOD("get_clip_playback", "clip_index"), &AudioStreamPlaybackInteractive::get_clip_playback);
 }

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -262,6 +262,8 @@ public:
 	void switch_to_clip(int p_index);
 	int get_current_clip_index() const;
 
+	Ref<AudioStreamPlayback> get_clip_playback(int p_index) const;
+
 	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;
 	virtual Variant get_parameter(const StringName &p_name) const override;
 

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_clip_playback" qualifiers="const">
+			<return type="AudioStreamPlayback" />
+			<param index="0" name="clip_index" type="int" />
+			<description>
+				Returns the [AudioStreamPlayback] used to play the clip at [param clip_index].
+			</description>
+		</method>
 		<method name="get_current_clip_index" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
Implements godotengine/godot-proposals#14310.

This PR simply adds `AudioStreamPlayback AudioStreamPlaybackInteractive::get_clip_playback(p_index: int)` function.