### PR TITLE
Fix ObjectDB snapshot breaking with multiple debug instances

### DIFF
--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
@@ -41,8 +41,7 @@
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/debugger/script_editor_debugger.h"
+#include "editor/debugger/editor_debugger_plugin.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/inspector/editor_inspector.h"
@@ -59,32 +58,35 @@
 const int SNAPSHOT_CHUNK_SIZE = 6 << 20;
 
 void ObjectDBProfilerPanel::_request_object_snapshot() {
+	ERR_FAIL_COND(session.is_null());
 	take_snapshot->set_disabled(true);
 	take_snapshot->set_text(TTRC("Generating Snapshot"));
 	// Pause the game while the snapshot is taken so the state of the game isn't modified as we capture the snapshot.
-	if (EditorDebuggerNode::get_singleton()->get_current_debugger()->is_breaked()) {
+	if (session->is_breaked()) {
 		requested_break_for_snapshot = false;
 		_begin_object_snapshot();
 	} else {
 		awaiting_debug_break = true;
 		requested_break_for_snapshot = true; // We only need to resume the game if we are the ones who paused it.
-		EditorDebuggerNode::get_singleton()->debug_break();
+		session->send_message("break", Array());
 	}
 }
 
-void ObjectDBProfilerPanel::_on_debug_breaked(bool p_reallydid, bool p_can_debug, const String &p_reason, bool p_has_stackdump) {
-	if (p_reallydid && awaiting_debug_break) {
+void ObjectDBProfilerPanel::_on_debug_breaked(bool p_can_debug) {
+	if (awaiting_debug_break) {
 		awaiting_debug_break = false;
 		_begin_object_snapshot();
 	}
 }
 
 void ObjectDBProfilerPanel::_begin_object_snapshot() {
+	ERR_FAIL_COND(session.is_null());
 	Array args = { next_request_id++, SnapshotCollector::get_godot_version_string() };
-	EditorDebuggerNode::get_singleton()->get_current_debugger()->send_message("snapshot:request_prepare_snapshot", args);
+	session->send_message("snapshot:request_prepare_snapshot", args);
 }
 
 bool ObjectDBProfilerPanel::handle_debug_message(const String &p_message, const Array &p_data, int p_index) {
+	ERR_FAIL_COND_V(session.is_null(), false);
 	if (p_message == "snapshot:snapshot_prepared") {
 		int request_id = p_data[0];
 		int total_size = p_data[1];
@@ -92,7 +94,7 @@ bool ObjectDBProfilerPanel::handle_debug_message(const String &p_message, const 
 		partial_snapshots[request_id].total_size = total_size;
 		Array args = { request_id, 0, SNAPSHOT_CHUNK_SIZE };
 		take_snapshot->set_text(vformat(TTR("Receiving Snapshot (0/%s MiB)"), _to_mb(total_size)));
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->send_message("snapshot:request_snapshot_chunk", args);
+		session->send_message("snapshot:request_snapshot_chunk", args);
 		return true;
 	}
 	if (p_message == "snapshot:snapshot_chunk") {
@@ -102,7 +104,7 @@ bool ObjectDBProfilerPanel::handle_debug_message(const String &p_message, const 
 		take_snapshot->set_text(vformat(TTR("Receiving Snapshot (%s/%s MiB)"), _to_mb(chunk.data.size()), _to_mb(chunk.total_size)));
 		if (chunk.data.size() != chunk.total_size) {
 			Array args = { request_id, chunk.data.size(), chunk.data.size() + SNAPSHOT_CHUNK_SIZE };
-			EditorDebuggerNode::get_singleton()->get_current_debugger()->send_message("snapshot:request_snapshot_chunk", args);
+			session->send_message("snapshot:request_snapshot_chunk", args);
 			return true;
 		}
 
@@ -145,7 +147,7 @@ void ObjectDBProfilerPanel::receive_snapshot(int request_id) {
 	}
 	partial_snapshots.erase(request_id);
 	if (requested_break_for_snapshot) {
-		EditorDebuggerNode::get_singleton()->debug_continue();
+		session->send_message("continue", Array());
 	}
 	take_snapshot->set_disabled(false);
 	take_snapshot->set_text("Take ObjectDB Snapshot");
@@ -261,9 +263,19 @@ void ObjectDBProfilerPanel::clear_snapshot(bool p_update_view_tabs) {
 	}
 }
 
+void ObjectDBProfilerPanel::set_session(const Ref<EditorDebuggerSession> &p_session) {
+	session = p_session;
+	session->connect("breaked", callable_mp(this, &ObjectDBProfilerPanel::_on_debug_breaked));
+}
+
 void ObjectDBProfilerPanel::set_enabled(bool p_enabled) {
 	take_snapshot->set_text(TTRC("Take ObjectDB Snapshot"));
 	take_snapshot->set_disabled(!p_enabled);
+	if (!p_enabled) {
+		awaiting_debug_break = false;
+		requested_break_for_snapshot = false;
+		partial_snapshots.clear();
+	}
 }
 
 void ObjectDBProfilerPanel::_snapshot_rmb(const Vector2 &p_pos, MouseButton p_button) {
@@ -350,8 +362,6 @@ ObjectDBProfilerPanel::ObjectDBProfilerPanel() {
 	set_name(TTRC("ObjectDB Profiler"));
 
 	snapshot_cache = LRUCache<String, Ref<GameStateSnapshot>>(SNAPSHOT_CACHE_MAX_SIZE);
-
-	EditorDebuggerNode::get_singleton()->get_current_debugger()->connect("breaked", callable_mp(this, &ObjectDBProfilerPanel::_on_debug_breaked));
 
 	HSplitContainer *root_container = memnew(HSplitContainer);
 	root_container->set_anchors_preset(Control::LayoutPreset::PRESET_FULL_RECT);

--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.h
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.h
@@ -36,6 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/templates/lru.h"
 
+class EditorDebuggerSession;
 class TabContainer;
 class Tree;
 
@@ -57,6 +58,8 @@ protected:
 		Vector<uint8_t> data;
 	};
 
+	Ref<EditorDebuggerSession> session;
+
 	int next_request_id = 0;
 	bool awaiting_debug_break = false;
 	bool requested_break_for_snapshot = false;
@@ -75,7 +78,7 @@ protected:
 
 	void _request_object_snapshot();
 	void _begin_object_snapshot();
-	void _on_debug_breaked(bool p_reallydid, bool p_can_debug, const String &p_reason, bool p_has_stackdump);
+	void _on_debug_breaked(bool p_can_debug);
 	void _show_selected_snapshot();
 	void _on_snapshot_deselected();
 	Ref<DirAccess> _get_and_create_snapshot_storage_dir();
@@ -96,6 +99,7 @@ public:
 	void show_snapshot(const String &p_snapshot_file_name, const String &p_snapshot_diff_file_name);
 	void clear_snapshot(bool p_update_view_tabs = true);
 	Ref<GameStateSnapshot> get_snapshot(const String &p_snapshot_file_name);
+	void set_session(const Ref<EditorDebuggerSession> &p_session);
 	void set_enabled(bool p_enabled);
 	void add_view(SnapshotView *p_to_add);
 

--- a/modules/objectdb_profiler/editor/objectdb_profiler_plugin.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_plugin.cpp
@@ -39,17 +39,19 @@ bool ObjectDBProfilerDebuggerPlugin::has_capture(const String &p_capture) const 
 }
 
 bool ObjectDBProfilerDebuggerPlugin::capture(const String &p_message, const Array &p_data, int p_index) {
-	ERR_FAIL_NULL_V(debugger_panel, false);
-	return debugger_panel->handle_debug_message(p_message, p_data, p_index);
+	ERR_FAIL_COND_V(!panels.has(p_index), false);
+	return panels[p_index]->handle_debug_message(p_message, p_data, p_index);
 }
 
 void ObjectDBProfilerDebuggerPlugin::setup_session(int p_session_id) {
 	Ref<EditorDebuggerSession> session = get_session(p_session_id);
 	ERR_FAIL_COND(session.is_null());
-	debugger_panel = memnew(ObjectDBProfilerPanel);
-	session->connect("started", callable_mp(debugger_panel, &ObjectDBProfilerPanel::set_enabled).bind(true));
-	session->connect("stopped", callable_mp(debugger_panel, &ObjectDBProfilerPanel::set_enabled).bind(false));
-	session->add_session_tab(debugger_panel);
+	ObjectDBProfilerPanel *panel = memnew(ObjectDBProfilerPanel);
+	panel->set_session(session);
+	session->connect("started", callable_mp(panel, &ObjectDBProfilerPanel::set_enabled).bind(true));
+	session->connect("stopped", callable_mp(panel, &ObjectDBProfilerPanel::set_enabled).bind(false));
+	session->add_session_tab(panel);
+	panels[p_session_id] = panel;
 }
 
 ObjectDBProfilerPlugin::ObjectDBProfilerPlugin() {

--- a/modules/objectdb_profiler/editor/objectdb_profiler_plugin.h
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_plugin.h
@@ -52,9 +52,7 @@ class ObjectDBProfilerDebuggerPlugin : public EditorDebuggerPlugin {
 	GDCLASS(ObjectDBProfilerDebuggerPlugin, EditorDebuggerPlugin);
 
 protected:
-	ObjectDBProfilerPanel *debugger_panel = nullptr;
-
-	void _request_object_snapshot(int p_request_id);
+	HashMap<int, ObjectDBProfilerPanel *> panels;
 
 public:
 	ObjectDBProfilerDebuggerPlugin() {}


### PR DESCRIPTION
Fixes #118325.

## Summary

- `ObjectDBProfilerPanel` used the global "current" debugger for all communication, causing snapshot requests to go to the wrong debugger when multiple instances are running
- The plugin stored a single panel pointer overwritten on each `setup_session()` call, so only the last session's panel received messages
- `set_enabled(false)` (called on session stop) did not reset snapshot state, leaving the button permanently stuck

## Changes

- Each `ObjectDBProfilerPanel` now stores a `Ref<EditorDebuggerSession>` passed via `set_session()` and uses it for all `send_message()`, `is_breaked()`, and signal connections
- `ObjectDBProfilerDebuggerPlugin` tracks panels per session in a `HashMap<int, ObjectDBProfilerPanel *>` instead of a single pointer, and routes `capture()` messages to the correct panel by session ID
- `set_enabled(false)` now resets `awaiting_debug_break`, `requested_break_for_snapshot`, and clears `partial_snapshots` so the button recovers if a session ends mid-snapshot
- Removed the global debugger "breaked" signal connection from the constructor; the session's "breaked" signal is connected in `set_session()` instead
- Changed `_on_debug_breaked` signature to match `EditorDebuggerSession::breaked` (which already filters `p_really_did`)
- Follows the same per-session pattern used by `MultiplayerEditorDebugger`