### PR TITLE
Optimize performance when selecting and dragging multiple keys

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -6266,6 +6266,16 @@ void AnimationTrackEditor::_clear_selection(bool p_update) {
 }
 
 void AnimationTrackEditor::_update_key_edit() {
+	if (update_key_edit_pending) {
+		return;
+	}
+	update_key_edit_pending = true;
+	callable_mp(this, &AnimationTrackEditor::_update_key_edit_callback).call_deferred();
+}
+
+void AnimationTrackEditor::_update_key_edit_callback() {
+	update_key_edit_pending = false;
+
 	_clear_key_edit();
 	if (animation.is_null()) {
 		return;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -6266,6 +6266,19 @@ void AnimationTrackEditor::_clear_selection(bool p_update) {
 }
 
 void AnimationTrackEditor::_update_key_edit() {
+	if (update_key_edit_pending) {
+		return;
+	}
+	update_key_edit_pending = true;
+	callable_mp(this, &AnimationTrackEditor::_update_key_edit_callback).call_deferred();
+}
+
+void AnimationTrackEditor::_update_key_edit_callback() {
+	if (!update_key_edit_pending) {
+		return;
+	}
+	update_key_edit_pending = false;
+
 	_clear_key_edit();
 	if (animation.is_null()) {
 		return;

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -777,7 +777,9 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
+	bool update_key_edit_pending = false;
 	void _update_key_edit();
+	void _update_key_edit_callback();
 	void _clear_key_edit();
 
 	Control *box_selection_container = nullptr;


### PR DESCRIPTION
I select and drag 895 keys in the videos below.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/2876bebf-b8a3-478e-b8fa-ef77bc498394">|<video src="https://github.com/user-attachments/assets/1f9c63d3-0601-4071-b916-fe38bb68dcc1">|

**Laggy reason**

As shown in the profiler screenshot below, the performance bottleneck when selecting and moving multiple keys is `AnimationTrackEditor::_update_key_edit`. During the `// 7 - Reselect.` step in `AnimationTrackEditor::_move_selection_commit`, the UndoRedo system calls `_select_at_anim` for every selected key. Consequently, `_update_key_edit` is executed $O(N)$ times. 

<img width="1280" height="752" alt="analysiss" src="https://github.com/user-attachments/assets/fae2ec90-2c39-4ae4-bb26-431f6a8d916a" />

**Solution**

What `_update_key_edit` does is notifying EditorNode about the current editing target. So it is sufficient to only call it once after `selection` is completely updated. To fix the lag, I deffered the actual update logic using call_deferred and track a pending flag to ensure the update logic is only executed once.