### PR TITLE
Fix BaseButton shortcut feedback being affected by time scale

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1292,7 +1292,7 @@
 			LCD subpixel layout used for font anti-aliasing. See [enum TextServer.FontLCDSubpixelLayout].
 		</member>
 		<member name="gui/timers/button_shortcut_feedback_highlight_time" type="float" setter="" getter="" default="0.2">
-			When [member BaseButton.shortcut_feedback] is enabled, this is the time the [BaseButton] will remain highlighted after a shortcut.
+			When [member BaseButton.shortcut_feedback] is enabled, this is the time the [BaseButton] will remain highlighted after a shortcut. This duration is not affected by [member Engine.time_scale].
 		</member>
 		<member name="gui/timers/incremental_search_max_interval_msec" type="int" setter="" getter="" default="2000">
 			Timer setting for incremental search in [Tree], [ItemList], etc. controls (in milliseconds).

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -504,6 +504,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 			if (shortcut_feedback_timer == nullptr) {
 				shortcut_feedback_timer = memnew(Timer);
 				shortcut_feedback_timer->set_one_shot(true);
+				shortcut_feedback_timer->set_ignore_time_scale(true);
 				add_child(shortcut_feedback_timer, false, INTERNAL_MODE_BACK);
 				shortcut_feedback_timer->set_wait_time(GLOBAL_GET_CACHED(double, "gui/timers/button_shortcut_feedback_highlight_time"));
 				shortcut_feedback_timer->connect("timeout", callable_mp(this, &BaseButton::_shortcut_feedback_timeout));


### PR DESCRIPTION
Shortcut feedback is a purely UI concept, so it shouldn't be affected by `Engine.time_scale`.

- This closes https://github.com/godotengine/godot/issues/96359.

**Testing project:** [test_button_shortcut_feedback.zip](https://github.com/user-attachments/files/26635757/test_button_shortcut_feedback.zip)
<sub>Press up/down arrows to adjust the time scale, and <kbd>A</kbd>/<kbd>B</kbd>/<kbd>C</kbd> to trigger shortcuts.</sub>

## Preview

*I added a green outline to the `pressed` StyleBox for visibility.*

### Before

https://github.com/user-attachments/assets/5f1b4830-30ef-4583-a813-7aca230d8eae

### After

https://github.com/user-attachments/assets/bcdfa512-b89e-409b-9f98-29d1a29e5d22