### PR TITLE
Add Editor Setting to only close brace before whitespace

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -539,6 +539,9 @@
 		<member name="auto_brace_completion_highlight_matching" type="bool" setter="set_highlight_matching_braces_enabled" getter="is_highlight_matching_braces_enabled" default="false">
 			If [code]true[/code], highlights brace pairs when the caret is on either one, using [member auto_brace_completion_pairs]. If matching, the pairs will be underlined. If a brace is unmatched, it is colored with [theme_item brace_mismatch_color].
 		</member>
+		<member name="auto_brace_completion_mode" type="int" setter="set_auto_brace_completion_mode" getter="get_auto_brace_completion_mode" enum="CodeEdit.AutoBraceCompletionMode" default="0">
+			Sets the auto brace completion mode.
+		</member>
 		<member name="auto_brace_completion_pairs" type="Dictionary" setter="set_auto_brace_completion_pairs" getter="get_auto_brace_completion_pairs" default="{ &quot;\&quot;&quot;: &quot;\&quot;&quot;, &quot;&apos;&quot;: &quot;&apos;&quot;, &quot;(&quot;: &quot;)&quot;, &quot;[&quot;: &quot;]&quot;, &quot;{&quot;: &quot;}&quot; }">
 			Sets the brace pairs to be autocompleted. For each entry in the dictionary, the key is the opening brace and the value is the closing brace that matches it. A brace is a [String] made of symbols. See [member auto_brace_completion_enabled] and [member auto_brace_completion_highlight_matching].
 		</member>
@@ -640,6 +643,12 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="AUTO_BRACE_COMPLETION_ALWAYS" value="0" enum="AutoBraceCompletionMode">
+			Automatically close the brace independently of where it is inserted.
+		</constant>
+		<constant name="AUTO_BRACE_COMPLETION_BEFORE_WHITESPACE" value="1" enum="AutoBraceCompletionMode">
+			Automatically close the brace if inserted before a whitespace.
+		</constant>
 		<constant name="KIND_CLASS" value="0" enum="CodeCompletionKind">
 			Marks the option as a class.
 		</constant>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1563,6 +1563,11 @@
 		<member name="text_editor/completion/auto_brace_complete" type="bool" setter="" getter="">
 			If [code]true[/code], automatically inserts the matching closing brace when the opening brace is inserted by typing or autocompletion. Also automatically removes the closing brace when pressing [kbd]Backspace[/kbd] on the opening brace. This includes brackets ([code]()[/code], [code][][/code], [code]{}[/code]), string quotation marks ([code]''[/code], [code]""[/code]), and comments ([code]/**/[/code]) if the language supports it.
 		</member>
+		<member name="text_editor/completion/auto_brace_complete_mode" type="int" setter="" getter="">
+			If [member text_editor/completion/auto_brace_complete] is [code]true[/code], braces are auto-completed following the selected mode:
+			- [b]Always:[/b] Automatically close the brace independently of where it is inserted.
+			- [b]Before Whitespace:[/b] Automatically close the brace if inserted before a whitespace.
+		</member>
 		<member name="text_editor/completion/code_complete_delay" type="float" setter="" getter="">
 			The delay in seconds after which autocompletion suggestions should be displayed when the user stops typing.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1166,6 +1166,7 @@ void CodeTextEditor::update_editor_settings() {
 
 	// Completion
 	text_editor->set_auto_brace_completion_enabled(EDITOR_GET("text_editor/completion/auto_brace_complete"));
+	text_editor->set_auto_brace_completion_mode((CodeEdit::AutoBraceCompletionMode)(int)EDITOR_GET("text_editor/completion/auto_brace_complete_mode"));
 	text_editor->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
 	code_complete_enabled = EDITOR_GET("text_editor/completion/code_complete_enabled");
 	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -862,6 +862,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/completion/auto_brace_complete_mode", 0, "Always,Before Whitespace")
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -952,11 +952,16 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 				} else if (is_in_comment(cl, cc) != -1 || (is_in_string(cl, cc) != -1 && has_string_delimiter(chr))) {
 					insert_text_at_caret(chr, i);
 				} else {
+					char32_t next_char = (cc < get_line(cl).length()) ? get_line(cl)[cc] : 0;
 					insert_text_at_caret(chr, i);
 
 					int pre_brace_pair = _get_auto_brace_pair_open_at_pos(cl, cc + 1);
-					if (pre_brace_pair != -1) {
+					if (get_auto_brace_completion_mode() == AUTO_BRACE_COMPLETION_ALWAYS && pre_brace_pair != -1) {
 						insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key, i);
+					} else if (get_auto_brace_completion_mode() == AUTO_BRACE_COMPLETION_BEFORE_WHITESPACE && pre_brace_pair != -1) {
+						if (is_whitespace(next_char) || next_char == 0 || post_brace_pair != -1) {
+							insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key, i);
+						}
 					}
 				}
 				set_caret_column(cc + caret_move_offset, i == 0, i);
@@ -1412,6 +1417,14 @@ void CodeEdit::set_auto_brace_completion_enabled(bool p_enabled) {
 
 bool CodeEdit::is_auto_brace_completion_enabled() const {
 	return auto_brace_completion_enabled;
+}
+
+void CodeEdit::set_auto_brace_completion_mode(CodeEdit::AutoBraceCompletionMode p_mode) {
+	auto_brace_completion_mode = p_mode;
+}
+
+CodeEdit::AutoBraceCompletionMode CodeEdit::get_auto_brace_completion_mode() const {
+	return auto_brace_completion_mode;
 }
 
 void CodeEdit::set_highlight_matching_braces_enabled(bool p_enabled) {
@@ -2996,8 +3009,14 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("convert_indent", "from_line", "to_line"), &CodeEdit::convert_indent, DEFVAL(-1), DEFVAL(-1));
 
 	/* Auto brace completion */
+	BIND_ENUM_CONSTANT(AUTO_BRACE_COMPLETION_ALWAYS);
+	BIND_ENUM_CONSTANT(AUTO_BRACE_COMPLETION_BEFORE_WHITESPACE);
+
 	ClassDB::bind_method(D_METHOD("set_auto_brace_completion_enabled", "enable"), &CodeEdit::set_auto_brace_completion_enabled);
 	ClassDB::bind_method(D_METHOD("is_auto_brace_completion_enabled"), &CodeEdit::is_auto_brace_completion_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_auto_brace_completion_mode", "mode"), &CodeEdit::set_auto_brace_completion_mode);
+	ClassDB::bind_method(D_METHOD("get_auto_brace_completion_mode"), &CodeEdit::get_auto_brace_completion_mode);
 
 	ClassDB::bind_method(D_METHOD("set_highlight_matching_braces_enabled", "enable"), &CodeEdit::set_highlight_matching_braces_enabled);
 	ClassDB::bind_method(D_METHOD("is_highlight_matching_braces_enabled"), &CodeEdit::is_highlight_matching_braces_enabled);
@@ -3211,6 +3230,7 @@ void CodeEdit::_bind_methods() {
 
 	ADD_GROUP("Auto Brace Completion", "auto_brace_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_auto_brace_completion_enabled", "is_auto_brace_completion_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_brace_completion_mode", PROPERTY_HINT_ENUM, "Always,Before Whitespace"), "set_auto_brace_completion_mode", "get_auto_brace_completion_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_highlight_matching"), "set_highlight_matching_braces_enabled", "is_highlight_matching_braces_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "auto_brace_completion_pairs", PROPERTY_HINT_TYPE_STRING, "String;String"), "set_auto_brace_completion_pairs", "get_auto_brace_completion_pairs");
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -60,6 +60,11 @@ public:
 		LOCATION_OTHER = 1 << 10,
 	};
 
+	enum AutoBraceCompletionMode {
+		AUTO_BRACE_COMPLETION_ALWAYS,
+		AUTO_BRACE_COMPLETION_BEFORE_WHITESPACE,
+	};
+
 private:
 	/* Indent management */
 	int indent_size = 4;
@@ -76,6 +81,7 @@ private:
 
 	/* Auto brace completion */
 	bool auto_brace_completion_enabled = false;
+	AutoBraceCompletionMode auto_brace_completion_mode = AUTO_BRACE_COMPLETION_ALWAYS;
 
 	/* BracePair open_key must be uniquie and ordered by length. */
 	struct BracePair {
@@ -374,6 +380,9 @@ public:
 	void set_auto_brace_completion_enabled(bool p_enabled);
 	bool is_auto_brace_completion_enabled() const;
 
+	void set_auto_brace_completion_mode(AutoBraceCompletionMode p_mode);
+	AutoBraceCompletionMode get_auto_brace_completion_mode() const;
+
 	void set_highlight_matching_braces_enabled(bool p_enabled);
 	bool is_highlight_matching_braces_enabled() const;
 
@@ -538,6 +547,7 @@ public:
 
 VARIANT_ENUM_CAST(CodeEdit::CodeCompletionKind);
 VARIANT_ENUM_CAST(CodeEdit::CodeCompletionLocation);
+VARIANT_ENUM_CAST(CodeEdit::AutoBraceCompletionMode);
 
 // The custom comparer which will sort completion options.
 struct CodeCompletionOptionCompare {


### PR DESCRIPTION
Fixes [godotengine/godot-proposals/issues/14582](https://github.com/godotengine/godot-proposals/issues/14582)

Added an Editor Setting: Text Editor > Completion > "Auto Brace Complete Mode" just after "Auto Brace Complete", which adds different behavior to "Auto Brace Complete" for the user to select. The "Auto Brace Complete Mode" setting should always be defaulted to "Always" and only appear when advanced setting is enabled.  

The modes included in this PR:  
- Always: automatically close the brace independently of where it is inserted 
- Before Whitespace: automatically close the brace if inserted before a whitespace 

These modes functions similar to VSCode brace behavior modes. 

<img width="891" height="733" alt="auto_brace" src="https://github.com/user-attachments/assets/d2b14a50-c3f1-4567-91a2-8bb3d3379e37" />


<h2>Always: </h2>

![always_auto_brace](https://github.com/user-attachments/assets/54d3aae8-fa54-40c6-80b8-45b17208eb66)

<h2>Before Whitespace: </h2>

![before_whitespace_auto_brace](https://github.com/user-attachments/assets/3a4bab62-7828-4468-b6f4-634a80e6bdf2)