### PR TITLE
Add up_vector_sticky property to Curve3D to avoid extra roll

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -229,5 +229,8 @@
 		<member name="up_vector_enabled" type="bool" setter="set_up_vector_enabled" getter="is_up_vector_enabled" default="true">
 			If [code]true[/code], the curve will bake up vectors used for orientation. This is used when [member PathFollow3D.rotation_mode] is set to [constant PathFollow3D.ROTATION_ORIENTED]. Changing it forces the cache to be recomputed.
 		</member>
+		<member name="up_vector_sticky" type="bool" setter="set_up_vector_sticky" getter="is_up_vector_sticky" default="false">
+			If [code]true[/code], the baked up vectors used for orientation will be "sticky" which prevents unnecessary roll.
+		</member>
 	</members>
 </class>

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1724,6 +1724,7 @@ void Curve3D::_bake() const {
 			up_write[0] = frame_prev.get_column(1);
 		}
 
+		Vector3 sticky_up = frame_prev.get_column(1);
 		// Calculate the Parallel Transport Frame.
 		for (int idx = 1; idx < point_count; idx++) {
 			Vector3 forward = forward_ptr[idx];
@@ -1732,7 +1733,14 @@ void Curve3D::_bake() const {
 			rotate.rotate_to_align(-frame_prev.get_column(2), forward);
 			frame = rotate * frame_prev;
 			frame.orthonormalize(); // Guard against float error accumulation.
-
+			if (up_vector_sticky) {
+				if (sticky_up.angle_to(frame.get_column(1)) >= Math::PI * 0.5) {
+					sticky_up = frame.get_column(1);
+				} else {
+					Vector3 tangent = -frame.get_column(2);
+					frame = Basis::looking_at(tangent, sticky_up);
+				}
+			}
 			up_write[idx] = frame.get_column(1);
 			frame_prev = frame;
 		}
@@ -2169,6 +2177,15 @@ bool Curve3D::is_up_vector_enabled() const {
 	return up_vector_enabled;
 }
 
+void Curve3D::set_up_vector_sticky(bool p_sticky) {
+	up_vector_sticky = p_sticky;
+	mark_dirty();
+}
+
+bool Curve3D::is_up_vector_sticky() const {
+	return up_vector_sticky;
+}
+
 Dictionary Curve3D::_get_data() const {
 	Dictionary dc;
 
@@ -2354,6 +2371,8 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bake_interval"), &Curve3D::get_bake_interval);
 	ClassDB::bind_method(D_METHOD("set_up_vector_enabled", "enable"), &Curve3D::set_up_vector_enabled);
 	ClassDB::bind_method(D_METHOD("is_up_vector_enabled"), &Curve3D::is_up_vector_enabled);
+	ClassDB::bind_method(D_METHOD("set_up_vector_sticky", "sticky"), &Curve3D::set_up_vector_sticky);
+	ClassDB::bind_method(D_METHOD("is_up_vector_sticky"), &Curve3D::is_up_vector_sticky);
 
 	ClassDB::bind_method(D_METHOD("get_baked_length"), &Curve3D::get_baked_length);
 	ClassDB::bind_method(D_METHOD("sample_baked", "offset", "cubic"), &Curve3D::sample_baked, DEFVAL(0.0), DEFVAL(false));
@@ -2378,6 +2397,7 @@ void Curve3D::_bind_methods() {
 
 	ADD_GROUP("Up Vector", "up_vector_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "up_vector_enabled"), "set_up_vector_enabled", "is_up_vector_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "up_vector_sticky"), "set_up_vector_sticky", "is_up_vector_sticky");
 
 	Point defaults;
 

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -316,6 +316,7 @@ class Curve3D : public Resource {
 
 	real_t bake_interval = 0.2;
 	bool up_vector_enabled = true;
+	bool up_vector_sticky = false;
 
 	void _bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	void _bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_length) const;
@@ -366,6 +367,8 @@ public:
 	real_t get_bake_interval() const;
 	void set_up_vector_enabled(bool p_enable);
 	bool is_up_vector_enabled() const;
+	void set_up_vector_sticky(bool p_sticky);
+	bool is_up_vector_sticky() const;
 
 	real_t get_baked_length() const;
 	Vector3 sample_baked(real_t p_offset, bool p_cubic = false) const;


### PR DESCRIPTION
Fixes #118336

When up_vector_sticky is true the up vector will try to align with the latest 'sticky' up vector. If the new frame's up vector difference is 90 degrees or more then it's up vector replaces the sticky up vector.

This eliminates roll in the curve even if it contains loops or other complex geometry.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
