### PR TITLE
Add new icon_size field to CheckBox Control Nodes.

### DIFF
--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -24,6 +24,9 @@
 		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
+		<theme_item name="icon_size" data_type="constant" type="int" default="0">
+			The size of the check icon (in pixels). If set to 0, the icon's default size is used.
+		</theme_item>
 		<theme_item name="checked" data_type="icon" type="Texture2D">
 			The check icon to display when the [CheckBox] is checked.
 		</theme_item>

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -34,6 +34,10 @@
 #include "servers/display/accessibility_server.h"
 
 Size2 CheckBox::get_icon_size() const {
+	if (theme_cache.icon_size > 0) {
+		return Size2(theme_cache.icon_size, theme_cache.icon_size);
+	}
+
 	Size2 tex_size = Size2(0, 0);
 	if (theme_cache.checked.is_valid()) {
 		tex_size = theme_cache.checked->get_size();
@@ -138,9 +142,9 @@ void CheckBox::_notification(int p_what) {
 			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
-				on_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(on_tex->get_size())), false, theme_cache.checkbox_checked_color);
+				on_tex->draw_rect(ci, Rect2(ofs, theme_cache.icon_size > 0 ? get_icon_size() : _fit_icon_size(on_tex->get_size())), false, theme_cache.checkbox_checked_color);
 			} else {
-				off_tex->draw_rect(ci, Rect2(ofs, _fit_icon_size(off_tex->get_size())), false, theme_cache.checkbox_unchecked_color);
+				off_tex->draw_rect(ci, Rect2(ofs, theme_cache.icon_size > 0 ? get_icon_size() : _fit_icon_size(off_tex->get_size())), false, theme_cache.checkbox_unchecked_color);
 			}
 		} break;
 	}
@@ -153,6 +157,7 @@ bool CheckBox::is_radio() const {
 void CheckBox::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckBox, h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckBox, check_v_offset);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, CheckBox, icon_size);
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, CheckBox, normal_style, "normal");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, CheckBox, checked);

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -38,6 +38,7 @@ class CheckBox : public Button {
 	struct ThemeCache {
 		int h_separation = 0;
 		int check_v_offset = 0;
+		int icon_size = 0;
 		Ref<StyleBox> normal_style;
 
 		Ref<Texture2D> checked;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -307,6 +307,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("h_separation", "CheckBox", Math::round(4 * scale));
 	theme->set_constant("check_v_offset", "CheckBox", 0);
+	theme->set_constant("icon_size", "CheckBox", 0);
 	theme->set_constant("outline_size", "CheckBox", 0);
 
 	theme->set_color("checkbox_checked_color", "CheckBox", Color(1, 1, 1));


### PR DESCRIPTION
Adds a new theme constant for `CheckBox` `Control` `Node`s that allows the theme to specify a specific size for the `CheckBox` icon.
This solves the problem of having to scale the image file itself, and also allows multiple `CheckBox` `Control` `Node`s to use the same image texture at different sizes.

This PR adds a new constant in `default_theme.cpp`, "icon_size" to the `CheckBox`. It then binds that constant to the `Theme`.
For behavior, I have it detect at two different locations if the `icon_size` is greater than zero.
In `get_icon_size` there is a check, with an early `return` that simply returns a `Size2` with `x` and `y` set to the `icon_size`.
In the draw notification code block, I changed the `tex->draw_rect()` call to again check if `icon_size` is greater than zero. If it is, then I just call `get_icon_size()`. If it isn't, simply use the old draw behavior.

Screenshot of the theme constant in effect:
<img width="421" height="440" alt="screenshot" src="https://github.com/user-attachments/assets/a0f9d7f0-9122-4a93-9c23-05513deade3b" />
Each one has a smaller `icon_size` constant override, with the bottom-most one being set to zero, so that it uses the size of the source image.

I wasn't sure if I should keep it local to `CheckBox` or somehow generalize it to `Button` or copy the behavior to other `Button` types, so I just kept it local for now.