### PR TITLE
Random raytracing fixes

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5524,7 +5524,7 @@ void RenderingDeviceDriverD3D12::raytracing_pipeline_free(RDD::RaytracingPipelin
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
 }
 
-bool RenderingDeviceDriverD3D12::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+bool RenderingDeviceDriverD3D12::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) {
 	ERR_FAIL_V_MSG(false, "Ray tracing is not currently supported by the D3D12 driver.");
 }
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -846,7 +846,7 @@ public:
 	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
 
-	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) override final;
 
 	// ----- COMMANDS -----
 

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2292,7 +2292,7 @@ void RenderingDeviceDriverMetal::raytracing_pipeline_free(RDD::RaytracingPipelin
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
 }
 
-bool RenderingDeviceDriverMetal::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+bool RenderingDeviceDriverMetal::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) {
 	ERR_FAIL_V_MSG(false, "Ray tracing is not currently supported by the Metal driver.");
 }
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -472,7 +472,7 @@ public:
 	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
 
-	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) override final;
 
 	// ----- COMMANDS -----
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -6470,12 +6470,13 @@ void RenderingDeviceDriverVulkan::raytracing_pipeline_free(RaytracingPipelineID 
 #endif
 }
 
-bool RenderingDeviceDriverVulkan::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+bool RenderingDeviceDriverVulkan::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) {
 #if VULKAN_RAYTRACING_ENABLED
+	ERR_FAIL_COND_V_MSG(p_data_stride_bytes < raytracing_capabilities.shader_group_handle_size, false, "Data stride must be at least the size of shader group handles.");
 	for (uint32_t i = 0; i < p_group_indices.size(); i++) {
 		VkResult err = vkGetRayTracingShaderGroupHandlesKHR(vk_device, (VkPipeline)p_pipeline.id, p_group_index_offset + p_group_indices[i], 1, raytracing_capabilities.shader_group_handle_size, r_data);
 		ERR_FAIL_COND_V_MSG(err != VK_SUCCESS, false, "vkGetRayTracingShaderGroupHandlesKHR failed with error " + itos(err) + ".");
-		r_data += raytracing_capabilities.shader_group_handle_size;
+		r_data += p_data_stride_bytes;
 	}
 	return true;
 #else

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -735,7 +735,7 @@ public:
 	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
 
-	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) override final;
 
 	/*****************/
 	/**** QUERIES ****/

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6572,7 +6572,8 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 	ERR_FAIL_COND(hit_sbt->raytracing_pipeline != raytracing_list.state.pipeline_driver_id);
 
 	RDD::ShaderBindingTable rdd_hit_sbt;
-	_hit_sbt_buffer_update(hit_sbt, p_hit_sbt, rdd_hit_sbt);
+	Error err = _hit_sbt_buffer_update(hit_sbt, p_hit_sbt, rdd_hit_sbt);
+	ERR_FAIL_COND(err != OK);
 
 	if (hit_sbt->draw_tracker != nullptr) {
 		draw_graph.add_raytracing_list_usage(hit_sbt->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5072,7 +5072,7 @@ Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPip
 	uint32_t miss_sbt_size = p_miss_shader_count * shader_group_handle_size;
 
 	r_sbt_buffer.size = miss_sbt_offset + miss_sbt_size;
-	r_sbt_buffer.driver_id = driver->buffer_create(r_sbt_buffer.size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
+	r_sbt_buffer.driver_id = driver->buffer_create(r_sbt_buffer.size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	ERR_FAIL_COND_V(!r_sbt_buffer.driver_id, ERR_CANT_CREATE);
 
 	thread_local LocalVector<uint8_t> sbt_data;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -587,8 +587,11 @@ RDD::BufferID RenderingDevice::_hit_sbt_buffer_create(uint32_t p_buffer_size) {
 }
 
 Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, RID p_hit_sbt_id, RDD::ShaderBindingTable &r_sbt) {
-	uint32_t shader_group_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
-	uint32_t buffer_size = p_hit_sbt->hit_group_indices.size() * shader_group_size;
+	uint32_t shader_group_handle_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t shader_group_handle_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT);
+	uint32_t shader_group_stride = STEPIFY(shader_group_handle_size, shader_group_handle_alignment);
+
+	uint32_t buffer_size = p_hit_sbt->hit_group_indices.size() * shader_group_stride;
 
 	if (p_hit_sbt->size != buffer_size) {
 		RDD::BufferID buffer = _hit_sbt_buffer_create(buffer_size);
@@ -607,8 +610,8 @@ Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, 
 
 	if (p_hit_sbt->first_dirty_index != UINT32_MAX) {
 		uint32_t count = p_hit_sbt->last_dirty_index - p_hit_sbt->first_dirty_index;
-		uint32_t offset = shader_group_size * p_hit_sbt->first_dirty_index;
-		uint32_t size = shader_group_size * count;
+		uint32_t offset = shader_group_stride * p_hit_sbt->first_dirty_index;
+		uint32_t size = shader_group_stride * count;
 
 		thread_local LocalVector<uint8_t> data;
 		data.resize(size);
@@ -617,8 +620,8 @@ Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, 
 				p_hit_sbt->raytracing_pipeline,
 				p_hit_sbt->index_offset,
 				VectorView<uint32_t>(p_hit_sbt->hit_group_indices.ptr() + p_hit_sbt->first_dirty_index, count),
-				data.ptr());
-
+				data.ptr(),
+				shader_group_stride);
 		ERR_FAIL_COND_V(!success, ERR_CANT_CREATE);
 
 		Error err = _buffer_update(p_hit_sbt, p_hit_sbt_id, offset, size, data.ptr());
@@ -630,7 +633,7 @@ Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, 
 
 	r_sbt.buffer = p_hit_sbt->driver_id;
 	r_sbt.offset = 0;
-	r_sbt.stride = shader_group_size;
+	r_sbt.stride = shader_group_stride;
 	r_sbt.size = buffer_size;
 
 	return OK;
@@ -5065,11 +5068,17 @@ Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPip
 	// Ray generation and miss shader group handles are placed next to each other in the same buffer.
 
 	uint32_t shader_group_handle_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t shader_group_handle_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT);
 	uint32_t shader_group_base_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT);
 
-	uint32_t raygen_sbt_size = p_raygen_shader_count * shader_group_handle_size;
+	uint32_t shader_group_stride = STEPIFY(shader_group_handle_size, shader_group_handle_alignment);
+	uint32_t raygen_shader_group_stride = STEPIFY(shader_group_stride, shader_group_base_alignment);
+
+	// Make sure to reserve a full base-aligned slot for every raygen shader.
+	uint32_t raygen_sbt_size = p_raygen_shader_count * raygen_shader_group_stride;
 	uint32_t miss_sbt_offset = STEPIFY(raygen_sbt_size, shader_group_base_alignment);
-	uint32_t miss_sbt_size = p_miss_shader_count * shader_group_handle_size;
+	// Reserve handle-aligned slots for miss shaders.
+	uint32_t miss_sbt_size = p_miss_shader_count * shader_group_stride;
 
 	r_sbt_buffer.size = miss_sbt_offset + miss_sbt_size;
 	r_sbt_buffer.driver_id = driver->buffer_create(r_sbt_buffer.size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
@@ -5078,20 +5087,26 @@ Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPip
 	thread_local LocalVector<uint8_t> sbt_data;
 	sbt_data.resize(r_sbt_buffer.size);
 
+	thread_local LocalVector<uint32_t> raygen_shader_group_indices;
+	raygen_shader_group_indices.resize(p_raygen_shader_count);
 	for (uint32_t i = 0; i < p_raygen_shader_count; i++) {
-		bool success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, 0, VectorView<uint32_t>(i), sbt_data.ptr() + (i * shader_group_handle_size));
-		if (unlikely(!success)) {
-			driver->buffer_free(r_sbt_buffer.driver_id);
-			ERR_FAIL_V(ERR_CANT_CREATE);
-		}
+		raygen_shader_group_indices[i] = i;
+	}
+	bool success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, 0, VectorView<uint32_t>(raygen_shader_group_indices), sbt_data.ptr(), raygen_shader_group_stride);
+	if (unlikely(!success)) {
+		driver->buffer_free(r_sbt_buffer.driver_id);
+		ERR_FAIL_V(ERR_CANT_CREATE);
 	}
 
+	thread_local LocalVector<uint32_t> miss_shader_group_indices;
+	miss_shader_group_indices.resize(p_miss_shader_count);
 	for (uint32_t i = 0; i < p_miss_shader_count; i++) {
-		bool success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, p_raygen_shader_count, VectorView<uint32_t>(i), sbt_data.ptr() + miss_sbt_offset + (i * shader_group_handle_size));
-		if (unlikely(!success)) {
-			driver->buffer_free(r_sbt_buffer.driver_id);
-			ERR_FAIL_V(ERR_CANT_CREATE);
-		}
+		miss_shader_group_indices[i] = i;
+	}
+	success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, p_raygen_shader_count, VectorView<uint32_t>(miss_shader_group_indices), sbt_data.ptr() + miss_sbt_offset, shader_group_stride);
+	if (unlikely(!success)) {
+		driver->buffer_free(r_sbt_buffer.driver_id);
+		ERR_FAIL_V(ERR_CANT_CREATE);
 	}
 
 	Error err = _buffer_initialize(&r_sbt_buffer, sbt_data);
@@ -6551,21 +6566,25 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 	}
 
 	uint32_t shader_group_handle_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t shader_group_handle_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT);
 	uint32_t shader_group_base_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT);
+
+	uint32_t shader_group_stride = STEPIFY(shader_group_handle_size, shader_group_handle_alignment);
+	uint32_t raygen_shader_group_stride = STEPIFY(shader_group_stride, shader_group_base_alignment);
 
 	ERR_FAIL_COND(p_raygen_shader_index >= raytracing_list.state.raygen_shader_count);
 
 	RDD::ShaderBindingTable raygen_sbt;
 	raygen_sbt.buffer = raytracing_list.state.sbt_buffer;
-	raygen_sbt.offset = p_raygen_shader_index * shader_group_handle_size;
-	raygen_sbt.stride = shader_group_handle_size;
-	raygen_sbt.size = shader_group_handle_size;
+	raygen_sbt.offset = p_raygen_shader_index * raygen_shader_group_stride;
+	raygen_sbt.stride = raygen_shader_group_stride;
+	raygen_sbt.size = raygen_shader_group_stride;
 
 	RDD::ShaderBindingTable miss_sbt;
 	miss_sbt.buffer = raytracing_list.state.sbt_buffer;
-	miss_sbt.offset = STEPIFY(raytracing_list.state.raygen_shader_count * shader_group_handle_size, shader_group_base_alignment);
-	miss_sbt.stride = shader_group_handle_size;
-	miss_sbt.size = raytracing_list.state.miss_shader_count * shader_group_handle_size;
+	miss_sbt.offset = STEPIFY(raytracing_list.state.raygen_shader_count * raygen_shader_group_stride, shader_group_base_alignment);
+	miss_sbt.stride = shader_group_stride;
+	miss_sbt.size = raytracing_list.state.miss_shader_count * shader_group_stride;
 
 	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
 	ERR_FAIL_NULL(hit_sbt);

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -789,7 +789,7 @@ public:
 	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) = 0;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) = 0;
 
-	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) = 0;
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) = 0;
 
 	// ----- COMMANDS -----
 


### PR DESCRIPTION
Add device address flag to SBT buffer

---

Check error when updating hit SBT

---

Fix shader binding table record alignment:

Raytracing shader binding table records are addressed through Vulkan
alignment rules that distinguish between the raw shader group handle size,
the per-record handle alignment, and the base alignment required for SBT
region addresses.

The previous layout treated the shader group handle size as the record
stride everywhere. This worked only on devices where the handle size
already satisfied all relevant alignment requirements. It broke down once
multiple ray generation shaders were placed in the same SBT: selecting a
non-zero raygen index advanced the raygen region address by the raw handle
size, which could produce an address that was not aligned to the required
shader group base alignment.

Separate the SBT layout into the appropriate strides:

- ray generation records use a base-aligned stride, since selecting a
  raygen shader changes the SBT region start address for the dispatch.
- miss and hit records use the handle-aligned shader group stride, since
  their regions start at a base-aligned address and individual records are
  selected through the region stride.

This keeps the CPU-side SBT population and the dispatch-time SBT regions
using the same layout, so shader group handles are written to the same
aligned slots that Vulkan later addresses.