### PR TITLE
Add saving/loading for shader preview lines

### DIFF
--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -57,6 +57,9 @@
 		<member name="code" type="String" setter="set_code" getter="get_code" default="&quot;&quot;">
 			Returns the shader's code as the user has written it, not the full generated code used internally.
 		</member>
+		<member name="preview_lines" type="PackedInt32Array" setter="set_preview_lines" getter="get_preview_lines" default="PackedInt32Array()">
+			Returns the list of shader preview lines in use.
+		</member>
 	</members>
 	<constants>
 		<constant name="MODE_SPATIAL" value="0" enum="Mode">

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -650,6 +650,9 @@ void ShaderTextEditor::set_edited_shader(const Ref<Shader> &p_shader, const Stri
 	set_edited_code(p_code);
 
 	if (shader.is_valid()) {
+		for (int line : shader->get_preview_lines()) {
+			get_text_editor()->set_line_as_breakpoint(line, true);
+		}
 		shader->connect_changed(callable_mp(this, &ShaderTextEditor::_shader_changed));
 	}
 }
@@ -1825,15 +1828,18 @@ void TextShaderEditor::_update_shader_previews() {
 
 	const CodeEdit *ce = code_editor->get_text_editor();
 	code_editor->clear_previews();
+	shader->clear_preview_lines();
 	bool found = false;
 
 	for (int i = 0; i < ce->get_line_count(); i++) {
 		if (ce->is_line_breakpointed(i)) {
 			found = true;
 			code_editor->toggle_shader_preview(i);
+			shader->add_preview_line(i);
 		}
 	}
 
+	shader->emit_changed();
 	code_editor->redraw_preview_lines();
 
 	if (!found) {

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -143,6 +143,23 @@ String Shader::get_code() const {
 	return code;
 }
 
+void Shader::set_preview_lines(PackedInt32Array p_preview_lines) {
+	preview_lines = p_preview_lines;
+	emit_changed();
+}
+
+PackedInt32Array Shader::get_preview_lines() const {
+	return preview_lines;
+}
+
+void Shader::clear_preview_lines() {
+	preview_lines.clear();
+}
+
+void Shader::add_preview_line(int p_line) {
+	preview_lines.push_back(p_line);
+}
+
 void Shader::inspect_native_shader_code() {
 	SceneTree *st = SceneTree::get_singleton();
 	RID _shader = get_rid();
@@ -279,6 +296,9 @@ void Shader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_code", "code"), &Shader::set_code);
 	ClassDB::bind_method(D_METHOD("get_code"), &Shader::get_code);
 
+	ClassDB::bind_method(D_METHOD("set_preview_lines", "preview_lines"), &Shader::set_preview_lines);
+	ClassDB::bind_method(D_METHOD("get_preview_lines"), &Shader::get_preview_lines);
+
 	ClassDB::bind_method(D_METHOD("set_default_texture_parameter", "name", "texture", "index"), &Shader::set_default_texture_parameter, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_default_texture_parameter", "name", "index"), &Shader::get_default_texture_parameter, DEFVAL(0));
 
@@ -288,6 +308,7 @@ void Shader::_bind_methods() {
 	ClassDB::set_method_flags(get_class_static(), StringName("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "preview_lines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_preview_lines", "get_preview_lines");
 
 	BIND_ENUM_CONSTANT(MODE_SPATIAL);
 	BIND_ENUM_CONSTANT(MODE_CANVAS_ITEM);

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -61,6 +61,7 @@ private:
 	HashSet<Ref<ShaderInclude>> include_dependencies;
 	String code;
 	String include_path;
+	PackedInt32Array preview_lines;
 
 	HashMap<StringName, HashMap<int, Ref<Texture>>> default_textures;
 
@@ -88,6 +89,13 @@ public:
 
 	void set_code(const String &p_code);
 	String get_code() const;
+
+	void set_preview_lines(PackedInt32Array p_preview_lines);
+	PackedInt32Array get_preview_lines() const;
+
+	// Internal methods.
+	void clear_preview_lines();
+	void add_preview_line(int p_line);
 
 	void inspect_native_shader_code();
 

--- a/scene/resources/shader_resource_format.cpp
+++ b/scene/resources/shader_resource_format.cpp
@@ -51,6 +51,28 @@ Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const Strin
 	Ref<Shader> shader;
 	shader.instantiate();
 
+	if (str.begins_with("@")) {
+		String line = "";
+
+		for (int i = 1; i < str.size(); i++) {
+			if (str[i] == '\n') {
+				break;
+			}
+			line += str[i];
+		}
+		str = str.erase(0, line.size() + 1);
+
+		PackedStringArray line_strings = line.split(",");
+		PackedInt32Array lines;
+
+		for (const String &line_string : line_strings) {
+			ERR_FAIL_COND_V_MSG(!line_string.is_valid_int(), nullptr, "Cannot parse shader: " + p_path);
+			lines.push_back(line_string.to_int());
+		}
+
+		shader->set_preview_lines(lines);
+	}
+
 	shader->set_include_path(p_path);
 	shader->set_code(str);
 
@@ -86,6 +108,24 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
+
+	PackedInt32Array lines = shader->get_preview_lines();
+	if (!lines.is_empty()) {
+		String preview_lines = "@";
+
+		for (int i = 0; i < lines.size(); i++) {
+			if (i > 0) {
+				preview_lines += ",";
+			}
+			preview_lines += itos(lines[i]);
+		}
+		preview_lines += "\n";
+
+		file->store_string(preview_lines);
+		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
+			return ERR_CANT_CREATE;
+		}
+	}
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/117726, which saves the list of previews lines in the `Shader` resource to restore them when needed.
