### PR TITLE
Fix ChainIK3D debug drawing on scaled imported skeleton model

### DIFF
--- a/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/chain_ik_3d_gizmo_plugin.cpp
@@ -103,7 +103,7 @@ void ChainIK3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<ArrayMesh> skeleton_mesh;
 	Ref<ArrayMesh> mesh;
 	get_joints_mesh(skeleton, ik, p_gizmo->is_selected(), skeleton_mesh, mesh);
-	Transform3D skel_tr = ik->get_global_transform().inverse() * skeleton->get_global_transform();
+	Transform3D skel_tr = ik->get_global_transform().affine_inverse() * skeleton->get_global_transform();
 	p_gizmo->add_mesh(skeleton_mesh, Ref<Material>(), skel_tr, skeleton->register_skin(skeleton->create_skin_from_rest_transforms()));
 	p_gizmo->add_mesh(mesh, Ref<Material>(), skel_tr);
 }


### PR DESCRIPTION
**Bug:**

The position of debug lines and balls drawed by ChainIK3D is wrong when using a scaled imported skeleton model. 

Reproducible in v4.6.1.stable, v4.7.dev

MRP: [chain-ik-gizmo-draw.zip](https://github.com/user-attachments/files/26645882/chain-ik-gizmo-draw.zip)

**Fix:**

This is due to `Transform3D::inverse` assumes the basis is a rotation matrix, with no scaling. `Transform3D::affine_inverse` can handle matrices with scaling and we can use it to fix the bug.

Before:

<img width="1280" height="752" alt="before" src="https://github.com/user-attachments/assets/bd17c0ef-892d-49bf-a044-b92f96ecec28" />

After:

<img width="1280" height="752" alt="after" src="https://github.com/user-attachments/assets/bb2d448d-ec12-47d8-82a8-87f805f37aff" />
