### PR TITLE
Exclude user singletons from `@GlobalScope.xml`

### DIFF
--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1034,7 +1034,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 		// FIXME: this is kind of hackish...
 		for (const Engine::Singleton &s : singletons) {
 			DocData::PropertyDoc pd;
-			if (!s.ptr) {
+			if (!s.ptr || s.user_created) {
 				continue;
 			}
 			pd.name = s.name;


### PR DESCRIPTION
In Godot's auto-generated documentation, all singletons are added to `@GlobalScope.xml` to indicate their existence. However, this brings a problem: Singletons provided by third-party modules show up in this file as well, making the module no longer self-contained as soon as singletons are added to it.

Before, this was just a minor annoyance, and I could just commit these diffs along with the commit that adds the module as a submodule. However, Godot's CI checks now include more comprehensive documentation checks, meaning that I'm "damned if I do and damned if I don't". Without the `@GlobalScope.xml` changes committed, doctool will find diffs. With the `@GlobalScope.xml` committed, the RST generation check fails with "Unresolved type":

<img width="552" height="440" alt="Screenshot 2026-04-11 at 4 37 12 AM" src="https://github.com/user-attachments/assets/2f77ea6d-2ff4-43d9-a3ce-830962b2f0c0" />

This PR excludes user singletons from `@GlobalScope.xml`, allowing module authors to opt out of their singletons being included in `@GlobalScope.xml` if they register them as "user singletons", making the module self-contained, and allows Godot's CI to pass without doctool modifying the `@GlobalScope.xml`.