### PR TITLE
Provide `Engine::register_singleton` in the internal C++ API

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -395,6 +395,23 @@ void Engine::get_singletons(List<Singleton> *p_singletons) {
 	}
 }
 
+void Engine::register_singleton(const StringName &p_name, Object *p_object) {
+	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
+	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
+	Engine::Singleton s;
+	s.class_name = p_name;
+	s.name = p_name;
+	s.ptr = p_object;
+	s.user_created = true;
+	Engine::get_singleton()->add_singleton(s);
+}
+
+void Engine::unregister_singleton(const StringName &p_name) {
+	ERR_FAIL_COND_MSG(!has_singleton(p_name), vformat("Attempt to remove unregistered singleton: '%s'.", String(p_name)));
+	ERR_FAIL_COND_MSG(!::Engine::get_singleton()->is_singleton_user_created(p_name), vformat("Attempt to remove non-user created singleton: '%s'.", String(p_name)));
+	Engine::get_singleton()->remove_singleton(p_name);
+}
+
 String Engine::get_write_movie_path() const {
 	return write_movie_path;
 }

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -400,6 +400,23 @@ void Engine::get_singletons(List<Singleton> *p_singletons) {
 	}
 }
 
+void Engine::register_singleton(const StringName &p_name, Object *p_object) {
+	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
+	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
+	Engine::Singleton s;
+	s.class_name = p_name;
+	s.name = p_name;
+	s.ptr = p_object;
+	s.user_created = true;
+	Engine::get_singleton()->add_singleton(s);
+}
+
+void Engine::unregister_singleton(const StringName &p_name) {
+	ERR_FAIL_COND_MSG(!has_singleton(p_name), vformat("Attempt to remove unregistered singleton: '%s'.", String(p_name)));
+	ERR_FAIL_COND_MSG(!::Engine::get_singleton()->is_singleton_user_created(p_name), vformat("Attempt to remove non-user created singleton: '%s'.", String(p_name)));
+	Engine::get_singleton()->remove_singleton(p_name);
+}
+
 String Engine::get_write_movie_path() const {
 	return write_movie_path;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -164,6 +164,8 @@ public:
 	bool has_singleton(const StringName &p_name) const;
 	Object *get_singleton_object(const StringName &p_name) const;
 	void remove_singleton(const StringName &p_name);
+	void register_singleton(const StringName &p_name, Object *p_object);
+	void unregister_singleton(const StringName &p_name);
 	bool is_singleton_user_created(const StringName &p_name) const;
 	bool is_singleton_editor_only(const StringName &p_name) const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1998,20 +1998,11 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 
 void Engine::register_singleton(const StringName &p_name, RequiredParam<Object> rp_instance) {
 	EXTRACT_PARAM_OR_FAIL(p_object, rp_instance);
-	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
-	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
-	::Engine::Singleton s;
-	s.class_name = p_name;
-	s.name = p_name;
-	s.ptr = p_object;
-	s.user_created = true;
-	::Engine::get_singleton()->add_singleton(s);
+	::Engine::get_singleton()->register_singleton(p_name, p_object);
 }
 
 void Engine::unregister_singleton(const StringName &p_name) {
-	ERR_FAIL_COND_MSG(!has_singleton(p_name), vformat("Attempt to remove unregistered singleton: '%s'.", String(p_name)));
-	ERR_FAIL_COND_MSG(!::Engine::get_singleton()->is_singleton_user_created(p_name), vformat("Attempt to remove non-user created singleton: '%s'.", String(p_name)));
-	::Engine::get_singleton()->remove_singleton(p_name);
+	::Engine::get_singleton()->unregister_singleton(p_name);
 }
 
 Vector<String> Engine::get_singleton_list() const {

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2009,20 +2009,11 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 
 void Engine::register_singleton(const StringName &p_name, RequiredParam<Object> p_instance) {
 	EXTRACT_PARAM_OR_FAIL(object, p_instance);
-	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
-	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
-	::Engine::Singleton s;
-	s.class_name = p_name;
-	s.name = p_name;
-	s.ptr = object;
-	s.user_created = true;
-	::Engine::get_singleton()->add_singleton(s);
+	::Engine::get_singleton()->register_singleton(p_name, object);
 }
 
 void Engine::unregister_singleton(const StringName &p_name) {
-	ERR_FAIL_COND_MSG(!has_singleton(p_name), vformat("Attempt to remove unregistered singleton: '%s'.", String(p_name)));
-	ERR_FAIL_COND_MSG(!::Engine::get_singleton()->is_singleton_user_created(p_name), vformat("Attempt to remove non-user created singleton: '%s'.", String(p_name)));
-	::Engine::get_singleton()->remove_singleton(p_name);
+	::Engine::get_singleton()->unregister_singleton(p_name);
 }
 
 Vector<String> Engine::get_singleton_list() const {


### PR DESCRIPTION
So far, I have been using this code to support registering singletons in both GDExtensions and modules:

```cpp
inline void add_godot_singleton(const StringName &p_singleton_name, Object *p_object) {
#if GDEXTENSION
	Engine::get_singleton()->register_singleton(p_singleton_name, p_object);
#elif GODOT_MODULE
	Engine::get_singleton()->add_singleton(Engine::Singleton(p_singleton_name, p_object));
#endif
}
```

The main difference is that `register_singleton` is exposed and sets `user_created` to true.

However, based on this comment https://github.com/godotengine/godot/pull/118410#discussion_r3068077506 I realized that another option is to do this:

```cpp
inline void add_godot_singleton(const StringName &p_singleton_name, Object *p_object) {
#if GDEXTENSION
	Engine::get_singleton()->register_singleton(p_singleton_name, p_object);
#elif GODOT_MODULE
	CoreBind::Engine::get_singleton()->register_singleton(p_singleton_name, p_object);
#endif
}
```

However... why not just make this API available on `Engine` directly instead, so the same code works both in a GDExtension and internally/module code?[^1]

Discussion: We may want to rename these functions to distinguish them. For example, `add_internal_singleton`, `add_engine_singleton`, `register_user_singleton`, etc. However, if we rename `register_singleton` to anything else, then we need to keep the old name exposed to GDExtension for compatibility reasons.

[^1]: Another option is `#define CoreBind godot` in GDExtension only so that `CoreBind::Engine` resolves to `godot::Engine`.