### PR TITLE
Add search bar for the resource and variant popups in the inspector

### DIFF
--- a/editor/gui/editor_variant_type_selectors.cpp
+++ b/editor/gui/editor_variant_type_selectors.cpp
@@ -176,4 +176,5 @@ void EditorVariantTypePopupMenu::_popup_base(const Rect2i &p_bounds) {
 
 EditorVariantTypePopupMenu::EditorVariantTypePopupMenu(bool p_remove_item) {
 	remove_item = p_remove_item;
+	set_search_bar_enabled_on_item_count(10);
 }

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1240,6 +1240,7 @@ void EditorResourcePicker::_ensure_resource_menu() {
 		return;
 	}
 	edit_menu = memnew(PopupMenu);
+	edit_menu->set_search_bar_enabled_on_item_count(10);
 	edit_menu->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	add_child(edit_menu);
 	edit_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk));


### PR DESCRIPTION
Both popups can have lots of items depending on the situation. So I've set the search bar trigger for those two to 10, like in the other instances.