### PR TITLE
Fix Godot Physics missing area overlaps after `area_set_space`

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -76,6 +76,10 @@ void GodotArea2D::set_space(GodotSpace2D *p_space) {
 	monitored_areas.clear();
 
 	_set_space(p_space);
+
+	if (!moved_list.in_list() && get_space()) {
+		get_space()->area_add_to_moved_list(&moved_list);
+	}
 }
 
 void GodotArea2D::set_monitor_callback(const Callable &p_callback) {

--- a/modules/godot_physics_3d/godot_area_3d.cpp
+++ b/modules/godot_physics_3d/godot_area_3d.cpp
@@ -84,6 +84,10 @@ void GodotArea3D::set_space(GodotSpace3D *p_space) {
 	monitored_areas.clear();
 
 	_set_space(p_space);
+
+	if (!moved_list.in_list() && get_space()) {
+		get_space()->area_add_to_moved_list(&moved_list);
+	}
 }
 
 void GodotArea3D::set_monitor_callback(const Callable &p_callback) {


### PR DESCRIPTION
Fixes #118419.

This changes `GodotArea*D::set_space` to queue the area up as having "moved" when added to a physics space, similar to several other `GodotArea*D` methods (e.g. `GodotArea*D::set_monitor_callback`) and similar to how `GodotBody*D::set_space` queues up the body as being active/awake when added to a physics space.

This allows the area to actually have its overlaps be picked up properly, without needing to set its transform or anything like that.

As mentioned in #118419, this is only really an issue when dealing with areas created through `PhysicsServer*D`, as the `Area*D` nodes will push physics server transforms upon entering a space, which effectively does the exact same thing:

https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/modules/godot_physics_2d/godot_area_2d.cpp#L57-L59

---

_Disclaimer: AI tooling was used to both find and fix this bug, but I'm as confident in the fix as I can reasonably be._