### PR TITLE
Fix Viewport Texture Filter Mode Inheritance

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4065,7 +4065,8 @@ void Viewport::_refresh_texture_filter_cache() const {
 			if (parent_ci) {
 				default_canvas_item_texture_filter_cache = (RenderingServerEnums::CanvasItemTextureFilter)parent_ci->get_texture_filter_in_tree();
 				if (default_canvas_item_texture_filter_cache == RSE::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT) {
-					default_canvas_item_texture_filter_cache = RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
+					Viewport *parent_vp = parent_ci->get_viewport();
+					default_canvas_item_texture_filter_cache = parent_vp ? parent_vp->get_texture_filter_in_tree() : RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 				}
 				break;
 			}


### PR DESCRIPTION
This fix makes `Viewport`s properly inherit the Texture Filter mode from their `CanvasItem` parent's Texture Filter mode. The issue only arises when the `Viewport`'s `CanvasItem` parent has its Texture Filter mode set to 'Inherit', and the Project Settings default Texture Filter mode is set to anything other than Linear.

<br><img width="450" height="177" alt="old" src="https://github.com/user-attachments/assets/d65ccc6a-5fdd-441c-af1b-a92bd726761e" />
<br>This is the way Godot currently has `PopupMenu`'s render, even if the Project's default Texture Filter mode is set to something like Nearest. `OptionButton`'s `PopupMenu` uses a `Viewport` to render its contents, so this issue is visible with it.
<br><img width="458" height="184" alt="fixed" src="https://github.com/user-attachments/assets/712db557-2f56-4c47-90a0-8e9bbe44cfcc" />
<br>With the fix, the inherited Texture Filter mode works, such as when the Project's default Texture Filter mode is set to Nearest.