### PR TITLE
Fix null pointer dereference in Callable::callp() and rpcp() in release builds

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -58,7 +58,6 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 		custom->call(p_arguments, p_argcount, r_return_value, r_call_error);
 	} else {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));
-#ifdef DEBUG_ENABLED
 		if (!obj) {
 			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			r_call_error.argument = 0;
@@ -66,7 +65,6 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 			r_return_value = Variant();
 			return;
 		}
-#endif
 		r_return_value = obj->callp(method, p_arguments, p_argcount, r_call_error);
 	}
 }
@@ -94,8 +92,14 @@ Error Callable::rpcp(int p_id, const Variant **p_arguments, int p_argcount, Call
 		return ERR_UNCONFIGURED;
 	} else if (!is_custom()) {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));
+		if (!obj) {
+			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			r_call_error.argument = 0;
+			r_call_error.expected = 0;
+			return ERR_UNCONFIGURED;
+		}
 #ifdef DEBUG_ENABLED
-		if (!obj || !obj->is_class("Node")) {
+		if (!obj->is_class("Node")) {
 			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			r_call_error.argument = 0;
 			r_call_error.expected = 0;


### PR DESCRIPTION
Fixes #118428

The null check on `ObjectDB::get_instance()` was wrapped in `#ifdef DEBUG_ENABLED`, so calling a `Callable` whose target object has been freed would crash with a null pointer dereference in release/export templates.

**Changes:**
- `Callable::callp()`: Removed `#ifdef DEBUG_ENABLED` guard around the null check so it runs unconditionally.
- `Callable::rpcp()`: Split the combined `!obj || !obj->is_class("Node")` check. The null check now runs unconditionally; the `is_class("Node")` debug-only check remains under `#ifdef DEBUG_ENABLED`.