### PR TITLE
Fix XMLParser::close() calling memdelete_arr(data) instead of memdelete_arr(data_copy)

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -536,7 +536,7 @@ void XMLParser::skip_section() {
 
 void XMLParser::close() {
 	if (data_copy) {
-		memdelete_arr(data);
+		memdelete_arr(data_copy);
 		data_copy = nullptr;
 	}
 	data = nullptr;


### PR DESCRIPTION
Fixes #118431

`XMLParser::close()` called `memdelete_arr(data)` instead of `memdelete_arr(data_copy)`, inconsistent with the destructor which correctly calls `memdelete_arr(data_copy)`.

Currently benign because `data == data_copy` when `data_copy` is non-null, but the inconsistency is a maintenance hazard and should match the destructor.