### PR TITLE
Fix race conditions in WorkerThreadPool on shared HashMaps

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -40,6 +40,7 @@
 WorkerThreadPool::Task *const WorkerThreadPool::ThreadData::YIELDING = (Task *)1;
 
 HashMap<StringName, WorkerThreadPool *> WorkerThreadPool::named_pools;
+BinaryMutex WorkerThreadPool::named_pools_mutex;
 
 void WorkerThreadPool::Task::free_template_userdata() {
 	ERR_FAIL_NULL(template_userdata);
@@ -726,15 +727,17 @@ bool WorkerThreadPool::is_group_task_completed(GroupID p_group) const {
 
 void WorkerThreadPool::wait_for_group_task_completion(GroupID p_group) {
 #ifdef THREADS_ENABLED
-	task_mutex.lock();
-	Group **groupp = groups.getptr(p_group);
-	task_mutex.unlock();
-	if (!groupp) {
-		ERR_FAIL_MSG("Invalid Group ID.");
+	Group *group = nullptr;
+	{
+		MutexLock task_lock(task_mutex);
+		Group **groupp = groups.getptr(p_group);
+		if (!groupp) {
+			ERR_FAIL_MSG("Invalid Group ID.");
+		}
+		group = *groupp;
 	}
 
 	{
-		Group *group = *groupp;
 
 		if (this == singleton) {
 			_unlock_unlockable_mutexes();
@@ -900,6 +903,7 @@ void WorkerThreadPool::_bind_methods() {
 }
 
 WorkerThreadPool *WorkerThreadPool::get_named_pool(const StringName &p_name) {
+	MutexLock lock(named_pools_mutex);
 	WorkerThreadPool **pool_ptr = named_pools.getptr(p_name);
 	if (pool_ptr) {
 		return *pool_ptr;

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -173,6 +173,7 @@ private:
 	int pump_task_count = 0;
 
 	static HashMap<StringName, WorkerThreadPool *> named_pools;
+	static BinaryMutex named_pools_mutex;
 
 	static void _thread_function(void *p_user);
 


### PR DESCRIPTION
Fixes #118430

**Race 1: `get_named_pool()` — unsynchronized write to static `named_pools`**
The static `named_pools` HashMap was read and written without any mutex. Concurrent calls with new pool names could corrupt the HashMap. Added a dedicated `static BinaryMutex named_pools_mutex` to protect all access.

**Race 2: `wait_for_group_task_completion()` — dangling HashMap internal pointer**
The function obtained a `Group**` pointer into the HashMap's internal storage, then released the mutex before dereferencing it. A concurrent insert could trigger a rehash, invalidating the pointer. Now the `Group*` is copied under the lock, avoiding reliance on HashMap internals after the lock is released.