### PR TITLE
Fix BIG_ENDIAN_ENABLED byte-swap code calling .ptr() on raw pointers

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -528,7 +528,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			f->get_buffer((uint8_t *)w, len * sizeof(int32_t));
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint32_t *ptr = (uint32_t *)w.ptr();
+				uint32_t *ptr = (uint32_t *)w;
 				for (int i = 0; i < len; i++) {
 					ptr[i] = BSWAP32(ptr[i]);
 				}
@@ -547,7 +547,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			f->get_buffer((uint8_t *)w, len * sizeof(int64_t));
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint64_t *ptr = (uint64_t *)w.ptr();
+				uint64_t *ptr = (uint64_t *)w;
 				for (int i = 0; i < len; i++) {
 					ptr[i] = BSWAP64(ptr[i]);
 				}
@@ -566,7 +566,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			f->get_buffer((uint8_t *)w, len * sizeof(float));
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint32_t *ptr = (uint32_t *)w.ptr();
+				uint32_t *ptr = (uint32_t *)w;
 				for (int i = 0; i < len; i++) {
 					ptr[i] = BSWAP32(ptr[i]);
 				}
@@ -585,7 +585,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			f->get_buffer((uint8_t *)w, len * sizeof(double));
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint64_t *ptr = (uint64_t *)w.ptr();
+				uint64_t *ptr = (uint64_t *)w;
 				for (int i = 0; i < len; i++) {
 					ptr[i] = BSWAP64(ptr[i]);
 				}
@@ -644,7 +644,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			f->get_buffer((uint8_t *)w, len * sizeof(float) * 4);
 #ifdef BIG_ENDIAN_ENABLED
 			{
-				uint32_t *ptr = (uint32_t *)w.ptr();
+				uint32_t *ptr = (uint32_t *)w;
 				for (int i = 0; i < len * 4; i++) {
 					ptr[i] = BSWAP32(ptr[i]);
 				}


### PR DESCRIPTION
Fixes #118429

In `core/io/resource_format_binary.cpp`, the `BIG_ENDIAN_ENABLED` blocks called `.ptr()` on raw pointers (e.g., `int32_t *w`) instead of just using the pointer directly. Raw pointers don't have a `.ptr()` method, so this prevented compilation on big-endian platforms.

**Changes:**
Replaced `w.ptr()` with `w` in 5 `BIG_ENDIAN_ENABLED` blocks:
- `VARIANT_PACKED_INT32_ARRAY` (line 531)
- `VARIANT_PACKED_INT64_ARRAY` (line 550)
- `VARIANT_PACKED_FLOAT32_ARRAY` (line 569)
- `VARIANT_PACKED_FLOAT64_ARRAY` (line 588)
- `VARIANT_PACKED_COLOR_ARRAY` (line 647)