### PR TITLE
Fix memory leak in StreamPeerGZIP::_start() when zlib init fails

### DIFF
--- a/core/io/stream_peer_gzip.cpp
+++ b/core/io/stream_peer_gzip.cpp
@@ -97,7 +97,11 @@ Error StreamPeerGZIP::_start(bool p_compress, bool p_is_deflate, int buffer_size
 	} else {
 		err = inflateInit2(&strm, window_bits);
 	}
-	ERR_FAIL_COND_V(err != Z_OK, FAILED);
+	if (err != Z_OK) {
+		memfree(ctx);
+		ctx = nullptr;
+		ERR_FAIL_V(FAILED);
+	}
 	return OK;
 }
 


### PR DESCRIPTION
Fixes #118432

When `deflateInit2()` or `inflateInit2()` returned an error, `ctx` (allocated via `memalloc`) was not freed. Additionally, since `ctx` remained non-null, any subsequent call to `_start()` would fail with `ERR_ALREADY_IN_USE`, making the object permanently unusable.

Now `ctx` is freed and reset to `nullptr` before returning the error.