### PR TITLE
Core: Fix Dictionary iteration hang with freed Object keys

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3348,10 +3348,6 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Vector4, hash_compare_vector4);
 		} break;
 
-		case OBJECT: {
-			return _get_obj().id == p_variant._get_obj().id;
-		} break;
-
 		default:
 			bool v;
 			Variant r;
@@ -3402,6 +3398,9 @@ bool Variant::identity_compare(const Variant &p_variant) const {
 }
 
 bool StringLikeVariantComparator::compare(const Variant &p_lhs, const Variant &p_rhs) {
+	if (p_lhs.get_type() == Variant::OBJECT && p_rhs.get_type() == Variant::OBJECT) {
+		return p_lhs.identity_compare(p_rhs);
+	}
 	if (p_lhs.hash_compare(p_rhs)) {
 		return true;
 	}

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3348,6 +3348,10 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Vector4, hash_compare_vector4);
 		} break;
 
+		case OBJECT: {
+			return _get_obj().id == p_variant._get_obj().id;
+		} break;
+
 		default:
 			bool v;
 			Variant r;

--- a/tests/core/variant/test_dictionary.cpp
+++ b/tests/core/variant/test_dictionary.cpp
@@ -739,6 +739,28 @@ TEST_CASE("[Dictionary] Object value init") {
 	memdelete(b);
 }
 
+TEST_CASE("[Dictionary] Iteration with freed object keys") {
+	Object *a = memnew(Object);
+	Object *b = memnew(Object);
+	Dictionary dict;
+	dict[a] = 1;
+	dict[b] = 2;
+	CHECK_EQ(dict.size(), 2);
+
+	memdelete(a);
+	memdelete(b);
+
+	// Verify iteration terminates and visits all entries.
+	int count = 0;
+	const Variant *key = dict.next(nullptr);
+	while (key) {
+		count++;
+		key = dict.next(key);
+		REQUIRE(count <= dict.size()); // Guard: fail instead of hang if bug present.
+	}
+	CHECK_EQ(count, 2);
+}
+
 TEST_CASE("[Dictionary] RefCounted value init") {
 	Ref<RefCounted> a = memnew(RefCounted);
 	Ref<RefCounted> b = memnew(RefCounted);


### PR DESCRIPTION
Fixes #118422

Add explicit `case OBJECT` to `Variant::hash_compare()` that compares by ObjectID, matching the existing pattern in `identity_compare()`. Previously, OBJECT fell through to the default case which used `get_validated_object()` for equality, returning `nullptr` for freed objects and making all freed Objects compare as equal. When memory addresses were reused, this caused `Dictionary::next()` to loop infinitely between duplicate entries.