### PR TITLE
Revert "Fix EditorSpinSlider drag exceeding min/max boundaries"

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -143,8 +143,6 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 				const double new_value = pre_grab_value + drag_step * grabbing_spinner_dist_cache;
 
 				double val = (mm->is_command_or_control_pressed() && !editing_integer) ? Math::round(new_value) : new_value;
-				val = CLAMP(val, get_min(), get_max());
-
 				if (deferred_drag_mode) {
 					set_value_no_signal(val);
 				} else {


### PR DESCRIPTION
Fixes #118445

This reverts commit 0d3b41480f7978af05705f454f54caf7cb46c028 / #118204.
~Reopens: #118194~ As discussed on that issue, not actually something to be fixed

The change itself doesn't make sense. After the added clamping, the set calls from the `Range` base class already handles clamping which properly respects `allow_greater` and `allow_lesser`:
https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/gui/range.cpp#L170-L202

As far as I can tell, `EditorSpinSlider` was working correctly because the properties in question in #118194 are set to allow greater and lesser values:
https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/animation/animation_blend_tree.cpp#L796-L799
https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/animation/animation_blend_tree.cpp#L837-L840
https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/animation/animation_blend_tree.cpp#L881-L884
https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/animation/animation_blend_tree.cpp#L922-L925

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
