### PR TITLE
Fix null dereference in AudioEffectCompressor when sidechain buffer is unavailable

### DIFF
--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -55,7 +55,10 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 	if (base->sidechain != StringName() && current_channel != -1) {
 		int bus = AudioServer::get_singleton()->thread_find_bus_index(base->sidechain);
 		if (bus >= 0) {
-			src = AudioServer::get_singleton()->thread_get_channel_mix_buffer(bus, current_channel);
+			const AudioFrame *sidechain_src = AudioServer::get_singleton()->thread_get_channel_mix_buffer(bus, current_channel);
+			if (sidechain_src) {
+				src = sidechain_src;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #118456