### PR TITLE
Fix padding on Tree columns with only buttons

### DIFF
--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -260,7 +260,6 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_title(COLUMN_NAME, TTRC("Name"));
 	plugin_list->set_column_title(COLUMN_VERSION, TTRC("Version"));
 	plugin_list->set_column_title(COLUMN_AUTHOR, TTRC("Author"));
-	plugin_list->set_column_title(COLUMN_EDIT, TTRC("Edit"));
 	plugin_list->set_column_title_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_NAME, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
@@ -279,7 +278,6 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 80 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_VERSION, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_AUTHOR, 250 * EDSCALE);
-	plugin_list->set_column_custom_minimum_width(COLUMN_EDIT, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed), CONNECT_DEFERRED);
 

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -315,7 +315,7 @@ void GroupSettingsEditor::update_groups() {
 
 		item->set_text(1, groups_cache[E]);
 		item->set_editable(1, true);
-		item->add_button(2, get_editor_theme_icon(SNAME("Remove")));
+		item->add_button(2, get_editor_theme_icon(SNAME("Remove")), -1, false, TTRC("Remove Group"));
 		item->set_selectable(2, false);
 	}
 

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -621,7 +621,6 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->set_column_expand(1, false);
 	action_tree->set_column_custom_minimum_width(1, 80 * EDSCALE);
 	action_tree->set_column_expand(2, false);
-	action_tree->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	action_tree->connect("item_edited", callable_mp(this, &ActionMapEditor::_action_edited), CONNECT_DEFERRED);
 	action_tree->connect("item_activated", callable_mp(this, &ActionMapEditor::_tree_item_activated));
 	action_tree->connect("button_clicked", callable_mp(this, &ActionMapEditor::_tree_button_pressed));

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -45,7 +45,6 @@
 #include "scene/gui/button.h"
 #include "scene/gui/tree.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 
 #define PREVIEW_LIST_MAX_SIZE 10
@@ -533,9 +532,9 @@ void EditorAutoloadSettings::update_autoload() {
 		item->set_editable(2, true);
 		item->set_text(2, TTRC("Enable"));
 		item->set_checked(2, info.is_singleton);
-		item->add_button(3, get_editor_theme_icon(SNAME("MoveUp")), BUTTON_MOVE_UP);
-		item->add_button(3, get_editor_theme_icon(SNAME("MoveDown")), BUTTON_MOVE_DOWN);
-		item->add_button(3, get_editor_theme_icon(SNAME("Remove")), BUTTON_DELETE);
+		item->add_button(3, get_editor_theme_icon(SNAME("MoveUp")), BUTTON_MOVE_UP, false, TTRC("Move Up"));
+		item->add_button(3, get_editor_theme_icon(SNAME("MoveDown")), BUTTON_MOVE_DOWN, false, TTRC("Move Down"));
+		item->add_button(3, get_editor_theme_icon(SNAME("Remove")), BUTTON_DELETE, false, TTRC("Remove Autoload"));
 		item->set_selectable(3, false);
 	}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1741,10 +1741,9 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 	const TreeItem::Cell &cell = cells[p_column];
 
 	if (cell.cached_minimum_size_dirty || cell.text_buf->is_dirty() || cell.dirty) {
-		Size2 size = Size2(
-				parent_tree->theme_cache.inner_item_margin_left + parent_tree->theme_cache.inner_item_margin_right,
-				parent_tree->theme_cache.inner_item_margin_top + parent_tree->theme_cache.inner_item_margin_bottom);
+		Size2 size = Size2(0, parent_tree->theme_cache.inner_item_margin_top + parent_tree->theme_cache.inner_item_margin_bottom);
 		int content_height = size.height;
+		bool has_text_or_icon = false;
 
 		// Text.
 		if (!cell.text.is_empty()) {
@@ -1756,6 +1755,7 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 				size.width += text_size.width;
 			}
 			content_height = MAX(content_height, text_size.height);
+			has_text_or_icon = true;
 		}
 
 		// Icon.
@@ -1763,16 +1763,23 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 			Size2i check_size = parent_tree->theme_cache.checked->get_size();
 			size.width += check_size.width + parent_tree->theme_cache.h_separation;
 			content_height = MAX(content_height, check_size.height);
+			has_text_or_icon = true;
 		} else if (cell.mode == CELL_MODE_RANGE) {
 			Ref<Texture2D> icon = cell.text.is_empty() ? parent_tree->theme_cache.updown : parent_tree->theme_cache.select_arrow;
 			Size2i icon_size = icon->get_size();
 			size.width += icon_size.width + parent_tree->theme_cache.h_separation;
 			content_height = MAX(content_height, icon_size.height);
+			has_text_or_icon = true;
 		}
 		if (cell.icon.is_valid()) {
 			Size2i icon_size = parent_tree->_get_cell_icon_size(cell);
 			size.width += icon_size.width + parent_tree->theme_cache.icon_h_separation;
 			content_height = MAX(content_height, icon_size.height);
+			has_text_or_icon = true;
+		}
+
+		if (has_text_or_icon) {
+			size.width += parent_tree->theme_cache.inner_item_margin_left + parent_tree->theme_cache.inner_item_margin_right;
 		}
 
 		// Buttons.
@@ -2456,8 +2463,12 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 							}
 						}
 					} else if (!drop_mode_flags) {
+						bool cell_has_content = !p_item->cells[i].text.is_empty() || p_item->cells[i].icon.is_valid();
 						if (is_cell_button_hovered) {
-							theme_cache.hovered_dimmed->draw(stylebox_ci, row_rect);
+							// Button-only cells shouldn't show highlight when there is no other content.
+							if (cell_has_content) {
+								theme_cache.hovered_dimmed->draw(ci, row_rect);
+							}
 						} else {
 							theme_cache.hovered->draw(stylebox_ci, row_rect);
 						}
@@ -2470,8 +2481,12 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				// Cell hover.
 				if (is_cell_hovered && !p_item->cells[i].selected && !drop_mode_flags) {
+					bool cell_has_content = !p_item->cells[i].text.is_empty() || p_item->cells[i].icon.is_valid();
 					if (is_cell_button_hovered) {
-						theme_cache.hovered_dimmed->draw(stylebox_ci, r);
+						// Button-only cells shouldn't show highlight when there is no other content.
+						if (cell_has_content) {
+							theme_cache.hovered_dimmed->draw(ci, r);
+						}
 					} else {
 						theme_cache.hovered->draw(stylebox_ci, r);
 					}


### PR DESCRIPTION
There is an odd off-by-one padding present on the rightmost columns without titles, in Editor Settings' Input Map and Globals.

https://github.com/user-attachments/assets/e3c11c48-986f-43d3-b5bf-404397714c4d

This PR minimally fixes it.