### PR TITLE
Fix `ERR_PRINT` usage in forked child process lead to possible crashing

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -793,7 +793,7 @@ Dictionary OS_Unix::execute_with_pipe(const String &p_path, const List<String> &
 
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// The execvp() function only returns if an error occurs.
-		ERR_PRINT("Could not create child process: " + p_path);
+		fprintf(stderr, "Could not create child process: %s\n", p_path.utf8().get_data());
 		raise(SIGKILL);
 	}
 	::close(pipe_in[0]);
@@ -939,7 +939,7 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, St
 
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// The execvp() function only returns if an error occurs.
-		ERR_PRINT("Could not create child process: " + p_path);
+		fprintf(stderr, "Could not create child process: %s\n", p_path.utf8().get_data());
 		raise(SIGKILL);
 	}
 
@@ -981,7 +981,7 @@ Error OS_Unix::create_process(const String &p_path, const List<String> &p_argume
 
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// The execvp() function only returns if an error occurs.
-		ERR_PRINT("Could not create child process: " + p_path);
+		fprintf(stderr, "Could not create child process: %s\n", p_path.utf8().get_data());
 		raise(SIGKILL);
 	}
 


### PR DESCRIPTION
closes: #118189 

possibly related: #114393 #111813 #116983 #114547 #73965

## Investigation

In #118189 I said that deleting a file crashes godot-mono build on my machine. I managed to caught the crash site in a debugger on my machine, but they are almost always in C#'s JIT compiler in coreclr.

In my issue I also said I managed to find a way to not crash it if I built it, but later on I found out it didn't crash when I run it in my vscode terminal. Turns out my vscode package bundled `gio`.

So I started investigating the seemingly unharmful log "Could not create child process: gio". Found this `ERR_PRINT` call in a fork.

## Possible problems

I'm not 100% sure this is the case, but this did fix my crash on my machine. I couldn't dig any further into C# runtime or anything `ERR_PRINT` touches, but I have a rough feeling about the following things `ERR_PRINT` accesses:

* `OS::get_singleton()->print_error()`
  * This singleton is a frozen copy from the parent. It's probably fine, but I just have bad feeling about it.
* `ScriptServer::capture_script_backtraces()`
  * This is probably what crashed my editor on my machine, when it eventually want to capture C#'s stack trace, reaching `DebuggingUtils.GetCurrentStackInfo()` which does a `new StackTrace()`.
  * Without digging into .NET too much, I assume it accessed the heap from another process which leads to the eventual corruption of my C# runtime and crashes.
* `_global_lock()`
  * The lock is a copied over mutex. Just bad vibes.
* `error_handler_list`
  * Copied over handlers, if anything in it does anything cross process it's probably bad.

Anyway, doing anything other than `exec` after a `fork` feels bad.

## Alternative solutions

This fix moves the error messages out of the editor console and doesn't have pretty print or stack trace. If it has to have it, other solutions might be:

* A fork-friendly print function
* Some way to signal error back to parent process and print
* Give up `fork()` in favor of other way of spawning

## Pertinent

I also realized, there is almost no way on unix system for `create_process` caller to know the command didn't spawn and immediately quit since these methods always returns the pid of the fork.