### PR TITLE
Limit `OccluderInstance3D` editor inspector hack to the edited scene

### DIFF
--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -458,8 +458,9 @@ void OccluderInstance3D::set_occluder(const Ref<Occluder3D> &p_occluder) {
 	update_configuration_warnings();
 
 #ifdef TOOLS_ENABLED
-	// PolygonOccluder3D is edited via an editor plugin, this ensures the plugin is shown/hidden when necessary
-	if (Engine::get_singleton()->is_editor_hint()) {
+	// PolygonOccluder3D is edited via an editor plugin, this ensures the plugin is shown/hidden when necessary.
+	// HACK: This should only be called when this node is the currently edited object (i.e. when edited through the inspector) to prevent side effects. We use `is_part_of_edited_scene()` as approximation.
+	if (is_part_of_edited_scene()) {
 		callable_mp(EditorNode::get_singleton(), &EditorNode::edit_current).call_deferred();
 	}
 #endif


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115055 (I'm not able to actually reproduce the infinite instance loop, but this should address the root cause.)
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/973

`OccluderInstance3D::set_occluder` contains code which re-edits the last object from the editor selection history. This is meant to force refresh relevant editor plugins when the property is changed in the inspector. It must not be run for all instances in an editor process though, because it can cause unwanted side effects if the top of the editor history is another object.

For example the GDScript language server might instantiate scenes. When such a scene contained an OccluderInstance3D it would call the problematic code and if the current top of the editor selection history is a script this would open the script again in the external editor.

This PR limits this code to only run for scenes that are currently edited to prevent side effects for the language server.

In general this still feels hacky to me and should probably be a `PropertyUsageFlag` instead to ensure that it only applies to inspector edits, but I dunno. Would be out of scope for this PR anyway.