### PR TITLE
Fix issue in `BoxContainer` that clipped children with non-integer minimum sizes

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -67,7 +67,7 @@ void BoxContainer::_resort() {
 		if (propagating_max_size) {
 			c->set_parent_maximum_size_cache(combined_max_size);
 		}
-		Size2i min_size = c->get_combined_minimum_size();
+		Size2i min_size = c->get_combined_minimum_size().ceil();
 		Size2i max_size = c->get_combined_maximum_size();
 		_MinSizeCache msc;
 


### PR DESCRIPTION
* Fixes #118397

In `BoxContainer::_resort`, if a child had a minimum size with a fractional part between 0 and 0.5, it would get floored by the conversion to `Size2i`, and the child would not be given enough space. 

Certain `Control` subtypes, in particular `Label` with an MSDF font, compute a non-integer minimum size. In the issue MRP, notice how the `Label` changes from a height of 23 to 22.33 when MSDF is turned on. The `BoxContainer` would floor that to 22, which would then make the `Label` too small to render the MSDF font. 

This fixes that issue by always rounding minimum sizes up to the nearest integer using `.ceil()`, rather than the existing bidirectional rounding. 