### PR TITLE
Fix filter tree node order

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1083,11 +1083,13 @@ bool SceneTreeEditor::_update_filter_helper(TreeItem *p_parent, bool p_scroll_to
 		p_parent->set_visible(!hide_filtered_out_parents || is_root);
 
 		if (!p_parent->is_visible()) {
+			TreeItem *candidate_sibling = p_parent;
 			TreeItem *filtered_parent = p_parent->get_parent();
 			while (filtered_parent) {
 				if (filtered_parent == tree->get_root() || (filtered_parent->is_selectable(0) && filtered_parent->is_visible())) {
 					break;
 				}
+				candidate_sibling = filtered_parent;
 				filtered_parent = filtered_parent->get_parent();
 			}
 
@@ -1098,10 +1100,8 @@ bool SceneTreeEditor::_update_filter_helper(TreeItem *p_parent, bool p_scroll_to
 
 					p_parent->remove_child(ti);
 					filtered_parent->add_child(ti);
-					TreeItem *prev = p_parent->get_prev();
-					if (prev) {
-						ti->move_after(prev);
-					}
+					ti->move_after(candidate_sibling);
+					candidate_sibling = ti;
 
 					if (is_selected) {
 						ti->select(0);


### PR DESCRIPTION
- Fixes #108278

**_Bugsquad Edit:_**
- Fixes #118832
- Fixes #81875
- Possible fixes #106264

## Issue Description

Current behaviour of tree sorting is wired, it want to move the visible child node after the previous node of parent.

https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/editor/scene/scene_tree_editor.cpp#L1099-L1104

Let's replay the sorting steps using MPR from issue.

Before we filter `Logo` on the tree. Here is the original structure of the tree. Then we want to only filter nodes whose name contains **logo**.

```
- Node2D
    - Icon3
        - Logo (0)
    - Icon4
        - Logo (1)
    - Icon5
        - Logo (2)
```

Step 1: Find Logo (0) is visible, move it to the end of children of Node2D. Its parent node - Icon3 hasnot prev node, so wont move Logo (0) again.

```
- Node2D
    - Icon3
    - Icon4
        - Logo (1)
    - Icon5
        - Logo (2)
    - Logo (0)
```

Step 2: Find Logo (1) is visible, move it to the end of children of Node2D. Its parent node - Icon4 has prev node - Icon3, so move Logo (1) after Icon3.

```
- Node2D
    - Icon3
    - Logo (1)
    - Icon4
    - Icon5
        - Logo (2)
    - Logo (0)
```

Step 3: Find Logo (2) is visible, move it to the end of children of Node2D. Its parent node - Icon5 has prev node - Icon4, so move Logo (2) after Icon4.

```
- Node2D
    - Icon3
    - Logo (1)
    - Icon4
    - Logo (2)
    - Icon5
    - Logo (0)
```

Because Icon3, Icon4 and Icon4 are invisible for filtering, so we will get disordered list as following:

```
- Logo (1)
- Logo (2)
- Logo (0)
```

## Solution

The solution is dont using previous node of parent to do the re-order. We can record the first invisible parent node of branch, and set it as the candidate sibling node to move after. e.g. The first invisible parent node of Logo (0) branch is **Icon3**, so Logo (0) should move after **Icon3**.

```
- Node2D
    - Icon3
    - Logo (0)
    - Icon4
      - Logo (1)
    - Icon5
      - Logo (2)
 ```

So the Logo (1) and Logo (2), they should move after **Icon4** and **Icon5**. So we can keep the original order of tree after fitlering.

```
- Node2D
    - Icon3
    - Logo (0)
    - Icon4
    - Logo (1)
    - Icon5
    - Logo (2)
 ```


