### PR TITLE
Tweak the docs for VehicleWheel3D.wheel_friction_slip

### DIFF
--- a/doc/classes/VehicleWheel3D.xml
+++ b/doc/classes/VehicleWheel3D.xml
@@ -84,8 +84,7 @@
 			If [code]true[/code], this wheel transfers engine force to the ground to propel the vehicle forward. This value is used in conjunction with [member VehicleBody3D.engine_force] and ignored if you are using the per-wheel [member engine_force] value instead.
 		</member>
 		<member name="wheel_friction_slip" type="float" setter="set_friction_slip" getter="get_friction_slip" default="10.5">
-			This determines how much grip this wheel has. It is combined with the friction setting of the surface the wheel is in contact with. 0.0 means no grip, 1.0 is normal grip. For a drift car setup, try setting the grip of the rear wheels slightly lower than the front wheels, or use a lower value to simulate tire wear.
-			It's best to set this to 1.0 when starting out.
+			This determines how much grip this wheel has. A value of 0.0 means no grip and larger values increase grip. The effective range depends on the physical characteristics of the vehicle and the surface it is in contact with. For a drift car setup, try setting the grip of the rear wheels slightly lower than the front wheels, or use a lower value to simulate tire wear.
 		</member>
 		<member name="wheel_radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The radius of the wheel in meters.


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-docs/issues/11662

Removes the implication that the effective range is 0.0 to 1.0 and suggests that the effective range is dependent on other physics values.

I couldn't determine the origin of the 10.5 default value (I expect it just works reasonably for a vehicle with other default values) so I didn't mention it.

History:
- `wheel_friction_slip` exists (with default value 10.5) since 2ee4ac183babedd679e901b0158f5268556deceb
- Existing doc text originally added in 234b86e6b2d6ca22e0be6b5225b3763c057546cc

Relevant code:
- https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/3d/physics/vehicle_body_3d.cpp#L807
- https://github.com/godotengine/godot/blob/1aabcb9e9bc7a222a972731523831ec86b77ee20/scene/3d/physics/vehicle_body_3d.h#L97