### PR TITLE
ColorPicker: Fix Color loses precision when the color text `LineEdit` loses focus.

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -44,7 +44,6 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/link_button.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
@@ -64,7 +63,8 @@
 
 #ifdef MACOS_ENABLED
 #include "core/os/os.h"
-#endif
+#include "scene/gui/link_button.h"
+#endif // MACOS_ENABLED
 
 static inline bool is_color_overbright(const Color &color) {
 	return (color.r > 1.0) || (color.g > 1.0) || (color.b > 1.0);
@@ -356,6 +356,10 @@ void ColorPicker::_set_pick_color(const Color &p_color, bool p_update_sliders, b
 }
 
 void ColorPicker::set_pick_color(const Color &p_color) {
+	if (p_color == color) {
+		return;
+	}
+
 	_set_pick_color(p_color, true, true); // Because setters can't have more arguments.
 }
 
@@ -1888,7 +1892,7 @@ void ColorPicker::_picker_texture_input(const Ref<InputEvent> &p_event) {
 }
 
 void ColorPicker::_html_focus_exit() {
-	if (c_text->is_menu_visible()) {
+	if (c_text->is_menu_visible() || !text_changed) {
 		return;
 	}
 
@@ -2321,6 +2325,7 @@ ColorPicker::ColorPicker() {
 	btn_add_preset->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_add_preset_pressed));
 	preset_container->add_child(btn_add_preset);
 
+#ifdef MACOS_ENABLED
 	perm_hb = memnew(HBoxContainer);
 	perm_hb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
@@ -2331,13 +2336,14 @@ ColorPicker::ColorPicker() {
 	perm_hb->add_child(perm_link);
 	real_vbox->add_child(perm_hb);
 	perm_hb->set_visible(false);
+#endif // MACOS_ENABLED
 }
 
-void ColorPicker::_req_permission() {
 #ifdef MACOS_ENABLED
+void ColorPicker::_req_permission() {
 	OS::get_singleton()->request_permission("macos.permission.RECORD_SCREEN");
-#endif
 }
+#endif // MACOS_ENABLED
 
 ColorPicker::~ColorPicker() {
 	for (ColorMode *mode : modes) {
@@ -2455,7 +2461,7 @@ void ColorPickerButton::_notification(int p_what) {
 			draw_texture_rect(theme_cache.background_icon, r, true);
 			draw_rect(r, color);
 
-			if (color.r > 1 || color.g > 1 || color.b > 1) {
+			if (is_color_overbright(color)) {
 				// Draw an indicator to denote that the color is "overbright" and can't be displayed accurately in the preview
 				draw_texture(theme_cache.overbright_indicator, theme_cache.normal_style->get_offset());
 			}
@@ -2676,7 +2682,4 @@ ColorPresetButton::ColorPresetButton(Color p_color, int p_size, bool p_recent) {
 	set_custom_minimum_size(Size2(p_size, p_size));
 	set_accessibility_name(vformat(atr(ETR("Color: %s")), color_to_string(p_color, p_color.a < 1)));
 	set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-}
-
-ColorPresetButton::~ColorPresetButton() {
 }

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -33,7 +33,6 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/popup.h"
-#include "scene/resources/shader.h"
 
 class AspectRatioContainer;
 class ColorMode;
@@ -76,7 +75,6 @@ public:
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
 	ColorPresetButton(Color p_color, int p_size, bool p_recent);
-	~ColorPresetButton();
 };
 
 class ColorPicker : public VBoxContainer {
@@ -171,10 +169,6 @@ private:
 	static inline List<Color> preset_cache;
 	static inline List<Color> recent_preset_cache;
 
-#ifdef TOOLS_ENABLED
-	Object *editor_settings = nullptr;
-#endif
-
 	int current_slider_count = MODE_SLIDER_COUNT;
 
 	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 1.0 / 2;
@@ -230,10 +224,14 @@ private:
 	Ref<ButtonGroup> preset_group;
 	Ref<ButtonGroup> recent_preset_group;
 
+#ifdef MACOS_ENABLED
 	HBoxContainer *perm_hb = nullptr;
 	void _req_permission();
+#endif // MACOS_ENABLED
 
 #ifdef TOOLS_ENABLED
+	Object *editor_settings = nullptr;
+
 	Callable quick_open_callback;
 	Callable palette_saved_callback;
 #endif // TOOLS_ENABLED

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/gui/color_picker.h"
+#include "scene/resources/shader.h"
 
 class ColorPickerShape : public Object {
 	GDCLASS(ColorPickerShape, Object);


### PR DESCRIPTION
Prevent color text `focus_exited` signal from calling `set_pick_color` if the text is not changed. 

Other changes:

Return early when calling `set_pick_color` with the same color.

Also cleanup some includes, remove `ColorPresetButton` destructor, and disable macOS record screen permission changes on other platforms.