### PR TITLE
csg: Fix signed-to-unsigned implicit conversions flagged by UBSan.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -284,7 +284,7 @@ static void _unpack_manifold(
 	constexpr int32_t order[3] = { 0, 2, 1 };
 
 	for (size_t run_i = 0; run_i < mesh.runIndex.size() - 1; run_i++) {
-		uint32_t original_id = -1;
+		uint32_t original_id = UINT32_MAX;
 		if (run_i < mesh.runOriginalID.size()) {
 			original_id = mesh.runOriginalID[run_i];
 		}
@@ -400,7 +400,7 @@ static void _pack_manifold(
 		CSGShape3D *p_csg_shape) {
 	ERR_FAIL_NULL_MSG(p_mesh_merge, "p_mesh_merge is null");
 	ERR_FAIL_NULL_MSG(p_csg_shape, "p_shape is null");
-	HashMap<uint32_t, Vector<CSGBrush::Face>> faces_by_material;
+	HashMap<int32_t, Vector<CSGBrush::Face>> faces_by_material;
 	for (int face_i = 0; face_i < p_mesh_merge->faces.size(); face_i++) {
 		const CSGBrush::Face &face = p_mesh_merge->faces[face_i];
 		faces_by_material[face.material].push_back(face);


### PR DESCRIPTION
AI generated with Claude code. The hope is that I can clean up the sanitation errors. These fixes are 2-3 lines so they can be verified easily.

UBSan reports:
  csg_shape.cpp:287: implicit conversion from type 'int' of value -1
  to type 'uint32_t' changed the value to 4294967295
  csg_shape.cpp:406: implicit conversion from type 'int' of value -1
  to type 'const unsigned int' changed the value to 4294967295

Use UINT32_MAX instead of -1 for the original_id sentinel and change faces_by_material to HashMap<int32_t, ...> to match Face::material.