### PR TITLE
Allow selecting all previous or next siblings from TreeItem

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3979,6 +3979,34 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			prev->select(selected_col);
 		}
 		ensure_cursor_is_visible();
+	} else if (p_event->is_action("ui_home") && p_event->is_pressed()) {
+		if (select_mode == SELECT_MULTI && selected_item && k.is_valid() && k->is_shift_pressed()) {
+			if (!cursor_can_exit_tree) {
+				accept_event();
+			}
+			TreeItem *parent = selected_item->get_parent();
+			if (parent) {
+				TreeItem *first_sibling = parent->get_first_child();
+				while (first_sibling && !first_sibling->is_visible_in_tree()) {
+					first_sibling = first_sibling->get_next();
+				}
+				_shift_select_range(first_sibling);
+			}
+		}
+	} else if (p_event->is_action("ui_end") && p_event->is_pressed()) {
+		if (select_mode == SELECT_MULTI && selected_item && k.is_valid() && k->is_shift_pressed()) {
+			if (!cursor_can_exit_tree) {
+				accept_event();
+			}
+			TreeItem *parent = selected_item->get_parent();
+			if (parent) {
+				TreeItem *last_sibling = parent->get_last_child();
+				while (last_sibling && !last_sibling->is_visible_in_tree()) {
+					last_sibling = last_sibling->get_prev();
+				}
+				_shift_select_range(last_sibling);
+			}
+		}
 	} else if (p_event->is_action("ui_select") && p_event->is_pressed()) {
 		if (select_mode == SELECT_MULTI) {
 			if (!selected_item) {


### PR DESCRIPTION
Closes [#14645](https://github.com/godotengine/godot-proposals/issues/14645).

To accomplish this desired behaviour from the proposal...
> But does that mean that if I select another file than the first file, like the 5th file out of 10 files, will it add to the selection the files from 6 to 10 ?
If I use Shift + Home will it add to the selection from 1 to 4 ?
In that case we loose the ability to select any file or folder and select all files from there.

> You could press Shift+Home and Shift+End to select everything from any file.

...select any item, press Shift+Home, **then release Shift**, then press Shift+End.

https://github.com/user-attachments/assets/2ab3c7cb-1b17-4fa5-b909-55a05c093966

Continuing to hold Shift between Home or End presses will lead to either selection above or selection below.

https://github.com/user-attachments/assets/36621103-b737-48c2-a673-b92da711d297

I think this distinction can be well communicated by moving the primary selection highlight to the last TreeItem only once Shift is fully released in the former case, while retaining it in the center while Shift is held in the latter. Setting to draft while I investigate that.