### PR TITLE
Improve core and GDScript multi-threading performance

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -603,16 +603,19 @@ Variant Object::_call_bind(const Variant **p_args, int p_argcount, Callable::Cal
 		return Variant();
 	}
 
-	if (!p_args[0]->is_string()) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-		r_error.argument = 0;
-		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+	if (p_args[0]->get_type() == Variant::STRING_NAME) {
+		const StringName &method = *VariantInternal::get_string_name(p_args[0]);
+		return callp(method, &p_args[1], p_argcount - 1, r_error);
+	}
+	if (p_args[0]->get_type() == Variant::STRING) {
+		StringName method = *VariantInternal::get_string(p_args[0]);
+		return callp(method, &p_args[1], p_argcount - 1, r_error);
 	}
 
-	StringName method = *p_args[0];
-
-	return callp(method, &p_args[1], p_argcount - 1, r_error);
+	r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+	r_error.argument = 0;
+	r_error.expected = Variant::STRING_NAME;
+	return Variant();
 }
 
 Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -621,20 +624,22 @@ Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Call
 		r_error.expected = 1;
 		return Variant();
 	}
+	r_error.error = Callable::CallError::CALL_OK;
 
-	if (!p_args[0]->is_string()) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-		r_error.argument = 0;
-		r_error.expected = Variant::STRING_NAME;
+	if (p_args[0]->get_type() == Variant::STRING_NAME) {
+		const StringName &method = *VariantInternal::get_string_name(p_args[0]);
+		MessageQueue::get_singleton()->push_callp(get_instance_id(), method, &p_args[1], p_argcount - 1, true);
+		return Variant();
+	}
+	if (p_args[0]->get_type() == Variant::STRING) {
+		StringName method = *VariantInternal::get_string(p_args[0]);
+		MessageQueue::get_singleton()->push_callp(get_instance_id(), method, &p_args[1], p_argcount - 1, true);
 		return Variant();
 	}
 
-	r_error.error = Callable::CallError::CALL_OK;
-
-	StringName method = *p_args[0];
-
-	MessageQueue::get_singleton()->push_callp(get_instance_id(), method, &p_args[1], p_argcount - 1, true);
-
+	r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+	r_error.argument = 0;
+	r_error.expected = Variant::STRING_NAME;
 	return Variant();
 }
 
@@ -2371,15 +2376,17 @@ void postinitialize_handler(Object *p_object) {
 }
 
 void ObjectDB::debug_objects(DebugFunc p_func, void *p_user_data) {
-	spin_lock.lock();
+	mutex.lock();
 
 	for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {
-		if (object_slots[i].validator) {
-			p_func(object_slots[i].object, p_user_data);
+		const ObjectSlot &slot = blocks[i / block_size][i % block_size];
+		if (slot.get_data().validator) {
+			p_func(slot.object, p_user_data);
 			count--;
 		}
 	}
-	spin_lock.unlock();
+
+	mutex.unlock();
 }
 
 #ifdef TOOLS_ENABLED
@@ -2428,99 +2435,98 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 }
 #endif
 
-SpinLock ObjectDB::spin_lock;
-uint32_t ObjectDB::slot_count = 0;
-uint32_t ObjectDB::slot_max = 0;
-ObjectDB::ObjectSlot *ObjectDB::object_slots = nullptr;
-uint64_t ObjectDB::validator_counter = 0;
-
 int ObjectDB::get_object_count() {
 	return slot_count;
 }
 
 ObjectID ObjectDB::add_instance(Object *p_object) {
-	spin_lock.lock();
+	mutex.lock();
+
 	if (unlikely(slot_count == slot_max)) {
-		CRASH_COND(slot_count == (1 << OBJECTDB_SLOT_MAX_COUNT_BITS));
-
-		uint32_t new_slot_max = slot_max > 0 ? slot_max * 2 : 1;
-		object_slots = (ObjectSlot *)memrealloc(object_slots, sizeof(ObjectSlot) * new_slot_max);
-		for (uint32_t i = slot_max; i < new_slot_max; i++) {
-			object_slots[i].object = nullptr;
-			object_slots[i].is_ref_counted = false;
-			object_slots[i].next_free = i;
-			object_slots[i].validator = 0;
+		CRASH_COND(slot_count == max_slots);
+		uint32_t max = block_max.get();
+		blocks[max] = static_cast<ObjectSlot *>(memalloc(sizeof(ObjectSlot) * block_size));
+		for (uint32_t i = 0; i < block_size; i++) {
+			ObjectSlot &new_slot = *memnew_placement(&blocks[max][i], ObjectSlot);
+			ObjectSlotData data{};
+			data.block_idx = max;
+			data.slot_idx = i;
+			new_slot.set_data(data);
 		}
-		slot_max = new_slot_max;
+		block_max.add(1);
+		slot_max += block_size;
 	}
 
-	uint32_t slot = object_slots[slot_count].next_free;
-	if (object_slots[slot].object != nullptr) {
-		spin_lock.unlock();
-		ERR_FAIL_COND_V(object_slots[slot].object != nullptr, ObjectID());
-	}
-	object_slots[slot].object = p_object;
-	object_slots[slot].is_ref_counted = p_object->is_ref_counted();
-	validator_counter = (validator_counter + 1) & OBJECTDB_VALIDATOR_MASK;
-	if (unlikely(validator_counter == 0)) {
-		validator_counter = 1;
-	}
-	object_slots[slot].validator = validator_counter;
+	// Get the free slot.
+	ObjectSlotData next_free_slot_data = blocks[slot_count / block_size][slot_count % block_size].get_data();
+	ObjectSlot &free_slot = blocks[next_free_slot_data.block_idx][next_free_slot_data.slot_idx];
+	ObjectSlotData free_slot_data = free_slot.get_data();
 
-	uint64_t id = validator_counter;
-	id <<= OBJECTDB_SLOT_MAX_COUNT_BITS;
-	id |= uint64_t(slot);
-
-	if (p_object->is_ref_counted()) {
-		id |= OBJECTDB_REFERENCE_BIT;
+	if (free_slot.object != nullptr) {
+		mutex.unlock();
+		ERR_FAIL_COND_V(free_slot.object != nullptr, ObjectID());
 	}
+
+	free_slot_data.is_ref_counted = p_object->is_ref_counted();
+	free_slot_data.validator = validator_counter.incremented();
+
+	free_slot.object = p_object;
+	free_slot.set_data(free_slot_data);
 
 	slot_count++;
 
-	spin_lock.unlock();
+	mutex.unlock();
 
-	return ObjectID(id);
+	ObjectSlotData instance_data = free_slot_data;
+	instance_data.block_idx = next_free_slot_data.block_idx;
+	instance_data.slot_idx = next_free_slot_data.slot_idx;
+	return ObjectID(static_cast<uint64_t>(instance_data));
 }
 
 void ObjectDB::remove_instance(Object *p_object) {
-	uint64_t t = p_object->get_instance_id();
-	uint32_t slot = t & OBJECTDB_SLOT_MAX_COUNT_MASK; //slot is always valid on valid object
+	mutex.lock();
+	ObjectSlotData remove_data{ static_cast<uint64_t>(p_object->get_instance_id()) };
 
-	spin_lock.lock();
-
+	ObjectSlot &remove_slot = blocks[remove_data.block_idx][remove_data.slot_idx];
+	ObjectSlotData remove_slot_data = remove_slot.get_data();
 #ifdef DEBUG_ENABLED
-
-	if (object_slots[slot].object != p_object) {
-		spin_lock.unlock();
-		ERR_FAIL_COND(object_slots[slot].object != p_object);
+	if (remove_slot_data.validator != remove_data.validator) {
+		mutex.unlock();
+		ERR_FAIL_COND(remove_slot_data.validator != remove_data.validator);
 	}
-	{
-		uint64_t validator = (t >> OBJECTDB_SLOT_MAX_COUNT_BITS) & OBJECTDB_VALIDATOR_MASK;
-		if (object_slots[slot].validator != validator) {
-			spin_lock.unlock();
-			ERR_FAIL_COND(object_slots[slot].validator != validator);
-		}
+	if (remove_slot.object != p_object) {
+		mutex.unlock();
+		ERR_FAIL_COND(remove_slot.object != p_object);
 	}
-
 #endif
+
+	//invalidate, so checks against it fail
+	remove_slot_data.validator = 0;
+	remove_slot_data.is_ref_counted = false;
+	remove_slot.set_data(remove_slot_data);
+	remove_slot.object = nullptr;
+
 	//decrease slot count
 	slot_count--;
-	//set the free slot properly
-	object_slots[slot_count].next_free = slot;
-	//invalidate, so checks against it fail
-	object_slots[slot].validator = 0;
-	object_slots[slot].is_ref_counted = false;
-	object_slots[slot].object = nullptr;
 
-	spin_lock.unlock();
+	//set the free slot properly
+	ObjectSlot &top_slot = blocks[slot_count / block_size][slot_count % block_size];
+	ObjectSlotData top_slot_data = top_slot.get_data();
+	top_slot_data.block_idx = remove_data.block_idx;
+	top_slot_data.slot_idx = remove_data.slot_idx;
+	top_slot.set_data(top_slot_data);
+
+	mutex.unlock();
 }
 
 void ObjectDB::setup() {
-	//nothing to do now
+	mutex.lock();
+	blocks = static_cast<ObjectSlot **>(memalloc_zeroed(sizeof(ObjectSlot *) * max_blocks));
+	mutex.unlock();
 }
 
 void ObjectDB::cleanup() {
-	spin_lock.lock();
+	mutex.lock();
 
 	if (slot_count > 0) {
 		WARN_PRINT(vformat("%d ObjectDB %s leaked at exit (run with `--verbose` for details).", slot_count, slot_count == 1 ? "instance was" : "instances were"));
@@ -2533,8 +2539,11 @@ void ObjectDB::cleanup() {
 			Callable::CallError call_error;
 
 			for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {
-				if (object_slots[i].validator) {
-					Object *obj = object_slots[i].object;
+				uint32_t block_idx = i / block_size;
+				uint32_t slot_idx = i % block_size;
+				const ObjectSlot &slot = blocks[block_idx][slot_idx];
+				if (slot.get_data().validator) {
+					Object *obj = slot.object;
 
 					String extra_info;
 					if (obj->is_class("Node")) {
@@ -2547,20 +2556,22 @@ void ObjectDB::cleanup() {
 						extra_info = " - Reference count: " + itos((static_cast<RefCounted *>(obj))->get_reference_count());
 					}
 
-					uint64_t id = uint64_t(i) | (uint64_t(object_slots[i].validator) << OBJECTDB_SLOT_MAX_COUNT_BITS) | (object_slots[i].is_ref_counted ? OBJECTDB_REFERENCE_BIT : 0);
-					DEV_ASSERT(id == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
-					print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos(id) + extra_info);
-
-					count--;
+					ObjectSlotData slot_data = slot.get_data();
+					slot_data.block_idx = block_idx;
+					slot_data.slot_idx = slot_idx;
+					DEV_ASSERT((uint64_t)slot_data == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
+					print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos((uint64_t)slot_data) + extra_info);
 				}
 			}
 			print_line("Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).");
 		}
 	}
 
-	if (object_slots) {
-		memfree(object_slots);
+	for (uint32_t i = 0; i < block_max.get(); i++) {
+		memfree(blocks[i]);
 	}
+	memfree(blocks);
+	blocks = nullptr;
 
-	spin_lock.unlock();
+	mutex.unlock();
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -36,7 +36,7 @@
 #include "core/object/object_id.h"
 #include "core/object/property_info.h"
 #include "core/os/mutex.h"
-#include "core/os/spin_lock.h"
+#include "core/os/spin_lock.h" // IWYU pragma: keep. TODO: remove this and include thread and spin lock properly in other places.
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
@@ -867,25 +867,62 @@ bool Object::derives_from() const {
 }
 
 class ObjectDB {
-// This needs to add up to 63, 1 bit is for reference.
-#define OBJECTDB_VALIDATOR_BITS 39
-#define OBJECTDB_VALIDATOR_MASK ((uint64_t(1) << OBJECTDB_VALIDATOR_BITS) - 1)
-#define OBJECTDB_SLOT_MAX_COUNT_BITS 24
-#define OBJECTDB_SLOT_MAX_COUNT_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_COUNT_BITS) - 1)
-#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
+	static constexpr uint64_t block_bits = 10;
+	static constexpr uint64_t slot_bits = 14;
+	static constexpr uint64_t validator_bits = 39;
+	static constexpr uint64_t reference_bit = uint64_t(1) << 63;
+	static_assert((block_bits + slot_bits + validator_bits) == 63, "This needs to add up to 63, 1 bit is for reference.");
 
-	struct ObjectSlot { // 128 bits per slot.
-		uint64_t validator : OBJECTDB_VALIDATOR_BITS;
-		uint64_t next_free : OBJECTDB_SLOT_MAX_COUNT_BITS;
-		uint64_t is_ref_counted : 1;
+	static constexpr uint64_t block_mask = (uint64_t(1) << block_bits) - 1;
+	static constexpr uint64_t slot_mask = (uint64_t(1) << slot_bits) - 1;
+	static constexpr uint64_t validator_mask = (uint64_t(1) << validator_bits) - 1;
+
+	static constexpr uint64_t max_blocks = uint64_t(1) << block_bits;
+	static constexpr uint64_t max_slots = uint64_t(1) << (block_bits + slot_bits);
+	static constexpr uint64_t block_size = uint64_t(1) << slot_bits;
+
+	struct ObjectSlotData {
+		uint64_t validator = 0;
+		uint16_t block_idx = 0;
+		uint16_t slot_idx = 0;
+		bool is_ref_counted = false;
+
+		_ALWAYS_INLINE_ ObjectSlotData() {}
+		_ALWAYS_INLINE_ explicit ObjectSlotData(uint64_t p_id) {
+			block_idx = p_id & block_mask;
+			slot_idx = (p_id >> block_bits) & slot_mask;
+			validator = (p_id >> (block_bits + slot_bits)) & validator_mask;
+			is_ref_counted = (p_id & reference_bit) != 0;
+		}
+		_ALWAYS_INLINE_ explicit operator uint64_t() const {
+			return block_idx | (slot_idx << block_bits) | (validator << (block_bits + slot_bits)) | (is_ref_counted ? reference_bit : 0);
+		}
+	};
+	struct ObjectSlot {
+		SafeNumeric<uint64_t> data;
 		Object *object = nullptr;
+
+		_ALWAYS_INLINE_ ObjectSlotData get_data() const {
+			return ObjectSlotData{ data.get() };
+		}
+		_ALWAYS_INLINE_ void set_data(const ObjectSlotData &p_data) {
+			data.set(static_cast<uint64_t>(p_data));
+		}
 	};
 
-	static SpinLock spin_lock;
-	static uint32_t slot_count;
-	static uint32_t slot_max;
-	static ObjectSlot *object_slots;
-	static uint64_t validator_counter;
+	inline static ObjectSlot **blocks = nullptr;
+	inline static uint32_t slot_count = 0;
+	inline static uint32_t slot_max = 0;
+	inline static SafeNumeric<uint32_t> block_max{ 0 };
+
+	inline static BinaryMutex mutex;
+	inline static struct {
+		uint64_t value : validator_bits;
+		_ALWAYS_INLINE_ uint64_t incremented() {
+			value = value + 1 != 0 ? value + 1 : 1;
+			return value;
+		}
+	} validator_counter;
 
 	friend class Object;
 	friend void unregister_core_types();
@@ -901,25 +938,17 @@ public:
 	typedef void (*DebugFunc)(Object *p_obj, void *p_user_data);
 
 	_ALWAYS_INLINE_ static Object *get_instance(ObjectID p_instance_id) {
-		uint64_t id = p_instance_id;
-		uint32_t slot = id & OBJECTDB_SLOT_MAX_COUNT_MASK;
+		ObjectSlotData instance_data{ static_cast<uint64_t>(p_instance_id) };
 
-		ERR_FAIL_COND_V(slot >= slot_max, nullptr); // This should never happen unless RID is corrupted.
+		// This should never happen unless RID is corrupted.
+		ERR_FAIL_COND_V(instance_data.block_idx >= block_max.get() || instance_data.slot_idx >= block_size, nullptr);
+		const ObjectSlot &slot = blocks[instance_data.block_idx][instance_data.slot_idx];
 
-		spin_lock.lock();
-
-		uint64_t validator = (id >> OBJECTDB_SLOT_MAX_COUNT_BITS) & OBJECTDB_VALIDATOR_MASK;
-
-		if (unlikely(object_slots[slot].validator != validator)) {
-			spin_lock.unlock();
+		if (unlikely(instance_data.validator != slot.get_data().validator)) {
 			return nullptr;
 		}
 
-		Object *object = object_slots[slot].object;
-
-		spin_lock.unlock();
-
-		return object;
+		return slot.object;
 	}
 
 	template <typename T>

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -28,7 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
@@ -1416,19 +1415,16 @@ static void register_builtin_compat_method(const Vector<String> &p_argnames, con
 void Variant::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 	if (type == Variant::OBJECT) {
 		//call object
+#ifdef DEBUG_ENABLED
+		Object *obj = ObjectDB::get_instance(_get_obj().id);
+#else
 		Object *obj = _get_obj().obj;
+#endif // DEBUG_ENABLED
 		if (!obj) {
 			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			return;
 		}
-#ifdef DEBUG_ENABLED
-		if (EngineDebugger::is_active() && !_get_obj().id.is_ref_counted() && ObjectDB::get_instance(_get_obj().id) == nullptr) {
-			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
-			return;
-		}
-
-#endif // DEBUG_ENABLED
-		r_ret = _get_obj().obj->callp(p_method, p_args, p_argcount, r_error);
+		r_ret = obj->callp(p_method, p_args, p_argcount, r_error);
 
 	} else {
 		r_error.error = Callable::CallError::CALL_OK;
@@ -1447,19 +1443,16 @@ void Variant::callp(const StringName &p_method, const Variant **p_args, int p_ar
 void Variant::call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 	if (type == Variant::OBJECT) {
 		//call object
+#ifdef DEBUG_ENABLED
+		Object *obj = ObjectDB::get_instance(_get_obj().id);
+#else
 		Object *obj = _get_obj().obj;
+#endif // DEBUG_ENABLED
 		if (!obj) {
 			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			return;
 		}
-#ifdef DEBUG_ENABLED
-		if (EngineDebugger::is_active() && !_get_obj().id.is_ref_counted() && ObjectDB::get_instance(_get_obj().id) == nullptr) {
-			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
-			return;
-		}
-
-#endif // DEBUG_ENABLED
-		r_ret = _get_obj().obj->call_const(p_method, p_args, p_argcount, r_error);
+		r_ret = obj->call_const(p_method, p_args, p_argcount, r_error);
 
 		//else if (type==Variant::METHOD) {
 	} else {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -42,8 +42,8 @@ static bool _profile_count_as_native(const Object *p_base_obj, const StringName 
 	if (!p_base_obj) {
 		return false;
 	}
-	StringName cname = p_base_obj->get_class_name();
-	if ((p_methodname == "new" && cname == "GDScript") || p_methodname == "call") {
+	const StringName &cname = p_base_obj->get_class_name();
+	if ((p_methodname == SNAME("new") && cname == GDScript::get_class_static()) || p_methodname == CoreStringName(call)) {
 		return false;
 	}
 	return ClassDB::class_exists(cname) && ClassDB::has_method(cname, p_methodname, false);
@@ -748,7 +748,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 	bool awaited = false;
-	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptrw() : nullptr };
+	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance && p_instance->members.size() > 0 ? &p_instance->members.write[0] : nullptr };
 
 #ifdef DEBUG_ENABLED
 	OPCODE_WHILE(ip < _code_size) {
@@ -886,7 +886,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				bool result = false;
 				if (value->get_type() == Variant::ARRAY) {
@@ -909,13 +909,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 3);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				bool result = false;
 				if (value->get_type() == Variant::DICTIONARY) {
@@ -937,7 +937,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				int native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				bool was_freed = false;
 				Object *object = value->get_validated_object_with_check(was_freed);
@@ -1460,7 +1460,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				if (src->get_type() != Variant::ARRAY) {
 #ifdef DEBUG_ENABLED
@@ -1495,13 +1495,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 3);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				if (src->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED
@@ -1815,7 +1815,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				Array array;
 				array.set_typed(builtin_type, native_type, *script_type);
@@ -1870,13 +1870,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int key_native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_INSTRUCTION_ARG(value_script_type, argc * 2 + 2);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int value_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				Dictionary dict;
 				dict.set_typed(key_builtin_type, key_native_type, *key_script_type, value_builtin_type, value_native_type, *value_script_type);
@@ -1929,8 +1929,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					call_time = OS::get_singleton()->get_ticks_usec();
 				}
 				Variant::Type base_type = base->get_type();
-				Object *base_obj = base->get_validated_object();
-				StringName base_class = base_obj ? base_obj->get_class_name() : StringName();
 #endif
 
 				Variant temp_ret;
@@ -1942,9 +1940,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 					if (ret->get_type() == Variant::NIL) {
 						if (base_type == Variant::OBJECT) {
+							if (*methodname == CoreStringName(free_)) {
+								err_text = R"(Trying to get a return value of a method that returns "void")";
+								OPCODE_BREAK;
+							}
+							Object *base_obj = base->get_validated_object();
 							if (base_obj) {
-								MethodBind *method = ClassDB::get_method(base_class, *methodname);
-								if (*methodname == CoreStringName(free_) || (method && !method->has_return())) {
+								MethodBind *method = ClassDB::get_method(base_obj->get_class_name(), *methodname);
+								if (method && !method->has_return()) {
 									err_text = R"(Trying to get a return value of a method that returns "void")";
 									OPCODE_BREAK;
 								}
@@ -1955,15 +1958,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 					}
 
-					if (!call_async && ret->get_type() == Variant::OBJECT) {
-						// Check if getting a function state without await.
-						bool was_freed = false;
-						Object *obj = ret->get_validated_object_with_check(was_freed);
-
-						if (obj && obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
-							err_text = R"(Trying to call an async function without "await".)";
-							OPCODE_BREAK;
-						}
+					// Check if getting a function state without await.
+					if (!call_async && Object::cast_to<GDScriptFunctionState>(ret->get_validated_object())) {
+						err_text = R"(Trying to call an async function without "await".)";
+						OPCODE_BREAK;
 					}
 #endif
 				} else {
@@ -1972,14 +1970,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 
 				if (GDScriptLanguage::get_singleton()->profiling) {
+					Object *base_obj = base->get_validated_object();
 					uint64_t t_taken = OS::get_singleton()->get_ticks_usec() - call_time;
 					if (GDScriptLanguage::get_singleton()->profile_native_calls && _profile_count_as_native(base_obj, *methodname)) {
-						_profile_native_call(t_taken, *methodname, base_class);
+						_profile_native_call(t_taken, *methodname, base_obj->get_class_name());
 					}
 					function_call_time += t_taken;
 				}
 
-				if (err.error != Callable::CallError::CALL_OK) {
+				if (unlikely(err.error != Callable::CallError::CALL_OK)) {
 					String methodstr = *methodname;
 					String basestr = _get_var_type(base);
 					bool is_callable = false;
@@ -2409,7 +2408,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _global_names_count);
-				StringName function = _global_names_ptr[_code_ptr[ip + 2]];
+				const StringName &function = _global_names_ptr[_code_ptr[ip + 2]];
 
 				Variant **argptrs = instruction_args;
 
@@ -2848,7 +2847,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 3];
 				int native_type_idx = _code_ptr[ip + 4];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				if (r->get_type() != Variant::ARRAY) {
 #ifdef DEBUG_ENABLED
@@ -2884,13 +2883,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int key_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 2);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 6];
 				int value_native_type_idx = _code_ptr[ip + 7];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				if (r->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/58279
Fixes https://github.com/godotengine/godot/issues/65404

It was tested only on linux as I don't have access to other OS. Also as of current master the function calls don't have any obvious bottlenecks in release builds, but I found another one that is still relevant.

## Technical overview
 
After a bunch of random tests I found 1 bottleneck in release build and 2 in debug builds. For release build and 1 in debug it is reading and writing from the object, like `var test = obj.variable`, it stems from using `ObjectDB::get_instance` with a spin lock. And the last bottleneck in the debug builds is calling instance functions, which is also added by additional validation that calls  `ObjectDB::get_instance`, I also think changes to atomics affects debug the most, but it's just a strong suspicion. The relevant results are further in testing.

To fix them this PR implements lock-free `ObjectDB::get_instance`, changes StringName assignment to use const reference where possible, groups the code related to calls in a couple of places, replaces `ptrw` from `p_instance->members` to taking an address from a direct write proxy.

Similar PR: https://github.com/godotengine/godot/pull/98469

The major differences are the usage of fixed size blocks instead of exponential blocks, which leads to the validator bits being unchanged, the additional usage of `SafeNumeric` for the parts accessible from the now lock-free `ObjectDB::get_instance`, code shuffling is new, this PR doesn't change RWLock, and a variation of weak variant is already being used on master, so it's not here.

Also as mentioned in similar PR if the multiple threads work on the shared data you won't gain any speed when using multiple threads. I created a test case that proofs it. The case creates conditions that leads to `_ObjectDebugLock` being created from several threads on the same object. And then later for comparison I compiled the same PR without `_ObjectDebugLock`, with everything else being the same, and tested them both, the results are under `call_shared`.

Tbh, everything except lock-free `ObjectDB::get_instance` feels like manually implementing changes that will be applied automatically for a release build, but I still think they are worth making as it will make multi-threading also usable in debug builds.

I did a bunch of tests on [Godot v4.5.1](https://github.com/godotengine/godot/issues/65404#issuecomment-3764332291) and in comparison to current master the function calls on the same script actually get a speed up now in release, I think this is related to the new weak variant being used for the scripts inside the VM. Also the weak variant is a new addition, but I forgot what my results were without it as I didn't write them down. It feels like release build can perform some sort of optimization for `StringName` assignment that debug build just can't do.

If I tried to think of the downsides of this PR it would be the usage of fixed blocks for object db, as now it will be slower to create a large amount of objects at once.

## Performance testing

Tested on [testthreads4.6_2026-04-13_03-41-25.zip](https://github.com/user-attachments/files/26661552/testthreads4.6_2026-04-13_03-41-25.zip)

Build command editor: `scons target=editor accesskit=no use_llvm=yes linker=lld production=yes debug_symbols=yes tests=yes optimize=speed`
Build command release: `scons target=template_release accesskit=no use_llvm=yes linker=lld production=yes optimize=speed`

The basic test was to divide the iterations between threads and to perform the most basic interaction inside the loop, in theory this should imitate perfectly parallelizable work. The number of iterations was `200_000_000`. 

The results are presented as tables. In the columns was written the number of threads this attempt used, 0th thread is main thread that serves as the control.
Suffixes:
- `_debug` - tested it in launched from Godot project
- `_tool` - tested it inside tool script in editor
- `_release` - tested it in export release

Godot v4.7.dev (0509fd1b0) - EndeavourOS SMP PREEMPT_DYNAMIC Thu, 02 Apr 2026 23:33:01 +0000 on X11 - X11 display driver, Multi-window, 2 monitors - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 1650 (nvidia; 595.58.03) - Intel(R) Core(TM) i5-9300H CPU @ 2.40GHz (8 threads) - 15.49 GiB memory

<details>
<summary>func_var, this one is fine</summary>
Reading and writing from the instance field directly is actually fine.

```gdscript
var increment := 1
func func_var(count: int) -> int:
    var time_before: int = Time.get_ticks_msec()
    var sum := 0
    for i in count:
        sum += increment
    finished.emit.call_deferred(Time.get_ticks_msec() - time_before)
    return sum
```

Master
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| func_var_debug        |  3941 |  4516 |  3768 |  4169 |  4121 |  3466 |  2693 |  2638 |  2513 |
| func_var_tool        |  3541 |  3935 |  1961 |  1381 |  1118 |  1254 |  1098 |  1064 |  1009 |
| func_var_release        |  2564 |  2965 |  1639 |  1197 |   929 |   910 |   856 |   708 |   674 |

PR
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| func_var_debug        |  3875 |  4889 |  3434 |  3959 |  3965 |  3403 |  2993 |  2699 |  2508 |
| func_var_tool        |  3655 |  3584 |  2220 |  1342 |  1139 |  1259 |  1200 |  1225 |  1179 |
| func_var_release        |  2515 |  3259 |  1678 |  1112 |  1033 |  1312 |   742 |  1097 |   664 |
</details>
<details>
<summary>func_obj, all builds affected</summary>
This affects all builds.

```gdscript
func func_obj(count: int) -> int:
    var time_before: int = Time.get_ticks_msec()
    var sum := 0
    var obj := HelperObj.new() 
    for i in count:
        sum += obj.increment # increment is 1
    obj.free()
    finished.emit.call_deferred(Time.get_ticks_msec() - time_before)
    return sum
```

Master
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| func_obj_debug        |  9352 | 11108 | 12078 | 13996 | 16124 | 14252 | 14133 | 15946 | 18331 |
| func_obj_tool        |  8901 |  9492 | 16298 | 13736 | 16371 | 14391 | 14580 | 14918 | 15810 |
| func_obj_release        |  7453 |  7824 | 12125 | 17255 | 19763 | 17851 | 17745 | 18343 | 19532 |

PR
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| func_obj_debug        | 10225 | 10931 |  8934 |  7158 |  6465 |  5975 |  5242 |  4665 |  4517 |
| func_obj_tool        |  9091 |  9027 |  4900 |  3465 |  2661 |  3619 |  3175 |  3022 |  3058 |
| func_obj_release        |  7475 |  8349 |  4351 |  3402 |  3034 |  2671 |  2909 |  2187 |  2540 |
</details>
<details>
<summary>call_unique, debug only</summary>
This only affects debug.

```gdscript
func call_unique(count: int) -> int:
    var time_before: int = Time.get_ticks_msec()
    var sum := 0
    for i in count:
        sum += get_instance_increment()
    finished.emit.call_deferred(Time.get_ticks_msec() - time_before)
    return sum

func get_instance_increment() -> int:
    return 1
```

Master
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| call_unique_debug | 23744 | 26476 | 32111 | 30675 | 31940 | 31488 | 33194 | 36530 | 42334 |
| call_unique_tool | 22722 | 23416 | 28704 | 27576 | 29707 | 31220 | 34250 | 36061 | 38576 |
| call_unique_release | 15028 | 15766 |  8368 |  6642 |  5393 |  5457 |  5020 |  4949 |  5001 |

PR
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| call_unique_debug | 21476 | 22927 | 18353 | 14603 | 13299 | 12706 | 11031 |  9848 |  9366 |
| call_unique_tool | 19792 | 20555 | 10416 |  7472 |  5704 |  7233 |  6331 |  6540 |  6475 |
| call_unique_release | 14839 | 17010 |  9360 |  6564 |  5672 |  5789 |  5146 |  4871 |  4797 |
</details>
<details>
<summary>call_shared, _ObjectDebugLock debug test</summary>
The code is the same as `call_unique`, only it was being run on the node itself, so on one instance. There is no testing for release as it is not used in release build.

Master
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| call_shared_debug | 23782 | 25826 | 42679 | 44543 | 50338 | 48074 | 49899 | 53131 | 61984 |
| call_shared_tool | 20599 | 20673 | 31161 | 30979 | 29625 | 28246 | 28538 | 33447 | 37182 |

PR
| Name            |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| --------------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| call_shared_debug | 19878 | 21890 | 21836 | 19996 | 22220 | 21698 | 21566 | 21786 | 21941 |
| call_shared_tool | 17831 | 18907 | 16352 | 16666 | 19827 | 20293 | 20640 | 20784 | 20746 |

PR without `_ObjectDebugLock`
| Name        |     0 |     1 |     2 |     3 |     4 |     5 |     6 |     7 |     8 |
| ----------- | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: | ----: |
| call_shared_debug | 18055 | 19901 | 16174 | 13551 | 12380 | 12527 | 10661 |  9636 |  9347 |
| call_shared_tool | 16583 | 17187 |  8811 |  6181 |  4943 |  5700 |  5588 |  5416 |  5733 |

Just by creating `_ObjectDebugLock` from several threads on the same object, we didn't gain any speed.

</details>
