### PR TITLE
[macOS] Fix Metal crash in VM.

### DIFF
--- a/drivers/metal/metal_device_properties.cpp
+++ b/drivers/metal/metal_device_properties.cpp
@@ -164,7 +164,9 @@ void MetalDeviceProperties::init_features(MTL::Device *p_device) {
 		features.supports_native_image_atomics = false;
 	}
 
-	if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, *)) {
+	if (OS::get_singleton()->get_processor_name().contains("Virtual")) {
+		features.supports_residency_sets = false;
+	} else if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, *)) {
 		features.supports_residency_sets = true;
 	} else {
 		features.supports_residency_sets = false;

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2509,13 +2509,15 @@ Error RenderingDeviceDriverMetal::_copy_queue_initialize() {
 	copy_queue_buffer.get()->setLabel(MTLSTR("Copy Command Scratch Buffer"));
 
 	if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 1.0, *)) {
-		MTL::ResidencySetDescriptor *rs_desc = MTL::ResidencySetDescriptor::alloc()->init();
-		rs_desc->setInitialCapacity(2);
-		rs_desc->setLabel(MTLSTR("Copy Queue Residency Set"));
-		NS::Error *error = nullptr;
-		copy_queue_rs = NS::TransferPtr(device->newResidencySet(rs_desc, &error));
-		rs_desc->release();
-		copy_queue.get()->addResidencySet(copy_queue_rs.get());
+		if (!OS::get_singleton()->get_processor_name().contains("Virtual")) {
+			MTL::ResidencySetDescriptor *rs_desc = MTL::ResidencySetDescriptor::alloc()->init();
+			rs_desc->setInitialCapacity(2);
+			rs_desc->setLabel(MTLSTR("Copy Queue Residency Set"));
+			NS::Error *error = nullptr;
+			copy_queue_rs = NS::TransferPtr(device->newResidencySet(rs_desc, &error));
+			rs_desc->release();
+			copy_queue.get()->addResidencySet(copy_queue_rs.get());
+		}
 	}
 
 	return OK;


### PR DESCRIPTION
Seems like residency sets are non-functional in VM.

Fixes https://github.com/godotengine/godot/issues/117372