### PR TITLE
CI: Update all actions to latest versions, fixing Node 20 deprecation warnings

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Download Godot Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: godotengine/godot-cpp

--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -1,0 +1,25 @@
+name: Pre-commit
+description: Setup pre-commit, and run it.
+
+inputs:
+  extra_args:
+    description: Options to pass to pre-commit run
+    required: false
+    default: '--all-files'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - run: |
+        pip install pre-commit
+        pre-commit install
+      shell: bash
+
+    - run: |
+        pre-commit run --show-diff-on-failure --color=always --files ${{ inputs.extra_args }}
+      shell: bash

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Setup older .NET SDK as baseline
         if: matrix.build-mono
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           # Targeting the oldest version we want to support to ensure it still builds.
           dotnet-version: 8.0.100

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -40,7 +40,7 @@ jobs:
           files_yaml_from_source_file: .github/changed_files.yml
 
       - name: Style checks via pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: ./.github/actions/pre-commit
         env:
           CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
         with:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Emscripten latest
-        uses: mymindstorm/setup-emsdk@v14
+        uses: emscripten-core/setup-emsdk@v16
         with:
           version: ${{ env.EM_VERSION }}
           no-cache: true


### PR DESCRIPTION
Re-implement the pre-commit action locally as the upstream one is unmaintained and won't bump the actions/checkout version.