### PR TITLE
Fix max instance computation when creating vertex arrays.

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3970,6 +3970,12 @@ RID RenderingDevice::vertex_array_create(uint32_t p_vertex_count, VertexFormatID
 						vformat("Vertex attribute (%d) uses instancing, but it's just too small.", atf.location));
 
 				uint32_t instances_allowed = available / atf.stride;
+
+				// The remaining space might be able to fit another instance.
+				if ((available % atf.stride) >= element_size) {
+					++instances_allowed;
+				}
+
 				vertex_array.max_instances_allowed = MIN(instances_allowed, vertex_array.max_instances_allowed);
 			}
 		}


### PR DESCRIPTION
Fixes #118374.

The problem is caused by the calculation ignoring remaining space in the buffer. With the following configuration:

Format: R16G16
Offset: 4
Stride: 8

It computes the maximum number of instances using `(buffer_size - 4) / 8`. However, the 4 bytes at the end of the buffer that can fit `R16G16` are not counted due to truncation in the division. The PR makes it account for them.