### PR TITLE
Make ParticleProcessMaterial Amount Ratio deterministic

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -921,7 +921,13 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "	PhysicalParameters physics_params;\n";
 	code += "	calculate_initial_physical_params(physics_params, alt_seed);\n";
 	code += "	process_display_param(params, 0.0);\n";
-	code += "	if (rand_from_seed(alt_seed) > AMOUNT_RATIO) {\n";
+	code += "	if (AMOUNT_RATIO > 0.0) {\n";
+	code += "		const float inv_amount_ratio = 1.0 / AMOUNT_RATIO;\n";
+	code += "		float remainder = mod(float(NUMBER), inv_amount_ratio);\n";
+	code += "		if (remainder >= 1.0) {\n";
+	code += "			ACTIVE = false;\n";
+	code += "		}\n";
+	code += "	} else {\n";
 	code += "		ACTIVE = false;\n";
 	code += "	}\n\n";
 


### PR DESCRIPTION
Previously, a random check was used to discard particles according to the value of Amount Ratio in GPUParticles. This made its behavior less predictable.

The new behavior matches a GPUParticles node with a lowered Amount property. For example, a GPUParticles node with Amount = 8 and Amount Ratio = 0.25 will look the same as a GPUParticles node with Amount = 2 and Amount Ratio = 1.0.

- This closes https://github.com/godotengine/godot/issues/104276.

**Testing project:** [test_particle_amount_ratio_deterministic.zip](https://github.com/user-attachments/files/26681139/test_particle_amount_ratio_deterministic.zip)

## Preview

*This video was recorded on `master` to show a comparison with the current behavior. The behavior of this PR matches the particles on the right. If you run the testing project with this PR, all columns will look identical.*

[particle_amount_ratio_deterministic.webm](https://github.com/user-attachments/assets/f1de6d89-647d-4ee1-aac2-01f1398d0c13)
