### PR TITLE
Fix: Sync audio bus volume slider when AudioServer state changes exte…

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -158,6 +158,15 @@ void EditorAudioBus::_notification(int p_what) {
 				_update_visible_channels();
 			}
 
+			// Sync the volume slider if AudioServer state was changed externally.
+			float current_db = AudioServer::get_singleton()->get_bus_volume_db(get_index());
+			float current_normalized = _scaled_db_to_normalized_volume(current_db);
+			if (!Math::is_equal_approx((float)slider->get_value(), current_normalized)) {
+				updating_bus = true;
+				slider->set_value(current_normalized);
+				updating_bus = false;
+			}
+
 			for (int i = 0; i < cc; i++) {
 				float real_peak[2] = { -100, -100 };
 				bool activity_found = false;


### PR DESCRIPTION
The audio bus volume slider in the editor did not update when the
AudioServer volume was changed externally (e.g. by the audio import
settings dialog resetting the master bus to 0 dB). This caused the
slider to display a stale value after reimport, making it appear as
if the volume was unchanged until the user manually moved the slider.

Add a lightweight check in EditorAudioBus::NOTIFICATION_PROCESS that
compares the current AudioServer bus volume against the slider value
and syncs the slider when they diverge.