### PR TITLE
Don't print UID errors when cache is not initialized

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -169,6 +169,8 @@ void ResourceUID::add_id(ID p_id, const String &p_path) {
 		reverse_cache[c.cs] = p_id;
 	}
 	changed = true;
+	// The cache was never loaded (probably does not exist), so assume that first ID initializes it.
+	cache_initialized = true;
 }
 
 void ResourceUID::set_id(ID p_id, const String &p_path) {
@@ -207,7 +209,12 @@ String ResourceUID::get_id_path(ID p_id) const {
 	}
 #endif
 
-	ERR_FAIL_COND_V_MSG(!cache, String(), vformat("Unrecognized UID: \"%s\".", id_to_text(p_id)));
+	if (unlikely(!cache)) {
+		if (cache_initialized) {
+			ERR_PRINT(vformat("Unrecognized UID: \"%s\".", id_to_text(p_id)));
+		}
+		return String();
+	}
 	const CharString &cs = cache->cs;
 	return String::utf8(cs.ptr());
 }
@@ -329,6 +336,7 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 
 	cache_entries = entry_count;
 	changed = false;
+	cache_initialized = true;
 	return OK;
 }
 

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -61,6 +61,7 @@ private:
 
 	uint32_t cache_entries = 0;
 	bool changed = false;
+	bool cache_initialized = false;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Fixes #117362

I was only able to reproduce the errors if `uid_cache.bin` was missing. The errors come from ProjectSettings loading, so they are not relevant for the editor.