### PR TITLE
Make Camera3D inspector preview match viewport project settings

### DIFF
--- a/editor/scene/3d/camera_3d_editor_plugin.cpp
+++ b/editor/scene/3d/camera_3d_editor_plugin.cpp
@@ -86,9 +86,21 @@ Camera3DEditor::Camera3DEditor() {
 
 bool Camera3DPreview::camera_preview_folded = false;
 
-void Camera3DPreview::_update_sub_viewport_size() {
+void Camera3DPreview::_update_sub_viewport_settings() {
 	const Size2i camera_size = Node3DEditor::get_camera_viewport_size(camera);
 	centering_container->set_ratio(camera_size.aspect());
+
+	sub_viewport->set_msaa_3d(GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d"));
+	sub_viewport->set_screen_space_aa(GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa"));
+	sub_viewport->set_use_debanding(GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding"));
+	sub_viewport->set_transparent_background(GLOBAL_GET("rendering/viewport/transparent_background"));
+
+	sub_viewport->set_positional_shadow_atlas_size(GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_size"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(0, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(1, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(2, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(3, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_16_bits(GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_16_bits"));
 }
 
 void Camera3DPreview::_toggle_folding(bool p_folded) {
@@ -122,12 +134,16 @@ Camera3DPreview::Camera3DPreview(Camera3D *p_camera) {
 	EditorNode::get_singleton()->register_hdr_viewport(sub_viewport);
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_project_settings_changed));
-	_update_sub_viewport_size();
+	_update_sub_viewport_settings();
 }
 
 void Camera3DPreview::_project_settings_changed() {
-	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/size")) {
-		_update_sub_viewport_size();
+	if (
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/size") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/anti_aliasing/quality") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/viewport/transparent_background") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality")) {
+		_update_sub_viewport_settings();
 	}
 }
 

--- a/editor/scene/3d/camera_3d_editor_plugin.cpp
+++ b/editor/scene/3d/camera_3d_editor_plugin.cpp
@@ -85,9 +85,21 @@ Camera3DEditor::Camera3DEditor() {
 
 bool Camera3DPreview::camera_preview_folded = false;
 
-void Camera3DPreview::_update_sub_viewport_size() {
+void Camera3DPreview::_update_sub_viewport_settings() {
 	const Size2i camera_size = Node3DEditor::get_camera_viewport_size(camera);
 	centering_container->set_ratio(camera_size.aspect());
+
+	sub_viewport->set_msaa_3d(GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d"));
+	sub_viewport->set_screen_space_aa(GLOBAL_GET("rendering/anti_aliasing/quality/screen_space_aa"));
+	sub_viewport->set_use_debanding(GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding"));
+	sub_viewport->set_transparent_background(GLOBAL_GET("rendering/viewport/transparent_background"));
+
+	sub_viewport->set_positional_shadow_atlas_size(GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_size"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(0, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(1, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(2, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_quadrant_subdiv(3, GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv"));
+	sub_viewport->set_positional_shadow_atlas_16_bits(GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/atlas_16_bits"));
 }
 
 void Camera3DPreview::_toggle_folding(bool p_folded) {
@@ -121,12 +133,16 @@ Camera3DPreview::Camera3DPreview(Camera3D *p_camera) {
 	EditorNode::get_singleton()->register_hdr_viewport(sub_viewport);
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_project_settings_changed));
-	_update_sub_viewport_size();
+	_update_sub_viewport_settings();
 }
 
 void Camera3DPreview::_project_settings_changed() {
-	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/size")) {
-		_update_sub_viewport_size();
+	if (
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/size") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/anti_aliasing/quality") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/viewport/transparent_background") ||
+			ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality")) {
+		_update_sub_viewport_settings();
 	}
 }
 

--- a/editor/scene/3d/camera_3d_editor_plugin.h
+++ b/editor/scene/3d/camera_3d_editor_plugin.h
@@ -60,7 +60,7 @@ class Camera3DPreview : public MarginContainer {
 
 	static bool camera_preview_folded;
 
-	void _update_sub_viewport_size();
+	void _update_sub_viewport_settings();
 	void _project_settings_changed();
 	void _toggle_folding(bool p_folded);
 


### PR DESCRIPTION
This applies transparency, MSAA, screen-space AA, debanding and positional shadow quality settings to the [Camera3D inspector preview](https://github.com/godotengine/godot/pull/90778) to better match the main viewport.

Some other settings such as scaling 3D mode/scale were already applied to the preview, so the new code does not set those values.

**Testing project:** [test_camera_inspector_preview.zip](https://github.com/user-attachments/files/26682890/test_camera_inspector_preview.zip)

## Preview

*Look at the inspector preview on the right. The scene uses MSAA, SMAA, transparent background and a very low positional shadow resolution.*

*Since the viewport uses a transparent background, it'll show what's behind. The background behind the camera preview is darker than the main viewport, hence the different background color. We could look into displaying a checkerboard background later on to make transparency more obvious.*

Before | After
-|-
<img width="1634" height="892" alt="Screenshot_20260413_192611" src="https://github.com/user-attachments/assets/80691dc0-748e-4739-a699-756bfd3be350" /> | <img width="1634" height="892" alt="Screenshot_20260413_193124" src="https://github.com/user-attachments/assets/22450894-0591-4f9f-a027-fdd2c5cd2e8c" />
