### PR TITLE
Restore z-clip functionality in the Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -806,7 +806,7 @@ void vertex_shader(vec4 vertex_angle_attrib_input,
 
 #if !defined(RENDER_SHADOWS) && !defined(RENDER_SHADOWS_LINEAR)
 #ifdef Z_CLIP_SCALE_USED
-	gl_Position.z = mix(gl_Position.w, gl_Position.z, z_clip_scale);
+	clip_position_output.z = mix(clip_position_output.w, clip_position_output.z, z_clip_scale);
 #endif
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/118523

Regression from https://github.com/godotengine/godot/pull/97151

After https://github.com/godotengine/godot/pull/97151 `gl_Position` is no longer used directly. Instead we write to `clip_position_output` and then set `gl_Position` to `clip_position_output` in the main vertex shader. 