### PR TITLE
Remove `set_width` and `set_height` from DrawableTexture since they are not functional

### DIFF
--- a/doc/classes/DrawableTexture2D.xml
+++ b/doc/classes/DrawableTexture2D.xml
@@ -51,25 +51,11 @@
 				Sets the format of this DrawableTexture.
 			</description>
 		</method>
-		<method name="set_height">
-			<return type="void" />
-			<param index="0" name="height" type="int" />
-			<description>
-				Sets the height of this DrawableTexture.
-			</description>
-		</method>
 		<method name="set_use_mipmaps">
 			<return type="void" />
 			<param index="0" name="mipmaps" type="bool" />
 			<description>
 				Sets if mipmaps should be used on this DrawableTexture.
-			</description>
-		</method>
-		<method name="set_width">
-			<return type="void" />
-			<param index="0" name="width" type="int" />
-			<description>
-				Sets the width of this DrawableTexture.
 			</description>
 		</method>
 		<method name="setup" experimental="This function and its parameters are likely to change in the 4.7 Dev Cycle">

--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -70,28 +70,8 @@ void DrawableTexture2D::setup(int p_width, int p_height, DrawableFormat p_format
 	emit_changed();
 }
 
-void DrawableTexture2D::set_width(int p_width) {
-	ERR_FAIL_COND_MSG(p_width <= 0 || p_width > 16384, "Texture dimensions have to be in the 1 to 16384 range.");
-	if (width == p_width) {
-		return;
-	}
-	width = p_width;
-	notify_property_list_changed();
-	emit_changed();
-}
-
 int DrawableTexture2D::get_width() const {
 	return width;
-}
-
-void DrawableTexture2D::set_height(int p_height) {
-	ERR_FAIL_COND_MSG(p_height <= 0 || p_height > 16384, "Texture dimensions have to be in the 1 to 16384 range.");
-	if (height == p_height) {
-		return;
-	}
-	height = p_height;
-	notify_property_list_changed();
-	emit_changed();
 }
 
 int DrawableTexture2D::get_height() const {
@@ -249,8 +229,6 @@ void DrawableTexture2D::generate_mipmaps() {
 }
 
 void DrawableTexture2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_width", "width"), &DrawableTexture2D::set_width);
-	ClassDB::bind_method(D_METHOD("set_height", "height"), &DrawableTexture2D::set_height);
 	ClassDB::bind_method(D_METHOD("set_format", "format"), &DrawableTexture2D::set_drawable_format);
 	ClassDB::bind_method(D_METHOD("set_use_mipmaps", "mipmaps"), &DrawableTexture2D::set_use_mipmaps);
 	ClassDB::bind_method(D_METHOD("get_use_mipmaps"), &DrawableTexture2D::get_use_mipmaps);

--- a/scene/resources/drawable_texture_2d.h
+++ b/scene/resources/drawable_texture_2d.h
@@ -63,9 +63,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_width(int p_width);
 	int get_width() const override;
-	void set_height(int p_height);
 	int get_height() const override;
 
 	void set_drawable_format(DrawableFormat p_format);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/118178

Supersedes: https://github.com/godotengine/godot/pull/118243

The fundamental problem with set_width/height is that to set both, you end up recreating the texture twice (with https://github.com/godotengine/godot/pull/118243). Further, the API encourages you to frequently change width/height which is a very expensive operation. The reason to expose them is to allow users to easily change width/height (instead of having to call `setup()`). However, it was never a goal to allow users to resize the texture.

In general APIs should be designed so that things that are expected to be done frequently are cheap and easy to do while things that are expensive should be clear (and can be cumbersome). We should not have an API that looks cheap and easy that actually does something expensive and dangerous. 

Ultimately, I think this code slipped through from a previous version where Drawable Textures cached their size and could be serialized to disk. This code wasn't intended to be merged, so its better to remove it before we hit the beta phase. 
