### PR TITLE
Defer minimum size updates in maximum size handling

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1746,7 +1746,7 @@ void Control::update_maximum_size() {
 	}
 
 	// Keep minimum size propagation in sync so parent containers can relayout correctly.
-	update_minimum_size();
+	callable_mp(this, &Control::_update_minimum_size).call_deferred();
 
 	if (!is_visible_in_tree()) {
 		// Invalidate the last maximum size so it will update when made visible.


### PR DESCRIPTION
* Fixes #118501 
* Supersedes #118508 

Switching from a `update_minimum_size()` call to a deferred `_update_minimum_size()` call prevents the engine from doing unnecessary minimum size invalidation on parents when a child's maximum size is updated (relevant to `BoxContainer`, which clips its children through the parent max cache when doing layout) but doesn't result in actual changes. This prevents infinite loops of cache invalidation and size recomputation in those cases.