### PR TITLE
Search inside arrays and dicts when using the inspector filtering

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -49,6 +49,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/add_metadata_dialog.h"
 #include "editor/inspector/editor_properties.h"
+#include "editor/inspector/editor_properties_array_dict.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
@@ -96,126 +97,6 @@ bool EditorInspector::_property_path_matches(const String &p_property_path, cons
 			return true;
 		}
 	}
-	return false;
-}
-
-bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
-	String group;
-	String group_base;
-	String subgroup;
-	String subgroup_base;
-
-	List<PropertyInfo> plist;
-	p_resource->get_property_list(&plist, true);
-
-	// Employ a lighter version of the update_tree() property listing to find a match.
-	for (PropertyInfo &p : plist) {
-		if (p.usage & PROPERTY_USAGE_SUBGROUP) {
-			subgroup = p.name;
-			subgroup_base = p.hint_string.get_slicec(',', 0);
-
-			continue;
-
-		} else if (p.usage & PROPERTY_USAGE_GROUP) {
-			group = p.name;
-			group_base = p.hint_string.get_slicec(',', 0);
-			subgroup = "";
-			subgroup_base = "";
-
-			continue;
-
-		} else if (p.usage & PROPERTY_USAGE_CATEGORY) {
-			group = "";
-			group_base = "";
-			subgroup = "";
-			subgroup_base = "";
-
-			continue;
-
-		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
-				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
-			// Ignore properties that are not supposed to be in the inspector.
-			continue;
-		}
-
-		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_low_end()) {
-			// Do not show this property in low end gfx.
-			continue;
-		}
-
-		if (p.name == "script") {
-			// The script is always hidden in sub inspectors.
-			continue;
-		}
-
-		if (p.name.begins_with("metadata/") && bool(object->call(SNAME("_hide_metadata_from_inspector")))) {
-			// Hide metadata from inspector if required.
-			continue;
-		}
-
-		String path = p.name;
-
-		// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
-		if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
-			if (path.begins_with(subgroup_base)) {
-				path = path.trim_prefix(subgroup_base);
-			} else if (subgroup_base.begins_with(path)) {
-				// Keep it, this is used pretty often.
-			} else {
-				subgroup = ""; // The prefix changed, we are no longer in the subgroup.
-			}
-		}
-
-		// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
-		if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
-			if (path.begins_with(group_base)) {
-				path = path.trim_prefix(group_base);
-			} else if (group_base.begins_with(path)) {
-				// Keep it, this is used pretty often.
-			} else {
-				group = ""; // The prefix changed, we are no longer in the group.
-				subgroup = "";
-			}
-		}
-
-		// Add the group and subgroup to the path.
-		if (!subgroup.is_empty()) {
-			path = subgroup + "/" + path;
-		}
-		if (!group.is_empty()) {
-			path = group + "/" + path;
-		}
-
-		// Get the property label's string.
-		String name_override = (path.contains_char('/')) ? path.substr(path.rfind_char('/') + 1) : path;
-		const int dot = name_override.find_char('.');
-		if (dot != -1) {
-			name_override = name_override.substr(0, dot);
-		}
-
-		// Remove the property from the path.
-		int idx = path.rfind_char('/');
-		if (idx > -1) {
-			path = path.left(idx);
-		} else {
-			path = "";
-		}
-
-		// Check if the property matches the filter.
-		const String property_path = (path.is_empty() ? "" : path + "/") + name_override;
-		if (_property_path_matches(property_path, p_filter, property_name_style)) {
-			return true;
-		}
-
-		// Check if the sub-resource has any properties that match the filter.
-		if (p.hint && p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
-			Ref<Resource> res = p_resource->get(p.name);
-			if (res.is_valid() && _resource_properties_matches(res, p_filter)) {
-				return true;
-			}
-		}
-	}
-
 	return false;
 }
 
@@ -4018,6 +3899,215 @@ String EditorInspector::get_selected_path() const {
 	return property_selected;
 }
 
+bool EditorInspector::resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
+	String group;
+	String group_base;
+	String subgroup;
+	String subgroup_base;
+
+	List<PropertyInfo> plist;
+	p_resource->get_property_list(&plist, true);
+
+	// Employ a lighter version of the update_tree() property listing to find a match.
+	for (PropertyInfo &p : plist) {
+		if (p.usage & PROPERTY_USAGE_SUBGROUP) {
+			subgroup = p.name;
+			subgroup_base = p.hint_string.get_slicec(',', 0);
+
+			continue;
+
+		} else if (p.usage & PROPERTY_USAGE_GROUP) {
+			group = p.name;
+			group_base = p.hint_string.get_slicec(',', 0);
+			subgroup = "";
+			subgroup_base = "";
+
+			continue;
+
+		} else if (p.usage & PROPERTY_USAGE_CATEGORY) {
+			group = "";
+			group_base = "";
+			subgroup = "";
+			subgroup_base = "";
+
+			continue;
+
+		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
+				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+			// Ignore properties that are not supposed to be in the inspector.
+			continue;
+		}
+
+		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_low_end()) {
+			// Do not show this property in low end gfx.
+			continue;
+		}
+
+		if (p.name == "script") {
+			// The script is always hidden in sub inspectors.
+			continue;
+		}
+
+		if (p.name.begins_with("metadata/") && bool(object->call(SNAME("_hide_metadata_from_inspector")))) {
+			// Hide metadata from inspector if required.
+			continue;
+		}
+
+		String path = p.name;
+
+		// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
+		if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
+			if (path.begins_with(subgroup_base)) {
+				path = path.trim_prefix(subgroup_base);
+			} else if (subgroup_base.begins_with(path)) {
+				// Keep it, this is used pretty often.
+			} else {
+				subgroup = ""; // The prefix changed, we are no longer in the subgroup.
+			}
+		}
+
+		// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
+		if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
+			if (path.begins_with(group_base)) {
+				path = path.trim_prefix(group_base);
+			} else if (group_base.begins_with(path)) {
+				// Keep it, this is used pretty often.
+			} else {
+				group = ""; // The prefix changed, we are no longer in the group.
+				subgroup = "";
+			}
+		}
+
+		// Add the group and subgroup to the path.
+		if (!subgroup.is_empty()) {
+			path = subgroup + "/" + path;
+		}
+		if (!group.is_empty()) {
+			path = group + "/" + path;
+		}
+
+		// Get the property label's string.
+		String name_override = (path.contains_char('/')) ? path.substr(path.rfind_char('/') + 1) : path;
+		const int dot = name_override.find_char('.');
+		if (dot != -1) {
+			name_override = name_override.substr(0, dot);
+		}
+
+		// Remove the property from the path.
+		int idx = path.rfind_char('/');
+		if (idx > -1) {
+			path = path.left(idx);
+		} else {
+			path = "";
+		}
+
+		// Check if the property matches the filter.
+		const String property_path = (path.is_empty() ? "" : path + "/") + name_override;
+		if (_property_path_matches(property_path, p_filter, property_name_style)) {
+			return true;
+		}
+
+		// Check if the sub-resource has any properties that match the filter.
+		if (p.hint && p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			Ref<Resource> res = p_resource->get(p.name);
+			if (res.is_valid() && resource_properties_matches(res, p_filter)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool EditorInspector::array_properties_matches(const Array &p_array, const String &p_filter) {
+	bool found = false;
+	for (int i = 0; i < p_array.size(); i++) {
+		Ref<Resource> res = p_array.get(i);
+		if (res.is_valid()) {
+			if (resource_properties_matches(res, p_filter)) {
+				found = true;
+				break;
+			}
+
+			continue;
+		}
+
+		// Search inside inner arrays.
+		Variant var = p_array.get(i);
+		if (var.is_array()) {
+			const Array &array = var;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner dictionaries.
+		if (var.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = var;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
+bool EditorInspector::dict_properties_matches(const Dictionary &p_dict, const String &p_filter) {
+	bool found = false;
+	for (const Variant &k : p_dict.get_key_list()) {
+		Ref<Resource> res = k;
+		if (res.is_null()) {
+			res = p_dict[k];
+			if (res.is_null()) {
+				continue;
+			}
+		}
+
+		if (resource_properties_matches(res, p_filter)) {
+			found = true;
+			break;
+		}
+
+		// Search inside inner dictionaries.
+		if (k.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = k;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		Variant value = p_dict[k];
+		if (value.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = value;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner arrays.
+		if (k.is_array()) {
+			const Array &array = k;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		if (value.is_array()) {
+			const Array &array = value;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
 void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> p_plugin) {
 	for (const EditorInspectorPlugin::AddedEditor &F : p_plugin->added_editors) {
 		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
@@ -4517,21 +4607,32 @@ void EditorInspector::update_tree() {
 		if (use_filter && !filter.is_empty()) {
 			const String property_path = property_prefix + (path.is_empty() ? "" : path + "/") + name_override;
 			if (!_property_path_matches(property_path, filter, property_name_style)) {
-				if (!sub_inspectors_enabled || p.hint != PROPERTY_HINT_RESOURCE_TYPE) {
+				if (!sub_inspectors_enabled || !(p.hint == PROPERTY_HINT_RESOURCE_TYPE || p.type == Variant::ARRAY || p.type == Variant::DICTIONARY)) {
 					continue;
 				}
 
-				Ref<Resource> res = object->get(p.name);
-				if (res.is_null()) {
-					continue;
+				if (p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+					Ref<Resource> res = object->get(p.name);
+					if (res.is_valid() && resource_properties_matches(res, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::ARRAY) {
+					const Array &array = object->get(p.name);
+					if (array_properties_matches(array, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::DICTIONARY) {
+					const Dictionary &dict = object->get(p.name);
+					if (dict_properties_matches(dict, filter)) {
+						sub_inspector_use_filter = true;
+					}
 				}
 
-				// Check if the sub-resource has any properties that match the filter.
-				if (!_resource_properties_matches(res, filter)) {
+				if (!sub_inspector_use_filter) {
 					continue;
 				}
-
-				sub_inspector_use_filter = true;
 			}
 		}
 
@@ -4908,6 +5009,16 @@ void EditorInspector::update_tree() {
 					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(ep);
 					if (epr) {
 						epr->set_use_filter(true);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(ep);
+						if (epa) {
+							epa->set_use_filter(true);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(ep);
+							if (epd) {
+								epd->set_use_filter(true);
+							}
+						}
 					}
 				}
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -48,6 +48,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/add_metadata_dialog.h"
 #include "editor/inspector/editor_properties.h"
+#include "editor/inspector/editor_properties_array_dict.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
@@ -95,126 +96,6 @@ bool EditorInspector::_property_path_matches(const String &p_property_path, cons
 			return true;
 		}
 	}
-	return false;
-}
-
-bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
-	String group;
-	String group_base;
-	String subgroup;
-	String subgroup_base;
-
-	List<PropertyInfo> plist;
-	p_resource->get_property_list(&plist, true);
-
-	// Employ a lighter version of the update_tree() property listing to find a match.
-	for (PropertyInfo &p : plist) {
-		if (p.usage & PROPERTY_USAGE_SUBGROUP) {
-			subgroup = p.name;
-			subgroup_base = p.hint_string.get_slicec(',', 0);
-
-			continue;
-
-		} else if (p.usage & PROPERTY_USAGE_GROUP) {
-			group = p.name;
-			group_base = p.hint_string.get_slicec(',', 0);
-			subgroup = "";
-			subgroup_base = "";
-
-			continue;
-
-		} else if (p.usage & PROPERTY_USAGE_CATEGORY) {
-			group = "";
-			group_base = "";
-			subgroup = "";
-			subgroup_base = "";
-
-			continue;
-
-		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
-				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
-			// Ignore properties that are not supposed to be in the inspector.
-			continue;
-		}
-
-		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_low_end()) {
-			// Do not show this property in low end gfx.
-			continue;
-		}
-
-		if (p.name == "script") {
-			// The script is always hidden in sub inspectors.
-			continue;
-		}
-
-		if (p.name.begins_with("metadata/") && bool(object->call(SNAME("_hide_metadata_from_inspector")))) {
-			// Hide metadata from inspector if required.
-			continue;
-		}
-
-		String path = p.name;
-
-		// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
-		if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
-			if (path.begins_with(subgroup_base)) {
-				path = path.trim_prefix(subgroup_base);
-			} else if (subgroup_base.begins_with(path)) {
-				// Keep it, this is used pretty often.
-			} else {
-				subgroup = ""; // The prefix changed, we are no longer in the subgroup.
-			}
-		}
-
-		// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
-		if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
-			if (path.begins_with(group_base)) {
-				path = path.trim_prefix(group_base);
-			} else if (group_base.begins_with(path)) {
-				// Keep it, this is used pretty often.
-			} else {
-				group = ""; // The prefix changed, we are no longer in the group.
-				subgroup = "";
-			}
-		}
-
-		// Add the group and subgroup to the path.
-		if (!subgroup.is_empty()) {
-			path = subgroup + "/" + path;
-		}
-		if (!group.is_empty()) {
-			path = group + "/" + path;
-		}
-
-		// Get the property label's string.
-		String name_override = (path.contains_char('/')) ? path.substr(path.rfind_char('/') + 1) : path;
-		const int dot = name_override.find_char('.');
-		if (dot != -1) {
-			name_override = name_override.substr(0, dot);
-		}
-
-		// Remove the property from the path.
-		int idx = path.rfind_char('/');
-		if (idx > -1) {
-			path = path.left(idx);
-		} else {
-			path = "";
-		}
-
-		// Check if the property matches the filter.
-		const String property_path = (path.is_empty() ? "" : path + "/") + name_override;
-		if (_property_path_matches(property_path, p_filter, property_name_style)) {
-			return true;
-		}
-
-		// Check if the sub-resource has any properties that match the filter.
-		if (p.hint && p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
-			Ref<Resource> res = p_resource->get(p.name);
-			if (res.is_valid() && _resource_properties_matches(res, p_filter)) {
-				return true;
-			}
-		}
-	}
-
 	return false;
 }
 
@@ -4037,6 +3918,215 @@ String EditorInspector::get_selected_path() const {
 	return property_selected;
 }
 
+bool EditorInspector::resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
+	String group;
+	String group_base;
+	String subgroup;
+	String subgroup_base;
+
+	List<PropertyInfo> plist;
+	p_resource->get_property_list(&plist, true);
+
+	// Employ a lighter version of the update_tree() property listing to find a match.
+	for (PropertyInfo &p : plist) {
+		if (p.usage & PROPERTY_USAGE_SUBGROUP) {
+			subgroup = p.name;
+			subgroup_base = p.hint_string.get_slicec(',', 0);
+
+			continue;
+
+		} else if (p.usage & PROPERTY_USAGE_GROUP) {
+			group = p.name;
+			group_base = p.hint_string.get_slicec(',', 0);
+			subgroup = "";
+			subgroup_base = "";
+
+			continue;
+
+		} else if (p.usage & PROPERTY_USAGE_CATEGORY) {
+			group = "";
+			group_base = "";
+			subgroup = "";
+			subgroup_base = "";
+
+			continue;
+
+		} else if (p.name.begins_with("metadata/_") || !(p.usage & PROPERTY_USAGE_EDITOR) || _is_property_disabled_by_feature_profile(p.name) ||
+				(p_filter.is_empty() && restrict_to_basic && !(p.usage & PROPERTY_USAGE_EDITOR_BASIC_SETTING))) {
+			// Ignore properties that are not supposed to be in the inspector.
+			continue;
+		}
+
+		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_low_end()) {
+			// Do not show this property in low end gfx.
+			continue;
+		}
+
+		if (p.name == "script") {
+			// The script is always hidden in sub inspectors.
+			continue;
+		}
+
+		if (p.name.begins_with("metadata/") && bool(object->call(SNAME("_hide_metadata_from_inspector")))) {
+			// Hide metadata from inspector if required.
+			continue;
+		}
+
+		String path = p.name;
+
+		// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
+		if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
+			if (path.begins_with(subgroup_base)) {
+				path = path.trim_prefix(subgroup_base);
+			} else if (subgroup_base.begins_with(path)) {
+				// Keep it, this is used pretty often.
+			} else {
+				subgroup = ""; // The prefix changed, we are no longer in the subgroup.
+			}
+		}
+
+		// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
+		if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
+			if (path.begins_with(group_base)) {
+				path = path.trim_prefix(group_base);
+			} else if (group_base.begins_with(path)) {
+				// Keep it, this is used pretty often.
+			} else {
+				group = ""; // The prefix changed, we are no longer in the group.
+				subgroup = "";
+			}
+		}
+
+		// Add the group and subgroup to the path.
+		if (!subgroup.is_empty()) {
+			path = subgroup + "/" + path;
+		}
+		if (!group.is_empty()) {
+			path = group + "/" + path;
+		}
+
+		// Get the property label's string.
+		String name_override = (path.contains_char('/')) ? path.substr(path.rfind_char('/') + 1) : path;
+		const int dot = name_override.find_char('.');
+		if (dot != -1) {
+			name_override = name_override.substr(0, dot);
+		}
+
+		// Remove the property from the path.
+		int idx = path.rfind_char('/');
+		if (idx > -1) {
+			path = path.left(idx);
+		} else {
+			path = "";
+		}
+
+		// Check if the property matches the filter.
+		const String property_path = (path.is_empty() ? "" : path + "/") + name_override;
+		if (_property_path_matches(property_path, p_filter, property_name_style)) {
+			return true;
+		}
+
+		// Check if the sub-resource has any properties that match the filter.
+		if (p.hint && p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			Ref<Resource> res = p_resource->get(p.name);
+			if (res.is_valid() && resource_properties_matches(res, p_filter)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool EditorInspector::array_properties_matches(const Array &p_array, const String &p_filter) {
+	bool found = false;
+	for (int i = 0; i < p_array.size(); i++) {
+		Ref<Resource> res = p_array.get(i);
+		if (res.is_valid()) {
+			if (resource_properties_matches(res, p_filter)) {
+				found = true;
+				break;
+			}
+
+			continue;
+		}
+
+		// Search inside inner arrays.
+		Variant var = p_array.get(i);
+		if (var.is_array()) {
+			const Array &array = var;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner dictionaries.
+		if (var.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = var;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
+bool EditorInspector::dict_properties_matches(const Dictionary &p_dict, const String &p_filter) {
+	bool found = false;
+	for (const Variant &k : p_dict.get_key_list()) {
+		Ref<Resource> res = k;
+		if (res.is_null()) {
+			res = p_dict[k];
+			if (res.is_null()) {
+				continue;
+			}
+		}
+
+		if (resource_properties_matches(res, p_filter)) {
+			found = true;
+			break;
+		}
+
+		// Search inside inner dictionaries.
+		if (k.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = k;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		Variant value = p_dict[k];
+		if (value.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = value;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner arrays.
+		if (k.is_array()) {
+			const Array &array = k;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		if (value.is_array()) {
+			const Array &array = value;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
 void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> p_plugin) {
 	for (const EditorInspectorPlugin::AddedEditor &F : p_plugin->added_editors) {
 		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
@@ -4536,21 +4626,32 @@ void EditorInspector::update_tree() {
 		if (use_filter && !filter.is_empty()) {
 			const String property_path = property_prefix + (path.is_empty() ? "" : path + "/") + name_override;
 			if (!_property_path_matches(property_path, filter, property_name_style)) {
-				if (!sub_inspectors_enabled || p.hint != PROPERTY_HINT_RESOURCE_TYPE) {
+				if (!sub_inspectors_enabled || !(p.hint == PROPERTY_HINT_RESOURCE_TYPE || p.type == Variant::ARRAY || p.type == Variant::DICTIONARY)) {
 					continue;
 				}
 
-				Ref<Resource> res = object->get(p.name);
-				if (res.is_null()) {
-					continue;
+				if (p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+					Ref<Resource> res = object->get(p.name);
+					if (res.is_valid() && resource_properties_matches(res, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::ARRAY) {
+					const Array &array = object->get(p.name);
+					if (array_properties_matches(array, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::DICTIONARY) {
+					const Dictionary &dict = object->get(p.name);
+					if (dict_properties_matches(dict, filter)) {
+						sub_inspector_use_filter = true;
+					}
 				}
 
-				// Check if the sub-resource has any properties that match the filter.
-				if (!_resource_properties_matches(res, filter)) {
+				if (!sub_inspector_use_filter) {
 					continue;
 				}
-
-				sub_inspector_use_filter = true;
 			}
 		}
 
@@ -4927,6 +5028,16 @@ void EditorInspector::update_tree() {
 					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(ep);
 					if (epr) {
 						epr->set_use_filter(true);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(ep);
+						if (epa) {
+							epa->set_use_filter(true);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(ep);
+							if (epd) {
+								epd->set_use_filter(true);
+							}
+						}
 					}
 				}
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -48,6 +48,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/add_metadata_dialog.h"
 #include "editor/inspector/editor_properties.h"
+#include "editor/inspector/editor_properties_array_dict.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
@@ -98,7 +99,7 @@ bool EditorInspector::_property_path_matches(const String &p_property_path, cons
 	return false;
 }
 
-bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
+bool EditorInspector::resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter) {
 	String group;
 	String group_base;
 	String subgroup;
@@ -209,13 +210,102 @@ bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resour
 		// Check if the sub-resource has any properties that match the filter.
 		if (p.hint && p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 			Ref<Resource> res = p_resource->get(p.name);
-			if (res.is_valid() && _resource_properties_matches(res, p_filter)) {
+			if (res.is_valid() && resource_properties_matches(res, p_filter)) {
 				return true;
 			}
 		}
 	}
 
 	return false;
+}
+
+bool EditorInspector::array_properties_matches(const Array &p_array, const String &p_filter) {
+	bool found = false;
+	for (int i = 0; i < p_array.size(); i++) {
+		Ref<Resource> res = p_array.get(i);
+		if (res.is_valid()) {
+			if (resource_properties_matches(res, p_filter)) {
+				found = true;
+				break;
+			}
+
+			continue;
+		}
+
+		// Search inside inner arrays.
+		Variant var = p_array.get(i);
+		if (var.is_array()) {
+			const Array &array = var;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner dictionaries.
+		if (var.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = var;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
+bool EditorInspector::dict_properties_matches(const Dictionary &p_dict, const String &p_filter) {
+	bool found = false;
+	for (const Variant &k : p_dict.get_key_list()) {
+		Ref<Resource> res = k;
+		if (res.is_null()) {
+			res = p_dict[k];
+			if (res.is_null()) {
+				continue;
+			}
+		}
+
+		if (resource_properties_matches(res, p_filter)) {
+			found = true;
+			break;
+		}
+
+		// Search inside inner dictionaries.
+		if (k.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = k;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		Variant value = p_dict[k];
+		if (value.get_type() == Variant::DICTIONARY) {
+			const Dictionary &dict = value;
+			if (dict_properties_matches(dict, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+
+		// Search inside inner arrays.
+		if (k.is_array()) {
+			const Array &array = k;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+		if (value.is_array()) {
+			const Array &array = value;
+			if (array_properties_matches(array, p_filter)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
 }
 
 String EditorProperty::get_tooltip_string(const String &p_string) const {
@@ -4230,6 +4320,16 @@ void EditorInspector::_apply_property_editor_flags(EditorProperty *p_ep, bool p_
 		EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(p_ep);
 		if (epr) {
 			epr->set_use_filter(true);
+		} else {
+			EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(p_ep);
+			if (epa) {
+				epa->set_use_filter(true);
+			} else {
+				EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(p_ep);
+				if (epd) {
+					epd->set_use_filter(true);
+				}
+			}
 		}
 	}
 
@@ -4769,21 +4869,32 @@ void EditorInspector::update_tree() {
 		if (use_filter && !filter.is_empty()) {
 			const String property_path = property_prefix + (path.is_empty() ? "" : path + "/") + name_override;
 			if (!_property_path_matches(property_path, filter, property_name_style)) {
-				if (!sub_inspectors_enabled || p.hint != PROPERTY_HINT_RESOURCE_TYPE) {
+				if (!sub_inspectors_enabled || !(p.hint == PROPERTY_HINT_RESOURCE_TYPE || p.type == Variant::ARRAY || p.type == Variant::DICTIONARY)) {
 					continue;
 				}
 
-				Ref<Resource> res = object->get(p.name);
-				if (res.is_null()) {
-					continue;
+				if (p.hint == PROPERTY_HINT_RESOURCE_TYPE) {
+					Ref<Resource> res = object->get(p.name);
+					if (res.is_valid() && resource_properties_matches(res, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::ARRAY) {
+					const Array &array = object->get(p.name);
+					if (array_properties_matches(array, filter)) {
+						sub_inspector_use_filter = true;
+					}
+
+				} else if (p.type == Variant::DICTIONARY) {
+					const Dictionary &dict = object->get(p.name);
+					if (dict_properties_matches(dict, filter)) {
+						sub_inspector_use_filter = true;
+					}
 				}
 
-				// Check if the sub-resource has any properties that match the filter.
-				if (!_resource_properties_matches(res, filter)) {
+				if (!sub_inspector_use_filter) {
 					continue;
 				}
-
-				sub_inspector_use_filter = true;
 			}
 		}
 

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -732,6 +732,8 @@ class EditorInspector : public ScrollContainer {
 	GDCLASS(EditorInspector, ScrollContainer);
 
 	friend class EditorPropertyResource;
+	friend class EditorPropertyArray;
+	friend class EditorPropertyDictionary;
 
 public:
 	struct PropertyClipboard {
@@ -842,7 +844,6 @@ private:
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
 	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
-	bool _resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
 
 	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -904,6 +905,10 @@ public:
 
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
+
+	bool resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
+	bool array_properties_matches(const Array &p_array, const String &p_filter);
+	bool dict_properties_matches(const Dictionary &p_dict, const String &p_filter);
 
 	void update_tree();
 	void update_property(const String &p_prop);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -730,6 +730,8 @@ class EditorInspector : public ScrollContainer {
 	GDCLASS(EditorInspector, ScrollContainer);
 
 	friend class EditorPropertyResource;
+	friend class EditorPropertyArray;
+	friend class EditorPropertyDictionary;
 
 public:
 	struct PropertyClipboard {
@@ -840,7 +842,6 @@ private:
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
 	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
-	bool _resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
 
 	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -902,6 +903,10 @@ public:
 
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
+
+	bool resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
+	bool array_properties_matches(const Array &p_array, const String &p_filter);
+	bool dict_properties_matches(const Dictionary &p_dict, const String &p_filter);
 
 	void update_tree();
 	void update_property(const String &p_prop);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -753,6 +753,8 @@ class EditorInspector : public ScrollContainer {
 	GDCLASS(EditorInspector, ScrollContainer);
 
 	friend class EditorPropertyResource;
+	friend class EditorPropertyArray;
+	friend class EditorPropertyDictionary;
 
 public:
 	struct PropertyClipboard {
@@ -865,7 +867,6 @@ private:
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
 	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
-	bool _resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
 
 	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -937,6 +938,10 @@ public:
 
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
+
+	bool resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
+	bool array_properties_matches(const Array &p_array, const String &p_filter);
+	bool dict_properties_matches(const Dictionary &p_dict, const String &p_filter);
 
 	void update_tree();
 	void update_property(const String &p_prop);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3748,6 +3748,10 @@ void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 }
 
 void EditorPropertyResource::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
 	use_filter = p_use;
 	if (sub_inspector) {
 		update_property();

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3761,6 +3761,10 @@ void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 }
 
 void EditorPropertyResource::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
 	use_filter = p_use;
 	if (sub_inspector) {
 		update_property();

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3778,6 +3778,10 @@ void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 }
 
 void EditorPropertyResource::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
 	use_filter = p_use;
 	if (sub_inspector) {
 		update_property();

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -379,6 +379,17 @@ void EditorPropertyArray::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyArray::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyArray::update_property() {
 	Variant array = get_edited_property_value();
 
@@ -510,19 +521,51 @@ void EditorPropertyArray::update_property() {
 		paginator->update(page_index, max_page);
 		paginator->set_visible(max_page > 0);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property).unbind(1));
+				}
+			}
+		}
+
 		for (Slot &slot : slots) {
 			bool slot_visible = &slot != &reorder_slot && slot.index < size;
-			slot.container->set_visible(slot_visible);
-			// If not visible no need to update it
-			if (!slot_visible) {
-				continue;
-			}
-
 			int idx = slot.index;
-			Variant::Type value_type = subtype;
 
+			Variant::Type value_type = subtype;
 			if (value_type == Variant::NIL) {
 				value_type = array.get(idx).get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (slot_visible && !filter.is_empty()) {
+				bool matches = false;
+				if (value_type == Variant::OBJECT) {
+					Ref<Resource> res = array.get(idx);
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (value_type == Variant::ARRAY) {
+					Array arr = array.get(idx);
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (value_type == Variant::DICTIONARY) {
+					Dictionary dict = array.get(idx);
+					matches = parent_inspector->dict_properties_matches(dict, filter);
+				}
+
+				slot_visible = matches;
+			}
+
+			slot.container->set_visible(slot_visible);
+			// If not visible no need to update it.
+			if (!slot_visible) {
+				continue;
 			}
 
 			// Check if the editor property needs to be updated.
@@ -549,7 +592,24 @@ void EditorPropertyArray::update_property() {
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
 
-				if (slot.reorder_button) {
+				if (use_filter) {
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(true);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_use_filter(true);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_use_filter(true);
+							}
+						}
+					}
+				}
+
+				if (slot.reorder_button && filter.is_empty()) {
 					new_prop->add_inline_control(slot.reorder_button, INLINE_CONTROL_LEFT);
 					slot.reorder_button->get_parent()->move_child(slot.reorder_button, 0);
 				}
@@ -1257,6 +1317,17 @@ void EditorPropertyDictionary::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyDictionary::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyDictionary::update_property() {
 	Variant updated_val = get_edited_property_value();
 
@@ -1386,20 +1457,83 @@ void EditorPropertyDictionary::update_property() {
 
 		add_panel->set_visible(page_index == max_page);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property).unbind(1));
+				}
+			}
+		}
+
 		for (Slot &slot : slots) {
-			bool slot_visible = slot.index < size;
-			slot.container->set_visible(slot_visible);
 			// If not visible no need to update it.
-			if (!slot_visible) {
+			if (slot.index >= size) {
+				slot.container->hide();
 				continue;
 			}
 
+			Variant key;
+			object->get_by_property_name(slot.key_name, key);
+			Variant::Type key_type = key.get_type();
+
+			Variant value;
+			object->get_by_property_name(slot.prop_name, value);
+			Variant::Type value_type;
+			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
+				value_type = value_subtype;
+			} else {
+				value_type = value.get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (!filter.is_empty()) {
+				bool matches = false;
+
+				// Check key.
+				if (key_type == Variant::OBJECT) {
+					Ref<Resource> res = key;
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (key_type == Variant::ARRAY) {
+					Array arr = key;
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (key_type == Variant::DICTIONARY) {
+					Dictionary subdict = key;
+					matches = parent_inspector->dict_properties_matches(subdict, filter);
+				}
+
+				if (!matches) {
+					// Check value.
+					if (value_type == Variant::OBJECT) {
+						Ref<Resource> res = value;
+						if (res.is_valid()) {
+							matches = parent_inspector->resource_properties_matches(res, filter);
+						}
+					} else if (value_type == Variant::ARRAY) {
+						Array arr = value;
+						matches = parent_inspector->array_properties_matches(arr, filter);
+					} else if (value_type == Variant::DICTIONARY) {
+						Dictionary subdict = value;
+						matches = parent_inspector->dict_properties_matches(subdict, filter);
+					}
+				}
+
+				if (!matches) {
+					slot.container->hide();
+					continue;
+				}
+			}
+
+			slot.container->show();
+
 			// Check if the editor property key needs to be updated.
 			if (slot.prop_key) {
-				Variant key;
-				object->get_by_property_name(slot.key_name, key);
-				Variant::Type key_type = key.get_type();
-
 				bool key_as_id = Object::cast_to<EncodedObjectAsID>(key);
 				if (key_type != slot.key_type || (key_type == Variant::OBJECT && key_as_id != slot.key_as_id)) {
 					slot.key_as_id = key_as_id;
@@ -1412,6 +1546,7 @@ void EditorPropertyDictionary::update_property() {
 					} else {
 						new_prop = EditorInspector::instantiate_property_editor(this, key_type, "", key_subtype_hint, key_subtype_hint_string, PROPERTY_USAGE_NONE);
 					}
+
 					new_prop->set_read_only(true);
 					new_prop->set_selectable(false);
 					new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
@@ -1422,30 +1557,29 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_draw_label(false);
 					new_prop->set_mouse_filter(MOUSE_FILTER_PASS);
 					new_prop->set_mouse_behavior_recursive(MOUSE_BEHAVIOR_DISABLED);
-					EditorPropertyArray *arr_prop = Object::cast_to<EditorPropertyArray>(new_prop);
-					if (arr_prop) {
-						arr_prop->set_preview_value(true);
+
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(use_filter);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_preview_value(true);
+							epa->set_use_filter(use_filter);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_preview_value(true);
+								epd->set_use_filter(use_filter);
+							}
+						}
 					}
-					EditorPropertyDictionary *dict_prop = Object::cast_to<EditorPropertyDictionary>(new_prop);
-					if (dict_prop) {
-						dict_prop->set_preview_value(true);
-					}
+
 					slot.set_key_prop(new_prop);
 					if (slot.prop) {
 						slot.prop->add_inline_control(new_prop, INLINE_CONTROL_LEFT);
 					}
 				}
-			}
-
-			Variant value;
-			object->get_by_property_name(slot.prop_name, value);
-
-			Variant::Type value_type;
-
-			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
-				value_type = value_subtype;
-			} else {
-				value_type = value.get_type();
 			}
 
 			// Check if the editor property needs to be updated.
@@ -1489,8 +1623,8 @@ void EditorPropertyDictionary::update_property() {
 				slot.set_prop(new_prop);
 
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-				Variant key = dict.get_key_at_index(slot.index);
-				String cs = key.get_construct_string();
+				Variant idx_key = dict.get_key_at_index(slot.index);
+				String cs = idx_key.get_construct_string();
 				slot.prop->set_tooltip_text(cs);
 			}
 

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -363,6 +363,17 @@ void EditorPropertyArray::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyArray::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyArray::update_property() {
 	Variant array = get_edited_property_value();
 
@@ -494,20 +505,52 @@ void EditorPropertyArray::update_property() {
 		paginator->update(page_index, max_page);
 		paginator->set_visible(max_page > 0);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property).unbind(1));
+				}
+			}
+		}
+
 		float name_size = 0;
 		for (Slot &slot : slots) {
 			bool slot_visible = &slot != &reorder_slot && slot.index < size;
-			slot.container->set_visible(slot_visible);
-			// If not visible no need to update it
-			if (!slot_visible) {
-				continue;
-			}
-
 			int idx = slot.index;
-			Variant::Type value_type = subtype;
 
+			Variant::Type value_type = subtype;
 			if (value_type == Variant::NIL) {
 				value_type = array.get(idx).get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (slot_visible && !filter.is_empty()) {
+				bool matches = false;
+				if (value_type == Variant::OBJECT) {
+					Ref<Resource> res = array.get(idx);
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (value_type == Variant::ARRAY) {
+					Array arr = array.get(idx);
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (value_type == Variant::DICTIONARY) {
+					Dictionary dict = array.get(idx);
+					matches = parent_inspector->dict_properties_matches(dict, filter);
+				}
+
+				slot_visible = matches;
+			}
+
+			slot.container->set_visible(slot_visible);
+			// If not visible no need to update it.
+			if (!slot_visible) {
+				continue;
 			}
 
 			// Check if the editor property needs to be updated.
@@ -534,7 +577,24 @@ void EditorPropertyArray::update_property() {
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
 
-				if (slot.reorder_button) {
+				if (use_filter) {
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(true);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_use_filter(true);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_use_filter(true);
+							}
+						}
+					}
+				}
+
+				if (slot.reorder_button && filter.is_empty()) {
 					new_prop->add_inline_control(slot.reorder_button, INLINE_CONTROL_LEFT);
 					slot.reorder_button->get_parent()->move_child(slot.reorder_button, 0);
 				}
@@ -1248,6 +1308,17 @@ void EditorPropertyDictionary::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyDictionary::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyDictionary::update_property() {
 	Variant updated_val = get_edited_property_value();
 
@@ -1377,20 +1448,83 @@ void EditorPropertyDictionary::update_property() {
 
 		add_panel->set_visible(page_index == max_page);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property).unbind(1));
+				}
+			}
+		}
+
 		for (Slot &slot : slots) {
-			bool slot_visible = slot.index < size;
-			slot.container->set_visible(slot_visible);
 			// If not visible no need to update it.
-			if (!slot_visible) {
+			if (slot.index >= size) {
+				slot.container->hide();
 				continue;
 			}
 
+			Variant key;
+			object->get_by_property_name(slot.key_name, key);
+			Variant::Type key_type = key.get_type();
+
+			Variant value;
+			object->get_by_property_name(slot.prop_name, value);
+			Variant::Type value_type;
+			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
+				value_type = value_subtype;
+			} else {
+				value_type = value.get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (!filter.is_empty()) {
+				bool matches = false;
+
+				// Check key.
+				if (key_type == Variant::OBJECT) {
+					Ref<Resource> res = key;
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (key_type == Variant::ARRAY) {
+					Array arr = key;
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (key_type == Variant::DICTIONARY) {
+					Dictionary subdict = key;
+					matches = parent_inspector->dict_properties_matches(subdict, filter);
+				}
+
+				if (!matches) {
+					// Check value.
+					if (value_type == Variant::OBJECT) {
+						Ref<Resource> res = value;
+						if (res.is_valid()) {
+							matches = parent_inspector->resource_properties_matches(res, filter);
+						}
+					} else if (value_type == Variant::ARRAY) {
+						Array arr = value;
+						matches = parent_inspector->array_properties_matches(arr, filter);
+					} else if (value_type == Variant::DICTIONARY) {
+						Dictionary subdict = value;
+						matches = parent_inspector->dict_properties_matches(subdict, filter);
+					}
+				}
+
+				if (!matches) {
+					slot.container->hide();
+					continue;
+				}
+			}
+
+			slot.container->show();
+
 			// Check if the editor property key needs to be updated.
 			if (slot.prop_key) {
-				Variant key;
-				object->get_by_property_name(slot.key_name, key);
-				Variant::Type key_type = key.get_type();
-
 				bool key_as_id = Object::cast_to<EncodedObjectAsID>(key);
 				if (key_type != slot.key_type || (key_type == Variant::OBJECT && key_as_id != slot.key_as_id)) {
 					slot.key_as_id = key_as_id;
@@ -1403,6 +1537,7 @@ void EditorPropertyDictionary::update_property() {
 					} else {
 						new_prop = EditorInspector::instantiate_property_editor(this, key_type, "", key_subtype_hint, key_subtype_hint_string, PROPERTY_USAGE_NONE);
 					}
+
 					new_prop->set_read_only(true);
 					new_prop->set_selectable(false);
 					new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
@@ -1413,30 +1548,29 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_draw_label(false);
 					new_prop->set_mouse_filter(MOUSE_FILTER_PASS);
 					new_prop->set_mouse_behavior_recursive(MOUSE_BEHAVIOR_DISABLED);
-					EditorPropertyArray *arr_prop = Object::cast_to<EditorPropertyArray>(new_prop);
-					if (arr_prop) {
-						arr_prop->set_preview_value(true);
+
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(use_filter);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_preview_value(true);
+							epa->set_use_filter(use_filter);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_preview_value(true);
+								epd->set_use_filter(use_filter);
+							}
+						}
 					}
-					EditorPropertyDictionary *dict_prop = Object::cast_to<EditorPropertyDictionary>(new_prop);
-					if (dict_prop) {
-						dict_prop->set_preview_value(true);
-					}
+
 					slot.set_key_prop(new_prop);
 					if (slot.prop) {
 						slot.prop->add_inline_control(new_prop, INLINE_CONTROL_LEFT);
 					}
 				}
-			}
-
-			Variant value;
-			object->get_by_property_name(slot.prop_name, value);
-
-			Variant::Type value_type;
-
-			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
-				value_type = value_subtype;
-			} else {
-				value_type = value.get_type();
 			}
 
 			// Check if the editor property needs to be updated.
@@ -1480,8 +1614,8 @@ void EditorPropertyDictionary::update_property() {
 				slot.set_prop(new_prop);
 
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-				Variant key = dict.get_key_at_index(slot.index);
-				String cs = key.get_construct_string();
+				Variant idx_key = dict.get_key_at_index(slot.index);
+				String cs = idx_key.get_construct_string();
 				slot.prop->set_tooltip_text(cs);
 			}
 

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -383,6 +383,17 @@ void EditorPropertyArray::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyArray::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyArray::make_passthrough(bool p_passthrough) {
 	edit->set_mouse_filter(p_passthrough ? MOUSE_FILTER_PASS : MOUSE_FILTER_STOP);
 }
@@ -518,19 +529,51 @@ void EditorPropertyArray::update_property() {
 		paginator->update(page_index, max_page);
 		paginator->set_visible(max_page > 0);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyArray::update_property).unbind(1));
+				}
+			}
+		}
+
 		for (Slot &slot : slots) {
 			bool slot_visible = &slot != &reorder_slot && slot.index < size;
-			slot.container->set_visible(slot_visible);
-			// If not visible no need to update it
-			if (!slot_visible) {
-				continue;
-			}
-
 			int idx = slot.index;
-			Variant::Type value_type = subtype;
 
+			Variant::Type value_type = subtype;
 			if (value_type == Variant::NIL) {
 				value_type = array.get(idx).get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (slot_visible && !filter.is_empty()) {
+				bool matches = false;
+				if (value_type == Variant::OBJECT) {
+					Ref<Resource> res = array.get(idx);
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (value_type == Variant::ARRAY) {
+					Array arr = array.get(idx);
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (value_type == Variant::DICTIONARY) {
+					Dictionary dict = array.get(idx);
+					matches = parent_inspector->dict_properties_matches(dict, filter);
+				}
+
+				slot_visible = matches;
+			}
+
+			slot.container->set_visible(slot_visible);
+			// If not visible no need to update it.
+			if (!slot_visible) {
+				continue;
 			}
 
 			// Check if the editor property needs to be updated.
@@ -557,7 +600,24 @@ void EditorPropertyArray::update_property() {
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
 
-				if (slot.reorder_button) {
+				if (use_filter) {
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(true);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_use_filter(true);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_use_filter(true);
+							}
+						}
+					}
+				}
+
+				if (slot.reorder_button && filter.is_empty()) {
 					new_prop->add_inline_control(slot.reorder_button, INLINE_CONTROL_LEFT);
 					slot.reorder_button->get_parent()->move_child(slot.reorder_button, 0);
 				}
@@ -1268,6 +1328,17 @@ void EditorPropertyDictionary::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyDictionary::set_use_filter(bool p_use) {
+	if (use_filter == p_use) {
+		return;
+	}
+
+	use_filter = p_use;
+	if (is_inside_tree()) {
+		update_property();
+	}
+}
+
 void EditorPropertyDictionary::make_passthrough(bool p_passthrough) {
 	edit->set_mouse_filter(p_passthrough ? Control::MOUSE_FILTER_PASS : Control::MOUSE_FILTER_STOP);
 }
@@ -1401,20 +1472,83 @@ void EditorPropertyDictionary::update_property() {
 
 		add_panel->set_visible(page_index == max_page);
 
+		EditorInspector *parent_inspector = nullptr;
+		String filter;
+		if (use_filter) {
+			parent_inspector = get_parent_inspector();
+			LineEdit *search = parent_inspector->search_box;
+			if (search) {
+				filter = search->get_text();
+				if (!search->is_connected(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property))) {
+					search->connect(SceneStringName(text_changed), callable_mp(this, &EditorPropertyDictionary::update_property).unbind(1));
+				}
+			}
+		}
+
 		for (Slot &slot : slots) {
-			bool slot_visible = slot.index < size;
-			slot.container->set_visible(slot_visible);
 			// If not visible no need to update it.
-			if (!slot_visible) {
+			if (slot.index >= size) {
+				slot.container->hide();
 				continue;
 			}
 
+			Variant key;
+			object->get_by_property_name(slot.key_name, key);
+			Variant::Type key_type = key.get_type();
+
+			Variant value;
+			object->get_by_property_name(slot.prop_name, value);
+			Variant::Type value_type;
+			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
+				value_type = value_subtype;
+			} else {
+				value_type = value.get_type();
+			}
+
+			// Hide if it doesn't match the inspector filter.
+			if (!filter.is_empty()) {
+				bool matches = false;
+
+				// Check key.
+				if (key_type == Variant::OBJECT) {
+					Ref<Resource> res = key;
+					if (res.is_valid()) {
+						matches = parent_inspector->resource_properties_matches(res, filter);
+					}
+				} else if (key_type == Variant::ARRAY) {
+					Array arr = key;
+					matches = parent_inspector->array_properties_matches(arr, filter);
+				} else if (key_type == Variant::DICTIONARY) {
+					Dictionary subdict = key;
+					matches = parent_inspector->dict_properties_matches(subdict, filter);
+				}
+
+				if (!matches) {
+					// Check value.
+					if (value_type == Variant::OBJECT) {
+						Ref<Resource> res = value;
+						if (res.is_valid()) {
+							matches = parent_inspector->resource_properties_matches(res, filter);
+						}
+					} else if (value_type == Variant::ARRAY) {
+						Array arr = value;
+						matches = parent_inspector->array_properties_matches(arr, filter);
+					} else if (value_type == Variant::DICTIONARY) {
+						Dictionary subdict = value;
+						matches = parent_inspector->dict_properties_matches(subdict, filter);
+					}
+				}
+
+				if (!matches) {
+					slot.container->hide();
+					continue;
+				}
+			}
+
+			slot.container->show();
+
 			// Check if the editor property key needs to be updated.
 			if (slot.prop_key) {
-				Variant key;
-				object->get_by_property_name(slot.key_name, key);
-				Variant::Type key_type = key.get_type();
-
 				bool key_as_id = Object::cast_to<EncodedObjectAsID>(key);
 				if (key_type != slot.key_type || (key_type == Variant::OBJECT && key_as_id != slot.key_as_id)) {
 					slot.key_as_id = key_as_id;
@@ -1427,6 +1561,7 @@ void EditorPropertyDictionary::update_property() {
 					} else {
 						new_prop = EditorInspector::instantiate_property_editor(this, key_type, "", key_subtype_hint, key_subtype_hint_string, PROPERTY_USAGE_NONE);
 					}
+
 					new_prop->set_read_only(true);
 					new_prop->set_selectable(false);
 					new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
@@ -1436,30 +1571,29 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 					new_prop->make_passthrough(true);
 					new_prop->set_draw_label(false);
-					EditorPropertyArray *arr_prop = Object::cast_to<EditorPropertyArray>(new_prop);
-					if (arr_prop) {
-						arr_prop->set_preview_value(true);
+
+					EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(new_prop);
+					if (epr) {
+						epr->set_use_filter(use_filter);
+					} else {
+						EditorPropertyArray *epa = Object::cast_to<EditorPropertyArray>(new_prop);
+						if (epa) {
+							epa->set_preview_value(true);
+							epa->set_use_filter(use_filter);
+						} else {
+							EditorPropertyDictionary *epd = Object::cast_to<EditorPropertyDictionary>(new_prop);
+							if (epd) {
+								epd->set_preview_value(true);
+								epd->set_use_filter(use_filter);
+							}
+						}
 					}
-					EditorPropertyDictionary *dict_prop = Object::cast_to<EditorPropertyDictionary>(new_prop);
-					if (dict_prop) {
-						dict_prop->set_preview_value(true);
-					}
+
 					slot.set_key_prop(new_prop);
 					if (slot.prop) {
 						slot.prop->add_inline_control(new_prop, INLINE_CONTROL_LEFT);
 					}
 				}
-			}
-
-			Variant value;
-			object->get_by_property_name(slot.prop_name, value);
-
-			Variant::Type value_type;
-
-			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
-				value_type = value_subtype;
-			} else {
-				value_type = value.get_type();
 			}
 
 			// Check if the editor property needs to be updated.
@@ -1507,8 +1641,8 @@ void EditorPropertyDictionary::update_property() {
 				slot.set_prop(new_prop);
 
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-				Variant key = dict.get_key_at_index(slot.index);
-				String cs = key.get_construct_string();
+				Variant idx_key = dict.get_key_at_index(slot.index);
+				String cs = idx_key.get_construct_string();
 				slot.prop->set_tooltip_text(cs);
 			}
 

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -117,6 +117,7 @@ class EditorPropertyArray : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -172,6 +173,7 @@ protected:
 public:
 	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyArray();
@@ -236,6 +238,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -270,6 +273,7 @@ protected:
 public:
 	void setup(PropertyHint p_hint, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyDictionary();

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -117,6 +117,7 @@ class EditorPropertyArray : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -173,6 +174,7 @@ protected:
 public:
 	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyArray();
@@ -237,6 +239,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -271,6 +274,7 @@ protected:
 public:
 	void setup(PropertyHint p_hint, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyDictionary();

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -117,6 +117,7 @@ class EditorPropertyArray : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -173,6 +174,7 @@ protected:
 public:
 	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
 	virtual void update_properties_recursive() override;
@@ -239,6 +241,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
+	bool use_filter = false;
 	Button *edit = nullptr;
 	PanelContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
@@ -273,6 +276,7 @@ protected:
 public:
 	void setup(PropertyHint p_hint, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	void set_use_filter(bool p_use);
 	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
 	virtual void update_properties_recursive() override;


### PR DESCRIPTION
This PR adds property filtering to arrays and dictionaries. If those contain resources with properties that match the filter, they will stay, and only show the elements that contains those resources. It will also search inside nested arrays/dicts.

Just so this PR isn't misunderstood, I will reiterate this is just for searching **resource properties** inside arrays/dicts, as this is the purpose of the inspector filter. It won't search for values like strings or integers.

Closes #102370.

<img width="280" height="699" alt="image" src="https://github.com/user-attachments/assets/323ba676-ae2c-454d-8c26-33fdb9d1c083" />