### PR TITLE
Fix BaseButton popup unresponsive on touchscreen after first tap

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -67,7 +67,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->is_pressed()) {
+	if (p_event->is_pressed() && status.touch_index == -1) {
 		status.device_id = p_event->get_device();
 	}
 
@@ -267,6 +267,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
 					status.press_attempt = false;
 					status.pressing_inside = false;
+					status.touch_index = -1; // Action completed, release matching touch so later taps aren't dropped if a modal consumes the release.
 				}
 				status.pressed = !status.pressed;
 				_unpress_group();


### PR DESCRIPTION
Fixes #118517.

Regression from #110893.

On mobile browsers (e.g. iOS Safari), a tap delivers both touch and mouse events, and a popup opened from the
button becomes modal before the matching touch release is dispatched. The release is consumed by the popup,
leaving status.touch_index set so later taps are dropped as non-matching indices. Also only update
status.device_id while no touch interaction is active, so the originating device keeps ownership until its
release is processed.
