### PR TITLE
EditorSceneFormatImporterGLTF: Fix build with `deprecated=no`

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -81,7 +81,7 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	bool trimming = p_options.has("animation/trimming") ? (bool)p_options["animation/trimming"] : false;
 	return gltf_doc->generate_scene(gltf_state, gltf_state->get_bake_fps(), trimming, false);
 #else
-	return gltf->generate_scene(state, state->get_bake_fps(), (bool)p_options["animation/trimming"], false);
+	return gltf_doc->generate_scene(gltf_state, gltf_state->get_bake_fps(), (bool)p_options["animation/trimming"], false);
 #endif
 }
 


### PR DESCRIPTION
These variables were renamed in #96748 (eb8ec10), but the `DISABLE_DEPRECATED` branch was missed.