### PR TITLE
GDExtension: Use real GDType in placeholder

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -738,7 +738,7 @@ ObjectGDExtension *ClassDB::get_placeholder_extension(const StringName &p_class)
 	placeholder_extension->call_virtual_with_data = nullptr;
 	placeholder_extension->recreate_instance = &PlaceholderExtensionInstance::placeholder_class_recreate_instance;
 
-	placeholder_extension->create_gdtype();
+	placeholder_extension->gdtype = ti->gdtype;
 
 	return placeholder_extension;
 }


### PR DESCRIPTION
This fixes an issue that was brought to my attention by @Ivorforce and @raulsntos, where connecting to a signal on a runtime class in the Godot editor would lead to errors like:

```
ERROR: In Object of type 'Player': Attempt to connect nonexistent signal 'hit' to callable 'Main::game_over'.
   at: connect (./core/object/object.cpp:1535)
ERROR: In Object of type 'HUD': Attempt to connect nonexistent signal 'start_game' to callable 'Main::new_game'.
   at: connect (./core/object/object.cpp:1535)
```

Looking at the code, we appear to (incorrectly) be making a new empty GDType for placeholders (which naturally wouldn't have any signals on it), whereas we should probably reuse the real GDType, since nothing about the type itself changes on a placeholder, just the behavior of the instance