### PR TITLE
Add `follow_focus` padding

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -143,6 +143,18 @@
 		<theme_item name="scroll_hint_vertical_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			[Color] used to modulate the [theme_item scroll_hint_vertical] texture.
 		</theme_item>
+		<theme_item name="focus_padding_bottom" data_type="constant" type="int" default="0">
+			The spacing between the focused child and the bottom edge of the [ScrollContainer], used if [member follow_focus] is [code]true[/code].
+		</theme_item>
+		<theme_item name="focus_padding_left" data_type="constant" type="int" default="0">
+			The spacing between the focused child and the left edge of the [ScrollContainer], used if [member follow_focus] is [code]true[/code].
+		</theme_item>
+		<theme_item name="focus_padding_right" data_type="constant" type="int" default="0">
+			The spacing between the focused child and the right edge of the [ScrollContainer], used if [member follow_focus] is [code]true[/code].
+		</theme_item>
+		<theme_item name="focus_padding_top" data_type="constant" type="int" default="0">
+			The spacing between the focused child and the top edge of the [ScrollContainer], used if [member follow_focus] is [code]true[/code].
+		</theme_item>
 		<theme_item name="scrollbar_h_separation" data_type="constant" type="int" default="0">
 			The space between the ScrollContainer's vertical scroll bar and its content, in pixels. No space will be added when the content's minimum size is larger than the ScrollContainer's size.
 		</theme_item>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -363,6 +363,11 @@ void ScrollContainer::ensure_control_visible(Control *p_control) {
 	Size2 size = get_size();
 	Rect2 other_rect = other_in_this.xform(Rect2(Point2(), p_control->get_size()));
 
+	other_rect.position.x -= theme_cache.focus_padding_left;
+	other_rect.position.y -= theme_cache.focus_padding_top;
+	other_rect.size.x += theme_cache.focus_padding_left + theme_cache.focus_padding_right;
+	other_rect.size.y += theme_cache.focus_padding_top + theme_cache.focus_padding_bottom;
+
 	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
 	float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y : 0.0f;
 
@@ -939,6 +944,11 @@ void ScrollContainer::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, ScrollContainer, scroll_hint_vertical_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, ScrollContainer, scroll_hint_horizontal_color);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, focus_padding_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, focus_padding_top);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, focus_padding_right);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, focus_padding_bottom);
 
 	GLOBAL_DEF("gui/common/default_scroll_deadzone", 0);
 }

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -104,6 +104,11 @@ private:
 
 		int scrollbar_h_separation = 0;
 		int scrollbar_v_separation = 0;
+
+		int focus_padding_left = 0;
+		int focus_padding_top = 0;
+		int focus_padding_right = 0;
+		int focus_padding_bottom = 0;
 	} theme_cache;
 
 	void _cancel_drag();


### PR DESCRIPTION
Adds the following theme constants for `ScrollContainer`:
- `focus_padding_left`
- `focus_padding_top`
- `focus_padding_right`
- `focus_padding_bottom`

This adds padding to `ensure_control_visible` (used by `follow_focus`).
For example, if `focus_padding_top` is 100, then the scroll container will add an additional 100 pixels above the rect of the control in `ensure_control_visible`.

When using `follow_focus` without padding, if you are using arrow keys to navigate buttons in a scroll container, then the focused button will always be at the very edge of the scroll container. The padding allows you to add some space inbetween the focused button and the edge of the scroll container.

Partially implements https://github.com/godotengine/godot-proposals/issues/10244.

## Demo project

[follow-focus-padding.zip](https://github.com/user-attachments/files/26693465/follow-focus-padding.zip)
Press tab to focus a button, then use arrow keys to move up/down the scroll container. There will always be 100 pixels between the focused button and the top edge of the scroll container (unless there is less than 100 pixels above the focused button).

Moving to top of scroll container WITHOUT padding:
<img width="1154" height="680" alt="image" src="https://github.com/user-attachments/assets/bc833ed6-9fb6-47b8-8e60-df7c03f24748" />

Moving to top of scroll container WITH padding:
<img width="1154" height="680" alt="image" src="https://github.com/user-attachments/assets/a9a6af95-32a9-4292-8718-b11f7e797521" />

## Footnotes

- I'm not sure if it should be called `padding` or `margin`, but I chose `padding` since it's calculated by increasing the rect of the focused control.
- Since it applies to any usage of `ensure_control_visible` (not just `follow_focus`), it might be better to name it something like `target_padding` instead of `focus_padding`.
- It could alternatively be implemented as a property on the `ScrollContainer` rather than a theme property.