### PR TITLE
[iOS] Fix one-click deploy with Xcode 26.

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2478,7 +2478,7 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 			args.push_back(vformat("hardwareProperties.deviceType MATCHES '%s'", device_types));
 
 			int ec = 0;
-			Error err = OS::get_singleton()->execute("xcrun", args, &devices_json, &ec, true);
+			Error err = OS::get_singleton()->execute("xcrun", args, &devices_json, &ec, false);
 			if (err == OK && ec == 0) {
 				Ref<JSON> json;
 				json.instantiate();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118543

Seems like Xcode 26 `devicectl` can print provisioning profile related warnings (irrelevant for the device list) to the `stderr`, which were making captured JSON invalid.