### PR TITLE
Fix mixed-up German translation for "Copy UV to Polygon"

### DIFF
--- a/editor/translations/editor/de.po
+++ b/editor/translations/editor/de.po
@@ -10094,7 +10094,7 @@ msgid "Copy Polygon to UV"
 msgstr "Polygon zu UV kopieren"
 
 msgid "Copy UV to Polygon"
-msgstr "Polygon zu UV kopieren"
+msgstr "UV zu Polygon kopieren"
 
 msgid "Clear UV"
 msgstr "Leere UV-Map"


### PR DESCRIPTION
The words are swapped, so when the language in the editor is set to German the translation for "Copy UV to Polygon" reads the same as "Copy Polygon to UV" and I don't know one menu item from the other.