### PR TITLE
Add missing dictionary type hints in SVG DPITexture import options

### DIFF
--- a/editor/import/resource_importer_svg.cpp
+++ b/editor/import/resource_importer_svg.cpp
@@ -69,7 +69,7 @@ String ResourceImporterSVG::get_preset_name(int p_idx) const {
 void ResourceImporterSVG::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 1.0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "saturation", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), 1.0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "color_map"), Dictionary()));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "color_map", PROPERTY_HINT_DICTIONARY_TYPE, "Color;Color"), Dictionary()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "fix_alpha_border"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "premult_alpha"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress"), true));


### PR DESCRIPTION
Fixes #118566

This brings it in sync with the property on the DPITexture class.