### PR TITLE
Fix/improve `PopupMenu` and `EditorResourcePicker`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -315,6 +315,13 @@
 				Returns the max states of the item at the given [param index].
 			</description>
 		</method>
+		<method name="get_item_search_behavior" qualifiers="const">
+			<return type="int" enum="PopupMenu.SearchBehavior" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the search behavior of the item at the given [param index].
+			</description>
+		</method>
 		<method name="get_item_shortcut" qualifiers="const">
 			<return type="Shortcut" />
 			<param index="0" name="index" type="int" />
@@ -583,6 +590,14 @@
 				Sets the max states of a multistate item. See [method add_multistate_item] for details.
 			</description>
 		</method>
+		<method name="set_item_search_behavior">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="behavior" type="int" enum="PopupMenu.SearchBehavior" />
+			<description>
+				Sets the search behavior of the item at the given [param index]. See [member search_bar_enabled_on_item_count].
+			</description>
+		</method>
 		<method name="set_item_shortcut">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
@@ -751,6 +766,17 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="SEARCH_NORMAL" value="0" enum="SearchBehavior">
+			The item is visible when it matches the search filter and hidden when it doesn't. This is the default behavior.
+		</constant>
+		<constant name="SEARCH_ALWAYS_HIDE" value="1" enum="SearchBehavior">
+			The item is always hidden when there's a search filter.
+		</constant>
+		<constant name="SEARCH_ALWAYS_SHOW" value="2" enum="SearchBehavior">
+			The item is always visible when there's a search filter.
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="font_accelerator_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 0.8)">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -410,14 +410,14 @@ void EditorResourcePicker::_update_menu_items() {
 		edit_menu->add_separator();
 
 		if (edited_resource.is_valid()) {
-			edit_menu->add_item(TTRC("Copy"), OBJ_MENU_COPY);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCopy")), TTRC("Copy"), OBJ_MENU_COPY);
 			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		}
 
 		if (paste_valid) {
-			edit_menu->add_item(TTRC("Paste"), OBJ_MENU_PASTE);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste"), OBJ_MENU_PASTE);
 			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
-			edit_menu->add_item(TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
 			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		}
 	}

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -299,10 +299,7 @@ void EditorResourcePicker::_update_menu_items() {
 	_ensure_resource_menu();
 	edit_menu->clear();
 
-	// Add options for creating specific subtypes of the base resource type.
 	if (is_editable()) {
-		set_create_options(edit_menu);
-
 		// Add an option to load a resource from a file using the QuickOpen dialog.
 		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("LoadQuick")), TTR("Quick Load..."), OBJ_MENU_QUICKLOAD);
 		edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
@@ -441,6 +438,11 @@ void EditorResourcePicker::_update_menu_items() {
 			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + relative_id);
 			relative_id++;
 		}
+	}
+
+	// Add options for creating specific subtypes of the base resource type.
+	if (is_editable()) {
+		set_create_options(edit_menu);
 	}
 }
 
@@ -670,16 +672,17 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 
 		_ensure_allowed_types();
 		HashSet<StringName> allowed_types(allowed_types_without_convert);
-		if (!allowed_types.is_empty()) {
-			edit_menu->add_separator(TTRC("New"));
-			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_SHOW);
-		}
 
 		for (const StringName &E : allowed_types) {
 			const String &t = E;
 
 			if (!ClassDB::can_instantiate(t)) {
 				continue;
+			}
+
+			if (idx == 0) {
+				edit_menu->add_separator(TTRC("New"));
+				edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_SHOW);
 			}
 
 			inheritors_array.push_back(t);
@@ -695,10 +698,6 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 			}
 
 			idx++;
-		}
-
-		if (edit_menu->get_item_count()) {
-			edit_menu->add_separator();
 		}
 	}
 }
@@ -1534,6 +1533,9 @@ void EditorScriptPicker::set_create_options(Object *p_menu_node) {
 		return;
 	}
 
+	menu_node->add_separator(TTRC("New"));
+	menu_node->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_SHOW);
+
 	if (!(script_owner && script_owner->has_meta(SceneStringName(_custom_type_script)))) {
 		menu_node->add_icon_item(get_editor_theme_icon(SNAME("ScriptCreate")), TTR("New Script..."), OBJ_MENU_NEW_SCRIPT);
 	}
@@ -1544,7 +1546,6 @@ void EditorScriptPicker::set_create_options(Object *p_menu_node) {
 			menu_node->add_icon_item(get_editor_theme_icon(SNAME("ScriptExtend")), TTR("Extend Script..."), OBJ_MENU_EXTEND_SCRIPT);
 		}
 	}
-	menu_node->add_separator();
 }
 
 bool EditorScriptPicker::handle_menu_selected(int p_which) {
@@ -1590,8 +1591,9 @@ void EditorShaderPicker::set_create_options(Object *p_menu_node) {
 		return;
 	}
 
+	menu_node->add_separator(TTRC("New"));
+	menu_node->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_SHOW);
 	menu_node->add_icon_item(get_editor_theme_icon(SNAME("Shader")), TTR("New Shader..."), OBJ_MENU_NEW_SHADER);
-	menu_node->add_separator();
 }
 
 bool EditorShaderPicker::handle_menu_selected(int p_which) {

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -305,10 +305,12 @@ void EditorResourcePicker::_update_menu_items() {
 
 		// Add an option to load a resource from a file using the QuickOpen dialog.
 		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("LoadQuick")), TTR("Quick Load..."), OBJ_MENU_QUICKLOAD);
+		edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		edit_menu->set_item_tooltip(-1, TTR("Opens a quick menu to select from a list of allowed Resource files."));
 
 		// Add an option to load a resource from a file using the regular file dialog.
 		edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Load..."), OBJ_MENU_LOAD);
+		edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 	}
 
 	// Add options for changing existing value of the resource.
@@ -321,18 +323,22 @@ void EditorResourcePicker::_update_menu_items() {
 		if (is_edited_resource_foreign_import) {
 			// The 'Search' icon is a magnifying glass, which seems appropriate, but maybe a bespoke icon is preferred here.
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Search")), TTR("Inspect"), OBJ_MENU_INSPECT);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		} else {
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Edit")), TTR("Edit"), OBJ_MENU_INSPECT);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 			edit_menu->set_item_disabled(-1, force_allow_unique);
 		}
 
 		if (is_editable()) {
 			if (!_is_custom_type_script()) {
 				edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Clear")), TTR("Clear"), OBJ_MENU_CLEAR);
+				edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 				edit_menu->set_item_disabled(-1, force_allow_unique);
 			}
 			bool unique_enabled = _is_uniqueness_enabled();
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 			edit_menu->set_item_disabled(-1, !unique_enabled);
 
 			String modifier = "Ctrl";
@@ -354,6 +360,7 @@ void EditorResourcePicker::_update_menu_items() {
 			if (_has_sub_resources(edited_resource)) {
 				unique_enabled = _is_uniqueness_enabled(true);
 				edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Duplicate")), TTR("Make Unique (Recursive)"), OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
+				edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 				edit_menu->set_item_disabled(-1, !unique_enabled);
 				if (!unique_enabled) {
 					Ref<Resource> parent_res = _has_parent_resource();
@@ -364,14 +371,17 @@ void EditorResourcePicker::_update_menu_items() {
 			}
 
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Save")), TTR("Save"), OBJ_MENU_SAVE);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 			edit_menu->set_item_disabled(-1, force_allow_unique);
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("Save")), TTR("Save As..."), OBJ_MENU_SAVE_AS);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 			edit_menu->set_item_disabled(-1, force_allow_unique);
 		}
 
 		if (edited_resource->get_path().is_resource_file()) {
 			edit_menu->add_separator();
 			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ShowInFileSystem")), TTR("Show in FileSystem"), OBJ_MENU_SHOW_IN_FILE_SYSTEM);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		}
 	}
 
@@ -401,11 +411,14 @@ void EditorResourcePicker::_update_menu_items() {
 
 		if (edited_resource.is_valid()) {
 			edit_menu->add_item(TTRC("Copy"), OBJ_MENU_COPY);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		}
 
 		if (paste_valid) {
 			edit_menu->add_item(TTRC("Paste"), OBJ_MENU_PASTE);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 			edit_menu->add_item(TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_HIDE);
 		}
 	}
 
@@ -659,6 +672,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 		HashSet<StringName> allowed_types(allowed_types_without_convert);
 		if (!allowed_types.is_empty()) {
 			edit_menu->add_separator(TTRC("New"));
+			edit_menu->set_item_search_behavior(-1, PopupMenu::SEARCH_ALWAYS_SHOW);
 		}
 
 		for (const StringName &E : allowed_types) {
@@ -1240,6 +1254,7 @@ void EditorResourcePicker::_ensure_resource_menu() {
 		return;
 	}
 	edit_menu = memnew(PopupMenu);
+	edit_menu->set_search_bar_enabled_on_item_count(1);
 	edit_menu->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	add_child(edit_menu);
 	edit_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk));

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -915,13 +915,15 @@ void PopupMenu::_draw_items() {
 	Point2 ofs;
 
 	// Loop through all items and draw each.
+	bool first_visible = true;
 	for (int i = 0; i < items.size(); i++) {
 		if (!items[i].visible) {
 			continue;
 		}
 
-		// For the first item only add half a separation. For all other items, add a whole separation to the offset.
-		ofs.y += i > 0 ? theme_cache.v_separation : theme_cache.v_separation / 2;
+		// For the first visible item only add half a separation. For all other items, add a whole separation to the offset.
+		ofs.y += first_visible ? theme_cache.v_separation / 2 : theme_cache.v_separation;
+		first_visible = false;
 
 		_shape_item(i);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1518,7 +1518,7 @@ void PopupMenu::_notification(int p_what) {
 						if (!match_found) {
 							// If the last item is not selectable, try re-searching from the start.
 							for (int i = 0; i < search_from; i++) {
-								if (!items[i].separator && !items[i].disabled) {
+								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);
@@ -1538,7 +1538,7 @@ void PopupMenu::_notification(int p_what) {
 
 						bool match_found = false;
 						for (int i = search_from; i >= 0; i--) {
-							if (!items[i].separator && !items[i].disabled) {
+							if (!items[i].separator && !items[i].disabled && items[i].visible) {
 								mouse_over = i;
 								emit_signal(SNAME("id_focused"), items[i].id);
 								scroll_to_item(i);
@@ -1551,7 +1551,7 @@ void PopupMenu::_notification(int p_what) {
 						if (!match_found) {
 							// If the first item is not selectable, try re-searching from the end.
 							for (int i = items.size() - 1; i >= search_from; i--) {
-								if (!items[i].separator && !items[i].disabled) {
+								if (!items[i].separator && !items[i].disabled && items[i].visible) {
 									mouse_over = i;
 									emit_signal(SNAME("id_focused"), items[i].id);
 									scroll_to_item(i);

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3673,7 +3673,7 @@ void PopupMenu::set_visible(bool p_visible) {
 		if (!parent_popup) {
 			search_bar->set_visible(is_search_bar_enabled());
 			if (search_bar->is_visible()) {
-				search_bar->edit(true);
+				search_bar->edit();
 			}
 		}
 	}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -399,7 +399,7 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	const Point2 panel_offset_end = Point2(-panel->get_offset(SIDE_RIGHT), -panel->get_offset(SIDE_BOTTOM)) * win_scale;
 	const Vector2 scaled_this_size = this_rect.size * win_scale;
 	const float scaled_theme_v_separation = theme_cache.v_separation * win_scale;
-	const float scroll_offset = control->get_position().y;
+	const float scroll_offset = control->get_position().y + scroll_container->get_position().y;
 	const float scaled_ofs_cache = items[p_over]._ofs_cache * win_scale;
 	const float scaled_height_cache = items[p_over]._height_cache * win_scale;
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -248,6 +248,10 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 	for (int i = 0; i < items.size(); i++) {
 		_shape_item(i);
 
+		if (!items[i].visible) {
+			continue;
+		}
+
 		icon_max_w = MAX(_get_item_icon_size(i).width, icon_max_w);
 
 		if (items[i].checkable_type && !items[i].separator) {
@@ -1104,6 +1108,8 @@ void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 			}
 		}
 	}
+
+	_update_wrapped_size(true);
 
 	queue_accessibility_update();
 	control->queue_redraw();
@@ -3658,20 +3664,25 @@ void PopupMenu::_pre_popup() {
 	}
 
 	set_content_scale_factor(popup_scale);
-	if (is_wrapping_controls()) {
-		Size2 minsize = get_contents_minimum_size() * popup_scale;
-		Size2 maxsize = get_max_size();
-		if (maxsize.height > 0) {
-			minsize.height = MIN(minsize.height, maxsize.height);
-		}
-		if (maxsize.width > 0) {
-			minsize.width = MIN(minsize.width, maxsize.width);
-		}
-		minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
-		set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
-		Size2i sz = get_size(); // Shrinkwraps to min size.
-		set_size(Vector2i(shrink_width ? 0 : sz.x, shrink_height ? 0 : sz.y));
+	_update_wrapped_size();
+}
+
+void PopupMenu::_update_wrapped_size(bool p_keep_width) {
+	if (!is_wrapping_controls()) {
+		return;
 	}
+	Size2 minsize = get_contents_minimum_size() * get_content_scale_factor();
+	Size2 maxsize = get_max_size();
+	if (maxsize.height > 0) {
+		minsize.height = MIN(minsize.height, maxsize.height);
+	}
+	if (maxsize.width > 0) {
+		minsize.width = MIN(minsize.width, maxsize.width);
+	}
+	minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
+	set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
+	Size2i sz = get_size(); // Shrinkwraps to min size.
+	set_size(Vector2i(shrink_width && !p_keep_width ? 0 : sz.x, shrink_height ? 0 : sz.y));
 }
 
 void PopupMenu::set_visible(bool p_visible) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1091,6 +1091,20 @@ void PopupMenu::_search_bar_input(const Ref<InputEvent> &p_event) {
 void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 	_filter_items(p_new_text);
 
+	prev_mouse_over = mouse_over;
+	mouse_over = -1;
+
+	if (!p_new_text.is_empty()) {
+		for (int i = 0; i < items.size(); i++) {
+			if (!items[i].separator && !items[i].disabled && items[i].visible) {
+				mouse_over = i;
+				emit_signal(SNAME("id_focused"), items[i].id);
+				scroll_to_item(i);
+				break;
+			}
+		}
+	}
+
 	queue_accessibility_update();
 	control->queue_redraw();
 	child_controls_changed();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1338,7 +1338,14 @@ void PopupMenu::_notification(int p_what) {
 			ERR_FAIL_COND(ae.is_null());
 
 			AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_MENU);
-			AccessibilityServer::get_singleton()->update_set_list_item_count(ae, items.size());
+
+			int item_count = 0;
+			for (const Item &item : items) {
+				if (item.visible && !item.separator) {
+					item_count++;
+				}
+			}
+			AccessibilityServer::get_singleton()->update_set_list_item_count(ae, item_count);
 
 			if (accessibility_scroll_element.is_null()) {
 				accessibility_scroll_element = AccessibilityServer::get_singleton()->create_sub_element(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_CONTAINER);
@@ -1351,23 +1358,25 @@ void PopupMenu::_notification(int p_what) {
 
 			float scroll_width = scroll_container->get_v_scroll_bar()->is_visible_in_tree() ? scroll_container->get_v_scroll_bar()->get_size().width : 0;
 			float display_width = control->get_size().width - scroll_width;
-			Point2 ofs;
+			Point2 ofs = scroll_container->get_global_position();
 
+			int item_index = 0;
+			bool first_visible = true;
 			for (int i = 0; i < items.size(); i++) {
 				const Item &item = items.write[i];
-				if (!item.visible) {
-					continue;
-				}
 
-				// Avoid discrepancy between min size and drawn items due to rounding.
-				ofs.y += i > 0 ? theme_cache.v_separation : theme_cache.v_separation - (theme_cache.v_separation / 2);
-
-				Point2 item_ofs = ofs;
 				if (item.accessibility_item_element.is_null()) {
 					item.accessibility_item_element = AccessibilityServer::get_singleton()->create_sub_element(accessibility_scroll_element, AccessibilityServerEnums::AccessibilityRole::ROLE_MENU_ITEM);
 					item.accessibility_item_dirty = true;
 				}
 
+				if (item.visible) {
+					// Avoid discrepancy between min size and drawn items due to rounding.
+					ofs.y += first_visible ? 0 : theme_cache.v_separation;
+					first_visible = false;
+				}
+
+				Point2 item_ofs = ofs;
 				item_ofs.x += item.indent * theme_cache.indent;
 				float h = _get_item_height(i);
 
@@ -1387,18 +1396,26 @@ void PopupMenu::_notification(int p_what) {
 					}
 
 					AccessibilityServer::get_singleton()->update_add_action(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &PopupMenu::_accessibility_action_click).bind(i));
-					AccessibilityServer::get_singleton()->update_set_list_item_index(item.accessibility_item_element, i);
+					AccessibilityServer::get_singleton()->update_set_list_item_index(item.accessibility_item_element, item_index);
 					AccessibilityServer::get_singleton()->update_set_list_item_level(item.accessibility_item_element, 0);
 					AccessibilityServer::get_singleton()->update_set_list_item_selected(item.accessibility_item_element, i == mouse_over);
 					AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, item.xl_text);
 					AccessibilityServer::get_singleton()->update_set_flag(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_DISABLED, item.disabled);
+					AccessibilityServer::get_singleton()->update_set_flag(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !item.visible);
 					AccessibilityServer::get_singleton()->update_set_tooltip(item.accessibility_item_element, item.tooltip);
 
 					AccessibilityServer::get_singleton()->update_set_bounds(item.accessibility_item_element, Rect2(item_ofs, Size2(display_width, h + theme_cache.v_separation)));
 
 					item.accessibility_item_dirty = false;
 				}
-				ofs.y += h;
+
+				if (item.visible) {
+					ofs.y += h;
+
+					if (!item.separator) {
+						item_index++;
+					}
+				}
 			}
 			prev_mouse_over = -1;
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -502,6 +502,19 @@ void PopupMenu::_submenu_timeout() {
 
 void PopupMenu::_input_from_window(const Ref<InputEvent> &p_event) {
 	if (p_event.is_valid()) {
+		if (search_bar->is_visible() && search_bar->has_focus()) {
+			if (p_event->is_action("ui_select", true)) {
+				// Let this propagate to `search_bar`.
+				return;
+			}
+
+			if (p_event->is_action("ui_cancel", true) && !search_bar->get_text().is_empty()) {
+				search_bar->clear();
+				set_input_as_handled();
+				return;
+			}
+		}
+
 		_input_from_window_internal(p_event);
 	} else {
 		WARN_PRINT_ONCE("PopupMenu has received an invalid InputEvent. Consider filtering out invalid events.");
@@ -1083,12 +1096,10 @@ void PopupMenu::_draw_items() {
 }
 
 void PopupMenu::_search_bar_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			search_bar->accept_event();
-		}
+	if (p_event->is_action("ui_up", true) || p_event->is_action("ui_down", true) || p_event->is_action("ui_page_up") || p_event->is_action("ui_page_down")) {
+		// Prevent `LineEdit` from moving the caret when navigating through the list of items.
+		search_bar->accept_event();
+		return;
 	}
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1152,7 +1152,16 @@ void PopupMenu::_filter_items(const String &p_query) {
 
 	for (int i = 0; i < items.size(); i++) {
 		Item &item = items.write[i];
-		item.visible = false;
+
+		if (item.search_behavior == SEARCH_ALWAYS_HIDE) {
+			item.visible = false;
+			continue;
+		} else if (item.search_behavior == SEARCH_ALWAYS_SHOW) {
+			item.visible = true;
+			continue;
+		} else {
+			item.visible = false;
+		}
 
 		if (item.submenu) {
 			for (const PopupMenu::Item &submenu_item : item.submenu->items) {
@@ -2588,6 +2597,27 @@ int PopupMenu::get_item_state(int p_idx) const {
 	return items[p_idx].state;
 }
 
+void PopupMenu::set_item_search_behavior(int p_idx, SearchBehavior p_behavior) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
+	}
+	ERR_FAIL_INDEX(p_idx, items.size());
+	if (items[p_idx].search_behavior == p_behavior) {
+		return;
+	}
+	items.write[p_idx].search_behavior = p_behavior;
+	_filter_items(search_bar->get_text());
+	control->queue_redraw();
+}
+
+PopupMenu::SearchBehavior PopupMenu::get_item_search_behavior(int p_idx) const {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
+	}
+	ERR_FAIL_INDEX_V(p_idx, items.size(), SEARCH_NORMAL);
+	return items[p_idx].search_behavior;
+}
+
 void PopupMenu::set_item_as_separator(int p_idx, bool p_separator) {
 	if (p_idx < 0) {
 		p_idx += get_item_count();
@@ -3446,6 +3476,9 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_multistate_max", "index"), &PopupMenu::get_item_max_states);
 	ClassDB::bind_method(D_METHOD("get_item_multistate", "index"), &PopupMenu::get_item_state);
 
+	ClassDB::bind_method(D_METHOD("set_item_search_behavior", "index", "behavior"), &PopupMenu::set_item_search_behavior);
+	ClassDB::bind_method(D_METHOD("get_item_search_behavior", "index"), &PopupMenu::get_item_search_behavior);
+
 	ClassDB::bind_method(D_METHOD("set_focused_item", "index"), &PopupMenu::set_focused_item);
 	ClassDB::bind_method(D_METHOD("get_focused_item"), &PopupMenu::get_focused_item);
 	ClassDB::bind_method(D_METHOD("set_item_count", "count"), &PopupMenu::set_item_count);
@@ -3504,6 +3537,10 @@ void PopupMenu::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("menu_changed"));
+
+	BIND_ENUM_CONSTANT(SEARCH_NORMAL);
+	BIND_ENUM_CONSTANT(SEARCH_ALWAYS_HIDE);
+	BIND_ENUM_CONSTANT(SEARCH_ALWAYS_SHOW);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, PopupMenu, panel_style, "panel");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, PopupMenu, hover_style, "hover");

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1099,35 +1099,55 @@ void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 }
 
 void PopupMenu::_filter_items(const String &p_query) {
-	PackedStringArray search_names;
-	for (int i = 0; i < items.size(); i++) {
-		search_names.append(items[i].text);
-	}
-
-	Vector<FuzzySearchResult> results;
-	FuzzySearch fuzzy;
-	fuzzy.set_query(p_query, false);
-	fuzzy.search_all(search_names, results);
-
 	for (PopupMenu::Item &item : items) {
-		bool submenu_visible = false;
 		if (item.submenu) {
 			item.submenu->_filter_items(p_query);
-			for (PopupMenu::Item &submenu_item : item.submenu->items) {
+		}
+	}
+
+	for (PopupMenu::Item &item : items) {
+		item.visible = true;
+	}
+
+	if (p_query.is_empty()) {
+		return;
+	}
+
+	PackedStringArray search_candidates;
+	search_candidates.reserve(items.size());
+
+	Vector<int> search_candidate_to_item;
+	search_candidate_to_item.reserve(items.size());
+
+	for (int i = 0; i < items.size(); i++) {
+		Item &item = items.write[i];
+		item.visible = false;
+
+		if (item.submenu) {
+			for (const PopupMenu::Item &submenu_item : item.submenu->items) {
 				if (submenu_item.visible) {
-					submenu_visible = true;
+					item.visible = true;
 					break;
 				}
 			}
 		}
 
-		item.visible = p_query.length() == 0 || submenu_visible;
+		if (!item.separator) {
+			search_candidates.append(item.text);
+			search_candidate_to_item.append(i);
+		}
 	}
 
-	for (const FuzzySearchResult &res : results) {
-		items.write[res.original_index].visible = res.score > 0;
-		if (items[res.original_index].visible && items[res.original_index].submenu) {
-			for (PopupMenu::Item &submenu_item : items[res.original_index].submenu->items) {
+	Vector<FuzzySearchResult> results;
+	FuzzySearch fuzzy;
+	fuzzy.set_query(p_query, false);
+	fuzzy.search_all(search_candidates, results);
+
+	for (const FuzzySearchResult &result : results) {
+		PopupMenu::Item &item = items.write[search_candidate_to_item[result.original_index]];
+		item.visible = true;
+		if (item.submenu) {
+			for (PopupMenu::Item &submenu_item : item.submenu->items) {
 				submenu_item.visible = true;
 			}
 		}

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -45,6 +45,14 @@ class Timer;
 class PopupMenu : public Popup {
 	GDCLASS(PopupMenu, Popup);
 
+public:
+	enum SearchBehavior {
+		SEARCH_NORMAL,
+		SEARCH_ALWAYS_HIDE,
+		SEARCH_ALWAYS_SHOW,
+	};
+
+private:
 	static HashMap<NativeMenu::SystemMenus, PopupMenu *> system_menus;
 
 	struct Item {
@@ -65,6 +73,7 @@ class PopupMenu : public Popup {
 
 		bool checked = false;
 		bool visible = true;
+		SearchBehavior search_behavior = SEARCH_NORMAL;
 		enum {
 			CHECKABLE_TYPE_NONE,
 			CHECKABLE_TYPE_CHECK_BOX,
@@ -379,6 +388,9 @@ public:
 	int get_item_max_states(int p_idx) const;
 	int get_item_state(int p_idx) const;
 
+	void set_item_search_behavior(int p_idx, SearchBehavior p_behavior);
+	SearchBehavior get_item_search_behavior(int p_idx) const;
+
 	void set_focused_item(int p_idx);
 	int get_focused_item() const;
 
@@ -444,3 +456,5 @@ public:
 	PopupMenu();
 	~PopupMenu();
 };
+
+VARIANT_ENUM_CAST(PopupMenu::SearchBehavior);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -242,6 +242,7 @@ class PopupMenu : public Popup {
 	void _search_bar_input(const Ref<InputEvent> &p_event);
 	void _search_bar_text_changed(const String &p_new_text);
 	void _filter_items(const String &p_query);
+	void _update_wrapped_size(bool p_keep_width = false);
 
 	void _close_pressed();
 	void _menu_changed();


### PR DESCRIPTION
Resolves godotengine/godot-proposals#3333.
Relates to godotengine/godot-proposals#43.
Relates to godotengine/godot-proposals#3430.
Relates to godotengine/godot-proposals#3707.
Relates to (and maybe supersedes?) #105182.

> [!NOTE]
> This PR turned into a bit of a kitchen sink, but I've tried my best to split this up into useful commits, so as to make reviewing the individual parts easier. I will also split out the bug fixes into their own PRs, so they don't get held back by whatever UX discussion that might happen here, but I'll also keep them here so as to give anyone testing this the "full picture", and then rebase on top of them as they get merged.

This PR is another attempt at #117020, but rebased on top of the conflicting search functionality added in #114236. So the general focus of this PR is to make `EditorResourcePicker` easier to use when you have a lot of resources being shown in its `PopupMenu`.

For example, when there are hundreds of applicable resources, you're currently forced to scroll for quite a bit to get to the "Quick Load" actions and such, and the only search available is the "incremental search" as you type, which also isn't very practical when there's a lot of resources.

While addressing this I also ran into a number of issues/regressions with `PopupMenu`, some of which I highlighted in #114236 (but which didn't make it in) and some of which I've discovered since.

Here's a list of all the changes included in this PR, in commit order, with the bug fixes first and the `EditorResourcePicker` stuff further down the list. I've marked the changes that I imagine will be more controversial with ⚠️.

1. **[PopupMenu]** Fixed a regression to the positioning of sub-menus when search bar is enabled, caused by [#118014](https://github.com/godotengine/godot/pull/118014), as the positioning doesn't take the offset of `scroll_container` into account, resulting in them being positioned too far up and not where the parent item is.
    - Split out into #118842
1. **[PopupMenu]** Fixed gamepad navigation, as it only partially took `Item::visible` into account.
    - Split out into #118846
1. **[PopupMenu]** Fixed `_draw_items`, as it didn't correctly calculate the item offset if the first item was invisible.
    - Split out into #118849
1. **[PopupMenu]** Fixed a number accessibility issues, as `Item::visible` wasn't being considered during `NOTIFICATION_ACCESSIBILITY_UPDATE` at all, and separators were considered items, etc.
    - Split out into #119312.
1. **[PopupMenu]** Fixed/rewrote the fuzzy searching introduced in [#117958](https://github.com/godotengine/godot/pull/117958). The existing implementation was not done correctly, as it not only left text separators in, but manually culled results based on `FuzzySearchResult::score`, which is not really how that's meant to be used. It also didn't deal with sub-menu matches correctly.
    - Split out into #119117.
1. **[PopupMenu]** Changed the focus-grabbing done by `search_bar->edit()` to not hide focus. This lines up better with similar filters in the editor, and seems more correct from an accessibility standpoint.
    - Split out into #119312.
1. **[PopupMenu]** ⚠️ Changed so that the first item is pre-selected when search filtering, so that you can just "submit" the first result without having to navigate down to it.
    - Covered by #119613.
1. **[PopupMenu]** ⚠️ Changed so that it resizes as the search results get smaller. I thought this looked better for `EditorResourcePicker` specifically, but this might need to be configurable at least.
    - Covered by #120434.
1. **[PopupMenu]** Added ability to allow clearing the search text with `ui_cancel`.
1. **[PopupMenu]** Added a new API for defining a per-item search behavior, which can either be `SEARCH_NORMAL`, `SEARCH_ALWAYS_HIDE` or `SEARCH_ALWAYS_SHOW`. This allows `EditorResourcePicker` to hide the common actions (load, save, etc.) and only focus on the resources. It also allows keeping the `--- New ---` separator, which I thought looked nice.
1. **[EditorResourcePicker]** Enabled the search bar for any size list, along with the aforementioned search behavior overrides to hide the actions during filtering and such.
1. **[EditorResourcePicker]** Added icons to the copy/paste actions, since they looked weird without it.
    - Split out into #119314.
1. **[EditorResourcePicker]** ⚠️ Moved the `EditorResourcePicker` actions (load, save, copy, paste, etc.) to the top of the `PopupMenu` rather than being at the bottom, i.e. what [godotengine/godot-proposals#3333](https://github.com/godotengine/godot-proposals/issues/3333) suggests doing.

Again, I will split out the bug fixes to their own PRs, and add links to them here. I can split this up even more if it makes this easier to review, assuming the changes are desirable in the first place.

---

Here's what `EditorResourcePicker` looks like now (in single-window mode):

[Recording_20260414_154414.webm](https://github.com/user-attachments/assets/17f30528-937d-4ca6-b996-57b61c5b46b4)

---

I should also note that there are a couple of remaining input/accessibility issues that I haven't been able to figure out yet:

1. `ui_down` from the search bar doesn't release focus. This is consistent with how the "Create New Node" dialog behaves (just to give one example) but that also means screen readers have no clue what item they're selecting when the search bar is enabled.
1. `ui_focus_next`/`ui_focus_prev` should arguably let you switch focus from the search bar to the item list, but that's not the case currently.
1. The accessibility item bounds are broken when navigating into sub-menus. As far as I can tell this issue predates all of this search bar stuff.

Another thing worth bringing up is that the fuzzy searching doesn't currently sort based on score, so the closest match isn't necessarily at the top, which can make for some awkward results sometimes. Try exposing a `Resource` property and search for "curve" for example. Fixing this seemed quite invasive, so I've left it as a future potential improvement, but we could also disable `FuzzySearch::allow_subsequences` until then, which makes things a bit more predictable, but that kills a lot of the fuzzy search benefits.

---
_Disclaimer: AI tooling was used during both the planning and authoring of this change. Any code not physically typed out by myself has been carefully reviewed to the best of my ability._