### PR TITLE
SCons: Remove legacy `use_windows_spawn_fix`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -126,7 +126,6 @@ env.scons_version = env._get_major_minor_revision(scons_raw_version)
 env.__class__.add_module_version_string = methods.add_module_version_string
 
 env.__class__.add_source_files = methods.add_source_files
-env.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 
 env.__class__.add_shared_library = methods.add_shared_library
 env.__class__.add_library = methods.add_library

--- a/methods.py
+++ b/methods.py
@@ -379,49 +379,6 @@ def sort_module_list(env):
         env.module_list.move_to_end(k)
 
 
-def use_windows_spawn_fix(self, platform=None):
-    if os.name != "nt":
-        return  # not needed, only for windows
-
-    def mySubProcess(cmdline, env):
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        popen_args = {
-            "stdin": subprocess.PIPE,
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "startupinfo": startupinfo,
-            "shell": False,
-            "env": env,
-        }
-        popen_args["text"] = True
-        proc = subprocess.Popen(cmdline, **popen_args)
-        _, err = proc.communicate()
-        rv = proc.wait()
-        if rv:
-            print_error(err)
-        elif len(err) > 0 and not err.isspace():
-            print(err)
-        return rv
-
-    def mySpawn(sh, escape, cmd, args, env):
-        # Used by TEMPFILE.
-        if cmd == "del":
-            os.remove(args[1])
-            return 0
-
-        newargs = " ".join(args[1:])
-        cmdline = cmd + " " + newargs
-
-        rv = 0
-        env = {str(key): str(value) for key, value in iter(env.items())}
-        rv = mySubProcess(cmdline, env)
-
-        return rv
-
-    self["SPAWN"] = mySpawn
-
-
 def no_verbose(env):
     from misc.utility.color import Ansi, is_stdout_color
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -177,9 +177,6 @@ def configure(env: "SConsEnvironment"):
 
     env["SHLIBSUFFIX"] = ".so"
 
-    if env["PLATFORM"] == "win32":
-        env.use_windows_spawn_fix()
-
     if sys.platform.startswith("linux"):
         host_subpath = "linux-x86_64"
     elif sys.platform.startswith("darwin"):

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -643,10 +643,6 @@ def configure_mingw(env: "SConsEnvironment"):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
 
-    # Workaround for MinGW. See:
-    # https://www.scons.org/wiki/LongCmdLinesOnWin32
-    env.use_windows_spawn_fix()
-
     # HACK: For some reason, Windows-native shells have their MinGW tools
     # frequently fail as a result of parsing path separators incorrectly.
     # For some other reason, this issue is circumvented entirely if the


### PR DESCRIPTION
Looking more into what functions our builders are relying on, and I don't believe that `use_windows_spawn_fix` serves a function anymore. This was a system put in place for SCons ~2.4 in Python 2.7, and whatever it worked around no longer appears to be triggerable on CI nor locally. I can't say with *complete* certainty, so additional testing would be appreciated, but it appears we could get away with dropping this outright