### PR TITLE
Fix missing shortcut for "Open In Editor" in inherited scene root

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4118,11 +4118,10 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	// Group "open_in_editor" with "show_in_file_system", if it is available.
 	if (is_tool_scene_open_inherited_available) {
 		menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open in Editor"), TOOL_SCENE_OPEN_INHERITED);
-		// TODO: Missing shortcut?
+		menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/open_scene_in_editor"));
 	} else if (is_tool_scene_open_available) {
 		menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open in Editor"), TOOL_SCENE_OPEN);
 		menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/open_scene_in_editor"));
-		// TODO: Use add_icon_shortcut() instead?
 	}
 
 	if (full_selection.size() == 1 && selection.front()->get()->is_instance()) {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/118579

Changes:
- Fixes missing "Open In Editor" shortcut ("Slash") for inherited scene root.

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="771" height="592" alt="Image" src="https://github.com/user-attachments/assets/bd78ce4c-1405-47a8-a2c2-1f25304c4a5e" /> | <img width="771" height="599" alt="image" src="https://github.com/user-attachments/assets/84e26c64-6612-429d-abe4-2197d7f792ef" /> |




