### PR TITLE
Change `Object::is_class` to take `StringName` instead of `String`, for better performance

### DIFF
--- a/core/object/object.compat.inc
+++ b/core/object/object.compat.inc
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  object.compat.inc                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "object.h"
+
+#include "core/object/class_db.h"
+
+bool Object::_is_class_bind_compat_118582(const String &p_name) const {
+	for (const StringName &name : get_gdtype().get_name_hierarchy()) {
+		if (name == p_name) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void Object::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("is_class", "class"), &Object::_is_class_bind_compat_118582);
+}
+
+#else
+void Object::_bind_compatibility_methods() {}
+#endif // DISABLE_DEPRECATED

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "object.h"
+#include "object.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/extension/gdextension_manager.h"
@@ -2094,13 +2095,8 @@ const GDType &Object::get_gdtype() const {
 	return *_gdtype_ptr;
 }
 
-bool Object::is_class(const String &p_class) const {
-	for (const StringName &name : get_gdtype().get_name_hierarchy()) {
-		if (name == p_class) {
-			return true;
-		}
-	}
-	return false;
+bool Object::is_class(const StringName &p_class) const {
+	return get_gdtype().get_name_hierarchy().has(p_class);
 }
 
 const StringName &Object::get_class_name() const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -537,7 +537,7 @@ protected:
 	virtual String _to_string();
 
 	static void _bind_methods();
-	static void _bind_compatibility_methods() {}
+	static void _bind_compatibility_methods();
 	bool _set(const StringName &p_name, const Variant &p_property) { return false; }
 	bool _get(const StringName &p_name, Variant &r_property) const { return false; }
 	void _get_property_list(List<PropertyInfo> *p_list) const {}
@@ -612,6 +612,10 @@ protected:
 	mutable VirtualMethodTracker *virtual_method_list = nullptr;
 #endif
 
+#ifndef DISABLE_DEPRECATED
+	bool _is_class_bind_compat_118582(const String &p_name) const;
+#endif
+
 public: // Should be protected, but bug in clang++.
 	static void initialize_class();
 	_FORCE_INLINE_ static void register_custom_data_to_otdb() {}
@@ -669,7 +673,7 @@ public:
 
 	virtual String get_save_class() const { return get_class(); } //class stored when saving
 
-	bool is_class(const String &p_class) const;
+	bool is_class(const StringName &p_class) const;
 	virtual bool is_class_ptr(void *p_ptr) const { return get_class_ptr_static() == p_ptr; }
 
 	template <typename T, typename O>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -762,7 +762,7 @@
 		</method>
 		<method name="is_class" qualifiers="const">
 			<return type="bool" />
-			<param index="0" name="class" type="String" />
+			<param index="0" name="class" type="StringName" />
 			<description>
 				Returns [code]true[/code] if the object inherits from the given [param class]. See also [method get_class].
 				[codeblocks]

--- a/misc/extension_api_validation/4.6-stable/GH-118582.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-118582.txt
@@ -1,0 +1,6 @@
+GH-117399
+--------------
+
+Validate extension JSON: Error: Field 'classes/Object/methods/is_class/arguments/0': type changed value in new API, from "String" to "StringName".
+
+Changed String parameter to StringName. Compatibility method registered.


### PR DESCRIPTION
In the last GDExtension meeting, we briefly discussed what the 2026 fastest way to cast is for GDExtensions. The result was, there is no really fast and convenient way right now. Summary:

> - gdextension_object_cast_to() takes “class tag”, checks is_class_ptr()
>     - Native class (e.g. Node): unique tag per class
>     - GDExtension class: uses nearest native ancestor’s tag (not unique anymore)
> - Past issue: https://github.com/godotengine/godot-cpp/issues/995
> Code: [gdextension_object_cast_to](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/extension/gdextension_interface.cpp#L1403-L1410), [gdextension_classdb_get_class_tag](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/extension/gdextension_interface.cpp#L1667-L1671), 
[godot-cpp cast](https://github.com/godotengine/godot-cpp/blob/41cfbd1d3bc078d41d2dae284d834df4c541b4b9/include/godot_cpp/core/object.hpp#L119-L130), [godot-rust cast](https://github.com/godot-rust/gdext/blob/ed460cd7f83df4d6f06d5fba66323f3258f3cbb6/godot-core/src/obj/raw_gd.rs#L137-L141)

With this change, `Object::is_class` is fast and appropriate for inheritance checks, implemented as such:

```c++
return object && object->is_class(SNAME("Node")) ? (Node *)object : nullptr;
```

### Other relations

- Essentially a follow-up to https://github.com/godotengine/godot/pull/103708
- Somewhat related to https://github.com/godotengine/godot/pull/104992
- Somewhat related to https://github.com/godotengine/godot/pull/104924
- Somewhat related to https://github.com/godotengine/godot/pull/105215

This notably doesn't work towards addressing https://github.com/godotengine/godot/issues/21789; it's agnostic in behavior of `is_class` and merely adopts the interface.
