### PR TITLE
Fix LightmapperRD wrong API level (must initialize with LEVEL_EDITOR)

### DIFF
--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -43,6 +43,13 @@ static Ref<Lightmapper> create_lightmapper_rd() {
 #endif
 
 void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+#ifndef _3D_DISABLED
+		GDREGISTER_CLASS(LightmapperRD);
+#endif
+		return;
+	}
+
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
@@ -63,7 +70,6 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/denoising/denoiser", PROPERTY_HINT_ENUM, "JNLM,OIDN"), 0);
 #ifndef _3D_DISABLED
-	GDREGISTER_CLASS(LightmapperRD);
 	Lightmapper::create_gpu = create_lightmapper_rd;
 #endif
 }


### PR DESCRIPTION
LightmapperRD is only part of editor builds:

https://github.com/godotengine/godot/blob/90113707f2fd8386533134531e954baf4049e0fa/modules/lightmapper_rd/config.py#L1-L2

So it shouldn't be registered in ClassDB as a Core API, but as Editor API instead. This was making the LightmapperRD bindings to be included in the core C# bindings instead of the editor ones. The same might apply to **godot-cpp**, but I'm not actually sure how they do things there.

**This might be considered a breaking change!** For example, in C# someone might be using LightmapperRD and not surrounding it with `#if TOOLS`. With this PR, that code would no longer compile, and pre-built assemblies would complain about the type not being found.

I'm not aware of any existing problem the old code was causing. The only issue I found was on PR #116301. Since it was calling the static constructors for all classes, the creation-function static field was being initialized, and since the class did not exist in export templates, an exception was being thrown from the static constructor (which is **fatal**). This was easily solved with a workaround, which is better code any way because we shouldn't call all static constructors.

On user code, this fatal exception should happen **only** if a specific line of code that makes use of LightmapperRD is actually reached in an exported game. This is probably why this was never reported, because it's not a common scenario.

Also, it's probably a good idea to lazily initialize the C# static fields that fetch from ClassDB. That way, an exception would only be thrown when those fields are actually accessed, and the exception wouldn't be (necessarily) fatal.

All in all, unless someone reports experiencing the fatal exception, and considering the risk of breaking things, it might not be worth merging this... But I felt this had to be brought to attention.
