### PR TITLE
Fix EditorContextMenuPlugin shortcut support

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -260,7 +260,7 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	} else if (ED_IS_SHORTCUT("scene_tree/delete", p_event)) {
 		_tool_selected(TOOL_ERASE);
 	} else {
-		Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_event);
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_event);
 		if (custom_callback.is_valid()) {
 			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, _get_selection_array());
 		} else {

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -254,7 +254,7 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	} else if (ED_IS_SHORTCUT("scene_tree/delete", p_event)) {
 		_tool_selected(TOOL_ERASE);
 	} else {
-		Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_event);
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_event);
 		if (custom_callback.is_valid()) {
 			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, _get_selection_array());
 		} else {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1252,21 +1252,23 @@ void EditorProperty::_accessibility_action_menu(const Variant &p_data) {
 }
 
 void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
-	if (!selected || !p_event->is_pressed()) {
+	if (!selected || !p_event->is_pressed() || p_event->is_echo()) {
 		return;
 	}
 
-	const Ref<InputEventKey> k = p_event;
-
-	if (k.is_valid() && k->is_pressed()) {
-		if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
-			menu_option(MENU_COPY_VALUE);
-			accept_event();
-		} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value", p_event)) {
-			menu_option(MENU_PASTE_VALUE);
-			accept_event();
-		} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
-			menu_option(MENU_COPY_PROPERTY_PATH);
+	if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
+		menu_option(MENU_COPY_VALUE);
+		accept_event();
+	} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value", p_event)) {
+		menu_option(MENU_PASTE_VALUE);
+		accept_event();
+	} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
+		menu_option(MENU_COPY_PROPERTY_PATH);
+		accept_event();
+	} else {
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_INSPECTOR_PROPERTY, p_event);
+		if (custom_callback.is_valid()) {
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, this);
 			accept_event();
 		}
 	}

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1313,21 +1313,23 @@ void EditorProperty::_accessibility_action_menu(const Variant &p_data) {
 }
 
 void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
-	if (!selected || !p_event->is_pressed()) {
+	if (!selected || !p_event->is_pressed() || p_event->is_echo()) {
 		return;
 	}
 
-	const Ref<InputEventKey> k = p_event;
-
-	if (k.is_valid() && k->is_pressed()) {
-		if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
-			menu_option(MENU_COPY_VALUE);
-			accept_event();
-		} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value", p_event)) {
-			menu_option(MENU_PASTE_VALUE);
-			accept_event();
-		} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
-			menu_option(MENU_COPY_PROPERTY_PATH);
+	if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
+		menu_option(MENU_COPY_VALUE);
+		accept_event();
+	} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value", p_event)) {
+		menu_option(MENU_PASTE_VALUE);
+		accept_event();
+	} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
+		menu_option(MENU_COPY_PROPERTY_PATH);
+		accept_event();
+	} else {
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_INSPECTOR_PROPERTY, p_event);
+		if (custom_callback.is_valid()) {
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, this);
 			accept_event();
 		}
 	}

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -552,6 +552,21 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 			if (reset_transform_scale_shortcut.is_valid() && reset_transform_scale_shortcut->matches_event(p_ev)) {
 				_reset_transform(TransformType::SCALE);
 			}
+
+			const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, p_ev);
+			if (custom_callback.is_valid()) {
+				Vector<SelectResult> currently_hovered;
+				_get_canvas_items_at_pos(transform.affine_inverse().xform(viewport->get_local_mouse_position()), currently_hovered, true);
+
+				TypedArray<Node> nodes;
+				nodes.reserve(currently_hovered.size());
+				for (const SelectResult &result : currently_hovered) {
+					nodes.append(result.item);
+				}
+				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, nodes);
+
+				accept_event();
+			}
 		}
 	}
 }

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -556,6 +556,21 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 			if (reset_transform_scale_shortcut.is_valid() && reset_transform_scale_shortcut->matches_event(p_ev)) {
 				_reset_transform(TransformType::SCALE);
 			}
+
+			const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, p_ev);
+			if (custom_callback.is_valid()) {
+				Vector<SelectResult> currently_hovered;
+				_get_canvas_items_at_pos(transform.affine_inverse().xform(viewport->get_local_mouse_position()), currently_hovered, true);
+
+				TypedArray<Node> nodes;
+				nodes.reserve(currently_hovered.size());
+				for (const SelectResult &result : currently_hovered) {
+					nodes.append(result.item);
+				}
+				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, nodes);
+
+				accept_event();
+			}
 		}
 	}
 }

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -410,18 +410,25 @@ void EditorSceneTabs::_global_menu_new_window(const Variant &p_tag) {
 
 void EditorSceneTabs::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
+	if (!p_event->is_pressed()) {
+		return;
+	}
 
-	Ref<InputEventKey> k = p_event;
-	if ((k.is_valid() && k->is_pressed() && !k->is_echo()) || Object::cast_to<InputEventShortcut>(*p_event)) {
-		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
-			int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
-			next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
-			_scene_tab_changed(next_tab);
-		}
-		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
-			int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
-			next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
-			_scene_tab_changed(next_tab);
+	if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
+		int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
+		next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
+		_scene_tab_changed(next_tab);
+		accept_event();
+	} else if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
+		int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
+		next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
+		_scene_tab_changed(next_tab);
+		accept_event();
+	} else if (!p_event->is_echo()) {
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, p_event);
+		if (custom_callback.is_valid()) {
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, last_hovered_tab >= 0 ? EditorNode::get_editor_data().get_scene_path(last_hovered_tab) : String());
+			accept_event();
 		}
 	}
 }

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -411,18 +411,25 @@ void EditorSceneTabs::_global_menu_new_window(const Variant &p_tag) {
 
 void EditorSceneTabs::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
+	if (!p_event->is_pressed() || p_event->is_echo()) {
+		return;
+	}
 
-	Ref<InputEventKey> k = p_event;
-	if ((k.is_valid() && k->is_pressed() && !k->is_echo()) || Object::cast_to<InputEventShortcut>(*p_event)) {
-		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
-			int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
-			next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
-			set_current_tab(next_tab);
-		}
-		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
-			int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
-			next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
-			set_current_tab(next_tab);
+	if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
+		int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
+		next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
+		set_current_tab(next_tab);
+		accept_event();
+	} else if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
+		int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
+		next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
+		set_current_tab(next_tab);
+		accept_event();
+	} else {
+		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, p_event);
+		if (custom_callback.is_valid()) {
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, last_hovered_tab >= 0 ? EditorNode::get_editor_data().get_scene_path(last_hovered_tab) : String());
+			accept_event();
 		}
 	}
 }

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3105,7 +3105,7 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
+	const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
 	if (custom_callback.is_valid()) {
 		Ref<Resource> resource;
 		if (ScriptEditorBase *current = _get_current_editor()) {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3160,7 +3160,7 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
+	const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
 	if (custom_callback.is_valid()) {
 		Ref<Resource> resource;
 		if (ScriptEditorBase *current = _get_current_editor()) {

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1625,6 +1625,18 @@ void ScriptTextEditor::_update_connected_methods() {
 	}
 }
 
+void ScriptTextEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!p_event->is_pressed() || p_event->is_echo()) {
+		return;
+	}
+
+	const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE, p_event);
+	if (custom_callback.is_valid()) {
+		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, code_editor->get_text_editor());
+		accept_event();
+	}
+}
+
 void ScriptTextEditor::_update_gutter_indexes() {
 	for (int i = 0; i < code_editor->get_text_editor()->get_gutter_count(); i++) {
 		if (code_editor->get_text_editor()->get_gutter_name(i) == "connection_gutter") {
@@ -2785,6 +2797,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 
 	update_settings();
+	set_process_shortcut_input(true);
 
 	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
 }

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1618,6 +1618,18 @@ void ScriptTextEditor::_update_connected_methods() {
 	}
 }
 
+void ScriptTextEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!p_event->is_pressed() || p_event->is_echo()) {
+		return;
+	}
+
+	const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE, p_event);
+	if (custom_callback.is_valid()) {
+		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, code_editor->get_text_editor());
+		accept_event();
+	}
+}
+
 void ScriptTextEditor::_update_gutter_indexes() {
 	for (int i = 0; i < code_editor->get_text_editor()->get_gutter_count(); i++) {
 		if (code_editor->get_text_editor()->get_gutter_name(i) == "connection_gutter") {
@@ -2699,6 +2711,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 
 	update_settings();
+	set_process_shortcut_input(true);
 
 	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
 }

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -216,6 +216,8 @@ protected:
 public:
 	void _update_connected_methods();
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 	virtual void apply_code() override;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -212,6 +212,8 @@ protected:
 public:
 	void _update_connected_methods();
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 	virtual void apply_code() override;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;


### PR DESCRIPTION
While working on #118569 I realized that no context menu slot after the original 4 supports shortcuts 🤦‍♂️ They have to be manually implemented.

This PR fixes it. You can test it with this project, which adds plugin for every context menu slot:
[All-Context.zip](https://github.com/user-attachments/files/26728318/All-Context.zip)
