### PR TITLE
Use `RequiredParam`/`RequiredResult` in several more APIs

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -94,11 +94,13 @@ Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &
 	return ret;
 }
 
-void ResourceLoader::add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front) {
+void ResourceLoader::add_resource_format_loader(RequiredParam<ResourceFormatLoader> rp_format_loader, bool p_at_front) {
+	EXTRACT_PARAM_OR_FAIL(p_format_loader, rp_format_loader);
 	::ResourceLoader::add_resource_format_loader(p_format_loader, p_at_front);
 }
 
-void ResourceLoader::remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader) {
+void ResourceLoader::remove_resource_format_loader(RequiredParam<ResourceFormatLoader> rp_format_loader) {
+	EXTRACT_PARAM_OR_FAIL(p_format_loader, rp_format_loader);
 	::ResourceLoader::remove_resource_format_loader(p_format_loader);
 }
 
@@ -179,7 +181,8 @@ Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	return ::ResourceSaver::set_uid(p_path, p_uid);
 }
 
-Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
+Vector<String> ResourceSaver::get_recognized_extensions(RequiredParam<Resource> rp_resource) {
+	EXTRACT_PARAM_OR_FAIL_V(p_resource, rp_resource, Vector<String>());
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
 	Vector<String> ret;
@@ -189,11 +192,13 @@ Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_r
 	return ret;
 }
 
-void ResourceSaver::add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front) {
+void ResourceSaver::add_resource_format_saver(RequiredParam<ResourceFormatSaver> rp_format_saver, bool p_at_front) {
+	EXTRACT_PARAM_OR_FAIL(p_format_saver, rp_format_saver);
 	::ResourceSaver::add_resource_format_saver(p_format_saver, p_at_front);
 }
 
-void ResourceSaver::remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver) {
+void ResourceSaver::remove_resource_format_saver(RequiredParam<ResourceFormatSaver> rp_format_saver) {
+	EXTRACT_PARAM_OR_FAIL(p_format_saver, rp_format_saver);
 	::ResourceSaver::remove_resource_format_saver(p_format_saver);
 }
 
@@ -708,8 +713,8 @@ String OS::get_unique_id() const {
 	return ::OS::get_singleton()->get_unique_id();
 }
 
-void OS::add_logger(const Ref<Logger> &p_logger) {
-	ERR_FAIL_COND(p_logger.is_null());
+void OS::add_logger(RequiredParam<Logger> rp_logger) {
+	EXTRACT_PARAM_OR_FAIL(p_logger, rp_logger);
 
 	if (!logger_bind) {
 		logger_bind = memnew(LoggerBind);
@@ -720,8 +725,8 @@ void OS::add_logger(const Ref<Logger> &p_logger) {
 	logger_bind->loggers.push_back(p_logger);
 }
 
-void OS::remove_logger(const Ref<Logger> &p_logger) {
-	ERR_FAIL_COND(p_logger.is_null());
+void OS::remove_logger(RequiredParam<Logger> rp_logger) {
+	EXTRACT_PARAM_OR_FAIL(p_logger, rp_logger);
 	ERR_FAIL_COND_MSG(!logger_bind || logger_bind->loggers.find(p_logger) == -1, "Could not remove logger, as it hasn't been added.");
 	logger_bind->loggers.erase(p_logger);
 }
@@ -1666,13 +1671,15 @@ StringName ClassDB::class_get_property_setter(const StringName &p_class, const S
 	return ::ClassDB::get_property_setter(p_class, p_property);
 }
 
-Variant ClassDB::class_get_property(Object *p_object, const StringName &p_property) const {
+Variant ClassDB::class_get_property(RequiredParam<Object> rp_object, const StringName &p_property) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_object, rp_object, Variant());
 	Variant ret;
 	::ClassDB::get_property(p_object, p_property, ret);
 	return ret;
 }
 
-Error ClassDB::class_set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const {
+Error ClassDB::class_set_property(RequiredParam<Object> rp_object, const StringName &p_property, const Variant &p_value) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_object, rp_object, ERR_INVALID_PARAMETER);
 	Variant ret;
 	bool valid;
 	if (!::ClassDB::set_property(p_object, p_property, p_value, &valid)) {
@@ -1989,7 +1996,8 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 	return ::Engine::get_singleton()->get_singleton_object(p_name);
 }
 
-void Engine::register_singleton(const StringName &p_name, Object *p_object) {
+void Engine::register_singleton(const StringName &p_name, RequiredParam<Object> rp_instance) {
+	EXTRACT_PARAM_OR_FAIL(p_object, rp_instance);
 	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
 	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
 	::Engine::Singleton s;
@@ -2016,11 +2024,13 @@ Vector<String> Engine::get_singleton_list() const {
 	return ret;
 }
 
-Error Engine::register_script_language(ScriptLanguage *p_language) {
+Error Engine::register_script_language(RequiredParam<ScriptLanguage> rp_language) {
+	EXTRACT_PARAM_OR_FAIL_V(p_language, rp_language, ERR_INVALID_PARAMETER);
 	return ScriptServer::register_language(p_language);
 }
 
-Error Engine::unregister_script_language(const ScriptLanguage *p_language) {
+Error Engine::unregister_script_language(RequiredParam<const ScriptLanguage> rp_language) {
+	EXTRACT_PARAM_OR_FAIL_V(p_language, rp_language, ERR_INVALID_PARAMETER);
 	return ScriptServer::unregister_language(p_language);
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -76,8 +76,8 @@ public:
 
 	Ref<Resource> load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	Vector<String> get_recognized_extensions_for_type(const String &p_type);
-	void add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front);
-	void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
+	void add_resource_format_loader(RequiredParam<ResourceFormatLoader> p_format_loader, bool p_at_front);
+	void remove_resource_format_loader(RequiredParam<ResourceFormatLoader> p_format_loader);
 	void set_abort_on_missing_resources(bool p_abort);
 	PackedStringArray get_dependencies(const String &p_path);
 	bool has_cached(const String &p_path);
@@ -113,9 +113,9 @@ public:
 
 	Error save(RequiredParam<Resource> p_resource, const String &p_path, BitField<SaverFlags> p_flags);
 	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
-	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
-	void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front);
-	void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
+	Vector<String> get_recognized_extensions(RequiredParam<Resource> p_resource);
+	void add_resource_format_saver(RequiredParam<ResourceFormatSaver> p_format_saver, bool p_at_front);
+	void remove_resource_format_saver(RequiredParam<ResourceFormatSaver> p_format_saver);
 
 	ResourceUID::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
 
@@ -311,8 +311,8 @@ public:
 	Vector<String> get_granted_permissions() const;
 	void revoke_granted_permissions();
 
-	void add_logger(const Ref<Logger> &p_logger);
-	void remove_logger(const Ref<Logger> &p_logger);
+	void add_logger(RequiredParam<Logger> p_logger);
+	void remove_logger(RequiredParam<Logger> p_logger);
 	void remove_script_loggers(const ScriptLanguage *p_script);
 
 	static OS *get_singleton() { return singleton; }
@@ -533,8 +533,8 @@ public:
 	TypedArray<Dictionary> class_get_property_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	StringName class_get_property_getter(const StringName &p_class, const StringName &p_property);
 	StringName class_get_property_setter(const StringName &p_class, const StringName &p_property);
-	Variant class_get_property(Object *p_object, const StringName &p_property) const;
-	Error class_set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;
+	Variant class_get_property(RequiredParam<Object> p_object, const StringName &p_property) const;
+	Error class_set_property(RequiredParam<Object> p_object, const StringName &p_property, const Variant &p_value) const;
 
 	Variant class_get_property_default_value(const StringName &p_class, const StringName &p_property) const;
 
@@ -611,12 +611,12 @@ public:
 
 	bool has_singleton(const StringName &p_name) const;
 	Object *get_singleton_object(const StringName &p_name) const;
-	void register_singleton(const StringName &p_name, Object *p_object);
+	void register_singleton(const StringName &p_name, RequiredParam<Object> p_instance);
 	void unregister_singleton(const StringName &p_name);
 	Vector<String> get_singleton_list() const;
 
-	Error register_script_language(ScriptLanguage *p_language);
-	Error unregister_script_language(const ScriptLanguage *p_language);
+	Error register_script_language(RequiredParam<ScriptLanguage> p_language);
+	Error unregister_script_language(RequiredParam<const ScriptLanguage> p_language);
 	int get_script_language_count();
 	ScriptLanguage *get_script_language(int p_index) const;
 	TypedArray<ScriptBacktrace> capture_script_backtraces(bool p_include_variables = false) const;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -395,7 +395,8 @@ void Node2D::set_global_transform(const Transform2D &p_transform) {
 	}
 }
 
-Transform2D Node2D::get_relative_transform_to_parent(const Node *p_parent) const {
+Transform2D Node2D::get_relative_transform_to_parent(RequiredParam<const Node> rp_parent) const {
+	EXTRACT_PARAM_OR_FAIL_V(p_parent, rp_parent, Transform2D());
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	if (p_parent == this) {
 		return Transform2D();

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -114,7 +114,7 @@ public:
 	Point2 to_local(Point2 p_global) const;
 	Point2 to_global(Point2 p_local) const;
 
-	Transform2D get_relative_transform_to_parent(const Node *p_parent) const;
+	Transform2D get_relative_transform_to_parent(RequiredParam<const Node> p_parent) const;
 
 	Transform2D get_transform() const override;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1804,7 +1804,7 @@ TypedArray<Tween> SceneTree::get_processed_tweens() {
 	return ret;
 }
 
-Ref<MultiplayerAPI> SceneTree::get_multiplayer(const NodePath &p_for_path) const {
+RequiredResult<MultiplayerAPI> SceneTree::get_multiplayer(const NodePath &p_for_path) const {
 	ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<MultiplayerAPI>(), "Multiplayer can only be manipulated from the main thread.");
 	if (p_for_path.is_empty()) {
 		return multiplayer;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -446,7 +446,7 @@ public:
 
 	//network API
 
-	Ref<MultiplayerAPI> get_multiplayer(const NodePath &p_for_path = NodePath()) const;
+	RequiredResult<MultiplayerAPI> get_multiplayer(const NodePath &p_for_path = NodePath()) const;
 	void set_multiplayer(Ref<MultiplayerAPI> p_multiplayer, const NodePath &p_root_path = NodePath());
 	void set_multiplayer_poll_enabled(bool p_enabled);
 	bool is_multiplayer_poll_enabled() const;


### PR DESCRIPTION
Inspired by #113282, this PR marks more object parameters and return values as required (non-null).

_AI Disclosure: used Claude to explore APIs' data flow, to get more confidence whether non-null is safe._

## Changed APIs

### Node APIs

- `SceneTree::get_multiplayer()`, return `MultiplayerAPI`
  - Default multiplayer is created in the [constructor](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L2095) via `set_multiplayer(...)`, which [guards against null](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L1839) when called with an empty root path.
  - All code paths in `get_multiplayer()` fall back to the always-valid default.
  - `set_multiplayer()` accepts null: when called with a non-empty `p_root_path`, null is valid and [erases the custom entry](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L1871). Entries are never stored as null -- they're removed from the map. So `get_multiplayer()` only returns valid entries or falls back to default.
- `Node2D::get_relative_transform_to_parent()`, param `const Node p_parent`
  - There is [no null guard](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/2d/node_2d.cpp#L398); null causes infinite recursion until `ERR_FAIL_NULL_V` fires at the tree root, which is always a caller bug.

### Registration / unregistration APIs

- `Engine::register_singleton()`, param `Object p_instance`
  - Registering a null singleton is meaningless and likely leads to follow-up logic errors.
  - The implementation had [no null guard](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/core_bind.cpp#L1992) before this PR; was this a bug?
- `Engine::register_script_language()`, param `ScriptLanguage p_language`
  - `ScriptServer::register_language()` already [rejects null](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/object/script_language.cpp#L241) via `ERR_FAIL_NULL_V`.
- `Engine::unregister_script_language()`, param `const ScriptLanguage p_language`
  - Passing null would silently return `ERR_DOES_NOT_EXIST` without registering an error -> bug.
- `ClassDB::class_get_property()`, param `Object p_object`
  - The internal `::ClassDB::get_property()` [rejects null](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/object/class_db.cpp#L1559) via `ERR_FAIL_NULL_V`.
- `ClassDB::class_set_property()`, param `Object p_object`
  - The internal `::ClassDB::set_property()` [rejects null](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/object/class_db.cpp#L1510) via `ERR_FAIL_NULL_V`.
- `OS::add_logger()`, param `Logger p_logger`
  - The [previous implementation](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/core_bind.cpp#L711) already had `ERR_FAIL_COND(p_logger.is_null())`.
- `OS::remove_logger()`, param `Logger p_logger`
  - same here, [previous impl](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/core_bind.cpp#L723) already had `ERR_FAIL_COND(p_logger.is_null())`.
- `ResourceLoader::add_resource_format_loader()`, param `ResourceFormatLoader p_format_loader`
  - Rejects null via [`ERR_FAIL_COND(p_format_loader.is_null())`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/io/resource_loader.cpp#L1063), confirming null is never valid.
- `ResourceLoader::remove_resource_format_loader()`, param `ResourceFormatLoader p_format_loader`
  - Rejects null via [`ERR_FAIL_COND(p_format_loader.is_null())`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/io/resource_loader.cpp#L1078).
- `ResourceSaver::get_recognized_extensions()`, param `Resource p_resource`
  - Rejects null via [`ERR_FAIL_COND_MSG(p_resource.is_null(), ...)`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/io/resource_saver.cpp#L179).
- `ResourceSaver::add_resource_format_saver()`, param `ResourceFormatSaver p_format_saver`
  - Rejects null via [`ERR_FAIL_COND_MSG(p_format_saver.is_null(), ...)`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/io/resource_saver.cpp#L186).
- `ResourceSaver::remove_resource_format_saver()`, param `ResourceFormatSaver p_format_saver`
  - Rejects null via [`ERR_FAIL_COND_MSG(p_format_saver.is_null(), ...)`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/io/resource_saver.cpp#L201).


---

## Unchanged APIs

I investigated a few more API that may _look_ at first glance like they could be candidates, but aren't.

- `SceneTree::get_current_scene()` -- Can return `nullptr` between scene transitions. It is initialized to [`nullptr` in the constructor](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L2098), or in [`node_removed()`](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L162).
- `SceneTree::set_multiplayer()`, param `MultiplayerAPI p_multiplayer` -- Null is intentionally valid when `p_root_path` is non-empty; it [erases the custom multiplayer entry](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/main/scene_tree.cpp#L1871) for that path. The method has dual semantics that cannot be captured by a single `RequiredParam`.
- `Engine::get_main_loop()` -- Can return `nullptr` before initialization and after finalization; [multiple callers](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/core/string/translation_server.cpp#L492) explicitly null-check the result.
- `Node::get_parent()` -- Returns `nullptr` for root nodes or nodes not in the tree.
- `Node::get_owner()` -- Owner is optional; `nullptr` means no owner.
- `Node3D::get_parent_node_3d()` -- Returns `nullptr` for top-level nodes or when parent isn't `Node3D`.
- `CanvasItem::get_world_2d()` -- Can return an empty `Ref` when not in the tree.
- `Engine::get_singleton_object()` -- Returns `nullptr` when singleton is not found.
- `Control::set_theme()`, param `Theme p_theme` -- Null is intentional; it clears the theme override.
- `CanvasItem::set_material()`, param `Material p_material` -- Null is intentional; it clears the material.
- `Node3D::add_gizmo()`, param `Node3DGizmo p_gizmo` -- Explicitly handles null as a [no-op early return](https://github.com/godotengine/godot/blob/f94bbfc07c8ee6f61165848b7abf45a148d51747/scene/3d/node_3d.cpp#L920).
