### PR TITLE
Add `RequiredParam` -> `RequiredResult` conversion

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1101,6 +1101,15 @@ public:
 	}
 
 	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	_FORCE_INLINE_ RequiredParam(const RequiredResult<T_Other> &p_other) :
+			_value(p_other.ptr()) {}
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	_FORCE_INLINE_ RequiredParam &operator=(const RequiredResult<T_Other> &p_other) {
+		_value = p_other.ptr();
+		return *this;
+	}
+
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
 	_FORCE_INLINE_ RequiredParam(T_Other *p_ptr) :
 			_value(p_ptr) {}
 	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -354,6 +354,10 @@ void SceneTree::_update_group_order(SceneTreeGroup &g) {
 	g.changed = false;
 }
 
+RequiredResult<Window> SceneTree::get_root() const {
+	return root;
+}
+
 void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount) {
 	Vector<Node *> nodes_copy;
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -300,7 +300,7 @@ public:
 		GROUP_CALL_UNIQUE = 4,
 	};
 
-	_FORCE_INLINE_ Window *get_root() const { return root; }
+	RequiredResult<Window> get_root() const;
 
 	void call_group_flagsp(uint32_t p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount);
 	void notify_group_flags(uint32_t p_call_flags, const StringName &p_group, int p_notification);


### PR DESCRIPTION
Related to #118588.

Adds implicit conversion from `RequiredResult<T_Other>` to `RequiredParam<T>` (where `T_Other` derives from `T`). This allows passing a `RequiredResult` directly to a `RequiredParam` without an intermediate variable. 

My SFINAE skills are a bit dated, I mostly looked at the conversion between two `RequiredParam`s :slightly_smiling_face: 
  Feedback is welcome.

---

Also changes `SceneTree::get_root()` to return `RequiredResult<Window>`.

It is used in a conversion as described above (`reparent` takes `RequiredParam`):
https://github.com/godotengine/godot/blob/90113707f2fd8386533134531e954baf4049e0fa/tests/scene/test_node.cpp#L211

Why `get_root` can be non-null: The root window is created in the `SceneTree` constructor and only set to null in the destructor, so it is always valid during normal use. The function is no longer `_FORCE_INLINE_` because `RequiredResult<Window>` requires Window to be a complete type.

For this, I had to move the `_FORCE_INLINE_ Window *get_root()` method to the .cpp file, because `RequiredResult<Window>` won't compile due to incomplete type. I'm not sure if there's something we can do about this?