### PR TITLE
Fix `MeshLibrary` crash

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1745,9 +1745,6 @@ void Control::update_maximum_size() {
 		}
 	}
 
-	// Keep minimum size propagation in sync so parent containers can relayout correctly.
-	callable_mp(this, &Control::_update_minimum_size).call_deferred();
-
 	if (!is_visible_in_tree()) {
 		// Invalidate the last maximum size so it will update when made visible.
 		data.last_maximum_size = Size2(-1, -1);
@@ -1758,6 +1755,12 @@ void Control::update_maximum_size() {
 		return;
 	}
 	data.updating_last_maximum_size = true;
+
+	// Keep minimum size propagation in sync so parent containers can relayout correctly.
+	if (!data.updating_last_minimum_size) {
+		data.updating_last_minimum_size = true;
+		callable_mp(this, &Control::_update_minimum_size).call_deferred();
+	}
 
 	callable_mp(this, &Control::_update_maximum_size).call_deferred();
 }


### PR DESCRIPTION
* Fixes #118587

When I fixed the label crash in #118536, I did not add the necessary guards to ensure `_update_minimum_size()` wasn't being `call_deferred` in the case where the minimum size was already updating and/or the node wasn't in the tree anymore. The latter caused the crash observed by Yeldham in his bug report. Fixed both at the same time since the former would likely also result in a crash and unnecessary multiple updates. 

Made sure that this does not reintroduce the problem that the first PR solved, and that parent resizing still happens as needed for layout. 

Review request/cc both @YeldhamDev @bruvzg

Note to reviewers: please give this extra scrutiny. I was already careless in the PR that introduced this regression, wouldn't want that to happen again.
As far as I see it, this change should be solid now, but so did I then. 