### PR TITLE
Make empty `AudioStreamOggVorbis` exit gracefully when inspected in `AudioStreamPlayer`

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -516,7 +516,9 @@ double AudioStreamOggVorbis::get_loop_offset() const {
 }
 
 double AudioStreamOggVorbis::get_length() const {
-	ERR_FAIL_COND_V(packet_sequence.is_null(), 0);
+	if (packet_sequence.is_null()) {
+		return 0;
+	}
 	return packet_sequence->get_length();
 }
 


### PR DESCRIPTION
Replaced ERR_FAIL_COND_V with a silent null check in get_length() to prevent error spam when an empty AudioStreamOggVorbis is open in the Inspector. Should be noted there are still errors when creating an empty AudioStreamOggVorbis resource.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/118574*