### PR TITLE
Fix for crash when parsing and current_function was null

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2224,7 +2224,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (result != nullptr) {
+	if (result != nullptr && current_function != nullptr) {
 		MemberDocData doc_data;
 		if (has_comment(result->start_line, true)) {
 			// Inline doc comment.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/1007

Might be related to https://github.com/godotengine/godot/issues/94843