### PR TITLE
Allow ScriptExtension implementations to override callp

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -85,6 +85,8 @@ void ScriptExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_rpc_config);
 
+	GDVIRTUAL_BIND(_callp, "method", "args");
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_instance_has, "object");
 #endif // !DISABLE_DEPRECATED

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -97,6 +97,8 @@ void ScriptExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_rpc_config);
 
+	GDVIRTUAL_BIND(_callp, "method", "args");
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_instance_has, "object");
 #endif // !DISABLE_DEPRECATED

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -218,6 +218,35 @@ public:
 		return ret;
 	}
 
+	GDVIRTUAL2R(Dictionary, _callp, const StringName &, const Array &)
+	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override {
+		Array args;
+		for (int i = 0; i < p_argcount; i++) {
+			args.push_back(*p_args[i]);
+		}
+
+		Dictionary ret;
+		if (GDVIRTUAL_CALL(_callp, p_method, args, ret)) {
+			if (ret.has("result")) {
+				Variant result = ret["result"];
+				if (ret.has("error")) {
+					r_error.error = Callable::CallError::Error(ret["error"]);
+					if (ret.has("argument")) {
+						r_error.argument = ret["argument"];
+					}
+					if (ret.has("expected")) {
+						r_error.expected = ret["expected"];
+					}
+				} else {
+					r_error.error = Callable::CallError::CALL_OK;
+				}
+				return result;
+			}
+		}
+
+		return Script::callp(p_method, p_args, p_argcount, r_error);
+	}
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL1RC(bool, _instance_has, const Object *)
 #endif // !DISABLE_DEPRECATED

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -214,6 +214,35 @@ public:
 		return ret;
 	}
 
+	GDVIRTUAL2R(Dictionary, _callp, const StringName &, const Array &)
+	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override {
+		Array args;
+		for (int i = 0; i < p_argcount; i++) {
+			args.push_back(*p_args[i]);
+		}
+
+		Dictionary ret;
+		if (GDVIRTUAL_CALL(_callp, p_method, args, ret)) {
+			if (ret.has("result")) {
+				Variant result = ret["result"];
+				if (ret.has("error")) {
+					r_error.error = Callable::CallError::Error(ret["error"]);
+					if (ret.has("argument")) {
+						r_error.argument = ret["argument"];
+					}
+					if (ret.has("expected")) {
+						r_error.expected = ret["expected"];
+					}
+				} else {
+					r_error.error = Callable::CallError::CALL_OK;
+				}
+				return result;
+			}
+		}
+
+		return Script::callp(p_method, p_args, p_argcount, r_error);
+	}
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL1RC(bool, _instance_has, const Object *)
 #endif // !DISABLE_DEPRECATED

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -7,6 +7,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_callp" qualifiers="virtual">
+			<return type="Dictionary" />
+			<param index="0" name="method" type="StringName" />
+			<param index="1" name="args" type="Array" />
+			<description>
+			</description>
+		</method>
 		<method name="_can_instantiate" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -7,6 +7,20 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_callp" qualifiers="virtual">
+			<return type="Dictionary" />
+			<param index="0" name="method" type="StringName" />
+			<param index="1" name="args" type="Array" />
+			<description>
+				Overrides the behavior of [Script]'s [code]callp[/code], allowing the extension to supply its own logic when [param method] is called with [param args].
+				When this method is overridden, it should return a [Dictionary] with the following keys:
+				- [code]"result"[/code] - The call's return value, or [code]null[/code] if the call has no return value.
+				- [code]"error"[/code] - [i](Optional)[/i] The error code. Defaults to no error (i.e. the equivalent of [code]OK[/code]).
+				- [code]"argument"[/code] - [i](Optional)[/i] The index of the argument that caused the error as an [int]. Only used when [code]"error"[/code] is present.
+				- [code]"expected"[/code] - [i](Optional)[/i] The expected argument type or count as an [int], depending on the error. Only used when [code]"error"[/code] is present.
+				If the returned [Dictionary] does not contain a [code]"result"[/code] key, the call delegates to [Script]'s default behavior.
+			</description>
+		</method>
 		<method name="_can_instantiate" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14614

### Description 

Introduces a virtual override handler on `ScriptExtension` for hierarchy calls via `callp`, delegating them to the underlying script implementation and enabling GDExtension-based scripting languages to handle calls from GDScript or CSharp that invoke statically declared script functions.

