### PR TITLE
Build: Remove redundant SCons environment clones

### DIFF
--- a/core/config/SCsub
+++ b/core/config/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_config = env.Clone()
-
-env_config.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/error/SCsub
+++ b/core/error/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_error = env.Clone()
-
-env_error.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -19,6 +19,4 @@ env.CommandNoCache(
     env.Run(make_interface_header.run),
 )
 
-env_extension = env.Clone()
-
-env_extension.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_math = env.Clone()
-
-env_math.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -7,6 +7,4 @@ import make_virtuals
 
 env.CommandNoCache("gdvirtual.gen.h", "make_virtuals.py", env.Run(make_virtuals.run))
 
-env_object = env.Clone()
-
-env_object.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/string/SCsub
+++ b/core/string/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_string = env.Clone()
-
-env_string.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/templates/SCsub
+++ b/core/templates/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_templates = env.Clone()
-
-env_templates.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/variant/SCsub
+++ b/core/variant/SCsub
@@ -3,6 +3,4 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-env_variant = env.Clone()
-
-env_variant.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files(env.core_sources, "*.cpp")


### PR DESCRIPTION
When peeking around at the SCsub files after building source, I noticed there was some redundant 'env.Clone()'.

To verify that these were redundant I did a dry run with logs before and after. And verified compiler commands were identical. 

Using scons debug time I also noticed that the scons execution time was also reduced by 2 seconds.