### PR TITLE
Remove unused parameter in timer.h and timer.cpp

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -187,7 +187,7 @@ Timer::TimerProcessCallback Timer::get_timer_process_callback() const {
 	return timer_process_callback;
 }
 
-void Timer::_set_process(bool p_process, bool p_force) {
+void Timer::_set_process(bool p_process) {
 	switch (timer_process_callback) {
 		case TIMER_PROCESS_PHYSICS:
 			set_physics_process_internal(p_process && !paused);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -83,7 +83,7 @@ public:
 
 private:
 	TimerProcessCallback timer_process_callback = TIMER_PROCESS_IDLE;
-	void _set_process(bool p_process, bool p_force = false);
+	void _set_process(bool p_process);
 };
 
 VARIANT_ENUM_CAST(Timer::TimerProcessCallback);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

The parameter `p_force` in `_set_process` is unused.

Noticed it while reading the source code.
Could also not find any calls using it.