### PR TITLE
ClassDB: Fix build with `deprecated=no`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -780,8 +780,8 @@ ObjectGDExtension *ClassDB::get_placeholder_extension(const StringName &p_class)
 	placeholder_extension->class_userdata = ti;
 #ifndef DISABLE_DEPRECATED
 	placeholder_extension->create_instance = nullptr;
-#endif // DISABLE_DEPRECATED
 	placeholder_extension->create_instance2 = &PlaceholderExtensionInstance::placeholder_class_create_instance;
+#endif // DISABLE_DEPRECATED
 	placeholder_extension->free_instance = &PlaceholderExtensionInstance::placeholder_class_free_instance;
 #ifndef DISABLE_DEPRECATED
 	placeholder_extension->get_virtual = nullptr;
@@ -880,7 +880,7 @@ bool ClassDB::is_abstract(const StringName &p_class) {
 			return true;
 		}
 #ifndef DISABLE_DEPRECATED
-		return ti->gdextension->create_instance3 == nullptr && ti->gdextension->create_instance2 == nullptr && ti->gdextension->create_instance2 == nullptr;
+		return ti->gdextension->create_instance3 == nullptr && ti->gdextension->create_instance2 == nullptr && ti->gdextension->create_instance == nullptr;
 #else
 		return ti->gdextension->create_instance3 == nullptr;
 #endif //  DISABLE_DEPRECATED


### PR DESCRIPTION
Since #118214 /  8f7bdc1, ObjectGDExtension has ONLY `create_instance3` when building with `deprecated=no`.  So we should only assign `create_instance2` when `deprecated=yes`

Also noticed: A comparison checking for `create_instance2` against null twice, where I am pretty sure the intent was to check for *any* of the `create_instance` methods.