### PR TITLE
Replace Godot's joypad mapping system with SDL's own on supported platforms

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -33,7 +33,6 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/input/default_controller_mappings.h"
 #include "core/input/input_map.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -45,6 +44,9 @@
 #include <thirdparty/gamepadmotionhelpers/GamepadMotion.hpp>
 
 #define STANDARD_GRAVITY 9.80665f
+
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+#include "core/input/default_controller_mappings.h"
 
 static const char *_joy_buttons[(size_t)JoyButton::SDL_MAX] = {
 	"a",
@@ -83,6 +85,7 @@ static const char *_joy_axes[(size_t)JoyAxis::SDL_MAX] = {
 	"lefttrigger",
 	"righttrigger",
 };
+#endif
 
 void (*Input::set_mouse_mode_func)(Input::MouseMode) = nullptr;
 Input::MouseMode (*Input::get_mouse_mode_func)() = nullptr;
@@ -709,6 +712,10 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_
 		}
 		js.uid = uidname;
 		js.connected = true;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+		js.is_known = p_joypad_info.get("mapping_handled", false);
+#else
 		int mapping = fallback_mapping;
 		// Bypass the mapping system if the joypad's mapping is already handled by its driver
 		// (for example, the SDL joypad driver).
@@ -725,10 +732,30 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_
 				}
 			}
 		}
+
+		_set_joypad_mapping(js, mapping);
+#endif
 		// We don't want this setting to be exposed to the user, because it's not very useful outside of this method.
 		js.info.erase("mapping_handled");
 
-		_set_joypad_mapping(js, mapping);
+		if (joypad_features != nullptr) {
+			if (joypad_features->has_joy_vibration(p_idx)) {
+				js.has_vibration = true;
+			}
+			if (joypad_features->has_joy_light(p_idx)) {
+				js.has_light = true;
+			}
+			if (joypad_features->has_joy_motion_sensors(p_idx)) {
+				MotionInfo &motion = joy_motion[p_idx];
+
+				if (!motion.gamepad_motion) {
+					motion.gamepad_motion = new GamepadMotion();
+				} else {
+					motion.gamepad_motion->Reset();
+				}
+				motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
+			}
+		}
 	} else {
 		js.connected = false;
 		for (int i = 0; i < (int)JoyButton::MAX; i++) {
@@ -1055,15 +1082,6 @@ void Input::set_joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_joy_axis[c] = p_value;
 }
 
-void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
-	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad) {
-		return;
-	}
-	joypad->features = p_features;
-	_update_joypad_features(p_device);
-}
-
 void Input::set_joy_light(int p_device, const Color &p_color) {
 	_THREAD_SAFE_METHOD_
 
@@ -1072,11 +1090,11 @@ void Input::set_joy_light(int p_device, const Color &p_color) {
 	}
 
 	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad || !joypad->has_light || joypad->features == nullptr) {
+	if (!joypad || !joypad->has_light || joypad_features == nullptr) {
 		return;
 	}
 	Color linear = p_color.srgb_to_linear();
-	joypad->features->set_joy_light(linear);
+	joypad_features->set_joy_light(p_device, linear);
 }
 
 bool Input::has_joy_light(int p_device) const {
@@ -1148,14 +1166,14 @@ Vector3 Input::get_joy_gyroscope(int p_device) const {
 void Input::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
 	_THREAD_SAFE_METHOD_
 	Joypad *joypad = joy_names.getptr(p_device);
-	if (joypad == nullptr || joypad->features == nullptr) {
+	if (joypad == nullptr || joypad_features == nullptr) {
 		return;
 	}
 	MotionInfo *motion = joy_motion.getptr(p_device);
 	if (motion == nullptr) {
 		return;
 	}
-	joypad->features->set_joy_motion_sensors_enabled(p_enable);
+	joypad_features->set_joy_motion_sensors_enabled(p_device, p_enable);
 	motion->sensors_enabled = p_enable;
 }
 
@@ -1663,6 +1681,10 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 		return;
 	}
 	joy.last_buttons[(size_t)p_button] = p_pressed;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	_button_event(p_device, p_button, p_pressed);
+#else
 	if (joy.mapping == -1) {
 		_button_event(p_device, p_button, p_pressed);
 		return;
@@ -1679,6 +1701,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 		_axis_event(p_device, (JoyAxis)map.index, p_pressed ? map.value : 0.0);
 	}
 	// no event?
+#endif
 }
 
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
@@ -1698,6 +1721,9 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 
 	joy.last_axis[(size_t)p_axis] = p_value;
 
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	_axis_event(p_device, p_axis, p_value);
+#else
 	if (joy.mapping == -1) {
 		_axis_event(p_device, p_axis, p_value);
 		return;
@@ -1753,6 +1779,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 		_axis_event(p_device, axis, value);
 		return;
 	}
+#endif
 }
 
 void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
@@ -1762,8 +1789,25 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		return;
 	}
 
-	const Joypad &joy = joy_names[p_device];
+	Joypad &joy = joy_names[p_device];
 
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	JoyButton map[(size_t)HatDir::MAX];
+	map[(size_t)HatDir::UP] = JoyButton::DPAD_UP;
+	map[(size_t)HatDir::RIGHT] = JoyButton::DPAD_RIGHT;
+	map[(size_t)HatDir::DOWN] = JoyButton::DPAD_DOWN;
+	map[(size_t)HatDir::LEFT] = JoyButton::DPAD_LEFT;
+
+	int cur_val = joy.hat_current;
+
+	for (int hat_direction = 0, hat_mask = 1; hat_direction < (int)HatDir::MAX; hat_direction++, hat_mask <<= 1) {
+		if (((int)p_val & hat_mask) != (cur_val & hat_mask)) {
+			_button_event(p_device, map[hat_direction], (int)p_val & hat_mask);
+		}
+	}
+
+	joy.hat_current = (int)p_val;
+#else
 	JoyEvent map[(size_t)HatDir::MAX];
 
 	map[(size_t)HatDir::UP].type = TYPE_BUTTON;
@@ -1786,7 +1830,7 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		_get_mapped_hat_events(map_db[joy.mapping], (HatDir)0, map);
 	}
 
-	int cur_val = joy_names[p_device].hat_current;
+	int cur_val = joy.hat_current;
 
 	for (int hat_direction = 0, hat_mask = 1; hat_direction < (int)HatDir::MAX; hat_direction++, hat_mask <<= 1) {
 		if (((int)p_val & hat_mask) != (cur_val & hat_mask)) {
@@ -1799,7 +1843,8 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		}
 	}
 
-	joy_names[p_device].hat_current = (int)p_val;
+	joy.hat_current = (int)p_val;
+#endif
 }
 
 void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, const Vector3 &p_gyroscope) {
@@ -1866,29 +1911,37 @@ void Input::_update_action_cache(const StringName &p_action_name, ActionState &r
 	}
 }
 
-void Input::_update_joypad_features(int p_device) {
-	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad || joypad->features == nullptr) {
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
+	if (joypad_features == nullptr) {
 		return;
 	}
-	if (joypad->features->has_joy_vibration()) {
-		joypad->has_vibration = true;
-	}
-	if (joypad->features->has_joy_light()) {
-		joypad->has_light = true;
-	}
-	if (joypad->features->has_joy_motion_sensors()) {
-		MotionInfo &motion = joy_motion[p_device];
-
-		if (!motion.gamepad_motion) {
-			motion.gamepad_motion = new GamepadMotion();
-		} else {
-			motion.gamepad_motion->Reset();
-		}
-		motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
-	}
+	joypad_features->add_joy_mapping(p_mapping, p_update_existing);
 }
 
+void Input::remove_joy_mapping(const String &p_guid) {
+	if (joypad_features == nullptr) {
+		return;
+	}
+	joypad_features->remove_joy_mapping(p_guid);
+}
+
+void Input::set_joy_name(int p_device, const String &p_name) {
+	Joypad *joy = joy_names.getptr(p_device);
+	if (joy == nullptr) {
+		return;
+	}
+	joy->name = p_name;
+}
+
+void Input::set_joy_known(int p_device, bool p_known) {
+	Joypad *joy = joy_names.getptr(p_device);
+	if (joy == nullptr) {
+		return;
+	}
+	joy->is_known = p_known;
+}
+#else
 Input::JoyEvent Input::_get_mapped_button_event(const JoyDeviceMapping &mapping, JoyButton p_button) {
 	JoyEvent event;
 
@@ -2267,6 +2320,7 @@ void Input::set_fallback_mapping(const String &p_guid) {
 		}
 	}
 }
+#endif
 
 //platforms that use the remapping system can override and call to these ones
 bool Input::is_joy_known(int p_device) {
@@ -2317,9 +2371,14 @@ bool Input::is_input_disabled() const {
 	return disable_input;
 }
 
+void Input::set_joypad_features(JoypadFeatures *p_features) {
+	joypad_features = p_features;
+}
+
 Input::Input() {
 	singleton = this;
 
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
 	// Parse default mappings.
 	{
 		int i = 0;
@@ -2339,6 +2398,7 @@ Input::Input() {
 			parse_mapping(entries[i]);
 		}
 	}
+#endif
 
 	String env_ignore_devices = OS::get_singleton()->get_environment("SDL_GAMECONTROLLER_IGNORE_DEVICES");
 	if (!env_ignore_devices.is_empty()) {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -33,7 +33,6 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/input/default_controller_mappings.h"
 #include "core/input/input_map.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -45,6 +44,9 @@
 #include <thirdparty/gamepadmotionhelpers/GamepadMotion.hpp>
 
 #define STANDARD_GRAVITY 9.80665f
+
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+#include "core/input/default_controller_mappings.h"
 
 static const char *_joy_buttons[(size_t)JoyButton::SDL_MAX] = {
 	"a",
@@ -83,6 +85,7 @@ static const char *_joy_axes[(size_t)JoyAxis::SDL_MAX] = {
 	"lefttrigger",
 	"righttrigger",
 };
+#endif
 
 void (*Input::set_mouse_mode_func)(Input::MouseMode) = nullptr;
 Input::MouseMode (*Input::get_mouse_mode_func)() = nullptr;
@@ -713,6 +716,10 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_
 		}
 		js.uid = uidname;
 		js.connected = true;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+		js.is_known = p_joypad_info.get("mapping_handled", false);
+#else
 		int mapping = fallback_mapping;
 		// Bypass the mapping system if the joypad's mapping is already handled by its driver
 		// (for example, the SDL joypad driver).
@@ -729,10 +736,33 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, const String &p_
 				}
 			}
 		}
+
+		_set_joypad_mapping(js, mapping);
+#endif
 		// We don't want this setting to be exposed to the user, because it's not very useful outside of this method.
 		js.info.erase("mapping_handled");
 
-		_set_joypad_mapping(js, mapping);
+		if (joypad_features != nullptr) {
+			if (joypad_features->has_joy_vibration(p_idx)) {
+				js.has_vibration = true;
+			}
+			if (joypad_features->has_joy_light(p_idx)) {
+				js.has_light = true;
+			}
+			if (joypad_features->has_joy_motion_sensors(p_idx)) {
+				MotionInfo &motion = joy_motion[p_idx];
+
+				if (!motion.gamepad_motion) {
+					motion.gamepad_motion = new GamepadMotion();
+				} else {
+					motion.gamepad_motion->Reset();
+				}
+				motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
+			}
+			if (joypad_features->get_joy_num_touchpads(p_idx) > 0) {
+				joy_touch[p_idx].num_touchpads = joypad_features->get_joy_num_touchpads(p_idx);
+			}
+		}
 	} else {
 		js.connected = false;
 		for (int i = 0; i < (int)JoyButton::MAX; i++) {
@@ -1117,15 +1147,6 @@ void Input::set_joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_joy_axis[c] = p_value;
 }
 
-void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
-	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad) {
-		return;
-	}
-	joypad->features = p_features;
-	_update_joypad_features(p_device);
-}
-
 void Input::set_joy_light(int p_device, const Color &p_color) {
 	_THREAD_SAFE_METHOD_
 
@@ -1134,11 +1155,11 @@ void Input::set_joy_light(int p_device, const Color &p_color) {
 	}
 
 	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad || !joypad->has_light || joypad->features == nullptr) {
+	if (!joypad || !joypad->has_light || joypad_features == nullptr) {
 		return;
 	}
 	Color linear = p_color.srgb_to_linear();
-	joypad->features->set_joy_light(linear);
+	joypad_features->set_joy_light(p_device, linear);
 }
 
 bool Input::has_joy_light(int p_device) const {
@@ -1210,14 +1231,14 @@ Vector3 Input::get_joy_gyroscope(int p_device) const {
 void Input::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
 	_THREAD_SAFE_METHOD_
 	Joypad *joypad = joy_names.getptr(p_device);
-	if (joypad == nullptr || joypad->features == nullptr) {
+	if (joypad == nullptr || joypad_features == nullptr) {
 		return;
 	}
 	MotionInfo *motion = joy_motion.getptr(p_device);
 	if (motion == nullptr) {
 		return;
 	}
-	joypad->features->set_joy_motion_sensors_enabled(p_enable);
+	joypad_features->set_joy_motion_sensors_enabled(p_device, p_enable);
 	motion->sensors_enabled = p_enable;
 }
 
@@ -1728,6 +1749,10 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 		return;
 	}
 	joy.last_buttons[(size_t)p_button] = p_pressed;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	_button_event(p_device, p_button, p_pressed);
+#else
 	if (joy.mapping == -1) {
 		_button_event(p_device, p_button, p_pressed);
 		return;
@@ -1744,6 +1769,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 		_axis_event(p_device, (JoyAxis)map.index, p_pressed ? map.value : 0.0);
 	}
 	// no event?
+#endif
 }
 
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
@@ -1763,6 +1789,9 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 
 	joy.last_axis[(size_t)p_axis] = p_value;
 
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	_axis_event(p_device, p_axis, p_value);
+#else
 	if (joy.mapping == -1) {
 		_axis_event(p_device, p_axis, p_value);
 		return;
@@ -1818,6 +1847,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 		_axis_event(p_device, axis, value);
 		return;
 	}
+#endif
 }
 
 void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
@@ -1827,8 +1857,25 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		return;
 	}
 
-	const Joypad &joy = joy_names[p_device];
+	Joypad &joy = joy_names[p_device];
 
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	JoyButton map[(size_t)HatDir::MAX];
+	map[(size_t)HatDir::UP] = JoyButton::DPAD_UP;
+	map[(size_t)HatDir::RIGHT] = JoyButton::DPAD_RIGHT;
+	map[(size_t)HatDir::DOWN] = JoyButton::DPAD_DOWN;
+	map[(size_t)HatDir::LEFT] = JoyButton::DPAD_LEFT;
+
+	int cur_val = joy.hat_current;
+
+	for (int hat_direction = 0, hat_mask = 1; hat_direction < (int)HatDir::MAX; hat_direction++, hat_mask <<= 1) {
+		if (((int)p_val & hat_mask) != (cur_val & hat_mask)) {
+			_button_event(p_device, map[hat_direction], (int)p_val & hat_mask);
+		}
+	}
+
+	joy.hat_current = (int)p_val;
+#else
 	JoyEvent map[(size_t)HatDir::MAX];
 
 	map[(size_t)HatDir::UP].type = TYPE_BUTTON;
@@ -1851,7 +1898,7 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		_get_mapped_hat_events(map_db[joy.mapping], (HatDir)0, map);
 	}
 
-	int cur_val = joy_names[p_device].hat_current;
+	int cur_val = joy.hat_current;
 
 	for (int hat_direction = 0, hat_mask = 1; hat_direction < (int)HatDir::MAX; hat_direction++, hat_mask <<= 1) {
 		if (((int)p_val & hat_mask) != (cur_val & hat_mask)) {
@@ -1864,7 +1911,8 @@ void Input::joy_hat(int p_device, BitField<HatMask> p_val) {
 		}
 	}
 
-	joy_names[p_device].hat_current = (int)p_val;
+	joy.hat_current = (int)p_val;
+#endif
 }
 
 void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, const Vector3 &p_gyroscope) {
@@ -1947,32 +1995,38 @@ void Input::_update_action_cache(const StringName &p_action_name, ActionState &r
 	}
 }
 
-void Input::_update_joypad_features(int p_device) {
-	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad || joypad->features == nullptr) {
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
+	if (joypad_features == nullptr) {
 		return;
 	}
-	if (joypad->features->has_joy_vibration()) {
-		joypad->has_vibration = true;
-	}
-	if (joypad->features->has_joy_light()) {
-		joypad->has_light = true;
-	}
-	if (joypad->features->has_joy_motion_sensors()) {
-		MotionInfo &motion = joy_motion[p_device];
-
-		if (!motion.gamepad_motion) {
-			motion.gamepad_motion = new GamepadMotion();
-		} else {
-			motion.gamepad_motion->Reset();
-		}
-		motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
-	}
-	if (joypad->features->get_joy_num_touchpads() > 0) {
-		joy_touch[p_device].num_touchpads = joypad->features->get_joy_num_touchpads();
-	}
+	// p_update_existing is ignored, because SDL doesn't support it.
+	joypad_features->add_joy_mapping(p_mapping);
 }
 
+void Input::remove_joy_mapping(const String &p_guid) {
+	if (joypad_features == nullptr) {
+		return;
+	}
+	joypad_features->remove_joy_mapping(p_guid);
+}
+
+void Input::set_joy_name(int p_device, const String &p_name) {
+	Joypad *joy = joy_names.getptr(p_device);
+	if (joy == nullptr) {
+		return;
+	}
+	joy->name = p_name;
+}
+
+void Input::set_joy_known(int p_device, bool p_known) {
+	Joypad *joy = joy_names.getptr(p_device);
+	if (joy == nullptr) {
+		return;
+	}
+	joy->is_known = p_known;
+}
+#else
 Input::JoyEvent Input::_get_mapped_button_event(const JoyDeviceMapping &mapping, JoyButton p_button) {
 	JoyEvent event;
 
@@ -2250,13 +2304,12 @@ void Input::parse_mapping(const String &p_mapping) {
 
 void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
 	parse_mapping(p_mapping);
-	if (p_update_existing) {
-		const String uid = p_mapping.get_slicec(',', 0);
-		for (KeyValue<int, Joypad> &E : joy_names) {
-			Joypad &joy = E.value;
-			if (joy.uid == uid) {
-				_set_joypad_mapping(joy, map_db.size() - 1);
-			}
+	// p_update_existing is ignored, because SDL doesn't support it (all platforms should have the same behavior).
+	const String uid = p_mapping.get_slicec(',', 0);
+	for (KeyValue<int, Joypad> &E : joy_names) {
+		Joypad &joy = E.value;
+		if (joy.uid == uid) {
+			_set_joypad_mapping(joy, map_db.size() - 1);
 		}
 	}
 }
@@ -2351,6 +2404,7 @@ void Input::set_fallback_mapping(const String &p_guid) {
 		}
 	}
 }
+#endif
 
 //platforms that use the remapping system can override and call to these ones
 bool Input::is_joy_known(int p_device) {
@@ -2401,9 +2455,14 @@ bool Input::is_input_disabled() const {
 	return disable_input;
 }
 
+void Input::set_joypad_features(JoypadFeatures *p_features) {
+	joypad_features = p_features;
+}
+
 Input::Input() {
 	singleton = this;
 
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
 	// Parse default mappings.
 	{
 		int i = 0;
@@ -2423,6 +2482,7 @@ Input::Input() {
 			parse_mapping(entries[i]);
 		}
 	}
+#endif
 
 	String env_ignore_devices = OS::get_singleton()->get_environment("SDL_GAMECONTROLLER_IGNORE_DEVICES");
 	if (!env_ignore_devices.is_empty()) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -92,13 +92,18 @@ public:
 	public:
 		virtual ~JoypadFeatures() {}
 
-		virtual bool has_joy_vibration() const { return false; }
+		virtual bool has_joy_vibration(int p_device) const { return false; }
 
-		virtual bool has_joy_light() const { return false; }
-		virtual void set_joy_light(const Color &p_color) {}
+		virtual bool has_joy_light(int p_device) const { return false; }
+		virtual void set_joy_light(int p_device, const Color &p_color) {}
 
-		virtual bool has_joy_motion_sensors() const { return false; }
-		virtual void set_joy_motion_sensors_enabled(bool p_enable) {}
+		virtual bool has_joy_motion_sensors(int p_device) const { return false; }
+		virtual void set_joy_motion_sensors_enabled(int p_device, bool p_enable) {}
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+		virtual void add_joy_mapping(const String &p_mapping, bool p_update_existing) {}
+		virtual void remove_joy_mapping(const String &p_guid) {}
+#endif
 	};
 
 	static constexpr int32_t JOYPADS_MAX = 16;
@@ -215,23 +220,26 @@ private:
 		bool last_buttons[(size_t)JoyButton::MAX] = { false };
 		float last_axis[(size_t)JoyAxis::MAX] = { 0.0f };
 		HatMask last_hat = HatMask::CENTER;
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
 		int mapping = -1;
+#endif
 		int hat_current = 0;
 		Dictionary info;
 		bool has_light = false;
 		bool has_vibration = false;
-		Input::JoypadFeatures *features = nullptr;
 	};
 
 	VelocityTrack mouse_velocity_track;
 	HashMap<int, VelocityTrack> touch_velocity_track;
 	HashMap<int, Joypad> joy_names;
+	JoypadFeatures *joypad_features = nullptr;
 
 	HashSet<uint32_t> ignored_device_ids;
 
-	int fallback_mapping = -1; // Index of the guid in map_db.
-
 	CursorShape default_shape = CursorShape::CURSOR_ARROW;
+
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	int fallback_mapping = -1; // Index of the guid in map_db.
 
 	enum JoyType {
 		TYPE_BUTTON,
@@ -297,10 +305,13 @@ private:
 	void _get_mapped_hat_events(const JoyDeviceMapping &mapping, HatDir p_hat, JoyEvent r_events[(size_t)HatDir::MAX]);
 	JoyButton _get_output_button(const String &output);
 	JoyAxis _get_output_axis(const String &output);
+
+	void parse_mapping(const String &p_mapping);
+#endif
+
 	void _button_event(int p_device, JoyButton p_index, bool p_pressed);
 	void _axis_event(int p_device, JoyAxis p_axis, float p_value);
 	void _update_action_cache(const StringName &p_action_name, ActionState &r_action_state);
-	void _update_joypad_features(int p_device);
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
@@ -401,8 +412,6 @@ public:
 	void set_gyroscope(const Vector3 &p_gyroscope);
 	void set_joy_axis(int p_device, JoyAxis p_axis, float p_value);
 
-	void set_joy_features(int p_device, JoypadFeatures *p_features);
-
 	void set_joy_light(int p_device, const Color &p_color);
 	bool has_joy_light(int p_device) const;
 
@@ -452,7 +461,6 @@ public:
 	CursorShape get_current_cursor_shape() const;
 	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CursorShape::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
-	void parse_mapping(const String &p_mapping);
 	void joy_button(int p_device, JoyButton p_button, bool p_pressed);
 	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
@@ -467,7 +475,13 @@ public:
 	String get_joy_guid(int p_device) const;
 	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
 	Dictionary get_joy_info(int p_device) const;
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	// These should only be used by the joypad input drivers that provide their own mapping system.
+	void set_joy_name(int p_device, const String &p_name);
+	void set_joy_known(int p_device, bool p_known);
+#else
 	void set_fallback_mapping(const String &p_guid);
+#endif
 
 #ifdef DEBUG_ENABLED
 	void flush_frame_parsed_events();
@@ -484,6 +498,8 @@ public:
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;
+
+	void set_joypad_features(JoypadFeatures *p_features);
 
 	Input();
 	~Input();

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -92,15 +92,20 @@ public:
 	public:
 		virtual ~JoypadFeatures() {}
 
-		virtual bool has_joy_vibration() const { return false; }
+		virtual bool has_joy_vibration(int p_device) const { return false; }
 
-		virtual bool has_joy_light() const { return false; }
-		virtual void set_joy_light(const Color &p_color) {}
+		virtual bool has_joy_light(int p_device) const { return false; }
+		virtual void set_joy_light(int p_device, const Color &p_color) {}
 
-		virtual bool has_joy_motion_sensors() const { return false; }
-		virtual void set_joy_motion_sensors_enabled(bool p_enable) {}
+		virtual bool has_joy_motion_sensors(int p_device) const { return false; }
+		virtual void set_joy_motion_sensors_enabled(int p_device, bool p_enable) {}
 
-		virtual int get_joy_num_touchpads() const { return 0; }
+		virtual int get_joy_num_touchpads(int p_device) const { return 0; }
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+		virtual void add_joy_mapping(const String &p_mapping) {}
+		virtual void remove_joy_mapping(const String &p_guid) {}
+#endif
 	};
 
 	static constexpr int32_t JOYPADS_MAX = 16;
@@ -229,23 +234,26 @@ private:
 		bool last_buttons[(size_t)JoyButton::MAX] = { false };
 		float last_axis[(size_t)JoyAxis::MAX] = { 0.0f };
 		HatMask last_hat = HatMask::CENTER;
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
 		int mapping = -1;
+#endif
 		int hat_current = 0;
 		Dictionary info;
 		bool has_light = false;
 		bool has_vibration = false;
-		Input::JoypadFeatures *features = nullptr;
 	};
 
 	VelocityTrack mouse_velocity_track;
 	HashMap<int, VelocityTrack> touch_velocity_track;
 	HashMap<int, Joypad> joy_names;
+	JoypadFeatures *joypad_features = nullptr;
 
 	HashSet<uint32_t> ignored_device_ids;
 
-	int fallback_mapping = -1; // Index of the guid in map_db.
-
 	CursorShape default_shape = CursorShape::CURSOR_ARROW;
+
+#ifndef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	int fallback_mapping = -1; // Index of the guid in map_db.
 
 	enum JoyType {
 		TYPE_BUTTON,
@@ -311,10 +319,13 @@ private:
 	void _get_mapped_hat_events(const JoyDeviceMapping &mapping, HatDir p_hat, JoyEvent r_events[(size_t)HatDir::MAX]);
 	JoyButton _get_output_button(const String &output);
 	JoyAxis _get_output_axis(const String &output);
+
+	void parse_mapping(const String &p_mapping);
+#endif
+
 	void _button_event(int p_device, JoyButton p_index, bool p_pressed);
 	void _axis_event(int p_device, JoyAxis p_axis, float p_value);
 	void _update_action_cache(const StringName &p_action_name, ActionState &r_action_state);
-	void _update_joypad_features(int p_device);
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
@@ -417,8 +428,6 @@ public:
 	void set_gyroscope(const Vector3 &p_gyroscope);
 	void set_joy_axis(int p_device, JoyAxis p_axis, float p_value);
 
-	void set_joy_features(int p_device, JoypadFeatures *p_features);
-
 	void set_joy_light(int p_device, const Color &p_color);
 	bool has_joy_light(int p_device) const;
 
@@ -472,7 +481,6 @@ public:
 	CursorShape get_current_cursor_shape() const;
 	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CursorShape::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
-	void parse_mapping(const String &p_mapping);
 	void joy_button(int p_device, JoyButton p_button, bool p_pressed);
 	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
@@ -488,7 +496,13 @@ public:
 	String get_joy_guid(int p_device) const;
 	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
 	Dictionary get_joy_info(int p_device) const;
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	// These should only be used by the joypad input drivers that provide their own mapping system.
+	void set_joy_name(int p_device, const String &p_name);
+	void set_joy_known(int p_device, bool p_known);
+#else
 	void set_fallback_mapping(const String &p_guid);
+#endif
 
 #ifdef DEBUG_ENABLED
 	void flush_frame_parsed_events();
@@ -505,6 +519,8 @@ public:
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;
+
+	void set_joypad_features(JoypadFeatures *p_features);
 
 	Input();
 	~Input();

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -35,8 +35,9 @@
 			<param index="0" name="mapping" type="String" />
 			<param index="1" name="update_existing" type="bool" default="false" />
 			<description>
-				Adds a new joypad mapping entry (in SDL format) to the mapping database, and optionally updates the already connected devices.
+				Adds a new joypad mapping entry (in SDL format) to the mapping database, and updates the already connected devices.
 				[b]Note:[/b] See [url=https://wiki.libsdl.org/SDL3/SDL_AddGamepadMapping#remarks]SDL documentation[/url] for more information about the SDL controller mapping format.
+				[b]Note:[/b] Since Godot 4.8, [param update_existing] is no longer functional, and the already connected devices, if applicable, will always be updated regardless of the value of this parameter.
 			</description>
 		</method>
 		<method name="clear_joy_motion_sensors_calibration" experimental="">

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -33,6 +33,7 @@
 #ifdef SDL_ENABLED
 
 #include "core/input/default_controller_mappings.h"
+#include "core/input/input_enums.h"
 #include "core/variant/dictionary.h"
 
 #include <SDL3/SDL.h>
@@ -45,7 +46,12 @@
 // Macro to skip the SDL joystick event handling if the device is an SDL gamepad, because
 // there are separate events for SDL gamepads
 #define SKIP_EVENT_FOR_GAMEPAD \
-	if (SDL_IsGamepad(sdl_event.jdevice.which)) { \
+	if (joypads[joy_id].gamepad) { \
+		continue; \
+	}
+
+#define SKIP_EVENT_FOR_NON_GAMEPAD \
+	if (!joypads[joy_id].gamepad) { \
 		continue; \
 	}
 
@@ -61,6 +67,8 @@ JoypadSDL::~JoypadSDL() {
 }
 
 Error JoypadSDL::initialize() {
+	Input::get_singleton()->set_joypad_features(this);
+
 	SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
 	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 	ERR_FAIL_COND_V_MSG(!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD), FAILED, SDL_GetError());
@@ -68,10 +76,7 @@ Error JoypadSDL::initialize() {
 	// Add Godot's mapping database from memory
 	int i = 0;
 	while (DefaultControllerMappings::mappings[i]) {
-		String mapping_string = DefaultControllerMappings::mappings[i++];
-		CharString data = mapping_string.utf8();
-		SDL_IOStream *rw = SDL_IOFromMem((void *)data.ptr(), data.size());
-		SDL_AddGamepadMappingsFromIO(rw, true);
+		SDL_AddGamepadMapping(DefaultControllerMappings::mappings[i++]);
 	}
 
 	// Make sure that we handle already connected joypads when the driver is initialized.
@@ -82,21 +87,23 @@ Error JoypadSDL::initialize() {
 }
 
 void JoypadSDL::process_events() {
+	Input *input = Input::get_singleton();
+
 	// Update rumble first for it to be applied when we handle SDL events
 	for (int i = 0; i < Input::JOYPADS_MAX; i++) {
 		Joypad &joy = joypads[i];
 		if (joy.attached && joy.supports_force_feedback) {
-			uint64_t timestamp = Input::get_singleton()->get_joy_vibration_timestamp(i);
+			uint64_t timestamp = input->get_joy_vibration_timestamp(i);
 
 			// Update the joypad rumble only if there was a new vibration request
 			if (timestamp > joy.ff_effect_timestamp) {
 				joy.ff_effect_timestamp = timestamp;
 
 				SDL_Joystick *sdl_joy = SDL_GetJoystickFromID(joypads[i].sdl_instance_idx);
-				Vector2 strength = Input::get_singleton()->get_joy_vibration_strength(i);
+				Vector2 strength = input->get_joy_vibration_strength(i);
 				// Invalid values for strength are filtered by Input::start_joy_vibration().
 
-				float duration = Input::get_singleton()->get_joy_vibration_duration(i);
+				float duration = input->get_joy_vibration_duration(i);
 				Uint32 duration_ms = 0;
 				if (duration < 0.0f) {
 					continue; // Invalid duration.
@@ -125,7 +132,7 @@ void JoypadSDL::process_events() {
 	while (SDL_PollEvent(&sdl_event)) {
 		// A new joypad was attached
 		if (sdl_event.type == SDL_EVENT_JOYSTICK_ADDED) {
-			int joy_id = Input::get_singleton()->get_unused_joy_id();
+			int joy_id = input->get_unused_joy_id();
 			if (joy_id == -1) {
 				// There is no space for more joypads...
 				print_error("A new joypad was attached but couldn't allocate a new id for it because joypad limit was reached.");
@@ -166,6 +173,7 @@ void JoypadSDL::process_events() {
 				joypads[joy_id].supports_force_feedback = SDL_GetBooleanProperty(propertiesID, SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, false);
 				joypads[joy_id].guid = StringName(String(guid));
 				joypads[joy_id].supports_motion_sensors = SDL_GamepadHasSensor(gamepad, SDL_SENSOR_ACCEL) || SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO);
+				joypads[joy_id].gamepad = SDL_IsGamepad(sdl_event.jdevice.which);
 
 				sdl_instance_id_to_joypad_id.insert(sdl_event.jdevice.which, joy_id);
 
@@ -196,18 +204,16 @@ void JoypadSDL::process_events() {
 				}
 #endif
 
-				Input::get_singleton()->joy_connection_changed(
+				input->joy_connection_changed(
 						joy_id,
 						true,
 						device_name,
 						joypads[joy_id].guid,
 						joypad_info);
 
-				Input::get_singleton()->set_joy_features(joy_id, &joypads[joy_id]);
-
 				if (joypads[joy_id].supports_motion_sensors) {
 					// Data rate for all sensors should be the same.
-					Input::get_singleton()->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
+					input->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
 				}
 			}
 			// An event for an attached joypad
@@ -216,14 +222,42 @@ void JoypadSDL::process_events() {
 
 			switch (sdl_event.type) {
 				case SDL_EVENT_JOYSTICK_REMOVED:
-					Input::get_singleton()->joy_connection_changed(joy_id, false, "");
+					input->joy_connection_changed(joy_id, false, "");
 					close_joypad(joy_id);
+					break;
+
+				case SDL_EVENT_GAMEPAD_ADDED: // A controller mapping has been added to a controller that wasn't mapped before.
+					if (!update_existing_mappings || input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_known(joy_id, true);
+					input->set_joy_name(joy_id, SDL_GetGamepadNameForID(sdl_event.gdevice.which));
+					joypads[joy_id].gamepad = true;
+					break;
+
+				case SDL_EVENT_GAMEPAD_REMOVED: // A controller's mapping has been removed.
+					if (!update_existing_mappings || !input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_known(joy_id, false);
+					input->set_joy_name(joy_id, SDL_GetJoystickNameForID(sdl_event.gdevice.which));
+					joypads[joy_id].gamepad = false;
+					break;
+
+				case SDL_EVENT_GAMEPAD_REMAPPED: // A controller's mapping was updated.
+					if (!update_existing_mappings || !input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_name(joy_id, SDL_GetGamepadNameForID(sdl_event.gdevice.which));
 					break;
 
 				case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 					SKIP_EVENT_FOR_GAMEPAD;
 
-					Input::get_singleton()->joy_axis(
+					input->joy_axis(
 							joy_id,
 							static_cast<JoyAxis>(sdl_event.jaxis.axis), // Godot joy axis constants are already intentionally the same as SDL's
 							((sdl_event.jaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f);
@@ -239,7 +273,7 @@ void JoypadSDL::process_events() {
 						continue;
 					}
 
-					Input::get_singleton()->joy_button(
+					input->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.jbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them
 							sdl_event.jbutton.down);
@@ -248,13 +282,14 @@ void JoypadSDL::process_events() {
 				case SDL_EVENT_JOYSTICK_HAT_MOTION:
 					SKIP_EVENT_FOR_GAMEPAD;
 
-					Input::get_singleton()->joy_hat(
+					input->joy_hat(
 							joy_id,
 							(HatMask)sdl_event.jhat.value // Godot hat masks are identical to SDL hat masks, so we can just use them as-is.
 					);
 					break;
 
 				case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
+					SKIP_EVENT_FOR_NON_GAMEPAD;
 					float axis_value;
 
 					if (sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_LEFT_TRIGGER || sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
@@ -266,7 +301,7 @@ void JoypadSDL::process_events() {
 								((sdl_event.gaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f;
 					}
 
-					Input::get_singleton()->joy_axis(
+					input->joy_axis(
 							joy_id,
 							static_cast<JoyAxis>(sdl_event.gaxis.axis), // Godot joy axis constants are already intentionally the same as SDL's
 							axis_value);
@@ -275,7 +310,8 @@ void JoypadSDL::process_events() {
 				// Do note SDL gamepads do not have separate events for the dpad
 				case SDL_EVENT_GAMEPAD_BUTTON_UP:
 				case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-					Input::get_singleton()->joy_button(
+					SKIP_EVENT_FOR_NON_GAMEPAD;
+					input->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.gbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them
 							sdl_event.gbutton.down);
@@ -297,7 +333,7 @@ void JoypadSDL::process_events() {
 		SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_ACCEL, accel_data, 3);
 		SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_GYRO, gyro_data, 3);
 
-		Input::get_singleton()->joy_motion_sensors(
+		input->joy_motion_sensors(
 				i,
 				Vector3(-accel_data[0], -accel_data[1], -accel_data[2]),
 				Vector3(gyro_data[0], gyro_data[1], gyro_data[2]));
@@ -319,8 +355,8 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 	}
 }
 
-bool JoypadSDL::Joypad::has_joy_light() const {
-	SDL_Joystick *joystick = get_sdl_joystick();
+bool JoypadSDL::has_joy_light(int p_device) const {
+	SDL_Joystick *joystick = joypads[p_device].get_sdl_joystick();
 	SDL_PropertiesID properties_id = SDL_GetJoystickProperties(joystick);
 	if (properties_id == 0) {
 		return false;
@@ -328,23 +364,63 @@ bool JoypadSDL::Joypad::has_joy_light() const {
 	return SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN, false) || SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN, false);
 }
 
-void JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
-	SDL_SetJoystickLED(get_sdl_joystick(), p_color.get_r8(), p_color.get_g8(), p_color.get_b8());
+void JoypadSDL::set_joy_light(int p_device, const Color &p_color) {
+	SDL_SetJoystickLED(joypads[p_device].get_sdl_joystick(), p_color.get_r8(), p_color.get_g8(), p_color.get_b8());
 }
 
-bool JoypadSDL::Joypad::has_joy_motion_sensors() const {
-	return supports_motion_sensors;
+bool JoypadSDL::has_joy_motion_sensors(int p_device) const {
+	return joypads[p_device].supports_motion_sensors;
 }
 
-void JoypadSDL::Joypad::set_joy_motion_sensors_enabled(bool p_enable) {
-	SDL_Gamepad *gamepad = get_sdl_gamepad();
+void JoypadSDL::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
+	SDL_Gamepad *gamepad = joypads[p_device].get_sdl_gamepad();
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_ACCEL, p_enable);
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, p_enable);
 }
 
-bool JoypadSDL::Joypad::has_joy_vibration() const {
-	return supports_force_feedback;
+bool JoypadSDL::has_joy_vibration(int p_device) const {
+	return joypads[p_device].supports_force_feedback;
 }
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+
+void JoypadSDL::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
+	update_existing_mappings = p_update_existing;
+	SDL_AddGamepadMapping(p_mapping.utf8().ptr());
+
+	// Process events in case the user might want to call the function several times with different
+	// values for p_update_existing, or call remove_joy_mapping immediately after (while this function
+	// was called with p_update_existing=false, in which case I feel there might be bugs).
+	process_events();
+}
+
+void JoypadSDL::remove_joy_mapping(const String &p_guid) {
+	SDL_GUID guid = SDL_StringToGUID(p_guid.utf8().ptr());
+	char *check_mapping = SDL_GetGamepadMappingForGUID(guid);
+	if (!check_mapping) {
+		// Mapping doesn't exist, nothing to remove.
+		return;
+	}
+
+	int mapping_count;
+	char **mappings = SDL_GetGamepadMappings(&mapping_count);
+	update_existing_mappings = true;
+
+	SDL_ReloadGamepadMappings();
+
+	for (int i = 0; i < mapping_count; i++) {
+		if (SDL_strcmp(mappings[i], check_mapping) != 0) {
+			SDL_AddGamepadMapping(mappings[i]);
+		}
+	}
+
+	SDL_free(check_mapping);
+	SDL_free(mappings);
+
+	// Process new gamepad events.
+	process_events();
+}
+#endif
 
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {
 	return SDL_GetJoystickFromID(sdl_instance_idx);

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -33,6 +33,7 @@
 #ifdef SDL_ENABLED
 
 #include "core/input/default_controller_mappings.h"
+#include "core/input/input_enums.h"
 #include "core/variant/dictionary.h"
 
 #include <SDL3/SDL.h>
@@ -45,7 +46,12 @@
 // Macro to skip the SDL joystick event handling if the device is an SDL gamepad, because
 // there are separate events for SDL gamepads
 #define SKIP_EVENT_FOR_GAMEPAD \
-	if (SDL_IsGamepad(sdl_event.jdevice.which)) { \
+	if (joypads[joy_id].gamepad) { \
+		continue; \
+	}
+
+#define SKIP_EVENT_FOR_NON_GAMEPAD \
+	if (!joypads[joy_id].gamepad) { \
 		continue; \
 	}
 
@@ -65,13 +71,12 @@ Error JoypadSDL::initialize() {
 	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 	ERR_FAIL_COND_V_MSG(!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD), FAILED, SDL_GetError());
 
+	Input::get_singleton()->set_joypad_features(this);
+
 	// Add Godot's mapping database from memory
 	int i = 0;
 	while (DefaultControllerMappings::mappings[i]) {
-		String mapping_string = DefaultControllerMappings::mappings[i++];
-		CharString data = mapping_string.utf8();
-		SDL_IOStream *rw = SDL_IOFromMem((void *)data.ptr(), data.size());
-		SDL_AddGamepadMappingsFromIO(rw, true);
+		SDL_AddGamepadMapping(DefaultControllerMappings::mappings[i++]);
 	}
 
 	// Make sure that we handle already connected joypads when the driver is initialized.
@@ -82,21 +87,23 @@ Error JoypadSDL::initialize() {
 }
 
 void JoypadSDL::process_events() {
+	Input *input = Input::get_singleton();
+
 	// Update rumble first for it to be applied when we handle SDL events
 	for (int i = 0; i < Input::JOYPADS_MAX; i++) {
 		Joypad &joy = joypads[i];
 		if (joy.attached && joy.supports_force_feedback) {
-			uint64_t timestamp = Input::get_singleton()->get_joy_vibration_timestamp(i);
+			uint64_t timestamp = input->get_joy_vibration_timestamp(i);
 
 			// Update the joypad rumble only if there was a new vibration request
 			if (timestamp > joy.ff_effect_timestamp) {
 				joy.ff_effect_timestamp = timestamp;
 
 				SDL_Joystick *sdl_joy = SDL_GetJoystickFromID(joypads[i].sdl_instance_idx);
-				Vector2 strength = Input::get_singleton()->get_joy_vibration_strength(i);
+				Vector2 strength = input->get_joy_vibration_strength(i);
 				// Invalid values for strength are filtered by Input::start_joy_vibration().
 
-				float duration = Input::get_singleton()->get_joy_vibration_duration(i);
+				float duration = input->get_joy_vibration_duration(i);
 				Uint32 duration_ms = 0;
 				if (duration < 0.0f) {
 					continue; // Invalid duration.
@@ -125,7 +132,7 @@ void JoypadSDL::process_events() {
 	while (SDL_PollEvent(&sdl_event)) {
 		// A new joypad was attached
 		if (sdl_event.type == SDL_EVENT_JOYSTICK_ADDED) {
-			int joy_id = Input::get_singleton()->get_unused_joy_id();
+			int joy_id = input->get_unused_joy_id();
 			if (joy_id == -1) {
 				// There is no space for more joypads...
 				print_error("A new joypad was attached but couldn't allocate a new id for it because joypad limit was reached.");
@@ -166,6 +173,7 @@ void JoypadSDL::process_events() {
 				joypads[joy_id].supports_force_feedback = SDL_GetBooleanProperty(propertiesID, SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, false);
 				joypads[joy_id].guid = StringName(String(guid));
 				joypads[joy_id].supports_motion_sensors = SDL_GamepadHasSensor(gamepad, SDL_SENSOR_ACCEL) || SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO);
+				joypads[joy_id].gamepad = SDL_IsGamepad(sdl_event.jdevice.which);
 
 				sdl_instance_id_to_joypad_id.insert(sdl_event.jdevice.which, joy_id);
 
@@ -196,18 +204,16 @@ void JoypadSDL::process_events() {
 				}
 #endif
 
-				Input::get_singleton()->joy_connection_changed(
+				input->joy_connection_changed(
 						joy_id,
 						true,
 						device_name,
 						joypads[joy_id].guid,
 						joypad_info);
 
-				Input::get_singleton()->set_joy_features(joy_id, &joypads[joy_id]);
-
 				if (joypads[joy_id].supports_motion_sensors) {
 					// Data rate for all sensors should be the same.
-					Input::get_singleton()->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
+					input->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
 				}
 			}
 			// An event for an attached joypad
@@ -216,14 +222,42 @@ void JoypadSDL::process_events() {
 
 			switch (sdl_event.type) {
 				case SDL_EVENT_JOYSTICK_REMOVED:
-					Input::get_singleton()->joy_connection_changed(joy_id, false, "");
+					input->joy_connection_changed(joy_id, false, "");
 					close_joypad(joy_id);
+					break;
+
+				case SDL_EVENT_GAMEPAD_ADDED: // A controller mapping has been added to a controller that wasn't mapped before.
+					if (input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_known(joy_id, true);
+					input->set_joy_name(joy_id, SDL_GetGamepadNameForID(sdl_event.gdevice.which));
+					joypads[joy_id].gamepad = true;
+					break;
+
+				case SDL_EVENT_GAMEPAD_REMOVED: // A controller's mapping has been removed.
+					if (!input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_known(joy_id, false);
+					input->set_joy_name(joy_id, SDL_GetJoystickNameForID(sdl_event.gdevice.which));
+					joypads[joy_id].gamepad = false;
+					break;
+
+				case SDL_EVENT_GAMEPAD_REMAPPED: // A controller's mapping was updated.
+					if (!input->is_joy_known(joy_id)) {
+						// Nothing to change here.
+						break;
+					}
+					input->set_joy_name(joy_id, SDL_GetGamepadNameForID(sdl_event.gdevice.which));
 					break;
 
 				case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 					SKIP_EVENT_FOR_GAMEPAD;
 
-					Input::get_singleton()->joy_axis(
+					input->joy_axis(
 							joy_id,
 							static_cast<JoyAxis>(sdl_event.jaxis.axis), // Godot joy axis constants are already intentionally the same as SDL's
 							((sdl_event.jaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f);
@@ -239,7 +273,7 @@ void JoypadSDL::process_events() {
 						continue;
 					}
 
-					Input::get_singleton()->joy_button(
+					input->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.jbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them
 							sdl_event.jbutton.down);
@@ -248,13 +282,14 @@ void JoypadSDL::process_events() {
 				case SDL_EVENT_JOYSTICK_HAT_MOTION:
 					SKIP_EVENT_FOR_GAMEPAD;
 
-					Input::get_singleton()->joy_hat(
+					input->joy_hat(
 							joy_id,
 							(HatMask)sdl_event.jhat.value // Godot hat masks are identical to SDL hat masks, so we can just use them as-is.
 					);
 					break;
 
 				case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
+					SKIP_EVENT_FOR_NON_GAMEPAD;
 					float axis_value;
 
 					if (sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_LEFT_TRIGGER || sdl_event.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
@@ -266,7 +301,7 @@ void JoypadSDL::process_events() {
 								((sdl_event.gaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f;
 					}
 
-					Input::get_singleton()->joy_axis(
+					input->joy_axis(
 							joy_id,
 							static_cast<JoyAxis>(sdl_event.gaxis.axis), // Godot joy axis constants are already intentionally the same as SDL's
 							axis_value);
@@ -275,7 +310,8 @@ void JoypadSDL::process_events() {
 				// Do note SDL gamepads do not have separate events for the dpad
 				case SDL_EVENT_GAMEPAD_BUTTON_UP:
 				case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-					Input::get_singleton()->joy_button(
+					SKIP_EVENT_FOR_NON_GAMEPAD;
+					input->joy_button(
 							joy_id,
 							static_cast<JoyButton>(sdl_event.gbutton.button), // Godot button constants are intentionally the same as SDL's, so we can just straight up use them
 							sdl_event.gbutton.down);
@@ -284,7 +320,7 @@ void JoypadSDL::process_events() {
 				case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
 				case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
 				case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
-					Input::get_singleton()->joy_touchpad(
+					input->joy_touchpad(
 							joy_id,
 							sdl_event.gtouchpad.touchpad,
 							sdl_event.gtouchpad.finger,
@@ -309,7 +345,7 @@ void JoypadSDL::process_events() {
 		SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_ACCEL, accel_data, 3);
 		SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_GYRO, gyro_data, 3);
 
-		Input::get_singleton()->joy_motion_sensors(
+		input->joy_motion_sensors(
 				i,
 				Vector3(-accel_data[0], -accel_data[1], -accel_data[2]),
 				Vector3(gyro_data[0], gyro_data[1], gyro_data[2]));
@@ -331,8 +367,8 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 	}
 }
 
-bool JoypadSDL::Joypad::has_joy_light() const {
-	SDL_Joystick *joystick = get_sdl_joystick();
+bool JoypadSDL::has_joy_light(int p_device) const {
+	SDL_Joystick *joystick = joypads[p_device].get_sdl_joystick();
 	SDL_PropertiesID properties_id = SDL_GetJoystickProperties(joystick);
 	if (properties_id == 0) {
 		return false;
@@ -340,27 +376,52 @@ bool JoypadSDL::Joypad::has_joy_light() const {
 	return SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN, false) || SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN, false);
 }
 
-void JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
-	SDL_SetJoystickLED(get_sdl_joystick(), p_color.get_r8(), p_color.get_g8(), p_color.get_b8());
+void JoypadSDL::set_joy_light(int p_device, const Color &p_color) {
+	SDL_SetJoystickLED(joypads[p_device].get_sdl_joystick(), p_color.get_r8(), p_color.get_g8(), p_color.get_b8());
 }
 
-bool JoypadSDL::Joypad::has_joy_motion_sensors() const {
-	return supports_motion_sensors;
+bool JoypadSDL::has_joy_motion_sensors(int p_device) const {
+	return joypads[p_device].supports_motion_sensors;
 }
 
-void JoypadSDL::Joypad::set_joy_motion_sensors_enabled(bool p_enable) {
-	SDL_Gamepad *gamepad = get_sdl_gamepad();
+void JoypadSDL::set_joy_motion_sensors_enabled(int p_device, bool p_enable) {
+	SDL_Gamepad *gamepad = joypads[p_device].get_sdl_gamepad();
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_ACCEL, p_enable);
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, p_enable);
 }
 
-bool JoypadSDL::Joypad::has_joy_vibration() const {
-	return supports_force_feedback;
+bool JoypadSDL::has_joy_vibration(int p_device) const {
+	return joypads[p_device].supports_force_feedback;
 }
 
-int JoypadSDL::Joypad::get_joy_num_touchpads() const {
-	return SDL_GetNumGamepadTouchpads(get_sdl_gamepad());
+int JoypadSDL::get_joy_num_touchpads(int p_device) const {
+	return SDL_GetNumGamepadTouchpads(joypads[p_device].get_sdl_gamepad());
 }
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+
+void JoypadSDL::add_joy_mapping(const String &p_mapping) {
+	SDL_AddGamepadMapping(p_mapping.utf8().ptr());
+	process_events();
+}
+
+void JoypadSDL::remove_joy_mapping(const String &p_guid) {
+	SDL_GUID joy_guid = SDL_StringToGUID(p_guid.utf8().ptr());
+	char *check_mapping = SDL_GetGamepadMappingForGUID(joy_guid);
+	if (!check_mapping) {
+		// Mapping doesn't exist, nothing to remove.
+		return;
+	}
+
+	SDL_free(check_mapping);
+
+	// Clear the mapping for this GUID (see also SDL_SetGamepadMapping)
+	SDL_AddGamepadMapping((p_guid + ",*,").utf8().ptr());
+
+	// Process new gamepad events.
+	process_events();
+}
+#endif
 
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {
 	return SDL_GetJoystickFromID(sdl_instance_idx);

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -36,17 +36,30 @@ typedef uint32_t SDL_JoystickID;
 typedef struct SDL_Joystick SDL_Joystick;
 typedef struct SDL_Gamepad SDL_Gamepad;
 
-class JoypadSDL {
+class JoypadSDL : public Input::JoypadFeatures {
 public:
 	~JoypadSDL();
 
 	Error initialize();
 	void process_events();
 
+	virtual bool has_joy_light(int p_device) const override;
+	virtual void set_joy_light(int p_device, const Color &p_color) override;
+
+	virtual bool has_joy_motion_sensors(int p_device) const override;
+	virtual void set_joy_motion_sensors_enabled(int p_device, bool p_enable) override;
+
+	virtual bool has_joy_vibration(int p_device) const override;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	virtual void add_joy_mapping(const String &p_mapping, bool p_update_existing) override;
+	virtual void remove_joy_mapping(const String &p_guid) override;
+#endif
+
 private:
-	class Joypad : public Input::JoypadFeatures {
-	public:
+	struct Joypad {
 		bool attached = false;
+		bool gamepad = false;
 		StringName guid;
 
 		SDL_JoystickID sdl_instance_idx;
@@ -55,20 +68,13 @@ private:
 		bool supports_motion_sensors = false;
 		uint64_t ff_effect_timestamp = 0;
 
-		virtual bool has_joy_light() const override;
-		virtual void set_joy_light(const Color &p_color) override;
-
-		virtual bool has_joy_motion_sensors() const override;
-		virtual void set_joy_motion_sensors_enabled(bool p_enable) override;
-
-		virtual bool has_joy_vibration() const override;
-
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;
 	};
 
 	Joypad joypads[Input::JOYPADS_MAX];
 	HashMap<SDL_JoystickID, int> sdl_instance_id_to_joypad_id;
+	bool update_existing_mappings = false;
 
 	void close_joypad(int p_pad_idx);
 };

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -36,17 +36,32 @@ typedef uint32_t SDL_JoystickID;
 typedef struct SDL_Joystick SDL_Joystick;
 typedef struct SDL_Gamepad SDL_Gamepad;
 
-class JoypadSDL {
+class JoypadSDL : public Input::JoypadFeatures {
 public:
 	~JoypadSDL();
 
 	Error initialize();
 	void process_events();
 
+	virtual bool has_joy_light(int p_device) const override;
+	virtual void set_joy_light(int p_device, const Color &p_color) override;
+
+	virtual bool has_joy_motion_sensors(int p_device) const override;
+	virtual void set_joy_motion_sensors_enabled(int p_device, bool p_enable) override;
+
+	virtual bool has_joy_vibration(int p_device) const override;
+
+	virtual int get_joy_num_touchpads(int p_device) const override;
+
+#ifdef GODOT_CUSTOM_JOY_MAPPING_DISABLED
+	virtual void add_joy_mapping(const String &p_mapping) override;
+	virtual void remove_joy_mapping(const String &p_guid) override;
+#endif
+
 private:
-	class Joypad : public Input::JoypadFeatures {
-	public:
+	struct Joypad {
 		bool attached = false;
+		bool gamepad = false;
 		StringName guid;
 
 		SDL_JoystickID sdl_instance_idx;
@@ -54,16 +69,6 @@ private:
 		bool supports_force_feedback = false;
 		bool supports_motion_sensors = false;
 		uint64_t ff_effect_timestamp = 0;
-
-		virtual bool has_joy_light() const override;
-		virtual void set_joy_light(const Color &p_color) override;
-
-		virtual bool has_joy_motion_sensors() const override;
-		virtual void set_joy_motion_sensors_enabled(bool p_enable) override;
-
-		virtual bool has_joy_vibration() const override;
-
-		virtual int get_joy_num_touchpads() const override;
 
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -186,7 +186,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["sdl"]:
         if env["builtin_sdl"]:
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         else:
             print_warning("`builtin_sdl` was explicitly disabled. Disabling SDL input driver support.")
             env["sdl"] = False

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -428,10 +428,10 @@ def configure(env: "SConsEnvironment"):
 
     if env["sdl"]:
         if env["builtin_sdl"]:
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         elif os.system("pkg-config --exists sdl3") == 0:  # 0 means found
             env.ParseConfig("pkg-config sdl3 --cflags --libs")
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         else:
             print_warning(
                 "SDL3 development libraries not found, and `builtin_sdl` was explicitly disabled. Disabling SDL input driver support."

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -423,10 +423,10 @@ def configure(env: "SConsEnvironment"):
 
     if env["sdl"]:
         if env["builtin_sdl"]:
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         elif os.system("pkg-config --exists sdl3") == 0:  # 0 means found
             env.ParseConfig("pkg-config sdl3 --cflags --libs")
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         else:
             print_warning(
                 "SDL3 development libraries not found, and `builtin_sdl` was explicitly disabled. Disabling SDL input driver support."

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -235,7 +235,7 @@ def configure(env: "SConsEnvironment"):
         env["x86_libtheora_opt_gcc"] = True
 
     if env["sdl"]:
-        env.Append(CPPDEFINES=["SDL_ENABLED"])
+        env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         env.Append(LINKFLAGS=["-framework", "ForceFeedback"])
 
     ## Flags

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -165,7 +165,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["sdl"]:
         if env["builtin_sdl"]:
-            env.Append(CPPDEFINES=["SDL_ENABLED"])
+            env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
         else:
             print_warning("`builtin_sdl` was explicitly disabled. Disabling SDL input driver support.")
             env["sdl"] = False

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -468,7 +468,7 @@ def configure_msvc(env: "SConsEnvironment"):
             LIBS += ["vulkan"]
 
     if env["sdl"]:
-        env.Append(CPPDEFINES=["SDL_ENABLED"])
+        env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
 
     if env["d3d12"]:
         check_d3d12_installed(env, env["arch"] + "-msvc")
@@ -899,7 +899,7 @@ def configure_mingw(env: "SConsEnvironment"):
             env.Append(LIBS=["vulkan"])
 
     if env["sdl"]:
-        env.Append(CPPDEFINES=["SDL_ENABLED"])
+        env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
 
     if env["d3d12"]:
         if env["use_llvm"]:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -509,7 +509,7 @@ def configure_msvc(env: "SConsEnvironment"):
             LIBS += ["vulkan"]
 
     if env["sdl"]:
-        env.Append(CPPDEFINES=["SDL_ENABLED"])
+        env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
 
     if env["d3d12"]:
         check_d3d12_installed(env, env["arch"] + "-msvc")
@@ -941,7 +941,7 @@ def configure_mingw(env: "SConsEnvironment"):
             env.Append(LIBS=["vulkan"])
 
     if env["sdl"]:
-        env.Append(CPPDEFINES=["SDL_ENABLED"])
+        env.Append(CPPDEFINES=["SDL_ENABLED", "GODOT_CUSTOM_JOY_MAPPING_DISABLED"])
 
     if env["d3d12"]:
         if env["use_llvm"]:


### PR DESCRIPTION
This PR completely replaces Godot's custom joypad mapping system with the one included in SDL.
This PR defines `GODOT_CUSTOM_JOY_MAPPING_DISABLED` for platforms with SDL support (currently it's Windows, Linux, macOS, and iOS), which removes Godot's custom joypad mapping system from the compiled binary, and it makes Godot use SDL's mapping system directly for `Input.add_joy_mapping()` and `Input.remove_joy_mapping()` .

The joypad features functionality had to be reworked a little bit to add new methods that aren't bound to specific joypad IDs (`add_joy_mapping` and `remove_joy_mapping`), so now `Input.add_joy_mapping()` and `Input.remove_joy_mapping()` should work properly now because they weren't working as expected since 4.5 (they were adding/removing mappings *on top* of the ones SDL provides).

Currently `Input.remove_joy_mapping()` doesn't remove the mappings for joypads whose mappings exist in the internal SDL mappings database, since after reloading the gamepad mappings (which is supposed to clear all of them) loads the internal ones immediately after. But I think it's possible to circumvent that by having a `HashSet` of GUIDs that should ignore `SDL_IsGamepad()` returning `true` and treat the controller as a regular unmapped controller. Should we do that?

There's a difference in binary size: 83095 kB (before) vs 83087 kB (after) (on Windows).