### PR TITLE
Fix BaseButton multitouch signals firing for only 1 button

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -251,7 +251,8 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	Ref<InputEventScreenDrag> screen_drag = p_event;
 
 	bool is_accept_event = mouse_button.is_null() && screen_touch.is_null() && screen_drag.is_null();
-	if (p_event->is_pressed() && (is_accept_event || status.hovering)) {
+	bool is_touch_press_inside = screen_touch.is_valid() && screen_touch->is_pressed() && status.pressing_inside;
+	if (p_event->is_pressed() && (is_accept_event || status.hovering || is_touch_press_inside)) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
 		if (!status.pressed_down_with_focus) {


### PR DESCRIPTION
Fixes #118581.

Regression from #110893.

Multitouch `button_down` / `button_up` signals only fired for one button at a time. When a second
`InputEventScreenTouch` press arrived on another button, `on_action_event()` rejected it because
`status.hovering` is only set by mouse motion and the event was not treated as an accept event, so
`status.press_attempt` never became true and no signal was emitted.

Also accept the press when the touch event targets a button whose `pressing_inside` is already true
(i.e. the touch that started inside the button's rect), so each button processes its own touch stream
independently and multiple buttons can emit `button_down` / `button_up` simultaneously.

- Verified on iOS Safari with a Web export of the MRP, pressing 4 buttons simultaneously with 4 fingers.
    
    https://github.com/user-attachments/assets/8c20ce9f-247e-44f5-ab2d-0a34f2e75aa4

- Verified on Android Chrome
    
    https://github.com/user-attachments/assets/d4108a70-1778-4bc4-b972-c64be668745b
