### PR TITLE
Remove obsolete header guard comment

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-// Note: _GODOT suffix added to header guard to avoid conflict with ICU header.
-
 #include "core/string/char_utils.h" // IWYU pragma: export
 #include "core/templates/cowdata.h"
 #include "core/templates/hashfuncs.h"


### PR DESCRIPTION
This comment isn't relevant since we don't use header guards anymore since https://github.com/godotengine/godot/pull/102298