### PR TITLE
GDScript: Lock cache while the analyzer is running

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6567,6 +6567,10 @@ Error GDScriptAnalyzer::resolve_dependencies() {
 }
 
 Error GDScriptAnalyzer::analyze() {
+	// When loading a script we already hold this lock.
+	// But certain editor functions call to `Analyzer.analyze()` directly.
+	MutexLock lock(GDScriptCache::mutex);
+
 	parser->errors.clear();
 
 	Error err = resolve_inheritance();

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -149,12 +149,8 @@ GDScriptParserRef::~GDScriptParserRef() {
 
 GDScriptCache *GDScriptCache::singleton = nullptr;
 
-SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG> &_get_gdscript_cache_mutex() {
-	return GDScriptCache::mutex;
-}
-
 template <>
-thread_local SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG>::TLSData SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG>::tls_data(_get_gdscript_cache_mutex());
+thread_local SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG>::TLSData SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG>::tls_data(GDScriptCache::mutex);
 SafeBinaryMutex<GDScriptCache::BINARY_MUTEX_TAG> GDScriptCache::mutex;
 
 void GDScriptCache::move_script(const String &p_from, const String &p_to) {

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -103,12 +103,8 @@ class GDScriptCache {
 
 public:
 	static const int BINARY_MUTEX_TAG = 2;
-
-private:
 	static SafeBinaryMutex<BINARY_MUTEX_TAG> mutex;
-	friend SafeBinaryMutex<BINARY_MUTEX_TAG> &_get_gdscript_cache_mutex();
 
-public:
 	static void move_script(const String &p_from, const String &p_to);
 	static void remove_script(const String &p_path);
 	static Ref<GDScriptParserRef> get_parser(const String &p_path, GDScriptParserRef::Status status, Error &r_error, const String &p_owner = String());


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/118593

This fix is hypothetical as I never encountered issues. But I'm quite sure that a race condition could happen in the situation described by the issue:

- When we receive a `didSave` call and the language server is running on a thread, we defer a script reload on the main thread (for hot reloading).
- When before the reload on the main thread is started we recieve a `didChange` notification (might happen in some editor configurations I guess), we start analyzing the new content on the LSP thread. The analyzer can obtain a parser ref here: https://github.com/HolonProduction/godot/blob/436c32393025043f3a6edb439d5554ab5c90e651/modules/gdscript/gdscript_analyzer.cpp#L4569 this does only lock the GDScriptCache while obtaining the parser.
- The analyzer stores the parser ref, without locking the GDScriptCache, so the main thread can now enter the reload and obtain a pointer to the same parser (since it is cached).
- The analyzer then raises this parser ref from the LSP thread: https://github.com/HolonProduction/godot/blob/436c32393025043f3a6edb439d5554ab5c90e651/modules/gdscript/gdscript_analyzer.cpp#L4571 while this is done the GDScriptCache is not locked.
- When the main thread reload accesses the same AST during this, we got ourself a race condition.

I decided to solve this by locking the GDScriptCache while `analyze` is running. For the standard loading code this has no impact, since the analyzer is always called from some `GDScriptCache` methods which hold the lock.

I'm putting this as draft, because I'm pretty sure there could be some hypothetical deadlock, since analyzing also has interaction with the resource loader, which also has a lock. So I'm pretty sure the LSP thread and the main thread could end in a situation were one is holding the GDS Lock and the other one the ResourceLoader lock.