### PR TITLE
Fix TreePrinter for match dictionary pattern with no value

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6216,9 +6216,12 @@ void GDScriptParser::TreePrinter::print_match_pattern(PatternNode *p_match_patte
 				if (p_match_pattern->dictionary[i].key != nullptr) {
 					// Key can be null for rest pattern.
 					print_expression(p_match_pattern->dictionary[i].key);
-					push_text(" : ");
+					if (p_match_pattern->dictionary[i].value_pattern != nullptr) {
+						// Value can be null when only matching key.
+						push_text(" : ");
+						print_match_pattern(p_match_pattern->dictionary[i].value_pattern);
+					}
 				}
-				print_match_pattern(p_match_pattern->dictionary[i].value_pattern);
 			}
 			push_text(" }");
 			break;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes #118141.

## Case

```
match x:
    {"key"}:
        ...
```
The above code would previously crash the TreePrinter but with the fix will correctly print:
```
...
Match x :
|   { "key" } :
|   |   ...
```

## Problem

`print_match_pattern` was not expecting the value to be null. 

## Changes

These changes only affect the TreePrinter. 

1. The value is only printed when there is a key (and value). 
2. The colon is only printed when there is both a key and value.

## Testing

Help with adding a test would be appreciated.

It seems the gdscript parser tests don't check the printer. I am able to cause the issue using the existing `match_dictionary` test.
```
./bin/<godot>.exe --headless --test gdscript-parser modules/gdscript/tests/scripts/parser/features/match_dictionary.gd
```
I tested all the other files in `tests/scripts/parser` and none of the others fail this check.