### PR TITLE
Add headings to GitHub pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,3 +4,23 @@ Please target the `master` branch. We will take care of backporting relevant fix
 Before submitting, please read our checklist for new contributors:
 https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
 -->
+
+### What problem(s) does this PR solve?
+
+<!--
+If the problems are described in an existing issue or proposal, you may link to them here. Use closing keywords if this PR closes the issue or proposal: https://docs.github.com/articles/closing-issues-using-keywords
+-->
+
+### What is the rationale for the approach used in this PR?
+
+<!--
+Providing a rationale is optional and may be omitted for simple PRs.
+-->
+
+### Was AI used to create any part of this PR?
+
+<!--
+The Godot project requires AI-assisted contributions to be disclosed. You can find out more about this policy in the docs: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#ai-assisted-contributions
+-->
+
+### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?


### PR DESCRIPTION
**Superseded by https://github.com/godotengine/godot/pull/118855**.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

### What problem(s) does this PR solve?

<!--
If the problems are described in an existing issue or proposal, you may link to them here. Use closing keywords if this PR closes the issue or proposal: https://docs.github.com/articles/closing-issues-using-keywords
-->

1. During PR review, especially in team meetings, it can take too much time to understand the root problem that a PR aims to solve.
2. During PR review, it is sometimes difficult to understand the rationale that was used for changes. This is especially a problem when an incorrect assumption is made by the reviewer regarding why a change was necessary.
3. PR authors who have not recently read the updated contributing docs may be unaware that they must now disclose their use of AI tools.
4. PR authors may assume that PR review will be extremely thorough and will catch any mistakes or sub-optimal decisions that were made in the PR, even when the PR author is aware of areas that may have mistakes or sub-optimal decisions. But, in practice, reviewers are left unaware of what specific parts of a PR might need special attention, making the review process more difficult and sometimes more error prone.
5. PR authors may desire and assume and that a review will initiate discussion over a technical detail that is relevant to the review, but the discussion will never happen because the technical detail was never brought up.

### What is the rationale for the approach used in this PR?

<!--
Providing a rationale is optional and may be omitted for simple PRs.
-->

This PR adds headings to the pull request template that prompt the PR author to answer some basic questions about their PR. The headings that I have chosen are designed primarily to improve the process for reviewing PRs.

By having standard headings for all new PRs, it will become much faster for reviewers to understand the PR in the ways that are necessary for a good and thorough review.

By asking the PR author to provide the problem that their PR reviews, it reinforces the Godot way of making changes: [The problem always comes first](https://contributing.godotengine.org/en/latest/engine/guidelines/best_practices.html#best-practices).

I have been trialing this new template on a number of my PRs. You can take a look and see how it plays out in practice on the following PRs:

1. https://github.com/godotengine/godot/pull/117754
2. https://github.com/godotengine/godot/pull/117800
3. https://github.com/godotengine/godot/pull/117837
4. https://github.com/godotengine/godot/pull/117913
5. https://github.com/godotengine/godot/pull/118076
6. https://github.com/godotengine/godot/pull/118079
7. https://github.com/godotengine/godot/pull/118083
9. https://github.com/godotengine/godot/pull/118355
10. https://github.com/godotengine/godot-docs/pull/11920
11. https://github.com/godotengine/godot/pull/117537
12. https://github.com/godotengine/godot/pull/118692
13. https://github.com/godotengine/godot-docs/pull/11931

Note that in my initial draft of this template, I also added the heading: "Does this PR include any additional changes beyond those required to solve these problems?". I later chose to remove this heading because it was often empty and it felt like it clashed with the first "What problem(s) does this PR solve?" heading.

As an anecdote: After attending many core and rendering team meetings, I have found that it is somewhat common for PR review to spend 10 or 15 minutes discussing a PR before Clay finally steps in and asks "What problem is this PR even aiming to solve?" and then we realize immediately that all of our talk was pointless because the PR doesn't do a good job of solving that problem or tries to do more than is necessary to actually solve this problem. My goal with this change to the PR template is that this waste of time will be avoided because all reviewers will be brought up to speed on what problem a PR solves as the first step in the review process.

### Was AI used to create any part of this PR?

<!--
The Godot project requires AI-assisted contributions to be disclosed. You can find out more about this policy in the docs: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#ai-assisted-contributions
-->

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

Although I have included a heading for disclosing use of AI, this is the least important part of this PR to me personally. I'm fine with omitting this heading entirely and leaving it to a separate PR if there is any strong pushback or a large amount more work will be needed before this sort of thing can be merged into `master`.