### PR TITLE
Fix crash when starting debug session on linux with vscode

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -100,6 +100,11 @@ def configure(env: "SConsEnvironment"):
 
     ## Build type
 
+    if env.dev_build:
+        # This is needed for our crash handler to work properly.
+        # gdb works fine without it though, so maybe our crash handler could too.
+        env.Append(LINKFLAGS=["-rdynamic"])
+
     # Cross-compilation
     # TODO: Support cross-compilation on architectures other than x86.
     host_is_64_bit = sys.maxsize > 2**32


### PR DESCRIPTION
A recent change caused the VSCode debugger to instantly show 
`SIGSEGV (Address boundary error)`
when godot launched.

I use VSCode to run and debug the engine, so without this change I can't test the godot master branch

Fixes https://github.com/godotengine/godot/issues/118626

Reverts part of the recent change in 8fe0028 by @AThousandShips