### PR TITLE
Make BlendSpace point labels rearrange to avoid intersection

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -348,6 +348,62 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 
 		points.push_back(point + ofs.x);
 
+		Vector2 gui_point = (ofs + Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
+
+		if (point >= 0.0 && point <= s.width) {
+			String name_text = show_indices ? itos(i) : String(blend_space->get_blend_point_name(i));
+			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+			float base_x = CLAMP(point - text_size.x / 2.0, 0, s.width - text_size.x);
+			float above_y = gui_point.y - ofs.y - 4 * EDSCALE;
+			float below_y = gui_point.y - ofs.y + icon->get_size().y / 2.0 + 4 * EDSCALE + font->get_ascent(font_size);
+			float label_h = text_size.y;
+
+			// Try above, below, above+offset, below+offset... until we find a spot that doesn't intersect with another label.
+			Vector2 text_pos;
+			bool show_line = false;
+			bool is_below = false;
+			for (int attempt = 0; attempt <= i; attempt++) {
+				show_line = attempt > 0;
+				int step = attempt / 2;
+				is_below = (attempt % 2 == 1);
+				float base_y = is_below ? below_y : above_y;
+				float offset_y = is_below ? (step * (label_h + 2 * EDSCALE)) : -(step * (label_h + 2 * EDSCALE));
+				text_pos = ofs + Vector2(base_x, base_y + offset_y);
+
+				Rect2 candidate(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
+				int blocking_label = -1;
+				for (int j = 0; j < i; j++) {
+					if (text_rects[j].intersects(candidate)) {
+						blocking_label = j;
+						break;
+					}
+				}
+				if (blocking_label == -1) {
+					break;
+				}
+			}
+
+			if (text_rects.size() <= i) {
+				text_rects.resize(i + 1);
+			}
+			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
+
+			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
+			if (editing_point != i) {
+				blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
+			}
+
+			if (show_line) {
+				name_color.a *= 0.55;
+				Vector2 pos = text_pos;
+				pos.x = (ofs.x + point);
+				if (is_below) {
+					pos.y -= text_size.y / 2;
+				}
+				blend_space_draw->draw_line(ofs + Vector2(point, s.height / 2.0), pos, name_color, Math::round(1 * EDSCALE));
+			}
+		}
+
 		// Draw × marker on non-AnimationNodeAnimation points when in cyclic mode.
 		bool is_key_valid = true;
 		AnimationNodeBlendSpace1D::SyncMode sync_mode = blend_space->get_sync_mode();
@@ -359,23 +415,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 				does_include_invalid_key = true;
 			}
 		}
-		Vector2 gui_point = (ofs + Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
 		blend_space_draw->draw_texture(is_key_valid ? (i == selected_point ? icon_selected : icon) : icon_invalid, gui_point);
-
-		if (point >= 0.0 && point <= s.width && editing_point != i) {
-			String name_text = show_indices ? itos(i) : String(blend_space->get_blend_point_name(i));
-			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
-			Vector2 text_pos = ofs + Vector2(CLAMP(point - text_size.x / 2.0, 0, s.width - text_size.x), gui_point.y - ofs.y - 4 * EDSCALE);
-
-			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
-			blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
-
-			if (text_rects.size() <= i) {
-				text_rects.resize(i + 1);
-			}
-
-			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
-		}
 	}
 	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
 			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -609,11 +609,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			bl_points.write[j] = ofs + point;
 		}
 
+		Color color = linecolor;
+		color.a *= 0.4;
 		for (int j = 0; j < 3; j++) {
-			blend_space_draw->draw_line(bl_points[j], bl_points[(j + 1) % 3], linecolor, Math::round(EDSCALE), true);
+			blend_space_draw->draw_line(bl_points[j], bl_points[(j + 1) % 3], color, Math::round(EDSCALE), true);
 		}
 
-		Color color;
 		if (i == selected_triangle) {
 			color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 			color.a *= 0.5;
@@ -648,6 +649,87 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		points.push_back(ofs + point);
 
+		Vector2 gui_point = (ofs + point - icon->get_size() / 2).floor();
+
+		if (point.x >= 0.0 && point.x <= s.width && point.y >= 0.0 && point.y <= s.height) {
+			String name_text = show_indices ? itos(i) : String(blend_space->get_blend_point_name(i));
+			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
+			float base_x = CLAMP(point.x - text_size.x / 2.0, 0, s.width - text_size.x);
+			float above_y = gui_point.y - ofs.y - 4 * EDSCALE;
+			float below_y = gui_point.y - ofs.y + icon->get_size().y / 2.0 + 4 * EDSCALE + font->get_ascent(font_size);
+
+			// Try above, below, above+nudge, below+nudge... until we find a spot that doesn't intersect with another label.
+			Vector2 text_pos;
+			bool show_line = false;
+			bool is_below = false;
+			bool above_oob = false;
+			bool below_oob = false;
+			for (int attempt = 0; attempt <= i + 1; attempt++) {
+				show_line = above_oob ? attempt > 1 : attempt > 0; // Only show line if ambiguous.
+				float base_y = is_below ? below_y : above_y;
+				text_pos = ofs + Vector2(base_x, base_y);
+				Rect2 candidate(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
+
+				// Lock orientation after going out of bounds, and break if it happens again.
+				if (candidate.position.y < ofs.y || candidate.get_end().y > ofs.y + s.height) {
+					if (is_below) {
+						below_oob = true;
+					} else {
+						above_oob = true;
+					}
+					if (above_oob && below_oob) {
+						break;
+					}
+					is_below = !is_below;
+					continue;
+				}
+
+				int blocking_label = -1;
+				for (int j = 0; j < i; j++) {
+					if (text_rects[j].intersects(candidate)) {
+						blocking_label = j;
+						break;
+					}
+				}
+				if (blocking_label == -1) {
+					break;
+				}
+
+				Rect2 blocker = text_rects[blocking_label];
+				if (is_below) {
+					below_y = blocker.get_end().y + font->get_ascent(font_size) - 6 * EDSCALE;
+					if (!above_oob) {
+						is_below = false;
+					}
+				} else {
+					above_y = blocker.position.y - text_size.y + font->get_ascent(font_size) - 6 * EDSCALE;
+					if (!below_oob) {
+						is_below = true;
+					}
+				}
+			}
+
+			if (text_rects.size() <= i) {
+				text_rects.resize(i + 1);
+			}
+			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
+
+			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
+			if (editing_point != i) {
+				blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
+			}
+
+			if (show_line) {
+				name_color.a *= 0.55;
+				Vector2 pos = text_pos;
+				pos.x = (ofs + point).x;
+				if (is_below) {
+					pos.y -= text_size.y / 2;
+				}
+				blend_space_draw->draw_line(ofs + point, pos, name_color, Math::round(1 * EDSCALE));
+			}
+		}
+
 		// Draw × marker on non-AnimationNodeAnimation points when in cyclic mode.
 		bool is_key_valid = true;
 		AnimationNodeBlendSpace2D::SyncMode sync_mode = blend_space->get_sync_mode();
@@ -659,28 +741,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 				does_include_invalid_key = true;
 			}
 		}
-		Vector2 gui_point = (ofs + point - icon->get_size() / 2).floor();
 		blend_space_draw->draw_texture(is_key_valid ? (i == selected_point ? icon_selected : icon) : icon_invalid, gui_point);
-
-		if (point.x >= 0.0 && point.x <= s.width && point.y >= 0.0 && point.y <= s.height && editing_point != i) {
-			String name_text = show_indices ? itos(i) : String(blend_space->get_blend_point_name(i));
-			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
-
-			float half_icon_h = icon->get_size().y / 2.0;
-			float above_pos_y = (ofs.y + point.y) - half_icon_h - 4 * EDSCALE;
-			float text_x = CLAMP((ofs.x + point.x) - text_size.x / 2.0, ofs.x, ofs.x + s.width - text_size.x);
-			float text_y = above_pos_y >= (ofs.y + text_size.y) ? above_pos_y : (ofs.y + point.y) + half_icon_h + font->get_ascent(font_size);
-			Vector2 text_pos = Vector2(text_x, text_y);
-
-			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
-			blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
-
-			if (text_rects.size() <= i) {
-				text_rects.resize(i + 1);
-			}
-
-			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
-		}
 	}
 	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
 			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")


### PR DESCRIPTION
Quality-of-life follow up to #110369.

BlendSpaces have always been unable to represent fully overlapping points, which accidentally happens often when working with wide snapping ranges, and causes confusion. With the addition of name labels, this was at least somewhat alleviated, but these labels overlapping isn't ideal either, and outside of that case, may trouble users with dense layouts too.

This PR allows BlendSpace name labels to self-manage Y position to avoid this intersection. Attempted position is above, below, above+offset, below+offset... and so on. Priority in this is determined via index.

https://github.com/user-attachments/assets/bc1fb821-3b0d-4a2e-860c-6e2a22cd1710

https://github.com/user-attachments/assets/694eec3e-7f06-4ac9-9c62-64e164427e39

While there are other ways to move that could provide better proximity to the point (eg. clockwise for BlendSpace2D), this way ends up being the least complex, most predictable, and more than good enough for all but the most extreme situations, as evidenced above. Feedback for further whittling down complexity would be very appreciated.

> [!NOTE]
> LLM used in first iteration to negotiate BlendSpace2D logic. It has since been fully discarded.