### PR TITLE
Prepare for a CSG face editor

### DIFF
--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -99,8 +99,6 @@ void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<
 	for (const KeyValue<Ref<Material>, int> &E : material_map) {
 		materials.write[E.value] = E.key;
 	}
-
-	_regen_face_aabbs();
 }
 
 void CSGBrush::copy_from(const CSGBrush &p_brush, const Transform3D &p_xform) {
@@ -112,6 +110,31 @@ void CSGBrush::copy_from(const CSGBrush &p_brush, const Transform3D &p_xform) {
 			faces.write[i].vertices[j] = p_xform.xform(p_brush.faces[i].vertices[j]);
 		}
 	}
+}
 
-	_regen_face_aabbs();
+void CSGBrush::add_ngons(const Vector<int> &p_ngons) {
+	ERR_FAIL_COND_MSG(p_ngons.size() > faces.size(), "Wrong number of elements in p_ngons.");
+	ngons = p_ngons;
+	for (int i = 0; i < ngons.size(); i++) {
+		if (ngons[i] > num_ngons) {
+			num_ngons++;
+		}
+	}
+
+	if (ngons.size() > 0) {
+		num_ngons++;
+	}
+}
+
+Vector<int> CSGBrush::get_ngon_faces(int p_ngon) {
+	Vector<int> ret;
+	ERR_FAIL_COND_V_MSG(p_ngon >= num_ngons, ret, "Invalid ngon ID.");
+	ERR_FAIL_COND_V_MSG(num_ngons == 0, ret, "Ngons not set in CSGBrush.");
+
+	for (int i = 0; i < ngons.size(); i++) {
+		if (ngons[i] == p_ngon) {
+			ret.push_back(i);
+		}
+	}
+	return ret;
 }

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/math/aabb.h"
 #include "core/math/transform_3d.h"
 #include "core/math/vector2.h"
 #include "core/math/vector3.h"
@@ -42,7 +41,6 @@ struct CSGBrush {
 	struct Face {
 		Vector3 vertices[3];
 		Vector2 uvs[3];
-		AABB aabb;
 		bool smooth = false;
 		bool invert = false;
 		int material = 0;
@@ -50,17 +48,12 @@ struct CSGBrush {
 
 	Vector<Face> faces;
 	Vector<Ref<Material>> materials;
-
-	inline void _regen_face_aabbs() {
-		for (int i = 0; i < faces.size(); i++) {
-			faces.write[i].aabb = AABB();
-			faces.write[i].aabb.position = faces[i].vertices[0];
-			faces.write[i].aabb.expand_to(faces[i].vertices[1]);
-			faces.write[i].aabb.expand_to(faces[i].vertices[2]);
-		}
-	}
+	Vector<int> ngons;
+	int num_ngons = 0;
 
 	// Create a brush from faces.
 	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces);
 	void copy_from(const CSGBrush &p_brush, const Transform3D &p_xform);
+	void add_ngons(const Vector<int> &p_ngons);
+	Vector<int> get_ngon_faces(int p_ngon);
 };

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -262,6 +262,19 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 #endif // PHYSICS_3D_DISABLED
 
 	dirty = true;
+	notify_property_list_changed();
+}
+
+void CSGShape3D::_make_painted() {
+	// TODO Fix this mess.
+	if (!is_root_shape()) {
+		notify_property_list_changed();
+		// We force a rebuild of the parent shape only.
+		parent_shape->_make_dirty();
+	} else {
+		// With this we can replace most calls to _make_dirty().
+		_make_dirty();
+	}
 }
 
 enum ManifoldProperty {
@@ -936,7 +949,9 @@ void CSGShape3D::_notification(int p_what) {
 					root_mesh.unref();
 				}
 			}
-			if (!brush || parent_shape) {
+			if (parent_shape) {
+				_make_painted();
+			} else if (!brush) {
 				// Update this node if uninitialized, or both this node and its new parent if it gets added to another CSG shape
 				_make_dirty();
 			}
@@ -946,13 +961,14 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_UNPARENTED: {
 			if (!is_root_shape()) {
 				// Update this node and its previous parent only if it's currently being removed from another CSG shape
+				// TODO investigate.
 				_make_dirty(true); // Must be forced since is_root_shape() uses the previous parent
 			}
 			parent_shape = nullptr;
 		} break;
 
 		case NOTIFICATION_CHILD_ORDER_CHANGED: {
-			_make_dirty();
+			_make_painted();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -1009,7 +1025,7 @@ void CSGShape3D::_notification(int p_what) {
 
 void CSGShape3D::set_operation(Operation p_operation) {
 	operation = p_operation;
-	_make_dirty();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1050,6 +1066,128 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	} else if (is_collision_prefixed && !bool(get("use_collision"))) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
+}
+
+Dictionary CSGShape3D::get_csg_brush() const {
+	if (!brush) {
+		return Dictionary();
+	}
+
+	CSGBrush *n = brush;
+
+	Dictionary p_brush_data;
+	Vector<Vector3> vertices;
+	Vector<Vector2> uvs;
+	Vector<uint8_t> smooths;
+	Vector<uint8_t> inverts;
+	Vector<uint8_t> mat_id;
+	Array materials;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			vertices.push_back(n->faces[i].vertices[j]);
+			uvs.push_back(n->faces[i].uvs[j]);
+		}
+
+		smooths.push_back(n->faces[i].smooth ? 1 : 0);
+		inverts.push_back(n->faces[i].invert ? 1 : 0);
+		mat_id.push_back(n->faces[i].material);
+	}
+
+	p_brush_data["vertices"] = vertices;
+	p_brush_data["uvs"] = uvs;
+	// Replace with smooth groups in the future.
+	p_brush_data["smooth"] = smooths;
+	p_brush_data["invert"] = inverts;
+	p_brush_data["material_id"] = mat_id;
+
+	for (int i = 0; i < n->materials.size(); i++) {
+		// TODO Make sure something is written in the space if the material is not valid.
+		if (n->materials[i].is_valid()) {
+			materials.push_back(n->materials[i]);
+		}
+	}
+
+	p_brush_data["materials"] = materials;
+
+	return p_brush_data;
+}
+
+void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
+	ERR_FAIL_COND(!p_brush_data.has("material_id"));
+	ERR_FAIL_COND(!p_brush_data.has("vertices"));
+	ERR_FAIL_COND(!p_brush_data.has("uvs"));
+	ERR_FAIL_COND(!p_brush_data.has("smooth"));
+	ERR_FAIL_COND(!p_brush_data.has("invert"));
+	ERR_FAIL_COND(!p_brush_data.has("materials"));
+
+	CSGBrush *n = memnew(CSGBrush);
+
+	Vector<uint8_t> mat_id = p_brush_data["material_id"];
+
+	int face_count = mat_id.size();
+
+	Vector<Vector3> faces = p_brush_data["vertices"];
+	Vector<Vector2> uvs = p_brush_data["uvs"];
+	Vector<bool> smooth;
+	Vector<Ref<Material>> materials;
+	Vector<bool> invert;
+
+	smooth.resize(face_count);
+	materials.resize(face_count);
+	invert.resize(face_count);
+
+	{
+		Vector<uint8_t> invrt = p_brush_data["invert"];
+		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
+		Array mats = p_brush_data["materials"];
+
+		bool *smoothw = smooth.ptrw();
+		Ref<Material> *materialsw = materials.ptrw();
+		bool *invertw = invert.ptrw();
+
+		for (int i = 0; i < face_count; i++) {
+			smoothw[i] = smooth_i[i] > 0;
+			int i_mat = mat_id[i];
+			if (i_mat < mats.size()) {
+				Ref<Material> t_mat = mats[i_mat];
+				if (t_mat.is_valid()) {
+					materialsw[i] = t_mat;
+				}
+			}
+			invertw[i] = invrt[i] > 0;
+		}
+	}
+
+	n->build_from_faces(faces, uvs, smooth, materials, invert);
+
+	if (brush) {
+		memdelete(brush);
+	}
+
+	brush = n;
+}
+
+void CSGShape3D::rebuild_brush() {
+	_make_dirty();
+}
+
+void CSGShape3D::rotate_uv(const Vector<int> &p_faces, const float angle) {
+	CSGBrush *n = _get_brush();
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	Transform2D p_rotation = Transform2D(angle, Vector2(0.0, 0.0));
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = p_rotation.xform(n->faces[p].uvs[j]);
+		}
+	}
+	_make_painted();
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1123,6 +1261,11 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_calculate_tangents", "enabled"), &CSGShape3D::set_calculate_tangents);
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
+	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
+	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
+
+	ClassDB::bind_method(D_METHOD("rotate_uv", "faces", "angle"), &CSGShape3D::rotate_uv);
+
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
 	ClassDB::bind_method(D_METHOD("bake_static_mesh"), &CSGShape3D::bake_static_mesh);
@@ -1132,6 +1275,8 @@ void CSGShape3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_smoothing_angle", "smoothing_angle"), &CSGShape3D::set_smoothing_angle);
 	ClassDB::bind_method(D_METHOD("get_smoothing_angle"), &CSGShape3D::get_smoothing_angle);
+
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_csg_brush", "get_csg_brush");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autosmooth"), "set_autosmooth", "is_autosmooth");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), "set_smoothing_angle", "get_smoothing_angle");
@@ -1379,6 +1524,7 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 }
 
@@ -1576,6 +1722,7 @@ void CSGSphere3D::_bind_methods() {
 void CSGSphere3D::set_radius(const float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
 	radius = p_radius;
+	// TODO Make painted and add a method to change scale.
 	_make_dirty();
 	update_gizmos();
 }
@@ -1606,6 +1753,7 @@ int CSGSphere3D::get_rings() const {
 
 void CSGSphere3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
+	// TODO Make painted and change smooth of all faces.
 	_make_dirty();
 }
 
@@ -1615,6 +1763,7 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 }
 
@@ -1745,6 +1894,7 @@ void CSGBox3D::_bind_methods() {
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
 	size = p_size;
+	// TODO Make painted and add a method to change scale of CSGBrush.
 	_make_dirty();
 	update_gizmos();
 }
@@ -1779,6 +1929,7 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 	update_gizmos();
 }
@@ -1953,6 +2104,7 @@ void CSGCylinder3D::_bind_methods() {
 
 void CSGCylinder3D::set_radius(const float p_radius) {
 	radius = p_radius;
+	// TODO Make painted and add a method to change scale of CSGBrush.
 	_make_dirty();
 	update_gizmos();
 }
@@ -1963,6 +2115,7 @@ float CSGCylinder3D::get_radius() const {
 
 void CSGCylinder3D::set_height(const float p_height) {
 	height = p_height;
+	// TODO Make painted and add a method to change scale of CSGBrush.
 	_make_dirty();
 	update_gizmos();
 }
@@ -2003,6 +2156,7 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 }
 
@@ -2229,6 +2383,7 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 }
 
@@ -2889,6 +3044,7 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
+	// TODO Make painted and add a method to change material of CSGBrush.
 	_make_dirty();
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -113,7 +113,7 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		set_collision_layer(collision_layer);
 		set_collision_mask(collision_mask);
 		set_collision_priority(collision_priority);
-		_make_dirty(); //force update
+		_make_painted(); //force update
 	} else {
 		PhysicsServer3D::get_singleton()->free_rid(root_collision_instance);
 		root_collision_instance = RID();
@@ -207,7 +207,7 @@ real_t CSGShape3D::get_collision_priority() const {
 
 void CSGShape3D::set_autosmooth(bool p_smooth) {
 	autosmooth = p_smooth;
-	_make_dirty();
+	_make_painted();
 	notify_property_list_changed();
 }
 
@@ -217,7 +217,7 @@ bool CSGShape3D::is_autosmooth() const {
 
 void CSGShape3D::set_smoothing_angle(const float p_angle) {
 	smoothing_angle = p_angle;
-	_make_dirty();
+	_make_painted();
 }
 
 float CSGShape3D::get_smoothing_angle() const {
@@ -237,7 +237,7 @@ void CSGShape3D::set_snap(float p_snap) {
 	}
 
 	snap = p_snap;
-	_make_dirty();
+	_make_painted();
 }
 
 float CSGShape3D::get_snap() const {
@@ -253,15 +253,44 @@ void CSGShape3D::_make_dirty(bool p_parent_removing) {
 #endif // PHYSICS_3D_DISABLED
 
 	if (!is_root_shape()) {
-		parent_shape->_make_dirty();
+		parent_shape->_make_painted();
 	}
 #ifndef PHYSICS_3D_DISABLED
 	else if (!dirty) {
 		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
 	}
 #endif // PHYSICS_3D_DISABLED
-
+	children_modified = true;
+	painted = false;
 	dirty = true;
+	notify_property_list_changed();
+}
+
+void CSGShape3D::_make_painted(bool p_paint, bool p_parent_removing) {
+	// Update combined_brush.
+	children_modified = true;
+
+	painted = painted || p_paint;
+	if (!painted) {
+		_make_dirty(p_parent_removing);
+		return;
+	} else if (!brush) {
+		_make_dirty(p_parent_removing);
+		return;
+	}
+
+	if (p_parent_removing) {
+		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
+	} else if (!is_root_shape()) {
+		// The !is_root_shape() means the node has a parent so it has been added already.
+		update_configuration_warnings();
+		notify_property_list_changed();
+		// We force a rebuild of the root shape only.
+		parent_shape->_make_painted();
+	} else {
+		// Properties are set before add_child, so the node is root shape because it doesn't have a parent.
+		callable_mp(this, &CSGShape3D::update_shape).call_deferred();
+	}
 }
 
 enum ManifoldProperty {
@@ -323,8 +352,6 @@ static void _unpack_manifold(
 			r_mesh_merge->faces.push_back(face);
 		}
 	}
-
-	r_mesh_merge->_regen_face_aabbs();
 }
 
 #ifdef DEV_ENABLED
@@ -488,18 +515,64 @@ CSGBrush *CSGShape3D::_get_brush() {
 	}
 	brush = nullptr;
 	CSGBrush *n = _build_brush();
+	if (get_child_count() < 1 || !combined_brush) {
+		// This is a hack and needs a better solution to the problem of non CSGShape3D children.
+		_expand_aabb(n);
+	}
+	brush = n;
+	dirty = false;
+	update_configuration_warnings();
+	return brush;
+}
+
+CSGBrush *CSGShape3D::_get_combined_brush() {
+	int child_count = get_child_count();
+	if (!dirty && !children_modified) {
+		if (child_count < 1) {
+			// Single node should not have combined_brush.
+			if (combined_brush) {
+				memdelete(combined_brush);
+				combined_brush = nullptr;
+			}
+			if (brush) {
+				return brush;
+			}
+		}
+		if (combined_brush) {
+			return combined_brush;
+		}
+	}
+	// If dirty or doesn't have combined_brush, perform boolean operations and store combined_brush.
+	if (combined_brush) {
+		memdelete(combined_brush);
+	}
+
+	// This will generate a CSGBrush if it's not assigned.
+	CSGBrush *orig = _get_brush();
+
+	if (child_count < 1) {
+		// Dirty but single node, we can skip the rest of the code.
+		combined_brush = nullptr;
+		children_modified = false;
+		return brush;
+	}
+
+	CSGBrush *n = memnew(CSGBrush);
+	n->copy_from(*orig, Transform3D());
 	HashMap<int32_t, Ref<Material>> mesh_materials;
 	manifold::Manifold root_manifold;
 	_pack_manifold(n, root_manifold, mesh_materials, this);
 	manifold::OpType current_op = ManifoldOperation::convert_csg_op(get_operation());
 	std::vector<manifold::Manifold> manifolds;
 	manifolds.push_back(root_manifold);
-	for (int i = 0; i < get_child_count(); i++) {
+
+	bool has_children = false;
+	for (int i = 0; i < child_count; i++) {
 		CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
 		if (!child || !child->is_visible()) {
 			continue;
 		}
-		CSGBrush *child_brush = child->_get_brush();
+		CSGBrush *child_brush = child->_get_combined_brush();
 		if (!child_brush) {
 			continue;
 		}
@@ -515,6 +588,8 @@ CSGBrush *CSGShape3D::_get_brush() {
 			current_op = child_operation;
 		}
 		manifolds.push_back(child_manifold);
+		// Node has at least one CSGShape3D child.
+		has_children = true;
 	}
 	if (!manifolds.empty()) {
 		manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
@@ -523,21 +598,36 @@ CSGBrush *CSGShape3D::_get_brush() {
 		}
 		n = memnew(CSGBrush);
 		_unpack_manifold(manifold_result, mesh_materials, n);
+		if (n == nullptr) {
+			csg_push_warning(NON_MANIFOLD);
+		} else if (n->faces.is_empty()) {
+			csg_push_warning(NON_MANIFOLD);
+		}
 	}
+	if (has_children) {
+		_expand_aabb(n);
+	} else {
+		// Node has children but those children are not CSGShape3D.
+		_expand_aabb(orig);
+	}
+	combined_brush = n;
+	dirty = false;
+	children_modified = false;
+	update_configuration_warnings();
+	return combined_brush;
+}
+
+void CSGShape3D::_expand_aabb(CSGBrush *p_brush) {
 	AABB aabb;
-	if (n && !n->faces.is_empty()) {
-		aabb.position = n->faces[0].vertices[0];
-		for (const CSGBrush::Face &face : n->faces) {
+	if (p_brush && !p_brush->faces.is_empty()) {
+		aabb.position = p_brush->faces[0].vertices[0];
+		for (const CSGBrush::Face &face : p_brush->faces) {
 			for (int i = 0; i < 3; ++i) {
 				aabb.expand_to(face.vertices[i]);
 			}
 		}
 	}
 	node_aabb = aabb;
-	brush = n;
-	dirty = false;
-	update_configuration_warnings();
-	return brush;
 }
 
 int CSGShape3D::mikktGetNumFaces(const SMikkTSpaceContext *pContext) {
@@ -602,7 +692,7 @@ void CSGShape3D::update_shape() {
 	set_base(RID());
 	root_mesh.unref(); //byebye root mesh
 
-	CSGBrush *n = _get_brush();
+	CSGBrush *n = _get_combined_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
 	Vector<int> face_count;
@@ -821,7 +911,7 @@ Ref<ArrayMesh> CSGShape3D::bake_static_mesh() {
 #ifndef PHYSICS_3D_DISABLED
 Vector<Vector3> CSGShape3D::_get_brush_collision_faces() {
 	Vector<Vector3> collision_faces;
-	CSGBrush *n = _get_brush();
+	CSGBrush *n = _get_combined_brush();
 	ERR_FAIL_NULL_V_MSG(n, collision_faces, "Cannot get CSGBrush.");
 	collision_faces.resize(n->faces.size() * 3);
 	Vector3 *collision_faces_ptrw = collision_faces.ptrw();
@@ -905,7 +995,8 @@ AABB CSGShape3D::get_aabb() const {
 
 Vector<Vector3> CSGShape3D::get_brush_faces() {
 	ERR_FAIL_COND_V(!is_inside_tree(), Vector<Vector3>());
-	CSGBrush *b = _get_brush();
+	// This should fix the unit test. But should brush faces return the combined brush like it did before, or just the current brush? This is an important question for when a face editor is implemented.
+	CSGBrush *b = _get_combined_brush();
 	if (!b) {
 		return Vector<Vector3>();
 	}
@@ -936,29 +1027,26 @@ void CSGShape3D::_notification(int p_what) {
 					root_mesh.unref();
 				}
 			}
-			if (!brush || parent_shape) {
-				// Update this node if uninitialized, or both this node and its new parent if it gets added to another CSG shape
-				_make_dirty();
-			}
+			_make_painted();
 			last_visible = is_visible();
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {
 			if (!is_root_shape()) {
 				// Update this node and its previous parent only if it's currently being removed from another CSG shape
-				_make_dirty(true); // Must be forced since is_root_shape() uses the previous parent
+				_make_painted(false, true); // Must be forced since is_root_shape() uses the previous parent
 			}
 			parent_shape = nullptr;
 		} break;
 
 		case NOTIFICATION_CHILD_ORDER_CHANGED: {
-			_make_dirty();
+			_make_painted();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_root_shape() && last_visible != is_visible()) {
 				// Update this node's parent only if its own visibility has changed, not the visibility of parent nodes
-				parent_shape->_make_dirty();
+				parent_shape->_make_painted();
 			}
 			last_visible = is_visible();
 		} break;
@@ -966,7 +1054,7 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (!is_root_shape()) {
 				// Update this node's parent only if its own transformation has changed, not the transformation of parent nodes
-				parent_shape->_make_dirty();
+				parent_shape->_make_painted();
 			}
 		} break;
 
@@ -984,7 +1072,7 @@ void CSGShape3D::_notification(int p_what) {
 				set_collision_mask(collision_mask);
 				set_collision_priority(collision_priority);
 				debug_shape_old_transform = get_global_transform();
-				_make_dirty();
+				_make_painted();
 			}
 		} break;
 
@@ -1009,7 +1097,7 @@ void CSGShape3D::_notification(int p_what) {
 
 void CSGShape3D::set_operation(Operation p_operation) {
 	operation = p_operation;
-	_make_dirty();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1019,7 +1107,7 @@ CSGShape3D::Operation CSGShape3D::get_operation() const {
 
 void CSGShape3D::set_calculate_tangents(bool p_calculate_tangents) {
 	calculate_tangents = p_calculate_tangents;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGShape3D::is_calculating_tangents() const {
@@ -1043,6 +1131,12 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 		}
 	}
 
+	if (p_property.name == "combine_csg_children") {
+		if (is_inside_tree() && is_root_shape()) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
+	}
+
 	bool is_collision_prefixed = p_property.name.begins_with("collision_");
 	if ((is_collision_prefixed || p_property.name.begins_with("use_collision")) && is_inside_tree() && !is_root_shape()) {
 		//hide collision if not root
@@ -1050,6 +1144,917 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	} else if (is_collision_prefixed && !bool(get("use_collision"))) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
+}
+
+void CSGShape3D::csg_push_warning(CSGWarning p_warning) {
+	brush_warning = p_warning;
+}
+
+void CSGShape3D::rebuild_brush() {
+	if (is_inside_tree()) {
+		_make_dirty();
+	}
+}
+
+void CSGShape3D::brush_modified() {
+	// The method set_csg_brush() doesn't call _make_painted() and that causes issues with undo. This can be called at that point.
+	_make_painted();
+}
+
+Dictionary CSGShape3D::get_csg_brush() {
+	Dictionary p_brush_data;
+	p_brush_data["painted"] = painted;
+
+	if (!brush) {
+		return p_brush_data;
+	}
+
+	if (!painted) {
+		// Only save painted brushes.
+		return p_brush_data;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return p_brush_data;
+	}
+
+	if (n->faces.size() <= 0) {
+		return p_brush_data;
+	}
+
+	Vector<Vector3> vertices;
+	Vector<Vector2> uvs;
+	Vector<uint8_t> smooths;
+	Vector<uint8_t> mat_id;
+	Array materials;
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			vertices.push_back(n->faces[i].vertices[j]);
+			uvs.push_back(n->faces[i].uvs[j]);
+		}
+
+		smooths.push_back(n->faces[i].smooth ? 1 : 0);
+		mat_id.push_back(n->faces[i].material);
+	}
+
+	p_brush_data["vertices"] = vertices;
+	p_brush_data["uvs"] = uvs;
+	p_brush_data["smooth"] = smooths;
+	// We will not save combined shapes.
+	p_brush_data["inverted"] = n->faces[0].invert;
+	p_brush_data["material_id"] = mat_id;
+	p_brush_data["ngons"] = n->ngons;
+
+	for (int i = 0; i < n->materials.size(); i++) {
+		materials.push_back(n->materials[i]);
+	}
+
+	p_brush_data["materials"] = materials;
+
+	return p_brush_data;
+}
+
+void CSGShape3D::set_csg_brush(const Dictionary &p_brush_data) {
+	ERR_FAIL_COND_MSG(!p_brush_data.has("painted"), "Node doesn't have a valid _csg_brush Dictionary.");
+
+	if (!p_brush_data["painted"]) {
+		// Brush has not been modified or is root shape. Rebuild brush.
+		return;
+	}
+
+	ERR_FAIL_COND(!p_brush_data.has("material_id"));
+	ERR_FAIL_COND(!p_brush_data.has("vertices"));
+	ERR_FAIL_COND(!p_brush_data.has("uvs"));
+	ERR_FAIL_COND(!p_brush_data.has("smooth"));
+	ERR_FAIL_COND(!p_brush_data.has("inverted"));
+	ERR_FAIL_COND(!p_brush_data.has("materials"));
+
+	painted = p_brush_data["painted"];
+
+	Vector<uint8_t> mat_id = p_brush_data["material_id"];
+
+	int face_count = mat_id.size();
+	if (face_count < 4) {
+		// The smallest shape with volume is a 3 sided pyramid.
+		csg_push_warning(CSG_SET_NON_MANIFOLD);
+		update_configuration_warnings();
+		ERR_FAIL_MSG("Brush is not manifold!");
+	}
+
+	Vector<Vector3> faces = p_brush_data["vertices"];
+	ERR_FAIL_COND_MSG((faces.size() / 3) != face_count, "The number of elements in 'vertices' should be 3 times the number of elements in 'material_id'.");
+
+	Vector<Vector2> uvs = p_brush_data["uvs"];
+	ERR_FAIL_COND_MSG(faces.size() != uvs.size(), "The number of elements in 'vertices' and 'uvs' should be the same.");
+
+	Vector<bool> smooth;
+	Vector<Ref<Material>> materials;
+	Vector<bool> invert;
+
+	smooth.resize(face_count);
+	materials.resize(face_count);
+	invert.resize(face_count);
+
+	{
+		bool invrt = p_brush_data["inverted"];
+		Vector<uint8_t> smooth_i = p_brush_data["smooth"];
+		ERR_FAIL_COND_MSG(smooth_i.size() != face_count, "The number of elements in 'smooth' and 'vertices' should be the same.");
+
+		Array mats = p_brush_data["materials"];
+
+		bool *smoothw = smooth.ptrw();
+		Ref<Material> *materialsw = materials.ptrw();
+		bool *invertw = invert.ptrw();
+
+		for (int i = 0; i < face_count; i++) {
+			smoothw[i] = smooth_i[i] > 0;
+			int i_mat = mat_id[i];
+			if (i_mat < mats.size()) {
+				Ref<Material> t_mat = mats[i_mat];
+				if (t_mat.is_valid()) {
+					materialsw[i] = t_mat;
+				} else {
+					materialsw[i] = nullptr;
+				}
+			}
+			invertw[i] = invrt;
+		}
+	}
+
+	CSGBrush *n = memnew(CSGBrush);
+	n->build_from_faces(faces, uvs, smooth, materials, invert);
+
+	if (p_brush_data.has("ngons")) {
+		Vector<int> t_ngons = p_brush_data["ngons"];
+		if (t_ngons.size() != face_count) {
+			WARN_PRINT("The number of elements in 'ngons' and 'material_id' should be the same. Invalid ngon data!");
+		} else {
+			n->add_ngons(t_ngons);
+		}
+	} else {
+		WARN_PRINT("Resource doesn't have ngon data.");
+	}
+
+	if (brush) {
+		memdelete(brush);
+		brush = nullptr;
+	}
+
+	{
+		// Test if CSGBrush is manifold.
+		HashMap<int32_t, Ref<Material>> mesh_materials;
+		manifold::Manifold t_manifold;
+		_pack_manifold(n, t_manifold, mesh_materials, this);
+		if (t_manifold.Status() != manifold::Manifold::Error::NoError) {
+			// We don't save a non-manifold brush so the warning triggers.
+			memdelete(n);
+			csg_push_warning(CSG_SET_NON_MANIFOLD);
+			update_configuration_warnings();
+			ERR_FAIL_MSG("Brush is not manifold!");
+		}
+		csg_push_warning(NO_WARNING);
+	}
+
+	_expand_aabb(n);
+	brush = n;
+	dirty = false;
+	update_configuration_warnings();
+	// Recalculate parent.
+	_make_painted();
+}
+
+void CSGShape3D::set_uv_offsets(const Vector<int> &p_faces, const Vector2 &p_prev_offset, const Vector2 &p_offset) {
+	// Use the offset obtained from `get_uv_offsets` when selecting faces.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = n->faces[p].uvs[j] + p_offset - p_prev_offset;
+		}
+	}
+	_make_painted(true);
+}
+
+Vector2 CSGShape3D::get_uv_offsets(int p_face) {
+	if (!brush) {
+		return Vector2(0.0, 0.0);
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return Vector2(0.0, 0.0);
+	}
+
+	if (n->faces.is_empty()) {
+		return Vector2(0.0, 0.0);
+	}
+
+	if (p_face > n->faces.size() || p_face < 0) {
+		return Vector2(0.0, 0.0);
+	}
+
+	Vector2 smallest = n->faces[p_face].uvs[0];
+
+	for (int j = 1; j < 3; j++) {
+		smallest = smallest.min(n->faces[p_face].uvs[j]);
+	}
+	return smallest;
+}
+
+void CSGShape3D::set_uv_scale(const Vector<int> &p_faces, const Vector2 &p_prev_scale, const Vector2 &p_scale) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	if (p_scale.x == 0.0 || p_scale.y == 0.0) {
+		ERR_PRINT("Scale should not be zero!");
+		notify_property_list_changed();
+		return;
+	}
+
+	if (p_prev_scale.x == 0.0 || p_prev_scale.y == 0.0) {
+		// We fix this mess.
+		ERR_PRINT("Scale is zero, rebuilding shape.");
+		_make_dirty();
+		return;
+	}
+
+	Vector2 offset = get_uv_offsets(p_faces[0]);
+	Vector2 n_scale = p_scale / p_prev_scale;
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = (n->faces[p].uvs[j] * n_scale) + offset;
+		}
+	}
+	_make_painted(true);
+}
+
+Vector2 CSGShape3D::get_uv_scale(int p_face) {
+	if (!brush) {
+		return Vector2(1.0, 1.0);
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return Vector2(1.0, 1.0);
+	}
+
+	if (n->faces.is_empty()) {
+		return Vector2(1.0, 1.0);
+	}
+
+	Vector2 offset = get_uv_offsets(p_face);
+	if (p_face > n->faces.size() || p_face < 0) {
+		return Vector2(1.0, 1.0);
+	}
+
+	Vector2 largest = (n->faces[p_face].uvs[0] - offset).abs();
+
+	for (int j = 1; j < 3; j++) {
+		largest = largest.max(n->faces[p_face].uvs[j] - offset);
+	}
+	return largest;
+}
+
+void CSGShape3D::rotate_uv(const Vector<int> &p_faces, float p_angle) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	Transform2D p_rotation = Transform2D(p_angle, Vector2(0.0, 0.0));
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].uvs[j] = p_rotation.xform(n->faces[p].uvs[j]);
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::flip_x(const Vector<int> &p_faces) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	float mirror_x = -1.0;
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			Vector2 curr = n->faces[p].uvs[j];
+			curr.x *= mirror_x;
+			n->faces.write[p].uvs[j] = curr;
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::flip_y(const Vector<int> &p_faces) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	float mirror_y = -1.0;
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			Vector2 curr = n->faces[p].uvs[j];
+			curr.y *= mirror_y;
+			n->faces.write[p].uvs[j] = curr;
+		}
+	}
+	_make_painted(true);
+}
+
+Vector<Vector2> CSGShape3D::get_brush_uvs() {
+	Vector<Vector2> r_uvs;
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return r_uvs;
+	}
+
+	if (n->faces.is_empty()) {
+		return r_uvs;
+	}
+
+	r_uvs.resize(n->faces.size() * 3);
+	Vector2 *r_uvs_ptrw = r_uvs.ptrw();
+
+	int w = 0;
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			r_uvs_ptrw[w] = n->faces[i].uvs[j];
+			w++;
+		}
+	}
+
+	return r_uvs;
+}
+
+void CSGShape3D::set_brush_uvs(const Vector<Vector2> &p_uvs) {
+	ERR_FAIL_COND_MSG(p_uvs.is_empty(), "`p_uvs` is empty");
+
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+	ERR_FAIL_COND_MSG(n->faces.is_empty(), "CSGBrush is empty.");
+
+	ERR_FAIL_COND_MSG(p_uvs.size() != n->faces.size() * 3, "`p_uvs` has an invalid number of elements.");
+
+	int w = 0;
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[i].uvs[j] = p_uvs[w];
+			w++;
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::calculate_cube_map(const Vector<int> &p_faces, const Vector3 &uv_scale, bool p_use_global) {
+	// Simple cube map unwrapping. Calculates the normal of each face and aligns them with one of three axes.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+	Vector3 p_scale = uv_scale;
+	if (p_scale.x == 0.0) {
+		// Continue working.
+		p_scale.x = 1.0;
+	}
+	if (p_scale.y == 0.0) {
+		p_scale.y = 1.0;
+	}
+	if (p_scale.z == 0.0) {
+		p_scale.z = 1.0;
+	}
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	// 3D goes bot to top while 2D goes top to bottom.
+	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
+	Transform3D trans = get_global_transform();
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+
+		Vector3 v1 = n->faces[p].vertices[0];
+		Vector3 v2 = n->faces[p].vertices[1];
+		Vector3 v3 = n->faces[p].vertices[2];
+
+		if (p_use_global) {
+			// This includes rotation, position and scale. More parameters could be added to handle rotation and position separately.
+			v1 = trans.xform(v1);
+			v2 = trans.xform(v2);
+			v3 = trans.xform(v3);
+		}
+
+		Plane ang(v1, v2, v3);
+		Vector3 nor = ang.normal.abs();
+
+		if (nor.x > nor.y && nor.x > nor.z) {
+			// Direction X, ZY.
+			float mir_x = ang.normal.x < 0.0 ? -p_scale.z : p_scale.z;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.z, v1.y * p_scale.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.z, v2.y * p_scale.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.z, v3.y * p_scale.y));
+		} else if (nor.y > nor.z) {
+			// Direction Y, XZ.
+			float mir_x = ang.normal.y < 0.0 ? -p_scale.x : p_scale.x;
+			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z * p_scale.z);
+			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z * p_scale.z);
+			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z * p_scale.z);
+		} else {
+			// Direction Z, XY.
+			float mir_x = ang.normal.z < 0.0 ? p_scale.x : -p_scale.x;
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(mir_x * v1.x, v1.y * p_scale.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(mir_x * v2.x, v2.y * p_scale.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(mir_x * v3.x, v3.y * p_scale.y));
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::calculate_cylinder_map(const Vector<int> &p_faces, const Vector3 &uv_scale, bool p_use_global) {
+	// Simple cylinder unwrapping.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+	Vector3 p_scale = uv_scale;
+	if (p_scale.x == 0.0) {
+		// Continue working.
+		p_scale.x = p_scale.z == 0.0 ? 1.0 : p_scale.z;
+	}
+	if (p_scale.y == 0.0) {
+		p_scale.y = 1.0;
+	}
+	if (p_scale.z == 0.0) {
+		p_scale.z = p_scale.x == 0.0 ? 1.0 : p_scale.x;
+	}
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	float flatten = 1.0 / Math::PI;
+	// 3D goes bot to top while 2D goes top to bottom.
+	Transform2D p_rotation = Transform2D(Math::deg_to_rad(180.0), Vector2(0.0, 0.0));
+	Transform3D trans = get_global_transform();
+	// Cylinder map is generated around the center, using global position breaks it, so we reset position.
+	trans.set_origin(Vector3(0, 0, 0));
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+
+		Vector3 v1 = n->faces[p].vertices[0];
+		Vector3 v2 = n->faces[p].vertices[1];
+		Vector3 v3 = n->faces[p].vertices[2];
+
+		if (p_use_global) {
+			// Not sure how useful this will be for cylinder.
+			v1 = trans.xform(v1);
+			v2 = trans.xform(v2);
+			v3 = trans.xform(v3);
+		}
+
+		Plane ang(v1, v2, v3);
+		if (Math::abs(ang.normal.y) > 0.6) {
+			// Top and bottom faces.
+			float mir_x = ang.normal.x < 0.0 ? -p_scale.x : p_scale.x;
+			n->faces.write[p].uvs[0] = Vector2(mir_x * v1.x, v1.z * p_scale.z);
+			n->faces.write[p].uvs[1] = Vector2(mir_x * v2.x, v2.z * p_scale.z);
+			n->faces.write[p].uvs[2] = Vector2(mir_x * v3.x, v3.z * p_scale.z);
+		} else {
+			// This calculates two mirrored sides and then mirrors one back.
+			float inv = ang.normal.z < 0.0 ? -1.0 : 1.0;
+			// MAX is needed because under one specific circumstance the resulting value is -0.0 and that returns the angle -PI, causing the UV to stretch on the last face.
+			Vector2 t_vec_1(v1.x, MAX(0.0, v1.z * inv));
+			Vector2 t_vec_2(v2.x, MAX(0.0, v2.z * inv));
+			Vector2 t_vec_3(v3.x, MAX(0.0, v3.z * inv));
+			float t_ang_1 = t_vec_1.normalized().angle() * flatten * inv * Math::ceil(t_vec_1.length() * 4.0);
+			float t_ang_2 = t_vec_2.normalized().angle() * flatten * inv * Math::ceil(t_vec_2.length() * 4.0);
+			float t_ang_3 = t_vec_3.normalized().angle() * flatten * inv * Math::ceil(t_vec_3.length() * 4.0);
+			// Correctly calculating `uv_scale` makes the code too complicated. Using `x` only.
+			n->faces.write[p].uvs[0] = p_rotation.xform(Vector2(t_ang_1 * p_scale.x, v1.y * p_scale.y));
+			n->faces.write[p].uvs[1] = p_rotation.xform(Vector2(t_ang_2 * p_scale.x, v2.y * p_scale.y));
+			n->faces.write[p].uvs[2] = p_rotation.xform(Vector2(t_ang_3 * p_scale.x, v3.y * p_scale.y));
+		}
+	}
+	_make_painted(true);
+}
+
+void CSGShape3D::set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		for (int j = 0; j < 3; j++) {
+			n->faces.write[p].smooth = p_smooth > 0;
+		}
+	}
+	_make_painted(true);
+}
+
+int CSGShape3D::get_csg_face_smooth_group(int p_face) {
+	if (!brush) {
+		return 0;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return 0;
+	}
+
+	if (n->faces.is_empty()) {
+		return 0;
+	}
+
+	if (p_face > n->faces.size() || p_face < 0) {
+		return 0;
+	}
+
+	return n->faces[p_face].smooth ? 1 : 0;
+}
+
+void CSGShape3D::set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	int find_mat = -2;
+	if (p_material.is_valid()) {
+		for (int j = 0; j < n->materials.size(); j++) {
+			if (p_material == n->materials[j]) {
+				find_mat = j;
+				break;
+			}
+		}
+		if (find_mat == -2) {
+			find_mat = n->materials.size();
+			n->materials.push_back(p_material);
+		}
+	} else {
+		find_mat = -1;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_FAIL_INDEX(p, n->faces.size());
+		n->faces.write[p].material = find_mat;
+	}
+
+	{
+		Vector<Ref<Material>> nmats;
+		Vector<int> minds;
+		minds.resize(n->faces.size());
+		int k = 0;
+		for (int i = 0; i < n->materials.size(); i++) {
+			bool is_material_used = false;
+			for (int j = 0; j < n->faces.size(); j++) {
+				if (n->faces[j].material == i) {
+					minds.write[j] = k;
+					is_material_used = true;
+				}
+			}
+			if (is_material_used) {
+				nmats.push_back(n->materials[i]);
+				k++;
+			}
+		}
+
+		for (int i = 0; i < n->faces.size(); i++) {
+			if (n->faces[i].material == -1) {
+				n->faces.write[i].material = -1;
+			} else {
+				n->faces.write[i].material = minds[i];
+			}
+		}
+
+		n->materials.resize(nmats.size());
+		for (int i = 0; i < nmats.size(); i++) {
+			n->materials.write[i] = nmats[i];
+		}
+	}
+	_make_painted(true);
+}
+
+Ref<Material> CSGShape3D::get_face_material(int p_face) {
+	// Using only one face as only one material will be returned.
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return nullptr;
+	}
+
+	if (n->faces.is_empty()) {
+		return nullptr;
+	}
+
+	if (p_face > n->faces.size() || p_face < 0) {
+		return nullptr;
+	}
+
+	int mat = n->faces[p_face].material;
+	if (mat < 0) {
+		// mat can be -1
+		return nullptr;
+	}
+	return n->materials[mat];
+}
+
+bool CSGShape3D::resize_brush(const Vector3 &p_prev_size, const Vector3 &p_size) {
+	if (!is_inside_tree()) {
+		return true;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return true;
+	}
+
+	if (n->faces.is_empty()) {
+		return false;
+	}
+
+	if (p_prev_size.x == 0.0 || p_prev_size.y == 0.0 || p_prev_size.z == 0.0) {
+		ERR_PRINT("size can should be non-zero!");
+		_make_dirty();
+		return false;
+	}
+
+	if (p_size.x == 0.0 || p_size.y == 0.0 || p_size.z == 0.0) {
+		ERR_FAIL_V_MSG(false, "Size should be non-zero.");
+	}
+
+	Vector3 n_size = p_size / p_prev_size;
+	AABB aabb;
+	aabb.position = n->faces[0].vertices[0];
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			Vector3 curr = n->faces[i].vertices[j];
+			curr *= n_size;
+			aabb.expand_to(curr);
+			n->faces.write[i].vertices[j] = curr;
+		}
+	}
+	if (get_child_count() < 1 || !combined_brush) {
+		// This is a hack and needs a better solution to the problem of non CSGShape3D children.
+		node_aabb = aabb;
+	}
+
+	return true;
+}
+
+void CSGShape3D::resize_brush_rework() {
+	// Resizes the brush without lossing changes. Used for CSGTorus3D.
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	CSGBrush *n = _get_brush();
+	if (n == nullptr) {
+		return;
+	}
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	CSGBrush *b = _build_brush();
+
+	if (b->faces.size() != n->faces.size()) {
+		memdelete(b);
+		csg_push_warning(NON_MANIFOLD);
+		return;
+	}
+
+	AABB aabb;
+	if (b) {
+		if (!b->faces.is_empty()) {
+			aabb.position = b->faces[0].vertices[0];
+			for (const CSGBrush::Face &face : b->faces) {
+				for (int i = 0; i < 3; ++i) {
+					aabb.expand_to(face.vertices[i]);
+				}
+			}
+			for (int i = 0; i < n->faces.size(); i++) {
+				for (int j = 0; j < 3; j++) {
+					n->faces.write[i].vertices[j] = b->faces[i].vertices[j];
+				}
+			}
+			if (get_child_count() < 1 || !combined_brush) {
+				// This is a hack and needs a better solution to the problem of non CSGShape3D children.
+				node_aabb = aabb;
+			}
+		}
+		memdelete(b);
+	}
+}
+
+void CSGShape3D::set_csg_invert(bool p_inv_val) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		n->faces.write[i].invert = p_inv_val;
+	}
+	_make_painted();
+}
+
+void CSGShape3D::set_csg_flat(bool p_mode) {
+	// This changes all faces so it can't be used with CSGCylinder3D.
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		return;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		n->faces.write[i].smooth = p_mode;
+	}
+}
+
+Vector<Vector3> CSGShape3D::get_vertices() {
+	// Use this for making a vertex editor.
+	CSGBrush *n = _get_brush();
+
+	Vector<Vector3> vertices;
+
+	if (n == nullptr) {
+		return vertices;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			Vector3 v = n->faces[i].vertices[j];
+			bool found_v = false;
+			for (int k = 0; k < vertices.size(); k++) {
+				if (vertices[k].is_equal_approx(v)) {
+					found_v = true;
+					break;
+				}
+			}
+			if (!found_v) {
+				vertices.push_back(v);
+			}
+		}
+	}
+
+	return vertices;
+}
+
+void CSGShape3D::set_vertex_position(const Vector3 &p_curr_pos, const Vector3 &p_pos) {
+	CSGBrush *n = _get_brush();
+	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
+
+	if (n->faces.is_empty()) {
+		WARN_PRINT("CSGBrush is empty.");
+		return;
+	}
+
+	for (int i = 0; i < n->faces.size(); i++) {
+		for (int j = 0; j < 3; j++) {
+			if (n->faces[i].vertices[j].is_equal_approx(p_curr_pos)) {
+				n->faces.write[i].vertices[j] = p_pos;
+			}
+		}
+	}
+	_make_painted(true);
+}
+
+Vector<Vector3> CSGShape3D::get_selected_faces(const Vector<int> &p_faces) {
+	// Use this to obtain a vector of selected faces to display as a mesh in editor.
+	CSGBrush *n = _get_brush();
+
+	Vector<Vector3> ret;
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		return ret;
+	}
+
+	for (int i = 0; i < p_faces.size(); i++) {
+		int p = p_faces[i];
+		ERR_CONTINUE_MSG(p > n->faces.size() || p < 0, "Invalid face in p_faces.");
+		for (int j = 0; j < 3; j++) {
+			ret.push_back(n->faces[p].vertices[j]);
+		}
+	}
+	return ret;
+}
+
+int CSGShape3D::get_csg_num_faces() {
+	CSGBrush *n = _get_brush();
+
+	if (n == nullptr) {
+		return 0;
+	}
+
+	return n->faces.size();
+}
+
+Vector<int> CSGShape3D::get_all_csg_faces() {
+	Vector<int> all_faces;
+	all_faces.resize(get_csg_num_faces());
+	for (int i = 0; i < all_faces.size(); i++) {
+		all_faces.write[i] = i;
+	}
+	return all_faces;
+}
+
+Vector<int> CSGShape3D::get_faces_from_ngon(int p_ngon) {
+	// Returns the faces (tris) forming the requested ngon. Use in combination with get_selected_faces().
+	CSGBrush *n = _get_brush();
+	Vector<int> ret;
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	if (n->faces.is_empty()) {
+		return ret;
+	}
+
+	ERR_FAIL_COND_V_MSG(n->ngons.is_empty() || n->num_ngons < 1, ret, "CSGBrush has no ngons!");
+
+	ret = n->get_ngon_faces(p_ngon);
+	return ret;
+}
+
+TypedArray<Vector<Vector3>> CSGShape3D::get_csg_ngon_colliders() {
+	// Returns an array of Vector<Vector3> to use to create a TriangleMesh for each collider of ngon to be used in gizmos.
+	TypedArray<Vector<Vector3>> ret;
+	CSGBrush *n = _get_brush();
+
+	if (n == nullptr) {
+		return ret;
+	}
+
+	ERR_FAIL_COND_V_MSG(n->ngons.is_empty() || n->num_ngons < 1, ret, "CSGBrush has no ngons");
+	ERR_FAIL_COND_V_MSG(n->faces.is_empty(), ret, "CSGBrush has no faces!");
+	ERR_FAIL_COND_V_MSG(n->num_ngons < 0, ret, "num_ngons is less than 0.");
+
+	for (int i = 0; i < n->num_ngons; i++) {
+		Vector<int> curr_ngon = n->get_ngon_faces(i);
+		if (!curr_ngon.is_empty()) {
+			Vector<Vector3> curr_faces;
+			for (int j = 0; j < curr_ngon.size(); j++) {
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[0]);
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[1]);
+				curr_faces.push_back(n->faces[curr_ngon[j]].vertices[2]);
+			}
+			ret.push_back(curr_faces);
+		}
+	}
+
+	return ret;
+}
+
+bool CSGShape3D::is_painted() const {
+	return painted;
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -1066,13 +2071,15 @@ Array CSGShape3D::get_meshes() const {
 
 PackedStringArray CSGShape3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
-	const CSGShape3D *current_shape = this;
-	while (current_shape) {
-		if (!current_shape->brush || current_shape->brush->faces.is_empty()) {
-			warnings.push_back(RTR("The CSGShape3D has an empty shape.\nCSGShape3D empty shapes typically occur because the mesh is not manifold.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces."));
-			break;
-		}
-		current_shape = current_shape->parent_shape;
+	// We can make the errors more specific. Also, CSGCombiner3D will no longer raise a warning.
+	if (brush_warning == NON_MANIFOLD) {
+		warnings.push_back(RTR("This CSGShape3D has an empty shape.\nCSGShape3D empty shapes typically occur because the mesh is not manifold.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces."));
+	} else if (brush_warning == CSG_SET_NON_MANIFOLD) {
+		warnings.push_back(RTR("This CSGShape3D has an empty shape because `set_csg_brush` was called on it with a non-manifold mesh.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces.\nYou can press the `Rebuild` button on the top bar to reconstruct this node's shape using its node properties.\nThis node can not be saved with a non-manifold shape and will be automatically rebuilt the next time the scene loads."));
+	} else if (brush_warning == CSG_MESH_NOT_ASSIGNED) {
+		warnings.push_back(RTR("This CSGMesh3D has an empty shape because its `mesh` has not been set or is not valid."));
+	} else if (brush_warning == CSG_MESH_NON_MANIFOLD) {
+		warnings.push_back(RTR("This CSGMesh3D has an empty shape because its `mesh` is not manifold.\nA manifold mesh forms a solid object without gaps, holes, or loose edges.\nEach edge must be a member of exactly two faces."));
 	}
 	return warnings;
 }
@@ -1123,6 +2130,34 @@ void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_calculate_tangents", "enabled"), &CSGShape3D::set_calculate_tangents);
 	ClassDB::bind_method(D_METHOD("is_calculating_tangents"), &CSGShape3D::is_calculating_tangents);
 
+	ClassDB::bind_method(D_METHOD("rebuild_brush"), &CSGShape3D::rebuild_brush);
+	ClassDB::bind_method(D_METHOD("brush_modified"), &CSGShape3D::brush_modified);
+	ClassDB::bind_method(D_METHOD("set_csg_brush", "csg_brush"), &CSGShape3D::set_csg_brush);
+	ClassDB::bind_method(D_METHOD("get_csg_brush"), &CSGShape3D::get_csg_brush);
+	ClassDB::bind_method(D_METHOD("set_uv_offsets", "faces", "prev_offset", "offset"), &CSGShape3D::set_uv_offsets);
+	ClassDB::bind_method(D_METHOD("get_uv_offsets", "face"), &CSGShape3D::get_uv_offsets);
+	ClassDB::bind_method(D_METHOD("set_uv_scale", "faces", "prev_scale", "scale"), &CSGShape3D::set_uv_scale);
+	ClassDB::bind_method(D_METHOD("get_uv_scale", "face"), &CSGShape3D::get_uv_scale);
+	ClassDB::bind_method(D_METHOD("rotate_uv", "faces", "angle"), &CSGShape3D::rotate_uv);
+	ClassDB::bind_method(D_METHOD("flip_x", "faces"), &CSGShape3D::flip_x);
+	ClassDB::bind_method(D_METHOD("flip_y", "faces"), &CSGShape3D::flip_y);
+	ClassDB::bind_method(D_METHOD("get_brush_uvs"), &CSGShape3D::get_brush_uvs);
+	ClassDB::bind_method(D_METHOD("set_brush_uvs", "uvs"), &CSGShape3D::set_brush_uvs);
+	ClassDB::bind_method(D_METHOD("calculate_cube_map", "faces", "uv_scale", "use_global"), &CSGShape3D::calculate_cube_map);
+	ClassDB::bind_method(D_METHOD("calculate_cylinder_map", "faces", "uv_scale", "use_global"), &CSGShape3D::calculate_cylinder_map);
+	ClassDB::bind_method(D_METHOD("set_csg_face_smooth_group", "faces", "smooth"), &CSGShape3D::set_csg_face_smooth_group);
+	ClassDB::bind_method(D_METHOD("get_csg_face_smooth_group", "face"), &CSGShape3D::get_csg_face_smooth_group);
+	ClassDB::bind_method(D_METHOD("set_face_material", "faces", "material"), &CSGShape3D::set_face_material);
+	ClassDB::bind_method(D_METHOD("get_face_material", "face"), &CSGShape3D::get_face_material);
+	ClassDB::bind_method(D_METHOD("resize_brush", "prev_size", "size"), &CSGShape3D::resize_brush);
+	ClassDB::bind_method(D_METHOD("get_vertices"), &CSGShape3D::get_vertices);
+	ClassDB::bind_method(D_METHOD("set_vertex_position", "from", "to"), &CSGShape3D::set_vertex_position);
+	ClassDB::bind_method(D_METHOD("get_selected_faces", "faces"), &CSGShape3D::get_selected_faces);
+	ClassDB::bind_method(D_METHOD("get_csg_num_faces"), &CSGShape3D::get_csg_num_faces);
+	ClassDB::bind_method(D_METHOD("get_all_csg_faces"), &CSGShape3D::get_all_csg_faces);
+	ClassDB::bind_method(D_METHOD("get_faces_from_ngon", "ngon"), &CSGShape3D::get_faces_from_ngon);
+	ClassDB::bind_method(D_METHOD("get_csg_ngon_colliders"), &CSGShape3D::get_csg_ngon_colliders);
+
 	ClassDB::bind_method(D_METHOD("get_meshes"), &CSGShape3D::get_meshes);
 
 	ClassDB::bind_method(D_METHOD("bake_static_mesh"), &CSGShape3D::bake_static_mesh);
@@ -1135,6 +2170,7 @@ void CSGShape3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autosmooth"), "set_autosmooth", "is_autosmooth");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "smoothing_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), "set_smoothing_angle", "get_smoothing_angle");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_csg_brush", PROPERTY_HINT_NO_NODEPATH, "", PROPERTY_USAGE_NO_EDITOR), "set_csg_brush", "get_csg_brush");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "operation", PROPERTY_HINT_ENUM, "Union,Intersection,Subtraction"), "set_operation", "get_operation");
 #ifndef DISABLE_DEPRECATED
@@ -1164,11 +2200,16 @@ CSGShape3D::~CSGShape3D() {
 		memdelete(brush);
 		brush = nullptr;
 	}
+	if (combined_brush) {
+		memdelete(combined_brush);
+		combined_brush = nullptr;
+	}
 }
 
 //////////////////////////////////
 
 CSGBrush *CSGCombiner3D::_build_brush() {
+	csg_push_warning(NO_WARNING);
 	return memnew(CSGBrush); //does not build anything
 }
 
@@ -1177,7 +2218,7 @@ CSGCombiner3D::CSGCombiner3D() {
 
 /////////////////////
 
-CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials) {
+CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<int> &p_ngons) {
 	CSGBrush *new_brush = memnew(CSGBrush);
 
 	Vector<bool> invert;
@@ -1190,6 +2231,21 @@ CSGBrush *CSGPrimitive3D::_create_brush_from_arrays(const Vector<Vector3> &p_ver
 		}
 	}
 	new_brush->build_from_faces(p_vertices, p_uv, p_smooth, p_materials, invert);
+	new_brush->add_ngons(p_ngons);
+
+	// Test if CSGBrush is manifold.
+	HashMap<int32_t, Ref<Material>> mesh_materials;
+	manifold::Manifold t_manifold;
+	_pack_manifold(new_brush, t_manifold, mesh_materials, this);
+	if (t_manifold.Status() != manifold::Manifold::Error::NoError) {
+		// We don't save a non-manifold brush so the warning triggers.
+		memdelete(new_brush);
+		csg_push_warning(CSG_MESH_NON_MANIFOLD);
+		update_configuration_warnings();
+		ERR_FAIL_V_MSG(nullptr, "CSGMesh3D brush is not manifold!");
+	} else {
+		csg_push_warning(NO_WARNING);
+	}
 
 	return new_brush;
 }
@@ -1208,7 +2264,11 @@ void CSGPrimitive3D::set_flip_faces(bool p_invert) {
 
 	flip_faces = p_invert;
 
-	_make_dirty();
+	if (!is_root_shape() && is_inside_tree()) {
+		set_csg_invert(flip_faces);
+	}
+
+	_make_painted();
 }
 
 bool CSGPrimitive3D::get_flip_faces() {
@@ -1223,6 +2283,7 @@ CSGPrimitive3D::CSGPrimitive3D() {
 
 CSGBrush *CSGMesh3D::_build_brush() {
 	if (mesh.is_null()) {
+		csg_push_warning(CSG_MESH_NOT_ASSIGNED);
 		return memnew(CSGBrush);
 	}
 
@@ -1231,6 +2292,9 @@ CSGBrush *CSGMesh3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<Vector2> uvs;
 	Ref<Material> base_material = get_material();
+	Vector<int> ngons;
+
+	int ngon_counter = 0;
 
 	for (int i = 0; i < mesh->get_surface_count(); i++) {
 		if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
@@ -1279,13 +2343,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			smooth.resize((as + is) / 3);
 			materials.resize((as + is) / 3);
 			uvs.resize(as + is);
+			ngons.resize((as + is) / 3);
 
 			Vector3 *vw = vertices.ptrw();
 			bool *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
+			int *ngonw = ngons.ptrw();
 
 			const int *ir = aindices.ptr();
+
+			Vector3 prev_tri_normal = Vector3(0, 0, 0);
 
 			for (int j = 0; j < is; j += 3) {
 				Vector3 vertex[3];
@@ -1304,6 +2372,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				}
 
 				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
+
+				if (flat) {
+					if (!prev_tri_normal.is_equal_approx(normal[0])) {
+						ngon_counter++;
+					}
+					prev_tri_normal = normal[0];
+				} else {
+					prev_tri_normal = Vector3(0, 0, 0);
+					ngon_counter++;
+				}
+				ngonw[(as + j) / 3] = ngon_counter;
 
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];
@@ -1324,11 +2403,15 @@ CSGBrush *CSGMesh3D::_build_brush() {
 			smooth.resize((as + is) / 3);
 			uvs.resize(as + is);
 			materials.resize((as + is) / 3);
+			ngons.resize((as + is) / 3);
 
 			Vector3 *vw = vertices.ptrw();
 			bool *sw = smooth.ptrw();
 			Vector2 *uvw = uvs.ptrw();
 			Ref<Material> *mw = materials.ptrw();
+			int *ngonw = ngons.ptrw();
+
+			Vector3 prev_tri_normal = Vector3(0, 0, 0);
 
 			for (int j = 0; j < is; j += 3) {
 				Vector3 vertex[3];
@@ -1347,6 +2430,17 @@ CSGBrush *CSGMesh3D::_build_brush() {
 
 				bool flat = normal[0].is_equal_approx(normal[1]) && normal[0].is_equal_approx(normal[2]);
 
+				if (flat) {
+					if (!prev_tri_normal.is_equal_approx(normal[0])) {
+						ngon_counter++;
+					}
+					prev_tri_normal = normal[0];
+				} else {
+					prev_tri_normal = Vector3(0, 0, 0);
+					ngon_counter++;
+				}
+				ngonw[(as + j) / 3] = ngon_counter;
+
 				vw[as + j + 0] = vertex[0];
 				vw[as + j + 1] = vertex[1];
 				vw[as + j + 2] = vertex[2];
@@ -1362,10 +2456,12 @@ CSGBrush *CSGMesh3D::_build_brush() {
 	}
 
 	if (vertices.is_empty()) {
+		csg_push_warning(CSG_MESH_NON_MANIFOLD);
 		return memnew(CSGBrush);
 	}
 
-	return _create_brush_from_arrays(vertices, uvs, smooth, materials);
+	csg_push_warning(NO_WARNING);
+	return _create_brush_from_arrays(vertices, uvs, smooth, materials, ngons);
 }
 
 void CSGMesh3D::_mesh_changed() {
@@ -1379,7 +2475,9 @@ void CSGMesh3D::set_material(const Ref<Material> &p_material) {
 		return;
 	}
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGMesh3D::get_material() const {
@@ -1436,6 +2534,9 @@ CSGBrush *CSGSphere3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -1449,6 +2550,9 @@ CSGBrush *CSGSphere3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+		int *ngonw = ngons.ptrw();
+
+		int ngon_counter = 0;
 
 		// We want to follow an order that's convenient for UVs.
 		// For latitude step we start at the top and move down like in an image.
@@ -1519,6 +2623,8 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
 
@@ -1536,8 +2642,11 @@ CSGBrush *CSGSphere3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
+				ngon_counter++;
 			}
 		}
 
@@ -1547,6 +2656,8 @@ CSGBrush *CSGSphere3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
+	csg_push_warning(NO_WARNING);
 
 	return new_brush;
 }
@@ -1575,8 +2686,12 @@ void CSGSphere3D::_bind_methods() {
 
 void CSGSphere3D::set_radius(const float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
-	radius = p_radius;
-	_make_dirty();
+	if (!is_painted()) {
+		radius = p_radius;
+	} else if (resize_brush(Vector3(radius, radius, radius), Vector3(p_radius, p_radius, p_radius))) {
+		radius = p_radius;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1586,7 +2701,7 @@ float CSGSphere3D::get_radius() const {
 
 void CSGSphere3D::set_radial_segments(const int p_radial_segments) {
 	radial_segments = p_radial_segments > 4 ? p_radial_segments : 4;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -1596,7 +2711,7 @@ int CSGSphere3D::get_radial_segments() const {
 
 void CSGSphere3D::set_rings(const int p_rings) {
 	rings = p_rings > 1 ? p_rings : 1;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -1606,7 +2721,10 @@ int CSGSphere3D::get_rings() const {
 
 void CSGSphere3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_csg_flat(smooth_faces);
+	}
+	_make_painted();
 }
 
 bool CSGSphere3D::get_smooth_faces() const {
@@ -1615,7 +2733,9 @@ bool CSGSphere3D::get_smooth_faces() const {
 
 void CSGSphere3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGSphere3D::get_material() const {
@@ -1648,6 +2768,9 @@ CSGBrush *CSGBox3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -1661,12 +2784,14 @@ CSGBrush *CSGBox3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+		int *ngonw = ngons.ptrw();
 
 		int face = 0;
 
 		Vector3 vertex_mul = size / 2;
 
 		{
+			int ngon_counter = 0;
 			for (int i = 0; i < 6; i++) {
 				Vector3 face_points[4];
 				float uv_points[8] = { 0, 0, 0, 1, 1, 1, 1, 0 };
@@ -1703,6 +2828,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
 
 				face++;
 				//face 2
@@ -1717,6 +2843,8 @@ CSGBrush *CSGBox3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
+				ngon_counter++;
 
 				face++;
 			}
@@ -1728,6 +2856,8 @@ CSGBrush *CSGBox3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
+	csg_push_warning(NO_WARNING);
 
 	return new_brush;
 }
@@ -1744,8 +2874,12 @@ void CSGBox3D::_bind_methods() {
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
-	size = p_size;
-	_make_dirty();
+	if (!is_painted()) {
+		size = p_size;
+	} else if (resize_brush(size / 2, p_size / 2)) {
+		size = p_size;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1758,17 +2892,17 @@ Vector3 CSGBox3D::get_size() const {
 bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "width") {
 		size.x = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else if (p_name == "height") {
 		size.y = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else if (p_name == "depth") {
 		size.z = p_value;
-		_make_dirty();
+		_make_painted();
 		update_gizmos();
 		return true;
 	} else {
@@ -1779,7 +2913,9 @@ bool CSGBox3D::_set(const StringName &p_name, const Variant &p_value) {
 
 void CSGBox3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 	update_gizmos();
 }
 
@@ -1805,6 +2941,9 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -1819,11 +2958,14 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
+		int *ngonw = ngons.ptrw();
+
 		int face = 0;
 
 		Vector3 vertex_mul(radius, height * 0.5, radius);
 
 		{
+			int ngon_counter = cone ? 1 : 2;
 			for (int i = 0; i < sides; i++) {
 				float inc = float(i) / sides;
 				float inc_n = float((i + 1)) / sides;
@@ -1864,6 +3006,8 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
 
+				ngonw[face] = ngon_counter;
+
 				face++;
 
 				if (!cone) {
@@ -1879,8 +3023,13 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					smoothw[face] = smooth_faces;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+
+					ngonw[face] = ngon_counter;
+
 					face++;
 				}
+
+				ngon_counter++;
 
 				//bottom face 1
 				facesw[face * 3 + 0] = face_points[1] * vertex_mul;
@@ -1894,6 +3043,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				smoothw[face] = false;
 				invertw[face] = invert_val;
 				materialsw[face] = base_material;
+				ngonw[face] = 0;
 				face++;
 
 				if (!cone) {
@@ -1909,6 +3059,7 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 					smoothw[face] = false;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+					ngonw[face] = 1;
 					face++;
 				}
 			}
@@ -1920,6 +3071,8 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
+	csg_push_warning(NO_WARNING);
 
 	return new_brush;
 }
@@ -1952,8 +3105,12 @@ void CSGCylinder3D::_bind_methods() {
 }
 
 void CSGCylinder3D::set_radius(const float p_radius) {
-	radius = p_radius;
-	_make_dirty();
+	if (!is_painted()) {
+		radius = p_radius;
+	} else if (resize_brush(Vector3(radius, 1.0, radius), Vector3(p_radius, 1.0, p_radius))) {
+		radius = p_radius;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1962,8 +3119,12 @@ float CSGCylinder3D::get_radius() const {
 }
 
 void CSGCylinder3D::set_height(const float p_height) {
-	height = p_height;
-	_make_dirty();
+	if (!is_painted()) {
+		height = p_height;
+	} else if (resize_brush(Vector3(1.0, height * 0.5, 1.0), Vector3(1.0, p_height * 0.5, 1.0))) {
+		height = p_height;
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -1974,7 +3135,9 @@ float CSGCylinder3D::get_height() const {
 void CSGCylinder3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	_make_dirty();
+	if (is_inside_tree()) {
+		rebuild_brush();
+	}
 	update_gizmos();
 }
 
@@ -1984,7 +3147,7 @@ int CSGCylinder3D::get_sides() const {
 
 void CSGCylinder3D::set_cone(const bool p_cone) {
 	cone = p_cone;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -1994,7 +3157,7 @@ bool CSGCylinder3D::is_cone() const {
 
 void CSGCylinder3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGCylinder3D::get_smooth_faces() const {
@@ -2003,7 +3166,9 @@ bool CSGCylinder3D::get_smooth_faces() const {
 
 void CSGCylinder3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGCylinder3D::get_material() const {
@@ -2050,6 +3215,9 @@ CSGBrush *CSGTorus3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 
@@ -2064,9 +3232,12 @@ CSGBrush *CSGTorus3D::_build_brush() {
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
 
+		int *ngonw = ngons.ptrw();
+
 		int face = 0;
 
 		{
+			int ngon_counter = 0;
 			for (int i = 0; i < sides; i++) {
 				float inci = float(i) / sides;
 				float inci_n = float((i + 1)) / sides;
@@ -2120,6 +3291,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
 
+					ngonw[face] = ngon_counter;
+
 					face++;
 
 					//face 2
@@ -2134,7 +3307,11 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					smoothw[face] = smooth_faces;
 					invertw[face] = invert_val;
 					materialsw[face] = base_material;
+
+					ngonw[face] = ngon_counter;
+
 					face++;
+					ngon_counter++;
 				}
 			}
 		}
@@ -2145,6 +3322,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
+	csg_push_warning(NO_WARNING);
 
 	return new_brush;
 }
@@ -2178,7 +3357,10 @@ void CSGTorus3D::_bind_methods() {
 
 void CSGTorus3D::set_inner_radius(const float p_inner_radius) {
 	inner_radius = p_inner_radius;
-	_make_dirty();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2188,7 +3370,10 @@ float CSGTorus3D::get_inner_radius() const {
 
 void CSGTorus3D::set_outer_radius(const float p_outer_radius) {
 	outer_radius = p_outer_radius;
-	_make_dirty();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2199,7 +3384,7 @@ float CSGTorus3D::get_outer_radius() const {
 void CSGTorus3D::set_sides(const int p_sides) {
 	ERR_FAIL_COND(p_sides < 3);
 	sides = p_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2210,7 +3395,7 @@ int CSGTorus3D::get_sides() const {
 void CSGTorus3D::set_ring_sides(const int p_ring_sides) {
 	ERR_FAIL_COND(p_ring_sides < 3);
 	ring_sides = p_ring_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2220,7 +3405,10 @@ int CSGTorus3D::get_ring_sides() const {
 
 void CSGTorus3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_csg_flat(smooth_faces);
+	}
+	_make_painted();
 }
 
 bool CSGTorus3D::get_smooth_faces() const {
@@ -2229,7 +3417,9 @@ bool CSGTorus3D::get_smooth_faces() const {
 
 void CSGTorus3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGTorus3D::get_material() const {
@@ -2338,6 +3528,9 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
+	Vector<int> ngons;
+	ngons.resize(face_count);
+
 	faces.resize(face_count * 3);
 	uvs.resize(face_count * 3);
 	smooth.resize(face_count);
@@ -2351,6 +3544,10 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 		bool *smoothw = smooth.ptrw();
 		Ref<Material> *materialsw = materials.ptrw();
 		bool *invertw = invert.ptrw();
+
+		int *ngonw = ngons.ptrw();
+
+		int ngon_counter = 0;
 
 		int face = 0;
 		Transform3D base_xform;
@@ -2433,8 +3630,10 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = false;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
+				ngonw[face] = ngon_counter;
 				face++;
 			}
+			ngon_counter++;
 		}
 
 		real_t angle_simplify_dot = Math::cos(Math::deg_to_rad(path_simplify_angle));
@@ -2549,6 +3748,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = smooth_faces;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
 
 				face++;
 
@@ -2564,6 +3764,8 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = smooth_faces;
 				invertw[face] = flip_faces;
 				materialsw[face] = base_material;
+				ngonw[face] = ngon_counter;
+				ngon_counter++;
 
 				face++;
 			}
@@ -2588,6 +3790,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 				smoothw[face] = false;
 				materialsw[face] = base_material;
 				invertw[face] = flip_faces;
+				ngonw[face] = ngon_counter;
 				face++;
 			}
 		}
@@ -2602,9 +3805,12 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 		smooth.resize(face_count);
 		materials.resize(face_count);
 		invert.resize(face_count);
+		ngons.resize(face_count); // What does this do?
 	}
 
 	new_brush->build_from_faces(faces, uvs, smooth, materials, invert);
+	new_brush->add_ngons(ngons);
+	csg_push_warning(NO_WARNING);
 
 	return new_brush;
 }
@@ -2632,7 +3838,7 @@ void CSGPolygon3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CSGPolygon3D::_path_changed() {
-	_make_dirty();
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2727,7 +3933,7 @@ void CSGPolygon3D::_bind_methods() {
 
 void CSGPolygon3D::set_polygon(const Vector<Vector2> &p_polygon) {
 	polygon = p_polygon;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2737,7 +3943,7 @@ Vector<Vector2> CSGPolygon3D::get_polygon() const {
 
 void CSGPolygon3D::set_mode(Mode p_mode) {
 	mode = p_mode;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 	notify_property_list_changed();
 }
@@ -2749,7 +3955,10 @@ CSGPolygon3D::Mode CSGPolygon3D::get_mode() const {
 void CSGPolygon3D::set_depth(const float p_depth) {
 	ERR_FAIL_COND(p_depth < 0.001);
 	depth = p_depth;
-	_make_dirty();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2759,7 +3968,7 @@ float CSGPolygon3D::get_depth() const {
 
 void CSGPolygon3D::set_path_continuous_u(bool p_enable) {
 	path_continuous_u = p_enable;
-	_make_dirty();
+	rebuild_brush();
 }
 
 bool CSGPolygon3D::is_path_continuous_u() const {
@@ -2768,7 +3977,7 @@ bool CSGPolygon3D::is_path_continuous_u() const {
 
 void CSGPolygon3D::set_path_u_distance(real_t p_path_u_distance) {
 	path_u_distance = p_path_u_distance;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2779,7 +3988,7 @@ real_t CSGPolygon3D::get_path_u_distance() const {
 void CSGPolygon3D::set_spin_degrees(const float p_spin_degrees) {
 	ERR_FAIL_COND(p_spin_degrees < 0.01 || p_spin_degrees > 360);
 	spin_degrees = p_spin_degrees;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2790,7 +3999,7 @@ float CSGPolygon3D::get_spin_degrees() const {
 void CSGPolygon3D::set_spin_sides(int p_spin_sides) {
 	ERR_FAIL_COND(p_spin_sides < 3);
 	spin_sides = p_spin_sides;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2800,7 +4009,7 @@ int CSGPolygon3D::get_spin_sides() const {
 
 void CSGPolygon3D::set_path_node(const NodePath &p_path) {
 	path_node = p_path;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2810,7 +4019,7 @@ NodePath CSGPolygon3D::get_path_node() const {
 
 void CSGPolygon3D::set_path_interval_type(PathIntervalType p_interval_type) {
 	path_interval_type = p_interval_type;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2820,7 +4029,7 @@ CSGPolygon3D::PathIntervalType CSGPolygon3D::get_path_interval_type() const {
 
 void CSGPolygon3D::set_path_interval(float p_interval) {
 	path_interval = p_interval;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2830,7 +4039,7 @@ float CSGPolygon3D::get_path_interval() const {
 
 void CSGPolygon3D::set_path_simplify_angle(float p_angle) {
 	path_simplify_angle = p_angle;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2840,7 +4049,7 @@ float CSGPolygon3D::get_path_simplify_angle() const {
 
 void CSGPolygon3D::set_path_rotation(PathRotation p_rotation) {
 	path_rotation = p_rotation;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2850,7 +4059,7 @@ CSGPolygon3D::PathRotation CSGPolygon3D::get_path_rotation() const {
 
 void CSGPolygon3D::set_path_rotation_accurate(bool p_enabled) {
 	path_rotation_accurate = p_enabled;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2860,7 +4069,10 @@ bool CSGPolygon3D::get_path_rotation_accurate() const {
 
 void CSGPolygon3D::set_path_local(bool p_enable) {
 	path_local = p_enable;
-	_make_dirty();
+	if (is_painted()) {
+		resize_brush_rework();
+	}
+	_make_painted();
 	update_gizmos();
 }
 
@@ -2870,7 +4082,7 @@ bool CSGPolygon3D::is_path_local() const {
 
 void CSGPolygon3D::set_path_joined(bool p_enable) {
 	path_joined = p_enable;
-	_make_dirty();
+	rebuild_brush();
 	update_gizmos();
 }
 
@@ -2880,7 +4092,7 @@ bool CSGPolygon3D::is_path_joined() const {
 
 void CSGPolygon3D::set_smooth_faces(const bool p_smooth_faces) {
 	smooth_faces = p_smooth_faces;
-	_make_dirty();
+	_make_painted();
 }
 
 bool CSGPolygon3D::get_smooth_faces() const {
@@ -2889,7 +4101,9 @@ bool CSGPolygon3D::get_smooth_faces() const {
 
 void CSGPolygon3D::set_material(const Ref<Material> &p_material) {
 	material = p_material;
-	_make_dirty();
+	if (is_inside_tree()) {
+		set_face_material(get_all_csg_faces(), material);
+	}
 }
 
 Ref<Material> CSGPolygon3D::get_material() const {

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -56,15 +56,28 @@ public:
 
 	};
 
+	enum CSGWarning {
+		NO_WARNING,
+		NON_MANIFOLD,
+		CSG_SET_NON_MANIFOLD,
+		CSG_MESH_NOT_ASSIGNED,
+		CSG_MESH_NON_MANIFOLD,
+	};
+
 private:
 	Operation operation = OPERATION_UNION;
 	CSGShape3D *parent_shape = nullptr;
 
 	CSGBrush *brush = nullptr;
+	CSGBrush *combined_brush = nullptr;
+
+	CSGWarning brush_warning = NO_WARNING;
 
 	AABB node_aabb;
 
 	bool dirty = false;
+	bool children_modified = false;
+	bool painted = false;
 	bool last_visible = false;
 	float snap = 0.001;
 
@@ -122,16 +135,61 @@ protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
+	void _make_painted(bool p_paint = false, bool p_parent_removing = false);
 	PackedStringArray get_configuration_warnings() const override;
 
 	static void _bind_methods();
 
 	friend class CSGCombiner3D;
 	CSGBrush *_get_brush();
+	CSGBrush *_get_combined_brush();
+
+	void _expand_aabb(CSGBrush *p_brush);
 
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	void csg_push_warning(CSGWarning p_warning = NO_WARNING);
+	void rebuild_brush();
+	void brush_modified();
+	Dictionary get_csg_brush();
+	void set_csg_brush(const Dictionary &p_brush_data);
+	// These work on selected faces.
+	void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &p_prev_offset, const Vector2 &p_offset);
+	Vector2 get_uv_offsets(int p_face);
+	void set_uv_scale(const Vector<int> &p_faces, const Vector2 &p_prev_scale, const Vector2 &p_scale);
+	Vector2 get_uv_scale(int p_face);
+	void rotate_uv(const Vector<int> &p_faces, float p_angle);
+	void flip_x(const Vector<int> &p_faces);
+	void flip_y(const Vector<int> &p_faces);
+	// These are meant to be used to create a UV editor like blender's.
+	Vector<Vector2> get_brush_uvs();
+	void set_brush_uvs(const Vector<Vector2> &p_uvs);
+	// These calculate UVs.
+	void calculate_cube_map(const Vector<int> &p_faces, const Vector3 &uv_scale, bool p_use_global = false);
+	void calculate_cylinder_map(const Vector<int> &p_faces, const Vector3 &uv_scale, bool p_use_global = false);
+	// These change smoothing groups.
+	void set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth);
+	int get_csg_face_smooth_group(int p_face);
+	// These change material.
+	void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
+	Ref<Material> get_face_material(int p_face);
+	// These affect the entire brush.
+	bool resize_brush(const Vector3 &p_prev_size, const Vector3 &p_size);
+	void resize_brush_rework();
+	void set_csg_invert(bool p_inv_val);
+	void set_csg_flat(bool p_mode);
+	// These affect vertices.
+	Vector<Vector3> get_vertices();
+	void set_vertex_position(const Vector3 &p_curr_pos, const Vector3 &p_pos);
+	// These are helper methods for UX.
+	Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
+	int get_csg_num_faces();
+	Vector<int> get_all_csg_faces();
+	Vector<int> get_faces_from_ngon(int p_ngon);
+	TypedArray<Vector<Vector3>> get_csg_ngon_colliders();
+	bool is_painted() const;
+
 	Array get_meshes() const;
 	void update_shape();
 
@@ -216,7 +274,7 @@ class CSGPrimitive3D : public CSGShape3D {
 
 protected:
 	bool flip_faces;
-	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials);
+	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<int> &p_ngons);
 	static void _bind_methods();
 
 public:

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -122,6 +122,7 @@ protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
 	void _make_dirty(bool p_parent_removing = false);
+	void _make_painted();
 	PackedStringArray get_configuration_warnings() const override;
 
 	static void _bind_methods();
@@ -132,6 +133,12 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	Dictionary get_csg_brush() const;
+	void set_csg_brush(const Dictionary &p_brush_data);
+	void rebuild_brush();
+
+	void rotate_uv(const Vector<int> &p_faces, const float angle);
+
 	Array get_meshes() const;
 	void update_shape();
 

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -29,6 +29,67 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty mesh or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method bake_static_mesh] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="brush_modified">
+			<return type="void" />
+			<description>
+				Forces an update of the root CSG shape visuals.
+			</description>
+		</method>
+		<method name="calculate_cube_map">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="uv_scale" type="Vector3" />
+			<param index="2" name="use_global" type="bool" />
+			<description>
+				Generates cube map UVs for the selected faces. This is a simple unwrapping that calculates the UVs based on the direction of the face.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+				[param uv_scale]: Can be used to scale the UVs. If any of the components is [code]0[/code], it will be set to [code]1[/code] to prevent bad UVs.
+				[param use_global]: When set to [code]true[/code], calculates the UVs in global space instead of local space.
+			</description>
+		</method>
+		<method name="calculate_cylinder_map">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="uv_scale" type="Vector3" />
+			<param index="2" name="use_global" type="bool" />
+			<description>
+				Generates cylinder UVs for the selected faces. This is a simple unwrapping that calculates the side UVs based on the angle from the center.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+				[param uv_scale]: Can be used to scale the UVs. If any of the components is [code]0[/code], it will be set to [code]1[/code] to prevent bad UVs. Only the first two components will be taken into account.
+				[param use_global]: When set to [code]true[/code], calculates the UVs in global space instead of local space.
+				[b]Note:[/b] [code]use_global = true[/code] will not take position into account and instead calculate UVs around the center of the node to prevent bad UVs.
+			</description>
+		</method>
+		<method name="flip_x">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Flips [param faces] in X.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+			</description>
+		</method>
+		<method name="flip_y">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Flips [param faces] in Y.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+			</description>
+		</method>
+		<method name="get_all_csg_faces">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns a [PackedInt32Array] of all the faces of the CSGBrush, with each face being represented by a number.
+				Equivalent to doing [code]range(get_csg_num_faces())[/code].
+			</description>
+		</method>
+		<method name="get_brush_uvs">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns a [PackedVector2Array] with the UVs of CSGBrush, where every [code]3[/code] elements represents a face.
+				This is intended for creating a UV editor for more advanced UV unwrapping.
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -43,6 +104,39 @@
 				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_csg_face_smooth_group">
+			<return type="int" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the smooth value of the face.
+			</description>
+		</method>
+		<method name="get_csg_ngon_colliders">
+			<return type="PackedVector3Array[]" />
+			<description>
+				Returns an array of triangles for creating colliders for gizmos.
+			</description>
+		</method>
+		<method name="get_csg_num_faces">
+			<return type="int" />
+			<description>
+				Returns the number of faces of the CSGBrush.
+			</description>
+		</method>
+		<method name="get_face_material">
+			<return type="Material" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Gets the material of [param face] in the CSGBrush.
+			</description>
+		</method>
+		<method name="get_faces_from_ngon">
+			<return type="PackedInt32Array" />
+			<param index="0" name="ngon" type="int" />
+			<description>
+				Returns the ID of the faces assigned to ngon [param ngon].
+			</description>
+		</method>
 		<method name="get_meshes" qualifiers="const">
 			<return type="Array" />
 			<description>
@@ -50,10 +144,72 @@
 				[b]Note:[/b] CSG mesh data updates are deferred, which means they are updated with a delay of one rendered frame. To avoid getting an empty shape or outdated mesh data, make sure to call [code]await get_tree().process_frame[/code] before using [method get_meshes] in [method Node._ready] or after changing properties on the [CSGShape3D].
 			</description>
 		</method>
+		<method name="get_selected_faces">
+			<return type="PackedVector3Array" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<description>
+				Returns the vertices used to generate the selected faces. This is intended for generating a mesh to display the selected faces in the editor.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+			</description>
+		</method>
+		<method name="get_uv_offsets">
+			<return type="Vector2" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the calculated offset of the UVs of the [param face] of the CSGBrush.
+			</description>
+		</method>
+		<method name="get_uv_scale">
+			<return type="Vector2" />
+			<param index="0" name="face" type="int" />
+			<description>
+				Returns the calculated scale of the UVs of the [param face] of the CSGBrush.
+			</description>
+		</method>
+		<method name="get_vertices">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a [PackedVector3Array] with the positions of the vertices of the CSGBrush. This method ignores duplicated positions and is intended to be used with [method set_vertex_position].
+			</description>
+		</method>
 		<method name="is_root_shape" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this is a root shape and is thus the object that is rendered.
+			</description>
+		</method>
+		<method name="rebuild_brush">
+			<return type="void" />
+			<description>
+				Rebuilds the CSGBrush based on the properties of the CSG node. Overrides any changes to the faces or vertices. Internally sets [code]painted[/code] to false.
+			</description>
+		</method>
+		<method name="resize_brush">
+			<return type="bool" />
+			<param index="0" name="prev_size" type="Vector3" />
+			<param index="1" name="size" type="Vector3" />
+			<description>
+				Resizes the CSGBrush from [param prev_size] to [param size].
+				For a [CSGBox3D], [param prev_size] would be the size property, and [param size] the new dimensions.
+				[b]Note:[/b] Both components of [param size] and both components of [param prev_size] must be non-zero.
+			</description>
+		</method>
+		<method name="rotate_uv">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="angle" type="float" />
+			<description>
+				Rotates [param faces] of the CSGBrush by [param angle].
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+				[param angle] must be in radians.
+			</description>
+		</method>
+		<method name="set_brush_uvs">
+			<return type="void" />
+			<param index="0" name="uvs" type="PackedVector2Array" />
+			<description>
+				Sets the UVs of CSGBrush from [param uvs].
+				[b]Note:[/b][param uvs] must be divisible by 3.
 			</description>
 		</method>
 		<method name="set_collision_layer_value">
@@ -72,8 +228,96 @@
 				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="set_csg_face_smooth_group">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="smooth" type="int" />
+			<description>
+				Sets the smoothing of [param faces]. A value of [code]0[/code] will make the face flat while any value above will make it smooth.
+				[b]Note:[/b] This is a work in progress, at the moment, all values above [code]0[/code] will blend together.
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+			</description>
+		</method>
+		<method name="set_face_material">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="material" type="Material" />
+			<description>
+				Sets [param material] on [param faces].
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+			</description>
+		</method>
+		<method name="set_uv_offsets">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="prev_offset" type="Vector2" />
+			<param index="2" name="offset" type="Vector2" />
+			<description>
+				Sets the UVs of [param faces] of the CSGBrush using [param offset].
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+				Usage:
+				[codeblocks]
+				[gdscript]
+				# Offset the first and second faces of CSGBrush.
+				var faces = PackedInt32Array([0, 1])
+				set_uv_offsets(faces, get_uv_offsets(faces[0]), get_uv_offsets(faces[0]) + Vector2(0.25, 0.0))
+				[/gdscript]
+				[csharp]
+				// Offset the first and second faces of CSGBrush.
+				var faces = new PackedInt32Array([0, 1]);
+				SetUvOffsets(faces, GetUvOffsets(faces[0]), GetUvOffsets(faces[0]) + new Vector2(0.1f, 0.0f));
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="set_uv_scale">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedInt32Array" />
+			<param index="1" name="prev_scale" type="Vector2" />
+			<param index="2" name="scale" type="Vector2" />
+			<description>
+				Sets the UVs of [param faces] of the CSGBrush using [param scale].
+				[param faces]: Must be a [PackedInt32Array] containing valid indices of faces in the CSGBrush.
+				Usage:
+				[codeblocks]
+				[gdscript]
+				# Scale the first and second faces of CSGBrush.
+				var faces = PackedInt32Array([0, 1])
+				var curr_scale = get_uv_scale(faces[0])
+				set_uv_scale(faces, curr_scale, Vector2(2.0, 2.0))
+				[/gdscript]
+				[csharp]
+				// Scale the first and second faces of CSGBrush.
+				var faces = new PackedInt32Array([0, 1]);
+				var currentUvScale = GetUvScale(faces[0]);
+				SetUvScale(faces, currentUvScale, new Vector2(2.0f, 2.0f));
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] Both components of [param scale] must be non-zero.
+			</description>
+		</method>
+		<method name="set_vertex_position">
+			<return type="void" />
+			<param index="0" name="from" type="Vector3" />
+			<param index="1" name="to" type="Vector3" />
+			<description>
+				Sets all the vertices of the CSGBrush in position [param from] to [param to].
+			</description>
+		</method>
 	</methods>
 	<members>
+		<member name="_csg_brush" type="Dictionary" setter="set_csg_brush" getter="get_csg_brush" default="{ &quot;painted&quot;: false }">
+			The CSGBrush of the node as a [Dictionary] containing the following entries:
+			- [code]material_id[/code]: [PackedByteArray] with the IDs of the material assigned to each face. See [code]materials[/code].
+			- [code]vertices[/code]: [PackedVector3Array] containing the positions of the triangles that make up the CSGBrush, must be divisible by 3.
+			- [code]uvs[/code]: [PackedVector2Array] containing the UVs of the triangles of the CSGBrush, must be divisible by 3.
+			- [code]smooth[/code]: [PackedByteArray] with the smoothing groups of the faces of the CSGBrush. A value of [code]0[/code] disables the effect and any value above enables it.
+			[b]NOTE:[/b] This is a work in progress, at the moment, all values above [code]0[/code] will blend together.
+			- [code]inverted[/code]: Needed since [code]flip_faces[/code] is a property of [CSGPrimitive3D] and not [CSGShape3D].
+			- [code]materials[/code]: [Array] of [Material]s of the CSGBrush.
+			- [code]painted[/code]: When set to [code]true[/code], tells the engine not to rebuild the CSGBrush. Must always be [code]true[/code] for this to work.
+			- [code]ngons[/code]: [PackedInt32Array] with the ngons assigned to each face.
+		</member>
 		<member name="autosmooth" type="bool" setter="set_autosmooth" getter="is_autosmooth" default="false">
 			Enables automatic smoothing. This overrides any smoothing on the CSG node and instead uses [member smoothing_angle] to calculate normals based on the angle between faces.
 			Children of a [CSGCombiner3D] node will be treated as a single mesh.

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -152,6 +152,11 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 	ur->commit_action();
 }
 
+void CSGShapeEditor::_rebuild_brush() {
+	node->rebuild_brush();
+	// TODO Undo, Redo, Etc.
+}
+
 CSGShapeEditor::CSGShapeEditor() {
 	options = memnew(MenuButton);
 	options->hide();
@@ -168,6 +173,15 @@ CSGShapeEditor::CSGShapeEditor() {
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
+
+	// TODO check.
+	rebuild_csg = memnew(Button);
+	rebuild_csg->hide();
+	rebuild_csg->set_text(TTR("REBUILD"));
+	rebuild_csg->set_flat(false);
+	rebuild_csg->set_theme_type_variation("FlatMenuButton");
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(rebuild_csg);
+	rebuild_csg->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_rebuild_brush));
 }
 
 ///////////

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -40,6 +40,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/menu_button.h"
 #include "scene/main/scene_tree.h"
@@ -48,15 +49,26 @@ void CSGShapeEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
 		node = nullptr;
 		options->hide();
+		hbox->hide();
 	}
 }
 
 void CSGShapeEditor::edit(CSGShape3D *p_csg_shape) {
 	node = p_csg_shape;
 	if (node) {
-		options->show();
+		hbox->show();
+		if (node->is_root_shape()) {
+			options->show();
+		} else {
+			options->hide();
+		}
+		cubemap_uvs->show();
+		cylinder_uvs->show();
+		global_uv_toggle->show();
+		rebuild_csg->show();
 	} else {
 		options->hide();
+		hbox->hide();
 	}
 }
 
@@ -64,6 +76,8 @@ void CSGShapeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			options->set_button_icon(get_editor_theme_icon(SNAME("CSGCombiner3D")));
+			// FIXME We need an icon for this button. Using KeepAspect for now.
+			global_uv_toggle->set_button_icon(get_editor_theme_icon(SNAME("KeepAspect")));
 		} break;
 	}
 }
@@ -152,6 +166,36 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 	ur->commit_action();
 }
 
+void CSGShapeEditor::_rebuild_brush() {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
+	ur->create_action(TTR("Rebuild CSG Brush"));
+	ur->add_do_method(node, "rebuild_brush");
+	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->commit_action();
+}
+
+void CSGShapeEditor::_make_cube_uv() {
+	// This is just too practical to not have it as a button.
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
+	ur->create_action(TTR("Make Cube UV"));
+	// TODO Add a SpinBox to set uv_scale before pressing the button.
+	ur->add_do_method(node, "calculate_cube_map", node->get_all_csg_faces(), Vector3(1.0, 1.0, 1.0), global_uv_toggle->is_pressed());
+	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->commit_action();
+}
+
+void CSGShapeEditor::_make_cylinder_uv() {
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	Dictionary dict = node->get_csg_brush();
+	ur->create_action(TTR("Make Cylinder UV"));
+	// TODO Add a SpinBox to set uv_scale before pressing the button.
+	ur->add_do_method(node, "calculate_cylinder_map", node->get_all_csg_faces(), Vector3(1.0, 1.0, 1.0), global_uv_toggle->is_pressed());
+	ur->add_undo_method(node, "set_csg_brush", dict);
+	ur->commit_action();
+}
+
 CSGShapeEditor::CSGShapeEditor() {
 	options = memnew(MenuButton);
 	options->hide();
@@ -168,6 +212,41 @@ CSGShapeEditor::CSGShapeEditor() {
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
+
+	hbox = memnew(HBoxContainer);
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(hbox);
+	hbox->hide();
+
+	rebuild_csg = memnew(Button);
+	rebuild_csg->hide();
+	rebuild_csg->set_text(TTR("Rebuild"));
+	rebuild_csg->set_flat(false);
+	hbox->add_child(rebuild_csg);
+	rebuild_csg->set_tooltip_text(TTRC("Rebuild this brush, removing any changes to faces or vertices. Children of this node will not be affected."));
+	rebuild_csg->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_rebuild_brush));
+
+	cubemap_uvs = memnew(Button);
+	cubemap_uvs->hide();
+	cubemap_uvs->set_text(TTR("Make cube UV"));
+	cubemap_uvs->set_flat(false);
+	hbox->add_child(cubemap_uvs);
+	cubemap_uvs->set_tooltip_text(TTRC("Apply cube map UVs to this node's CSGBrush."));
+	cubemap_uvs->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_make_cube_uv));
+
+	cylinder_uvs = memnew(Button);
+	cylinder_uvs->hide();
+	cylinder_uvs->set_text(TTR("Make cylinder UV"));
+	cylinder_uvs->set_flat(false);
+	hbox->add_child(cylinder_uvs);
+	cylinder_uvs->set_tooltip_text(TTRC("Apply cylinder map UVs to this node's CSGBrush."));
+	cylinder_uvs->connect(SceneStringName(pressed), callable_mp(this, &CSGShapeEditor::_make_cylinder_uv));
+
+	global_uv_toggle = memnew(Button);
+	global_uv_toggle->set_toggle_mode(true);
+	global_uv_toggle->hide();
+	hbox->add_child(global_uv_toggle);
+	// TODO Shortcut.
+	global_uv_toggle->set_tooltip_text(TTRC("When enabled, pressing the `Make cube UV` or `Make cylinder UV` buttons will calculate UVs using global space instead of local space."));
 }
 
 ///////////
@@ -389,16 +468,52 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Vector<Vector3> lines;
-	lines.resize(faces.size() * 2);
-	{
-		const Vector3 *r = faces.ptr();
+	TypedArray<Vector<Vector3>> local_csg_faces = cs->get_csg_ngon_colliders();
+	bool skip = local_csg_faces.is_empty();
+	if (!skip) {
+		for (int i = 0; i < local_csg_faces.size(); i++) {
+			Vector<Vector3> curr_ngon = local_csg_faces[i];
+			// Convert to lines.
+			if (curr_ngon.size() == 6) {
+				// Quad.
+				lines.push_back(curr_ngon[0]);
+				lines.push_back(curr_ngon[1]);
+				lines.push_back(curr_ngon[1]);
+				lines.push_back(curr_ngon[2]);
+				lines.push_back(curr_ngon[3]);
+				lines.push_back(curr_ngon[4]);
+				lines.push_back(curr_ngon[4]);
+				lines.push_back(curr_ngon[5]);
+			} else if (curr_ngon.size() > 6) {
+				// Since the only way to generate Ngons is through CSG building and they are always surrounded by quads, we just skip the ngons.
+				continue;
+			} else {
+				// Tris.
+				for (int j = 0; j < curr_ngon.size() / 3; j++) {
+					for (int k = 0; k < 3; k++) {
+						int k_n = (k + 1) % 3;
+						lines.push_back(curr_ngon[j * 3 + k]);
+						lines.push_back(curr_ngon[j * 3 + k_n]);
+					}
+				}
+			}
+		}
+		if (lines.is_empty()) {
+			skip = true;
+		}
+	}
+	if (skip) {
+		lines.resize(faces.size() * 2);
+		{
+			const Vector3 *r = faces.ptr();
 
-		for (int i = 0; i < lines.size(); i += 6) {
-			int f = i / 6;
-			for (int j = 0; j < 3; j++) {
-				int j_n = (j + 1) % 3;
-				lines.write[i + j * 2 + 0] = r[f * 3 + j];
-				lines.write[i + j * 2 + 1] = r[f * 3 + j_n];
+			for (int i = 0; i < lines.size(); i += 6) {
+				int f = i / 6;
+				for (int j = 0; j < 3; j++) {
+					int j_n = (j + 1) % 3;
+					lines.write[i + j * 2 + 0] = r[f * 3 + j];
+					lines.write[i + j * 2 + 1] = r[f * 3 + j_n];
+				}
 			}
 		}
 	}
@@ -486,16 +601,12 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 void EditorPluginCSG::edit(Object *p_object) {
 	CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_object);
-	if (csg_shape && csg_shape->is_root_shape()) {
-		csg_shape_editor->edit(csg_shape);
-	} else {
-		csg_shape_editor->edit(nullptr);
-	}
+	csg_shape_editor->edit(csg_shape);
 }
 
 bool EditorPluginCSG::handles(Object *p_object) const {
 	CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_object);
-	return csg_shape && csg_shape->is_root_shape();
+	return csg_shape != nullptr;
 }
 
 EditorPluginCSG::EditorPluginCSG() {

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -38,6 +38,7 @@
 
 class AcceptDialog;
 class Gizmo3DHelper;
+class HBoxContainer;
 class MenuButton;
 
 class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
@@ -71,12 +72,22 @@ class CSGShapeEditor : public Control {
 
 	CSGShape3D *node = nullptr;
 	MenuButton *options = nullptr;
+	HBoxContainer *hbox = nullptr;
+	Button *rebuild_csg = nullptr;
+	Button *cubemap_uvs = nullptr;
+	Button *cylinder_uvs = nullptr;
+	Button *global_uv_toggle = nullptr;
+	// TODO Add a SpinBox to set uv_scale when applying uv.
 	AcceptDialog *err_dialog = nullptr;
 
 	void _menu_option(int p_option);
 
 	void _create_baked_mesh_instance();
 	void _create_baked_collision_shape();
+
+	void _rebuild_brush();
+	void _make_cube_uv();
+	void _make_cylinder_uv();
 
 protected:
 	void _node_removed(Node *p_node);

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -71,12 +71,15 @@ class CSGShapeEditor : public Control {
 
 	CSGShape3D *node = nullptr;
 	MenuButton *options = nullptr;
+	Button *rebuild_csg = nullptr;
 	AcceptDialog *err_dialog = nullptr;
 
 	void _menu_option(int p_option);
 
 	void _create_baked_mesh_instance();
 	void _create_baked_collision_shape();
+
+	void _rebuild_brush();
 
 protected:
 	void _node_removed(Node *p_node);


### PR DESCRIPTION
Prepares for https://github.com/godotengine/godot-proposals/issues/14464
Related https://github.com/godotengine/godot-proposals/issues/14319
Closes https://github.com/godotengine/godot-proposals/issues/12745
Partially addresses https://github.com/godotengine/godot-proposals/issues/2879
Closes https://github.com/godotengine/godot-proposals/issues/937
Closes https://github.com/godotengine/godot-proposals/issues/11602

This PR allows editing of CSGBrushes of CSG nodes, introduces methods for altering them, and makes necessary modifications to the overall system.
A CSG face editor can now be created to more easily interact with them, in the meanwhile, most of these properties are exposed to gdscript.

#### Save CSG brush
CSG nodes can be set to `painted`, allowing the CSGBrush to be saved and loaded from disk.
The painted state can be checked internally with the method `bool is_painted() const;`.
The methods `Dictionary get_csg_brush();` and `void set_csg_brush(const Dictionary &p_brush_data);` of property `_csg_brush` can be used to save or load the CSGBrush.
~Only non-root CSG nodes can be modified or saved and loaded. Root CSG nodes will loose the painted status and any changes made.~ (See last post)
Edit: set_csg_brush should now test whether the brush is manifold through the manifold library and return a specific warning for this case while also setting the brush to null. This means a node can fail without breaking the entire csg tree.

#### Methods for modifying faces
Added methods for modifying faces. Most of these methods take a PackedInt32 with the selected faces and apply modifications to them:
```c++
void set_uv_offsets(const Vector<int> &p_faces, const Vector2 &p_prev_offset, const Vector2 &p_offset);
Vector2 get_uv_offsets(int p_face);
void set_uv_scale(const Vector<int> &p_faces, const Vector2 &p_prev_scale, const Vector2 &p_scale);
Vector2 get_uv_scale(int p_face);
void rotate_uv(const Vector<int> &p_faces, const float p_angle);
void flip_x(const Vector<int> &p_faces);
void flip_y(const Vector<int> &p_faces);
void set_csg_face_smooth_group(const Vector<int> &p_faces, int p_smooth);
int get_csg_face_smooth_group(int p_face);
```
This method changes the material of the selected faces.
```c++
void set_face_material(const Vector<int> &p_faces, const Ref<Material> &p_material);
Ref<Material> get_face_material(int p_face);
```
<img width="636" height="463" alt="Captura desde 2026-04-15 19-45-40" src="https://github.com/user-attachments/assets/d0623d13-6455-4088-8fd9-3e30d574f67c" />


These can be used to generate UVs based on the local positions of CSGBrush vertices. UV_scale can be used to scale the result:
```c++
void calculate_cube_map(const Vector<int> &p_faces, const Vector3 &uv_scale);
void calculate_cylinder_map(const Vector<int> &p_faces, const Vector3 &uv_scale);

```

These methods affect the entire brush and are used internally to maintain modifications of painted brushes when editing them with the gizmos or properties:
```c++
bool resize_brush(const Vector3 &p_prev_size, const Vector3 &p_size);
void resize_brush_rework();
void set_csg_invert(bool p_inv_val);
void set_csg_flat(bool p_mode);
```

These methods affect vertices and can be used to create a simple vertex editor.
```c++
Vector<Vector3> get_vertices();
void set_vertex_position(const Vector3 &curr_pos, const Vector3 &p_pos);

```
These are helper methods for UX.
```c++
Vector<Vector3> get_selected_faces(const Vector<int> &p_faces);
int get_csg_num_faces();
Vector<int> get_all_csg_faces();
Vector<int> get_faces_from_ngon(int p_ngon);
TypedArray<Vector<Vector3>> get_csg_ngon_colliders();
```

#### ~CSG nesting~
~All CSG nodes are now treated as siblings, with the root shape getting all its children and children's children recursively with `void get_csg_children_recursive(Vector<CSGShape3D *> &p_nodes);`.
This means that CSGBrushes of nested nodes are no longer modified, only the root shape performs manifold operations.~ (See last post) Visually, nothing changes, ~but CSGCombiner3D can no longer be a child of other CSG nodes (an explanation was added to the empty shape warning). Using a CSGCombiner3D as child of a CSG node doesn't break anything, and its children are still visible and usable by the root, it just triggers a warning.~
edit: This problem has been fixed by implementing a more specific warning system. ~Since all CSGs are siblings~, a CSG can fail and throw a warning on the node, and not affect the rest of the tree. And CSGCombiner3D will no longer throw a warning and can be used anywhere. (needs testing after last changes)
Specific warnings where also added for CSGMesh3D without a mesh set and non-manifold CSGMesh3D.

#### Painted
Nodes should no longer call `_make_dirty()` directly. Instead they must call `_make_painted()`. When used without parameters, if the node is root shape, or is not painted, it will act in the same way as `_make_dirty()`, rebuilding the brush.
When run with the first parameter `_make_painted(true)` it will make the brush painted. This is only done with the methods that modify faces or vertices of the brush.
For rebuilding the brush, the method `rebuild_brush()` should be called instead, this will force a rebuild of the brush, but will be called inside a check for `is_inside_tree()`, this is done to prevent it from being called when the property is loaded and override the brush.
`void brush_modified();` calls _make_painted() without parameters ~and was added to use after `set_csg_brush()` for undo to work properly.~ (This is no longer the case, the method just updates the CSG tree)

#### CSG Buttons
Added 3 buttons to the toolbar when a CSG node is selected. These will greatly improve CSG level creation until a face editor is implemented. 
REBUILD: This button forces a manual rebuild of the CSGBrush of the CSG node and removes the painted state.
Make cube uvs: This generates cube uv maps for the selected brush.
Make cylinder uvs: Same but with the top and bottom being aligned, and the sides making a circle.
<img width="1910" height="1040" alt="Captura desde 2026-04-17 17-50-49" src="https://github.com/user-attachments/assets/51e057f9-9c33-4522-8081-67e7647b120d" />
A SpinBox could be added to allow setting uv_scale before pressing the button.

#### Ngons
Ngons were added to CSGBrush. These are generated in the `_build_brush` of each CSG node and are meant to be able to select multiple faces at the same time when a face editor is introduced. For now, they are used to improve visualization of CSG nodes:
<img width="848" height="390" alt="Captura desde 2026-04-15 19-45-13" src="https://github.com/user-attachments/assets/e564820b-8f7c-4e4c-8bf3-005cf6d7c0d1" />
<img width="1171" height="584" alt="Captura desde 2026-04-15 19-48-04" src="https://github.com/user-attachments/assets/3b3a529c-0ca0-4e24-b547-46e83ce1b447" />

#### ~Smooth groups~
~Smooth groups were implemented in CSGBrush. Smooth groups can be set per face, and faces of different brushes with the same smooth group should blend together.~ (See last post)

#### Testing
Testing was made using this script on different CSG nodes. I am unable to upload the much larger godot project at the time.
[csg_box_3d_5.zip](https://github.com/user-attachments/files/26766570/csg_box_3d_5.zip)

#### known bugs

- There were problems trying to make this work because of how nodes and node properties are initialized and when _make_dirty() was called. More work on this area could improve this PR.
  - First, node properties are assigned. These used to call _make_dirty, which caused the changes to painted brushes to be removed. Now properties that need a rebuild of the brush check is_inside_tree before calling rebuild_brush(), this allows these properties to work in the inspector when the node is painted, without clearing it at the start. using these properties will cause the brush to be rebuilt and **the process can't be undone at the time**.
  - ~Second, the node is added to the tree, but all nodes are not ready or technically inside the tree, which was causing an error with the linux mono test. This is why the root shape is built during `NOTIFICATION_READY`.~ (See last post)
- ~Many warnings appear on CSG nodes of the scene tree, but can't be clicked. This is likely due to the order in which the brushes are generated. I'm investigating a solution to this problem.~ Fixed.