### PR TITLE
Ignore non-Scene resources in the "Quick Open Scene..." context

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -36,6 +36,7 @@
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
+#include "core/templates/fixed_vector.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -745,6 +746,22 @@ void QuickOpenResultContainer::_add_candidate(QuickOpenResultCandidate &p_candid
 	}
 
 	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.uid);
+
+	// Verify that a PackedScene is actually a "real" Scene if in a Open Scene context.
+	if (base_types[0] == SNAME("PackedScene")) {
+		static FixedVector<String, 3> valid_extensions = { "tscn", "scn", "res" };
+		bool is_valid_type = false;
+		for (const String &ext : valid_extensions) {
+			if (file_path.has_extension(ext)) {
+				is_valid_type = true;
+				break;
+			}
+		}
+		if (!is_valid_type) {
+			return;
+		}
+	}
+
 	EditorResourcePreview::PreviewItem item = EditorResourcePreview::get_singleton()->get_resource_preview_if_available(file_path);
 	if (item.preview.is_valid()) {
 		p_candidate.thumbnail = item.preview;


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14678

This PR changes the `Quick Open Scene...` dialog to ignore non-Scene `PackedScenes` (meaning anything that isn't a `.tscn`, `.scn`, etc) while still leaving them accessible via `Quick Open Resource...`.
Exact types are stored in this fixed vector. 
```cpp
FixedVector<String, 3> valid_types{ ".tscn", ".scn", ".res" };
```
~~I could not find anyway to actually create a ".tres" scene, but I was told to include it.~~
The rationale for implementing this within the `_add_candiate` method is mostly compatibility. If I were to move this function lower then it would break user history if the user had previously selected a "model scene" while in the Open Scene context. It would require some one-time look up code that would need to run through all the UIDs and check if their path ends in a valid extension and remove them from the history. Which I could do if requested.

<img width="1066" height="701" alt="image" src="https://github.com/user-attachments/assets/5f18e17c-6e89-4749-811a-acc250d06768" />
<img width="1023" height="740" alt="image" src="https://github.com/user-attachments/assets/93cde58a-ffe7-407b-8c60-d0cf24df52f4" />
