### PR TITLE
Fix max icon width in remote scene view/debugger

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1669,6 +1669,14 @@ void EditorPropertyObjectID::update_property() {
 	}
 }
 
+void EditorPropertyObjectID::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			edit->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
+		} break;
+	}
+}
+
 void EditorPropertyObjectID::setup(const String &p_base_type) {
 	base_type = p_base_type;
 }

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -421,6 +421,7 @@ class EditorPropertyObjectID : public EditorProperty {
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
+	void _notification(int p_what);
 
 public:
 	virtual void update_property() override;


### PR DESCRIPTION
Small fix to limit the max width of the remote scene icons.

--

| Before | After |
| ------------- | ------------- |
|  ![image](https://github.com/user-attachments/assets/2bc4f470-8e94-4209-a1f4-eb61712a5924) | ![image](https://github.com/user-attachments/assets/a51d4b9e-a3b0-49d7-9a1d-69fb442f84b9) |