### PR TITLE
Record `tris_count` and `texture_sizes` metadata on scene import

### DIFF
--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1802,7 +1802,7 @@ void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions
 	r_extensions->push_back("dae");
 }
 
-Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	if (r_err) {
 		*r_err = OK;
 	}
@@ -1853,6 +1853,21 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 		}
 		state.scene->add_child(ap, true);
 		ap->set_owner(state.scene);
+	}
+
+	// Record meta
+	if (r_meta != nullptr) {
+		// tris count
+		for (HashMap<String, Ref<ImporterMesh>>::Iterator it = state.mesh_cache.begin(); it != state.mesh_cache.end(); ++it) {
+			Ref<ImporterMesh> imesh = state.mesh_cache[it->key];
+			if (!imesh.is_valid()) {
+				continue;
+			}
+			Ref<ArrayMesh> arr_mesh = imesh->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
 	}
 
 	return state.scene;

--- a/editor/import/3d/editor_import_collada.h
+++ b/editor/import/3d/editor_import_collada.h
@@ -37,5 +37,7 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 
 public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
+			const HashMap<StringName, Variant> &p_options,
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 };

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -569,7 +569,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	return OK;
 }
 
-Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	List<Ref<ImporterMesh>> meshes;
 
 	// LOD, shadow mesh and lightmap UV2 generation are handled by ResourceImporterScene in this case,
@@ -592,6 +592,14 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, co
 		mi->set_name(m->get_name());
 		scene->add_child(mi, true);
 		mi->set_owner(scene);
+
+		// Record tris count to meta
+		if (r_meta != nullptr) {
+			Ref<ArrayMesh> arr_mesh = m->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
 	}
 
 	if (r_err) {

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -37,7 +37,9 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 
 public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
+			const HashMap<StringName, Variant> &p_options,
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 };
 
 class ResourceImporterOBJ : public ResourceImporter {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -69,7 +69,7 @@ void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const
 	}
 }
 
-Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	Dictionary options_dict;
 	for (const KeyValue<StringName, Variant> &elem : p_options) {
 		options_dict[elem.key] = elem.value;
@@ -285,7 +285,7 @@ String ResourceImporterScene::get_resource_type() const {
 }
 
 int ResourceImporterScene::get_format_version() const {
-	return 1;
+	return 2;
 }
 
 bool ResourceImporterScene::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
@@ -3091,8 +3091,11 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
 
 	Error err = OK;
+	uint32_t flags = EditorSceneFormatImporter::IMPORT_ANIMATION |
+			EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS |
+			EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION;
 
-	Node *scene = importer->import_scene(p_source_file, EditorSceneFormatImporter::IMPORT_ANIMATION | EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS | EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION, p_options, nullptr, &err);
+	Node *scene = importer->import_scene(p_source_file, flags, p_options, nullptr, nullptr, &err);
 	if (!scene || err != OK) {
 		return nullptr;
 	}
@@ -3242,10 +3245,19 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		}
 	}
 
+	ImportMeta import_meta;
 	List<String> missing_deps; // for now, not much will be done with this
-	Node *scene = importer->import_scene(src_path, import_flags, p_options, &missing_deps, &err);
+	Node *scene = importer->import_scene(src_path, import_flags, p_options, &missing_deps, &import_meta, &err);
 	if (!scene || err != OK) {
 		return err;
+	}
+
+	// Write metadata
+	if (r_metadata != nullptr) {
+		Dictionary import_meta_dict;
+		import_meta_dict.set("tris_count", import_meta.tris_count);
+		import_meta_dict.set("texture_sizes", import_meta.texture_sizes);
+		*r_metadata = import_meta_dict;
 	}
 
 	bool apply_root = true;
@@ -3528,7 +3540,7 @@ void EditorSceneFormatImporterESCN::get_extensions(List<String> *r_extensions) c
 	r_extensions->push_back("escn");
 }
 
-Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	Error error;
 	Ref<PackedScene> ps = ResourceFormatLoaderText::singleton->load(p_path, p_path, &error);
 	ERR_FAIL_COND_V_MSG(ps.is_null(), nullptr, "Cannot load scene as text resource from path '" + p_path + "'.");

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -46,6 +46,12 @@ class AnimationPlayer;
 class ImporterMesh;
 class Material;
 
+class ImportMeta {
+public:
+	uint32_t tris_count = 0;
+	PackedInt32Array texture_sizes;
+};
+
 class EditorSceneFormatImporter : public RefCounted {
 	GDCLASS(EditorSceneFormatImporter, RefCounted);
 
@@ -76,7 +82,9 @@ public:
 	void add_import_option(const String &p_name, const Variant &p_default_value);
 	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
 	virtual void get_extensions(List<String> *r_extensions) const;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
+			const HashMap<StringName, Variant> &p_options,
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options);
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {}
@@ -314,7 +322,9 @@ class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
 
 public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
+			const HashMap<StringName, Variant> &p_options,
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 };
 
 template <typename M>

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -45,12 +45,12 @@ void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> *r_extension
 
 Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
-		List<String> *r_missing_deps, Error *r_err) {
+		List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	// FIXME: Hack to work around GH-86309.
 	if (p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == EditorSceneFormatImporterUFBX::FBX_IMPORTER_UFBX) {
 		Ref<EditorSceneFormatImporterUFBX> fbx2gltf_importer;
 		fbx2gltf_importer.instantiate();
-		Node *scene = fbx2gltf_importer->import_scene(p_path, p_flags, p_options, r_missing_deps, r_err);
+		Node *scene = fbx2gltf_importer->import_scene(p_path, p_flags, p_options, r_missing_deps, r_meta, r_err);
 		if (r_err && *r_err == OK) {
 			return scene;
 		} else {
@@ -115,6 +115,26 @@ Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint
 			*r_err = FAILED;
 		}
 		return nullptr;
+	}
+
+	// Record meta
+	if (r_meta != nullptr) {
+		// Texture sizes
+		Vector<Ref<Texture2D>> images = state->get_images();
+		r_meta->texture_sizes.resize(images.size());
+		for (int i = 0; i < images.size(); i++) {
+			Size2 img_size = images[i]->get_size();
+			r_meta->texture_sizes.set(i, img_size.x * img_size.y);
+		}
+
+		// Tris count
+		Vector<Ref<GLTFMesh>> meshes = state->get_meshes();
+		for (const Ref<GLTFMesh> &mesh : meshes) {
+			Ref<ArrayMesh> arr_mesh = mesh->get_mesh()->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
 	}
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
@@ -42,7 +42,7 @@ public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
-			List<String> *r_missing_deps, Error *r_err = nullptr) override;
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option,

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -42,12 +42,12 @@ void EditorSceneFormatImporterUFBX::get_extensions(List<String> *r_extensions) c
 
 Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
-		List<String> *r_missing_deps, Error *r_err) {
+		List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	// FIXME: Hack to work around GH-86309.
 	if (p_options.has("fbx/importer") && int(p_options["fbx/importer"]) == FBX_IMPORTER_FBX2GLTF && GLOBAL_GET_CACHED(bool, "filesystem/import/fbx2gltf/enabled")) {
 		Ref<EditorSceneFormatImporterFBX2GLTF> fbx2gltf_importer;
 		fbx2gltf_importer.instantiate();
-		Node *scene = fbx2gltf_importer->import_scene(p_path, p_flags, p_options, r_missing_deps, r_err);
+		Node *scene = fbx2gltf_importer->import_scene(p_path, p_flags, p_options, r_missing_deps, r_meta, r_err);
 		if (r_err && *r_err == OK) {
 			return scene;
 		} else {
@@ -84,6 +84,35 @@ Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t
 		}
 		return nullptr;
 	}
+
+	// Record meta
+	if (r_meta != nullptr) {
+		// Texture sizes
+		if (p_options.has("fbx/embedded_image_handling")) {
+			int32_t image_handle_mode = p_options["fbx/embedded_image_handling"];
+			bool uses_embed_image = image_handle_mode == GLTFState::HandleBinaryImageMode::HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU ||
+					image_handle_mode == GLTFState::HandleBinaryImageMode::HANDLE_BINARY_IMAGE_MODE_EMBED_AS_UNCOMPRESSED;
+
+			if (uses_embed_image) {
+				Vector<Ref<Texture2D>> images = state->get_images();
+				r_meta->texture_sizes.resize(images.size());
+				for (int i = 0; i < images.size(); i++) {
+					Size2 img_size = images[i]->get_size();
+					r_meta->texture_sizes.set(i, img_size.x * img_size.y);
+				}
+			}
+		}
+
+		// Tris count
+		Vector<Ref<GLTFMesh>> meshes = state->get_meshes();
+		for (const Ref<GLTFMesh> &mesh : meshes) {
+			Ref<ArrayMesh> arr_mesh = mesh->get_mesh()->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
+	}
+
 	return fbx->generate_scene(state, state->get_bake_fps(), (bool)p_options["animation/trimming"], false);
 }
 

--- a/modules/fbx/editor/editor_scene_importer_ufbx.h
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.h
@@ -46,7 +46,7 @@ public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
-			List<String> *r_missing_deps, Error *r_err = nullptr) override;
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option,

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -105,7 +105,7 @@ void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) 
 
 Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
-		List<String> *r_missing_deps, Error *r_err) {
+		List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	String blender_path = EDITOR_GET("filesystem/import/blender/blender_path");
 
 	ERR_FAIL_COND_V_MSG(blender_path.is_empty(), nullptr, "Blender path is empty, check your Editor Settings.");
@@ -351,6 +351,26 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		return nullptr;
 	}
 	ERR_FAIL_COND_V(!p_options.has("animation/fps"), nullptr);
+
+	// Record meta
+	if (r_meta != nullptr) {
+		// Texture sizes
+		Vector<Ref<Texture2D>> images = state->get_images();
+		r_meta->texture_sizes.resize(images.size());
+		for (int i = 0; i < images.size(); i++) {
+			Size2 img_size = images[i]->get_size();
+			r_meta->texture_sizes.set(i, img_size.x * img_size.y);
+		}
+
+		// Tris count
+		Vector<Ref<GLTFMesh>> meshes = state->get_meshes();
+		for (const Ref<GLTFMesh> &mesh : meshes) {
+			Ref<ArrayMesh> arr_mesh = mesh->get_mesh()->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
+	}
 
 #ifndef DISABLE_DEPRECATED
 	bool trimming = p_options.has("animation/trimming") ? (bool)p_options["animation/trimming"] : false;

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -73,7 +73,7 @@ public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
-			List<String> *r_missing_deps, Error *r_err = nullptr) override;
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option,

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -42,7 +42,7 @@ void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) c
 
 Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t p_flags,
 		const HashMap<StringName, Variant> &p_options,
-		List<String> *r_missing_deps, Error *r_err) {
+		List<String> *r_missing_deps, ImportMeta *r_meta, Error *r_err) {
 	Ref<GLTFDocument> gltf_doc;
 	gltf_doc.instantiate();
 	Ref<GLTFState> gltf_state;
@@ -75,6 +75,34 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	}
 	if (p_options.has("animation/import")) {
 		gltf_state->set_create_animations(bool(p_options["animation/import"]));
+	}
+
+	// Record meta
+	if (r_meta != nullptr) {
+		// Texture sizes
+		if (p_options.has("gltf/embedded_image_handling")) {
+			int32_t image_handle_mode = p_options["gltf/embedded_image_handling"];
+			bool uses_embed_image = image_handle_mode == GLTFState::HandleBinaryImageMode::HANDLE_BINARY_IMAGE_MODE_EMBED_AS_BASISU ||
+					image_handle_mode == GLTFState::HandleBinaryImageMode::HANDLE_BINARY_IMAGE_MODE_EMBED_AS_UNCOMPRESSED;
+
+			if (uses_embed_image) {
+				Vector<Ref<Texture2D>> images = gltf_state->get_images();
+				r_meta->texture_sizes.resize(images.size());
+				for (int i = 0; i < images.size(); i++) {
+					Size2 img_size = images[i]->get_size();
+					r_meta->texture_sizes.set(i, img_size.x * img_size.y);
+				}
+			}
+		}
+
+		// Tris count
+		Vector<Ref<GLTFMesh>> meshes = gltf_state->get_meshes();
+		for (const Ref<GLTFMesh> &mesh : meshes) {
+			Ref<ArrayMesh> arr_mesh = mesh->get_mesh()->get_mesh();
+			for (int i = 0; i < arr_mesh->get_surface_count(); i++) {
+				r_meta->tris_count += arr_mesh->surface_get_array_index_len(i) / 3;
+			}
+		}
 	}
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -42,7 +42,7 @@ public:
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
-			List<String> *r_missing_deps, Error *r_err = nullptr) override;
+			List<String> *r_missing_deps, ImportMeta *r_meta = nullptr, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;


### PR DESCRIPTION
Added `texture_sizes` (in pixels) and `tris_count` in scene `.import` metadata, also bumped scene `.import` file version to **2**.

Affects file type: gltf, fbx, dae, obj (as scene)

Example scene `.import` file after this PR:
```text
[remap]

importer="scene"
importer_version=2
type="PackedScene"
uid="uid://c61qknak454m3"
path="res://.godot/imported/Lucy.glb-90f8a353936365b09c0f7fc62f6c6e64.scn"
metadata={
"texture_sizes": PackedInt32Array(4194304, 4194304),
"tris_count": 12288
}

...
```
So we can retrieve later with `ResourceFormatImporter::get_resource_metadata()`

This is a small update that I hope can improve PR #112060 to do more checks to avoid heavy scenes when creating thumbnails. Now that PR only checks for file sizes and dependencies, which is inaccurate to represent the complexity of a scene.

I am also considering to record texture resource's resolution into its `.import` metadata (This PR only records sizes of internal/embedded textures for a 3d file), but I reckon one small step at a time.

With this PR added we can estimate scene complexity more accurately by just peeking the `.tscn` and scene `.import` files. Total tris count of a scene can be calculated by then.

