### PR TITLE
Fix `MeshLibrary` editor taking priority over `GridMap` when it shouldn't

### DIFF
--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -796,6 +796,10 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
+void MeshLibraryEditorPlugin::open_editor() {
+	mesh_library_editor->open();
+}
+
 MeshLibraryEditorPlugin::MeshLibraryEditorPlugin() {
 	singleton = this;
 

--- a/editor/scene/3d/mesh_library_editor_plugin.h
+++ b/editor/scene/3d/mesh_library_editor_plugin.h
@@ -137,6 +137,8 @@ public:
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;
 
+	void open_editor();
+
 	MeshLibraryEditorPlugin();
 	~MeshLibraryEditorPlugin() { singleton = nullptr; }
 };

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1183,7 +1183,7 @@ void GridMapEditor::_update_mesh_library() {
 
 		if (mesh_library_editor_plugin) {
 			mesh_library_editor_plugin->edit(*mesh_library);
-			mesh_library_editor_plugin->make_visible(true);
+			mesh_library_editor_plugin->open_editor();
 		}
 	} else if (mesh_library_editor_plugin) {
 		mesh_library_editor_plugin->edit(nullptr);


### PR DESCRIPTION
This fixes some situations where the `MeshLibrary` editor would be set as the current one over the `GridMap` editor when not appropriate.