### PR TITLE
Fix: support multi-input for `BaseButton` with Alt + Click

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -67,14 +67,6 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->is_pressed() && status.touch_index == -1) {
-		status.device_id = p_event->get_device();
-	}
-
-	if (p_event->get_device() != status.device_id) {
-		return;
-	}
-
 	Ref<InputEventScreenTouch> touch = p_event;
 	if (touch.is_valid()) {
 		if (status.touch_index == -1) {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -64,7 +64,6 @@ private:
 		bool pressed_down_with_focus = false;
 		bool disabled = false;
 		int touch_index = -1;
-		int device_id = InputEvent::DEVICE_ID_EMULATION;
 	} status;
 
 	Ref<ButtonGroup> button_group;


### PR DESCRIPTION
Fixes #118640

Follow up: #110893

After about 30 minutes of testing, I see no reason to prevent this with multitouch.

```cpp
	if (p_event->get_device() != status.device_id) {
		return;
	}
```


Test project: [multi_input.zip](https://github.com/user-attachments/files/26794539/multi_input.zip)

### Tests on Android with BT keyboard and BT mouse

Keyboard Ctrl + Multitouch
<img width="573" height="180" alt="Bildschirmfoto 2026-04-16 um 19 17 50" src="https://github.com/user-attachments/assets/613e64d3-4ec7-4d04-b964-a8669b98199e" />

------------

Keyboard Alt / Shift / Ctrl + Mouse Click

<img width="559" height="166" alt="Bildschirmfoto 2026-04-16 um 19 21 48" src="https://github.com/user-attachments/assets/5c89f1b2-2410-49c5-a896-3d5e4d5685ad" />


