### PR TITLE
Implement raytracing in D3D12 driver.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -563,7 +563,7 @@ void RenderingDeviceDriverD3D12::_resource_transition_batch(CommandBufferInfo *p
 	bool any_state_is_common = *curr_state == D3D12_RESOURCE_STATE_COMMON || p_new_state == D3D12_RESOURCE_STATE_COMMON;
 	bool redundant_transition = any_state_is_common ? *curr_state == p_new_state : ((*curr_state) & p_new_state) == p_new_state;
 	if (redundant_transition) {
-		bool just_written = *curr_state == D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+		bool just_written = *curr_state == D3D12_RESOURCE_STATE_UNORDERED_ACCESS || *curr_state == D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 		bool needs_uav_barrier = just_written && res_states->last_batch_with_uav_barrier != p_command_buffer->res_barriers_batch;
 		if (needs_uav_barrier) {
 			if (p_command_buffer->res_barriers.size() < p_command_buffer->res_barriers_count + 1) {
@@ -766,7 +766,7 @@ void RenderingDeviceDriverD3D12::_resource_transitions_flush(CommandBufferInfo *
 				if (may_do_single_barrier) {
 					// Hurray!, we can do a single barrier (plus maybe a UAV one, too).
 
-					bool just_written = res_states->subresource_states[0] == D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+					bool just_written = res_states->subresource_states[0] == D3D12_RESOURCE_STATE_UNORDERED_ACCESS || res_states->subresource_states[0] == D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 					bool needs_uav_barrier = just_written && res_states->last_batch_with_uav_barrier != p_command_buffer->res_barriers_batch;
 
 					uint32_t needed_barriers = (needs_uav_barrier ? 1 : 0) + 1;
@@ -817,7 +817,7 @@ void RenderingDeviceDriverD3D12::_resource_transitions_flush(CommandBufferInfo *
 
 					D3D12_RESOURCE_STATES *curr_state = &res_states->subresource_states[subresource];
 
-					bool just_written = *curr_state == D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+					bool just_written = *curr_state == D3D12_RESOURCE_STATE_UNORDERED_ACCESS || *curr_state == D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 					bool needs_uav_barrier = just_written && res_states->last_batch_with_uav_barrier != p_command_buffer->res_barriers_batch;
 
 					uint32_t needed_barriers = (needs_uav_barrier ? 1 : 0) + br.planes;
@@ -877,8 +877,12 @@ RDD::BufferID RenderingDeviceDriverD3D12::buffer_create(uint64_t p_size, BitFiel
 	CD3DX12_RESOURCE_DESC1 resource_desc = CD3DX12_RESOURCE_DESC1::Buffer(p_size);
 	if (p_usage.has_flag(RDD::BUFFER_USAGE_STORAGE_BIT)) {
 		resource_desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-	} else {
+	} else if (!p_usage.has_flag(BUFFER_USAGE_SHADER_BINDING_TABLE_BIT) && !p_usage.has_flag(RDD::BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT)) {
 		resource_desc.Flags |= D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
+	}
+
+	if (p_usage.has_flag(RDD::BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT)) {
+		resource_desc.Flags |= D3D12_RESOURCE_FLAG_RAYTRACING_ACCELERATION_STRUCTURE;
 	}
 
 	D3D12MA::ALLOCATION_DESC allocation_desc = {};
@@ -911,6 +915,9 @@ RDD::BufferID RenderingDeviceDriverD3D12::buffer_create(uint64_t p_size, BitFiel
 
 				// We can't use STORAGE for write access, just for read.
 				resource_desc.Flags = resource_desc.Flags & ~D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+			}
+			if (p_usage.has_flag(RDD::BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT)) {
+				initial_state = D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 			}
 		} break;
 	}
@@ -2103,11 +2110,23 @@ static void _rd_access_to_d3d12_and_mask(BitField<RDD::BarrierAccessBits> p_acce
 	}
 
 	const D3D12_BARRIER_SYNC unordered_access_mask = D3D12_BARRIER_SYNC_VERTEX_SHADING | D3D12_BARRIER_SYNC_PIXEL_SHADING | D3D12_BARRIER_SYNC_COMPUTE_SHADING |
-			D3D12_BARRIER_SYNC_VERTEX_SHADING | D3D12_BARRIER_SYNC_DRAW | D3D12_BARRIER_SYNC_ALL_SHADING | D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW;
+			D3D12_BARRIER_SYNC_VERTEX_SHADING | D3D12_BARRIER_SYNC_DRAW | D3D12_BARRIER_SYNC_ALL_SHADING | D3D12_BARRIER_SYNC_CLEAR_UNORDERED_ACCESS_VIEW |
+			D3D12_BARRIER_SYNC_EMIT_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO | D3D12_BARRIER_SYNC_RAYTRACING;
 
 	if (p_access.has_flag(RDD::BARRIER_ACCESS_STORAGE_CLEAR_BIT)) {
 		r_access |= D3D12_BARRIER_ACCESS_UNORDERED_ACCESS;
 		r_sync_mask |= unordered_access_mask;
+	}
+
+	if (p_access.has_flag(RDD::BARRIER_ACCESS_ACCELERATION_STRUCTURE_READ_BIT)) {
+		r_access |= D3D12_BARRIER_ACCESS_RAYTRACING_ACCELERATION_STRUCTURE_READ;
+		r_sync_mask |= D3D12_BARRIER_SYNC_COMPUTE_SHADING | D3D12_BARRIER_SYNC_RAYTRACING | D3D12_BARRIER_SYNC_ALL_SHADING |
+				D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE | D3D12_BARRIER_SYNC_COPY_RAYTRACING_ACCELERATION_STRUCTURE | D3D12_BARRIER_SYNC_EMIT_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO;
+	}
+
+	if (p_access.has_flag(RDD::BARRIER_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT)) {
+		r_access |= D3D12_BARRIER_ACCESS_RAYTRACING_ACCELERATION_STRUCTURE_WRITE;
+		r_sync_mask |= D3D12_BARRIER_SYNC_COMPUTE_SHADING | D3D12_BARRIER_SYNC_RAYTRACING | D3D12_BARRIER_SYNC_ALL_SHADING | D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE | D3D12_BARRIER_SYNC_COPY_RAYTRACING_ACCELERATION_STRUCTURE;
 	}
 
 	// These access bits only have compatibility with certain layouts unlike in Vulkan where they imply specific operations in the same layout.
@@ -2121,7 +2140,8 @@ static void _rd_access_to_d3d12_and_mask(BitField<RDD::BarrierAccessBits> p_acce
 			r_sync_mask |= unordered_access_mask;
 		} else {
 			r_access |= D3D12_BARRIER_ACCESS_SHADER_RESOURCE;
-			r_sync_mask |= D3D12_BARRIER_SYNC_VERTEX_SHADING | D3D12_BARRIER_SYNC_PIXEL_SHADING | D3D12_BARRIER_SYNC_COMPUTE_SHADING | D3D12_BARRIER_SYNC_DRAW | D3D12_BARRIER_SYNC_ALL_SHADING;
+			r_sync_mask |= D3D12_BARRIER_SYNC_VERTEX_SHADING | D3D12_BARRIER_SYNC_PIXEL_SHADING | D3D12_BARRIER_SYNC_COMPUTE_SHADING | D3D12_BARRIER_SYNC_DRAW | D3D12_BARRIER_SYNC_ALL_SHADING |
+					D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE | D3D12_BARRIER_SYNC_RAYTRACING;
 		}
 	}
 
@@ -2191,6 +2211,14 @@ static void _rd_stages_to_d3d12(BitField<RDD::PipelineStageBits> p_stages, D3D12
 
 		if (p_stages.has_flag(RDD::PIPELINE_STAGE_ALL_GRAPHICS_BIT)) {
 			r_sync |= D3D12_BARRIER_SYNC_DRAW;
+		}
+
+		if (p_stages.has_flag(RDD::PIPELINE_STAGE_RAY_TRACING_SHADER_BIT)) {
+			r_sync |= D3D12_BARRIER_SYNC_RAYTRACING;
+		}
+
+		if (p_stages.has_flag(RDD::PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT)) {
+			r_sync |= D3D12_BARRIER_SYNC_EMIT_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO | D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE | D3D12_BARRIER_SYNC_COPY_RAYTRACING_ACCELERATION_STRUCTURE;
 		}
 	}
 }
@@ -2307,6 +2335,16 @@ void RenderingDeviceDriverD3D12::command_pipeline_barrier(CommandBufferID p_cmd_
 		const BufferInfo *buffer_info = (const BufferInfo *)(buffer_barrier_rd.buffer.id);
 		_rd_stages_and_access_to_d3d12(p_src_stages, RDD::TEXTURE_LAYOUT_MAX, buffer_barrier_rd.src_access, buffer_barrier_d3d12.SyncBefore, buffer_barrier_d3d12.AccessBefore);
 		_rd_stages_and_access_to_d3d12(p_dst_stages, RDD::TEXTURE_LAYOUT_MAX, buffer_barrier_rd.dst_access, buffer_barrier_d3d12.SyncAfter, buffer_barrier_d3d12.AccessAfter);
+		buffer_barrier_d3d12.pResource = buffer_info->resource;
+		buffer_barriers.push_back(buffer_barrier_d3d12);
+	}
+
+	for (uint32_t i = 0; i < p_acceleration_structure_barriers.size(); i++) {
+		const AccelerationStructureBarrier &acceleration_structure_barrier = p_acceleration_structure_barriers[i];
+		const AccelerationStructureInfo *acceleration_structure_info = (const AccelerationStructureInfo *)(acceleration_structure_barrier.acceleration_structure.id);
+		const BufferInfo *buffer_info = (const BufferInfo *)(acceleration_structure_info->buffer.id);
+		_rd_stages_and_access_to_d3d12(p_src_stages, RDD::TEXTURE_LAYOUT_MAX, acceleration_structure_barrier.src_access, buffer_barrier_d3d12.SyncBefore, buffer_barrier_d3d12.AccessBefore);
+		_rd_stages_and_access_to_d3d12(p_dst_stages, RDD::TEXTURE_LAYOUT_MAX, acceleration_structure_barrier.dst_access, buffer_barrier_d3d12.SyncAfter, buffer_barrier_d3d12.AccessAfter);
 		buffer_barrier_d3d12.pResource = buffer_info->resource;
 		buffer_barriers.push_back(buffer_barrier_d3d12);
 	}
@@ -2542,6 +2580,7 @@ void RenderingDeviceDriverD3D12::command_pool_free(CommandPoolID p_cmd_pool) {
 
 		cmd_buf_info->cmd_list.Reset();
 		cmd_buf_info->cmd_list_1.Reset();
+		cmd_buf_info->cmd_list_4.Reset();
 		cmd_buf_info->cmd_list_5.Reset();
 		cmd_buf_info->cmd_list_7.Reset();
 		cmd_buf_info->cmd_allocator.Reset();
@@ -2620,6 +2659,7 @@ RDD::CommandBufferID RenderingDeviceDriverD3D12::command_buffer_create(CommandPo
 	cmd_buf_info->cmd_list = cmd_list;
 
 	cmd_list->QueryInterface(cmd_buf_info->cmd_list_1.GetAddressOf());
+	cmd_list->QueryInterface(cmd_buf_info->cmd_list_4.GetAddressOf());
 	cmd_list->QueryInterface(cmd_buf_info->cmd_list_5.GetAddressOf());
 	cmd_list->QueryInterface(cmd_buf_info->cmd_list_7.GetAddressOf());
 
@@ -2659,6 +2699,7 @@ void RenderingDeviceDriverD3D12::command_buffer_end(CommandBufferID p_cmd_buffer
 	cmd_buf_info->graphics_pso = nullptr;
 	cmd_buf_info->graphics_root_signature_crc = 0;
 	cmd_buf_info->compute_pso = nullptr;
+	cmd_buf_info->raytracing_pso = nullptr;
 	cmd_buf_info->compute_root_signature_crc = 0;
 	cmd_buf_info->pending_dyn_params = true;
 	cmd_buf_info->descriptor_heaps_set = false;
@@ -3230,6 +3271,34 @@ void RenderingDeviceDriverD3D12::framebuffer_free(FramebufferID p_framebuffer) {
 /**** SHADER ****/
 /****************/
 
+bool RenderingDeviceDriverD3D12::_shader_apply_specialization_constants(const ShaderInfo *p_shader_info, VectorView<PipelineSpecializationConstant> p_specialization_constants, ShaderStage p_stage, Vector<uint8_t> &r_bytecode) {
+	bool re_sign = false;
+	for (uint32_t i = 0; i < p_specialization_constants.size(); i++) {
+		const PipelineSpecializationConstant &psc = p_specialization_constants[i];
+		if (!(p_shader_info->spirv_specialization_constants_ids_mask & (1 << psc.constant_id))) {
+			// This SC wasn't even in the original SPIR-V shader.
+			continue;
+		}
+		for (const ShaderInfo::SpecializationConstant &sc : p_shader_info->specialization_constants) {
+			if (psc.constant_id == sc.constant_id) {
+				uint64_t offset = sc.stages_bit_offsets[RenderingShaderContainerD3D12::SHADER_STAGES_BIT_OFFSET_INDICES[p_stage]];
+				if (offset != 0 && psc.int_value != sc.int_value) {
+					RenderingDXIL::patch_specialization_constant(psc.type, &psc.int_value, offset, r_bytecode, false);
+					re_sign = true;
+				}
+				break;
+			}
+		}
+	}
+
+	// Re-sign the patched stage.
+	if (re_sign) {
+		RenderingDXIL::sign_bytecode(p_stage, r_bytecode);
+	}
+
+	return true;
+}
+
 bool RenderingDeviceDriverD3D12::_shader_apply_specialization_constants(
 		const ShaderInfo *p_shader_info,
 		VectorView<PipelineSpecializationConstant> p_specialization_constants,
@@ -3330,6 +3399,11 @@ RDD::ShaderID RenderingDeviceDriverD3D12::shader_create_from_container(const Ref
 		} else {
 			shader_info_in.stages_bytecode[shader.shader_stage] = shader.code_compressed_bytes;
 		}
+
+		ShaderInfo::ShaderConfig shader_config;
+		shader_config.payload_size_in_bytes = shader_refl_d3d12.shader_config_data_d3d12[i].payload_size_in_bytes;
+		shader_config.attribute_size_in_bytes = shader_refl_d3d12.shader_config_data_d3d12[i].attribute_size_in_bytes;
+		shader_info_in.stages_shader_config[shader.shader_stage] = shader_config;
 	}
 
 	PFN_D3D12_CREATE_ROOT_SIGNATURE_DESERIALIZER d3d_D3D12CreateRootSignatureDeserializer = (PFN_D3D12_CREATE_ROOT_SIGNATURE_DESERIALIZER)(void *)GetProcAddress(context_driver->lib_d3d12, "D3D12CreateRootSignatureDeserializer");
@@ -3347,7 +3421,7 @@ RDD::ShaderID RenderingDeviceDriverD3D12::shader_create_from_container(const Ref
 
 	// Bookkeep.
 	ShaderInfo *shader_info_ptr = VersatileResource::allocate<ShaderInfo>(resources_allocator);
-	*shader_info_ptr = shader_info_in;
+	*shader_info_ptr = std::move(shader_info_in);
 	return ShaderID(shader_info_ptr);
 }
 
@@ -3590,6 +3664,21 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 					ns.shader_uniform_idx_mask |= ((uint64_t)1 << i);
 					ns.states |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
 				}
+			} break;
+			case UNIFORM_TYPE_ACCELERATION_STRUCTURE: {
+				AccelerationStructureInfo *acceleration_structure_info = (AccelerationStructureInfo *)uniform.ids[0].id;
+
+				D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
+				srv_desc.ViewDimension = D3D12_SRV_DIMENSION_RAYTRACING_ACCELERATION_STRUCTURE;
+				srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+				srv_desc.RaytracingAccelerationStructure.Location = acceleration_structure_info->build_desc.DestAccelerationStructureData;
+				device->CreateShaderResourceView(nullptr, &srv_desc, get_cpu_handle(uniform_set_info->resource_descriptor_heap_alloc.cpu_handle, binding.resource_descriptor_offset, resource_descriptor_heap.increment_size));
+
+				BufferInfo *acceleration_structure_buffer_info = (BufferInfo *)acceleration_structure_info->buffer.id;
+
+				NeededState &ns = resource_states[acceleration_structure_buffer_info];
+				ns.shader_uniform_idx_mask |= ((uint64_t)1 << i);
+				ns.states |= D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
 			} break;
 			default: {
 				DEV_ASSERT(false);
@@ -4794,6 +4883,7 @@ void RenderingDeviceDriverD3D12::command_bind_render_pipeline(CommandBufferID p_
 
 		cmd_buf_info->graphics_pso = pipeline_info->pso.Get();
 		cmd_buf_info->compute_pso = nullptr;
+		cmd_buf_info->raytracing_pso = nullptr;
 	}
 
 	if (cmd_buf_info->graphics_root_signature_crc != shader_info_in->root_signature_crc) {
@@ -5374,8 +5464,9 @@ void RenderingDeviceDriverD3D12::command_bind_compute_pipeline(CommandBufferID p
 	if (cmd_buf_info->compute_pso != pipeline_info->pso.Get()) {
 		cmd_buf_info->cmd_list->SetPipelineState(pipeline_info->pso.Get());
 
-		cmd_buf_info->compute_pso = pipeline_info->pso.Get();
 		cmd_buf_info->graphics_pso = nullptr;
+		cmd_buf_info->compute_pso = pipeline_info->pso.Get();
+		cmd_buf_info->raytracing_pso = nullptr;
 	}
 
 	if (cmd_buf_info->compute_root_signature_crc != shader_info_in->root_signature_crc) {
@@ -5492,62 +5583,404 @@ RDD::PipelineID RenderingDeviceDriverD3D12::compute_pipeline_create(ShaderID p_s
 /**** RAYTRACING ****/
 /********************/
 
+// RDD::AccelerationStructureFlagBits == D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS.
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_PREFER_FAST_BUILD_BIT, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_LOW_MEMORY_BIT, D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY));
+
+// RDD::AccelerationStructureGeometryBits == D3D12_RAYTRACING_GEOMETRY_FLAGS.
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT, D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT, D3D12_RAYTRACING_GEOMETRY_FLAG_NO_DUPLICATE_ANYHIT_INVOCATION));
+
 // ---- ACCELERATION STRUCTURES ----
 
+bool RenderingDeviceDriverD3D12::_acceleration_structure_create(AccelerationStructureInfo *r_acceleration_structure_info) {
+	ComPtr<ID3D12Device5> device_5;
+	device->QueryInterface(device_5.GetAddressOf());
+
+	D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuild_info = {};
+	device_5->GetRaytracingAccelerationStructurePrebuildInfo(&r_acceleration_structure_info->build_desc.Inputs, &prebuild_info);
+
+	r_acceleration_structure_info->buffer = buffer_create(prebuild_info.ResultDataMaxSizeInBytes, BUFFER_USAGE_STORAGE_BIT | BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT, MEMORY_ALLOCATION_TYPE_GPU, UINT64_MAX);
+	if (!r_acceleration_structure_info->buffer) {
+		return false;
+	}
+
+	r_acceleration_structure_info->scratch_buffer_size = prebuild_info.ScratchDataSizeInBytes;
+
+	const BufferInfo *buffer_info = (const BufferInfo *)r_acceleration_structure_info->buffer.id;
+	r_acceleration_structure_info->build_desc.DestAccelerationStructureData = buffer_info->gpu_virtual_address;
+
+	return true;
+}
+
 RDD::AccelerationStructureID RenderingDeviceDriverD3D12::blas_create(VectorView<AccelerationStructureGeometry> p_geometries, BitField<AccelerationStructureFlagBits> p_flags) {
-	ERR_FAIL_V_MSG(AccelerationStructureID(), "Ray tracing is not currently supported by the D3D12 driver.");
+	AccelerationStructureInfo blas_info;
+
+	blas_info.geometries.resize_initialized(p_geometries.size());
+	for (uint32_t i = 0; i < p_geometries.size(); i++) {
+		const AccelerationStructureGeometry &geometry = p_geometries[i];
+
+		D3D12_RAYTRACING_GEOMETRY_DESC &d3d12_geometry = blas_info.geometries[i];
+		d3d12_geometry.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+		d3d12_geometry.Flags = (D3D12_RAYTRACING_GEOMETRY_FLAGS)(uint64_t)geometry.flags;
+
+		BufferInfo *vertex_buffer = (BufferInfo *)geometry.vertex_buffer.id;
+		d3d12_geometry.Triangles.VertexFormat = RD_TO_D3D12_FORMAT[geometry.vertex_format].general_format;
+		d3d12_geometry.Triangles.VertexCount = geometry.vertex_count;
+		d3d12_geometry.Triangles.VertexBuffer.StartAddress = vertex_buffer->gpu_virtual_address + geometry.vertex_offset;
+		d3d12_geometry.Triangles.VertexBuffer.StrideInBytes = geometry.vertex_stride;
+
+		if (!barrier_capabilities.enhanced_barriers_supported) {
+			blas_info.input_buffer_infos.push_back(vertex_buffer);
+		}
+
+		if (geometry.index_buffer) {
+			BufferInfo *index_buffer = (BufferInfo *)geometry.index_buffer.id;
+			d3d12_geometry.Triangles.IndexFormat = (geometry.index_format == INDEX_BUFFER_FORMAT_UINT16 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT);
+			d3d12_geometry.Triangles.IndexCount = geometry.index_count;
+			d3d12_geometry.Triangles.IndexBuffer = index_buffer->gpu_virtual_address + geometry.index_offset;
+
+			if (!barrier_capabilities.enhanced_barriers_supported) {
+				blas_info.input_buffer_infos.push_back(index_buffer);
+			}
+		}
+	}
+
+	blas_info.build_desc.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+	blas_info.build_desc.Inputs.Flags = (D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS)(uint64_t)p_flags;
+	blas_info.build_desc.Inputs.NumDescs = p_geometries.size();
+	blas_info.build_desc.Inputs.pGeometryDescs = blas_info.geometries.ptr();
+
+	bool ok = _acceleration_structure_create(&blas_info);
+	ERR_FAIL_COND_V(!ok, RDD::AccelerationStructureID());
+
+	// Bookkeep.
+	AccelerationStructureInfo *blas_info_ptr = VersatileResource::allocate<AccelerationStructureInfo>(resources_allocator);
+	*blas_info_ptr = std::move(blas_info);
+	return AccelerationStructureID(blas_info_ptr);
 }
 
 RDD::AccelerationStructureID RenderingDeviceDriverD3D12::tlas_create(uint32_t p_max_instance_count, BitField<AccelerationStructureFlagBits> p_flags) {
-	ERR_FAIL_V_MSG(AccelerationStructureID(), "Ray tracing is not currently supported by the D3D12 driver.");
+	AccelerationStructureInfo tlas_info;
+
+	tlas_info.build_desc.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+	tlas_info.build_desc.Inputs.Flags = (D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS)(uint64_t)p_flags;
+	tlas_info.build_desc.Inputs.NumDescs = p_max_instance_count;
+
+	bool ok = _acceleration_structure_create(&tlas_info);
+	ERR_FAIL_COND_V(!ok, RDD::AccelerationStructureID());
+
+	// Bookkeep.
+	AccelerationStructureInfo *tlas_info_ptr = VersatileResource::allocate<AccelerationStructureInfo>(resources_allocator);
+	*tlas_info_ptr = std::move(tlas_info);
+	return AccelerationStructureID(tlas_info_ptr);
+}
+
+static _FORCE_INLINE_ void _store_transform_transposed_3x4(const Transform3D &p_mtx, FLOAT r_mtx[3][4]) {
+	r_mtx[0][0] = p_mtx.basis.rows[0][0];
+	r_mtx[0][1] = p_mtx.basis.rows[0][1];
+	r_mtx[0][2] = p_mtx.basis.rows[0][2];
+	r_mtx[0][3] = p_mtx.origin.x;
+	r_mtx[1][0] = p_mtx.basis.rows[1][0];
+	r_mtx[1][1] = p_mtx.basis.rows[1][1];
+	r_mtx[1][2] = p_mtx.basis.rows[1][2];
+	r_mtx[1][3] = p_mtx.origin.y;
+	r_mtx[2][0] = p_mtx.basis.rows[2][0];
+	r_mtx[2][1] = p_mtx.basis.rows[2][1];
+	r_mtx[2][2] = p_mtx.basis.rows[2][2];
+	r_mtx[2][3] = p_mtx.origin.z;
 }
 
 void RenderingDeviceDriverD3D12::acceleration_structure_instance_write(uint8_t *r_driver_instance, const AccelerationStructureInstance &p_instance) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	D3D12_RAYTRACING_INSTANCE_DESC *instance_desc = (D3D12_RAYTRACING_INSTANCE_DESC *)r_driver_instance;
+
+	_store_transform_transposed_3x4(p_instance.transform, instance_desc->Transform);
+	instance_desc->InstanceID = p_instance.id;
+	instance_desc->InstanceMask = p_instance.mask;
+	instance_desc->InstanceContributionToHitGroupIndex = p_instance.hit_sbt_offset;
+	instance_desc->Flags = p_instance.flags;
+
+	if (p_instance.blas) {
+		AccelerationStructureInfo *blas_info = (AccelerationStructureInfo *)p_instance.blas.id;
+		instance_desc->AccelerationStructure = blas_info->build_desc.DestAccelerationStructureData;
+	} else {
+		instance_desc->AccelerationStructure = 0;
+	}
 }
 
 void RenderingDeviceDriverD3D12::acceleration_structure_free(AccelerationStructureID p_acceleration_structure) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	AccelerationStructureInfo *acceleration_structure_info = (AccelerationStructureInfo *)p_acceleration_structure.id;
+	buffer_free(acceleration_structure_info->buffer);
+
+	VersatileResource::free(resources_allocator, acceleration_structure_info);
 }
 
 uint32_t RenderingDeviceDriverD3D12::acceleration_structure_get_scratch_size_bytes(AccelerationStructureID p_acceleration_structure) {
-	ERR_FAIL_V_MSG(0, "Ray tracing is not currently supported by the D3D12 driver.");
+	AccelerationStructureInfo *acceleration_structure_info = (AccelerationStructureInfo *)p_acceleration_structure.id;
+	return acceleration_structure_info->scratch_buffer_size;
 }
 
 // ----- PIPELINE -----
 
 RDD::RaytracingPipelineID RenderingDeviceDriverD3D12::raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) {
-	ERR_FAIL_V_MSG(RaytracingPipelineID(), "Ray tracing is not currently supported by the D3D12 driver.");
+	// This RAII helper is to free patched shader bytecodes when the function returns.
+	thread_local LocalVector<Vector<uint8_t>> shader_bytecodes;
+	struct ClearShaderBytecodes {
+		~ClearShaderBytecodes() {
+			shader_bytecodes.clear();
+		}
+	} clear_shader_bytecodes;
+
+	thread_local LocalVector<LPCWSTR> export_names;
+	export_names.clear();
+
+	CD3DX12_STATE_OBJECT_DESC state_object_desc(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE);
+	uint32_t max_payload_size_in_bytes = 0;
+	uint32_t max_attribute_size_in_bytes = 0;
+
+	static_assert(sizeof(char16_t) == sizeof(wchar_t)); // For export names.
+
+	for (uint32_t i = 0; i < p_shaders.size(); i++) {
+		const PipelineShader &shader = p_shaders[i];
+		const ShaderInfo *shader_info_in = (const ShaderInfo *)shader.shader.id;
+
+		const Vector<uint8_t> *shader_bytecode_ptr = shader_info_in->stages_bytecode.getptr(shader.shader_stage);
+		ERR_FAIL_NULL_V(shader_bytecode_ptr, RaytracingPipelineID());
+
+		Vector<uint8_t> shader_bytecode = *shader_bytecode_ptr;
+		bool ok = _shader_apply_specialization_constants(shader_info_in, shader.specialization_constants, shader.shader_stage, shader_bytecode);
+		ERR_FAIL_COND_V(!ok, RaytracingPipelineID());
+
+		CD3DX12_DXIL_LIBRARY_SUBOBJECT *dxil_library_subobject = state_object_desc.CreateSubobject<CD3DX12_DXIL_LIBRARY_SUBOBJECT>();
+
+		D3D12_SHADER_BYTECODE d3d12_shader_bytecode = { shader_bytecode.ptr(), (SIZE_T)shader_bytecode.size() };
+		dxil_library_subobject->SetDXILLibrary(&d3d12_shader_bytecode);
+		shader_bytecodes.push_back(std::move(shader_bytecode)); // Store the shader bytecode to prevent stale pointers.
+
+		String export_name = vformat("dxil_library_subobject_%d", i);
+		dxil_library_subobject->DefineExport((LPCWSTR)export_name.utf16().ptr(), L"main");
+
+		const ShaderInfo::ShaderConfig *shader_config = shader_info_in->stages_shader_config.getptr(shader.shader_stage);
+		if (shader_config) {
+			max_payload_size_in_bytes = MAX(max_payload_size_in_bytes, shader_config->payload_size_in_bytes);
+			max_attribute_size_in_bytes = MAX(max_attribute_size_in_bytes, shader_config->attribute_size_in_bytes);
+		}
+
+		export_names.push_back(((const D3D12_DXIL_LIBRARY_DESC &)*dxil_library_subobject).pExports[0].Name);
+	}
+
+	thread_local LocalVector<LPCWSTR> shader_identifier_names;
+	shader_identifier_names.clear();
+
+	for (uint32_t i = 0; i < p_raygen_shader_indices.size(); i++) {
+		shader_identifier_names.push_back(export_names[p_raygen_shader_indices[i]]);
+	}
+
+	for (uint32_t i = 0; i < p_miss_shader_indices.size(); i++) {
+		shader_identifier_names.push_back(export_names[p_miss_shader_indices[i]]);
+	}
+
+	for (uint32_t i = 0; i < p_hit_groups.size(); i++) {
+		const HitGroup &hit_group = p_hit_groups[i];
+
+		CD3DX12_HIT_GROUP_SUBOBJECT *hit_group_subobject = state_object_desc.CreateSubobject<CD3DX12_HIT_GROUP_SUBOBJECT>();
+
+		String hit_group_export_name = vformat("hit_group_subobject_%d", i);
+		hit_group_subobject->SetHitGroupExport((LPCWSTR)hit_group_export_name.utf16().ptr());
+		hit_group_subobject->SetHitGroupType(hit_group.intersection_shader_index != UINT32_MAX ? D3D12_HIT_GROUP_TYPE_PROCEDURAL_PRIMITIVE : D3D12_HIT_GROUP_TYPE_TRIANGLES);
+
+		if (hit_group.closest_hit_shader_index != UINT32_MAX) {
+			hit_group_subobject->SetClosestHitShaderImport(export_names[hit_group.closest_hit_shader_index]);
+		}
+
+		if (hit_group.any_hit_shader_index != UINT32_MAX) {
+			hit_group_subobject->SetAnyHitShaderImport(export_names[hit_group.any_hit_shader_index]);
+		}
+
+		if (hit_group.intersection_shader_index != UINT32_MAX) {
+			hit_group_subobject->SetIntersectionShaderImport(export_names[hit_group.intersection_shader_index]);
+		}
+
+		shader_identifier_names.push_back(((const D3D12_HIT_GROUP_DESC &)*hit_group_subobject).HitGroupExport);
+	}
+
+	CD3DX12_RAYTRACING_SHADER_CONFIG_SUBOBJECT shader_config_subobject(state_object_desc);
+	shader_config_subobject.Config(max_payload_size_in_bytes, max_attribute_size_in_bytes);
+
+	CD3DX12_RAYTRACING_PIPELINE_CONFIG_SUBOBJECT pipeline_config_subobject(state_object_desc);
+	pipeline_config_subobject.Config(p_max_trace_recursion_depth);
+
+	const ShaderInfo *layout_defining_shader_info = (const ShaderInfo *)p_layout_defining_shader.id;
+	CD3DX12_GLOBAL_ROOT_SIGNATURE_SUBOBJECT root_signature_subobject(state_object_desc);
+	root_signature_subobject.SetRootSignature(layout_defining_shader_info->root_signature.Get());
+
+	ComPtr<ID3D12Device5> device_5;
+	device->QueryInterface(device_5.GetAddressOf());
+
+	ComPtr<ID3D12StateObject> state_object;
+	HRESULT hr = device_5->CreateStateObject(state_object_desc, IID_PPV_ARGS(state_object.GetAddressOf()));
+	ERR_FAIL_COND_V_MSG(FAILED(hr), RaytracingPipelineID(), "CreateStateObject failed with error " + vformat("0x%08ux", (uint64_t)hr) + ".");
+
+	ComPtr<ID3D12StateObjectProperties> state_object_properties;
+	state_object->QueryInterface(state_object_properties.GetAddressOf());
+
+	TightLocalVector<const void *> shader_identifiers;
+	shader_identifiers.resize(shader_identifier_names.size());
+
+	for (uint32_t i = 0; i < shader_identifier_names.size(); i++) {
+		shader_identifiers[i] = state_object_properties->GetShaderIdentifier(shader_identifier_names[i]);
+	}
+
+	// Bookkeep.
+	RaytracingPipelineInfo *raytracing_pipeline_info = VersatileResource::allocate<RaytracingPipelineInfo>(resources_allocator);
+	raytracing_pipeline_info->pso = std::move(state_object);
+	raytracing_pipeline_info->layout_defining_shader_info = layout_defining_shader_info;
+	raytracing_pipeline_info->shader_identifiers = std::move(shader_identifiers);
+
+	return RaytracingPipelineID(raytracing_pipeline_info);
 }
 
 void RenderingDeviceDriverD3D12::raytracing_pipeline_free(RDD::RaytracingPipelineID p_pipeline) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	const RaytracingPipelineInfo *raytracing_pipeline_info = (const RaytracingPipelineInfo *)p_pipeline.id;
+	VersatileResource::free(resources_allocator, raytracing_pipeline_info);
 }
 
 bool RenderingDeviceDriverD3D12::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) {
-	ERR_FAIL_V_MSG(false, "Ray tracing is not currently supported by the D3D12 driver.");
+	const RaytracingPipelineInfo *raytracing_pipeline_info = (const RaytracingPipelineInfo *)p_pipeline.id;
+
+	for (uint32_t i = 0; i < p_group_indices.size(); i++) {
+		uint32_t group_index = p_group_index_offset + p_group_indices[i];
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_COND_V_MSG(group_index >= raytracing_pipeline_info->shader_identifiers.size(), false, "Shader group index is out of bounds.");
+#endif
+		memcpy(r_data, raytracing_pipeline_info->shader_identifiers[group_index], D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
+		r_data += p_data_stride_bytes;
+	}
+
+	return true;
 }
 
 // ----- COMMANDS -----
 
 void RenderingDeviceDriverD3D12::command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	CommandBufferInfo *cmd_buffer_info = (CommandBufferInfo *)p_cmd_buffer.id;
+
+	AccelerationStructureInfo *acceleration_structure_info = (AccelerationStructureInfo *)p_acceleration_structure.id;
+	const BufferInfo *scratch_buffer_info = (const BufferInfo *)p_scratch_buffer.id;
+
+	acceleration_structure_info->build_desc.ScratchAccelerationStructureData = scratch_buffer_info->gpu_virtual_address;
+
+	if (!barrier_capabilities.enhanced_barriers_supported) {
+		for (BufferInfo *input_buffer_info : acceleration_structure_info->input_buffer_infos) {
+			_resource_transition_batch(cmd_buffer_info, input_buffer_info, 0, 1, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+		}
+
+		BufferInfo *acceleration_structure_buffer_info = (BufferInfo *)acceleration_structure_info->buffer.id;
+		_resource_transition_batch(cmd_buffer_info, acceleration_structure_buffer_info, 0, 1, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+		_resource_transitions_flush(cmd_buffer_info);
+	}
+
+	cmd_buffer_info->cmd_list_4->BuildRaytracingAccelerationStructure(&acceleration_structure_info->build_desc, 0, nullptr);
 }
 
-void RenderingDeviceDriverD3D12::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+void RenderingDeviceDriverD3D12::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) {
+	CommandBufferInfo *cmd_buffer_info = (CommandBufferInfo *)p_cmd_buffer.id;
+
+	AccelerationStructureInfo *acceleration_structure_info = (AccelerationStructureInfo *)p_acceleration_structure.id;
+	const BufferInfo *scratch_buffer_info = (const BufferInfo *)p_scratch_buffer.id;
+	const BufferInfo *instance_buffer_info = (const BufferInfo *)p_instance_buffer.id;
+
+	acceleration_structure_info->build_desc.Inputs.NumDescs = p_instance_count;
+	acceleration_structure_info->build_desc.Inputs.InstanceDescs = instance_buffer_info->gpu_virtual_address + p_instance_offset;
+	acceleration_structure_info->build_desc.ScratchAccelerationStructureData = scratch_buffer_info->gpu_virtual_address;
+
+	if (!barrier_capabilities.enhanced_barriers_supported) {
+		for (uint32_t i = 0; i < p_blases.size(); i++) {
+			AccelerationStructureInfo *blas_info = (AccelerationStructureInfo *)p_blases[i].id;
+			BufferInfo *blas_buffer_info = (BufferInfo *)blas_info->buffer.id;
+			_resource_transition_batch(cmd_buffer_info, blas_buffer_info, 0, 1, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+		}
+
+		BufferInfo *acceleration_structure_buffer_info = (BufferInfo *)acceleration_structure_info->buffer.id;
+		_resource_transition_batch(cmd_buffer_info, acceleration_structure_buffer_info, 0, 1, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
+		_resource_transitions_flush(cmd_buffer_info);
+	}
+
+	cmd_buffer_info->cmd_list_4->BuildRaytracingAccelerationStructure(&acceleration_structure_info->build_desc, 0, nullptr);
 }
 
 void RenderingDeviceDriverD3D12::command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	CommandBufferInfo *cmd_buf_info = (CommandBufferInfo *)p_cmd_buffer.id;
+
+	const RaytracingPipelineInfo *pipeline_info = (const RaytracingPipelineInfo *)p_pipeline.id;
+	const ShaderInfo *shader_info_in = pipeline_info->layout_defining_shader_info;
+
+	if (cmd_buf_info->raytracing_pso != pipeline_info->pso.Get()) {
+		cmd_buf_info->cmd_list_4->SetPipelineState1(pipeline_info->pso.Get());
+
+		cmd_buf_info->graphics_pso = nullptr;
+		cmd_buf_info->compute_pso = nullptr;
+		cmd_buf_info->raytracing_pso = pipeline_info->pso.Get();
+	}
+
+	if (cmd_buf_info->compute_root_signature_crc != shader_info_in->root_signature_crc) {
+		cmd_buf_info->cmd_list->SetComputeRootSignature(shader_info_in->root_signature.Get());
+		cmd_buf_info->compute_root_signature_crc = shader_info_in->root_signature_crc;
+	}
 }
 
 void RenderingDeviceDriverD3D12::command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	command_bind_compute_uniform_sets(p_cmd_buffer, VectorView(p_uniform_set), p_shader, p_set_index, 1, 0);
+}
+
+D3D12_GPU_VIRTUAL_ADDRESS_RANGE RenderingDeviceDriverD3D12::_sbt_to_gpu_virtual_address_range(const ShaderBindingTable &p_sbt) {
+	D3D12_GPU_VIRTUAL_ADDRESS_RANGE gpu_virtual_address_range = {};
+	if (p_sbt.buffer) {
+		const BufferInfo *buffer_info = (const BufferInfo *)p_sbt.buffer.id;
+
+		gpu_virtual_address_range.StartAddress = buffer_info->gpu_virtual_address + p_sbt.offset;
+		gpu_virtual_address_range.SizeInBytes = p_sbt.size;
+
+		DEV_ASSERT((gpu_virtual_address_range.StartAddress & (D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT - 1)) == 0 && "Shader binding table address must be aligned to API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT.");
+	}
+	return gpu_virtual_address_range;
+}
+
+D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE RenderingDeviceDriverD3D12::_sbt_to_gpu_virtual_address_range_and_stride(const ShaderBindingTable &p_sbt) {
+	D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE gpu_virtual_address_range_and_stride = {};
+	if (p_sbt.buffer) {
+		const BufferInfo *buffer_info = (const BufferInfo *)p_sbt.buffer.id;
+
+		gpu_virtual_address_range_and_stride.StartAddress = buffer_info->gpu_virtual_address + p_sbt.offset;
+		gpu_virtual_address_range_and_stride.SizeInBytes = p_sbt.size;
+		gpu_virtual_address_range_and_stride.StrideInBytes = p_sbt.stride;
+
+		DEV_ASSERT((gpu_virtual_address_range_and_stride.StartAddress & (D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT - 1)) == 0 && "Shader binding table address must be aligned to API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT.");
+		DEV_ASSERT((gpu_virtual_address_range_and_stride.StrideInBytes & (D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT - 1)) == 0 && "Shader binding table stride must be aligned to API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT.");
+	}
+	return gpu_virtual_address_range_and_stride;
 }
 
 void RenderingDeviceDriverD3D12::command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
-	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+	CommandBufferInfo *cmd_buffer_info = (CommandBufferInfo *)p_cmd_buffer.id;
+
+	if (!barrier_capabilities.enhanced_barriers_supported) {
+		BufferInfo *hit_sbt_buffer_info = (BufferInfo *)p_hit_sbt.buffer.id;
+		_resource_transition_batch(cmd_buffer_info, hit_sbt_buffer_info, 0, 1, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+		_resource_transitions_flush(cmd_buffer_info);
+	}
+
+	D3D12_DISPATCH_RAYS_DESC desc = {};
+	desc.RayGenerationShaderRecord = _sbt_to_gpu_virtual_address_range(p_raygen_sbt);
+	desc.MissShaderTable = _sbt_to_gpu_virtual_address_range_and_stride(p_miss_sbt);
+	desc.HitGroupTable = _sbt_to_gpu_virtual_address_range_and_stride(p_hit_sbt);
+	desc.Width = p_width;
+	desc.Height = p_height;
+	desc.Depth = p_depth;
+	cmd_buffer_info->cmd_list_4->DispatchRays(&desc);
 }
 
 /*****************/
@@ -5707,6 +6140,15 @@ void RenderingDeviceDriverD3D12::set_object_name(ObjectType p_type, ID p_driver_
 			const PipelineInfo *pipeline_info = (const PipelineInfo *)p_driver_id.id;
 			_set_object_name(pipeline_info->pso.Get(), p_name);
 		} break;
+		case OBJECT_TYPE_ACCELERATION_STRUCTURE: {
+			const AccelerationStructureInfo *acceleration_structure_info = (const AccelerationStructureInfo *)p_driver_id.id;
+			const BufferInfo *buffer_info = (const BufferInfo *)acceleration_structure_info->buffer.id;
+			_set_object_name(buffer_info->resource, p_name);
+		} break;
+		case OBJECT_TYPE_RAYTRACING_PIPELINE: {
+			const RaytracingPipelineInfo *pipeline_info = (const RaytracingPipelineInfo *)p_driver_id.id;
+			_set_object_name(pipeline_info->pso.Get(), p_name);
+		} break;
 		default: {
 			DEV_ASSERT(false);
 		}
@@ -5852,6 +6294,14 @@ uint64_t RenderingDeviceDriverD3D12::api_trait_get(ApiTrait p_trait) {
 			return !barrier_capabilities.enhanced_barriers_supported;
 		case API_TRAIT_TEXTURE_OUTPUTS_REQUIRE_CLEARS:
 			return true;
+		case API_TRAIT_ACCELERATION_STRUCTURE_INSTANCE_SIZE:
+			return sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
+		case API_TRAIT_SHADER_GROUP_HANDLE_SIZE:
+			return D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES;
+		case API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT:
+			return D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT;
+		case API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT:
+			return D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT;
 		default:
 			return RenderingDeviceDriver::api_trait_get(p_trait);
 	}
@@ -5871,6 +6321,10 @@ bool RenderingDeviceDriverD3D12::has_feature(Features p_feature) {
 			return false;
 		case SUPPORTS_POINT_SIZE:
 			return false;
+		case SUPPORTS_RAY_QUERY:
+			return raytracing_capabilities.ray_query_supported;
+		case SUPPORTS_RAYTRACING_PIPELINE:
+			return raytracing_capabilities.raytracing_pipeline_supported;
 		case SUPPORTS_HDR_OUTPUT:
 			return true;
 		default:
@@ -6177,6 +6631,13 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 	res = device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS4, &options4, sizeof(options4));
 	if (SUCCEEDED(res)) {
 		shader_capabilities.native_16bit_ops = options4.Native16BitShaderOpsSupported;
+	}
+
+	D3D12_FEATURE_DATA_D3D12_OPTIONS5 options5 = {};
+	res = device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS5, &options5, sizeof(options5));
+	if (SUCCEEDED(res)) {
+		raytracing_capabilities.ray_query_supported = options5.RaytracingTier >= D3D12_RAYTRACING_TIER_1_1;
+		raytracing_capabilities.raytracing_pipeline_supported = options5.RaytracingTier >= D3D12_RAYTRACING_TIER_1_0;
 	}
 
 	D3D12_FEATURE_DATA_D3D12_OPTIONS6 options6 = {};

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -109,6 +109,11 @@ class RenderingDeviceDriverD3D12 : public RenderingDeviceDriver {
 		bool aniso_filter_with_point_mip_supported = false;
 	};
 
+	struct RaytracingCapabilities {
+		bool ray_query_supported = false;
+		bool raytracing_pipeline_supported = false;
+	};
+
 	RenderingContextDriverD3D12 *context_driver = nullptr;
 	RenderingContextDriver::Device context_device;
 	Microsoft::WRL::ComPtr<IDXGIAdapter> adapter;
@@ -125,6 +130,7 @@ class RenderingDeviceDriverD3D12 : public RenderingDeviceDriver {
 	BarrierCapabilities barrier_capabilities;
 	MiscFeaturesSupport misc_features_support;
 	SamplerCapabilities sampler_capabilities;
+	RaytracingCapabilities raytracing_capabilities;
 	RenderingShaderContainerFormatD3D12 shader_container_format;
 	String pipeline_cache_id;
 	D3D12_HEAP_TYPE dynamic_persistent_upload_heap = D3D12_HEAP_TYPE_UPLOAD;
@@ -485,11 +491,13 @@ private:
 		Microsoft::WRL::ComPtr<ID3D12CommandAllocator> cmd_allocator;
 		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> cmd_list;
 		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList1> cmd_list_1;
+		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList4> cmd_list_4;
 		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList5> cmd_list_5;
 		Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList7> cmd_list_7;
 
 		ID3D12PipelineState *graphics_pso = nullptr;
 		ID3D12PipelineState *compute_pso = nullptr;
+		ID3D12StateObject *raytracing_pso = nullptr;
 
 		DynParams dyn_params;
 		bool pending_dyn_params = true;
@@ -638,7 +646,20 @@ private:
 		Microsoft::WRL::ComPtr<ID3D12RootSignatureDeserializer> root_signature_deserializer;
 		const D3D12_ROOT_SIGNATURE_DESC *root_signature_desc = nullptr; // Owned by the deserializer.
 		uint32_t root_signature_crc = 0;
+
+		struct ShaderConfig {
+			uint32_t payload_size_in_bytes = 0;
+			uint32_t attribute_size_in_bytes = 0;
+		};
+
+		HashMap<ShaderStage, ShaderConfig> stages_shader_config;
 	};
+
+	bool _shader_apply_specialization_constants(
+			const ShaderInfo *p_shader_info,
+			VectorView<PipelineSpecializationConstant> p_specialization_constants,
+			ShaderStage p_stage,
+			Vector<uint8_t> &r_bytecode);
 
 	bool _shader_apply_specialization_constants(
 			const ShaderInfo *p_shader_info,
@@ -835,6 +856,18 @@ public:
 
 	// ---- ACCELERATION STRUCTURES ----
 
+private:
+	struct AccelerationStructureInfo {
+		TightLocalVector<D3D12_RAYTRACING_GEOMETRY_DESC> geometries;
+		D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC build_desc = {};
+		BufferID buffer;
+		uint32_t scratch_buffer_size = 0;
+		LocalVector<BufferInfo *> input_buffer_infos; // For legacy barriers.
+	};
+
+	bool _acceleration_structure_create(AccelerationStructureInfo *r_acceleration_structure_info);
+
+public:
 	virtual AccelerationStructureID blas_create(VectorView<AccelerationStructureGeometry> p_geometries, BitField<AccelerationStructureFlagBits> p_flags) override final;
 	virtual AccelerationStructureID tlas_create(uint32_t p_max_instance_count, BitField<AccelerationStructureFlagBits> p_flags) override final;
 	virtual void acceleration_structure_instance_write(uint8_t *r_driver_instance, const AccelerationStructureInstance &p_instance) override final;
@@ -842,16 +875,27 @@ public:
 	virtual uint32_t acceleration_structure_get_scratch_size_bytes(AccelerationStructureID p_acceleration_structure) override final;
 
 	// ----- PIPELINE -----
+private:
+	struct RaytracingPipelineInfo {
+		Microsoft::WRL::ComPtr<ID3D12StateObject> pso;
+		const ShaderInfo *layout_defining_shader_info = nullptr;
+		TightLocalVector<const void *> shader_identifiers;
+	};
 
+public:
 	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
 
 	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data, uint32_t p_data_stride_bytes) override final;
 
-	// ----- COMMANDS -----
+private:
+	D3D12_GPU_VIRTUAL_ADDRESS_RANGE _sbt_to_gpu_virtual_address_range(const ShaderBindingTable &p_sbt);
+	D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE _sbt_to_gpu_virtual_address_range_and_stride(const ShaderBindingTable &p_sbt);
 
+public:
+	// ----- COMMANDS -----
 	virtual void command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) override final;
-	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
+	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
 	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;
@@ -950,6 +994,8 @@ private:
 			ShaderInfo,
 			UniformSetInfo,
 			RenderPassInfo,
+			AccelerationStructureInfo,
+			RaytracingPipelineInfo,
 			TimestampQueryPoolInfo>;
 	PagedAllocator<VersatileResource, true> resources_allocator;
 

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -146,12 +146,9 @@ static D3D12_SHADER_VISIBILITY stages_to_d3d12_visibility(uint32_t p_stages_mask
 	}
 }
 
-uint32_t RenderingDXIL::patch_specialization_constant(
+static int64_t _get_specialization_constant_patch_value(
 		RenderingDeviceCommons::PipelineSpecializationConstantType p_type,
-		const void *p_value,
-		const uint64_t (&p_stages_bit_offsets)[D3D12_BITCODE_OFFSETS_NUM_STAGES],
-		HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_stages_bytecodes,
-		bool p_is_first_patch) {
+		const void *p_value) {
 	int64_t patch_val = 0;
 	switch (p_type) {
 		case RenderingDeviceCommons::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT: {
@@ -173,44 +170,81 @@ uint32_t RenderingDXIL::patch_specialization_constant(
 		patch_val = ((-patch_val) << 1) | 1;
 	}
 
-	auto tamper_bits = [](uint8_t *p_start, uint64_t p_bit_offset, uint64_t p_tb_value) -> uint64_t {
-		uint64_t original = 0;
-		uint32_t curr_input_byte = p_bit_offset / 8;
-		uint8_t curr_input_bit = p_bit_offset % 8;
-		auto get_curr_input_bit = [&]() -> bool {
-			return ((p_start[curr_input_byte] >> curr_input_bit) & 1);
-		};
-		auto move_to_next_input_bit = [&]() {
-			if (curr_input_bit == 7) {
-				curr_input_bit = 0;
-				curr_input_byte++;
-			} else {
-				curr_input_bit++;
-			}
-		};
-		auto tamper_input_bit = [&](bool p_new_bit) {
-			p_start[curr_input_byte] &= ~((uint8_t)1 << curr_input_bit);
-			if (p_new_bit) {
-				p_start[curr_input_byte] |= (uint8_t)1 << curr_input_bit;
-			}
-		};
-		uint8_t value_bit_idx = 0;
-		for (uint32_t i = 0; i < 5; i++) { // 32 bits take 5 full bytes in VBR.
-			for (uint32_t j = 0; j < 7; j++) {
-				bool input_bit = get_curr_input_bit();
-				original |= (uint64_t)(input_bit ? 1 : 0) << value_bit_idx;
-				tamper_input_bit((p_tb_value >> value_bit_idx) & 1);
-				move_to_next_input_bit();
-				value_bit_idx++;
-			}
-#ifdef DEV_ENABLED
-			bool input_bit = get_curr_input_bit();
-			DEV_ASSERT((i < 4 && input_bit) || (i == 4 && !input_bit));
-#endif
-			move_to_next_input_bit();
-		}
-		return original;
+	return patch_val;
+}
+
+static uint64_t _tamper_bits(uint8_t *p_start, uint64_t p_bit_offset, uint64_t p_tb_value) {
+	uint64_t original = 0;
+	uint32_t curr_input_byte = p_bit_offset / 8;
+	uint8_t curr_input_bit = p_bit_offset % 8;
+	auto get_curr_input_bit = [&]() -> bool {
+		return ((p_start[curr_input_byte] >> curr_input_bit) & 1);
 	};
+	auto move_to_next_input_bit = [&]() {
+		if (curr_input_bit == 7) {
+			curr_input_bit = 0;
+			curr_input_byte++;
+		} else {
+			curr_input_bit++;
+		}
+	};
+	auto tamper_input_bit = [&](bool p_new_bit) {
+		p_start[curr_input_byte] &= ~((uint8_t)1 << curr_input_bit);
+		if (p_new_bit) {
+			p_start[curr_input_byte] |= (uint8_t)1 << curr_input_bit;
+		}
+	};
+	uint8_t value_bit_idx = 0;
+	for (uint32_t i = 0; i < 5; i++) { // 32 bits take 5 full bytes in VBR.
+		for (uint32_t j = 0; j < 7; j++) {
+			bool input_bit = get_curr_input_bit();
+			original |= (uint64_t)(input_bit ? 1 : 0) << value_bit_idx;
+			tamper_input_bit((p_tb_value >> value_bit_idx) & 1);
+			move_to_next_input_bit();
+			value_bit_idx++;
+		}
+#ifdef DEV_ENABLED
+		bool input_bit = get_curr_input_bit();
+		DEV_ASSERT((i < 4 && input_bit) || (i == 4 && !input_bit));
+#endif
+		move_to_next_input_bit();
+	}
+	return original;
+}
+
+static void _patch_specialization_constant(
+		int64_t p_patch_value,
+		const uint64_t p_bit_offset,
+		Vector<uint8_t> &r_bytecode,
+		bool p_is_first_patch) {
+#ifdef DEV_ENABLED
+	uint64_t orig_patch_val = _tamper_bits(r_bytecode.ptrw(), p_bit_offset, (uint64_t)p_patch_value);
+	// Checking against the value the NIR patch should have set.
+	DEV_ASSERT(!p_is_first_patch || ((orig_patch_val >> 1) & GODOT_NIR_SC_SENTINEL_MAGIC_MASK) == GODOT_NIR_SC_SENTINEL_MAGIC);
+	uint64_t readback_patch_val = _tamper_bits(r_bytecode.ptrw(), p_bit_offset, (uint64_t)p_patch_value);
+	DEV_ASSERT(readback_patch_val == (uint64_t)p_patch_value);
+#else
+	_tamper_bits(r_bytecode.ptrw(), p_bit_offset, (uint64_t)p_patch_value);
+#endif
+}
+
+void RenderingDXIL::patch_specialization_constant(
+		RenderingDeviceCommons::PipelineSpecializationConstantType p_type,
+		const void *p_value,
+		const uint64_t p_bit_offset,
+		Vector<uint8_t> &r_bytecode,
+		bool p_is_first_patch) {
+	int64_t patch_val = _get_specialization_constant_patch_value(p_type, p_value);
+	_patch_specialization_constant(patch_val, p_bit_offset, r_bytecode, p_is_first_patch);
+}
+
+uint32_t RenderingDXIL::patch_specialization_constant(
+		RenderingDeviceCommons::PipelineSpecializationConstantType p_type,
+		const void *p_value,
+		const uint64_t (&p_stages_bit_offsets)[D3D12_BITCODE_OFFSETS_NUM_STAGES],
+		HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_stages_bytecodes,
+		bool p_is_first_patch) {
+	int64_t patch_val = _get_specialization_constant_patch_value(p_type, p_value);
 	uint32_t stages_patched_mask = 0;
 	for (int stage = 0; stage < RenderingDeviceCommons::SHADER_STAGE_MAX; stage++) {
 		if (!r_stages_bytecodes.has((RenderingDeviceCommons::ShaderStage)stage)) {
@@ -224,15 +258,7 @@ uint32_t RenderingDXIL::patch_specialization_constant(
 		}
 
 		Vector<uint8_t> &bytecode = r_stages_bytecodes[(RenderingDeviceCommons::ShaderStage)stage];
-#ifdef DEV_ENABLED
-		uint64_t orig_patch_val = tamper_bits(bytecode.ptrw(), offset, (uint64_t)patch_val);
-		// Checking against the value the NIR patch should have set.
-		DEV_ASSERT(!p_is_first_patch || ((orig_patch_val >> 1) & GODOT_NIR_SC_SENTINEL_MAGIC_MASK) == GODOT_NIR_SC_SENTINEL_MAGIC);
-		uint64_t readback_patch_val = tamper_bits(bytecode.ptrw(), offset, (uint64_t)patch_val);
-		DEV_ASSERT(readback_patch_val == (uint64_t)patch_val);
-#else
-		tamper_bits(bytecode.ptrw(), offset, (uint64_t)patch_val);
-#endif
+		_patch_specialization_constant(patch_val, offset, bytecode, p_is_first_patch);
 
 		stages_patched_mask |= (1 << stage);
 	}
@@ -286,10 +312,15 @@ uint32_t RenderingShaderContainerD3D12::_from_bytes_reflection_specialization_ex
 
 uint32_t RenderingShaderContainerD3D12::_from_bytes_footer_extra_data(const uint8_t *p_bytes) {
 	ContainerFooterD3D12 footer = *(const ContainerFooterD3D12 *)(p_bytes);
+
 	root_signature_crc = footer.root_signature_crc;
 	root_signature_bytes.resize(footer.root_signature_length);
 	memcpy(root_signature_bytes.ptrw(), p_bytes + sizeof(ContainerFooterD3D12), root_signature_bytes.size());
-	return sizeof(ContainerFooterD3D12) + footer.root_signature_length;
+
+	shader_config_data_d3d12.resize(shaders.size());
+	memcpy(shader_config_data_d3d12.ptrw(), p_bytes + sizeof(ContainerFooterD3D12) + footer.root_signature_length, shader_config_data_d3d12.size() * sizeof(ShaderConfigDataD3D12));
+
+	return sizeof(ContainerFooterD3D12) + footer.root_signature_length + (shader_config_data_d3d12.size() * sizeof(ShaderConfigDataD3D12));
 }
 
 uint32_t RenderingShaderContainerD3D12::_to_bytes_reflection_extra_data(uint8_t *p_bytes) const {
@@ -325,13 +356,14 @@ uint32_t RenderingShaderContainerD3D12::_to_bytes_footer_extra_data(uint8_t *p_b
 		footer.root_signature_length = root_signature_bytes.size();
 		footer.root_signature_crc = root_signature_crc;
 		memcpy(p_bytes + sizeof(ContainerFooterD3D12), root_signature_bytes.ptr(), root_signature_bytes.size());
+		memcpy(p_bytes + sizeof(ContainerFooterD3D12) + root_signature_bytes.size(), shader_config_data_d3d12.ptr(), shader_config_data_d3d12.size() * sizeof(ShaderConfigDataD3D12));
 	}
 
-	return sizeof(ContainerFooterD3D12) + root_signature_bytes.size();
+	return sizeof(ContainerFooterD3D12) + root_signature_bytes.size() + (shader_config_data_d3d12.size() * sizeof(ShaderConfigDataD3D12));
 }
 
 #if NIR_ENABLED
-bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStage> p_spirv, const nir_shader_compiler_options *p_compiler_options, HashMap<int, nir_shader *> &r_stages_nir_shaders, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed) {
+bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStage> p_spirv, const nir_shader_compiler_options *p_compiler_options, HashMap<int, nir_shader *> &r_stages_nir_shaders, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed, Vector<ShaderConfigDataD3D12> &r_shader_configs) {
 	r_stages_processed.clear();
 
 	dxil_spirv_runtime_conf dxil_runtime_conf = {};
@@ -359,6 +391,11 @@ bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStag
 			MESA_SHADER_TESS_CTRL, // SHADER_STAGE_TESSELATION_CONTROL
 			MESA_SHADER_TESS_EVAL, // SHADER_STAGE_TESSELATION_EVALUATION
 			MESA_SHADER_COMPUTE, // SHADER_STAGE_COMPUTE
+			MESA_SHADER_RAYGEN, // SHADER_STAGE_RAYGEN,
+			MESA_SHADER_ANY_HIT, // SHADER_STAGE_ANY_HIT
+			MESA_SHADER_CLOSEST_HIT, // SHADER_STAGE_CLOSEST_HIT
+			MESA_SHADER_MISS, // SHADER_STAGE_MISS
+			MESA_SHADER_INTERSECTION, // SHADER_STAGE_INTERSECTION
 		};
 
 		Span<uint32_t> code = p_spirv[i].spirv();
@@ -385,6 +422,36 @@ bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStag
 		dxil_spirv_nir_prep(shader);
 		dxil_spirv_metadata dxil_metadata = {};
 		dxil_spirv_nir_passes(shader, &dxil_runtime_conf, &dxil_metadata);
+
+		bool has_payload = stage == RenderingDeviceCommons::SHADER_STAGE_ANY_HIT ||
+				stage == RenderingDeviceCommons::SHADER_STAGE_CLOSEST_HIT ||
+				stage == RenderingDeviceCommons::SHADER_STAGE_MISS;
+
+		bool has_attribute = stage == RenderingDeviceCommons::SHADER_STAGE_ANY_HIT ||
+				stage == RenderingDeviceCommons::SHADER_STAGE_CLOSEST_HIT;
+
+		ShaderConfigDataD3D12 shader_config = {};
+		if (has_payload) {
+			shader_config.payload_size_in_bytes = sizeof(uint32_t);
+
+			nir_foreach_variable_with_modes(var, shader, nir_var_shader_call_data) {
+				unsigned size, alignment;
+				glsl_get_natural_size_align_bytes(var->type, &size, &alignment);
+				shader_config.payload_size_in_bytes = size;
+			}
+		}
+
+		if (has_attribute) {
+			shader_config.attribute_size_in_bytes = sizeof(uint32_t);
+
+			nir_foreach_variable_with_modes(var, shader, nir_var_ray_hit_attrib) {
+				unsigned size, alignment;
+				glsl_get_natural_size_align_bytes(var->type, &size, &alignment);
+				shader_config.attribute_size_in_bytes = size;
+			}
+		}
+
+		r_shader_configs.push_back(shader_config);
 
 		r_stages_nir_shaders[stage] = shader;
 	}
@@ -469,6 +536,19 @@ bool RenderingShaderContainerD3D12::_convert_nir_to_dxil(const HashMap<int, nir_
 		nir_to_dxil_options.validator_version_max = NO_DXIL_VALIDATION;
 		nir_to_dxil_options.godot_nir_callbacks = &godot_nir_callbacks;
 
+		// Minimum 6.3 is required for raytracing stages.
+		switch (stage) {
+			case RDC::SHADER_STAGE_RAYGEN:
+			case RDC::SHADER_STAGE_ANY_HIT:
+			case RDC::SHADER_STAGE_CLOSEST_HIT:
+			case RDC::SHADER_STAGE_MISS:
+			case RDC::SHADER_STAGE_INTERSECTION: {
+				nir_to_dxil_options.shader_model_max = MAX(nir_to_dxil_options.shader_model_max, SHADER_MODEL_6_3);
+			} break;
+			default: {
+			}
+		}
+
 		dxil_logger logger = {};
 		logger.log = [](void *p_priv, const char *p_msg) {
 #ifdef DEBUG_ENABLED
@@ -490,7 +570,7 @@ bool RenderingShaderContainerD3D12::_convert_nir_to_dxil(const HashMap<int, nir_
 	return true;
 }
 
-bool RenderingShaderContainerD3D12::_convert_spirv_to_dxil(Span<ReflectShaderStage> p_spirv, HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_dxil_blobs, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed) {
+bool RenderingShaderContainerD3D12::_convert_spirv_to_dxil(Span<ReflectShaderStage> p_spirv, HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_dxil_blobs, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed, Vector<ShaderConfigDataD3D12> &r_shader_configs) {
 	r_dxil_blobs.clear();
 
 	HashMap<int, nir_shader *> stages_nir_shaders;
@@ -509,7 +589,7 @@ bool RenderingShaderContainerD3D12::_convert_spirv_to_dxil(Span<ReflectShaderSta
 
 	// This is based on spirv2dxil.c. May need updates when it changes.
 	// Also, this has to stay around until after linking.
-	if (!_convert_spirv_to_nir(p_spirv, &compiler_options, stages_nir_shaders, r_stages, r_stages_processed)) {
+	if (!_convert_spirv_to_nir(p_spirv, &compiler_options, stages_nir_shaders, r_stages, r_stages_processed, r_shader_configs)) {
 		free_nir_shaders();
 		return false;
 	}
@@ -655,6 +735,9 @@ bool RenderingShaderContainerD3D12::_generate_root_signature(BitField<RenderingD
 					range_type = uniform.writable ? D3D12_DESCRIPTOR_RANGE_TYPE_UAV : D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 				} break;
 				case RDC::UNIFORM_TYPE_INPUT_ATTACHMENT: {
+					range_type = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+				} break;
+				case RDC::UNIFORM_TYPE_ACCELERATION_STRUCTURE: {
 					range_type = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 				} break;
 				default: {
@@ -911,7 +994,7 @@ bool RenderingShaderContainerD3D12::_set_code_from_spirv(const ReflectShader &p_
 	HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> dxil_blobs;
 	Vector<RenderingDeviceCommons::ShaderStage> stages;
 	BitField<RenderingDeviceCommons::ShaderStage> stages_processed = {};
-	if (!_convert_spirv_to_dxil(p_spirv, dxil_blobs, stages, stages_processed)) {
+	if (!_convert_spirv_to_dxil(p_spirv, dxil_blobs, stages, stages_processed, shader_config_data_d3d12)) {
 		return false;
 	}
 
@@ -972,6 +1055,7 @@ RenderingShaderContainerD3D12::ShaderReflectionD3D12 RenderingShaderContainerD3D
 	reflection.reflection_specialization_data_d3d12 = reflection_specialization_data_d3d12;
 	reflection.root_signature_bytes = root_signature_bytes;
 	reflection.root_signature_crc = root_signature_crc;
+	reflection.shader_config_data_d3d12 = shader_config_data_d3d12;
 
 	// Transform data vector into a vector of vectors that's easier to user.
 	uint32_t uniform_index = 0;

--- a/drivers/d3d12/rendering_shader_container_d3d12.h
+++ b/drivers/d3d12/rendering_shader_container_d3d12.h
@@ -40,7 +40,7 @@
 
 #include "drivers/d3d12/d3d12_godot_nir_bridge.h"
 
-#define D3D12_BITCODE_OFFSETS_NUM_STAGES 3
+#define D3D12_BITCODE_OFFSETS_NUM_STAGES 8
 
 #if NIR_ENABLED
 struct nir_shader;
@@ -60,6 +60,13 @@ enum ResourceClass {
 };
 
 struct RenderingDXIL {
+	static void patch_specialization_constant(
+			RenderingDeviceCommons::PipelineSpecializationConstantType p_type,
+			const void *p_value,
+			const uint64_t p_bit_offset,
+			Vector<uint8_t> &r_bytecode,
+			bool p_is_first_patch);
+
 	static uint32_t patch_specialization_constant(
 			RenderingDeviceCommons::PipelineSpecializationConstantType p_type,
 			const void *p_value,
@@ -84,6 +91,11 @@ public:
 		UINT32_MAX, // SHADER_STAGE_TESSELATION_CONTROL
 		UINT32_MAX, // SHADER_STAGE_TESSELATION_EVALUATION
 		2, // SHADER_STAGE_COMPUTE
+		3, // SHADER_STAGE_RAYGEN,
+		4, // SHADER_STAGE_ANY_HIT
+		5, // SHADER_STAGE_CLOSEST_HIT
+		6, // SHADER_STAGE_MISS
+		7, // SHADER_STAGE_INTERSECTION
 	};
 
 	struct ReflectionBindingSetDataD3D12 {
@@ -106,6 +118,11 @@ public:
 		uint64_t stages_bit_offsets[D3D12_BITCODE_OFFSETS_NUM_STAGES] = {};
 	};
 
+	struct ShaderConfigDataD3D12 {
+		uint32_t payload_size_in_bytes = 0;
+		uint32_t attribute_size_in_bytes = 0;
+	};
+
 protected:
 	struct ReflectionDataD3D12 {
 		uint32_t spirv_specialization_constants_ids_mask = 0;
@@ -125,11 +142,12 @@ protected:
 	Vector<ReflectionSpecializationDataD3D12> reflection_specialization_data_d3d12;
 	Vector<uint8_t> root_signature_bytes;
 	uint32_t root_signature_crc = 0;
+	Vector<ShaderConfigDataD3D12> shader_config_data_d3d12;
 
 #if NIR_ENABLED
-	bool _convert_spirv_to_nir(Span<ReflectShaderStage> p_spirv, const nir_shader_compiler_options *p_compiler_options, HashMap<int, nir_shader *> &r_stages_nir_shaders, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed);
+	bool _convert_spirv_to_nir(Span<ReflectShaderStage> p_spirv, const nir_shader_compiler_options *p_compiler_options, HashMap<int, nir_shader *> &r_stages_nir_shaders, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed, Vector<ShaderConfigDataD3D12> &r_shader_configs);
 	bool _convert_nir_to_dxil(const HashMap<int, nir_shader *> &p_stages_nir_shaders, BitField<RenderingDeviceCommons::ShaderStage> p_stages_processed, HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_dxil_blobs);
-	bool _convert_spirv_to_dxil(Span<ReflectShaderStage> p_spirv, HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_dxil_blobs, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed);
+	bool _convert_spirv_to_dxil(Span<ReflectShaderStage> p_spirv, HashMap<RenderingDeviceCommons::ShaderStage, Vector<uint8_t>> &r_dxil_blobs, Vector<RenderingDeviceCommons::ShaderStage> &r_stages, BitField<RenderingDeviceCommons::ShaderStage> &r_stages_processed, Vector<ShaderConfigDataD3D12> &r_shader_configs);
 	bool _generate_root_signature(BitField<RenderingDeviceCommons::ShaderStage> p_stages_processed);
 
 	// GodotNirCallbacks.
@@ -164,6 +182,7 @@ public:
 		Vector<ReflectionSpecializationDataD3D12> reflection_specialization_data_d3d12;
 		Vector<uint8_t> root_signature_bytes;
 		uint32_t root_signature_crc = 0;
+		Vector<ShaderConfigDataD3D12> shader_config_data_d3d12;
 	};
 
 	RenderingShaderContainerD3D12();

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2302,7 +2302,7 @@ void RenderingDeviceDriverMetal::command_build_blas(CommandBufferID p_cmd_buffer
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
 }
 
-void RenderingDeviceDriverMetal::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) {
+void RenderingDeviceDriverMetal::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) {
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
 }
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -477,7 +477,7 @@ public:
 	// ----- COMMANDS -----
 
 	virtual void command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) override final;
-	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
+	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
 	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -6322,7 +6322,7 @@ void RenderingDeviceDriverVulkan::command_build_blas(CommandBufferID p_cmd_buffe
 #endif
 }
 
-void RenderingDeviceDriverVulkan::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) {
+void RenderingDeviceDriverVulkan::command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) {
 #if VULKAN_RAYTRACING_ENABLED
 	const CommandBufferInfo *command_buffer = (const CommandBufferInfo *)p_cmd_buffer.id;
 	AccelerationStructureInfo *accel_info = (AccelerationStructureInfo *)p_acceleration_structure.id;

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -725,7 +725,7 @@ private:
 public:
 	// ----- COMMANDS -----
 	virtual void command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) override final;
-	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
+	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
 	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -33,7 +33,7 @@ else:
 # Mesa NIR
 # Sync with `drivers/d3d12/SCsub` when updating Mesa.
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
-mesa_version = "25.3.1-1"
+mesa_version = "raytracing-rel"
 # WinPixEventRuntime
 # Check for latest version: https://www.nuget.org/api/v2/package/WinPixEventRuntime (check downloaded filename)
 pix_version = "1.0.240308001"
@@ -71,7 +71,7 @@ for arch in [
         os.remove(mesa_archive)
     print(f"Downloading Mesa NIR {mesa_filename} ...")
     urllib.request.urlretrieve(
-        f"https://github.com/godotengine/godot-nir-static/releases/download/{mesa_version}/{mesa_filename}",
+        f"https://github.com/blueskythlikesclouds/godot-nir-static/releases/download/{mesa_version}/{mesa_filename}",
         mesa_archive,
     )
     if os.path.exists(mesa_folder):

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -529,7 +529,9 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 
 	_tlas_remove_blas_dependencies(tlas, p_tlas);
 
+	thread_local LocalVector<RDD::AccelerationStructureID> blases;
 	thread_local LocalVector<RDG::ResourceTracker *> draw_trackers;
+	blases.clear();
 	draw_trackers.clear();
 
 	for (uint32_t i = 0; i < p_instances.size(); i++) {
@@ -555,6 +557,8 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 				tlas->acceleration_structure_dependencies.insert(rd_instance.blas);
 				blas->acceleration_structure_dependencies.insert(p_tlas);
 
+				blases.push_back(blas->driver_id);
+
 				if (blas->draw_tracker != nullptr) {
 					draw_trackers.push_back(blas->draw_tracker);
 				}
@@ -564,7 +568,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 		driver->acceleration_structure_instance_write(instance_buffer.data_ptr + instance_buffer_offset + (instance_size * i), rdd_instance);
 	}
 
-	draw_graph.add_tlas_build(tlas->driver_id, tlas->scratch_buffer, instance_buffer.driver_id, instance_buffer_offset, p_instances.size(), tlas->draw_tracker, draw_trackers);
+	draw_graph.add_tlas_build(tlas->driver_id, tlas->scratch_buffer, instance_buffer.driver_id, instance_buffer_offset, p_instances.size(), blases, tlas->draw_tracker, draw_trackers);
 
 	tlas->invalidated = false;
 

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -794,7 +794,7 @@ public:
 	// ----- COMMANDS -----
 
 	virtual void command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) = 0;
-	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) = 0;
+	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<AccelerationStructureID> p_blases) = 0;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) = 0;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) = 0;
 

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1087,7 +1087,7 @@ void RenderingDeviceGraph::_run_render_commands(int32_t p_level, const RecordedC
 			} break;
 			case RecordedCommand::TYPE_TOP_LEVEL_ACCELERATION_STRUCTURE_BUILD: {
 				const RecordedTopLevelAccelerationStructureBuildCommand *tlas_build_command = reinterpret_cast<const RecordedTopLevelAccelerationStructureBuildCommand *>(command);
-				driver->command_build_tlas(r_command_buffer, tlas_build_command->acceleration_structure, tlas_build_command->scratch_buffer, tlas_build_command->instance_buffer, tlas_build_command->instance_offset, tlas_build_command->instance_count);
+				driver->command_build_tlas(r_command_buffer, tlas_build_command->acceleration_structure, tlas_build_command->scratch_buffer, tlas_build_command->instance_buffer, tlas_build_command->instance_offset, tlas_build_command->instance_count, VectorView<RDD::AccelerationStructureID>(tlas_build_command->blases(), tlas_build_command->blas_count));
 			} break;
 			case RecordedCommand::TYPE_BUFFER_CLEAR: {
 				const RecordedBufferClearCommand *buffer_clear_command = reinterpret_cast<const RecordedBufferClearCommand *>(command);
@@ -1810,9 +1810,12 @@ void RenderingDeviceGraph::add_blas_build(RDD::AccelerationStructureID p_acceler
 	_add_command_to_graph(trackers.ptr(), usages.ptr(), usages.size(), command_index, command);
 }
 
-void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceleration_structure, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers) {
+void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceleration_structure, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<RDD::AccelerationStructureID> p_blases, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers) {
+	uint32_t blases_size = sizeof(RDD::AccelerationStructureID) * p_blases.size();
+	uint32_t command_size = sizeof(RecordedTopLevelAccelerationStructureBuildCommand) + blases_size;
+
 	int32_t command_index;
-	RecordedTopLevelAccelerationStructureBuildCommand *command = static_cast<RecordedTopLevelAccelerationStructureBuildCommand *>(_allocate_command(sizeof(RecordedTopLevelAccelerationStructureBuildCommand), command_index));
+	RecordedTopLevelAccelerationStructureBuildCommand *command = static_cast<RecordedTopLevelAccelerationStructureBuildCommand *>(_allocate_command(command_size, command_index));
 	command->type = RecordedCommand::TYPE_TOP_LEVEL_ACCELERATION_STRUCTURE_BUILD;
 	command->self_stages = RDD::PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT;
 	command->acceleration_structure = p_acceleration_structure;
@@ -1820,6 +1823,11 @@ void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceler
 	command->instance_buffer = p_instance_buffer;
 	command->instance_offset = p_instance_offset;
 	command->instance_count = p_instance_count;
+	command->blas_count = p_blases.size();
+
+	for (uint32_t i = 0; i < p_blases.size(); i++) {
+		command->blases()[i] = p_blases[i];
+	}
 
 	thread_local LocalVector<ResourceTracker *> trackers;
 	thread_local LocalVector<ResourceUsage> usages;

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -353,6 +353,15 @@ private:
 		RDD::BufferID instance_buffer;
 		uint32_t instance_offset = 0;
 		uint32_t instance_count = 0;
+		uint32_t blas_count = 0;
+
+		_FORCE_INLINE_ RDD::AccelerationStructureID *blases() {
+			return reinterpret_cast<RDD::AccelerationStructureID *>(&this[1]);
+		}
+
+		_FORCE_INLINE_ const RDD::AccelerationStructureID *blases() const {
+			return reinterpret_cast<const RDD::AccelerationStructureID *>(&this[1]);
+		}
 	};
 
 	struct RecordedBufferClearCommand : RecordedCommand {
@@ -891,7 +900,7 @@ public:
 	void finalize();
 	void begin();
 	void add_blas_build(RDD::AccelerationStructureID p_blas, RDD::BufferID p_scratch_buffer, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers);
-	void add_tlas_build(RDD::AccelerationStructureID p_tlas, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers);
+	void add_tlas_build(RDD::AccelerationStructureID p_tlas, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, VectorView<RDD::AccelerationStructureID> p_blases, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers);
 	void add_buffer_clear(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, uint32_t p_offset, uint32_t p_size);
 	void add_buffer_copy(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, RDD::BufferCopyRegion p_region);
 	void add_buffer_get_data(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, RDD::BufferCopyRegion p_region);


### PR DESCRIPTION
The driver implementation is basically done.

I've been working on Mesa's spirv2dxil to add raytracing support to it and I'm nearly there. I temporarily made [my Mesa branch](https://github.com/blueskythlikesclouds/mesa/tree/spirv2dxil-rt) into a [godot-nir-static patch](https://github.com/blueskythlikesclouds/godot-nir-static/tree/raytracing). The plan later is to contribute it back to the upstream Mesa repository.

The shader converter has a few remaining issues that needs to be taken care of:
- [ ] Payload/attribute definitions mismatching between shader stages is UB in D3D12. What can we do when the shader does not define them? GLSL and SPIR-V allow this.
- [ ] Unused resources present in the raytracing DXIL libraries cause the validation to fail.
