### PR TITLE
Fix `EditorScenePostImportPlugin::_get_internal_option_visibility()` having no effect

### DIFF
--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -81,7 +81,7 @@ Variant PostImportPluginSkeletonRestFixer::get_internal_option_visibility(Intern
 			return int(p_options["retarget/rest_fixer/retarget_method"]) == 2 && bool(p_options["retarget/bone_renamer/rename_bones"]) == false;
 		}
 	}
-	return true;
+	return Variant();
 }
 
 void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) {


### PR DESCRIPTION

post_import_plugin_skeleton_rest_fixer::_get_internal_option_visibility() gets called before user plugins. as it used to return true by default, it would always override/intercept any user implementation.

now it returns null for those cases it is not explicitly coded to handle, indicating "ignore". see also: https://github.com/godotengine/godot/issues/118652

EditorScenePostImportPlugin's _get_internal_option_visibility had no effect

*Bugsquad edit:*
- Fixes #118652