### PR TITLE
Fix argument count error on editing SpringBoneSimulator3D curves

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -669,7 +669,7 @@ void SpringBoneSimulator3D::set_radius_damping_curve(int p_index, const Ref<Curv
 	}
 	settings[p_index]->radius_damping_curve = p_damping_curve;
 	if (settings[p_index]->radius_damping_curve.is_valid()) {
-		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -703,7 +703,7 @@ void SpringBoneSimulator3D::set_stiffness_damping_curve(int p_index, const Ref<C
 	}
 	settings[p_index]->stiffness_damping_curve = p_damping_curve;
 	if (settings[p_index]->stiffness_damping_curve.is_valid()) {
-		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -737,7 +737,7 @@ void SpringBoneSimulator3D::set_drag_damping_curve(int p_index, const Ref<Curve>
 	}
 	settings[p_index]->drag_damping_curve = p_damping_curve;
 	if (settings[p_index]->drag_damping_curve.is_valid()) {
-		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -771,7 +771,7 @@ void SpringBoneSimulator3D::set_gravity_damping_curve(int p_index, const Ref<Cur
 	}
 	settings[p_index]->gravity_damping_curve = p_damping_curve;
 	if (settings[p_index]->gravity_damping_curve.is_valid()) {
-		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }


### PR DESCRIPTION
Steps to reproduce:
1. Add a SpringBoneSimulator3D node to a mesh
2. Add a Setting
3. Create a new curve inside an inspector field that requires a curve (like Swiftness>Dumping Curve)
4. Add a point and start moving it

On a dev build those steps result in the following error on every curve update:
ERROR: Error calling from signal 'changed' to callable: 'SpringBoneSimulator3D::SpringBoneSimulator3D::_make_joints_dirty': Method expected 2 argument(s), but called with 1.
   at: Object::emit_signalp (E:\godot\core/object/object.cpp:1297) 