### PR TITLE
Fix asymmetric bitmask update in Vulkan acceleration-structure barrier

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2892,7 +2892,7 @@ void RenderingDeviceDriverVulkan::command_pipeline_barrier(
 			// VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR, srcStageMask must not include any of the
 			// VK_PIPELINE_STAGE_*_SHADER_BIT stages except VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR
 			if ((src_access & VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR) != 0) {
-				accel_src_stages &= _remove_pipeline_stage_shader_bits(accel_src_stages);
+				accel_src_stages = _remove_pipeline_stage_shader_bits(accel_src_stages);
 			}
 
 			// If the rayQuery feature is not enabled and a memory barrier dstAccessMask includes


### PR DESCRIPTION
Follow-up on #116227. The `src` branch of the `ray_query_support` fallback uses `&=` to combine the returned value of `_remove_pipeline_stage_shader_bits(accel_src_stages)` with itself, while the `dst` branch uses plain assignment:

```cpp
if ((src_access & VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR) != 0) {
    accel_src_stages &= _remove_pipeline_stage_shader_bits(accel_src_stages);  // <— here
}
// ...
if ((dst_access & VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR) != 0) {
    accel_dst_stages = _remove_pipeline_stage_shader_bits(accel_dst_stages);
}
```

The helper takes its argument by value, clears the shader-stage bits, and returns the result. Both expressions are mathematically equal today only because the body is pure mask-clearing (`X &= (X & ~M) == X & ~M`). If the helper is ever extended to OR in a replacement bit (e.g. to swap a stage for `VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR`), the `&=` on the `src` side will silently mask it back out while the `dst` side won't — a subtle bug that the current expression actively hides.

This is a one-line consistency fix. No behavior change on master.

---

> [!NOTE]
> 🤖 AI Disclosure
>
> AI assistance (Claude) was used to scan the diff range introduced by the referenced upstream PR and to draft this patch and PR description. The finding and the patch were verified by hand against the surrounding code before pushing.