### PR TITLE
[Windows] Guard HDR callbacks against destroyed windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3456,6 +3456,7 @@ DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(D
 }
 
 void DisplayServerWindows::_winrt_adv_color_info_cb(DisplayServerEnums::WindowID p_id) {
+	ERR_FAIL_COND(!windows.has(p_id));
 	WindowData &wd = windows[p_id];
 
 	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(p_id, true);
@@ -4746,6 +4747,8 @@ DisplayServerEnums::VSyncMode DisplayServerWindows::window_get_vsync_mode(Displa
 bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
+
 #if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
 		return false; // HDR output is not supported by the rendering device.
@@ -4759,6 +4762,8 @@ bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::Wi
 
 void DisplayServerWindows::window_request_hdr_output(const bool p_enable, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
 
 #if defined(RD_ENABLED)
 	ERR_FAIL_COND_EDMSG(p_enable && (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) == false, "HDR output is not supported by the rendering device.");
@@ -4792,6 +4797,8 @@ bool DisplayServerWindows::window_is_hdr_output_enabled(DisplayServerEnums::Wind
 
 void DisplayServerWindows::window_set_hdr_output_reference_luminance(const float p_reference_luminance, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
 
 	WindowData &wd = windows[p_window];
 
@@ -4837,6 +4844,8 @@ float DisplayServerWindows::window_get_hdr_output_current_reference_luminance(Di
 
 void DisplayServerWindows::window_set_hdr_output_max_luminance(const float p_max_luminance, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
 
 	WindowData &wd = windows[p_window];
 


### PR DESCRIPTION
Fixes #118672

## Summary

Follow-up on #118339. `DisplayServerWindows::_get_screen_hdr_data` and the WinRT-deferred callback `_winrt_adv_color_info_cb` access `windows[p_window]` without the `windows.has(...)` guard that every other public method on `DisplayServerWindows` already uses. Because `windows[]` auto-inserts a default `WindowData` on miss (non-const) or hits UB (const), a callback that fires after the window is gone — or a public HDR call against an already-closed `WindowID` — leaks an entry or crashes.

Per @bruvzg's review feedback, this PR places the guard at the API boundary — the public HDR methods that own the `WindowID` lookup — rather than inside the helper, so the pattern matches the rest of the class. The deferred callback keeps its own guard since it owns the entry path coming back in from the WinRT dispatcher.

## Changes

`platform/windows/display_server_windows.cpp`:

- Add `ERR_FAIL_COND(!windows.has(p_id))` to `_winrt_adv_color_info_cb`.
- Add `ERR_FAIL_COND_V(!windows.has(p_window), false)` to `window_is_hdr_output_supported`.
- Add `ERR_FAIL_COND(!windows.has(p_window))` to `window_request_hdr_output`, `window_set_hdr_output_reference_luminance`, and `window_set_hdr_output_max_luminance`.

The originally proposed `controller.ShutdownQueueAsync().get()` change in `winrt_utils.cpp` was **dropped**: @bruvzg confirmed it would deadlock since `destroy_queue` runs on the main thread after the event pump has already stopped, so `.get()` would never return. The token is revoked per-window in `destroy_wd` before the queue tears down, so no callback can fire across the destructor in practice.

## Testing

Reproduced (1) by cycling HDR on/off via Windows Settings on a secondary monitor while a second editor window is dragged onto/off that monitor and closed during the toggle. Without the guards, `windows[p_id]` auto-inserts a fresh `WindowData` (visible as a leaked entry in debug builds) and `_update_hdr_output_for_window` runs against a default-initialized struct.

No behaviour change outside the error paths.

---

> [!NOTE]
> 🤖 AI Disclosure
>
> AI assistance (Claude) was used to scan the diff range introduced by #118339 and to draft this patch and PR description. The findings, the placement of the guards, and the rejection of the `ShutdownQueueAsync().get()` approach were verified by hand against the surrounding code and against @bruvzg's review feedback before pushing.
