### PR TITLE
[Android] Clamp aspect-locked embedded game window to `MIN_WINDOW_SIZE`

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
@@ -143,7 +143,7 @@ class EmbeddedGodotGame : GodotGame() {
 			hideResizeUI()
 			if (isChecked) {
 				val lp = window.attributes
-				lockedAspectRatio = lp.width.toFloat() / lp.height.toFloat()
+				lockedAspectRatio = lp.width.toFloat() / lp.height.toFloat().coerceAtLeast(1f)
 			}
 			saveWindowBounds(updatePiPParams = false)
 		}
@@ -310,6 +310,20 @@ class EmbeddedGodotGame : GodotGame() {
 			}
 		}
 
+		// Clamp aspect-locked resize to MIN_WINDOW_SIZE so the height-derived branch
+		// can't settle below the floor that the free-resize branch already enforces.
+		if (!isFreeResize && newH < MIN_WINDOW_SIZE) {
+			newH = MIN_WINDOW_SIZE
+			newW = (newH * lockedAspectRatio).toInt().coerceAtMost(maxAllowedWidth)
+
+			if (activeCorner == (Gravity.TOP or Gravity.START) || activeCorner == (Gravity.TOP or Gravity.END)) {
+				layoutParams.y = initialWinY + (initialHeight - newH)
+			}
+			if (activeCorner == (Gravity.TOP or Gravity.START) || activeCorner == (Gravity.BOTTOM or Gravity.START)) {
+				layoutParams.x = initialWinX + (initialWidth - newW)
+			}
+		}
+
 		layoutParams.width = newW
 		layoutParams.height = newH
 
@@ -355,7 +369,7 @@ class EmbeddedGodotGame : GodotGame() {
 		layoutParams.y = prefs.getInt(KEY_Y, screenBounds.height() - layoutHeightInPx)
 		layoutParams.width = layoutWidthInPx
 		layoutParams.height = layoutHeightInPx
-		lockedAspectRatio = layoutParams.width.toFloat() / layoutParams.height.toFloat()
+		lockedAspectRatio = layoutParams.width.toFloat() / layoutParams.height.toFloat().coerceAtLeast(1f)
 		updateLabelText(layoutWidthInPx, layoutHeightInPx)
 	}
 


### PR DESCRIPTION
Fixes #118673

## Summary

Follow-up on #118417. Two issues in `EmbeddedGodotGame.dispatchTouchEvent` / `loadWindowBounds` that let the aspect-locked resize path settle below `MIN_WINDOW_SIZE`:

1. **Divide-by-zero on ratio capture.** Both the lock-ratio checkbox handler (line 146) and `loadWindowBounds` (line 358) compute

   ```kotlin
   lockedAspectRatio = lp.width.toFloat() / lp.height.toFloat()
   ```

   with no guard on `lp.height`. Kotlin `Float` division follows IEEE 754, so `W / 0f == Float.POSITIVE_INFINITY`; subsequent `(newW / lockedAspectRatio).toInt()` yields `0`. `lp.height == 0` is unusual but reachable: right after inflate, during a display-rotation race, or restored from a SharedPreferences entry that was saved with a zero value.
2. **Height below floor in aspect-locked resize.** In the four corner branches of `applyResizeLogic`, the free-resize path uses `coerceIn(MIN_WINDOW_SIZE, maxAllowedHeight)` but the locked-resize fallback `(newW / lockedAspectRatio).toInt()` is unclamped. With a wide ratio (e.g. 21:9 ≈ 2.33), dragging the corner in to `newW == MIN_WINDOW_SIZE` (400 px) produces `newH ≈ 171`, well below the 400 px floor the unlocked branches enforce. There is already a matching clamp *against* `maxAllowedHeight` at line 300, but none against `MIN_WINDOW_SIZE`.

## Changes

`platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt`:

- Guard the aspect-ratio capture against `height == 0` by `coerceAtLeast(1f)` on both assignment sites (lines 146 and 358).
- Mirror the existing `maxAllowedHeight` block at 300-311 with a `MIN_WINDOW_SIZE` block: clamp `newH` up to the floor, recompute `newW` from the locked ratio bounded by `maxAllowedWidth`, and re-adjust the pivot offsets for TOP/START anchors the same way the max block already does.

## Testing

Manually on a Pixel Tablet emulator:

- Locked at 21:9; dragged each of the four corners inward until the gesture stopped tracking. Before: window height drifts to ~171 px, checkbox label still paints. After: each axis settles at `MIN_WINDOW_SIZE` (height) / the corresponding locked width.
- Toggled lock on a window inflated with `height = 0` (forced via debug tool). Before: `lockedAspectRatio = Infinity`, subsequent resize instantly collapses height to 0 and the CheckBox row overlaps the drag handle. After: ratio captures as `width / 1`, behaviour identical to a 1-px-tall starting window (recoverable with one resize gesture).

Closes nothing open; this is a defensive follow-up to #118417.

---

> [!NOTE]
> 🤖 AI Disclosure
>
> AI assistance (Claude) was used to scan the diff range introduced by the referenced upstream PR and to draft this patch and PR description. The finding and the patch were verified by hand against the surrounding code before pushing.