### PR TITLE
[LinuxBSD] Restore shell_open fallback by gating each handler on binary availability

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -542,40 +542,76 @@ Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_
 	return values;
 }
 
+// Return true when `p_binary` resolves to an executable file in any `$PATH` entry.
+// Needed by `shell_open` because `create_process()` returns OK as soon as `fork()`
+// succeeds — `execvp` failures in the child are invisible to the parent, so the
+// fallback chain below would otherwise treat a missing handler as a silent success.
+static bool _binary_in_path(const String &p_binary) {
+	const char *path_env = getenv("PATH");
+	if (!path_env) {
+		return false;
+	}
+	PackedStringArray dirs = String::utf8(path_env).split(":");
+	for (const String &dir : dirs) {
+		if (dir.is_empty()) {
+			continue;
+		}
+		const String full = dir.path_join(p_binary);
+		if (access(full.utf8().get_data(), X_OK) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 Error OS_LinuxBSD::shell_open(const String &p_uri) {
 	List<String> args;
 	args.push_back(p_uri);
 
 	// Use create_process() instead of execute() to avoid blocking the main thread.
 	// This prevents the UI from freezing when opening file managers or other applications.
-	Error ok = create_process("xdg-open", args);
-	if (ok == OK) {
-		return OK;
+	// Each handler is gated on $PATH availability so that a missing binary falls
+	// through to the next one instead of being treated as success — see #114521.
+	if (_binary_in_path("xdg-open")) {
+		Error ok = create_process("xdg-open", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
 	// GNOME
 	args.push_front("open"); // The command is `gio open`, so we need to add it to args
-	ok = create_process("gio", args);
-	if (ok == OK) {
-		return OK;
+	if (_binary_in_path("gio")) {
+		Error ok = create_process("gio", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
 	args.pop_front();
-	ok = create_process("gvfs-open", args);
-	if (ok == OK) {
-		return OK;
+	if (_binary_in_path("gvfs-open")) {
+		Error ok = create_process("gvfs-open", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
 	// KDE
-	ok = create_process("kde-open5", args);
-	if (ok == OK) {
-		return OK;
+	if (_binary_in_path("kde-open5")) {
+		Error ok = create_process("kde-open5", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
-	ok = create_process("kde-open", args);
-	if (ok == OK) {
-		return OK;
+	if (_binary_in_path("kde-open")) {
+		Error ok = create_process("kde-open", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
 	// XFCE
-	ok = create_process("exo-open", args);
-	if (ok == OK) {
-		return OK;
+	if (_binary_in_path("exo-open")) {
+		Error ok = create_process("exo-open", args);
+		if (ok == OK) {
+			return OK;
+		}
 	}
 	return FAILED;
 }


### PR DESCRIPTION
Fixes #118674

## Summary

#114521 correctly fixed issue #114213 (UI freeze on "Show in File Manager") by switching `OS_LinuxBSD::shell_open` from `execute()` to `create_process()`. That change preserves async behavior, but it silently broke the handler-fallback chain: `OS_Unix::create_process` returns `OK` as soon as `fork()` succeeds, so `execvp` failures inside the child never surface. In practice the first handler is always treated as a success; `gio`, `gvfs-open`, `kde-open5`, `kde-open`, `exo-open` are never attempted.

On a machine that only has `kde-open5` installed:

```
$ strace -f -e execve godot-editor
...
[child] execve("/usr/bin/xdg-open", …) = -1 ENOENT
[child] write(2, "Could not create child process: xdg-open\n", …)
[child] SIGKILL
[parent] returns OK from create_process()
[editor] shell_open() returns OK  — URL silently dropped
```

## Problem statement

`shell_open` is defined by a prioritized list of URL handlers. The contract the callers rely on is "if one handler is unavailable, fall through to the next one." Before #114521, `execute()` surfaced `execvp` errors synchronously via the exit code, which the chain used to skip missing handlers. After #114521, the same chain is dead code because `create_process()`'s return value is decoupled from the child's lifecycle.

This PR keeps the async behavior from #114521 (so #114213 does not regress) and restores fallback semantics by gating each attempt on binary availability — if the binary isn't resolvable in `$PATH`, we skip it before fork.

## Changes

`platform/linuxbsd/os_linuxbsd.cpp`:

- Add a file-local `static bool _binary_in_path(const String &p_binary)` helper that walks `getenv("PATH")` and returns true when at least one entry resolves to an executable file via `access(..., X_OK)`. Returns false on null `$PATH` or missing binary.
- Wrap each of the six `create_process(...)` calls in `shell_open` with `if (_binary_in_path(...)) { … }`. The first handler that both exists and returns `OK` wins; non-existent handlers are skipped instead of being treated as silent successes.

## Testing

- Minimal Xfce container (`exo-open` only, all other handlers removed):
  - Before: `shell_open("file:///")` returned `OK`, no file manager opened, child SIGKILL'd itself.
  - After: skipped to `exo-open`, file manager opened.
- KDE container (`kde-open5` only): same pattern — skipped 3 missing handlers, opened `kde-open5`.
- Default GNOME install (`xdg-open` present): unchanged behavior — first-handler path hits `xdg-open`, returns `OK` on the first attempt.
- #114213 stays fixed: the editor's UI thread is not blocked during any of the above.

## Related PRs

- Fixes the fallback regression introduced alongside the fix for #114213 in #114521.
- Preserves the async design intent of #114521 rather than reverting it.

---

> [!NOTE]
> 🤖 AI Disclosure
>
> AI assistance (Claude) was used to scan the diff range introduced by the referenced upstream PR and to draft this patch and PR description. The finding and the patch were verified by hand against the surrounding code before pushing.