### PR TITLE
[WinRT] Wait for DispatcherQueueController shutdown.

### DIFF
--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -132,7 +132,15 @@ bool WinRTUtils::create_queue() {
 }
 
 void WinRTUtils::destroy_queue() {
-	controller.ShutdownQueueAsync();
+	IAsyncAction action = controller.ShutdownQueueAsync();
+	while (action.Status() == AsyncStatus::Started) {
+		MSG msg = {};
+		while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+			TranslateMessage(&msg);
+			DispatchMessageW(&msg);
+		}
+	}
+	ERR_FAIL_COND_MSG(action.Status() == AsyncStatus::Error, "DispatcherQueueController shutdown failed.");
 }
 
 bool WinRTUtils::try_show_onecore_emoji_picker() {


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/118672

While it should not cause any issues in the current state, it is reasonable to future-proof it and ensure everything is cleared.

> Before the current thread exits, it must call [DispatcherQueueController.ShutdownQueueAsync](https://learn.microsoft.com/en-us/uwp/api/windows.system.dispatcherqueuecontroller.shutdownqueueasync), and continue pumping messages until the IAsyncAction completes.
>
> From https://learn.microsoft.com/en-us/windows/win32/api/dispatcherqueue/nf-dispatcherqueue-createdispatcherqueuecontroller#remarks