### PR TITLE
Fix `export_template_manager.cpp` compilation with `deprecated=no`

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -383,7 +383,7 @@ void ExportTemplateManager::_initialize_template_data() {
 	}
 
 	// Template directory status.
-	DirAccess::make_dir_recursive_absolute(_get_template_folder_path(VERSION_FULL_CONFIG));
+	DirAccess::make_dir_recursive_absolute(_get_template_folder_path(GODOT_VERSION_FULL_CONFIG));
 	Ref<DirAccess> templates_dir = DirAccess::open(EditorPaths::get_singleton()->get_export_templates_dir());
 	ERR_FAIL_COND(templates_dir.is_null());
 


### PR DESCRIPTION
Fixes compilation error in `export_template_manager.cpp` ~and `class_db.cpp`~ when building with `deprecated=no`.