### PR TITLE
Add a bunch of missing window existence checks to HDR methods

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1559,6 +1559,7 @@ bool DisplayServerWayland::window_is_hdr_output_requested(DisplayServerEnums::Wi
 }
 
 bool DisplayServerWayland::window_is_hdr_output_enabled(DisplayServerEnums::WindowID p_window_id) const {
+	ERR_FAIL_COND_V(!windows.has(p_window_id), false);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_enabled(p_window_id);
@@ -1579,6 +1580,7 @@ float DisplayServerWayland::window_get_hdr_output_reference_luminance(DisplaySer
 }
 
 float DisplayServerWayland::window_get_hdr_output_current_reference_luminance(DisplayServerEnums::WindowID p_window_id) const {
+	ERR_FAIL_COND_V(!windows.has(p_window_id), 0.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_reference_luminance(p_window_id);
@@ -1599,6 +1601,7 @@ float DisplayServerWayland::window_get_hdr_output_max_luminance(DisplayServerEnu
 }
 
 float DisplayServerWayland::window_get_hdr_output_current_max_luminance(DisplayServerEnums::WindowID p_window_id) const {
+	ERR_FAIL_COND_V(!windows.has(p_window_id), 0.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_max_luminance(p_window_id);
@@ -1608,6 +1611,7 @@ float DisplayServerWayland::window_get_hdr_output_current_max_luminance(DisplayS
 }
 
 float DisplayServerWayland::window_get_output_max_linear_value(DisplayServerEnums::WindowID p_window_id) const {
+	ERR_FAIL_COND_V(!windows.has(p_window_id), 1.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_output_max_linear_value(p_window_id);

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -242,7 +242,7 @@ private:
 public:
 	void menu_callback(id p_sender);
 
-	bool has_window(DisplayServerEnums::WindowID p_window) const;
+	virtual bool has_window(DisplayServerEnums::WindowID p_window) const override;
 	WindowData &get_window(DisplayServerEnums::WindowID p_window);
 
 	NSImage *_convert_to_nsimg(Ref<Image> &p_image) const;

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -107,6 +107,8 @@ protected:
 	void _update_hdr_output(DisplayServerEnums::WindowID p_window, const HDROutput &p_hdr);
 
 public:
+	virtual bool has_window(DisplayServerEnums::WindowID p_window) const { return p_window == DisplayServerEnums::MAIN_WINDOW_ID; }
+
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -589,6 +589,7 @@ void DisplayServerMacOSBase::_update_hdr_output(DisplayServerEnums::WindowID p_w
 bool DisplayServerMacOSBase::window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), false);
 #if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
 		return false;
@@ -602,6 +603,7 @@ bool DisplayServerMacOSBase::window_is_hdr_output_supported(DisplayServerEnums::
 void DisplayServerMacOSBase::window_request_hdr_output(const bool p_enabled, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND(!has_window(p_window));
 #if defined(RD_ENABLED)
 	ERR_FAIL_COND_MSG(p_enabled && rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT), "HDR output is not supported by the rendering device.");
 #endif
@@ -614,12 +616,14 @@ void DisplayServerMacOSBase::window_request_hdr_output(const bool p_enabled, Dis
 bool DisplayServerMacOSBase::window_is_hdr_output_requested(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), false);
 	return _get_hdr_output(p_window).requested;
 }
 
 bool DisplayServerMacOSBase::window_is_hdr_output_enabled(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), false);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_enabled(p_window);
@@ -644,6 +648,7 @@ constexpr float DisplayServerMacOSBase::_calculate_current_reference_luminance(C
 float DisplayServerMacOSBase::window_get_hdr_output_current_reference_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), 0.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_reference_luminance(p_window);
@@ -655,6 +660,7 @@ float DisplayServerMacOSBase::window_get_hdr_output_current_reference_luminance(
 void DisplayServerMacOSBase::window_set_hdr_output_max_luminance(const float p_max_luminance, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND(!has_window(p_window));
 	HDROutput &hdr = _get_hdr_output(p_window);
 
 	if (hdr.max_luminance == p_max_luminance) {
@@ -667,12 +673,14 @@ void DisplayServerMacOSBase::window_set_hdr_output_max_luminance(const float p_m
 float DisplayServerMacOSBase::window_get_hdr_output_max_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), 0.0);
 	return _get_hdr_output(p_window).max_luminance;
 }
 
 float DisplayServerMacOSBase::window_get_hdr_output_current_max_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), 0.0);
 	const HDROutput &hdr = _get_hdr_output(p_window);
 	if (hdr.is_auto_max_luminance()) {
 		CGFloat max_potential_edr;
@@ -685,6 +693,7 @@ float DisplayServerMacOSBase::window_get_hdr_output_current_max_luminance(Displa
 float DisplayServerMacOSBase::window_get_output_max_linear_value(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!has_window(p_window), 1.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_output_max_linear_value(p_window);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3456,6 +3456,9 @@ DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(D
 }
 
 void DisplayServerWindows::_winrt_adv_color_info_cb(DisplayServerEnums::WindowID p_id) {
+	if (!windows.has(p_id)) {
+		return;
+	}
 	WindowData &wd = windows[p_id];
 
 	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(p_id, true);
@@ -4746,6 +4749,7 @@ DisplayServerEnums::VSyncMode DisplayServerWindows::window_get_vsync_mode(Displa
 bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
 #if defined(RD_ENABLED)
 	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
 		return false; // HDR output is not supported by the rendering device.
@@ -4760,6 +4764,7 @@ bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::Wi
 void DisplayServerWindows::window_request_hdr_output(const bool p_enable, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND(!windows.has(p_window));
 #if defined(RD_ENABLED)
 	ERR_FAIL_COND_EDMSG(p_enable && (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) == false, "HDR output is not supported by the rendering device.");
 #endif
@@ -4774,6 +4779,7 @@ void DisplayServerWindows::window_request_hdr_output(const bool p_enable, Displa
 bool DisplayServerWindows::window_is_hdr_output_requested(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
 	const WindowData &wd = windows[p_window];
 	return wd.hdr_output_requested;
 }
@@ -4781,6 +4787,7 @@ bool DisplayServerWindows::window_is_hdr_output_requested(DisplayServerEnums::Wi
 bool DisplayServerWindows::window_is_hdr_output_enabled(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_enabled(p_window);
@@ -4793,6 +4800,7 @@ bool DisplayServerWindows::window_is_hdr_output_enabled(DisplayServerEnums::Wind
 void DisplayServerWindows::window_set_hdr_output_reference_luminance(const float p_reference_luminance, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
 	if (Math::is_equal_approx(wd.hdr_output_reference_luminance, p_reference_luminance)) {
@@ -4819,6 +4827,7 @@ void DisplayServerWindows::window_set_hdr_output_reference_luminance(const float
 float DisplayServerWindows::window_get_hdr_output_reference_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), 0.0);
 	const WindowData &wd = windows[p_window];
 	return wd.hdr_output_reference_luminance;
 }
@@ -4826,6 +4835,7 @@ float DisplayServerWindows::window_get_hdr_output_reference_luminance(DisplaySer
 float DisplayServerWindows::window_get_hdr_output_current_reference_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), 0.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_reference_luminance(p_window);
@@ -4838,6 +4848,7 @@ float DisplayServerWindows::window_get_hdr_output_current_reference_luminance(Di
 void DisplayServerWindows::window_set_hdr_output_max_luminance(const float p_max_luminance, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
 	if (Math::is_equal_approx(wd.hdr_output_max_luminance, p_max_luminance)) {
@@ -4864,6 +4875,7 @@ void DisplayServerWindows::window_set_hdr_output_max_luminance(const float p_max
 float DisplayServerWindows::window_get_hdr_output_max_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), 0.0);
 	const WindowData &wd = windows[p_window];
 	return wd.hdr_output_max_luminance;
 }
@@ -4871,6 +4883,7 @@ float DisplayServerWindows::window_get_hdr_output_max_luminance(DisplayServerEnu
 float DisplayServerWindows::window_get_hdr_output_current_max_luminance(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), 0.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_hdr_output_max_luminance(p_window);
@@ -4883,6 +4896,7 @@ float DisplayServerWindows::window_get_hdr_output_current_max_luminance(DisplayS
 float DisplayServerWindows::window_get_output_max_linear_value(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V(!windows.has(p_window), 1.0);
 #if defined(RD_ENABLED)
 	if (rendering_context) {
 		return rendering_context->window_get_output_max_linear_value(p_window);


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/118672

Supersede https://github.com/godotengine/godot/pull/118669

Crash is not practically reproducible (require exact timing of highly unlikely events), but it is user accessible functions and calling it with invalid argument will result in addition of corrupted window data.