### PR TITLE
Fix CLI parser to ensure project file check only applies to non-option arguments

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1789,7 +1789,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing number of iterations, aborting.\n");
 				goto error;
 			}
-		} else if (arg.ends_with("project.godot")) {
+		} else if (!arg.begins_with("--") && arg.ends_with("project.godot")) {
 #if defined(OVERRIDE_PATH_ENABLED)
 			String path;
 			String file = arg;


### PR DESCRIPTION
If a user-defined CLI flag takes in a parameter, and that parameter just so happens to end in `project.godot` (e.g. `--txt-to-bin=/path/to/project.godot`), the CLI parser currently interprets that as a request to load that project.

Changing it such that it only applies to non-option arguments (i.e. it doesn't begin with `--`) fixes the issue.