### PR TITLE
Prevent shader preview crash in loops

### DIFF
--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -463,7 +463,7 @@ void TextShaderPreview::show_shader_compile_error() {
 }
 
 void TextShaderPreview::recompile(const String &p_code) {
-	set_shader_code(p_code, line, in_comment);
+	set_shader_code(p_code, line, in_comment, *frag_loop_regions);
 }
 
 Ref<ShaderMaterial> TextShaderPreview::_get_source_material() const {
@@ -529,10 +529,11 @@ MarginContainer *TextShaderPreview::get_surface_container() const {
 	return surface_container;
 }
 
-void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p_in_comment) {
+void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p_in_comment, Vector<Vector2i> &p_frag_loop_regions) {
 	line = p_line;
 	in_comment = p_in_comment;
 	goto_button->set_text(vformat(TTR("Go to Line %d"), line + 1));
+	frag_loop_regions = &p_frag_loop_regions;
 
 	String shader_type = ShaderLanguage::get_shader_type(p_code);
 	bool mode_3d = shader_type == "spatial";
@@ -554,15 +555,23 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 	int start;
 	int end;
 
+	Vector2i loop_region;
+	bool in_loop_region = false;
+
+	for (const Vector2i &region : *frag_loop_regions) {
+		if (p_line >= region.x && p_line <= region.y) {
+			loop_region = region;
+			in_loop_region = true;
+			break;
+		}
+	}
+
 	if (in_comment || !_find_statement(lines, p_line, var_name, start, end)) {
 		_show_error(TTRC("The selected line needs to be an assignment."));
 		return;
 	}
 
 	String type = _find_var_type(lines, var_name, end, mode_3d);
-
-	// All code before assignment stays as it was.
-	PackedStringArray truncated_lines = lines.slice(0, end + 1);
 
 	String injection;
 	HashMap<String, String> &assignments = mode_3d ? spatial_assignments : canvas_assignments;
@@ -571,14 +580,33 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 		return;
 	}
 	injection = assignments[type].replace("%s", var_name);
-	truncated_lines.append(injection);
+
+	PackedStringArray truncated_lines;
+	PackedStringArray loop_lines;
+	if (in_loop_region) {
+		loop_lines = lines.slice(loop_region.x, loop_region.y + 1);
+		truncated_lines = lines.slice(0, loop_region.x);
+	} else {
+		truncated_lines = lines.slice(0, end + 1);
+		truncated_lines.append(injection);
+	}
+
+	String temp = "\n";
+	temp = temp.join(truncated_lines);
+
+	int open_braces = temp.count("{");
+	int closed_braces = temp.count("}");
+	int needed_closures = open_braces - closed_braces;
 
 	String full_truncated_text = "\n";
-	full_truncated_text = full_truncated_text.join(truncated_lines);
+	if (in_loop_region) {
+		truncated_lines.append_array(loop_lines);
+		truncated_lines.insert(end + 1, injection);
 
-	int open_braces = full_truncated_text.count("{");
-	int closed_braces = full_truncated_text.count("}");
-	int needed_closures = open_braces - closed_braces;
+		full_truncated_text = full_truncated_text.join(truncated_lines);
+	} else {
+		full_truncated_text = temp;
+	}
 
 	for (int i = 0; i < needed_closures; i++) {
 		full_truncated_text += "\n}";
@@ -744,7 +772,7 @@ void ShaderTextEditor::toggle_shader_preview(int p_line) {
 	if (last_compile_result != OK) {
 		preview->show_shader_compile_error();
 	} else {
-		preview->set_shader_code(tx->get_text(), p_line, tx->is_in_comment(p_line) != -1);
+		preview->set_shader_code(tx->get_text(), p_line, tx->is_in_comment(p_line) != -1, frag_loop_regions);
 	}
 
 	preview->connect("goto_btn_pressed", callable_mp(this, &ShaderTextEditor::goto_shader_preview).bind(p_line));
@@ -1171,6 +1199,9 @@ void ShaderTextEditor::_validate_script() {
 		last_compile_result = sl.compile(code, comp_info);
 
 		if (last_compile_result != OK) {
+#ifdef DEBUG_ENABLED
+			frag_loop_regions.clear();
+#endif // DEBUG_ENABLED
 			Vector<ShaderLanguage::FilePosition> include_positions = sl.get_include_positions();
 
 			String err_text;
@@ -1205,9 +1236,11 @@ void ShaderTextEditor::_validate_script() {
 			}
 		} else {
 			set_error("");
-
+#ifdef DEBUG_ENABLED
+			frag_loop_regions = sl.get_fragment_loop_regions();
+#endif // DEBUG_ENABLED
 			for (KeyValue<int, TextShaderPreview *> pair : previews) {
-				pair.value->set_shader_code(code, pair.key, get_text_editor()->is_in_comment(pair.key) != -1);
+				pair.value->set_shader_code(code, pair.key, get_text_editor()->is_in_comment(pair.key) != -1, frag_loop_regions);
 			}
 		}
 

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -70,6 +70,7 @@ private:
 
 	int line = -1;
 	bool in_comment = false;
+	Vector<Vector2i> *frag_loop_regions = nullptr;
 
 	static HashMap<String, String> spatial_assignments;
 	static HashMap<String, String> canvas_assignments;
@@ -92,7 +93,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void set_shader_code(const String &p_code, int p_line, bool p_in_comment);
+	void set_shader_code(const String &p_code, int p_line, bool p_in_comment, Vector<Vector2i> &p_frag_loop_regions);
 	void show_shader_compile_error();
 	void recompile(const String &p_code);
 	void sync_shader_parameters();
@@ -139,6 +140,7 @@ class ShaderTextEditor : public CodeTextEditor {
 	HashMap<int, TextShaderPreview *> previews;
 	Control *preview_box = nullptr;
 	TextShaderPreviewLineLayer *preview_line_layer = nullptr;
+	Vector<Vector2i> frag_loop_regions;
 
 	void _check_shader_mode();
 	void _update_warning_panel();

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1345,6 +1345,7 @@ void ShaderLanguage::clear() {
 	used_structs.clear();
 	used_local_vars.clear();
 	warnings.clear();
+	fragment_loop_regions.clear();
 #endif // DEBUG_ENABLED
 
 	error_line = 0;
@@ -8775,6 +8776,15 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			// while() {}
 			bool is_do = tk.type == TK_CF_DO;
 
+#ifdef DEBUG_ENABLED
+			bool record_region = !p_block->parent_block && current_function == "fragment";
+
+			Vector2i region;
+			if (record_region) {
+				region.x = pos.tk_line;
+			}
+#endif // DEBUG_ENABLED
+
 			BlockNode *do_block = nullptr;
 			if (is_do) {
 				do_block = alloc_node<BlockNode>();
@@ -8784,7 +8794,12 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				if (err) {
 					return err;
 				}
-
+#ifdef DEBUG_ENABLED
+				if (record_region) {
+					region.y = tk_line;
+					fragment_loop_regions.push_back(region);
+				}
+#endif // DEBUG_ENABLED
 				tk = _get_token();
 				if (tk.type != TK_CF_WHILE) {
 					_set_expected_after_error("while", "do");
@@ -8825,6 +8840,12 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				if (err) {
 					return err;
 				}
+#ifdef DEBUG_ENABLED
+				if (record_region) {
+					region.y = tk_line;
+					fragment_loop_regions.push_back(region);
+				}
+#endif // DEBUG_ENABLED
 			} else {
 				cf->expressions.push_back(n);
 				cf->blocks.push_back(do_block);
@@ -8837,6 +8858,15 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				}
 			}
 		} else if (tk.type == TK_CF_FOR) {
+#ifdef DEBUG_ENABLED
+			bool record_region = !p_block->parent_block && current_function == "fragment";
+
+			Vector2i region;
+			if (record_region) {
+				region.x = pos.tk_line;
+			}
+#endif // DEBUG_ENABLED
+
 			// for() {}
 			tk = _get_token();
 			if (tk.type != TK_PARENTHESIS_OPEN) {
@@ -8898,6 +8928,12 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (err != OK) {
 				return err;
 			}
+#ifdef DEBUG_ENABLED
+			if (record_region) {
+				region.y = tk_line;
+				fragment_loop_regions.push_back(region);
+			}
+#endif // DEBUG_ENABLED
 
 		} else if (tk.type == TK_CF_RETURN) {
 			//check return type
@@ -11437,6 +11473,9 @@ void ShaderLanguage::set_warning_flags(uint32_t p_flags) {
 }
 uint32_t ShaderLanguage::get_warning_flags() const {
 	return warning_flags;
+}
+Vector<Vector2i> ShaderLanguage::get_fragment_loop_regions() {
+	return fragment_loop_regions;
 }
 #endif // DEBUG_ENABLED
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1049,6 +1049,8 @@ private:
 		warnings.push_back(ShaderWarning(p_code, p_line, p_subject, p_extra_args));
 	}
 	void _check_warning_accums();
+
+	Vector<Vector2i> fragment_loop_regions;
 #endif // DEBUG_ENABLED
 
 	String code;
@@ -1247,6 +1249,8 @@ public:
 
 	void set_warning_flags(uint32_t p_flags);
 	uint32_t get_warning_flags() const;
+
+	Vector<Vector2i> get_fragment_loop_regions();
 #endif // DEBUG_ENABLED
 
 	//static void get_keyword_list(ShaderType p_type,List<String> *p_keywords);
@@ -1274,7 +1278,6 @@ public:
 	Vector<FilePosition> get_include_positions();
 	CompletionType get_completion_type() const { return completion_type; }
 	int get_error_line();
-
 	ShaderNode *get_shader();
 
 	String token_debug(const String &p_code);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/118639 by introducing a region recording which then used to inject whole loop code to the preview shader to prevent a crash.