### PR TITLE
[WinRT] Update compiler version checks when WinRT is enabled.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -720,15 +720,26 @@ if cc_version_major == -1:
         "Build may fail if the compiler doesn't support C++17 fully."
     )
 elif methods.using_gcc(env):
-    if cc_version_major < 9:
-        print_error(
-            "Detected GCC version older than 9, which does not fully support "
-            "C++17, or has bugs when compiling Godot. Supported versions are 9 "
-            "and later. Use a newer GCC version, or Clang 6 or later by passing "
-            '"use_llvm=yes" to the SCons command line.'
-        )
-        Exit(255)
-    elif cc_version_metadata1 == "win32":
+    if env.get("winrt"):
+        if cc_version_major < 11:
+            print_error(
+                "Detected GCC version older than 11, which does not fully support "
+                "C++20, or has bugs when compiling Godot. Supported versions are 12 "
+                "and later. Use a newer GCC version, or Clang 14 or later by passing "
+                '"use_llvm=yes" to the SCons command line, or disable WinRT support by '
+                'passing "winrt=no" to the SCons command line.'
+            )
+            Exit(255)
+    else:
+        if cc_version_major < 9:
+            print_error(
+                "Detected GCC version older than 9, which does not fully support "
+                "C++17, or has bugs when compiling Godot. Supported versions are 9 "
+                "and later. Use a newer GCC version, or Clang 6 or later by passing "
+                '"use_llvm=yes" to the SCons command line.'
+            )
+            Exit(255)
+    if cc_version_metadata1 == "win32":
         print_error(
             "Detected mingw version is not using posix threads. Only posix "
             "version of mingw is supported. "
@@ -746,37 +757,55 @@ elif methods.using_clang(env):
             )
             Exit(255)
     else:
-        if cc_version_major < 6:
-            print_error(
-                "Detected Clang version older than 6, which does not fully support "
-                "C++17. Supported versions are Clang 6 and later."
-            )
-            Exit(255)
-        elif env["debug_paths_relative"] and cc_version_major < 10:
-            print_warning("Clang < 10 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option.")
-            env["debug_paths_relative"] = False
+        if env.get("winrt"):
+            if cc_version_major < 13:
+                print_error(
+                    "Detected Clang version older than 13, which does not fully support "
+                    "C++20. Supported versions are Clang 14 and later, or disable WinRT "
+                    'support by passing "winrt=no" to the SCons command line.'
+                )
+                Exit(255)
+        else:
+            if cc_version_major < 6:
+                print_error(
+                    "Detected Clang version older than 6, which does not fully support "
+                    "C++17. Supported versions are Clang 6 and later."
+                )
+                Exit(255)
+            elif env["debug_paths_relative"] and cc_version_major < 10:
+                print_warning("Clang < 10 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option.")
+                env["debug_paths_relative"] = False
 
 elif env.msvc:
     # Ensure latest minor builds of Visual Studio 2017/2019.
     # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
-    if cc_version_major == 16 and cc_version_minor < 11:
-        print_error(
-            "Detected Visual Studio 2019 version older than 16.11, which has bugs "
-            "when compiling Godot. Use a newer VS2019 version, or VS2022."
-        )
-        Exit(255)
-    if cc_version_major == 15 and cc_version_minor < 9:
-        print_error(
-            "Detected Visual Studio 2017 version older than 15.9, which has bugs "
-            "when compiling Godot. Use a newer VS2017 version, or VS2019/VS2022."
-        )
-        Exit(255)
-    if cc_version_major < 15:
-        print_error(
-            "Detected Visual Studio 2015 or earlier, which is unsupported in Godot. "
-            "Supported versions are Visual Studio 2017 and later."
-        )
-        Exit(255)
+    if env.get("winrt"):
+        if cc_version_major < 16 or (cc_version_major == 16 and cc_version_minor < 11):
+            print_error(
+                "Detected Visual Studio 2019 version older than 16.11, which does not fully support "
+                "C++20. Use a newer VS2019 version, or VS2022, or disable WinRT support by passing "
+                '"winrt=no" to the SCons command line.'
+            )
+            Exit(255)
+    else:
+        if cc_version_major == 16 and cc_version_minor < 11:
+            print_error(
+                "Detected Visual Studio 2019 version older than 16.11, which has bugs "
+                "when compiling Godot. Use a newer VS2019 version, or VS2022."
+            )
+            Exit(255)
+        if cc_version_major == 15 and cc_version_minor < 9:
+            print_error(
+                "Detected Visual Studio 2017 version older than 15.9, which has bugs "
+                "when compiling Godot. Use a newer VS2017 version, or VS2019/VS2022."
+            )
+            Exit(255)
+        if cc_version_major < 15:
+            print_error(
+                "Detected Visual Studio 2015 or earlier, which is unsupported in Godot. "
+                "Supported versions are Visual Studio 2017 and later."
+            )
+            Exit(255)
 
 # Set x86 CPU instruction sets to use by the compiler's autovectorization.
 if env["arch"] == "x86_64":


### PR DESCRIPTION
Building with WinRT require compiler with C++20 support.