### PR TITLE
Link to tutorial and add platform notes to HDR output docs.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2246,7 +2246,7 @@
 			<return type="float" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the maximum value for linear color components that can be displayed for the window specified by [param window_id], regardless of SDR or HDR output. Returns [code]1.0[/code] if HDR is not enabled or not supported. When HDR output is enabled, this is calculated based on [method window_get_hdr_output_current_reference_luminance] and [method window_get_hdr_output_current_max_luminance]. This value is used by tonemapping and other [Environment] effects to ensure that bright colors are presented in the range that can be displayed by this window. Corresponds to [method Window.get_output_max_linear_value].
+				Returns the maximum value for linear color components that can be displayed for the window specified by [param window_id], regardless of SDR or HDR output. Returns [code]1.0[/code] if HDR is not enabled or not supported. When HDR output is enabled, this is calculated based on [method window_get_hdr_output_current_reference_luminance] and [method window_get_hdr_output_current_max_luminance]. The [signal Window.output_max_linear_value_changed] signal will be emitted whenever this value changes. This value is used by tonemapping and other [Environment] effects to ensure that bright colors are presented in the range that can be displayed by this window. Corresponds to [method Window.get_output_max_linear_value].
 			</description>
 		</method>
 		<method name="window_get_popup_safe_rect" qualifiers="const">
@@ -2431,6 +2431,7 @@
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
 				Sets the maximum luminance in nits (cd/m²) for HDR output by the window specified by [param window_id]. If [param max_luminance] is negative, the window uses the screen's maximum luminance that is reported by the operating system. By default, this luminance is set to [code]-1.0[/code] for every window. Typically this property should be left at this default value, but may optionally be exposed through in-game settings to allow the player to correct an inaccurate maximum luminance reported by the operating system. See also [method window_get_hdr_output_current_max_luminance] and [method window_get_hdr_output_max_luminance].
+				[b]Note:[/b] This method is only implemented on macOS and Windows. Other platforms will always use the screen's maximum luminance that is reported by the operating system.
 			</description>
 		</method>
 		<method name="window_set_hdr_output_reference_luminance">
@@ -2439,6 +2440,7 @@
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
 				Sets the reference white luminance in nits (cd/m²) for HDR output by the window specified by [param window_id]. If [param reference_luminance] is negative, the window automatically adjusts to the brightness set by the operating system. By default, this luminance is set to [code]-1.0[/code] for every window. Typically this property should be left at this default value, but may optionally be exposed as an "HDR Brightness" in-game setting to allow the player to adjust the brightness of their game, independently of their device settings. See also [method window_get_hdr_output_current_reference_luminance] and [method window_get_hdr_output_reference_luminance].
+				[b]Note:[/b] This method is only implemented on Windows. Other platforms will always use the reference luminance that is reported by the operating system.
 			</description>
 		</method>
 		<method name="window_set_icon">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -8,6 +8,7 @@
 		At runtime, [Window]s will not close automatically when requested. You need to handle it manually using the [signal close_requested] signal (this applies both to pressing the close button and clicking outside of a popup).
 	</description>
 	<tutorials>
+		<link title="HDR output">$DOCS_URL/tutorials/rendering/hdr_output.html</link>
 	</tutorials>
 	<methods>
 		<method name="_get_contents_minimum_size" qualifiers="virtual const">
@@ -124,7 +125,7 @@
 			<return type="float" />
 			<description>
 				Returns the maximum value for linear color components that can be displayed in this window, regardless of SDR or HDR output. Returns [code]1.0[/code] if HDR is not enabled or not supported. The [signal output_max_linear_value_changed] signal will be emitted whenever this value changes.
-				This value is used by tonemapping and other [Environment] effects to ensure that bright colors are presented in the range that can be displayed by this window. When using the Linear tonemapper without [Environment] effects or no [WorldEnvironment], use the returned value to scale content to maximize the screen's brightness, such as for lasers or other bright effects. The following is an example that produces the brightest purple color that the screen can produce:
+				This value is used by tonemapping and other [Environment] effects to ensure that bright colors are presented in the range that can be displayed by this window. When using this maximum linear value in your project, it should only be used to present colors directly to the screen without tonemapping and without influencing lighting, post-processing effects, or surrounding color. The following is an example that produces the brightest purple color that the screen can produce:
 				[codeblocks]
 				[gdscript]
 				func _process(_delta):


### PR DESCRIPTION
### What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot-docs/issues/11913 for the class documentation.
- No documentation states that the maximum and reference luminance setters can only be used on certain platforms.
- No class documentation links to the [HDR output manual page](https://docs.godotengine.org/en/latest/tutorials/rendering/hdr_output.html).
- `DisplayServer.window_get_output_max_linear_value` was not updated to mention the new `Window.output_max_linear_value_changed` signal. I think this was a simple oversight and not intentional.

### How did you solve these problem(s) and why do it this way?

To resolve https://github.com/godotengine/godot-docs/issues/11913, I used the wording from https://github.com/godotengine/godot-docs/pull/11920.

### Was AI used to create any part of this PR?

No

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

No