### PR TITLE
[visionOS] Add visionOS to export template download list

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -493,6 +493,13 @@ void ExportTemplateManager::_initialize_template_data() {
 		info.file_list = { "ios.zip" };
 		template_data[TemplateID::IOS] = info;
 	}
+	{
+		TemplateInfo info;
+		info.name = "visionOS";
+		info.description = TTRC("Build for Apple's visionOS.");
+		info.file_list = { "visionos.zip" };
+		template_data[TemplateID::VISIONOS] = info;
+	}
 
 	{
 		TemplateInfo info;
@@ -542,6 +549,14 @@ void ExportTemplateManager::_initialize_template_data() {
 		info.templates = { TemplateID::IOS };
 		info.group = TTR("Mobile", "Platform Group");
 		platform_map[PlatformID::IOS] = info;
+	}
+	{
+		PlatformInfo info;
+		info.name = "visionOS";
+		info.icon = _get_platform_icon("visionOS");
+		info.templates = { TemplateID::VISIONOS };
+		info.group = TTR("Mobile", "Platform Group");
+		platform_map[PlatformID::VISIONOS] = info;
 	}
 	{
 		PlatformInfo info;

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -317,6 +317,13 @@ void ExportTemplateManager::_initialize_template_data() {
 		info.file_list = { "ios.zip" };
 		template_data[TemplateID::IOS] = info;
 	}
+	{
+		TemplateInfo info;
+		info.name = "visionOS";
+		info.description = TTRC("Build for Apple's visionOS.");
+		info.file_list = { "visionos.zip" };
+		template_data[TemplateID::VISIONOS] = info;
+	}
 
 	{
 		TemplateInfo info;
@@ -366,6 +373,14 @@ void ExportTemplateManager::_initialize_template_data() {
 		info.templates = { TemplateID::IOS };
 		info.group = TTR("Mobile", "Platform Group");
 		platform_map[PlatformID::IOS] = info;
+	}
+	{
+		PlatformInfo info;
+		info.name = "visionOS";
+		info.icon = _get_platform_icon("visionOS");
+		info.templates = { TemplateID::VISIONOS };
+		info.group = TTR("Mobile", "Platform Group");
+		platform_map[PlatformID::VISIONOS] = info;
 	}
 	{
 		PlatformInfo info;

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -117,6 +117,7 @@ class ExportTemplateManager : public AcceptDialog {
 		ANDROID_SOURCE,
 
 		IOS,
+		VISIONOS,
 
 		ICU_DATA,
 	};
@@ -128,6 +129,7 @@ class ExportTemplateManager : public AcceptDialog {
 		WEB,
 		ANDROID,
 		IOS,
+		VISIONOS,
 		COMMON,
 	};
 

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -134,6 +134,7 @@ class ExportTemplateManager : public AcceptDialog {
 		ANDROID,
 
 		IOS,
+		VISIONOS,
 
 		ICU_DATA,
 	};
@@ -145,6 +146,7 @@ class ExportTemplateManager : public AcceptDialog {
 		WEB,
 		ANDROID,
 		IOS,
+		VISIONOS,
 		COMMON,
 	};
 


### PR DESCRIPTION
Fixes #118702.

Adds visionOS to the per-platform export template download list in the Export Template Manager, introduced by #117072.

The TemplateID and PlatformID enums in export_template_manager.h had no visionOS entry, causing it to be absent from the download UI despite visionOS having a fully implemented export plugin under platform/visionos/.

<img width="764" height="1318" alt="スクリーンショット 2026-04-18 092230" src="https://github.com/user-attachments/assets/1d67adde-c31e-443e-b4b8-d30b02d5115b" />

> [!NOTE]
> The template filename is currently set to visionos.zip as a placeholder, since no official visionOS export templates have been built yet. Please point out the correct filename if it differs.