### PR TITLE
Fix the credits not being centered

### DIFF
--- a/editor/gui/credits_roll.cpp
+++ b/editor/gui/credits_roll.cpp
@@ -230,7 +230,7 @@ void CreditsRoll::roll_credits() {
 		_create_nothing(400 * EDSCALE);
 		_create_label(TTRC("Thank you for choosing Godot Engine!"), LabelSize::BIG_HEADER);
 	}
-	// Needs to be set here, so it stays centered even if the window is resized.
+	// Needs to be set here, otherwise the starting position will be incorrect.
 	content->set_anchors_and_offsets_preset(Control::PRESET_VCENTER_WIDE);
 
 	Window *root = get_tree()->get_root();
@@ -247,5 +247,6 @@ CreditsRoll::CreditsRoll() {
 	add_child(background);
 
 	content = memnew(VBoxContainer);
+	content->set_grow_direction_preset(Control::PRESET_VCENTER_WIDE);
 	add_child(content);
 }


### PR DESCRIPTION
* Fixes #118696 

#118536 introduced a deferred `_update_minimum_size()` call, which, for some reason, messed up the credits roll. 
Turns out, due to the way the credits are constructed, this deferred update caused the content VBox to realize "oh, hey, I'm supposed to expand since I have content", a realization it was not having before somehow. So the bug had actually been dormant until now, and it's only now that it's triggered by this deferred call. 
I'm still not exactly sure how that's possible, but that knowledge is not needed to fix it.

The solution: simply make it grow correctly. 

AI disclaimer: Opus 4.6 helped me understand what changed with the commit from that PR. Once it told me, the fix was trivial, and I did it myself. 