### PR TITLE
Add search bar for the Opened Scenes List popup

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -500,6 +500,7 @@ EditorSceneTabs::EditorSceneTabs() {
 	scene_list->set_accessibility_name(TTRC("Show Opened Scenes List"));
 	scene_list->set_shortcut(ED_SHORTCUT("editor/show_opened_scenes_list", TTRC("Show Opened Scenes List"), KeyModifierMask::ALT | Key::T));
 	scene_list->get_popup()->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	scene_list->get_popup()->set_search_bar_enabled_on_item_count(10);
 	scene_list->get_popup()->connect("about_to_popup", callable_mp(this, &EditorSceneTabs::_update_scene_list));
 	scene_list->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
 	tabbar_container->add_child(scene_list);


### PR DESCRIPTION
As suggested in https://github.com/godotengine/godot/pull/108079#issuecomment-3016350723
Similar to https://github.com/godotengine/godot/pull/118413

<img src="https://github.com/user-attachments/assets/6fc3e265-425b-44c0-9a1a-d862bed08661" />
