### PR TITLE
Disable shader previews for loops

### DIFF
--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -316,6 +316,39 @@ String TextShaderPreview::_get_enclosing_function(const PackedStringArray &p_lin
 	return String(); // Global scope.
 }
 
+bool TextShaderPreview::_is_inside_loop(const PackedStringArray &p_lines, int p_line) const {
+	int brace_stack = 0;
+
+	Ref<RegEx> loop_regex;
+	loop_regex.instantiate();
+	loop_regex->compile(R"(\b(for|while|do)\b)");
+
+	Ref<RegEx> func_regex;
+	func_regex.instantiate();
+	func_regex->compile(R"(\b(?!for\b|while\b|do\b|if\b|else\b|return\b|switch\b)\w+\s+\w+\s*\()");
+
+	for (int i = p_line; i >= 0; i--) {
+		String clean_line = p_lines[i].split("//")[0].strip_edges();
+		if (clean_line.is_empty()) {
+			continue;
+		}
+
+		brace_stack += clean_line.count("}");
+		brace_stack -= clean_line.count("{");
+
+		if (brace_stack < 0) {
+			if (loop_regex->search(clean_line).is_valid()) {
+				return true;
+			}
+			if (func_regex->search(clean_line).is_valid()) {
+				return false;
+			}
+		}
+	}
+
+	return false;
+}
+
 bool TextShaderPreview::_find_statement(const PackedStringArray &p_lines, int p_line, String &r_var_name, int &r_start, int &r_end) const {
 	Ref<RegEx> var_regex;
 	var_regex.instantiate();
@@ -547,6 +580,11 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 
 	if (enclosing_function != "fragment") {
 		_show_error(TTRC("Preview only supports assignments in the `fragment()` function."));
+		return;
+	}
+
+	if (_is_inside_loop(lines, p_line)) {
+		_show_error(TTRC("Preview is not supported inside loops."));
 		return;
 	}
 

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -77,6 +77,7 @@ private:
 	static HashMap<String, String> builtin_canvas_types;
 
 	String _get_enclosing_function(const PackedStringArray &p_lines, int p_line) const;
+	bool _is_inside_loop(const PackedStringArray &p_lines, int p_line) const;
 	bool _find_statement(const PackedStringArray &p_lines, int p_line, String &r_var_name, int &r_start, int &r_end) const;
 	String _find_var_type(const PackedStringArray &p_lines, const String &p_var_name, int p_line, bool p_mode_3d);
 	bool _match_uniforms(const Ref<ShaderMaterial> &p_source, const Ref<ShaderMaterial> &p_target) const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Closes https://github.com/godotengine/godot/issues/118639 by removing the preview feature inside loops.

https://github.com/user-attachments/assets/1a9621dd-dc54-4fa5-bd5b-ab2bfcce55a7

Note: The function regex is pretty complex. I initially wanted to only check for `void\s+fragment\s*\(` since the previewer only works inside the fragment function, but I thought it'd be a better idea to make this generic in case someone in the future wants to use this function for a different check, unrelated to the previewer functionality