### PR TITLE
Add optional default value argument for GDScript Object.get()

### DIFF
--- a/core/object/object.compat.inc
+++ b/core/object/object.compat.inc
@@ -43,8 +43,13 @@ bool Object::_is_class_bind_compat_118582(const String &p_name) const {
 	return false;
 }
 
+Variant Object::_get_bind_compat_118717(const StringName &p_name) const {
+	return _get_bind(p_name, Variant());
+}
+
 void Object::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_class", "class"), &Object::_is_class_bind_compat_118582);
+	ClassDB::bind_compatibility_method(D_METHOD("get", "property"), &Object::_get_bind_compat_118717);
 }
 
 #else

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1673,8 +1673,13 @@ void Object::_set_bind(const StringName &p_set, const Variant &p_value) {
 	set(p_set, p_value);
 }
 
-Variant Object::_get_bind(const StringName &p_name) const {
-	return get(p_name);
+Variant Object::_get_bind(const StringName &p_name, const Variant &p_default) const {
+	bool valid = false;
+	Variant value = get(p_name, &valid);
+	if (valid) {
+		return value;
+	}
+	return p_default;
 }
 
 void Object::_set_indexed_bind(const NodePath &p_name, const Variant &p_value) {
@@ -1823,7 +1828,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
-	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
+	ClassDB::bind_method(D_METHOD("get", "property", "default"), &Object::_get_bind, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("set_indexed", "property_path", "value"), &Object::_set_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -478,7 +478,7 @@ private:
 	TypedArray<Dictionary> _get_signal_connection_list(const StringName &p_signal) const;
 	TypedArray<Dictionary> _get_incoming_connections() const;
 	void _set_bind(const StringName &p_set, const Variant &p_value);
-	Variant _get_bind(const StringName &p_name) const;
+	Variant _get_bind(const StringName &p_name, const Variant &p_default) const;
 	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
 	Variant _get_indexed_bind(const NodePath &p_name) const;
 	int _get_method_argument_count_bind(const StringName &p_name) const;
@@ -615,6 +615,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	bool _is_class_bind_compat_118582(const String &p_name) const;
+	Variant _get_bind_compat_118717(const StringName &p_name) const;
 #endif
 
 public: // Should be protected, but bug in clang++.

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -571,8 +571,9 @@
 		<method name="get" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
+			<param index="1" name="default" type="Variant" default="null" />
 			<description>
-				Returns the [Variant] value of the given [param property]. If the [param property] does not exist, this method returns [code]null[/code].
+				Returns the [Variant] value of the given [param property]. If the [param property] does not exist, this method returns [param default].
 				[codeblocks]
 				[gdscript]
 				var node = Node2D.new()
@@ -586,6 +587,19 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.
+				Specifying a [param default] eliminates the need to check whether a property exists before using its value. This is particularly useful when handling objects of unknown type, or when a property is only defined on some objects in a collection.
+				[codeblocks]
+				[gdscript]
+				func double_rotation(object: Object) -&gt; float:
+					return 2 * object.get("rotation", 0.0)
+				[/gdscript]
+				[csharp]
+				private static float DoubleRotation(GodotObject obj)
+				{
+					return 2.0 * (float)obj.Get(Node2D.PropertyName.Rotation, 0.0f);
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_class" qualifiers="const">

--- a/misc/extension_api_validation/4.6-stable/GH-118717.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-118717.txt
@@ -1,0 +1,6 @@
+GH-118717
+---------
+Validate extension JSON: Error: Field 'classes/Object/methods/get/arguments': size changed value in new API, from 1 to 2.
+
+Added optional "default" argument to get method in Object class.
+Compatibility methods registered.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/overriding_native_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/overriding_native_method.gd
@@ -1,5 +1,5 @@
 func test():
 	print("warn")
 
-func get(_property: StringName) -> Variant:
+func get(_property: StringName, _default: Variant = null) -> Variant:
 	return null

--- a/modules/gdscript/tests/scripts/runtime/object_get_default.gd
+++ b/modules/gdscript/tests/scripts/runtime/object_get_default.gd
@@ -1,0 +1,9 @@
+class MyObject:
+	var my_prop = 0
+
+func test():
+	var obj = MyObject.new()
+	print(obj.get('my_prop'))
+	print(obj.get('my_prop', -1))
+	print(obj.get('missing_prop'))
+	print(obj.get('missing_prop', -1))

--- a/modules/gdscript/tests/scripts/runtime/object_get_default.out
+++ b/modules/gdscript/tests/scripts/runtime/object_get_default.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+0
+0
+<null>
+-1


### PR DESCRIPTION
This PR adds a `default` parameter to the GDScript/scripting binding of `Object.get()`, allowing a fallback value to be returned when the property does not exist:

```gdscript
# Before: requires a null check
var rotation = obj.get("rotation")
if rotation == null:
    rotation = 0.0

# After
var rotation = obj.get("rotation", 0.0)
```

**Why this is a GDScript binding change only**

A previous attempt to make this change at the C++ level (#80841) stalled due to the scope of changes required across the codebase. There was a suggestion in that PR that a binding-level solution may be the appropriate path. This PR implements exactly that.

The underlying C++ API is unchanged. A default value is already achievable in C++ using the existing `r_valid` flag, that is not available in GDScript:

```cpp
bool valid;
Variant result = obj->get("rotation", &valid);
float rotation = valid ? (float)result : 0.0f;
```

Supersedes #80841
closes https://github.com/godotengine/godot-proposals/issues/3841

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
