### PR TITLE
Add setting to adjust maximum number of lights that can affect VoxelGI

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3070,6 +3070,10 @@
 			The number of rays to throw per frame when computing signed distance field global illumination. Higher values lead to a less noisy result, at the cost of performance. See also [member rendering/global_illumination/sdfgi/frames_to_converge] and [member rendering/global_illumination/sdfgi/frames_to_update_lights].
 			[b]Note:[/b] This property is only read when the project starts. To control SDFGI quality at runtime, call [method RenderingServer.environment_set_sdfgi_ray_count] instead.
 		</member>
+		<member name="rendering/global_illumination/voxel_gi/max_lights" type="int" setter="" getter="" default="32">
+			The maximum number of [Light3D]s that can affect [VoxelGI] instances in the scene. If more lights than this number are used within the bounds of [i]all[/i] VoxelGI instances, they will be ignored by VoxelGI but will still render real-time direct light. Setting this lower than the default will slightly reduce memory usage and may decrease shader compile times. To get the best possible performance, only set this value as high as you need it.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.
+		</member>
 		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="0">
 			The VoxelGI quality to use. High quality leads to more precise lighting and better reflections, but is slower to render. This setting does not affect the baked data and doesn't require baking the [VoxelGI] again to apply.
 			[b]Note:[/b] This property is only read when the project starts. To control VoxelGI quality at runtime, call [method RenderingServer.voxel_gi_set_quality] instead.

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3506,6 +3506,8 @@ GI::GI() {
 	sdfgi_ray_count = RSE::EnvironmentSDFGIRayCount(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")), 0, int32_t(RSE::ENV_SDFGI_RAY_COUNT_MAX - 1)));
 	sdfgi_frames_to_converge = RSE::EnvironmentSDFGIFramesToConverge(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")), 0, int32_t(RSE::ENV_SDFGI_CONVERGE_MAX - 1)));
 	sdfgi_frames_to_update_light = RSE::EnvironmentSDFGIFramesToUpdateLight(CLAMP(int32_t(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_update_lights")), 0, int32_t(RSE::ENV_SDFGI_UPDATE_LIGHT_MAX - 1)));
+
+	voxel_gi_max_lights = CLAMP(uint32_t(GLOBAL_GET("rendering/global_illumination/voxel_gi/max_lights")), uint32_t(1), uint32_t(512));
 }
 
 GI::~GI() {

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3707,6 +3707,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"), 0);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/max_lights", PROPERTY_HINT_RANGE, "1,512,1"), 32);
 
 	GLOBAL_DEF_RST("rendering/shading/overrides/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley", false);


### PR DESCRIPTION
The number of lights that can affect all VoxelGI instances in the scene used to be hardcoded to 32. This can now be increased up to 512, at the cost of increased shader compilation times and memory usage. This can also be decreased to slightly reduce memory usage if you only need a few lights.

To get the best possible performance, only set this value as high as you need it.

- This closes https://github.com/godotengine/godot/issues/117297.

**Testing project:** [test_voxelgi_light_count.zip](https://github.com/user-attachments/files/26856767/test_voxelgi_light_count.zip)

## Preview

*Scene has 100 lights in a 10×10 arrangement.*

No GI | SDFGI[^1] | VoxelGI `master` | VoxelGI (this PR with max lights = 100)
-|-|-|-
<img width="1152" height="648" alt="Screenshot_20260418_165002_no_gi" src="https://github.com/user-attachments/assets/e3602b23-96c5-4eae-891d-e616f7fb8c51" /> | <img width="1152" height="648" alt="Screenshot_20260418_164748_sdfgi" src="https://github.com/user-attachments/assets/4ff8bb39-0b58-42e7-ab13-c93c986d56e8" /> | <img width="1152" height="648" alt="Screenshot_20260418_164733_voxelgi" src="https://github.com/user-attachments/assets/765c7044-92c9-4aa9-b4f8-58e3880de501" /> | <img width="1152" height="648" alt="Screenshot_20260418_165614_increased_limit" src="https://github.com/user-attachments/assets/93fcd108-6c2d-4b6b-a0ac-146b3a869a14" />

In the editor with 512 lights:

Max Lights = 32 | Max Lights = 512
-|-
<img width="1920" height="1052" alt="Screenshot_20260418_170154" src="https://github.com/user-attachments/assets/953d1622-3f3f-4354-9b0c-3d1602ad6118" /> | <img width="1920" height="1052" alt="Screenshot_20260418_170135" src="https://github.com/user-attachments/assets/8e50859c-6a02-41c1-a517-abf74358dd6c" />

[^1]: Renders indirect light for all 100 lights correctly.

## TODO

- [ ] Test on old/low-end GPUs (that can still run Forward+) to make sure the highest possible value (currently `512`) works without shader compilation errors or rendering glitches.