### PR TITLE
Fix leaked `custom_ci` RIDs in `Tree`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -7493,5 +7493,6 @@ Tree::~Tree() {
 	}
 	RenderingServer::get_singleton()->free_rid(drop_indicator_ci);
 	RenderingServer::get_singleton()->free_rid(content_ci);
+	RenderingServer::get_singleton()->free_rid(custom_ci);
 	RenderingServer::get_singleton()->free_rid(header_ci);
 }


### PR DESCRIPTION
- Resolves #118721

Frees `custom_ci` in the destructor of `Tree` which otherwise causes warnings when a project is closed.