### PR TITLE
Fix ItemList Shift+Up/Down selection using wrong column count

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -928,7 +928,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		// Shift Up Selection.
 		if (select_mode == SELECT_MULTI && p_event->is_action("ui_up", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
-			int next = MAX(current - max_columns, 0);
+			int next = MAX(current - current_columns, 0);
 			_shift_range_select(current, next);
 			accept_event();
 		}
@@ -975,7 +975,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 		// Shift Down Selection.
 		else if (select_mode == SELECT_MULTI && p_event->is_action("ui_down", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
-			int next = MIN(current + max_columns, items.size() - 1);
+			int next = MIN(current + current_columns, items.size() - 1);
 			_shift_range_select(current, next);
 			accept_event();
 		}


### PR DESCRIPTION
FIx #118723
When "max_columns" is set to 0 (auto), the selection offset becomes 0 and Shift+Up/Down does nothing.
Changed to use "current_columns" to match regular navigation behavior.