### PR TITLE
Fix sub-emitter AT_START first emission lost after inactivity

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1153,8 +1153,10 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 
 	if (sub_emitter && sub_emitter->emission_storage_buffer.is_valid()) {
 		//	print_line("updating subemitter buffer");
-		int32_t zero[4] = { 0, sub_emitter->amount, 0, 0 };
-		RD::get_singleton()->buffer_update(sub_emitter->emission_storage_buffer, 0, sizeof(uint32_t) * 4, zero);
+		if (!sub_emitter->force_sub_emit) {
+			int32_t zero[4] = { 0, sub_emitter->amount, 0, 0 };
+			RD::get_singleton()->buffer_update(sub_emitter->emission_storage_buffer, 0, sizeof(uint32_t) * 4, zero);
+		}
 		push_constant.can_emit = true;
 
 		if (sub_emitter->emitting) {


### PR DESCRIPTION
**Summary of changes:** Only clear the sub-emitter buffer when force_sub_emit is false.

**Motivation:** [issue](https://github.com/godotengine/godot/issues/118727) - GPUParticles3D sub-emitter AT_START: first emission after inactivity does not spawns sub-particles

**Related work:** N/A

**Technical overview:** Only clear the sub-emitter buffer when force_sub_emit is false, indicating the sub-emitter has consumed its data. force_sub_emit is set to true by the parent, and reset to false by the sub-emitter at the start of its own _particles_process().

**Testing:** Manually tested in my own game. I also created a dedicated scene consistently demonstrating this bug (see [issue](https://github.com/godotengine/godot/issues/118727)). After applying the fix the bug disappeared. Additionally confirmed with print_line debugging that force_sub_emit was indeed true when the buffer was being cleared, validating the root cause.

**Discussion:** Particles are complex systems, as a first time contributor feels impossible to oversee and test all possible scenario's. However, I believe the question to be answered is: "Why would anyone want to unconditionally clear the sub-emitter buffer when force_sub_emit is set to true?". I couldn't think of a good reason.

**Additional work:** N/A

**AI disclosure:** I used Claude to explore the engine codebase. The bug discovery, analysis, and fix are my own work.

- *Bugsquad edit:* This PR fixes https://github.com/godotengine/godot/issues/118727