### PR TITLE
Add settings for FXAA iterations and subpixel quality.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2853,18 +2853,6 @@
 			[b]Note:[/b] [Control] nodes are snapped to the nearest pixel by default. This is controlled by [member gui/common/snap_controls_to_pixels].
 			[b]Note:[/b] It is not recommended to use this setting together with [member rendering/2d/snap/snap_2d_transforms_to_pixel], as movement may appear even less smooth. Prefer only enabling that setting instead.
 		</member>
-		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
-			Sets the maximum threshold for dealing with subpixel aliasing. A higher value restricts smoothing to sharp edges, but may leave some aliasing. A lower value detects more edges, but may increase blurring.
-		</member>
-		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
-			Sets the minimum threshold for dealing with subpixel aliasing. A higher value prevents the algorithm from processing low contrast areas, reducing blurring but increasing aliasing. A lower value increases blurring but decreases aliasing.
-		</member>
-		<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
-			Sets the maximum steps along an edge the algorithm will perform. A higher value may result in more effective aliasing on long edges, with a moderate performance decrease.
-		</member>
-		<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
-			Sets the strength of the subpixel blur used by the algorithm. Lower values may result in a sharper image, but with more aliasing. Higher values may result in a less sharp, but less aliased image.
-		</member>
 		<member name="rendering/anti_aliasing/quality/msaa_2d" type="int" setter="" getter="" default="0">
 			Sets the number of multisample antialiasing (MSAA) samples to use for 2D/Canvas rendering (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware, especially integrated graphics due to their limited memory bandwidth. This has no effect on shader-induced aliasing or texture aliasing.
 			[b]Note:[/b] MSAA is only supported in the Forward+ and Mobile rendering methods, not Compatibility.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2868,6 +2868,14 @@
 			[b]Note:[/b] Screen-space antialiasing is only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 			[b]Note:[/b] This property is only read when the project starts. To set the screen-space antialiasing mode at runtime, set [member Viewport.screen_space_aa] on the root [Viewport] instead, or use [method RenderingServer.viewport_set_screen_space_aa].
 		</member>
+			<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
++		</member>
++			<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
++		</member>
++			<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
++		</member>
++			<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
++		</member>
 		<member name="rendering/anti_aliasing/quality/smaa_edge_detection_threshold" type="float" setter="" getter="" default="0.05">
 			Sets the sensitivity to edges when using SMAA for antialiasing. Lower values will catch more edges, at a potentially higher performance cost.
 			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2853,6 +2853,18 @@
 			[b]Note:[/b] [Control] nodes are snapped to the nearest pixel by default. This is controlled by [member gui/common/snap_controls_to_pixels].
 			[b]Note:[/b] It is not recommended to use this setting together with [member rendering/2d/snap/snap_2d_transforms_to_pixel], as movement may appear even less smooth. Prefer only enabling that setting instead.
 		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
+			Sets the maximum threshold for dealing with subpixel aliasing. A higher value restricts smoothing to sharp edges, but may leave some aliasing. A lower value detects more edges, but may increase blurring.
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
+			Sets the minimum threshold for dealing with subpixel aliasing. A higher value prevents the algorithm from processing low contrast areas, reducing blurring but increasing aliasing. A lower value increases blurring but decreases aliasing.
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
+			Sets the maximum steps along an edge the algorithm will perform. A higher value may result in more effective aliasing on long edges, with a moderate performance decrease.
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
+			Sets the strength of the subpixel blur used by the algorithm. Lower values may result in a sharper image, but with more aliasing. Higher values may result in a less sharp, but less aliased image.
+		</member>
 		<member name="rendering/anti_aliasing/quality/msaa_2d" type="int" setter="" getter="" default="0">
 			Sets the number of multisample antialiasing (MSAA) samples to use for 2D/Canvas rendering (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware, especially integrated graphics due to their limited memory bandwidth. This has no effect on shader-induced aliasing or texture aliasing.
 			[b]Note:[/b] MSAA is only supported in the Forward+ and Mobile rendering methods, not Compatibility.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2854,12 +2854,16 @@
 			[b]Note:[/b] It is not recommended to use this setting together with [member rendering/2d/snap/snap_2d_transforms_to_pixel], as movement may appear even less smooth. Prefer only enabling that setting instead.
 		</member>
 		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
+			Sets the maximum threshold for dealing with subpixel aliasing. A higher value restricts smoothing to sharp edges, but may leave some aliasing. A lower value detects more edges, but may increase blurring.
 		</member>
 		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
+			Sets the minimum threshold for dealing with subpixel aliasing. A higher value prevents the algorithm from processing low contrast areas, reducing blurring but increasing aliasing. A lower value increases blurring but decreases aliasing.
 		</member>
 		<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
+			Sets the maximum steps along an edge the algorithm will perform. A higher value may result in more effective aliasing on long edges, with a moderate performance decrease.
 		</member>
 		<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
+			Sets the strength of the subpixel blur used by the algorithm. Lower values may result in a sharper image, but with more aliasing. Higher values may result in a less sharp, but less aliased image.
 		</member>
 		<member name="rendering/anti_aliasing/quality/msaa_2d" type="int" setter="" getter="" default="0">
 			Sets the number of multisample antialiasing (MSAA) samples to use for 2D/Canvas rendering (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware, especially integrated graphics due to their limited memory bandwidth. This has no effect on shader-induced aliasing or texture aliasing.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2853,6 +2853,14 @@
 			[b]Note:[/b] [Control] nodes are snapped to the nearest pixel by default. This is controlled by [member gui/common/snap_controls_to_pixels].
 			[b]Note:[/b] It is not recommended to use this setting together with [member rendering/2d/snap/snap_2d_transforms_to_pixel], as movement may appear even less smooth. Prefer only enabling that setting instead.
 		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
+		</member>
+		<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
+		</member>
 		<member name="rendering/anti_aliasing/quality/msaa_2d" type="int" setter="" getter="" default="0">
 			Sets the number of multisample antialiasing (MSAA) samples to use for 2D/Canvas rendering (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware, especially integrated graphics due to their limited memory bandwidth. This has no effect on shader-induced aliasing or texture aliasing.
 			[b]Note:[/b] MSAA is only supported in the Forward+ and Mobile rendering methods, not Compatibility.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2868,14 +2868,6 @@
 			[b]Note:[/b] Screen-space antialiasing is only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 			[b]Note:[/b] This property is only read when the project starts. To set the screen-space antialiasing mode at runtime, set [member Viewport.screen_space_aa] on the root [Viewport] instead, or use [method RenderingServer.viewport_set_screen_space_aa].
 		</member>
-			<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_max" type="float" setter="" getter="" default="0.125">
-+		</member>
-+			<member name="rendering/anti_aliasing/quality/fxaa_edge_threshold_min" type="float" setter="" getter="" default="0.0312">
-+		</member>
-+			<member name="rendering/anti_aliasing/quality/fxaa_iterations" type="int" setter="" getter="" default="12">
-+		</member>
-+			<member name="rendering/anti_aliasing/quality/fxaa_subpixel_quality" type="float" setter="" getter="" default="0.75">
-+		</member>
 		<member name="rendering/anti_aliasing/quality/smaa_edge_detection_threshold" type="float" setter="" getter="" default="0.05">
 			Sets the sensitivity to edges when using SMAA for antialiasing. Lower values will catch more edges, at a potentially higher performance cost.
 			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -34,6 +34,20 @@
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
 
+#include "core/config/project_settings.h"
+#include "core/math/math_defs.h"
+#include "servers/rendering/renderer_rd/effects/copy_effects.h"
+#include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
+#include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_data_rd.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"
+#include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
+#include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
+#include "servers/rendering/rendering_server_default.h"
+#include "servers/rendering/rendering_server_globals.h"
+
 using namespace RendererRD;
 
 ToneMapper::ToneMapper(bool p_use_mobile_version) {
@@ -141,6 +155,9 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	tonemap.push_constant.glow_texture_size[0] = p_settings.glow_texture_size.x;
 	tonemap.push_constant.glow_texture_size[1] = p_settings.glow_texture_size.y;
 	tonemap.push_constant.glow_mode = p_settings.glow_mode;
+
+	tonemap.push_constant.fxaa_subpixel_quality = p_settings.fxaa_subpixel_quality;
+	tonemap.push_constant.fxaa_iterations = p_settings.fxaa_iterations;
 
 	int mode = p_settings.glow_use_bicubic_upscale ? TONEMAP_MODE_BICUBIC_GLOW_FILTER : TONEMAP_MODE_NORMAL;
 	if (p_settings.use_1d_color_correction) {

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -34,8 +34,6 @@
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
 
-#include "core/config/project_settings.h"
-
 using namespace RendererRD;
 
 ToneMapper::ToneMapper(bool p_use_mobile_version) {

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -35,18 +35,6 @@
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
 
 #include "core/config/project_settings.h"
-#include "core/math/math_defs.h"
-#include "servers/rendering/renderer_rd/effects/copy_effects.h"
-#include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
-#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
-#include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
-#include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
-#include "servers/rendering/renderer_rd/storage_rd/render_data_rd.h"
-#include "servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"
-#include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
-#include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
-#include "servers/rendering/rendering_server_default.h"
-#include "servers/rendering/rendering_server_globals.h"
 
 using namespace RendererRD;
 

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -124,6 +124,8 @@ private:
 		float tonemapper_params[4]; //  16 - 112
 
 		float fxaa_subpixel_quality;
+		float fxaa_edge_threshold_min;
+		float fxaa_edge_threshold_max;
 		uint32_t fxaa_iterations;
 	};
 
@@ -199,6 +201,8 @@ public:
 
 		bool use_fxaa = false;
 		float fxaa_subpixel_quality = 0.75f;
+		float fxaa_edge_threshold_min = 0.0312f;
+		float fxaa_edge_threshold_max = 0.125f;
 		uint32_t fxaa_iterations = 12;
 
 		enum DebandingMode {

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -122,6 +122,9 @@ private:
 		float luminance_multiplier; //  4 - 96
 
 		float tonemapper_params[4]; //  16 - 112
+
+		float fxaa_subpixel_quality;
+		uint32_t fxaa_iterations;
 	};
 
 	struct TonemapPushConstantMobile {
@@ -195,6 +198,9 @@ public:
 		RID color_correction_texture;
 
 		bool use_fxaa = false;
+		float fxaa_subpixel_quality = 0.75f;
+		uint32_t fxaa_iterations = 12;
+
 		enum DebandingMode {
 			DEBANDING_MODE_DISABLED,
 			DEBANDING_MODE_8_BIT,

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -719,6 +719,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		if (rb->get_screen_space_aa() == RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA) {
 			tonemap.use_fxaa = true;
+			tonemap.fxaa_subpixel_quality = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_subpixel_quality");
+			tonemap.fxaa_iterations = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_iterations");
 		}
 
 		tonemap.texture_size = Vector2i(color_size.x, color_size.y);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -720,6 +720,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		if (rb->get_screen_space_aa() == RSE::VIEWPORT_SCREEN_SPACE_AA_FXAA) {
 			tonemap.use_fxaa = true;
 			tonemap.fxaa_subpixel_quality = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_subpixel_quality");
+			tonemap.fxaa_edge_threshold_min = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_edge_threshold_min");
+			tonemap.fxaa_edge_threshold_max = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_edge_threshold_max");
 			tonemap.fxaa_iterations = GLOBAL_GET("rendering/anti_aliasing/quality/fxaa_iterations");
 		}
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -86,6 +86,8 @@ layout(push_constant, std430) uniform Params {
 	vec4 tonemapper_params;
 
 	float fxaa_subpixel_quality;
+	float fxaa_edge_threshold_min;
+	float fxaa_edge_threshold_max;
 	uint fxaa_iterations;
 }
 params;
@@ -542,8 +544,8 @@ float rgb2luma(vec3 rgb) {
 }
 
 vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
-	const float EDGE_THRESHOLD_MIN = 0.0312;
-	const float EDGE_THRESHOLD_MAX = 0.125;
+	const float EDGE_THRESHOLD_MIN = params.fxaa_edge_threshold_min;
+	const float EDGE_THRESHOLD_MAX = params.fxaa_edge_threshold_max;
 
 	const uint ITERATIONS = params.fxaa_iterations;
 	const float SUBPIXEL_QUALITY = params.fxaa_subpixel_quality;

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -62,7 +62,7 @@ layout(set = 3, binding = 0) uniform sampler3D source_color_correction;
 #define FLAG_USE_FXAA (1 << 4)
 #define FLAG_USE_8_BIT_DEBANDING (1 << 5)
 #define FLAG_CONVERT_TO_SRGB (1 << 6)
-
+	
 layout(push_constant, std430) uniform Params {
 	vec3 bcs;
 	uint flags;
@@ -84,6 +84,9 @@ layout(push_constant, std430) uniform Params {
 	float luminance_multiplier;
 
 	vec4 tonemapper_params;
+
+	float fxaa_subpixel_quality;
+	uint fxaa_iterations;
 }
 params;
 
@@ -541,8 +544,9 @@ float rgb2luma(vec3 rgb) {
 vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 	const float EDGE_THRESHOLD_MIN = 0.0312;
 	const float EDGE_THRESHOLD_MAX = 0.125;
-	const int ITERATIONS = 12;
-	const float SUBPIXEL_QUALITY = 0.75;
+
+	const uint ITERATIONS = params.fxaa_iterations;
+	const float SUBPIXEL_QUALITY = params.fxaa_subpixel_quality;
 
 #ifdef USE_MULTIVIEW
 	float lumaUp = rgb2luma(textureLodOffset(source_color, vec3(uv_interp, ViewIndex), 0.0, ivec2(0, 1)).xyz * exposure * params.luminance_multiplier);

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -62,7 +62,7 @@ layout(set = 3, binding = 0) uniform sampler3D source_color_correction;
 #define FLAG_USE_FXAA (1 << 4)
 #define FLAG_USE_8_BIT_DEBANDING (1 << 5)
 #define FLAG_CONVERT_TO_SRGB (1 << 6)
-	
+
 layout(push_constant, std430) uniform Params {
 	vec3 bcs;
 	uint flags;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3749,6 +3749,8 @@ void RenderingServer::init() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/smaa_edge_detection_threshold", PROPERTY_HINT_RANGE, "0.01,0.2,0.01"), 0.05);
 
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/fxaa_subpixel_quality", PROPERTY_HINT_RANGE, "0.0,1.0"), 0.75f);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/fxaa_edge_threshold_min", PROPERTY_HINT_RANGE, "0.0,1.0"), 0.0312f);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/fxaa_edge_threshold_max", PROPERTY_HINT_RANGE, "0.0,1.0"), 0.125f);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/fxaa_iterations", PROPERTY_HINT_RANGE, "1,32"), 12);
 
 	GLOBAL_DEF("rendering/anti_aliasing/quality/use_debanding", false);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3748,6 +3748,9 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/smaa_edge_detection_threshold", PROPERTY_HINT_RANGE, "0.01,0.2,0.01"), 0.05);
 
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/anti_aliasing/quality/fxaa_subpixel_quality", PROPERTY_HINT_RANGE, "0.0,1.0"), 0.75f);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/fxaa_iterations", PROPERTY_HINT_RANGE, "1,32"), 12);
+
 	GLOBAL_DEF("rendering/anti_aliasing/quality/use_debanding", false);
 
 	{


### PR DESCRIPTION
Advanced settings: <img width="1473" height="545" alt="{73ECB503-5FFF-4F66-8265-5B91003EF6F2}" src="https://github.com/user-attachments/assets/800961c6-6526-4d46-bb30-a396e57a1d14" />
