### PR TITLE
Fix TextServerAdvanced: Stop resetting adv_rem for blanks

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -7300,8 +7300,8 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 				gl.index = 0;
 				gl.advance = 0.0;
 			}
-			if ((p_sd->text[glyph_info[i].cluster] == 0x0009) || u_isblank(p_sd->text[glyph_info[i].cluster]) || is_linebreak(p_sd->text[glyph_info[i].cluster])) {
-				adv_rem = 0.0; // Reset on blank.
+			if ((p_sd->text[glyph_info[i].cluster] == 0x0009) || is_linebreak(p_sd->text[glyph_info[i].cluster])) {
+				adv_rem = 0.0; // Reset on tabs and line breaks.
 			}
 			if (gl.index != 0) {
 				FontGlyph fgl;


### PR DESCRIPTION
**Summary:** Stops resetting `adv_rem` for regular spaces in `TextServerAdvanced::_shape_run()`, while preserving the existing resets for tabs and line breaks.

**Motivation:** Closes #118411.

Monospace text in `CodeEdit` can become visually inconsistent across zoom levels because regular spaces are treated as a reset boundary for fractional advance rounding. This is especially noticeable in whitespace-based alignment such as comment block diagrams and other monospace layouts.

**Technical Overview:** `adv_rem` acts as the carry for fractional advance rounding across shaped glyphs. In this code path, tabs and line breaks should still reset that carry, but regular spaces should remain part of the same shaping run.

This change removes the reset for regular spaces only, so spaces continue the same carry chain as neighboring glyphs instead of incorrectly breaking it.

**Testing:** Built the editor successfully and manually tested the change in the script editor using monospace text in `CodeEdit` with whitespace-based alignment across multiple zoom levels.

After removing the regular-space reset, the alignment remained consistent at all tested zoom levels. Tabs and line breaks still behaved as expected and continued to reset the carry.

**Discussion:** The behavior change is intentionally narrow: it affects only regular spaces in this shaping path and preserves the existing handling for tabs and line breaks.

I also noticed other areas in the text server path where zoom/reset-related behavior is handled, but this looked like the most direct cause of the reported issue.

**Additional Work:** Feedback would be helpful on whether this should stay as a local fix in `_shape_run()` or whether a more central adjustment in the text server chain would be preferable.