### PR TITLE
Fix 3D grid snap precision to use `default_float_step`

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9618,6 +9618,9 @@ void Node3DEditor::_notification(int p_what) {
 				update_all_gizmos();
 			}
 			_update_vertex_snap_tooltips();
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/inspector")) {
+				snap_translate->set_step(EDITOR_GET("interface/inspector/default_float_step"));
+			}
 		} break;
 
 		case NOTIFICATION_PHYSICS_PROCESS: {
@@ -10687,7 +10690,7 @@ Node3DEditor::Node3DEditor() {
 
 	snap_translate = memnew(EditorSpinSlider);
 	snap_translate->set_min(0.0);
-	snap_translate->set_step(0.001);
+	snap_translate->set_step(EDITOR_GET("interface/inspector/default_float_step"));
 	snap_translate->set_max(10.0);
 	snap_translate->set_suffix("m");
 	snap_translate->set_allow_greater(true);


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/118737

Changes:
- 3D grid snap precision now uses `interface/inspector/default_float_step` instead of `0.001`.
  - "Translate Snap" setting updates when the "Snap Settings" pop-up is reopened.

| Before        | After         |
| ------------- | ------------- |
| <img width="155" height="182" alt="Image 2026-04-18_22-30-15" src="https://github.com/user-attachments/assets/9a1a1a19-61d5-462f-af3d-7d63e0b859b3" /> | <img width="155" height="182" alt="Image 2026-04-18_22-50-03" src="https://github.com/user-attachments/assets/5d819469-dc72-4444-92aa-d02abf0b976d" /> |