### PR TITLE
Fix Visual Profiler reference frame line being drawn outside its container

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -489,6 +489,7 @@ void EditorVisualProfiler::_graph_tex_draw() {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 	const Color color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
+	Size2 graph_size = graph->get_size();
 
 	if (seeking) {
 		int max_frames = frame_metrics.size();
@@ -497,17 +498,19 @@ void EditorVisualProfiler::_graph_tex_draw() {
 			frame = 0;
 		}
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph_size.x / 2;
 		int cur_x = frame * half_width / max_frames;
 
-		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph->get_size().y), color * Color(1, 1, 1));
-		graph->draw_line(Vector2(cur_x + half_width, 0), Vector2(cur_x + half_width, graph->get_size().y), color * Color(1, 1, 1));
+		graph->draw_line(Vector2(cur_x, 0), Vector2(cur_x, graph_size.y), color * Color(1, 1, 1));
+		graph->draw_line(Vector2(cur_x + half_width, 0), Vector2(cur_x + half_width, graph_size.y), color * Color(1, 1, 1));
 	}
 
 	if (graph_height_cpu > 0) {
-		int frame_y = graph->get_size().y - graph_limit * graph->get_size().y / graph_height_cpu - 1;
+		int cpu_height = graph_limit * graph_size.y / graph_height_cpu;
+		cpu_height = CLAMP(cpu_height, 0, graph_size.y - (font->get_ascent(font_size) + 2) * 2);
+		int frame_y = graph_size.y - cpu_height - 1;
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph_size.x / 2;
 
 		graph->draw_line(Vector2(0, frame_y), Vector2(half_width, frame_y), color * Color(1, 1, 1, 0.5));
 
@@ -516,18 +519,20 @@ void EditorVisualProfiler::_graph_tex_draw() {
 	}
 
 	if (graph_height_gpu > 0) {
-		int frame_y = graph->get_size().y - graph_limit * graph->get_size().y / graph_height_gpu - 1;
+		int gpu_height = graph_limit * graph_size.y / graph_height_gpu;
+		gpu_height = CLAMP(gpu_height, 0, graph_size.y - (font->get_ascent(font_size) + 2) * 2);
+		int frame_y = graph_size.y - gpu_height - 1;
 
-		int half_width = graph->get_size().x / 2;
+		int half_width = graph_size.x / 2;
 
-		graph->draw_line(Vector2(half_width, frame_y), Vector2(graph->get_size().x, frame_y), color * Color(1, 1, 1, 0.5));
+		graph->draw_line(Vector2(half_width, frame_y), Vector2(graph_size.x, frame_y), color * Color(1, 1, 1, 0.5));
 
 		const String limit_str = String::num(graph_limit, 2) + " ms";
 		graph->draw_string(font, Vector2(half_width * 2 - font->get_string_size(limit_str, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 2, frame_y - 2), limit_str, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
 	}
 
 	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x, font->get_ascent(font_size) + 2), "CPU: " + cpu_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
-	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + graph->get_size().width / 2, font->get_ascent(font_size) + 2), "GPU: " + gpu_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
+	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + graph_size.width / 2, font->get_ascent(font_size) + 2), "GPU: " + gpu_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
 }
 
 void EditorVisualProfiler::_graph_tex_mouse_exit() {


### PR DESCRIPTION
Fixes #118123
Fixes #79842
Fixes #101577

It turned out that when the graph texture is drawn it clamps the values, but when the reference frame line is drawn the `frame_y` value can become negative thus showing outside the graph view. This PR clamps the reference line height to the graph view height. The offset from the top is 2x the font height so the CPU/GPU info line won't be blocked.

I also moved the `graph->get_size()` outside of the conditions because it is used in every each of them and the expressions get very noisy.

Result:

https://github.com/user-attachments/assets/cea49472-5271-4292-b55b-792ecfef6769