### PR TITLE
GDExtension: Clean up types for new `classdb_register_extension_class6`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -240,7 +240,7 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo *p_extension_funcs) {
-	const GDExtensionClassCreationInfo5 class_info5 = {
+	const GDExtensionClassCreationInfo6 class_info6 = {
 		p_extension_funcs->is_virtual, // GDExtensionBool is_virtual;
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		true, // GDExtensionBool is_exposed;
@@ -257,30 +257,30 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
 		p_extension_funcs->reference_func, // GDExtensionClassReference reference_func;
 		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
-		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
+		nullptr, // GDExtensionClassCreateInstance3 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		nullptr, // GDExtensionClassRecreateInstance recreate_instance_func;
-		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
-		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
-		nullptr, // GDExtensionClassCallVirtualWithData call_virtual_func;
+		nullptr, // GDExtensionClassGetVirtual2 get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+		nullptr, // GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
 	};
 
 	const ClassCreationDeprecatedInfo legacy = {
-		false,
+		false, // bool legacy_unexposed_class;
 		p_extension_funcs->notification_func, // GDExtensionClassNotification notification_func;
 		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func;
-		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		nullptr, // GDExtensionClassCreateInstance2 create_instance2_func;
+		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid_func;
 		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
-		nullptr,
-		false, // p_creation_is_with_refcount
+		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 	};
-	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info5, &legacy);
+	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info6, &legacy);
 }
 
 void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo2 *p_extension_funcs) {
-	const GDExtensionClassCreationInfo5 class_info5 = {
+	const GDExtensionClassCreationInfo6 class_info6 = {
 		p_extension_funcs->is_virtual, // GDExtensionBool is_virtual;
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
@@ -297,12 +297,12 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
 		p_extension_funcs->reference_func, // GDExtensionClassReference reference_func;
 		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
-		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
+		nullptr, // GDExtensionClassCreateInstance3 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
-		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
-		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
-		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_func;
+		nullptr, // GDExtensionClassGetVirtual2 get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
 	};
 
@@ -311,16 +311,16 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		nullptr, // GDExtensionClassNotification notification_func;
 		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func;
-		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		nullptr, // GDExtensionClassCreateInstance2 create_instance2_func;
+		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid_func;
 		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
-		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtual get_virtual_func;
-		false, // p_creation_is_with_refcount
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 	};
-	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info5, &legacy);
+	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info6, &legacy);
 }
 
 void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo3 *p_extension_funcs) {
-	const GDExtensionClassCreationInfo5 class_info5 = {
+	const GDExtensionClassCreationInfo6 class_info6 = {
 		p_extension_funcs->is_virtual, // GDExtensionBool is_virtual;
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
@@ -329,7 +329,7 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
 		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
 		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
-		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
+		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList2 free_property_list_func;
 		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
 		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
 		p_extension_funcs->validate_property_func, // GDExtensionClassValidateProperty validate_property_func;
@@ -337,12 +337,12 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
 		p_extension_funcs->reference_func, // GDExtensionClassReference reference_func;
 		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
-		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
+		nullptr, // GDExtensionClassCreateInstance3 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
-		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
-		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
-		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_func;
+		nullptr, // GDExtensionClassGetVirtual2 get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
 	};
 
@@ -350,34 +350,93 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		!p_extension_funcs->is_exposed, // bool legacy_unexposed_class;
 		nullptr, // GDExtensionClassNotification notification_func;
 		nullptr, // GDExtensionClassFreePropertyList free_property_list_func;
-		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance2 create_instance_func;
-		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func;
+		nullptr, // GDExtensionClassCreateInstance2 create_instance2_func;
+		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid_func;
 		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
-		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtual get_virtual_func;
-		false, // p_creation_is_with_refcount
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 	};
-	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info5, &legacy);
+	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info6, &legacy);
 }
 
 void GDExtension::_register_extension_class4(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo4 *p_extension_funcs) {
-	GDExtensionClassCreationInfo5 class_info5 = *p_extension_funcs;
+	const GDExtensionClassCreationInfo6 class_info6 = {
+		p_extension_funcs->is_virtual, // GDExtensionBool is_virtual;
+		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
+		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
+		p_extension_funcs->is_runtime, // GDExtensionBool is_runtime;
+		p_extension_funcs->icon_path, // GDExtensionConstStringPtr icon_path;
+		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
+		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
+		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
+		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList2 free_property_list_func;
+		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
+		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
+		p_extension_funcs->validate_property_func, // GDExtensionClassValidateProperty validate_property_func;
+		p_extension_funcs->notification_func, // GDExtensionClassNotification2 notification_func;
+		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
+		p_extension_funcs->reference_func, // GDExtensionClassReference reference_func;
+		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
+		nullptr, // GDExtensionClassCreateInstance3 create_instance_func; /* this one is mandatory */
+		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
+		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
+		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual2 get_virtual_func;
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
+		p_extension_funcs->class_userdata, // void *class_userdata;
+	};
+
 	const ClassCreationDeprecatedInfo legacy = {
 		!p_extension_funcs->is_exposed, // bool legacy_unexposed_class;
 		nullptr, // GDExtensionClassNotification notification_func;
 		nullptr, // GDExtensionClassFreePropertyList free_property_list_func;
-		nullptr, // GDExtensionClassCreateInstance2 create_instance_func;
-		nullptr, // GDExtensionClassGetRID get_rid;
+		nullptr, // GDExtensionClassCreateInstance create_instance_func;
+		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance2 create_instance2_func;
+		nullptr, // GDExtensionClassGetRID get_rid_func;
 		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
-		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
-		false, // p_creation_is_with_refcount
+		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 	};
-	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info5, &legacy);
+	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info6, &legacy);
 }
 
 void GDExtension::_register_extension_class5(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo5 *p_extension_funcs) {
-	ClassCreationDeprecatedInfo legacy = {};
-	legacy.p_creation_is_with_refcount = false;
-	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, p_extension_funcs, &legacy);
+	const GDExtensionClassCreationInfo6 class_info6 = {
+		p_extension_funcs->is_virtual, // GDExtensionBool is_virtual;
+		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
+		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
+		p_extension_funcs->is_runtime, // GDExtensionBool is_runtime;
+		p_extension_funcs->icon_path, // GDExtensionConstStringPtr icon_path;
+		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
+		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
+		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
+		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList2 free_property_list_func;
+		p_extension_funcs->property_can_revert_func, // GDExtensionClassPropertyCanRevert property_can_revert_func;
+		p_extension_funcs->property_get_revert_func, // GDExtensionClassPropertyGetRevert property_get_revert_func;
+		p_extension_funcs->validate_property_func, // GDExtensionClassValidateProperty validate_property_func;
+		p_extension_funcs->notification_func, // GDExtensionClassNotification2 notification_func;
+		p_extension_funcs->to_string_func, // GDExtensionClassToString to_string_func;
+		p_extension_funcs->reference_func, // GDExtensionClassReference reference_func;
+		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
+		nullptr, // GDExtensionClassCreateInstance3 create_instance_func; /* this one is mandatory */
+		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
+		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
+		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual2 get_virtual_func;
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
+		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
+		p_extension_funcs->class_userdata, // void *class_userdata;
+	};
+
+	const ClassCreationDeprecatedInfo legacy = {
+		false, // bool legacy_unexposed_class;
+		nullptr, // GDExtensionClassNotification notification_func;
+		nullptr, // GDExtensionClassFreePropertyList free_property_list_func;
+		nullptr, // GDExtensionClassCreateInstance create_instance_func;
+		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance2 create_instance2_func;
+		nullptr, // GDExtensionClassGetRID get_rid_func;
+		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+	};
+	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info6, &legacy);
 }
 #endif // DISABLE_DEPRECATED
 
@@ -385,7 +444,7 @@ void GDExtension::_register_extension_class6(GDExtensionClassLibraryPtr p_librar
 	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, p_extension_funcs);
 }
 
-void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo5 *p_extension_funcs, const ClassCreationDeprecatedInfo *p_deprecated_funcs) {
+void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo6 *p_extension_funcs, const ClassCreationDeprecatedInfo *p_deprecated_funcs) {
 	GDExtension *self = reinterpret_cast<GDExtension *>(p_library);
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
@@ -471,6 +530,7 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 		extension->gdextension.notification = p_deprecated_funcs->notification_func;
 		extension->gdextension.free_property_list = p_deprecated_funcs->free_property_list_func;
 		extension->gdextension.create_instance = p_deprecated_funcs->create_instance_func;
+		extension->gdextension.create_instance2 = p_deprecated_funcs->create_instance2_func;
 		extension->gdextension.get_rid = p_deprecated_funcs->get_rid_func;
 		extension->gdextension.get_virtual = p_deprecated_funcs->get_virtual_func;
 		extension->gdextension.get_virtual_call_data = p_deprecated_funcs->get_virtual_call_data_func;
@@ -481,14 +541,7 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	extension->gdextension.reference = p_extension_funcs->reference_func;
 	extension->gdextension.unreference = p_extension_funcs->unreference_func;
 	extension->gdextension.class_userdata = p_extension_funcs->class_userdata;
-#ifndef DISABLE_DEPRECATED
-	if (p_deprecated_funcs && !p_deprecated_funcs->p_creation_is_with_refcount) {
-		extension->gdextension.create_instance2 = p_extension_funcs->create_instance_func;
-	} else
-#endif
-	{
-		extension->gdextension.create_instance3 = p_extension_funcs->create_instance_func;
-	}
+	extension->gdextension.create_instance3 = p_extension_funcs->create_instance_func;
 	extension->gdextension.free_instance = p_extension_funcs->free_instance_func;
 	extension->gdextension.recreate_instance = p_extension_funcs->recreate_instance_func;
 	extension->gdextension.get_virtual2 = p_extension_funcs->get_virtual_func;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -69,10 +69,10 @@ class GDExtension : public Resource {
 		GDExtensionClassNotification notification_func = nullptr;
 		GDExtensionClassFreePropertyList free_property_list_func = nullptr;
 		GDExtensionClassCreateInstance create_instance_func = nullptr;
+		GDExtensionClassCreateInstance2 create_instance2_func = nullptr;
 		GDExtensionClassGetRID get_rid_func = nullptr;
 		GDExtensionClassGetVirtual get_virtual_func = nullptr;
 		GDExtensionClassGetVirtualCallData get_virtual_call_data_func = nullptr;
-		bool p_creation_is_with_refcount = true;
 #endif // DISABLE_DEPRECATED
 	};
 
@@ -84,7 +84,7 @@ class GDExtension : public Resource {
 	static void _register_extension_class5(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo5 *p_extension_funcs);
 #endif // DISABLE_DEPRECATED
 	static void _register_extension_class6(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo6 *p_extension_funcs);
-	static void _register_extension_class_internal(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo5 *p_extension_funcs, const ClassCreationDeprecatedInfo *p_deprecated_funcs = nullptr);
+	static void _register_extension_class_internal(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo6 *p_extension_funcs, const ClassCreationDeprecatedInfo *p_deprecated_funcs = nullptr);
 	static void _register_extension_class_method(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassMethodInfo *p_method_info);
 	static void _register_extension_class_virtual_method(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassVirtualMethodInfo *p_method_info);
 	static void _register_extension_class_integer_constant(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_enum_name, GDExtensionConstStringNamePtr p_constant_name, GDExtensionInt p_constant_value, GDExtensionBool p_is_bitfield);

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -1164,6 +1164,10 @@
                     "name": "p_class_userdata",
                     "type": "void*"
                 }
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should be zero."
             ]
         },
         {
@@ -1181,6 +1185,10 @@
                     "name": "p_notify_postinitialize",
                     "type": "GDExtensionBool"
                 }
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should be zero."
             ]
         },
         {
@@ -1198,6 +1206,10 @@
                     "name": "p_notify_postinitialize",
                     "type": "GDExtensionBool"
                 }
+            ],
+            "description": [
+                "Called to construct an instance of the class.",
+                "For classes descending from RefCounted, the reference count should already be incremented by 1."
             ]
         },
         {
@@ -1389,7 +1401,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1487,7 +1499,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1612,7 +1624,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1741,7 +1753,7 @@
                     "name": "create_instance_func",
                     "type": "GDExtensionClassCreateInstance2",
                     "description": [
-                        "(Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract."
+                        "Class constructor. Required unless the class is virtual or abstract."
                     ]
                 },
                 {
@@ -1797,8 +1809,124 @@
         },
         {
             "name": "GDExtensionClassCreationInfo6",
-            "kind": "alias",
-            "type": "GDExtensionClassCreationInfo5"
+            "kind": "struct",
+            "members": [
+                {
+                    "name": "is_virtual",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_abstract",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_exposed",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "is_runtime",
+                    "type": "GDExtensionBool"
+                },
+                {
+                    "name": "icon_path",
+                    "type": "GDExtensionConstStringPtr"
+                },
+                {
+                    "name": "set_func",
+                    "type": "GDExtensionClassSet"
+                },
+                {
+                    "name": "get_func",
+                    "type": "GDExtensionClassGet"
+                },
+                {
+                    "name": "get_property_list_func",
+                    "type": "GDExtensionClassGetPropertyList"
+                },
+                {
+                    "name": "free_property_list_func",
+                    "type": "GDExtensionClassFreePropertyList2"
+                },
+                {
+                    "name": "property_can_revert_func",
+                    "type": "GDExtensionClassPropertyCanRevert"
+                },
+                {
+                    "name": "property_get_revert_func",
+                    "type": "GDExtensionClassPropertyGetRevert"
+                },
+                {
+                    "name": "validate_property_func",
+                    "type": "GDExtensionClassValidateProperty"
+                },
+                {
+                    "name": "notification_func",
+                    "type": "GDExtensionClassNotification2"
+                },
+                {
+                    "name": "to_string_func",
+                    "type": "GDExtensionClassToString"
+                },
+                {
+                    "name": "reference_func",
+                    "type": "GDExtensionClassReference"
+                },
+                {
+                    "name": "unreference_func",
+                    "type": "GDExtensionClassUnreference"
+                },
+                {
+                    "name": "create_instance_func",
+                    "type": "GDExtensionClassCreateInstance3",
+                    "description": [
+                        "Class constructor. Required unless the class is virtual or abstract."
+                    ]
+                },
+                {
+                    "name": "free_instance_func",
+                    "type": "GDExtensionClassFreeInstance",
+                    "description": [
+                        "Destructor; mandatory."
+                    ]
+                },
+                {
+                    "name": "recreate_instance_func",
+                    "type": "GDExtensionClassRecreateInstance"
+                },
+                {
+                    "name": "get_virtual_func",
+                    "type": "GDExtensionClassGetVirtual2",
+                    "description": [
+                        "Queries a virtual function by name and returns a callback to invoke the requested virtual function."
+                    ]
+                },
+                {
+                    "name": "get_virtual_call_data_func",
+                    "type": "GDExtensionClassGetVirtualCallData2",
+                    "description": [
+                        "Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that",
+                        "need or benefit from extra data when calling virtual functions.",
+                        "Returns user data that will be passed to `call_virtual_with_data_func`.",
+                        "Returning `NULL` from this function signals to Godot that the virtual function is not overridden.",
+                        "Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.",
+                        "You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`."
+                    ]
+                },
+                {
+                    "name": "call_virtual_with_data_func",
+                    "type": "GDExtensionClassCallVirtualWithData",
+                    "description": [
+                        "Used to call virtual functions when `get_virtual_call_data_func` is not null."
+                    ]
+                },
+                {
+                    "name": "class_userdata",
+                    "type": "void*",
+                    "description": [
+                        "Per-class user data, later accessible in instance bindings."
+                    ]
+                }
+            ]
         },
         {
             "name": "GDExtensionClassLibraryPtr",
@@ -8640,8 +8768,7 @@
                     "name": "p_extension_funcs",
                     "type": "const GDExtensionClassCreationInfo6*",
                     "description": [
-                        "A pointer to a GDExtensionClassCreationInfo6 struct.",
-                        "In contrast to GDExtensionClassCreationInfo5, the creation function must return RefCounted subtypes with a refcount of 1."
+                        "A pointer to a GDExtensionClassCreationInfo6 struct."
                     ]
                 }
             ],


### PR DESCRIPTION
This is a follow-up to https://github.com/godotengine/godot/pull/118214 (a new feature for Godot 4.7 by @Ivorforce), in order to make it more consistent with how we've handled these changes in the past

The main change is making `GDExtensionClassCreationInfo6` into a "struct" rather than an "alias" for `GDExtensionClassCreationInfo5` so that it can explicitly take the `GDExtensionClassCreateInstance3` type

At a binary level this is equivalent to what was added in #118214, however, I think the important distinction here is the semantic difference between `GDExtensionClassCreateInstance2` and `GDExtensionClassCreateInstance3`, and so I'd prefer if it were documented in those terms, rather than just a note on `classdb_register_extension_class6`. This allows us to document the latest thing, rather than using a reference to the previous thing. I think this will be more "evergreen" as we continue to iterate and inevitably make new versions of this interface function and struct

This ends up having some follow on effects and I also did some small clean-up too:

- The description for the `create_instance_func` wasn't great, so updated it on `GDExtensionClassCreationInfo6` which is added in this PR, but then for consistency, I copied it to the older structs
- The `ClassCreationDeprecatedInfo` now takes the function pointer rather than a boolean flag (and everything is non-legacy when all fields on this struct are zero)
- `GDExtension::_register_extension_class_internal()` now takes a `GDExtensionClassCreationInfo6` and all the deprecated functions work in terms of that struct now
- There were a whole bunch of stale comments giving old types or field names which I've updated

Given that this is a new Godot 4.7 feature, and we don't want to change the `gdextension_interface.json` in patch releases, I think this qualifies for merge after the feature freeze :-)