### PR TITLE
Remove the separate "Android Source" group in  ExportTemplateManager

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -298,16 +298,9 @@ void ExportTemplateManager::_initialize_template_data() {
 	{
 		TemplateInfo info;
 		info.name = "Android";
-		info.description = TTRC("Basic Android APK template.");
-		info.file_list = { "android_debug.apk", "android_release.apk" };
+		info.description = TTRC("Android APK template and source for Gradle builds.");
+		info.file_list = { "android_debug.apk", "android_release.apk", "android_source.zip" };
 		template_data[TemplateID::ANDROID] = info;
-	}
-	{
-		TemplateInfo info;
-		info.name = TTR("Android Source");
-		info.description = TTRC("Template for Gradle builds for Android.");
-		info.file_list = { "android_source.zip" };
-		template_data[TemplateID::ANDROID_SOURCE] = info;
 	}
 
 	{
@@ -355,7 +348,7 @@ void ExportTemplateManager::_initialize_template_data() {
 		PlatformInfo info;
 		info.name = "Android";
 		info.icon = _get_platform_icon("Android");
-		info.templates = { TemplateID::ANDROID, TemplateID::ANDROID_SOURCE };
+		info.templates = { TemplateID::ANDROID };
 		info.group = TTR("Mobile", "Platform Group");
 		platform_map[PlatformID::ANDROID] = info;
 	}
@@ -1134,8 +1127,7 @@ void ExportTemplateManager::_notification(int p_what) {
 			template_data[TemplateID::WEB_EXTENSIONS].name = TTR("Web with Extensions");
 			template_data[TemplateID::WEB_NOTHREADS].name = TTR("Web Single-Threaded");
 			template_data[TemplateID::WEB_EXTENSIONS_NOTHREADS].name = TTR("Web with Extensions Single-Threaded");
-			template_data[TemplateID::ANDROID_SOURCE].name = TTR("Android Source");
-			template_data[TemplateID::ANDROID_SOURCE].name = TTR("ICU Data");
+			template_data[TemplateID::ICU_DATA].name = TTR("ICU Data");
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -114,7 +114,6 @@ class ExportTemplateManager : public AcceptDialog {
 		WEB_EXTENSIONS_NOTHREADS,
 
 		ANDROID,
-		ANDROID_SOURCE,
 
 		IOS,
 


### PR DESCRIPTION
It feels unnecessary to have a separate group for `android_source.zip`. It would be better to include it in the same group, as these are equally important. Most users rely on Gradle builds for release exports, since that provides support for java/kotlin plugins.


| Before | After |
|--------|--------|
| <img width="878" height="495" alt="Screenshot_20260419_185300" src="https://github.com/user-attachments/assets/de3ab1a8-75ee-4cc7-aeec-922d7f184d70" /> | <img width="853" height="480" alt="Screenshot_20260419_184930" src="https://github.com/user-attachments/assets/31dde449-8ea8-48d3-92af-0b027f95b9fe" /> |
