### PR TITLE
Disable rounding remainders and subpixel positioning for editor code fonts.

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -263,6 +263,8 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	default_font_bold_msdf->set_fallbacks(fallbacks_bold);
 
 	Ref<FontFile> default_font_mono = load_internal_font(_font_JetBrainsMono_Regular, _font_JetBrainsMono_Regular_size, font_mono_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
+	default_font_mono->set_subpixel_positioning(TextServer::SUBPIXEL_POSITIONING_DISABLED);
+	default_font_mono->set_keep_rounding_remainders(false);
 	default_font_mono->set_fallbacks(fallbacks);
 
 	// Init base font configs and load custom fonts.
@@ -389,6 +391,8 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	mono_fc.instantiate();
 	if (custom_font_path_source.length() > 0 && dir->file_exists(custom_font_path_source)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path_source, font_mono_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps);
+		custom_font->set_subpixel_positioning(TextServer::SUBPIXEL_POSITIONING_DISABLED);
+		custom_font->set_keep_rounding_remainders(false);
 		{
 			TypedArray<Font> fallback_custom = { default_font_mono };
 			custom_font->set_fallbacks(fallback_custom);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118411