### PR TITLE
Fix `_forward_3d_gui_input` passing editor camera instead of previewed camera

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2198,8 +2198,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
 	{
 		EditorNode *en = EditorNode::get_singleton();
+		Camera3D *input_camera = previewing ? previewing : camera;
 
-		switch (en->get_editor_plugins_force_input_forwarding()->forward_3d_gui_input(camera, p_event, true)) {
+		switch (en->get_editor_plugins_force_input_forwarding()->forward_3d_gui_input(input_camera, p_event, true)) {
 			case EditorPlugin::AFTER_GUI_INPUT_PASS: {
 				// Continue processing.
 			} break;
@@ -2213,7 +2214,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			} break;
 		}
 
-		switch (en->get_editor_plugins_over()->forward_3d_gui_input(camera, p_event, false)) {
+		switch (en->get_editor_plugins_over()->forward_3d_gui_input(input_camera, p_event, false)) {
 			case EditorPlugin::AFTER_GUI_INPUT_PASS: {
 				// Continue processing.
 			} break;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

* Fixes: https://github.com/godotengine/godot/issues/76873

Note the output prints in the videos showing the after video receiving the correct camera when going in and out of preview.

**Sidenote:** The variable names for all camera/previewing related code in the 3D editor are confusing and probably should be fixed in a seperate PR in the future. 

Before:

https://github.com/user-attachments/assets/7f1c9be7-0e61-4d06-b278-cf9263072133

After:

https://github.com/user-attachments/assets/c14a0b16-8c87-4509-8c38-55034c2c462b

