### PR TITLE
Improve SpringBoneSimulator3D multi-BoneChain workflow

### DIFF
--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -18,29 +18,26 @@
 	<methods>
 		<method name="are_all_child_collisions_enabled" qualifiers="const">
 			<return type="bool" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if all child [SpringBoneCollision3D]s are contained in the collision list at [param index] in the settings.
+				Returns [code]true[/code] if all child [SpringBoneCollision3D]s are contained in the collision list.
+			</description>
+		</method>
+		<method name="clear_bone_chains">
+			<return type="void" />
+			<description>
+				Clears all bone chains.
 			</description>
 		</method>
 		<method name="clear_collisions">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Clears all collisions from the collision list at [param index] in the settings when [method are_all_child_collisions_enabled] is [code]false[/code].
+				Clears all collisions from the collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="clear_exclude_collisions">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
 			<description>
 				Clears all exclude collisions from the collision list at [param index] in the settings when [method are_all_child_collisions_enabled] is [code]true[/code].
-			</description>
-		</method>
-		<method name="clear_settings">
-			<return type="void" />
-			<description>
-				Clears all settings.
 			</description>
 		</method>
 		<method name="get_center_bone" qualifiers="const">
@@ -73,31 +70,27 @@
 		</method>
 		<method name="get_collision_count" qualifiers="const">
 			<return type="int" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the collision count of the bone chain's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
+				Returns the collision count of the node's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="get_collision_path" qualifiers="const">
 			<return type="NodePath" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="collision" type="int" />
+			<param index="0" name="collision" type="int" />
 			<description>
-				Returns the node path of the [SpringBoneCollision3D] at [param collision] in the bone chain's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
+				Returns the node path of the [SpringBoneCollision3D] at [param collision] in the node's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="get_drag" qualifiers="const">
 			<return type="float" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the drag force damping curve of the bone chain.
+				Returns the drag force damping curve.
 			</description>
 		</method>
 		<method name="get_drag_damping_curve" qualifiers="const">
 			<return type="Curve" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the drag force damping curve of the bone chain.
+				Returns the drag force damping curve.
 			</description>
 		</method>
 		<method name="get_end_bone" qualifiers="const">
@@ -130,38 +123,33 @@
 		</method>
 		<method name="get_exclude_collision_count" qualifiers="const">
 			<return type="int" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the exclude collision count of the bone chain's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
+				Returns the exclude collision count of the node's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="get_exclude_collision_path" qualifiers="const">
 			<return type="NodePath" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="collision" type="int" />
+			<param index="0" name="collision" type="int" />
 			<description>
-				Returns the node path of the [SpringBoneCollision3D] at [param collision] in the bone chain's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
+				Returns the node path of the [SpringBoneCollision3D] at [param collision] in the node's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="get_gravity" qualifiers="const">
 			<return type="float" />
-			<param index="0" name="index" type="int" />
 			<description>
 				Returns the gravity amount of the bone chain.
 			</description>
 		</method>
 		<method name="get_gravity_damping_curve" qualifiers="const">
 			<return type="Curve" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the gravity amount damping curve of the bone chain.
+				Returns the gravity amount damping curve.
 			</description>
 		</method>
 		<method name="get_gravity_direction" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the gravity direction of the bone chain.
+				Returns the gravity direction.
 			</description>
 		</method>
 		<method name="get_joint_bone" qualifiers="const">
@@ -246,16 +234,14 @@
 		</method>
 		<method name="get_radius" qualifiers="const">
 			<return type="float" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the joint radius of the bone chain.
+				Returns the joint radius.
 			</description>
 		</method>
 		<method name="get_radius_damping_curve" qualifiers="const">
 			<return type="Curve" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the joint radius damping curve of the bone chain.
+				Returns the joint radius damping curve.
 			</description>
 		</method>
 		<method name="get_root_bone" qualifiers="const">
@@ -289,23 +275,14 @@
 		</method>
 		<method name="get_stiffness" qualifiers="const">
 			<return type="float" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the stiffness force of the bone chain.
+				Returns the stiffness force.
 			</description>
 		</method>
 		<method name="get_stiffness_damping_curve" qualifiers="const">
 			<return type="Curve" />
-			<param index="0" name="index" type="int" />
 			<description>
-				Returns the stiffness force damping curve of the bone chain.
-			</description>
-		</method>
-		<method name="is_config_individual" qualifiers="const">
-			<return type="bool" />
-			<param index="0" name="index" type="int" />
-			<description>
-				Returns [code]true[/code] if the config can be edited individually for each joint.
+				Returns the stiffness force damping curve.
 			</description>
 		</method>
 		<method name="is_end_bone_extended" qualifiers="const">
@@ -313,6 +290,13 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns [code]true[/code] if the end bone is extended to have a tail.
+			</description>
+		</method>
+		<method name="is_override_individual_joints" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns [code]true[/code] if the config can be edited individually for each joint.
 			</description>
 		</method>
 		<method name="reset">
@@ -359,44 +343,39 @@
 		</method>
 		<method name="set_collision_count">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="count" type="int" />
+			<param index="0" name="count" type="int" />
 			<description>
-				Sets the number of collisions in the collision list at [param index] in the settings when [method are_all_child_collisions_enabled] is [code]false[/code].
+				Sets the number of collisions in the collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="set_collision_path">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="collision" type="int" />
-			<param index="2" name="node_path" type="NodePath" />
+			<param index="0" name="collision" type="int" />
+			<param index="1" name="node_path" type="NodePath" />
 			<description>
-				Sets the node path of the [SpringBoneCollision3D] at [param collision] in the bone chain's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
+				Sets the node path of the [SpringBoneCollision3D] at [param collision] in the node's collision list when [method are_all_child_collisions_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="set_drag">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="drag" type="float" />
+			<param index="0" name="drag" type="float" />
 			<description>
-				Sets the drag force of the bone chain. The greater the value, the more suppressed the wiggling.
+				Sets the drag force. The greater the value, the more suppressed the wiggling.
 				The value is scaled by [method set_drag_damping_curve] and cached in each joint setting in the joint list.
 			</description>
 		</method>
 		<method name="set_drag_damping_curve">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="curve" type="Curve" />
+			<param index="0" name="curve" type="Curve" />
 			<description>
-				Sets the drag force damping curve of the bone chain.
+				Sets the drag force damping curve.
 			</description>
 		</method>
 		<method name="set_enable_all_child_collisions">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="enabled" type="bool" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code], all child [SpringBoneCollision3D]s are colliding and [method set_exclude_collision_path] is enabled as an exclusion list at [param index] in the settings.
+				If [param enabled] is [code]true[/code], all child [SpringBoneCollision3D]s are colliding and [method set_exclude_collision_path] is enabled as an exclusion list.
 				If [param enabled] is [code]false[/code], you need to manually register all valid collisions with [method set_collision_path].
 			</description>
 		</method>
@@ -435,19 +414,17 @@
 		</method>
 		<method name="set_exclude_collision_count">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="count" type="int" />
+			<param index="0" name="count" type="int" />
 			<description>
-				Sets the number of exclude collisions in the exclude collision list at [param index] in the settings when [method are_all_child_collisions_enabled] is [code]true[/code].
+				Sets the number of exclude collisions in the exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_exclude_collision_path">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="collision" type="int" />
-			<param index="2" name="node_path" type="NodePath" />
+			<param index="0" name="collision" type="int" />
+			<param index="1" name="node_path" type="NodePath" />
 			<description>
-				Sets the node path of the [SpringBoneCollision3D] at [param collision] in the bone chain's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
+				Sets the node path of the [SpringBoneCollision3D] at [param collision] in the node's exclude collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_extend_end_bone">
@@ -461,37 +438,26 @@
 		</method>
 		<method name="set_gravity">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="gravity" type="float" />
+			<param index="0" name="gravity" type="float" />
 			<description>
-				Sets the gravity amount of the bone chain. This value is not an acceleration, but a constant velocity of movement in [method set_gravity_direction].
+				Sets the gravity amount. This value is not an acceleration, but a constant velocity of movement in [method set_gravity_direction].
 				If [param gravity] is not [code]0[/code], the modified pose will not return to the original pose since it is always affected by gravity.
 				The value is scaled by [method set_gravity_damping_curve] and cached in each joint setting in the joint list.
 			</description>
 		</method>
 		<method name="set_gravity_damping_curve">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="curve" type="Curve" />
+			<param index="0" name="curve" type="Curve" />
 			<description>
-				Sets the gravity amount damping curve of the bone chain.
+				Sets the gravity amount damping curve.
 			</description>
 		</method>
 		<method name="set_gravity_direction">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="gravity_direction" type="Vector3" />
+			<param index="0" name="gravity_direction" type="Vector3" />
 			<description>
-				Sets the gravity direction of the bone chain. This value is internally normalized and then multiplied by [method set_gravity].
+				Sets the gravity direction. This value is internally normalized and then multiplied by [method set_gravity].
 				The value is cached in each joint setting in the joint list.
-			</description>
-		</method>
-		<method name="set_individual_config">
-			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="enabled" type="bool" />
-			<description>
-				If [param enabled] is [code]true[/code], the config can be edited individually for each joint.
 			</description>
 		</method>
 		<method name="set_joint_drag">
@@ -561,21 +527,26 @@
 				Sets the stiffness force at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
 			</description>
 		</method>
-		<method name="set_radius">
+		<method name="set_override_individual_joints">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
-			<param index="1" name="radius" type="float" />
+			<param index="1" name="enabled" type="bool" />
 			<description>
-				Sets the joint radius of the bone chain. It is used to move and slide with the [SpringBoneCollision3D] in the collision list.
+			</description>
+		</method>
+		<method name="set_radius">
+			<return type="void" />
+			<param index="0" name="radius" type="float" />
+			<description>
+				Sets the joint radius. It is used to move and slide with the [SpringBoneCollision3D] in the collision list.
 				The value is scaled by [method set_radius_damping_curve] and cached in each joint setting in the joint list.
 			</description>
 		</method>
 		<method name="set_radius_damping_curve">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="curve" type="Curve" />
+			<param index="0" name="curve" type="Curve" />
 			<description>
-				Sets the joint radius damping curve of the bone chain.
+				Sets the joint radius damping curve.
 			</description>
 		</method>
 		<method name="set_root_bone">
@@ -583,7 +554,6 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="bone" type="int" />
 			<description>
-				Sets the root bone index of the bone chain.
 			</description>
 		</method>
 		<method name="set_root_bone_name">
@@ -591,7 +561,6 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="bone_name" type="String" />
 			<description>
-				Sets the root bone name of the bone chain.
 			</description>
 		</method>
 		<method name="set_rotation_axis">
@@ -599,7 +568,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="axis" type="int" enum="SkeletonModifier3D.RotationAxis" />
 			<description>
-				Sets the rotation axis of the bone chain. If set to a specific axis, it acts like a hinge joint. The value is cached in each joint setting in the joint list.
+				Sets the rotation axis. If set to a specific axis, it acts like a hinge joint. The value is cached in each joint setting in the joint list.
 				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
 				[b]Note:[/b] The rotation axis vector and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
 			</description>
@@ -609,27 +578,25 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="vector" type="Vector3" />
 			<description>
-				Sets the rotation axis vector of the bone chain. The value is cached in each joint setting in the joint list.
+				Sets the rotation axis vector. The value is cached in each joint setting in the joint list.
 				This vector is normalized by an internal process and represents the axis around which the bone chain can rotate.
 				If the vector length is [code]0[/code], it is considered synonymous with [constant SkeletonModifier3D.ROTATION_AXIS_ALL].
 			</description>
 		</method>
 		<method name="set_stiffness">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="stiffness" type="float" />
+			<param index="0" name="stiffness" type="float" />
 			<description>
-				Sets the stiffness force of the bone chain. The greater the value, the faster it recovers to its initial pose.
+				Sets the stiffness force. The greater the value, the faster it recovers to its initial pose.
 				If [param stiffness] is [code]0[/code], the modified pose will not return to the original pose.
 				The value is scaled by [method set_stiffness_damping_curve] and cached in each joint setting in the joint list.
 			</description>
 		</method>
 		<method name="set_stiffness_damping_curve">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="curve" type="Curve" />
+			<param index="0" name="curve" type="Curve" />
 			<description>
-				Sets the stiffness force damping curve of the bone chain.
+				Sets the stiffness force damping curve.
 			</description>
 		</method>
 	</methods>
@@ -642,7 +609,7 @@
 			If [code]true[/code], the solver retrieves the bone axis from the bone pose every frame.
 			If [code]false[/code], the solver retrieves the bone axis from the bone rest and caches it, which increases performance slightly, but position changes in the bone pose made before processing this [SpringBoneSimulator3D] are ignored.
 		</member>
-		<member name="setting_count" type="int" setter="set_setting_count" getter="get_setting_count" default="0">
+		<member name="setting_count" type="int" setter="set_bone_chain_count" getter="get_bone_chain_count" default="0">
 			The number of settings.
 		</member>
 	</members>

--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -8,7 +8,7 @@
 		If you setup [method set_root_bone] and [method set_end_bone], it is treated as one bone chain. Note that it does not support a branched chain like Y-shaped chains.
 		When a bone chain is created, an array is generated from the bones that exist in between and listed in the joint list.
 		Several properties can be applied to each joint, such as [method set_joint_stiffness], [method set_joint_drag], and [method set_joint_gravity].
-		For simplicity, you can set values to all joints at the same time by using a [Curve]. If you want to specify detailed values individually, set [method set_individual_config] to [code]true[/code].
+		For simplicity, you can set values to all joints at the same time by using a [Curve]. If you want to specify detailed values individually, set [method set_override_individual_joints] to [code]true[/code].
 		For physical simulation, [SpringBoneSimulator3D] can have children as self-standing collisions that are not related to [PhysicsServer3D], see also [SpringBoneCollision3D].
 		[b]Warning:[/b] A scaled [SpringBoneSimulator3D] will likely not behave as expected. Make sure that the parent [Skeleton3D] and its bones are not scaled.
 		[b]Note:[/b] Most methods in this class take an [code]index[/code] parameter. This parameter specifies which setting list entry to return if the IK has multiple entries (e.g. [code]settings/&lt;index&gt;/root_bone_name[/code]).
@@ -37,7 +37,7 @@
 		<method name="clear_exclude_collisions">
 			<return type="void" />
 			<description>
-				Clears all exclude collisions from the collision list at [param index] in the settings when [method are_all_child_collisions_enabled] is [code]true[/code].
+				Clears all exclude collisions from the collision list when [method are_all_child_collisions_enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="get_center_bone" qualifiers="const">
@@ -466,7 +466,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="drag" type="float" />
 			<description>
-				Sets the drag force at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the drag force at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_gravity">
@@ -475,7 +475,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="gravity" type="float" />
 			<description>
-				Sets the gravity amount at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the gravity amount at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_gravity_direction">
@@ -484,7 +484,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="gravity_direction" type="Vector3" />
 			<description>
-				Sets the gravity direction at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the gravity direction at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_radius">
@@ -493,7 +493,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="radius" type="float" />
 			<description>
-				Sets the joint radius at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the joint radius at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_rotation_axis">
@@ -502,7 +502,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="axis" type="int" enum="SkeletonModifier3D.RotationAxis" />
 			<description>
-				Sets the rotation axis at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the rotation axis at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
 				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
 			</description>
@@ -524,7 +524,7 @@
 			<param index="1" name="joint" type="int" />
 			<param index="2" name="stiffness" type="float" />
 			<description>
-				Sets the stiffness force at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
+				Sets the stiffness force at [param joint] in the bone chain's joint list when [method is_override_individual_joints] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_override_individual_joints">

--- a/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -97,7 +97,7 @@ void SpringBoneSimulator3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	SpringBoneSimulator3D *simulator = Object::cast_to<SpringBoneSimulator3D>(p_gizmo->get_node_3d());
 	p_gizmo->clear();
 
-	if (!simulator->get_setting_count()) {
+	if (!simulator->get_bone_chain_count()) {
 		return;
 	}
 
@@ -135,7 +135,7 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 	}
 	weights[0] = 1;
 
-	for (int i = 0; i < p_simulator->get_setting_count(); i++) {
+	for (int i = 0; i < p_simulator->get_bone_chain_count(); i++) {
 		int current_bone = -1;
 		int prev_bone = -1;
 		int joint_end = p_simulator->get_joint_count(i) - 1;

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -669,7 +669,7 @@ void SpringBoneSimulator3D::set_radius_damping_curve(int p_index, const Ref<Curv
 	}
 	settings[p_index]->radius_damping_curve = p_damping_curve;
 	if (settings[p_index]->radius_damping_curve.is_valid()) {
-		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -703,7 +703,7 @@ void SpringBoneSimulator3D::set_stiffness_damping_curve(int p_index, const Ref<C
 	}
 	settings[p_index]->stiffness_damping_curve = p_damping_curve;
 	if (settings[p_index]->stiffness_damping_curve.is_valid()) {
-		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -737,7 +737,7 @@ void SpringBoneSimulator3D::set_drag_damping_curve(int p_index, const Ref<Curve>
 	}
 	settings[p_index]->drag_damping_curve = p_damping_curve;
 	if (settings[p_index]->drag_damping_curve.is_valid()) {
-		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -771,7 +771,7 @@ void SpringBoneSimulator3D::set_gravity_damping_curve(int p_index, const Ref<Cur
 	}
 	settings[p_index]->gravity_damping_curve = p_damping_curve;
 	if (settings[p_index]->gravity_damping_curve.is_valid()) {
-		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -353,63 +353,65 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 
 void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) const {
 	PackedStringArray split = p_property.name.split("/");
-	if (split.size() > 2 && split[0] == "bone_chains") {
-		int which = split[1].to_int();
+	if (split[0] == "bone_chains") {
+		if (split.size() > 2) {
+			int which = split[1].to_int();
 
-		// Extended end bone option.
-		bool force_hide = false;
-		if (split[2] == "extend_end_bone" && get_end_bone(which) == -1) {
-			p_property.usage = PROPERTY_USAGE_NONE;
-			force_hide = true;
-		}
-		if (force_hide || (split[2] == "end_bone" && !is_end_bone_extended(which) && split.size() > 3)) {
-			p_property.usage = PROPERTY_USAGE_NONE;
-		}
-
-		// Center option.
-		if (get_center_from(which) != CENTER_FROM_BONE && (split[2] == "center_bone" || split[2] == "center_bone_name")) {
-			p_property.usage = PROPERTY_USAGE_NONE;
-		}
-		if (get_center_from(which) != CENTER_FROM_NODE && split[2] == "center_node") {
-			p_property.usage = PROPERTY_USAGE_NONE;
-		}
-
-		// Joints option.
-		if (is_config_individual(which)) {
-			if (split[2] == "rotation_axis" || split[2] == "rotation_axis_vector" || split[2] == "radius" || split[2] == "radius_damping_curve" ||
-					split[2] == "stiffness" || split[2] == "stiffness_damping_curve" ||
-					split[2] == "drag" || split[2] == "drag_damping_curve" ||
-					split[2] == "gravity" || split[2] == "gravity_damping_curve" || split[2] == "gravity_direction") {
+			// Extended end bone option.
+			bool force_hide = false;
+			if (split[2] == "extend_end_bone" && get_end_bone(which) == -1) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+				force_hide = true;
+			}
+			if (force_hide || (split[2] == "end_bone" && !is_end_bone_extended(which) && split.size() > 3)) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
-		} else {
-			if (split[2] == "joints" || split[2] == "joint_count") {
-				// Don't storage them since they are overridden by _update_joints().
-				p_property.usage ^= PROPERTY_USAGE_STORAGE;
-				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
-			}
-			if (split[2] == "rotation_axis_vector" && get_rotation_axis(which) != ROTATION_AXIS_CUSTOM) {
+
+			// Center option.
+			if (get_center_from(which) != CENTER_FROM_BONE && (split[2] == "center_bone" || split[2] == "center_bone_name")) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
-		}
+			if (get_center_from(which) != CENTER_FROM_NODE && split[2] == "center_node") {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
 
+			// Joints option.
+			if (is_config_individual(which)) {
+				if (split[2] == "rotation_axis" || split[2] == "rotation_axis_vector" || split[2] == "radius" || split[2] == "radius_damping_curve" ||
+						split[2] == "stiffness" || split[2] == "stiffness_damping_curve" ||
+						split[2] == "drag" || split[2] == "drag_damping_curve" ||
+						split[2] == "gravity" || split[2] == "gravity_damping_curve" || split[2] == "gravity_direction") {
+					p_property.usage = PROPERTY_USAGE_NONE;
+				}
+			} else {
+				if (split[2] == "joints" || split[2] == "joint_count") {
+					// Don't storage them since they are overridden by _update_joints().
+					p_property.usage ^= PROPERTY_USAGE_STORAGE;
+					p_property.usage |= PROPERTY_USAGE_READ_ONLY;
+				}
+				if (split[2] == "rotation_axis_vector" && get_rotation_axis(which) != ROTATION_AXIS_CUSTOM) {
+					p_property.usage = PROPERTY_USAGE_NONE;
+				}
+			}
+		}
+		if (split.size() > 3) {
+			int which = split[1].to_int();
+			int joint = split[3].to_int();
+			// Joints option.
+			if (split[2] == "joints" && split.size() > 4) {
+				if (split[4] == "rotation_axis_vector" && get_joint_rotation_axis(which, joint) != ROTATION_AXIS_CUSTOM) {
+					p_property.usage = PROPERTY_USAGE_NONE;
+				}
+			}
+		}
+	} else {
 		// Collisions option.
 		if (are_all_child_collisions_enabled()) {
-			if (split[2] == "collisions" || split[2] == "collision_count") {
+			if (split[0] == "collisions" || split[0] == "collision_count") {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 		} else {
-			if (split[2] == "exclude_collisions" || split[2] == "exclude_collision_count") {
-				p_property.usage = PROPERTY_USAGE_NONE;
-			}
-		}
-	}
-	if (split.size() > 3 && split[0] == "bone_chains") {
-		int which = split[1].to_int();
-		int joint = split[3].to_int();
-		// Joints option.
-		if (split[2] == "joints" && split.size() > 4) {
-			if (split[4] == "rotation_axis_vector" && get_joint_rotation_axis(which, joint) != ROTATION_AXIS_CUSTOM) {
+			if (split[0] == "exclude_collisions" || split[0] == "exclude_collision_count") {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 		}

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -200,7 +200,7 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 			r_ret = (int)get_rotation_axis(which);
 		} else if (what == "rotation_axis_vector") {
 			r_ret = get_rotation_axis_vector(which);
-		}else if (what == "joint_count") {
+		} else if (what == "joint_count") {
 			r_ret = get_joint_count(which);
 		} else if (what == "joints") {
 			int idx = path.get_slicec('/', 3).to_int();
@@ -292,14 +292,14 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 
 	LocalVector<PropertyInfo> props;
 
-	props.push_back(PropertyInfo(Variant::FLOAT,   "radius/value", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
-	props.push_back(PropertyInfo(Variant::OBJECT,  "radius/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-	props.push_back(PropertyInfo(Variant::FLOAT,   "stiffness/value", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"));
-	props.push_back(PropertyInfo(Variant::OBJECT,  "stiffness/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-	props.push_back(PropertyInfo(Variant::FLOAT,   "drag/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"));
-	props.push_back(PropertyInfo(Variant::OBJECT,  "drag/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-	props.push_back(PropertyInfo(Variant::FLOAT,   "gravity/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater,or_less,suffix:m/s"));
-	props.push_back(PropertyInfo(Variant::OBJECT,  "gravity/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT, "radius/value", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
+	props.push_back(PropertyInfo(Variant::OBJECT, "radius/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT, "stiffness/value", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"));
+	props.push_back(PropertyInfo(Variant::OBJECT, "stiffness/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT, "drag/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"));
+	props.push_back(PropertyInfo(Variant::OBJECT, "drag/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT, "gravity/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater,or_less,suffix:m/s"));
+	props.push_back(PropertyInfo(Variant::OBJECT, "gravity/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
 	props.push_back(PropertyInfo(Variant::VECTOR3, "gravity/direction"));
 
 	props.push_back(PropertyInfo(Variant::BOOL, "enable_all_child_collisions"));

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -377,10 +377,7 @@ void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) con
 
 			// Joints option.
 			if (is_config_individual(which)) {
-				if (split[2] == "rotation_axis" || split[2] == "rotation_axis_vector" || split[2] == "radius" || split[2] == "radius_damping_curve" ||
-						split[2] == "stiffness" || split[2] == "stiffness_damping_curve" ||
-						split[2] == "drag" || split[2] == "drag_damping_curve" ||
-						split[2] == "gravity" || split[2] == "gravity_damping_curve" || split[2] == "gravity_direction") {
+				if (split[2] == "rotation_axis" || split[2] == "rotation_axis_vector") {
 					p_property.usage = PROPERTY_USAGE_NONE;
 				}
 			} else {

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -424,7 +424,7 @@ void SpringBoneSimulator3D::_notification(int p_what) {
 			}
 #endif // TOOLS_ENABLED
 			_make_collisions_dirty();
-			_make_all_joints_dirty();
+			_rebuild_bone_chains();
 		} break;
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
@@ -1297,13 +1297,13 @@ void SpringBoneSimulator3D::_bind_methods() {
 }
 
 void SpringBoneSimulator3D::_skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new) {
-	if (p_old && p_old->is_connected(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty))) {
-		p_old->disconnect(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	if (p_old && p_old->is_connected(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_rebuild_bone_chains))) {
+		p_old->disconnect(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_rebuild_bone_chains));
 	}
-	if (p_new && !p_new->is_connected(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty))) {
-		p_new->connect(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	if (p_new && !p_new->is_connected(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_rebuild_bone_chains))) {
+		p_new->connect(SNAME("rest_updated"), callable_mp(this, &SpringBoneSimulator3D::_rebuild_bone_chains));
 	}
-	_make_all_joints_dirty();
+	_rebuild_bone_chains();
 }
 
 void SpringBoneSimulator3D::_validate_bone_names() {
@@ -1334,6 +1334,12 @@ void SpringBoneSimulator3D::_make_joints_dirty(int p_index, bool p_reset) {
 }
 
 void SpringBoneSimulator3D::_make_all_joints_dirty() {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
+		_make_joints_dirty(i);
+	}
+}
+
+void SpringBoneSimulator3D::_rebuild_bone_chains() {
 	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
 		_update_joint_array(i);
 	}

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -41,10 +41,10 @@
 bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_value) {
 	String path = p_path;
 
-	if (path.begins_with("settings/")) {
+	if (path.begins_with("bone_chains/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)spring_bone_chains.size(), false);
 
 		if (what == "root_bone_name") {
 			set_root_bone_name(which, p_value);
@@ -162,10 +162,10 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const {
 	String path = p_path;
 
-	if (path.begins_with("settings/")) {
+	if (path.begins_with("bone_chains/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)spring_bone_chains.size(), false);
 
 		if (what == "root_bone_name") {
 			r_ret = get_root_bone_name(which);
@@ -226,7 +226,7 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 			} else {
 				return false;
 			}
-		} 
+		}
 	} else {
 		String what = path.get_slicec('/', 0);
 		String opt = path.get_slicec('/', 1);
@@ -314,8 +314,8 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		props.push_back(PropertyInfo(Variant::NODE_PATH, collision_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpringBoneCollision3D"));
 	}
 
-	for (uint32_t i = 0; i < settings.size(); i++) {
-		String path = "settings/" + itos(i) + "/";
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
+		String path = "bone_chains/" + itos(i) + "/";
 		props.push_back(PropertyInfo(Variant::STRING, path + "root_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
 		props.push_back(PropertyInfo(Variant::INT, path + "root_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 		props.push_back(PropertyInfo(Variant::STRING, path + "end_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
@@ -331,7 +331,7 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		props.push_back(PropertyInfo(Variant::INT, path + "rotation_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_rotation_axis()));
 		props.push_back(PropertyInfo(Variant::VECTOR3, path + "rotation_axis_vector"));
 		props.push_back(PropertyInfo(Variant::INT, path + "joint_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Joints," + path + "joints/,static,const"));
-		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
+		for (uint32_t j = 0; j < spring_bone_chains[i]->joints.size(); j++) {
 			String joint_path = path + "joints/" + itos(j) + "/";
 			props.push_back(PropertyInfo(Variant::STRING, joint_path + "bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint, PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
 			props.push_back(PropertyInfo(Variant::INT, joint_path + "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_READ_ONLY));
@@ -353,7 +353,7 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 
 void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) const {
 	PackedStringArray split = p_property.name.split("/");
-	if (split.size() > 2 && split[0] == "settings") {
+	if (split.size() > 2 && split[0] == "bone_chains") {
 		int which = split[1].to_int();
 
 		// Extended end bone option.
@@ -404,7 +404,7 @@ void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) con
 			}
 		}
 	}
-	if (split.size() > 3 && split[0] == "settings") {
+	if (split.size() > 3 && split[0] == "bone_chains") {
 		int which = split[1].to_int();
 		int joint = split[3].to_int();
 		// Joints option.
@@ -444,30 +444,30 @@ void SpringBoneSimulator3D::_notification(int p_what) {
 // Bone Chain Settings
 
 void SpringBoneSimulator3D::set_root_bone_name(int p_index, const String &p_bone_name) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->root_bone_name = p_bone_name;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->root_bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		set_root_bone(p_index, sk->find_bone(settings[p_index]->root_bone_name));
+		set_root_bone(p_index, sk->find_bone(spring_bone_chains[p_index]->root_bone_name));
 	}
 }
 
 String SpringBoneSimulator3D::get_root_bone_name(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
-	return settings[p_index]->root_bone_name;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), String());
+	return spring_bone_chains[p_index]->root_bone_name;
 }
 
 void SpringBoneSimulator3D::set_root_bone(int p_index, int p_bone) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	bool changed = settings[p_index]->root_bone != p_bone;
-	settings[p_index]->root_bone = p_bone;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	bool changed = spring_bone_chains[p_index]->root_bone != p_bone;
+	spring_bone_chains[p_index]->root_bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		if (settings[p_index]->root_bone <= -1 || settings[p_index]->root_bone >= sk->get_bone_count()) {
+		if (spring_bone_chains[p_index]->root_bone <= -1 || spring_bone_chains[p_index]->root_bone >= sk->get_bone_count()) {
 			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
-			settings[p_index]->root_bone = -1;
+			spring_bone_chains[p_index]->root_bone = -1;
 		} else {
-			settings[p_index]->root_bone_name = sk->get_bone_name(settings[p_index]->root_bone);
+			spring_bone_chains[p_index]->root_bone_name = sk->get_bone_name(spring_bone_chains[p_index]->root_bone);
 		}
 	}
 	if (changed) {
@@ -476,35 +476,35 @@ void SpringBoneSimulator3D::set_root_bone(int p_index, int p_bone) {
 }
 
 int SpringBoneSimulator3D::get_root_bone(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
-	return settings[p_index]->root_bone;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), -1);
+	return spring_bone_chains[p_index]->root_bone;
 }
 
 void SpringBoneSimulator3D::set_end_bone_name(int p_index, const String &p_bone_name) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->end_bone_name = p_bone_name;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->end_bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		set_end_bone(p_index, sk->find_bone(settings[p_index]->end_bone_name));
+		set_end_bone(p_index, sk->find_bone(spring_bone_chains[p_index]->end_bone_name));
 	}
 }
 
 String SpringBoneSimulator3D::get_end_bone_name(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
-	return settings[p_index]->end_bone_name;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), String());
+	return spring_bone_chains[p_index]->end_bone_name;
 }
 
 void SpringBoneSimulator3D::set_end_bone(int p_index, int p_bone) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	bool changed = settings[p_index]->end_bone != p_bone;
-	settings[p_index]->end_bone = p_bone;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	bool changed = spring_bone_chains[p_index]->end_bone != p_bone;
+	spring_bone_chains[p_index]->end_bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		if (settings[p_index]->end_bone <= -1 || settings[p_index]->end_bone >= sk->get_bone_count()) {
+		if (spring_bone_chains[p_index]->end_bone <= -1 || spring_bone_chains[p_index]->end_bone >= sk->get_bone_count()) {
 			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
-			settings[p_index]->end_bone = -1;
+			spring_bone_chains[p_index]->end_bone = -1;
 		} else {
-			settings[p_index]->end_bone_name = sk->get_bone_name(settings[p_index]->end_bone);
+			spring_bone_chains[p_index]->end_bone_name = sk->get_bone_name(spring_bone_chains[p_index]->end_bone);
 		}
 	}
 	if (changed) {
@@ -514,25 +514,25 @@ void SpringBoneSimulator3D::set_end_bone(int p_index, int p_bone) {
 }
 
 int SpringBoneSimulator3D::get_end_bone(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
-	return settings[p_index]->end_bone;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), -1);
+	return spring_bone_chains[p_index]->end_bone;
 }
 
 void SpringBoneSimulator3D::set_extend_end_bone(int p_index, bool p_enabled) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->extend_end_bone = p_enabled;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->extend_end_bone = p_enabled;
 	_make_joints_dirty(p_index, true);
 	notify_property_list_changed();
 }
 
 bool SpringBoneSimulator3D::is_end_bone_extended(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
-	return settings[p_index]->extend_end_bone;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), false);
+	return spring_bone_chains[p_index]->extend_end_bone;
 }
 
 void SpringBoneSimulator3D::set_end_bone_direction(int p_index, BoneDirection p_bone_direction) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->end_bone_direction = p_bone_direction;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->end_bone_direction = p_bone_direction;
 #ifdef TOOLS_ENABLED
 	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
@@ -543,14 +543,14 @@ void SpringBoneSimulator3D::set_end_bone_direction(int p_index, BoneDirection p_
 }
 
 SkeletonModifier3D::BoneDirection SpringBoneSimulator3D::get_end_bone_direction(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), BONE_DIRECTION_FROM_PARENT);
-	return settings[p_index]->end_bone_direction;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), BONE_DIRECTION_FROM_PARENT);
+	return spring_bone_chains[p_index]->end_bone_direction;
 }
 
 void SpringBoneSimulator3D::set_end_bone_length(int p_index, float p_length) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	float old = settings[p_index]->end_bone_length;
-	settings[p_index]->end_bone_length = p_length;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	float old = spring_bone_chains[p_index]->end_bone_length;
+	spring_bone_chains[p_index]->end_bone_length = p_length;
 #ifdef TOOLS_ENABLED
 	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
@@ -561,8 +561,8 @@ void SpringBoneSimulator3D::set_end_bone_length(int p_index, float p_length) {
 }
 
 float SpringBoneSimulator3D::get_end_bone_length(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	return settings[p_index]->end_bone_length;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	return spring_bone_chains[p_index]->end_bone_length;
 }
 
 Vector3 SpringBoneSimulator3D::get_end_bone_axis(int p_end_bone, BoneDirection p_direction) const {
@@ -580,9 +580,9 @@ Vector3 SpringBoneSimulator3D::get_end_bone_axis(int p_end_bone, BoneDirection p
 }
 
 void SpringBoneSimulator3D::set_center_from(int p_index, CenterFrom p_center_from) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	bool center_changed = settings[p_index]->center_from != p_center_from;
-	settings[p_index]->center_from = p_center_from;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	bool center_changed = spring_bone_chains[p_index]->center_from != p_center_from;
+	spring_bone_chains[p_index]->center_from = p_center_from;
 	if (center_changed) {
 		reset();
 	}
@@ -590,52 +590,52 @@ void SpringBoneSimulator3D::set_center_from(int p_index, CenterFrom p_center_fro
 }
 
 SpringBoneSimulator3D::CenterFrom SpringBoneSimulator3D::get_center_from(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), CENTER_FROM_WORLD_ORIGIN);
-	return settings[p_index]->center_from;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), CENTER_FROM_WORLD_ORIGIN);
+	return spring_bone_chains[p_index]->center_from;
 }
 
 void SpringBoneSimulator3D::set_center_node(int p_index, const NodePath &p_node_path) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	bool center_changed = settings[p_index]->center_node != p_node_path;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	bool center_changed = spring_bone_chains[p_index]->center_node != p_node_path;
 	if (should_check_node_path() && !p_node_path.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node_path))) {
 		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Center node '" + String(p_node_path) + "' not found.");
 	}
-	settings[p_index]->center_node = p_node_path;
+	spring_bone_chains[p_index]->center_node = p_node_path;
 	if (center_changed) {
 		reset();
 	}
 }
 
 NodePath SpringBoneSimulator3D::get_center_node(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), NodePath());
-	return settings[p_index]->center_node;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), NodePath());
+	return spring_bone_chains[p_index]->center_node;
 }
 
 void SpringBoneSimulator3D::set_center_bone_name(int p_index, const String &p_bone_name) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->center_bone_name = p_bone_name;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->center_bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		set_center_bone(p_index, sk->find_bone(settings[p_index]->center_bone_name));
+		set_center_bone(p_index, sk->find_bone(spring_bone_chains[p_index]->center_bone_name));
 	}
 }
 
 String SpringBoneSimulator3D::get_center_bone_name(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
-	return settings[p_index]->center_bone_name;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), String());
+	return spring_bone_chains[p_index]->center_bone_name;
 }
 
 void SpringBoneSimulator3D::set_center_bone(int p_index, int p_bone) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	bool center_changed = settings[p_index]->center_bone != p_bone;
-	settings[p_index]->center_bone = p_bone;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	bool center_changed = spring_bone_chains[p_index]->center_bone != p_bone;
+	spring_bone_chains[p_index]->center_bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
-		if (settings[p_index]->center_bone <= -1 || settings[p_index]->center_bone >= sk->get_bone_count()) {
+		if (spring_bone_chains[p_index]->center_bone <= -1 || spring_bone_chains[p_index]->center_bone >= sk->get_bone_count()) {
 			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Center bone index '" + itos(p_bone) + "' is out of range!");
-			settings[p_index]->center_bone = -1;
+			spring_bone_chains[p_index]->center_bone = -1;
 		} else {
-			settings[p_index]->center_bone_name = sk->get_bone_name(settings[p_index]->center_bone);
+			spring_bone_chains[p_index]->center_bone_name = sk->get_bone_name(spring_bone_chains[p_index]->center_bone);
 		}
 	}
 	if (center_changed) {
@@ -644,38 +644,38 @@ void SpringBoneSimulator3D::set_center_bone(int p_index, int p_bone) {
 }
 
 int SpringBoneSimulator3D::get_center_bone(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
-	return settings[p_index]->center_bone;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), -1);
+	return spring_bone_chains[p_index]->center_bone;
 }
 
 void SpringBoneSimulator3D::set_rotation_axis(int p_index, RotationAxis p_axis) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (is_config_individual(p_index)) {
 		return; // Joint config is individual mode.
 	}
-	settings[p_index]->rotation_axis = p_axis;
+	spring_bone_chains[p_index]->rotation_axis = p_axis;
 	_make_joints_dirty(p_index);
 	notify_property_list_changed();
 }
 
 SkeletonModifier3D::RotationAxis SpringBoneSimulator3D::get_rotation_axis(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), ROTATION_AXIS_ALL);
-	return settings[p_index]->rotation_axis;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), ROTATION_AXIS_ALL);
+	return spring_bone_chains[p_index]->rotation_axis;
 }
 
 void SpringBoneSimulator3D::set_rotation_axis_vector(int p_index, const Vector3 &p_vector) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index) || settings[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	if (is_config_individual(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
 		return; // Joint config is individual mode.
 	}
-	settings[p_index]->rotation_axis_vector = p_vector;
+	spring_bone_chains[p_index]->rotation_axis_vector = p_vector;
 	_make_joints_dirty(p_index);
 }
 
 Vector3 SpringBoneSimulator3D::get_rotation_axis_vector(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), Vector3());
 	Vector3 ret;
-	switch (settings[p_index]->rotation_axis) {
+	switch (spring_bone_chains[p_index]->rotation_axis) {
 		case ROTATION_AXIS_X:
 			ret = Vector3(1, 0, 0);
 			break;
@@ -689,7 +689,7 @@ Vector3 SpringBoneSimulator3D::get_rotation_axis_vector(int p_index) const {
 			ret = Vector3(0, 0, 0);
 			break;
 		case ROTATION_AXIS_CUSTOM:
-			ret = settings[p_index]->rotation_axis_vector;
+			ret = spring_bone_chains[p_index]->rotation_axis_vector;
 			break;
 	}
 	return ret;
@@ -802,58 +802,58 @@ Vector3 SpringBoneSimulator3D::get_gravity_direction() const {
 	return gravity_direction;
 }
 
-void SpringBoneSimulator3D::set_setting_count(int p_count) {
+void SpringBoneSimulator3D::set_bone_chain_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
 
-	int delta = p_count - (int)settings.size();
+	int delta = p_count - (int)spring_bone_chains.size();
 	if (delta < 0) {
 		for (int i = delta; i < 0; i++) {
-			memdelete(settings[(int)settings.size() + i]);
-			settings[(int)settings.size() + i] = nullptr;
+			memdelete(spring_bone_chains[(int)spring_bone_chains.size() + i]);
+			spring_bone_chains[(int)spring_bone_chains.size() + i] = nullptr;
 		}
 	}
-	settings.resize(p_count);
+	spring_bone_chains.resize(p_count);
 	delta++;
 	if (delta > 1) {
 		for (int i = 1; i < delta; i++) {
-			settings[p_count - i] = memnew(SpringBone3DSetting);
+			spring_bone_chains[p_count - i] = memnew(SpringBoneChain);
 		}
 	}
 	notify_property_list_changed();
 }
 
-int SpringBoneSimulator3D::get_setting_count() const {
-	return settings.size();
+int SpringBoneSimulator3D::get_bone_chain_count() const {
+	return spring_bone_chains.size();
 }
 
-void SpringBoneSimulator3D::clear_settings() {
-	set_setting_count(0);
+void SpringBoneSimulator3D::clear_bone_chains() {
+	set_bone_chain_count(0);
 }
 
 // Individual joint settings
 
 void SpringBoneSimulator3D::set_individual_config(int p_index, bool p_enabled) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->individual_config = p_enabled;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->individual_config = p_enabled;
 	_make_joints_dirty(p_index, true);
 	notify_property_list_changed();
 }
 
 bool SpringBoneSimulator3D::is_config_individual(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
-	return settings[p_index]->individual_config;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), false);
+	return spring_bone_chains[p_index]->individual_config;
 }
 
 String SpringBoneSimulator3D::get_joint_bone_name(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), String());
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), String());
 	return joints[p_joint]->bone_name;
 }
 
 void SpringBoneSimulator3D::_set_joint_bone(int p_index, int p_joint, int p_bone) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
@@ -868,18 +868,18 @@ void SpringBoneSimulator3D::_set_joint_bone(int p_index, int p_joint, int p_bone
 }
 
 int SpringBoneSimulator3D::get_joint_bone(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), -1);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), -1);
 	return joints[p_joint]->bone;
 }
 
 void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_radius) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->radius = p_radius;
 #ifdef TOOLS_ENABLED
@@ -888,87 +888,87 @@ void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_r
 }
 
 float SpringBoneSimulator3D::get_joint_radius(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), 0);
 	return joints[p_joint]->radius;
 }
 
 void SpringBoneSimulator3D::set_joint_stiffness(int p_index, int p_joint, float p_stiffness) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->stiffness = p_stiffness;
 }
 
 float SpringBoneSimulator3D::get_joint_stiffness(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), 0);
 	return joints[p_joint]->stiffness;
 }
 
 void SpringBoneSimulator3D::set_joint_drag(int p_index, int p_joint, float p_drag) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->drag = p_drag;
 }
 
 float SpringBoneSimulator3D::get_joint_drag(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), 0);
 	return joints[p_joint]->drag;
 }
 
 void SpringBoneSimulator3D::set_joint_gravity(int p_index, int p_joint, float p_gravity) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->gravity = p_gravity;
 }
 
 float SpringBoneSimulator3D::get_joint_gravity(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), 0);
 	return joints[p_joint]->gravity;
 }
 
 void SpringBoneSimulator3D::set_joint_gravity_direction(int p_index, int p_joint, const Vector3 &p_gravity_direction) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	ERR_FAIL_COND(p_gravity_direction.is_zero_approx());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->gravity_direction = p_gravity_direction;
 }
 
 Vector3 SpringBoneSimulator3D::get_joint_gravity_direction(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3(0, -1, 0));
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), Vector3(0, -1, 0));
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), Vector3(0, -1, 0));
 	return joints[p_joint]->gravity_direction;
 }
 
 void SpringBoneSimulator3D::set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	if (!is_config_individual(p_index)) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->rotation_axis = p_axis;
 	Skeleton3D *sk = get_skeleton();
@@ -976,48 +976,48 @@ void SpringBoneSimulator3D::set_joint_rotation_axis(int p_index, int p_joint, Ro
 		_validate_rotation_axis(sk, p_index, p_joint);
 	}
 	notify_property_list_changed();
-	settings[p_index]->simulation_dirty = true;
+	spring_bone_chains[p_index]->simulation_dirty = true;
 #ifdef TOOLS_ENABLED
 	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
 SkeletonModifier3D::RotationAxis SpringBoneSimulator3D::get_joint_rotation_axis(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), ROTATION_AXIS_ALL);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), ROTATION_AXIS_ALL);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), ROTATION_AXIS_ALL);
 	return joints[p_joint]->rotation_axis;
 }
 
 void SpringBoneSimulator3D::set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (!is_config_individual(p_index) || settings[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	if (!is_config_individual(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
 		return; // Joints are read-only.
 	}
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, (int)joints.size());
 	joints[p_joint]->rotation_axis_vector = p_vector;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		_validate_rotation_axis(sk, p_index, p_joint);
 	}
-	settings[p_index]->simulation_dirty = true;
+	spring_bone_chains[p_index]->simulation_dirty = true;
 #ifdef TOOLS_ENABLED
 	_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 }
 
 Vector3 SpringBoneSimulator3D::get_joint_rotation_axis_vector(int p_index, int p_joint) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), Vector3());
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	ERR_FAIL_INDEX_V(p_joint, (int)joints.size(), Vector3());
 	return joints[p_joint]->get_rotation_axis_vector();
 }
 
 void SpringBoneSimulator3D::set_joint_count(int p_index, int p_count) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	ERR_FAIL_COND(p_count < 0);
-	LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	int delta = p_count - joints.size();
 	if (delta < 0) {
 		for (int i = delta; i < 0; i++) {
@@ -1036,8 +1036,8 @@ void SpringBoneSimulator3D::set_joint_count(int p_index, int p_count) {
 }
 
 int SpringBoneSimulator3D::get_joint_count(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), 0);
+	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
 	return joints.size();
 }
 
@@ -1171,8 +1171,8 @@ Vector3 SpringBoneSimulator3D::get_external_force() const {
 
 void SpringBoneSimulator3D::set_mutable_bone_axes(bool p_enabled) {
 	mutable_bone_axes = p_enabled;
-	for (SpringBone3DSetting *setting : settings) {
-		setting->simulation_dirty = true;
+	for (SpringBoneChain *chain : spring_bone_chains) {
+		chain->simulation_dirty = true;
 	}
 }
 
@@ -1234,9 +1234,9 @@ void SpringBoneSimulator3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gravity_direction", "gravity_direction"), &SpringBoneSimulator3D::set_gravity_direction);
 	ClassDB::bind_method(D_METHOD("get_gravity_direction"), &SpringBoneSimulator3D::get_gravity_direction);
 
-	ClassDB::bind_method(D_METHOD("set_setting_count", "count"), &SpringBoneSimulator3D::set_setting_count);
-	ClassDB::bind_method(D_METHOD("get_setting_count"), &SpringBoneSimulator3D::get_setting_count);
-	ClassDB::bind_method(D_METHOD("clear_settings"), &SpringBoneSimulator3D::clear_settings);
+	ClassDB::bind_method(D_METHOD("set_bone_chain_count", "count"), &SpringBoneSimulator3D::set_bone_chain_count);
+	ClassDB::bind_method(D_METHOD("get_bone_chain_count"), &SpringBoneSimulator3D::get_bone_chain_count);
+	ClassDB::bind_method(D_METHOD("clear_bone_chains"), &SpringBoneSimulator3D::clear_bone_chains);
 
 	// Individual Joint Settings
 	ClassDB::bind_method(D_METHOD("set_individual_config", "index", "enabled"), &SpringBoneSimulator3D::set_individual_config);
@@ -1290,7 +1290,7 @@ void SpringBoneSimulator3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "external_force", PROPERTY_HINT_RANGE, "-99999,99999,or_greater,or_less,hide_control,suffix:m/s"), "set_external_force", "get_external_force");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mutable_bone_axes"), "set_mutable_bone_axes", "are_bone_axes_mutable");
-	ADD_ARRAY_COUNT("Settings", "setting_count", "set_setting_count", "get_setting_count", "settings/");
+	ADD_ARRAY_COUNT("Bone Chains", "setting_count", "set_bone_chain_count", "get_bone_chain_count", "bone_chains/");
 
 	BIND_ENUM_CONSTANT(CENTER_FROM_WORLD_ORIGIN);
 	BIND_ENUM_CONSTANT(CENTER_FROM_NODE);
@@ -1308,25 +1308,25 @@ void SpringBoneSimulator3D::_skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_n
 }
 
 void SpringBoneSimulator3D::_validate_bone_names() {
-	for (uint32_t i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
 		// Prior bone name.
-		if (!settings[i]->root_bone_name.is_empty()) {
-			set_root_bone_name(i, settings[i]->root_bone_name);
-		} else if (settings[i]->root_bone != -1) {
-			set_root_bone(i, settings[i]->root_bone);
+		if (!spring_bone_chains[i]->root_bone_name.is_empty()) {
+			set_root_bone_name(i, spring_bone_chains[i]->root_bone_name);
+		} else if (spring_bone_chains[i]->root_bone != -1) {
+			set_root_bone(i, spring_bone_chains[i]->root_bone);
 		}
 		// Prior bone name.
-		if (!settings[i]->end_bone_name.is_empty()) {
-			set_end_bone_name(i, settings[i]->end_bone_name);
-		} else if (settings[i]->end_bone != -1) {
-			set_end_bone(i, settings[i]->end_bone);
+		if (!spring_bone_chains[i]->end_bone_name.is_empty()) {
+			set_end_bone_name(i, spring_bone_chains[i]->end_bone_name);
+		} else if (spring_bone_chains[i]->end_bone != -1) {
+			set_end_bone(i, spring_bone_chains[i]->end_bone);
 		}
 	}
 }
 
 void SpringBoneSimulator3D::_make_joints_dirty(int p_index, bool p_reset) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->joints_dirty = true;
+	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
+	spring_bone_chains[p_index]->joints_dirty = true;
 	if (joints_dirty) {
 		return;
 	}
@@ -1335,7 +1335,7 @@ void SpringBoneSimulator3D::_make_joints_dirty(int p_index, bool p_reset) {
 }
 
 void SpringBoneSimulator3D::_make_all_joints_dirty() {
-	for (uint32_t i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
 		_update_joint_array(i);
 	}
 }
@@ -1359,29 +1359,29 @@ void SpringBoneSimulator3D::remove_child_notify(Node *p_child) {
 }
 
 void SpringBoneSimulator3D::_validate_rotation_axes(Skeleton3D *p_skeleton) const {
-	for (uint32_t i = 0; i < settings.size(); i++) {
-		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
+		for (uint32_t j = 0; j < spring_bone_chains[i]->joints.size(); j++) {
 			_validate_rotation_axis(p_skeleton, i, j);
+		}
 	}
-}
 }
 
 void SpringBoneSimulator3D::_validate_rotation_axis(Skeleton3D *p_skeleton, int p_index, int p_joint) const {
-	RotationAxis axis = settings[p_index]->joints[p_joint]->rotation_axis;
+	RotationAxis axis = spring_bone_chains[p_index]->joints[p_joint]->rotation_axis;
 	if (axis == ROTATION_AXIS_ALL) {
 		return;
 	}
 	Vector3 rot = get_joint_rotation_axis_vector(p_index, p_joint).normalized();
 	Vector3 fwd;
-	if (p_joint < (int)settings[p_index]->joints.size() - 1) {
-		fwd = p_skeleton->get_bone_rest(settings[p_index]->joints[p_joint + 1]->bone).origin;
-	} else if (settings[p_index]->extend_end_bone) {
-		fwd = get_end_bone_axis(settings[p_index]->end_bone, settings[p_index]->end_bone_direction);
-				if (fwd.is_zero_approx()) {
-					return;
-				}
-			}
-			fwd.normalize();
+	if (p_joint < (int)spring_bone_chains[p_index]->joints.size() - 1) {
+		fwd = p_skeleton->get_bone_rest(spring_bone_chains[p_index]->joints[p_joint + 1]->bone).origin;
+	} else if (spring_bone_chains[p_index]->extend_end_bone) {
+		fwd = get_end_bone_axis(spring_bone_chains[p_index]->end_bone, spring_bone_chains[p_index]->end_bone_direction);
+		if (fwd.is_zero_approx()) {
+			return;
+		}
+	}
+	fwd.normalize();
 	if (Math::is_equal_approx(Math::abs(rot.dot(fwd)), 1)) {
 		WARN_PRINT_ED("Setting: " + itos(p_index) + " Joint: " + itos(p_joint) + ": Rotation axis and forward vector are colinear. This is not advised as it may cause unwanted rotation.");
 	}
@@ -1401,7 +1401,7 @@ void SpringBoneSimulator3D::_find_collisions() {
 
 	bool setting_updated = false;
 
-	for (uint32_t i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
 		LocalVector<ObjectID> &cache = cached_collisions;
 		cache.clear();
 		if (!enable_all_child_collisions) {
@@ -1476,8 +1476,8 @@ void SpringBoneSimulator3D::_update_joint_array(int p_index) {
 	_make_joints_dirty(p_index, true);
 
 	Skeleton3D *sk = get_skeleton();
-	int current_bone = settings[p_index]->end_bone;
-	int root_bone = settings[p_index]->root_bone;
+	int current_bone = spring_bone_chains[p_index]->end_bone;
+	int root_bone = spring_bone_chains[p_index]->root_bone;
 	if (!sk || current_bone < 0 || root_bone < 0) {
 		set_joint_count(p_index, 0);
 		return;
@@ -1499,7 +1499,7 @@ void SpringBoneSimulator3D::_update_joint_array(int p_index) {
 	}
 
 	LocalVector<int> new_joints;
-	current_bone = settings[p_index]->end_bone;
+	current_bone = spring_bone_chains[p_index]->end_bone;
 	while (current_bone != root_bone) {
 		new_joints.push_back(current_bone);
 		current_bone = sk->get_bone_parent(current_bone);
@@ -1517,16 +1517,16 @@ void SpringBoneSimulator3D::_update_joints(bool p_reset) {
 	if (!joints_dirty) {
 		return;
 	}
-	for (uint32_t i = 0; i < settings.size(); i++) {
-		if (!settings[i]->joints_dirty) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
+		if (!spring_bone_chains[i]->joints_dirty) {
 			continue;
 		}
-		if (settings[i]->individual_config) {
-			settings[i]->simulation_dirty = p_reset;
-			settings[i]->joints_dirty = false;
+		if (spring_bone_chains[i]->individual_config) {
+			spring_bone_chains[i]->simulation_dirty = p_reset;
+			spring_bone_chains[i]->joints_dirty = false;
 			continue; // Abort.
 		}
-		LocalVector<SpringBone3DJointSetting *> &joints = settings[i]->joints;
+		LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[i]->joints;
 		float unit = joints.size() > 0 ? (1.0 / float(joints.size() - 1)) : 0.0;
 		for (uint32_t j = 0; j < joints.size(); j++) {
 			float offset = j * unit;
@@ -1556,11 +1556,11 @@ void SpringBoneSimulator3D::_update_joints(bool p_reset) {
 			}
 
 			joints[j]->gravity_direction = gravity_direction;
-			joints[j]->rotation_axis = settings[i]->rotation_axis;
-			joints[j]->rotation_axis_vector = settings[i]->rotation_axis_vector;
+			joints[j]->rotation_axis = spring_bone_chains[i]->rotation_axis;
+			joints[j]->rotation_axis_vector = spring_bone_chains[i]->rotation_axis_vector;
 		}
-		settings[i]->simulation_dirty = p_reset;
-		settings[i]->joints_dirty = false;
+		spring_bone_chains[i]->simulation_dirty = p_reset;
+		spring_bone_chains[i]->joints_dirty = false;
 	}
 	joints_dirty = false;
 	Skeleton3D *sk = get_skeleton();
@@ -1572,7 +1572,7 @@ void SpringBoneSimulator3D::_update_joints(bool p_reset) {
 #endif // TOOLS_ENABLED
 }
 
-void SpringBoneSimulator3D::_update_bone_axis(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting) {
+void SpringBoneSimulator3D::_update_bone_axis(Skeleton3D *p_skeleton, SpringBoneChain *p_setting) {
 #ifdef TOOLS_ENABLED
 	bool changed = false;
 #endif // TOOLS_ENABLED
@@ -1626,8 +1626,8 @@ Vector3 SpringBoneSimulator3D::get_bone_vector(int p_index, int p_joint) const {
 	if (!skeleton) {
 		return Vector3();
 	}
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3());
-	SpringBone3DSetting *setting = settings[p_index];
+	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), Vector3());
+	SpringBoneChain *setting = spring_bone_chains[p_index];
 	if (!setting) {
 		return Vector3();
 	}
@@ -1676,9 +1676,9 @@ void SpringBoneSimulator3D::_process_modification(double p_delta) {
 	}
 #endif // TOOLS_ENABLED
 
-	for (uint32_t i = 0; i < settings.size(); i++) {
-		_init_joints(skeleton, settings[i]);
-		_process_joints(p_delta, skeleton, settings[i]->joints, get_valid_collision_instance_ids(), settings[i]->cached_center, settings[i]->cached_inverted_center, settings[i]->cached_inverted_center.basis.get_rotation_quaternion());
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
+		_init_joints(skeleton, spring_bone_chains[i]);
+		_process_joints(p_delta, skeleton, spring_bone_chains[i]->joints, get_valid_collision_instance_ids(), spring_bone_chains[i]->cached_center, spring_bone_chains[i]->cached_inverted_center, spring_bone_chains[i]->cached_inverted_center.basis.get_rotation_quaternion());
 	}
 }
 
@@ -1692,78 +1692,78 @@ void SpringBoneSimulator3D::reset() {
 	}
 	_find_collisions();
 	_process_collisions();
-	for (uint32_t i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < spring_bone_chains.size(); i++) {
 		_make_joints_dirty(i, true);
-		_init_joints(skeleton, settings[i]);
+		_init_joints(skeleton, spring_bone_chains[i]);
 	}
 }
 
-void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSetting *setting) {
-	if (setting->center_from == CENTER_FROM_WORLD_ORIGIN) {
-		setting->cached_center = p_skeleton->get_global_transform_interpolated();
-	} else if (setting->center_from == CENTER_FROM_NODE) {
-		if (setting->center_node == NodePath()) {
-			setting->cached_center = Transform3D();
+void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBoneChain *chain) {
+	if (chain->center_from == CENTER_FROM_WORLD_ORIGIN) {
+		chain->cached_center = p_skeleton->get_global_transform_interpolated();
+	} else if (chain->center_from == CENTER_FROM_NODE) {
+		if (chain->center_node == NodePath()) {
+			chain->cached_center = Transform3D();
 		} else {
-			Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(setting->center_node));
+			Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(chain->center_node));
 			if (!nd) {
-				setting->cached_center = Transform3D();
+				chain->cached_center = Transform3D();
 			} else {
-				setting->cached_center = nd->get_global_transform_interpolated().affine_inverse() * p_skeleton->get_global_transform_interpolated();
+				chain->cached_center = nd->get_global_transform_interpolated().affine_inverse() * p_skeleton->get_global_transform_interpolated();
 			}
 		}
 	} else {
-		if (setting->center_bone >= 0) {
-			setting->cached_center = p_skeleton->get_bone_global_pose(setting->center_bone);
+		if (chain->center_bone >= 0) {
+			chain->cached_center = p_skeleton->get_bone_global_pose(chain->center_bone);
 		} else {
-			setting->cached_center = Transform3D();
+			chain->cached_center = Transform3D();
 		}
 	}
-	setting->cached_inverted_center = setting->cached_center.affine_inverse();
+	chain->cached_inverted_center = chain->cached_center.affine_inverse();
 
-	if (!setting->simulation_dirty) {
+	if (!chain->simulation_dirty) {
 		if (mutable_bone_axes) {
-			_update_bone_axis(p_skeleton, setting);
+			_update_bone_axis(p_skeleton, chain);
 		}
 		return;
 	}
-	for (uint32_t i = 0; i < setting->joints.size(); i++) {
-		if (setting->joints[i]->verlet) {
-			memdelete(setting->joints[i]->verlet);
-			setting->joints[i]->verlet = nullptr;
+	for (uint32_t i = 0; i < chain->joints.size(); i++) {
+		if (chain->joints[i]->verlet) {
+			memdelete(chain->joints[i]->verlet);
+			chain->joints[i]->verlet = nullptr;
 		}
-		if (i < setting->joints.size() - 1) {
-			Vector3 axis = p_skeleton->get_bone_rest(setting->joints[i + 1]->bone).origin;
+		if (i < chain->joints.size() - 1) {
+			Vector3 axis = p_skeleton->get_bone_rest(chain->joints[i + 1]->bone).origin;
 			if (axis.is_zero_approx()) {
 				continue;
 			}
-			setting->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
-			setting->joints[i]->verlet->current_tail = setting->cached_center.xform(p_skeleton->get_bone_global_pose(setting->joints[i]->bone).xform(axis));
-			setting->joints[i]->verlet->prev_tail = setting->joints[i]->verlet->current_tail;
-			setting->joints[i]->verlet->forward_vector = snap_vector_to_plane(setting->joints[i]->get_rotation_axis_vector(), axis.normalized());
-			setting->joints[i]->verlet->length = axis.length();
-			setting->joints[i]->verlet->current_rot = Quaternion(0, 0, 0, 1);
-		} else if (setting->extend_end_bone && setting->end_bone_length > 0) {
-			Vector3 axis = get_end_bone_axis(setting->end_bone, setting->end_bone_direction);
+			chain->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
+			chain->joints[i]->verlet->current_tail = chain->cached_center.xform(p_skeleton->get_bone_global_pose(chain->joints[i]->bone).xform(axis));
+			chain->joints[i]->verlet->prev_tail = chain->joints[i]->verlet->current_tail;
+			chain->joints[i]->verlet->forward_vector = snap_vector_to_plane(chain->joints[i]->get_rotation_axis_vector(), axis.normalized());
+			chain->joints[i]->verlet->length = axis.length();
+			chain->joints[i]->verlet->current_rot = Quaternion(0, 0, 0, 1);
+		} else if (chain->extend_end_bone && chain->end_bone_length > 0) {
+			Vector3 axis = get_end_bone_axis(chain->end_bone, chain->end_bone_direction);
 			if (axis.is_zero_approx()) {
 				continue;
 			}
-			setting->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
-			setting->joints[i]->verlet->forward_vector = snap_vector_to_plane(setting->joints[i]->get_rotation_axis_vector(), axis.normalized());
-			setting->joints[i]->verlet->length = setting->end_bone_length;
-			setting->joints[i]->verlet->current_tail = setting->cached_center.xform(p_skeleton->get_bone_global_pose(setting->joints[i]->bone).xform(axis * setting->end_bone_length));
-			setting->joints[i]->verlet->prev_tail = setting->joints[i]->verlet->current_tail;
-			setting->joints[i]->verlet->current_rot = Quaternion(0, 0, 0, 1);
+			chain->joints[i]->verlet = memnew(SpringBone3DVerletInfo);
+			chain->joints[i]->verlet->forward_vector = snap_vector_to_plane(chain->joints[i]->get_rotation_axis_vector(), axis.normalized());
+			chain->joints[i]->verlet->length = chain->end_bone_length;
+			chain->joints[i]->verlet->current_tail = chain->cached_center.xform(p_skeleton->get_bone_global_pose(chain->joints[i]->bone).xform(axis * chain->end_bone_length));
+			chain->joints[i]->verlet->prev_tail = chain->joints[i]->verlet->current_tail;
+			chain->joints[i]->verlet->current_rot = Quaternion(0, 0, 0, 1);
 		}
 	}
 	if (mutable_bone_axes) {
-		_update_bone_axis(p_skeleton, setting);
+		_update_bone_axis(p_skeleton, chain);
 #ifdef TOOLS_ENABLED
 	} else {
 		_make_gizmo_dirty();
 #endif // TOOLS_ENABLED
 	}
-	setting->simulation_dirty = false;
+	chain->simulation_dirty = false;
 }
 
 void SpringBoneSimulator3D::_process_joints(double p_delta, Skeleton3D *p_skeleton, LocalVector<SpringBone3DJointSetting *> &p_joints, const LocalVector<ObjectID> &p_collisions, const Transform3D &p_center_transform, const Transform3D &p_inverted_center_transform, const Quaternion &p_inverted_center_rotation) {
@@ -1828,5 +1828,5 @@ void SpringBoneSimulator3D::_process_joints(double p_delta, Skeleton3D *p_skelet
 }
 
 SpringBoneSimulator3D::~SpringBoneSimulator3D() {
-	clear_settings();
+	clear_bone_chains();
 }

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -73,8 +73,8 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 			set_center_bone(which, p_value);
 		} else if (what == "center_bone_name") {
 			set_center_bone_name(which, p_value);
-		} else if (what == "individual_config") {
-			set_individual_config(which, p_value);
+		} else if (what == "override_individual_joints") {
+			set_override_individual_joints(which, p_value);
 		} else if (what == "rotation_axis") {
 			set_rotation_axis(which, static_cast<RotationAxis>((int)p_value));
 		} else if (what == "rotation_axis_vector") {
@@ -194,8 +194,8 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 			r_ret = get_center_bone(which);
 		} else if (what == "center_bone_name") {
 			r_ret = get_center_bone_name(which);
-		} else if (what == "individual_config") {
-			r_ret = is_config_individual(which);
+		} else if (what == "override_individual_joints") {
+			r_ret = is_override_individual_joints(which);
 		} else if (what == "rotation_axis") {
 			r_ret = (int)get_rotation_axis(which);
 		} else if (what == "rotation_axis_vector") {
@@ -327,7 +327,7 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		props.push_back(PropertyInfo(Variant::NODE_PATH, path + "center_node"));
 		props.push_back(PropertyInfo(Variant::STRING, path + "center_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
 		props.push_back(PropertyInfo(Variant::INT, path + "center_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
-		props.push_back(PropertyInfo(Variant::BOOL, path + "individual_config"));
+		props.push_back(PropertyInfo(Variant::BOOL, path + "override_individual_joints"));
 		props.push_back(PropertyInfo(Variant::INT, path + "rotation_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_rotation_axis()));
 		props.push_back(PropertyInfo(Variant::VECTOR3, path + "rotation_axis_vector"));
 		props.push_back(PropertyInfo(Variant::INT, path + "joint_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Joints," + path + "joints/,static,const"));
@@ -376,7 +376,7 @@ void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) con
 			}
 
 			// Joints option.
-			if (is_config_individual(which)) {
+			if (is_override_individual_joints(which)) {
 				if (split[2] == "rotation_axis" || split[2] == "rotation_axis_vector") {
 					p_property.usage = PROPERTY_USAGE_NONE;
 				}
@@ -649,7 +649,7 @@ int SpringBoneSimulator3D::get_center_bone(int p_index) const {
 
 void SpringBoneSimulator3D::set_rotation_axis(int p_index, RotationAxis p_axis) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (is_config_individual(p_index)) {
+	if (is_override_individual_joints(p_index)) {
 		return; // Joint config is individual mode.
 	}
 	spring_bone_chains[p_index]->rotation_axis = p_axis;
@@ -664,7 +664,7 @@ SkeletonModifier3D::RotationAxis SpringBoneSimulator3D::get_rotation_axis(int p_
 
 void SpringBoneSimulator3D::set_rotation_axis_vector(int p_index, const Vector3 &p_vector) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (is_config_individual(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
+	if (is_override_individual_joints(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
 		return; // Joint config is individual mode.
 	}
 	spring_bone_chains[p_index]->rotation_axis_vector = p_vector;
@@ -831,16 +831,16 @@ void SpringBoneSimulator3D::clear_bone_chains() {
 
 // Individual joint settings
 
-void SpringBoneSimulator3D::set_individual_config(int p_index, bool p_enabled) {
+void SpringBoneSimulator3D::set_override_individual_joints(int p_index, bool p_enabled) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	spring_bone_chains[p_index]->individual_config = p_enabled;
+	spring_bone_chains[p_index]->override_individual_joints = p_enabled;
 	_make_joints_dirty(p_index, true);
 	notify_property_list_changed();
 }
 
-bool SpringBoneSimulator3D::is_config_individual(int p_index) const {
+bool SpringBoneSimulator3D::is_override_individual_joints(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, (int)spring_bone_chains.size(), false);
-	return spring_bone_chains[p_index]->individual_config;
+	return spring_bone_chains[p_index]->override_individual_joints;
 }
 
 String SpringBoneSimulator3D::get_joint_bone_name(int p_index, int p_joint) const {
@@ -875,7 +875,7 @@ int SpringBoneSimulator3D::get_joint_bone(int p_index, int p_joint) const {
 
 void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_radius) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -895,7 +895,7 @@ float SpringBoneSimulator3D::get_joint_radius(int p_index, int p_joint) const {
 
 void SpringBoneSimulator3D::set_joint_stiffness(int p_index, int p_joint, float p_stiffness) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -912,7 +912,7 @@ float SpringBoneSimulator3D::get_joint_stiffness(int p_index, int p_joint) const
 
 void SpringBoneSimulator3D::set_joint_drag(int p_index, int p_joint, float p_drag) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -929,7 +929,7 @@ float SpringBoneSimulator3D::get_joint_drag(int p_index, int p_joint) const {
 
 void SpringBoneSimulator3D::set_joint_gravity(int p_index, int p_joint, float p_gravity) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -947,7 +947,7 @@ float SpringBoneSimulator3D::get_joint_gravity(int p_index, int p_joint) const {
 void SpringBoneSimulator3D::set_joint_gravity_direction(int p_index, int p_joint, const Vector3 &p_gravity_direction) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
 	ERR_FAIL_COND(p_gravity_direction.is_zero_approx());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -964,7 +964,7 @@ Vector3 SpringBoneSimulator3D::get_joint_gravity_direction(int p_index, int p_jo
 
 void SpringBoneSimulator3D::set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index)) {
+	if (!is_override_individual_joints(p_index)) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -990,7 +990,7 @@ SkeletonModifier3D::RotationAxis SpringBoneSimulator3D::get_joint_rotation_axis(
 
 void SpringBoneSimulator3D::set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector) {
 	ERR_FAIL_INDEX(p_index, (int)spring_bone_chains.size());
-	if (!is_config_individual(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
+	if (!is_override_individual_joints(p_index) || spring_bone_chains[p_index]->rotation_axis != ROTATION_AXIS_CUSTOM) {
 		return; // Joints are read-only.
 	}
 	const LocalVector<SpringBone3DJointSetting *> &joints = spring_bone_chains[p_index]->joints;
@@ -1238,8 +1238,8 @@ void SpringBoneSimulator3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_bone_chains"), &SpringBoneSimulator3D::clear_bone_chains);
 
 	// Individual Joint Settings
-	ClassDB::bind_method(D_METHOD("set_individual_config", "index", "enabled"), &SpringBoneSimulator3D::set_individual_config);
-	ClassDB::bind_method(D_METHOD("is_config_individual", "index"), &SpringBoneSimulator3D::is_config_individual);
+	ClassDB::bind_method(D_METHOD("set_override_individual_joints", "index", "enabled"), &SpringBoneSimulator3D::set_override_individual_joints);
+	ClassDB::bind_method(D_METHOD("is_override_individual_joints", "index"), &SpringBoneSimulator3D::is_override_individual_joints);
 
 	ClassDB::bind_method(D_METHOD("get_joint_bone_name", "index", "joint"), &SpringBoneSimulator3D::get_joint_bone_name);
 	ClassDB::bind_method(D_METHOD("get_joint_bone", "index", "joint"), &SpringBoneSimulator3D::get_joint_bone);
@@ -1520,7 +1520,7 @@ void SpringBoneSimulator3D::_update_joints(bool p_reset) {
 		if (!spring_bone_chains[i]->joints_dirty) {
 			continue;
 		}
-		if (spring_bone_chains[i]->individual_config) {
+		if (spring_bone_chains[i]->override_individual_joints) {
 			spring_bone_chains[i]->simulation_dirty = p_reset;
 			spring_bone_chains[i]->joints_dirty = false;
 			continue; // Abort.

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -79,46 +79,7 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 			set_rotation_axis(which, static_cast<RotationAxis>((int)p_value));
 		} else if (what == "rotation_axis_vector") {
 			set_rotation_axis_vector(which, p_value);
-		} else if (what == "radius") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				set_radius(which, p_value);
-			} else if (opt == "damping_curve") {
-				set_radius_damping_curve(which, p_value);
-			} else {
-				return false;
-			}
-		} else if (what == "stiffness") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				set_stiffness(which, p_value);
-			} else if (opt == "damping_curve") {
-				set_stiffness_damping_curve(which, p_value);
-			} else {
-				return false;
-			}
-		} else if (what == "drag") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				set_drag(which, p_value);
-			} else if (opt == "damping_curve") {
-				set_drag_damping_curve(which, p_value);
-			} else {
-				return false;
-			}
-		} else if (what == "gravity") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				set_gravity(which, p_value);
-			} else if (opt == "damping_curve") {
-				set_gravity_damping_curve(which, p_value);
-			} else if (opt == "direction") {
-				set_gravity_direction(which, p_value);
-			} else {
-				return false;
-			}
-		} else if (what == "enable_all_child_collisions") {
-			set_enable_all_child_collisions(which, p_value);
+
 		} else if (what == "joint_count") {
 			set_joint_count(which, p_value);
 		} else if (what == "joints") {
@@ -141,16 +102,56 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 			} else {
 				return false;
 			}
+		}
+	} else {
+		String what = path.get_slicec('/', 0);
+		String opt = path.get_slicec('/', 1);
+		if (what == "radius") {
+			if (opt == "value") {
+				set_radius(p_value);
+			} else if (opt == "damping_curve") {
+				set_radius_damping_curve(p_value);
+			} else {
+				return false;
+			}
+		} else if (what == "stiffness") {
+			if (opt == "value") {
+				set_stiffness(p_value);
+			} else if (opt == "damping_curve") {
+				set_stiffness_damping_curve(p_value);
+			} else {
+				return false;
+			}
+		} else if (what == "drag") {
+			if (opt == "value") {
+				set_drag(p_value);
+			} else if (opt == "damping_curve") {
+				set_drag_damping_curve(p_value);
+			} else {
+				return false;
+			}
+		} else if (what == "gravity") {
+			if (opt == "value") {
+				set_gravity(p_value);
+			} else if (opt == "damping_curve") {
+				set_gravity_damping_curve(p_value);
+			} else if (opt == "direction") {
+				set_gravity_direction(p_value);
+			} else {
+				return false;
+			}
+		} else if (what == "enable_all_child_collisions") {
+			set_enable_all_child_collisions(p_value);
 		} else if (what == "exclude_collision_count") {
-			set_exclude_collision_count(which, p_value);
+			set_exclude_collision_count(p_value);
 		} else if (what == "exclude_collisions") {
-			int idx = path.get_slicec('/', 3).to_int();
-			set_exclude_collision_path(which, idx, p_value);
+			int idx = opt.to_int();
+			set_exclude_collision_path(idx, p_value);
 		} else if (what == "collision_count") {
-			set_collision_count(which, p_value);
+			set_collision_count(p_value);
 		} else if (what == "collisions") {
-			int idx = path.get_slicec('/', 3).to_int();
-			set_collision_path(which, idx, p_value);
+			int idx = opt.to_int();
+			set_collision_path(idx, p_value);
 		} else {
 			return false;
 		}
@@ -199,47 +200,7 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 			r_ret = (int)get_rotation_axis(which);
 		} else if (what == "rotation_axis_vector") {
 			r_ret = get_rotation_axis_vector(which);
-		} else if (what == "radius") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				r_ret = get_radius(which);
-			} else if (opt == "damping_curve") {
-				r_ret = get_radius_damping_curve(which);
-			} else {
-				return false;
-			}
-		} else if (what == "stiffness") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				r_ret = get_stiffness(which);
-			} else if (opt == "damping_curve") {
-				r_ret = get_stiffness_damping_curve(which);
-			} else {
-				return false;
-			}
-		} else if (what == "drag") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				r_ret = get_drag(which);
-			} else if (opt == "damping_curve") {
-				r_ret = get_drag_damping_curve(which);
-			} else {
-				return false;
-			}
-		} else if (what == "gravity") {
-			String opt = path.get_slicec('/', 3);
-			if (opt == "value") {
-				r_ret = get_gravity(which);
-			} else if (opt == "damping_curve") {
-				r_ret = get_gravity_damping_curve(which);
-			} else if (opt == "direction") {
-				r_ret = get_gravity_direction(which);
-			} else {
-				return false;
-			}
-		} else if (what == "enable_all_child_collisions") {
-			r_ret = are_all_child_collisions_enabled(which);
-		} else if (what == "joint_count") {
+		}else if (what == "joint_count") {
 			r_ret = get_joint_count(which);
 		} else if (what == "joints") {
 			int idx = path.get_slicec('/', 3).to_int();
@@ -265,16 +226,56 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 			} else {
 				return false;
 			}
+		} 
+	} else {
+		String what = path.get_slicec('/', 0);
+		String opt = path.get_slicec('/', 1);
+		if (what == "radius") {
+			if (opt == "value") {
+				r_ret = get_radius();
+			} else if (opt == "damping_curve") {
+				r_ret = get_radius_damping_curve();
+			} else {
+				return false;
+			}
+		} else if (what == "stiffness") {
+			if (opt == "value") {
+				r_ret = get_stiffness();
+			} else if (opt == "damping_curve") {
+				r_ret = get_stiffness_damping_curve();
+			} else {
+				return false;
+			}
+		} else if (what == "drag") {
+			if (opt == "value") {
+				r_ret = get_drag();
+			} else if (opt == "damping_curve") {
+				r_ret = get_drag_damping_curve();
+			} else {
+				return false;
+			}
+		} else if (what == "gravity") {
+			if (opt == "value") {
+				r_ret = get_gravity();
+			} else if (opt == "damping_curve") {
+				r_ret = get_gravity_damping_curve();
+			} else if (opt == "direction") {
+				r_ret = get_gravity_direction();
+			} else {
+				return false;
+			}
+		} else if (what == "enable_all_child_collisions") {
+			r_ret = are_all_child_collisions_enabled();
 		} else if (what == "exclude_collision_count") {
-			r_ret = get_exclude_collision_count(which);
+			r_ret = get_exclude_collision_count();
 		} else if (what == "exclude_collisions") {
-			int idx = path.get_slicec('/', 3).to_int();
-			r_ret = get_exclude_collision_path(which, idx);
+			int idx = opt.to_int();
+			r_ret = get_exclude_collision_path(idx);
 		} else if (what == "collision_count") {
-			r_ret = get_collision_count(which);
+			r_ret = get_collision_count();
 		} else if (what == "collisions") {
-			int idx = path.get_slicec('/', 3).to_int();
-			r_ret = get_collision_path(which, idx);
+			int idx = opt.to_int();
+			r_ret = get_collision_path(idx);
 		} else {
 			return false;
 		}
@@ -290,6 +291,28 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 	}
 
 	LocalVector<PropertyInfo> props;
+
+	props.push_back(PropertyInfo(Variant::FLOAT,   "radius/value", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
+	props.push_back(PropertyInfo(Variant::OBJECT,  "radius/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT,   "stiffness/value", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"));
+	props.push_back(PropertyInfo(Variant::OBJECT,  "stiffness/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT,   "drag/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"));
+	props.push_back(PropertyInfo(Variant::OBJECT,  "drag/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::FLOAT,   "gravity/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater,or_less,suffix:m/s"));
+	props.push_back(PropertyInfo(Variant::OBJECT,  "gravity/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
+	props.push_back(PropertyInfo(Variant::VECTOR3, "gravity/direction"));
+
+	props.push_back(PropertyInfo(Variant::BOOL, "enable_all_child_collisions"));
+	props.push_back(PropertyInfo(Variant::INT, "exclude_collision_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Exclude Collisions,exclude_collisions/"));
+	for (uint32_t j = 0; j < exclude_collisions.size(); j++) {
+		String collision_path = "exclude_collisions/" + itos(j);
+		props.push_back(PropertyInfo(Variant::NODE_PATH, collision_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpringBoneCollision3D"));
+	}
+	props.push_back(PropertyInfo(Variant::INT, "collision_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Collisions,collisions/"));
+	for (uint32_t j = 0; j < collisions.size(); j++) {
+		String collision_path = "collisions/" + itos(j);
+		props.push_back(PropertyInfo(Variant::NODE_PATH, collision_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpringBoneCollision3D"));
+	}
 
 	for (uint32_t i = 0; i < settings.size(); i++) {
 		String path = "settings/" + itos(i) + "/";
@@ -307,15 +330,6 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		props.push_back(PropertyInfo(Variant::BOOL, path + "individual_config"));
 		props.push_back(PropertyInfo(Variant::INT, path + "rotation_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_rotation_axis()));
 		props.push_back(PropertyInfo(Variant::VECTOR3, path + "rotation_axis_vector"));
-		props.push_back(PropertyInfo(Variant::FLOAT, path + "radius/value", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
-		props.push_back(PropertyInfo(Variant::OBJECT, path + "radius/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-		props.push_back(PropertyInfo(Variant::FLOAT, path + "stiffness/value", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"));
-		props.push_back(PropertyInfo(Variant::OBJECT, path + "stiffness/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-		props.push_back(PropertyInfo(Variant::FLOAT, path + "drag/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"));
-		props.push_back(PropertyInfo(Variant::OBJECT, path + "drag/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-		props.push_back(PropertyInfo(Variant::FLOAT, path + "gravity/value", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater,or_less,suffix:m/s"));
-		props.push_back(PropertyInfo(Variant::OBJECT, path + "gravity/damping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static()));
-		props.push_back(PropertyInfo(Variant::VECTOR3, path + "gravity/direction"));
 		props.push_back(PropertyInfo(Variant::INT, path + "joint_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Joints," + path + "joints/,static,const"));
 		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
 			String joint_path = path + "joints/" + itos(j) + "/";
@@ -328,17 +342,6 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 			props.push_back(PropertyInfo(Variant::FLOAT, joint_path + "drag", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"));
 			props.push_back(PropertyInfo(Variant::FLOAT, joint_path + "gravity", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater,or_less,suffix:m/s"));
 			props.push_back(PropertyInfo(Variant::VECTOR3, joint_path + "gravity_direction"));
-		}
-		props.push_back(PropertyInfo(Variant::BOOL, path + "enable_all_child_collisions"));
-		props.push_back(PropertyInfo(Variant::INT, path + "exclude_collision_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Exclude Collisions," + path + "exclude_collisions/"));
-		for (uint32_t j = 0; j < settings[i]->exclude_collisions.size(); j++) {
-			String collision_path = path + "exclude_collisions/" + itos(j);
-			props.push_back(PropertyInfo(Variant::NODE_PATH, collision_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpringBoneCollision3D"));
-		}
-		props.push_back(PropertyInfo(Variant::INT, path + "collision_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Collisions," + path + "collisions/"));
-		for (uint32_t j = 0; j < settings[i]->collisions.size(); j++) {
-			String collision_path = path + "collisions/" + itos(j);
-			props.push_back(PropertyInfo(Variant::NODE_PATH, collision_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpringBoneCollision3D"));
 		}
 	}
 
@@ -391,7 +394,7 @@ void SpringBoneSimulator3D::_validate_dynamic_prop(PropertyInfo &p_property) con
 		}
 
 		// Collisions option.
-		if (are_all_child_collisions_enabled(which)) {
+		if (are_all_child_collisions_enabled()) {
 			if (split[2] == "collisions" || split[2] == "collision_count") {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
@@ -438,7 +441,7 @@ void SpringBoneSimulator3D::_notification(int p_what) {
 	}
 }
 
-// Setting.
+// Bone Chain Settings
 
 void SpringBoneSimulator3D::set_root_bone_name(int p_index, const String &p_bone_name) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
@@ -645,157 +648,6 @@ int SpringBoneSimulator3D::get_center_bone(int p_index) const {
 	return settings[p_index]->center_bone;
 }
 
-void SpringBoneSimulator3D::set_radius(int p_index, float p_radius) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	settings[p_index]->radius = p_radius;
-	_make_joints_dirty(p_index);
-}
-
-float SpringBoneSimulator3D::get_radius(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	return settings[p_index]->radius;
-}
-
-void SpringBoneSimulator3D::set_radius_damping_curve(int p_index, const Ref<Curve> &p_damping_curve) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	if (settings[p_index]->radius_damping_curve.is_valid()) {
-		settings[p_index]->radius_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty));
-	}
-	settings[p_index]->radius_damping_curve = p_damping_curve;
-	if (settings[p_index]->radius_damping_curve.is_valid()) {
-		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
-	}
-	_make_joints_dirty(p_index);
-}
-
-Ref<Curve> SpringBoneSimulator3D::get_radius_damping_curve(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Ref<Curve>());
-	return settings[p_index]->radius_damping_curve;
-}
-
-void SpringBoneSimulator3D::set_stiffness(int p_index, float p_stiffness) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	settings[p_index]->stiffness = p_stiffness;
-	_make_joints_dirty(p_index);
-}
-
-float SpringBoneSimulator3D::get_stiffness(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	return settings[p_index]->stiffness;
-}
-
-void SpringBoneSimulator3D::set_stiffness_damping_curve(int p_index, const Ref<Curve> &p_damping_curve) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	if (settings[p_index]->stiffness_damping_curve.is_valid()) {
-		settings[p_index]->stiffness_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty));
-	}
-	settings[p_index]->stiffness_damping_curve = p_damping_curve;
-	if (settings[p_index]->stiffness_damping_curve.is_valid()) {
-		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
-	}
-	_make_joints_dirty(p_index);
-}
-
-Ref<Curve> SpringBoneSimulator3D::get_stiffness_damping_curve(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Ref<Curve>());
-	return settings[p_index]->stiffness_damping_curve;
-}
-
-void SpringBoneSimulator3D::set_drag(int p_index, float p_drag) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	settings[p_index]->drag = p_drag;
-	_make_joints_dirty(p_index);
-}
-
-float SpringBoneSimulator3D::get_drag(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	return settings[p_index]->drag;
-}
-
-void SpringBoneSimulator3D::set_drag_damping_curve(int p_index, const Ref<Curve> &p_damping_curve) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	if (settings[p_index]->drag_damping_curve.is_valid()) {
-		settings[p_index]->drag_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty));
-	}
-	settings[p_index]->drag_damping_curve = p_damping_curve;
-	if (settings[p_index]->drag_damping_curve.is_valid()) {
-		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
-	}
-	_make_joints_dirty(p_index);
-}
-
-Ref<Curve> SpringBoneSimulator3D::get_drag_damping_curve(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Ref<Curve>());
-	return settings[p_index]->drag_damping_curve;
-}
-
-void SpringBoneSimulator3D::set_gravity(int p_index, float p_gravity) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	settings[p_index]->gravity = p_gravity;
-	_make_joints_dirty(p_index);
-}
-
-float SpringBoneSimulator3D::get_gravity(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	return settings[p_index]->gravity;
-}
-
-void SpringBoneSimulator3D::set_gravity_damping_curve(int p_index, const Ref<Curve> &p_damping_curve) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	if (settings[p_index]->gravity_damping_curve.is_valid()) {
-		settings[p_index]->gravity_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty));
-	}
-	settings[p_index]->gravity_damping_curve = p_damping_curve;
-	if (settings[p_index]->gravity_damping_curve.is_valid()) {
-		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
-	}
-	_make_joints_dirty(p_index);
-}
-
-Ref<Curve> SpringBoneSimulator3D::get_gravity_damping_curve(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Ref<Curve>());
-	return settings[p_index]->gravity_damping_curve;
-}
-
-void SpringBoneSimulator3D::set_gravity_direction(int p_index, const Vector3 &p_gravity_direction) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	ERR_FAIL_COND(p_gravity_direction.is_zero_approx());
-	if (is_config_individual(p_index)) {
-		return; // Joint config is individual mode.
-	}
-	settings[p_index]->gravity_direction = p_gravity_direction;
-	_make_joints_dirty(p_index);
-}
-
-Vector3 SpringBoneSimulator3D::get_gravity_direction(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3(0, -1, 0));
-	return settings[p_index]->gravity_direction;
-}
-
 void SpringBoneSimulator3D::set_rotation_axis(int p_index, RotationAxis p_axis) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	if (is_config_individual(p_index)) {
@@ -843,6 +695,113 @@ Vector3 SpringBoneSimulator3D::get_rotation_axis_vector(int p_index) const {
 	return ret;
 }
 
+// Common Spring Bone Settings
+
+void SpringBoneSimulator3D::set_radius(float p_radius) {
+	radius = p_radius;
+	_make_all_joints_dirty();
+}
+
+float SpringBoneSimulator3D::get_radius() const {
+	return radius;
+}
+
+void SpringBoneSimulator3D::set_radius_damping_curve(const Ref<Curve> &p_damping_curve) {
+	if (radius_damping_curve.is_valid()) {
+		radius_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	}
+	radius_damping_curve = p_damping_curve;
+	if (radius_damping_curve.is_valid()) {
+		radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty).bind());
+	}
+	_make_all_joints_dirty();
+}
+
+Ref<Curve> SpringBoneSimulator3D::get_radius_damping_curve() const {
+	return radius_damping_curve;
+}
+
+void SpringBoneSimulator3D::set_stiffness(float p_stiffness) {
+	stiffness = p_stiffness;
+	_make_all_joints_dirty();
+}
+
+float SpringBoneSimulator3D::get_stiffness() const {
+	return stiffness;
+}
+
+void SpringBoneSimulator3D::set_stiffness_damping_curve(const Ref<Curve> &p_damping_curve) {
+	if (stiffness_damping_curve.is_valid()) {
+		stiffness_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	}
+	stiffness_damping_curve = p_damping_curve;
+	if (stiffness_damping_curve.is_valid()) {
+		stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty).bind());
+	}
+	_make_all_joints_dirty();
+}
+
+Ref<Curve> SpringBoneSimulator3D::get_stiffness_damping_curve() const {
+	return stiffness_damping_curve;
+}
+
+void SpringBoneSimulator3D::set_drag(float p_drag) {
+	drag = p_drag;
+	_make_all_joints_dirty();
+}
+
+float SpringBoneSimulator3D::get_drag() const {
+	return drag;
+}
+
+void SpringBoneSimulator3D::set_drag_damping_curve(const Ref<Curve> &p_damping_curve) {
+	if (drag_damping_curve.is_valid()) {
+		drag_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	}
+	drag_damping_curve = p_damping_curve;
+	if (drag_damping_curve.is_valid()) {
+		drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty).bind());
+	}
+	_make_all_joints_dirty();
+}
+
+Ref<Curve> SpringBoneSimulator3D::get_drag_damping_curve() const {
+	return drag_damping_curve;
+}
+
+void SpringBoneSimulator3D::set_gravity(float p_gravity) {
+	gravity = p_gravity;
+	_make_all_joints_dirty();
+}
+
+float SpringBoneSimulator3D::get_gravity() const {
+	return gravity;
+}
+
+void SpringBoneSimulator3D::set_gravity_damping_curve(const Ref<Curve> &p_damping_curve) {
+	if (gravity_damping_curve.is_valid()) {
+		gravity_damping_curve->disconnect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty));
+	}
+	gravity_damping_curve = p_damping_curve;
+	if (gravity_damping_curve.is_valid()) {
+		gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_all_joints_dirty).bind());
+	}
+	_make_all_joints_dirty();
+}
+
+Ref<Curve> SpringBoneSimulator3D::get_gravity_damping_curve() const {
+	return gravity_damping_curve;
+}
+
+void SpringBoneSimulator3D::set_gravity_direction(const Vector3 &p_gravity_direction) {
+	gravity_direction = p_gravity_direction;
+	_make_all_joints_dirty();
+}
+
+Vector3 SpringBoneSimulator3D::get_gravity_direction() const {
+	return gravity_direction;
+}
+
 void SpringBoneSimulator3D::set_setting_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
 
@@ -871,7 +830,7 @@ void SpringBoneSimulator3D::clear_settings() {
 	set_setting_count(0);
 }
 
-// Individual joints.
+// Individual joint settings
 
 void SpringBoneSimulator3D::set_individual_config(int p_index, bool p_enabled) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
@@ -1082,25 +1041,22 @@ int SpringBoneSimulator3D::get_joint_count(int p_index) const {
 	return joints.size();
 }
 
-// Individual collisions.
+// Collisions
 
-void SpringBoneSimulator3D::set_enable_all_child_collisions(int p_index, bool p_enabled) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	settings[p_index]->enable_all_child_collisions = p_enabled;
+void SpringBoneSimulator3D::set_enable_all_child_collisions(bool p_enabled) {
+	enable_all_child_collisions = p_enabled;
 	notify_property_list_changed();
 }
 
-bool SpringBoneSimulator3D::are_all_child_collisions_enabled(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
-	return settings[p_index]->enable_all_child_collisions;
+bool SpringBoneSimulator3D::are_all_child_collisions_enabled() const {
+	return enable_all_child_collisions;
 }
 
-void SpringBoneSimulator3D::set_exclude_collision_path(int p_index, int p_collision, const NodePath &p_node_path) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (!are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::set_exclude_collision_path(int p_collision, const NodePath &p_node_path) {
+	if (!are_all_child_collisions_enabled()) {
 		return; // Exclude collision list is disabled.
 	}
-	LocalVector<NodePath> &setting_exclude_collisions = settings[p_index]->exclude_collisions;
+	LocalVector<NodePath> &setting_exclude_collisions = exclude_collisions;
 	ERR_FAIL_INDEX(p_collision, (int)setting_exclude_collisions.size());
 	setting_exclude_collisions[p_collision] = NodePath(); // Reset first.
 	if (is_inside_tree()) {
@@ -1119,44 +1075,39 @@ void SpringBoneSimulator3D::set_exclude_collision_path(int p_index, int p_collis
 	_make_collisions_dirty();
 }
 
-NodePath SpringBoneSimulator3D::get_exclude_collision_path(int p_index, int p_collision) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), NodePath());
-	const LocalVector<NodePath> &setting_exclude_collisions = settings[p_index]->exclude_collisions;
+NodePath SpringBoneSimulator3D::get_exclude_collision_path(int p_collision) const {
+	const LocalVector<NodePath> &setting_exclude_collisions = exclude_collisions;
 	ERR_FAIL_INDEX_V(p_collision, (int)setting_exclude_collisions.size(), NodePath());
 	return setting_exclude_collisions[p_collision];
 }
 
-void SpringBoneSimulator3D::set_exclude_collision_count(int p_index, int p_count) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (!are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::set_exclude_collision_count(int p_count) {
+	if (!are_all_child_collisions_enabled()) {
 		return; // Exclude collision list is disabled.
 	}
-	LocalVector<NodePath> &setting_exclude_collisions = settings[p_index]->exclude_collisions;
+	LocalVector<NodePath> &setting_exclude_collisions = exclude_collisions;
 	setting_exclude_collisions.resize(p_count);
 	_make_collisions_dirty();
 	notify_property_list_changed();
 }
 
-int SpringBoneSimulator3D::get_exclude_collision_count(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<NodePath> &setting_exclude_collisions = settings[p_index]->exclude_collisions;
+int SpringBoneSimulator3D::get_exclude_collision_count() const {
+	const LocalVector<NodePath> &setting_exclude_collisions = exclude_collisions;
 	return setting_exclude_collisions.size();
 }
 
-void SpringBoneSimulator3D::clear_exclude_collisions(int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (!are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::clear_exclude_collisions() {
+	if (!are_all_child_collisions_enabled()) {
 		return; // Exclude collision list is disabled.
 	}
-	set_exclude_collision_count(p_index, 0);
+	set_exclude_collision_count(0);
 }
 
-void SpringBoneSimulator3D::set_collision_path(int p_index, int p_collision, const NodePath &p_node_path) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::set_collision_path(int p_collision, const NodePath &p_node_path) {
+	if (are_all_child_collisions_enabled()) {
 		return; // Collision list is disabled.
 	}
-	LocalVector<NodePath> &setting_collisions = settings[p_index]->collisions;
+	LocalVector<NodePath> &setting_collisions = collisions;
 	ERR_FAIL_INDEX(p_collision, (int)setting_collisions.size());
 	setting_collisions[p_collision] = NodePath(); // Reset first.
 	if (is_inside_tree()) {
@@ -1175,44 +1126,39 @@ void SpringBoneSimulator3D::set_collision_path(int p_index, int p_collision, con
 	_make_collisions_dirty();
 }
 
-NodePath SpringBoneSimulator3D::get_collision_path(int p_index, int p_collision) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), NodePath());
-	const LocalVector<NodePath> &setting_collisions = settings[p_index]->collisions;
+NodePath SpringBoneSimulator3D::get_collision_path(int p_collision) const {
+	const LocalVector<NodePath> &setting_collisions = collisions;
 	ERR_FAIL_INDEX_V(p_collision, (int)setting_collisions.size(), NodePath());
 	return setting_collisions[p_collision];
 }
 
-void SpringBoneSimulator3D::set_collision_count(int p_index, int p_count) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::set_collision_count(int p_count) {
+	if (are_all_child_collisions_enabled()) {
 		return; // Collision list is disabled.
 	}
-	LocalVector<NodePath> &setting_collisions = settings[p_index]->collisions;
+	LocalVector<NodePath> &setting_collisions = collisions;
 	setting_collisions.resize(p_count);
 	_make_collisions_dirty();
 	notify_property_list_changed();
 }
 
-int SpringBoneSimulator3D::get_collision_count(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
-	const LocalVector<NodePath> &setting_collisions = settings[p_index]->collisions;
+int SpringBoneSimulator3D::get_collision_count() const {
+	const LocalVector<NodePath> &setting_collisions = collisions;
 	return setting_collisions.size();
 }
 
-void SpringBoneSimulator3D::clear_collisions(int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)settings.size());
-	if (are_all_child_collisions_enabled(p_index)) {
+void SpringBoneSimulator3D::clear_collisions() {
+	if (are_all_child_collisions_enabled()) {
 		return; // Collision list is disabled.
 	}
-	set_collision_count(p_index, 0);
+	set_collision_count(0);
 }
 
-LocalVector<ObjectID> SpringBoneSimulator3D::get_valid_collision_instance_ids(int p_index) {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), LocalVector<ObjectID>());
+LocalVector<ObjectID> SpringBoneSimulator3D::get_valid_collision_instance_ids() {
 	if (collisions_dirty) {
 		_find_collisions();
 	}
-	return LocalVector<ObjectID>(settings[p_index]->cached_collisions);
+	return LocalVector<ObjectID>(cached_collisions);
 }
 
 void SpringBoneSimulator3D::set_external_force(const Vector3 &p_force) {
@@ -1235,7 +1181,7 @@ bool SpringBoneSimulator3D::are_bone_axes_mutable() const {
 }
 
 void SpringBoneSimulator3D::_bind_methods() {
-	// Setting.
+	// Bone Chain Settings
 	ClassDB::bind_method(D_METHOD("set_root_bone_name", "index", "bone_name"), &SpringBoneSimulator3D::set_root_bone_name);
 	ClassDB::bind_method(D_METHOD("get_root_bone_name", "index"), &SpringBoneSimulator3D::get_root_bone_name);
 	ClassDB::bind_method(D_METHOD("set_root_bone", "index", "bone"), &SpringBoneSimulator3D::set_root_bone);
@@ -1262,34 +1208,37 @@ void SpringBoneSimulator3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_center_bone", "index", "bone"), &SpringBoneSimulator3D::set_center_bone);
 	ClassDB::bind_method(D_METHOD("get_center_bone", "index"), &SpringBoneSimulator3D::get_center_bone);
 
-	ClassDB::bind_method(D_METHOD("set_radius", "index", "radius"), &SpringBoneSimulator3D::set_radius);
-	ClassDB::bind_method(D_METHOD("get_radius", "index"), &SpringBoneSimulator3D::get_radius);
 	ClassDB::bind_method(D_METHOD("set_rotation_axis", "index", "axis"), &SpringBoneSimulator3D::set_rotation_axis);
 	ClassDB::bind_method(D_METHOD("get_rotation_axis", "index"), &SpringBoneSimulator3D::get_rotation_axis);
 	ClassDB::bind_method(D_METHOD("set_rotation_axis_vector", "index", "vector"), &SpringBoneSimulator3D::set_rotation_axis_vector);
 	ClassDB::bind_method(D_METHOD("get_rotation_axis_vector", "index"), &SpringBoneSimulator3D::get_rotation_axis_vector);
-	ClassDB::bind_method(D_METHOD("set_radius_damping_curve", "index", "curve"), &SpringBoneSimulator3D::set_radius_damping_curve);
-	ClassDB::bind_method(D_METHOD("get_radius_damping_curve", "index"), &SpringBoneSimulator3D::get_radius_damping_curve);
-	ClassDB::bind_method(D_METHOD("set_stiffness", "index", "stiffness"), &SpringBoneSimulator3D::set_stiffness);
-	ClassDB::bind_method(D_METHOD("get_stiffness", "index"), &SpringBoneSimulator3D::get_stiffness);
-	ClassDB::bind_method(D_METHOD("set_stiffness_damping_curve", "index", "curve"), &SpringBoneSimulator3D::set_stiffness_damping_curve);
-	ClassDB::bind_method(D_METHOD("get_stiffness_damping_curve", "index"), &SpringBoneSimulator3D::get_stiffness_damping_curve);
-	ClassDB::bind_method(D_METHOD("set_drag", "index", "drag"), &SpringBoneSimulator3D::set_drag);
-	ClassDB::bind_method(D_METHOD("get_drag", "index"), &SpringBoneSimulator3D::get_drag);
-	ClassDB::bind_method(D_METHOD("set_drag_damping_curve", "index", "curve"), &SpringBoneSimulator3D::set_drag_damping_curve);
-	ClassDB::bind_method(D_METHOD("get_drag_damping_curve", "index"), &SpringBoneSimulator3D::get_drag_damping_curve);
-	ClassDB::bind_method(D_METHOD("set_gravity", "index", "gravity"), &SpringBoneSimulator3D::set_gravity);
-	ClassDB::bind_method(D_METHOD("get_gravity", "index"), &SpringBoneSimulator3D::get_gravity);
-	ClassDB::bind_method(D_METHOD("set_gravity_damping_curve", "index", "curve"), &SpringBoneSimulator3D::set_gravity_damping_curve);
-	ClassDB::bind_method(D_METHOD("get_gravity_damping_curve", "index"), &SpringBoneSimulator3D::get_gravity_damping_curve);
-	ClassDB::bind_method(D_METHOD("set_gravity_direction", "index", "gravity_direction"), &SpringBoneSimulator3D::set_gravity_direction);
-	ClassDB::bind_method(D_METHOD("get_gravity_direction", "index"), &SpringBoneSimulator3D::get_gravity_direction);
+
+	// Common Settings
+
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &SpringBoneSimulator3D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &SpringBoneSimulator3D::get_radius);
+	ClassDB::bind_method(D_METHOD("set_radius_damping_curve", "curve"), &SpringBoneSimulator3D::set_radius_damping_curve);
+	ClassDB::bind_method(D_METHOD("get_radius_damping_curve"), &SpringBoneSimulator3D::get_radius_damping_curve);
+	ClassDB::bind_method(D_METHOD("set_stiffness", "stiffness"), &SpringBoneSimulator3D::set_stiffness);
+	ClassDB::bind_method(D_METHOD("get_stiffness"), &SpringBoneSimulator3D::get_stiffness);
+	ClassDB::bind_method(D_METHOD("set_stiffness_damping_curve", "curve"), &SpringBoneSimulator3D::set_stiffness_damping_curve);
+	ClassDB::bind_method(D_METHOD("get_stiffness_damping_curve"), &SpringBoneSimulator3D::get_stiffness_damping_curve);
+	ClassDB::bind_method(D_METHOD("set_drag", "drag"), &SpringBoneSimulator3D::set_drag);
+	ClassDB::bind_method(D_METHOD("get_drag"), &SpringBoneSimulator3D::get_drag);
+	ClassDB::bind_method(D_METHOD("set_drag_damping_curve", "curve"), &SpringBoneSimulator3D::set_drag_damping_curve);
+	ClassDB::bind_method(D_METHOD("get_drag_damping_curve"), &SpringBoneSimulator3D::get_drag_damping_curve);
+	ClassDB::bind_method(D_METHOD("set_gravity", "gravity"), &SpringBoneSimulator3D::set_gravity);
+	ClassDB::bind_method(D_METHOD("get_gravity"), &SpringBoneSimulator3D::get_gravity);
+	ClassDB::bind_method(D_METHOD("set_gravity_damping_curve", "curve"), &SpringBoneSimulator3D::set_gravity_damping_curve);
+	ClassDB::bind_method(D_METHOD("get_gravity_damping_curve"), &SpringBoneSimulator3D::get_gravity_damping_curve);
+	ClassDB::bind_method(D_METHOD("set_gravity_direction", "gravity_direction"), &SpringBoneSimulator3D::set_gravity_direction);
+	ClassDB::bind_method(D_METHOD("get_gravity_direction"), &SpringBoneSimulator3D::get_gravity_direction);
 
 	ClassDB::bind_method(D_METHOD("set_setting_count", "count"), &SpringBoneSimulator3D::set_setting_count);
 	ClassDB::bind_method(D_METHOD("get_setting_count"), &SpringBoneSimulator3D::get_setting_count);
 	ClassDB::bind_method(D_METHOD("clear_settings"), &SpringBoneSimulator3D::clear_settings);
 
-	// Individual joints.
+	// Individual Joint Settings
 	ClassDB::bind_method(D_METHOD("set_individual_config", "index", "enabled"), &SpringBoneSimulator3D::set_individual_config);
 	ClassDB::bind_method(D_METHOD("is_config_individual", "index"), &SpringBoneSimulator3D::is_config_individual);
 
@@ -1312,23 +1261,23 @@ void SpringBoneSimulator3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_joint_count", "index"), &SpringBoneSimulator3D::get_joint_count);
 
-	// Individual collisions.
-	ClassDB::bind_method(D_METHOD("set_enable_all_child_collisions", "index", "enabled"), &SpringBoneSimulator3D::set_enable_all_child_collisions);
-	ClassDB::bind_method(D_METHOD("are_all_child_collisions_enabled", "index"), &SpringBoneSimulator3D::are_all_child_collisions_enabled);
+	// Collision Settings
+	ClassDB::bind_method(D_METHOD("set_enable_all_child_collisions", "enabled"), &SpringBoneSimulator3D::set_enable_all_child_collisions);
+	ClassDB::bind_method(D_METHOD("are_all_child_collisions_enabled"), &SpringBoneSimulator3D::are_all_child_collisions_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_exclude_collision_path", "index", "collision", "node_path"), &SpringBoneSimulator3D::set_exclude_collision_path);
-	ClassDB::bind_method(D_METHOD("get_exclude_collision_path", "index", "collision"), &SpringBoneSimulator3D::get_exclude_collision_path);
+	ClassDB::bind_method(D_METHOD("set_exclude_collision_path", "collision", "node_path"), &SpringBoneSimulator3D::set_exclude_collision_path);
+	ClassDB::bind_method(D_METHOD("get_exclude_collision_path", "collision"), &SpringBoneSimulator3D::get_exclude_collision_path);
 
-	ClassDB::bind_method(D_METHOD("set_exclude_collision_count", "index", "count"), &SpringBoneSimulator3D::set_exclude_collision_count);
-	ClassDB::bind_method(D_METHOD("get_exclude_collision_count", "index"), &SpringBoneSimulator3D::get_exclude_collision_count);
-	ClassDB::bind_method(D_METHOD("clear_exclude_collisions", "index"), &SpringBoneSimulator3D::clear_exclude_collisions);
+	ClassDB::bind_method(D_METHOD("set_exclude_collision_count", "count"), &SpringBoneSimulator3D::set_exclude_collision_count);
+	ClassDB::bind_method(D_METHOD("get_exclude_collision_count"), &SpringBoneSimulator3D::get_exclude_collision_count);
+	ClassDB::bind_method(D_METHOD("clear_exclude_collisions"), &SpringBoneSimulator3D::clear_exclude_collisions);
 
-	ClassDB::bind_method(D_METHOD("set_collision_path", "index", "collision", "node_path"), &SpringBoneSimulator3D::set_collision_path);
-	ClassDB::bind_method(D_METHOD("get_collision_path", "index", "collision"), &SpringBoneSimulator3D::get_collision_path);
+	ClassDB::bind_method(D_METHOD("set_collision_path", "collision", "node_path"), &SpringBoneSimulator3D::set_collision_path);
+	ClassDB::bind_method(D_METHOD("get_collision_path", "collision"), &SpringBoneSimulator3D::get_collision_path);
 
-	ClassDB::bind_method(D_METHOD("set_collision_count", "index", "count"), &SpringBoneSimulator3D::set_collision_count);
-	ClassDB::bind_method(D_METHOD("get_collision_count", "index"), &SpringBoneSimulator3D::get_collision_count);
-	ClassDB::bind_method(D_METHOD("clear_collisions", "index"), &SpringBoneSimulator3D::clear_collisions);
+	ClassDB::bind_method(D_METHOD("set_collision_count", "count"), &SpringBoneSimulator3D::set_collision_count);
+	ClassDB::bind_method(D_METHOD("get_collision_count"), &SpringBoneSimulator3D::get_collision_count);
+	ClassDB::bind_method(D_METHOD("clear_collisions"), &SpringBoneSimulator3D::clear_collisions);
 
 	ClassDB::bind_method(D_METHOD("set_external_force", "force"), &SpringBoneSimulator3D::set_external_force);
 	ClassDB::bind_method(D_METHOD("get_external_force"), &SpringBoneSimulator3D::get_external_force);
@@ -1413,8 +1362,8 @@ void SpringBoneSimulator3D::_validate_rotation_axes(Skeleton3D *p_skeleton) cons
 	for (uint32_t i = 0; i < settings.size(); i++) {
 		for (uint32_t j = 0; j < settings[i]->joints.size(); j++) {
 			_validate_rotation_axis(p_skeleton, i, j);
-		}
 	}
+}
 }
 
 void SpringBoneSimulator3D::_validate_rotation_axis(Skeleton3D *p_skeleton, int p_index, int p_joint) const {
@@ -1428,11 +1377,11 @@ void SpringBoneSimulator3D::_validate_rotation_axis(Skeleton3D *p_skeleton, int 
 		fwd = p_skeleton->get_bone_rest(settings[p_index]->joints[p_joint + 1]->bone).origin;
 	} else if (settings[p_index]->extend_end_bone) {
 		fwd = get_end_bone_axis(settings[p_index]->end_bone, settings[p_index]->end_bone_direction);
-		if (fwd.is_zero_approx()) {
-			return;
-		}
-	}
-	fwd.normalize();
+				if (fwd.is_zero_approx()) {
+					return;
+				}
+			}
+			fwd.normalize();
 	if (Math::is_equal_approx(Math::abs(rot.dot(fwd)), 1)) {
 		WARN_PRINT_ED("Setting: " + itos(p_index) + " Joint: " + itos(p_joint) + ": Rotation axis and forward vector are colinear. This is not advised as it may cause unwanted rotation.");
 	}
@@ -1442,29 +1391,29 @@ void SpringBoneSimulator3D::_find_collisions() {
 	if (!collisions_dirty) {
 		return;
 	}
-	collisions.clear();
+	collisions_internal.clear();
 	for (int i = 0; i < get_child_count(); i++) {
 		SpringBoneCollision3D *c = Object::cast_to<SpringBoneCollision3D>(get_child(i));
 		if (c) {
-			collisions.push_back(c->get_instance_id());
+			collisions_internal.push_back(c->get_instance_id());
 		}
 	}
 
 	bool setting_updated = false;
 
 	for (uint32_t i = 0; i < settings.size(); i++) {
-		LocalVector<ObjectID> &cache = settings[i]->cached_collisions;
+		LocalVector<ObjectID> &cache = cached_collisions;
 		cache.clear();
-		if (!settings[i]->enable_all_child_collisions) {
+		if (!enable_all_child_collisions) {
 			// Allow list.
-			LocalVector<NodePath> &setting_collisions = settings[i]->collisions;
+			LocalVector<NodePath> &setting_collisions = collisions;
 			for (uint32_t j = 0; j < setting_collisions.size(); j++) {
 				Node *n = get_node_or_null(setting_collisions[j]);
 				if (!n) {
 					continue;
 				}
 				ObjectID id = n->get_instance_id();
-				if (!collisions.has(id)) {
+				if (!collisions_internal.has(id)) {
 					setting_collisions[j] = NodePath(); // Clear path if not found.
 				} else {
 					cache.push_back(id);
@@ -1473,14 +1422,14 @@ void SpringBoneSimulator3D::_find_collisions() {
 		} else {
 			// Deny list.
 			LocalVector<uint32_t> masks;
-			LocalVector<NodePath> &setting_exclude_collisions = settings[i]->exclude_collisions;
+			LocalVector<NodePath> &setting_exclude_collisions = exclude_collisions;
 			for (uint32_t j = 0; j < setting_exclude_collisions.size(); j++) {
 				Node *n = get_node_or_null(setting_exclude_collisions[j]);
 				if (!n) {
 					continue;
 				}
 				ObjectID id = n->get_instance_id();
-				int find = collisions.find(id);
+				int find = collisions_internal.find(id);
 				if (find < 0) {
 					setting_exclude_collisions[j] = NodePath(); // Clear path if not found.
 				} else {
@@ -1488,12 +1437,12 @@ void SpringBoneSimulator3D::_find_collisions() {
 				}
 			}
 			uint32_t mask_index = 0;
-			for (uint32_t j = 0; j < collisions.size(); j++) {
+			for (uint32_t j = 0; j < collisions_internal.size(); j++) {
 				if (mask_index < masks.size() && j == masks[mask_index]) {
 					mask_index++;
 					continue;
 				}
-				cache.push_back(collisions[j]);
+				cache.push_back(collisions_internal[j]);
 			}
 		}
 	}
@@ -1506,7 +1455,7 @@ void SpringBoneSimulator3D::_find_collisions() {
 }
 
 void SpringBoneSimulator3D::_process_collisions() {
-	for (const ObjectID &oid : collisions) {
+	for (const ObjectID &oid : collisions_internal) {
 		Object *t_obj = ObjectDB::get_instance(oid);
 		if (!t_obj) {
 			continue;
@@ -1582,31 +1531,31 @@ void SpringBoneSimulator3D::_update_joints(bool p_reset) {
 		for (uint32_t j = 0; j < joints.size(); j++) {
 			float offset = j * unit;
 
-			if (settings[i]->radius_damping_curve.is_valid()) {
-				joints[j]->radius = settings[i]->radius * settings[i]->radius_damping_curve->sample_baked(offset);
+			if (radius_damping_curve.is_valid()) {
+				joints[j]->radius = radius * radius_damping_curve->sample_baked(offset);
 			} else {
-				joints[j]->radius = settings[i]->radius;
+				joints[j]->radius = radius;
 			}
 
-			if (settings[i]->stiffness_damping_curve.is_valid()) {
-				joints[j]->stiffness = settings[i]->stiffness * settings[i]->stiffness_damping_curve->sample_baked(offset);
+			if (stiffness_damping_curve.is_valid()) {
+				joints[j]->stiffness = stiffness * stiffness_damping_curve->sample_baked(offset);
 			} else {
-				joints[j]->stiffness = settings[i]->stiffness;
+				joints[j]->stiffness = stiffness;
 			}
 
-			if (settings[i]->drag_damping_curve.is_valid()) {
-				joints[j]->drag = settings[i]->drag * settings[i]->drag_damping_curve->sample_baked(offset);
+			if (drag_damping_curve.is_valid()) {
+				joints[j]->drag = drag * drag_damping_curve->sample_baked(offset);
 			} else {
-				joints[j]->drag = settings[i]->drag;
+				joints[j]->drag = drag;
 			}
 
-			if (settings[i]->gravity_damping_curve.is_valid()) {
-				joints[j]->gravity = settings[i]->gravity * settings[i]->gravity_damping_curve->sample_baked(offset);
+			if (gravity_damping_curve.is_valid()) {
+				joints[j]->gravity = gravity * gravity_damping_curve->sample_baked(offset);
 			} else {
-				joints[j]->gravity = settings[i]->gravity;
+				joints[j]->gravity = gravity;
 			}
 
-			joints[j]->gravity_direction = settings[i]->gravity_direction;
+			joints[j]->gravity_direction = gravity_direction;
 			joints[j]->rotation_axis = settings[i]->rotation_axis;
 			joints[j]->rotation_axis_vector = settings[i]->rotation_axis_vector;
 		}
@@ -1729,7 +1678,7 @@ void SpringBoneSimulator3D::_process_modification(double p_delta) {
 
 	for (uint32_t i = 0; i < settings.size(); i++) {
 		_init_joints(skeleton, settings[i]);
-		_process_joints(p_delta, skeleton, settings[i]->joints, get_valid_collision_instance_ids(i), settings[i]->cached_center, settings[i]->cached_inverted_center, settings[i]->cached_inverted_center.basis.get_rotation_quaternion());
+		_process_joints(p_delta, skeleton, settings[i]->joints, get_valid_collision_instance_ids(), settings[i]->cached_center, settings[i]->cached_inverted_center, settings[i]->cached_inverted_center.basis.get_rotation_quaternion());
 	}
 }
 

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -108,7 +108,7 @@ public:
 		SpringBone3DVerletInfo *verlet = nullptr;
 	};
 
-	struct SpringBone3DSetting {
+	struct SpringBoneChain {
 		bool joints_dirty = false;
 
 		String root_bone_name;
@@ -140,12 +140,12 @@ public:
 
 protected:
 
-// Common Properties
+	// Common Properties
 
-	LocalVector<SpringBone3DSetting *> settings;
+	LocalVector<SpringBoneChain *> spring_bone_chains;
 	Vector3 external_force;
 	bool mutable_bone_axes = true;
-	
+
 	float radius = 0.02;
 	Ref<Curve> radius_damping_curve;
 	float stiffness = 1.0;
@@ -177,7 +177,7 @@ protected:
 
 	virtual void _set_active(bool p_active) override;
 	virtual void _process_modification(double p_delta) override;
-	void _init_joints(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting);
+	void _init_joints(Skeleton3D *p_skeleton, SpringBoneChain *p_setting);
 	void _process_joints(double p_delta, Skeleton3D *p_skeleton, LocalVector<SpringBone3DJointSetting *> &p_joints, const LocalVector<ObjectID> &p_collisions, const Transform3D &p_center_transform, const Transform3D &p_inverted_center_transform, const Quaternion &p_inverted_center_rotation);
 
 	void _make_joints_dirty(int p_index, bool p_reset = false);
@@ -187,7 +187,7 @@ protected:
 	void _update_joints(bool p_reset);
 	void _set_joint_bone(int p_index, int p_joint, int p_bone);
 
-	void _update_bone_axis(Skeleton3D *p_skeleton, SpringBone3DSetting *p_setting);
+	void _update_bone_axis(Skeleton3D *p_skeleton, SpringBoneChain *p_setting);
 
 #ifdef TOOLS_ENABLED
 	bool gizmo_dirty = false;
@@ -293,9 +293,9 @@ public:
 	void set_gravity_direction(const Vector3 &p_gravity_direction);
 	Vector3 get_gravity_direction() const;
 
-	void set_setting_count(int p_count);
-	int get_setting_count() const;
-	void clear_settings();
+	void set_bone_chain_count(int p_count);
+	int get_bone_chain_count() const;
+	void clear_bone_chains();
 
 	// Collisions
 

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -182,6 +182,7 @@ protected:
 
 	void _make_joints_dirty(int p_index, bool p_reset = false);
 	void _make_all_joints_dirty();
+	void _rebuild_bone_chains();
 
 	void _update_joint_array(int p_index);
 	void _update_joints(bool p_reset);

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -139,7 +139,6 @@ public:
 	};
 
 protected:
-
 	// Common Properties
 
 	LocalVector<SpringBoneChain *> spring_bone_chains;

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -49,7 +49,7 @@ class SpringBoneSimulator3D : public SkeletonModifier3D {
 
 	bool joints_dirty = false;
 
-	LocalVector<ObjectID> collisions; // To process collisions for sync position with skeleton.
+	LocalVector<ObjectID> collisions_internal; // To process collisions for sync position with skeleton.
 	bool collisions_dirty = false;
 	void _find_collisions();
 	void _process_collisions();
@@ -127,37 +127,41 @@ public:
 		String center_bone_name;
 		int center_bone = -1;
 
-		// Cache into joints.
-		bool individual_config = false;
-		float radius = 0.02;
-		Ref<Curve> radius_damping_curve;
-		float stiffness = 1.0;
-		Ref<Curve> stiffness_damping_curve;
-		float drag = 0.4;
-		Ref<Curve> drag_damping_curve;
-		float gravity = 0.0;
-		Ref<Curve> gravity_damping_curve;
-		Vector3 gravity_direction = Vector3(0, -1, 0);
 		RotationAxis rotation_axis = ROTATION_AXIS_ALL;
 		Vector3 rotation_axis_vector = Vector3(1, 0, 0);
-		LocalVector<SpringBone3DJointSetting *> joints;
-
-		// Cache into collisions.
-		bool enable_all_child_collisions = true;
-		LocalVector<NodePath> collisions;
-		LocalVector<NodePath> exclude_collisions;
-		LocalVector<ObjectID> cached_collisions;
-
-		// To process.
-		bool simulation_dirty = false;
 		Transform3D cached_center;
 		Transform3D cached_inverted_center;
+
+		bool individual_config = false;
+		LocalVector<SpringBone3DJointSetting *> joints;
+
+		bool simulation_dirty = false;
 	};
 
 protected:
+
+// Common Properties
+
 	LocalVector<SpringBone3DSetting *> settings;
 	Vector3 external_force;
 	bool mutable_bone_axes = true;
+	
+	float radius = 0.02;
+	Ref<Curve> radius_damping_curve;
+	float stiffness = 1.0;
+	Ref<Curve> stiffness_damping_curve;
+	float drag = 0.4;
+	Ref<Curve> drag_damping_curve;
+	float gravity = 0.0;
+	Ref<Curve> gravity_damping_curve;
+	Vector3 gravity_direction = Vector3(0, -1, 0);
+
+	// Cache into collisions.
+	bool enable_all_child_collisions = true;
+	LocalVector<NodePath> collisions;
+	LocalVector<NodePath> exclude_collisions;
+
+	LocalVector<ObjectID> cached_collisions;
 
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -210,7 +214,7 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	// Setting.
+	// Bone Chain Settings
 	void set_root_bone_name(int p_index, const String &p_bone_name);
 	String get_root_bone_name(int p_index) const;
 	void set_root_bone(int p_index, int p_bone);
@@ -242,40 +246,19 @@ public:
 	RotationAxis get_rotation_axis(int p_index) const;
 	void set_rotation_axis_vector(int p_index, const Vector3 &p_vector);
 	Vector3 get_rotation_axis_vector(int p_index) const;
-	void set_radius(int p_index, float p_radius);
-	float get_radius(int p_index) const;
-	void set_radius_damping_curve(int p_index, const Ref<Curve> &p_damping_curve);
-	Ref<Curve> get_radius_damping_curve(int p_index) const;
-	void set_stiffness(int p_index, float p_stiffness);
-	float get_stiffness(int p_index) const;
-	void set_stiffness_damping_curve(int p_index, const Ref<Curve> &p_damping_curve);
-	Ref<Curve> get_stiffness_damping_curve(int p_index) const;
-	void set_drag(int p_index, float p_drag);
-	float get_drag(int p_index) const;
-	void set_drag_damping_curve(int p_index, const Ref<Curve> &p_damping_curve);
-	Ref<Curve> get_drag_damping_curve(int p_index) const;
-	void set_gravity(int p_index, float p_gravity);
-	float get_gravity(int p_index) const;
-	void set_gravity_damping_curve(int p_index, const Ref<Curve> &p_damping_curve);
-	Ref<Curve> get_gravity_damping_curve(int p_index) const;
-	void set_gravity_direction(int p_index, const Vector3 &p_gravity_direction);
-	Vector3 get_gravity_direction(int p_index) const;
 
-	void set_setting_count(int p_count);
-	int get_setting_count() const;
-	void clear_settings();
+	// Individual Joint Settings
+	void set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis);
+	RotationAxis get_joint_rotation_axis(int p_index, int p_joint) const;
+	void set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector);
+	Vector3 get_joint_rotation_axis_vector(int p_index, int p_joint) const;
 
-	// Individual joints.
 	void set_individual_config(int p_index, bool p_enabled);
 	bool is_config_individual(int p_index) const;
 
 	String get_joint_bone_name(int p_index, int p_joint) const;
 	int get_joint_bone(int p_index, int p_joint) const;
 
-	void set_joint_rotation_axis(int p_index, int p_joint, RotationAxis p_axis);
-	RotationAxis get_joint_rotation_axis(int p_index, int p_joint) const;
-	void set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector);
-	Vector3 get_joint_rotation_axis_vector(int p_index, int p_joint) const;
 	void set_joint_radius(int p_index, int p_joint, float p_radius);
 	float get_joint_radius(int p_index, int p_joint) const;
 	void set_joint_stiffness(int p_index, int p_joint, float p_stiffness);
@@ -290,25 +273,52 @@ public:
 	void set_joint_count(int p_index, int p_count);
 	int get_joint_count(int p_index) const;
 
-	// Individual collisions.
-	void set_enable_all_child_collisions(int p_index, bool p_enabled);
-	bool are_all_child_collisions_enabled(int p_index) const;
+	// Common Settings
+	void set_radius(float p_radius);
+	float get_radius() const;
+	void set_radius_damping_curve(const Ref<Curve> &p_damping_curve);
+	Ref<Curve> get_radius_damping_curve() const;
+	void set_stiffness(float p_stiffness);
+	float get_stiffness() const;
+	void set_stiffness_damping_curve(const Ref<Curve> &p_damping_curve);
+	Ref<Curve> get_stiffness_damping_curve() const;
+	void set_drag(float p_drag);
+	float get_drag() const;
+	void set_drag_damping_curve(const Ref<Curve> &p_damping_curve);
+	Ref<Curve> get_drag_damping_curve() const;
+	void set_gravity(float p_gravity);
+	float get_gravity() const;
+	void set_gravity_damping_curve(const Ref<Curve> &p_damping_curve);
+	Ref<Curve> get_gravity_damping_curve() const;
+	void set_gravity_direction(const Vector3 &p_gravity_direction);
+	Vector3 get_gravity_direction() const;
 
-	void set_exclude_collision_path(int p_index, int p_collision, const NodePath &p_node_path);
-	NodePath get_exclude_collision_path(int p_index, int p_collision) const;
+	void set_setting_count(int p_count);
+	int get_setting_count() const;
+	void clear_settings();
 
-	void set_exclude_collision_count(int p_index, int p_count);
-	int get_exclude_collision_count(int p_index) const;
-	void clear_exclude_collisions(int p_index);
+	// Collisions
 
-	void set_collision_path(int p_index, int p_collision, const NodePath &p_node_path);
-	NodePath get_collision_path(int p_index, int p_collision) const;
+	void set_enable_all_child_collisions(bool p_enabled);
+	bool are_all_child_collisions_enabled() const;
 
-	void set_collision_count(int p_index, int p_count);
-	int get_collision_count(int p_index) const;
-	void clear_collisions(int p_index);
+	void set_exclude_collision_path(int p_collision, const NodePath &p_node_path);
+	NodePath get_exclude_collision_path(int p_collision) const;
 
-	LocalVector<ObjectID> get_valid_collision_instance_ids(int p_index);
+	void set_exclude_collision_count(int p_count);
+	int get_exclude_collision_count() const;
+	void clear_exclude_collisions();
+
+	void set_collision_path(int p_collision, const NodePath &p_node_path);
+	NodePath get_collision_path(int p_collision) const;
+
+	void set_collision_count(int p_count);
+	int get_collision_count() const;
+	void clear_collisions();
+
+	LocalVector<ObjectID> get_valid_collision_instance_ids();
+
+	// Misc
 
 	void set_external_force(const Vector3 &p_force);
 	Vector3 get_external_force() const;

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -132,7 +132,7 @@ public:
 		Transform3D cached_center;
 		Transform3D cached_inverted_center;
 
-		bool individual_config = false;
+		bool override_individual_joints = false;
 		LocalVector<SpringBone3DJointSetting *> joints;
 
 		bool simulation_dirty = false;
@@ -253,8 +253,8 @@ public:
 	void set_joint_rotation_axis_vector(int p_index, int p_joint, const Vector3 &p_vector);
 	Vector3 get_joint_rotation_axis_vector(int p_index, int p_joint) const;
 
-	void set_individual_config(int p_index, bool p_enabled);
-	bool is_config_individual(int p_index) const;
+	void set_override_individual_joints(int p_index, bool p_enabled);
+	bool is_override_individual_joints(int p_index) const;
 
 	String get_joint_bone_name(int p_index, int p_joint) const;
 	int get_joint_bone(int p_index, int p_joint) const;


### PR DESCRIPTION
**Summary Of The Problem**
Right now there is no convenient way to edit many bone chains that are supposed to have identical physics settings at the same time. This use case is very common when working with bone physics, for example: skirt and cape physics, symmetrical hair physics, any kind of symmetrical jiggle physics.

I have explained the issue with the current workflow in more detail in [this](https://github.com/godotengine/godot-proposals/issues/14172) proposal.

**Explanation Of The Solution**
This PR moves the physics settings out of the settings array and repurposes the array to only store bone chain data instead.

**Reasoning Behind The Solution**
Previously, there wasn't any purpose to the settings array as its functionality was easily replicatable by simply using multiple SpringBoneSimulator3D nodes. In fact, I think it was enabling an anti-pattern where one would put all the physics settings in a single node, creating a massive super node with so many fields that the inspector would be starting to have trouble reconstructing the UI for the node. It was also subjectively a less convenient workflow to scroll through this array instead of being able to quickly go to the settings group you need just by clicking on a proper node in the node tree.
All of those issues can be easily solved by separating the physics settings from the bone chains settings and by making a single set of physics settings to affect all the bone chains in the node.

**User Experience Impact**
So what it does for the user experience is:
- Significantly improves the workflow for the cases where multiple bone chains reuse the same physics settings (any symmetrical physics setups, skirt physics, etc.)
- Removes an anti-pattern that had no purpose
- Makes the inspector window of the node display significantly less data per node, improving the ease of navigating it

**Drawbacks**
Might need migration logic, otherwise it would reset the bone chains settings. If it does need migration, then I would appreciate some good example of migration logic implementation.

**PR Summary And Review Notes**
I separated the overhaul and the renaming for the ease of reviewing because the combined PR has too many changes to make sense of them and the diff tool fails to resolve them properly.

The overhaul commit contains a lot of code movement, removal of p_index argument for now shared properties, parsing changes for them and replaces _make_bones_dirty with _make_all_bones_dirty for the shared properties.
_make_all_bones_dirty actually doesn't do what the function says unlike _make_bones_dirty, and it was a cause of some performance issues. I fixed this by renaming _make_all_bones_dirty to _rebuild_bone_chains (because that's what it actually does) and implemented a new version of _make_all_bones_dirty that does the same thing as _make_bones_dirty, but for every bone chain.

The very first commit is [this](https://github.com/godotengine/godot/pull/118662) PR, because it was inconvenient to work on the issue with this bug present, but later on  _make_bones_dirty gets replaced by _make_all_joints_dirty which takes 0 arguments, so it doesn't affect anything. In case this overhaul PR gets accepted before the bugfix, the bugfix PR can be closed.