### PR TITLE
Add default shortcut for "Emoji & Symbols".

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -433,6 +433,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
 	{ "ui_colorpicker_delete_preset",                  TTRC("ColorPicker: Delete Preset") },
 	{ "ui_accessibility_drag_and_drop",                TTRC("Accessibility: Keyboard Drag and Drop") },
+	{ "ui_emoji_and_symbols",                          TTRC("Emoji & Symbols") },
 	{ "",                                              ""}
 	/* clang-format on */
 };
@@ -541,6 +542,17 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::C | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::INSERT | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_copy", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	default_builtin_cache.insert("ui_emoji_and_symbols", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::SPACE | KeyModifierMask::META | KeyModifierMask::CTRL));
+	default_builtin_cache.insert("ui_emoji_and_symbols.macos", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::PERIOD | KeyModifierMask::META));
+	default_builtin_cache.insert("ui_emoji_and_symbols.windows", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::M | KeyModifierMask::CTRL));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1344,6 +1344,16 @@
 			Default [InputEventAction] to move down in the UI.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_emoji_and_symbols" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to open the emoji and symbol picker menu.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_emoji_and_symbols.macos" type="Dictionary" setter="" getter="">
+			macOS specific override for the shortcut to open the emoji and symbol picker menu.
+		</member>
+		<member name="input/ui_emoji_and_symbols.windows" type="Dictionary" setter="" getter="">
+			Windows specific override for the shortcut to open the emoji and symbol picker menu.
+		</member>
 		<member name="input/ui_end" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to go to the end position of a [Control] (e.g. last item in an [ItemList] or a [Tree]), matching the behavior of [constant KEY_END] on typical desktop UI systems.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -283,7 +283,7 @@ TextEditorBase::EditMenus::EditMenus() {
 void TextEditorBase::_make_context_menu(bool p_selection, bool p_foldable, const Vector2 &p_position, bool p_show) {
 	context_menu->clear();
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
-		context_menu->add_item(TTRC("Emoji & Symbols"), EDIT_EMOJI_AND_SYMBOL);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_emoji_and_symbols"), EDIT_EMOJI_AND_SYMBOL);
 		context_menu->add_separator();
 	}
 	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -2109,7 +2109,7 @@ void TextShaderEditor::_shader_preview_item_pressed(int p_idx) {
 void TextShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 	context_menu->clear();
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
-		context_menu->add_item(TTRC("Emoji & Symbols"), EDIT_EMOJI_AND_SYMBOL);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_emoji_and_symbols"), EDIT_EMOJI_AND_SYMBOL);
 		context_menu->add_separator();
 	}
 	if (p_selection) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -688,6 +688,12 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (is_shortcut_keys_enabled()) {
+		if (p_event->is_action("ui_emoji_and_symbols", true)) {
+			show_emoji_and_symbol_picker();
+			accept_event();
+			return;
+		}
+
 		if (p_event->is_action("ui_copy", true)) {
 			copy_text();
 			accept_event();
@@ -3303,7 +3309,7 @@ void LineEdit::_update_context_menu() {
 	}
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
-		MENU_ITEM_DISABLED(menu, MENU_EMOJI_AND_SYMBOL, !editable || !emoji_menu_enabled)
+		MENU_ITEM_ACTION_DISABLED(menu, MENU_EMOJI_AND_SYMBOL, "ui_emoji_and_symbols", !editable || !emoji_menu_enabled)
 	}
 	MENU_ITEM_ACTION_DISABLED(menu, MENU_CUT, "ui_cut", !editable)
 	MENU_ITEM_ACTION(menu, MENU_COPY, "ui_copy")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2722,6 +2722,11 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				accept_event();
 				return;
 			}
+			if (k->is_action("ui_emoji_and_symbols", true)) {
+				show_emoji_and_symbol_picker();
+				accept_event();
+				return;
+			}
 			if (k->is_action("ui_copy", true)) {
 				copy();
 				accept_event();
@@ -8149,7 +8154,7 @@ void TextEdit::_update_context_menu() {
 	}
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
-		MENU_ITEM_DISABLED(menu, MENU_EMOJI_AND_SYMBOL, !editable || !emoji_menu_enabled)
+		MENU_ITEM_ACTION_DISABLED(menu, MENU_EMOJI_AND_SYMBOL, "ui_emoji_and_symbols", !editable || !emoji_menu_enabled);
 	}
 	MENU_ITEM_ACTION_DISABLED(menu, MENU_CUT, "ui_cut", !editable)
 	MENU_ITEM_ACTION(menu, MENU_COPY, "ui_copy")


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118213
Fixes https://github.com/godotengine/godot-proposals/issues/11936

Adds default shortcut for emoji picker (Ctrl+Cmd+Space on macOS and Win+Period on Windows).