### PR TITLE
[Web] Remove undefined behavior around exit

### DIFF
--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -67,9 +67,10 @@ void exit_callback() {
 		main_started = false;
 	}
 	int exit_code = OS_Web::get_singleton()->get_exit_code();
-	memdelete(os);
+	delete os; // We used a normal new, so it needs a normal delete.
 	os = nullptr;
 	godot_cleanup_profiler();
+	emscripten_cancel_main_loop(); // We are exiting in this iteration.
 	emscripten_force_exit(exit_code); // Exit runtime.
 }
 


### PR DESCRIPTION
We can't use `free` on an object created with `new`, so this PR switches it to `delete`.

I only met the error related to it once in a medium custom PR and only in single threaded build for editor, but I can't reproduce it on master. 

Still one less undefined behaviour. The reason why this is ub: https://stackoverflow.com/a/22406540

Edit: Fixes https://github.com/godotengine/godot/issues/120323