### PR TITLE
[Web] Remove flags that prevent `proxy_to_pthread` from building

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -306,9 +306,6 @@ def configure(env: "SConsEnvironment"):
     if env["proxy_to_pthread"]:
         env.Append(LINKFLAGS=["-sPROXY_TO_PTHREAD=1"])
         env.Append(CPPDEFINES=["PROXY_TO_PTHREAD_ENABLED"])
-        env["EXPORTED_RUNTIME_METHODS"] += ["_emscripten_proxy_main"]
-        # https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925
-        env.Append(LINKFLAGS=["-sTEXTDECODER=0"])
 
     # Enable WebAssembly SIMD
     if env["wasm_simd"]:


### PR DESCRIPTION
This PR just aims to make it possible to build `proxy_to_pthread` again and it does 2 changes to make possible:
- Removes `-sTEXTDECODER=0`, if we search for the [PR number](https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-3074897173) that was linked as fixing this issue in the full changes we can see that it got fixed in 3.1.72.
<img width="1343" height="551" alt="image" src="https://github.com/user-attachments/assets/954e992b-67de-4d76-bfb3-9c0f5f6735d7" />
 
And the support for it itself was removed in [4.0.12](https://github.com/emscripten-core/emscripten/pull/24700), so in this and newer versions it errors.
<img width="1034" height="340" alt="image" src="https://github.com/user-attachments/assets/05c44763-af52-4ea8-84bd-ddefeb591bb2" />

- Removes `_emscripten_proxy_main`. I tried to build godot with it in both 4.0.0 and 5.0.4, but emscripten complained about undefined exported symbol, and after removing it godot was build successfully.

Seeing as minimum supported emscripten version(4.0.0) can work without these flags I didn't implement any version based differences and just removed them directly.