### PR TITLE
Disable the WebXR module if `proxy_to_pthread` is enabled

### DIFF
--- a/modules/webxr/config.py
+++ b/modules/webxr/config.py
@@ -1,4 +1,8 @@
 def can_build(env, platform):
+    if platform == "web":
+        # WebXR is incompatible with proxy_to_pthread.
+        return not env["proxy_to_pthread"]
+
     return env["opengl3"] and not env["disable_xr"]
 
 


### PR DESCRIPTION
Per (now closed) PR https://github.com/godotengine/godot/pull/83738, it's unlikely we'll get WebXR working with `proxy_to_pthread=yes` any time soon, or maybe even ever

So, rather than having folks build it and then not work at runtime, this will disable the WebXR module if `proxy_to_pthread` is enabled

I also considered having an error if both the WebXR and `proxy_to_pthread` were enabled, so folks would be aware that they are losing WebXR support if they use that option. If other folks think that's the way to go, I'd be happy to change the PR

Fixes https://github.com/godotengine/godot/issues/83733