### PR TITLE
Fix shader loop detection for shader previewer

### DIFF
--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -343,6 +343,8 @@ bool TextShaderPreview::_is_inside_loop(const PackedStringArray &p_lines, int p_
 			if (func_regex->search(clean_line).is_valid()) {
 				return false;
 			}
+
+			brace_stack = 0;
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

I added loop detection in #118712. However, what I forgot in my implementation was to reset the brace stack when finding the beginning of a scope block. This lead to wrongfully detecting loops when, for example, if statements were added after loops:

<img width="1870" height="1648" alt="image" src="https://github.com/user-attachments/assets/33acb7b4-aebc-4527-866c-17135b44c92a" />

This PR adds the brace stack reset and seems to solve the issue:

https://github.com/user-attachments/assets/e3782bd8-289b-43ba-91c9-c98b78100ed7