### PR TITLE
Add AnimationNodeObservers for signaling animation events

### DIFF
--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -7,6 +7,18 @@
 		A resource used by [AnimationNodeBlendTree].
 		[AnimationNodeBlendSpace1D] represents a virtual axis on which any type of [AnimationRootNode]s can be added using [method add_blend_point]. Outputs the linear blend of the two [AnimationRootNode]s adjacent to the current value.
 		You can set the extents of the axis with [member min_space] and [member max_space].
+
+		Optionally, signals can be used by setting an [AnimationNodeObserverBlendSpace] through [AnimationTree].
+		[codeblocks]
+		[gdscript]
+		var observer = tree.get("parameters/BlendSpace/observer")
+		observer.closest_point_changed.connect(on_closest_point_changed)
+		[/gdscript]
+		[csharp]
+		var observer = animationTree.Get("parameters/BlendSpace/observer").As&lt;AnimationNodeObserverBlendSpace&gt;();
+		observer.ClosestPointChanged += OnClosestPointChanged;
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -7,6 +7,18 @@
 		A resource used by [AnimationNodeBlendTree].
 		[AnimationNodeBlendSpace2D] represents a virtual 2D space on which [AnimationRootNode]s are placed. Outputs the linear blend of the three adjacent animations using a [Vector2] weight. Adjacent in this context means the three [AnimationRootNode]s making up the triangle that contains the current value.
 		You can add vertices to the blend space with [method add_blend_point] and automatically triangulate it by setting [member auto_triangles] to [code]true[/code]. Otherwise, use [method add_triangle] and [method remove_triangle] to triangulate the blend space by hand.
+
+		Optionally, signals can be used by setting an [AnimationNodeObserverBlendSpace] through [AnimationTree].
+		[codeblocks]
+		[gdscript]
+		var observer = tree.get("parameters/BlendSpace/observer")
+		observer.closest_point_changed.connect(on_closest_point_changed)
+		[/gdscript]
+		[csharp]
+		var observer = animationTree.Get("parameters/BlendSpace/observer").As&lt;AnimationNodeObserverBlendSpace&gt;();
+		observer.ClosestPointChanged += OnClosestPointChanged;
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeObserver.xml
+++ b/doc/classes/AnimationNodeObserver.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeObserver" inherits="Resource" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for observer types which relay [AnimationNode] events for a particular [AnimationTree] node.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
+	</members>
+</class>

--- a/doc/classes/AnimationNodeObserverBlendSpace.xml
+++ b/doc/classes/AnimationNodeObserverBlendSpace.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeObserverBlendSpace" inherits="AnimationNodeObserver" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Observer for events from [AnimationNodeBlendSpace1D] and [AnimationNodeBlendSpace2D] instances.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="closest_point_changed">
+			<param index="0" name="closest_point_name" type="StringName" />
+			<description>
+				Emitted when the closest point to the current blend position changes.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/AnimationNodeObserverOneShot.xml
+++ b/doc/classes/AnimationNodeObserverOneShot.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeObserverOneShot" inherits="AnimationNodeObserver" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Observer for events from [AnimationNodeOneShot] instances.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="fade_in_finished">
+			<description>
+				Emitted when the one-shot has finished fading in. Only emitted if fade-in time is greater than zero.
+			</description>
+		</signal>
+		<signal name="fade_out_started">
+			<description>
+				Emitted when the one-shot has started fading out. Only emitted if fade-out time is greater than zero.
+			</description>
+		</signal>
+		<signal name="finished">
+			<description>
+				Emitted when the one-shot has finished.
+			</description>
+		</signal>
+		<signal name="started">
+			<description>
+				Emitted when the one-shot has started.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/AnimationNodeObserverTransition.xml
+++ b/doc/classes/AnimationNodeObserverTransition.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeObserverTransition" inherits="AnimationNodeObserver" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Observer for events from [AnimationNodeTransition] instances.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<signals>
+		<signal name="state_finished">
+			<param index="0" name="state" type="String" />
+			<description>
+				Emitted when transitioning out of a state. If crossfade time is greater than zero, emits when the crossfade finishes. Otherwise, emits immediately before [signal state_started] emits for the new state.
+			</description>
+		</signal>
+		<signal name="state_started">
+			<param index="0" name="state" type="String" />
+			<description>
+				Emitted when a transition to a new state starts.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -50,6 +50,17 @@
 		animationTree.Get("parameters/OneShot/internal_active");
 		[/csharp]
 		[/codeblocks]
+		Optionally, signals can be used by setting an [AnimationNodeObserverOneShot] through [AnimationTree].
+		[codeblocks]
+		[gdscript]
+		var observer = tree.get("parameters/OneShot/observer")
+		observer.started.connect(on_one_shot_started)
+		[/gdscript]
+		[csharp]
+		var observer = animationTree.Get("parameters/OneShot/observer").As&lt;AnimationNodeObserverOneShot&gt;();
+		observer.Started += OnOneShotStarted;
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -35,6 +35,17 @@
 		animationTree.Get("parameters/Transition/current_index");
 		[/csharp]
 		[/codeblocks]
+		Optionally, signals can be used by setting an [AnimationNodeObserverTransition] through [AnimationTree].
+		[codeblocks]
+		[gdscript]
+		var observer = animation_tree.get("parameters/Transition/observer")
+		observer.state_started.connect(on_state_started)
+		[/gdscript]
+		[csharp]
+		var observer = animationTree.Get("parameters/Transition/observer").As&lt;AnimationNodeObserverTransition&gt;();
+		observer.StateStarted += OnStateStarted;
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -37,6 +37,7 @@
 void AnimationNodeBlendSpace1D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_position));
+	r_list->push_back(PropertyInfo(Variant::OBJECT, observer, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeObserverBlendSpace::get_class_static(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE));
 	r_list->push_back(PropertyInfo(Variant::INT, closest, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 }
 
@@ -606,6 +607,13 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_
 		NodeTimeInfo t = blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 		if (i == new_closest) {
 			mind = t;
+		}
+	}
+
+	if (!p_test_only && new_closest != cur_closest && new_closest != -1) {
+		Ref<AnimationNodeObserverBlendSpace> observer_ref = p_instance.get_parameter_observer();
+		if (observer_ref.is_valid()) {
+			observer_ref->emit_signal("closest_point_changed", get_blend_point_name(new_closest));
 		}
 	}
 

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -39,6 +39,7 @@
 void AnimationNodeBlendSpace2D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::VECTOR2, blend_position));
+	r_list->push_back(PropertyInfo(Variant::OBJECT, observer, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeObserverBlendSpace::get_class_static(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE));
 	r_list->push_back(PropertyInfo(Variant::INT, closest, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 }
 
@@ -761,6 +762,13 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_
 		NodeTimeInfo t = blend_node(p_process_state, p_instance, other_instance, pi, FILTER_IGNORE, true, p_test_only);
 		if (i == new_closest) {
 			mind = t;
+		}
+	}
+
+	if (!p_test_only && new_closest != cur_closest && new_closest != -1) {
+		Ref<AnimationNodeObserverBlendSpace> observer_ref = p_instance.get_parameter_observer();
+		if (observer_ref.is_valid()) {
+			observer_ref->emit_signal("closest_point_changed", get_blend_point_name(new_closest));
 		}
 	}
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -458,6 +458,7 @@ void AnimationNodeOneShot::get_parameter_list(LocalVector<PropertyInfo> *r_list)
 	r_list->push_back(PropertyInfo(Variant::BOOL, active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY));
 	r_list->push_back(PropertyInfo(Variant::BOOL, internal_active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY));
 	r_list->push_back(PropertyInfo(Variant::INT, request, PROPERTY_HINT_ENUM, ",Fire,Abort,Fade Out"));
+	r_list->push_back(PropertyInfo(Variant::OBJECT, observer, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeObserverOneShot::get_class_static(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, fade_in_remaining, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, fade_out_remaining, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, time_to_restart, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -579,6 +580,21 @@ bool AnimationNodeOneShot::has_filter() const {
 	return true;
 }
 
+void AnimationNodeOneShot::_check_and_notify_state_changes(AnimationNodeInstance &p_instance, bool p_prev_active, bool p_prev_internal_active, double p_prev_fade_in_remaining) {
+	Ref<AnimationNodeObserverOneShot> observer_ref = p_instance.get_parameter_observer();
+	if (observer_ref.is_valid()) {
+		if (!p_prev_active && p_instance.get_parameter_active()) {
+			observer_ref->emit_signal("started");
+		} else if (p_prev_active && !p_instance.get_parameter_active()) {
+			observer_ref->emit_signal(SceneStringName(finished));
+		} else if (Animation::is_greater_approx(p_prev_fade_in_remaining, 0) && Math::is_zero_approx(p_instance.get_parameter_fade_in_remaining())) {
+			observer_ref->emit_signal("fade_in_finished");
+		} else if (get_fade_out_time() > 0 && p_prev_internal_active && !p_instance.get_parameter_internal_active()) {
+			observer_ref->emit_signal("fade_out_started");
+		}
+	}
+}
+
 AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	OneShotRequest cur_request = static_cast<OneShotRequest>(p_instance.get_parameter_request());
 	bool cur_active = p_instance.get_parameter_active();
@@ -598,6 +614,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_proce
 	double abs_delta = Math::abs(p_delta);
 	bool p_seek = p_playback_info.seeked;
 	bool p_is_external_seeking = p_playback_info.is_external_seeking;
+	double prev_fade_in_remaining = cur_fade_in_remaining;
 
 	bool do_start = cur_request == ONE_SHOT_REQUEST_FIRE;
 
@@ -647,6 +664,9 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_proce
 	bool os_seek = p_seek;
 
 	if (!is_shooting) {
+		if (!p_test_only) {
+			_check_and_notify_state_changes(p_instance, cur_active, cur_internal_active, prev_fade_in_remaining);
+		}
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
 		pi.weight = 1.0;
 		return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
@@ -747,6 +767,9 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_proce
 	p_instance.set_parameter_fade_in_remaining(cur_fade_in_remaining, p_process_state.is_testing);
 	p_instance.set_parameter_fade_out_remaining(cur_fade_out_remaining, p_process_state.is_testing);
 
+	if (!p_test_only) {
+		_check_and_notify_state_changes(p_instance, cur_active, cur_internal_active, prev_fade_in_remaining);
+	}
 	return cur_internal_active ? os_nti : main_nti;
 }
 
@@ -1184,6 +1207,7 @@ void AnimationNodeTransition::get_parameter_list(LocalVector<PropertyInfo> *r_li
 	r_list->push_back(PropertyInfo(Variant::INT, current_index, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY)); // To avoid finding the index every frame, use this internally.
 	r_list->push_back(PropertyInfo(Variant::INT, prev_index, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, prev_xfading, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
+	r_list->push_back(PropertyInfo(Variant::OBJECT, observer, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeObserverTransition::get_class_static(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE));
 }
 
 Variant AnimationNodeTransition::get_parameter_default_value(const StringName &p_parameter) const {
@@ -1306,6 +1330,16 @@ bool AnimationNodeTransition::is_allow_transition_to_self() const {
 	return allow_transition_to_self;
 }
 
+void AnimationNodeTransition::_signal_state_change(const AnimationNodeInstance &p_instance, bool p_starting, int p_state, bool p_test_only) {
+	if (p_test_only) {
+		return;
+	}
+	Ref<AnimationNodeObserverTransition> observer_ref = p_instance.get_parameter_observer();
+	if (observer_ref.is_valid()) {
+		observer_ref->emit_signal(p_starting ? SceneStringName(state_started) : SceneStringName(state_finished), get_input_name(p_state));
+	}
+}
+
 AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	const String &cur_transition_request = p_instance.get_parameter_transition_request();
 	int cur_current_index = p_instance.get_parameter_current_index();
@@ -1352,6 +1386,10 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(ProcessState &p_pr
 				}
 			} else {
 				switched = true;
+				if (xfade_time == 0) {
+					_signal_state_change(p_instance, false, cur_current_index, p_test_only);
+				}
+				_signal_state_change(p_instance, true, new_idx, p_test_only);
 				cur_prev_index = cur_current_index;
 				p_instance.set_parameter_prev_index(cur_current_index, p_process_state.is_testing);
 				cur_current_index = new_idx;
@@ -1365,6 +1403,9 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(ProcessState &p_pr
 	}
 
 	if (clear_remaining_fade) {
+		if (xfade_time > 0 && Animation::is_greater_approx(cur_prev_xfading, 0.0)) {
+			_signal_state_change(p_instance, false, cur_prev_index, p_test_only);
+		}
 		cur_prev_xfading = 0;
 		p_instance.set_parameter_prev_xfading(0, p_process_state.is_testing);
 		cur_prev_index = -1;
@@ -1435,6 +1476,9 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(ProcessState &p_pr
 		blend_input(p_process_state, p_instance, cur_prev_index, pi, FILTER_IGNORE, true, p_test_only);
 		if (!p_seek) {
 			if (Animation::is_less_or_equal_approx(cur_prev_xfading, 0)) {
+				if (xfade_time > 0) {
+					_signal_state_change(p_instance, false, cur_prev_index, p_test_only);
+				}
 				p_instance.set_parameter_prev_index(-1, p_process_state.is_testing);
 			}
 			cur_prev_xfading -= Math::abs(p_playback_info.delta);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -124,6 +124,18 @@ public:
 	AnimationNodeSync();
 };
 
+class AnimationNodeObserverOneShot : public AnimationNodeObserver {
+	GDCLASS(AnimationNodeObserverOneShot, AnimationNodeObserver);
+
+protected:
+	static void _bind_methods() {
+		ADD_SIGNAL(MethodInfo("started"));
+		ADD_SIGNAL(MethodInfo("fade_in_finished"));
+		ADD_SIGNAL(MethodInfo("fade_out_started"));
+		ADD_SIGNAL(MethodInfo(SceneStringName(finished)));
+	}
+};
+
 class AnimationNodeOneShot : public AnimationNodeSync {
 	GDCLASS(AnimationNodeOneShot, AnimationNodeSync);
 
@@ -159,6 +171,8 @@ private:
 	StringName fade_in_remaining = "fade_in_remaining";
 	StringName fade_out_remaining = "fade_out_remaining";
 	StringName time_to_restart = "time_to_restart";
+
+	void _check_and_notify_state_changes(AnimationNodeInstance &p_instance, bool p_prev_active, bool p_prev_internal_active, double p_prev_fade_in_remaining);
 
 protected:
 	static void _bind_methods();
@@ -329,6 +343,16 @@ public:
 	AnimationNodeTimeSeek();
 };
 
+class AnimationNodeObserverTransition : public AnimationNodeObserver {
+	GDCLASS(AnimationNodeObserverTransition, AnimationNodeObserver);
+
+protected:
+	static void _bind_methods() {
+		ADD_SIGNAL(MethodInfo(SceneStringName(state_started), PropertyInfo(Variant::STRING, "state")));
+		ADD_SIGNAL(MethodInfo(SceneStringName(state_finished), PropertyInfo(Variant::STRING, "state")));
+	}
+};
+
 class AnimationNodeTransition : public AnimationNodeSync {
 	GDCLASS(AnimationNodeTransition, AnimationNodeSync);
 
@@ -350,6 +374,8 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	bool allow_transition_to_self = false;
 
 	bool pending_update = false;
+
+	void _signal_state_change(const AnimationNodeInstance &p_instance, bool p_starting, int p_state, bool p_test_only);
 
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -61,6 +61,9 @@ Variant AnimationNode::get_parameter_default_value(const StringName &p_parameter
 	if (p_parameter == current_length || p_parameter == current_position || p_parameter == current_delta) {
 		return 0.0;
 	}
+	if (p_parameter == observer) {
+		return Ref<AnimationNodeObserver>();
+	}
 	GDVIRTUAL_CALL(_get_parameter_default_value, p_parameter, ret);
 	return ret;
 }

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -45,6 +45,24 @@ class AnimationNodeEndState;
 class AnimationTree;
 struct AnimationNodeInstance;
 
+class AnimationNodeObserver : public Resource {
+	GDCLASS(AnimationNodeObserver, Resource);
+
+public:
+	AnimationNodeObserver() {
+		set_local_to_scene(true);
+	}
+};
+
+class AnimationNodeObserverBlendSpace : public AnimationNodeObserver {
+	GDCLASS(AnimationNodeObserverBlendSpace, AnimationNodeObserver);
+
+protected:
+	static void _bind_methods() {
+		ADD_SIGNAL(MethodInfo("closest_point_changed", PropertyInfo(Variant::STRING_NAME, "closest_point_name")));
+	}
+};
+
 class AnimationNode : public Resource {
 	GDCLASS(AnimationNode, Resource);
 
@@ -146,6 +164,7 @@ protected:
 	StringName current_length = "current_length";
 	StringName current_position = "current_position";
 	StringName current_delta = "current_delta";
+	StringName observer = "observer";
 
 	NodeTimeInfo process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false);
 	// Virtualizing for especially AnimationNodeAnimation needs to take "backward" into account.
@@ -303,40 +322,41 @@ struct AnimationNodeInstance {
 	X(0, CURRENT_LENGTH, current_length, Variant::FLOAT, double) \
 	X(1, CURRENT_POSITION, current_position, Variant::FLOAT, double) \
 	X(2, CURRENT_DELTA, current_delta, Variant::FLOAT, double) \
+	X(3, OBSERVER, observer, Variant::OBJECT, Ref<AnimationNodeObserver>) \
 	/* AnimationNodeTimeScale. */ \
-	X(3, TIME_SCALE, scale, Variant::FLOAT, double) \
+	X(4, TIME_SCALE, scale, Variant::FLOAT, double) \
 	/* AnimationNodeTimeSeek. */ \
-	X(3, SEEK_REQUEST, seek_request, Variant::FLOAT, double) \
+	X(4, SEEK_REQUEST, seek_request, Variant::FLOAT, double) \
 	/* AnimationNodeAdd2, AnimationNodeAdd3. */ \
-	X(3, ADD_AMOUNT, add_amount, Variant::FLOAT, double) \
+	X(4, ADD_AMOUNT, add_amount, Variant::FLOAT, double) \
 	/* AnimationNodeBlend2, AnimationNodeBlend3. */ \
-	X(3, BLEND_AMOUNT, blend_amount, Variant::FLOAT, double) \
+	X(4, BLEND_AMOUNT, blend_amount, Variant::FLOAT, double) \
 	/* AnimationNodeSub2. */ \
-	X(3, SUB_AMOUNT, sub_amount, Variant::FLOAT, double) \
+	X(4, SUB_AMOUNT, sub_amount, Variant::FLOAT, double) \
 	/* AnimationNodeOneShot. */ \
-	X(3, ONESHOT_TIME_TO_RESTART, time_to_restart, Variant::FLOAT, double) \
-	X(4, ONESHOT_FADE_IN_REMAINING, fade_in_remaining, Variant::FLOAT, double) \
-	X(5, ONESHOT_FADE_OUT_REMAINING, fade_out_remaining, Variant::FLOAT, double) \
-	X(6, ONESHOT_ACTIVE, active, Variant::BOOL, bool) \
-	X(7, ONESHOT_INTERNAL_ACTIVE, internal_active, Variant::BOOL, bool) \
-	X(8, ONESHOT_REQUEST, request, Variant::INT, int) \
+	X(4, ONESHOT_TIME_TO_RESTART, time_to_restart, Variant::FLOAT, double) \
+	X(5, ONESHOT_FADE_IN_REMAINING, fade_in_remaining, Variant::FLOAT, double) \
+	X(6, ONESHOT_FADE_OUT_REMAINING, fade_out_remaining, Variant::FLOAT, double) \
+	X(7, ONESHOT_ACTIVE, active, Variant::BOOL, bool) \
+	X(8, ONESHOT_INTERNAL_ACTIVE, internal_active, Variant::BOOL, bool) \
+	X(9, ONESHOT_REQUEST, request, Variant::INT, int) \
 	/* AnimationNodeAnimation */ \
-	X(3, ANIMATION_BACKWARD, backward, Variant::BOOL, bool) \
+	X(4, ANIMATION_BACKWARD, backward, Variant::BOOL, bool) \
 	/* AnimationNodeTransition TODO: Make ref & */ \
-	X(3, TRANSITION_REQUEST, transition_request, Variant::STRING, String) \
-	X(4, CURRENT_INDEX, current_index, Variant::INT, int) \
-	X(5, PREV_INDEX, prev_index, Variant::INT, int) \
-	X(6, PREV_XFADING, prev_xfading, Variant::FLOAT, double) \
-	X(7, CURRENT_STATE, current_state, Variant::STRING, String) \
+	X(4, TRANSITION_REQUEST, transition_request, Variant::STRING, String) \
+	X(5, CURRENT_INDEX, current_index, Variant::INT, int) \
+	X(6, PREV_INDEX, prev_index, Variant::INT, int) \
+	X(7, PREV_XFADING, prev_xfading, Variant::FLOAT, double) \
+	X(8, CURRENT_STATE, current_state, Variant::STRING, String) \
 	/* AnimationNodeBlendSpace1D and AnimationNodeBlendSpace2D, \
 	We currently cannot do blend_position, due to type same name but different type */ \
-	X(3, CLOSEST, closest, Variant::INT, int)
+	X(4, CLOSEST, closest, Variant::INT, int)
 
 	enum Slot : uint8_t {
 #define SLOT_ENUM(index, e, _member, _variant_type, _native_type) SLOT_##e = index,
 		ANIM_SLOT_LIST(SLOT_ENUM)
 #undef SLOT_ENUM
-				SLOT_MAX = 9
+				SLOT_MAX = 10
 	};
 
 	void maybe_bind_slot_property(const StringName &p_name, Variant *p_property) {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -593,10 +593,12 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationPlayer);
 	GDREGISTER_CLASS(AnimationTree);
 	GDREGISTER_CLASS(AnimationNode);
+	GDREGISTER_ABSTRACT_CLASS(AnimationNodeObserver);
 	GDREGISTER_CLASS(AnimationRootNode);
 	GDREGISTER_CLASS(AnimationNodeBlendTree);
 	GDREGISTER_CLASS(AnimationNodeBlendSpace1D);
 	GDREGISTER_CLASS(AnimationNodeBlendSpace2D);
+	GDREGISTER_CLASS(AnimationNodeObserverBlendSpace);
 	GDREGISTER_CLASS(AnimationNodeStateMachine);
 	GDREGISTER_CLASS(AnimationNodeStateMachinePlayback);
 	GDREGISTER_VIRTUAL_CLASS(AnimationNodeExtension);
@@ -605,6 +607,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeStateMachineTransition);
 	GDREGISTER_CLASS(AnimationNodeOutput);
 	GDREGISTER_CLASS(AnimationNodeOneShot);
+	GDREGISTER_CLASS(AnimationNodeObserverOneShot);
 	GDREGISTER_CLASS(AnimationNodeAnimation);
 	GDREGISTER_CLASS(AnimationNodeAdd2);
 	GDREGISTER_CLASS(AnimationNodeAdd3);
@@ -614,6 +617,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeTimeScale);
 	GDREGISTER_CLASS(AnimationNodeTimeSeek);
 	GDREGISTER_CLASS(AnimationNodeTransition);
+	GDREGISTER_CLASS(AnimationNodeObserverTransition);
 
 	GDREGISTER_CLASS(ShaderGlobalsOverride); // can be used in any shader
 


### PR DESCRIPTION
This implements https://github.com/godotengine/godot-proposals/issues/13386 For `AnimationNodeOneShot`, `AnimationNodeTransition`, `AnimationNodeBlendSpace1D`, and `AnimationNodeBlendSpace2D`.

The new parameter matches how it looks in the proposed mockup:


<img width="382" height="230" alt="Screenshot 2026-04-20 at 11 28 07 AM" src="https://github.com/user-attachments/assets/58e09b95-98b5-43d8-9c22-c16df4a9caeb" />
<br />

And here's how it appears in the tree itself:

<img width="515" height="331" alt="Screenshot 2026-04-20 at 11 27 11 AM" src="https://github.com/user-attachments/assets/7439f7a4-5692-449d-ae27-889b43807a29" />
<br />

I think this is OK although the view within the AnimationTree tab is a bit confusing without labels or tooltips.

Usage is to manually set the observer in the animation tree's parameter list and then in code like:
```gdscript
var observer := tree.get(observer_path) as AnimationNodeObserverOneShot
if observer:
    observer.started.connect(callback)
```

The following test project has scenes testing each of the new observer types. Arrow keys to drive the animation node(s) and escape to return to the main menu.


[animation_tree_test.zip](https://github.com/user-attachments/files/27068062/animation_tree_test.zip)

