### PR TITLE
Expose `EditorNode3DGizmo::is_selected`

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -193,6 +193,12 @@
 				Returns a list of the currently selected subgizmos. Can be used to highlight selected elements during [method _redraw].
 			</description>
 		</method>
+		<method name="is_selected" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this gizmo is currently selected. Can be used to write custom visualization logic during [method _redraw].
+			</description>
+		</method>
 		<method name="is_subgizmo_selected" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="id" type="int" />

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -863,6 +863,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &EditorNode3DGizmo::set_hidden);
 	ClassDB::bind_method(D_METHOD("is_subgizmo_selected", "id"), &EditorNode3DGizmo::is_subgizmo_selected);
 	ClassDB::bind_method(D_METHOD("get_subgizmo_selection"), &EditorNode3DGizmo::get_subgizmo_selection);
+	ClassDB::bind_method(D_METHOD("is_selected"), &EditorNode3DGizmo::is_selected);
 
 	GDVIRTUAL_BIND(_redraw);
 	GDVIRTUAL_BIND(_get_handle_name, "id", "secondary");


### PR DESCRIPTION
When working with custom editor gizmos it is really useful to know when a gizmo is selected to do custom visualization logic based on that. 

All of the editor code already uses this method to do custom logic in their respective `EditorNode3DGizmoPlugin`'s since its public and is exposed on the inner C++ side.