### PR TITLE
Bbcode mapping

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -723,6 +723,10 @@
 			If [code]true[/code], the label uses BBCode formatting.
 			[b]Note:[/b] This only affects the contents of [member text], not the tag stack.
 		</member>
+		<member name="bbcode_mapping" type="Dictionary" setter="set_bbcode_mapping" getter="get_bbcode_mapping" default="{}">
+			A Dictionary of Strings which can be used to make certain combinations of effects easier when used often. For example, adding an entry with [code]important[/code] as key and [code skip-lint][b][color=red][/code] lets you use [code skip-lint][important]Text here[/important][/code] to apply bold red formatting to [code]Text here[/code].
+			[b]Note:[/b] Keys must not be enclosed in brackets. Values must use tags enclosed in brackets.
+		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="false">
 			If [code]true[/code], a right-click displays the context menu.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -36,9 +36,13 @@
 #include "core/math/math_defs.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/object/property_info.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/translation_server.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/variant.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_effect.h"
@@ -5539,6 +5543,35 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 	String bbcode = p_bbcode.replace("\r\n", "\n");
 
+	// replace bbcode mappings
+	if (!bbcode_mapping.is_empty()) {
+		for (const KeyValue<Variant, Variant> &kv : bbcode_mapping) {
+			const String mapping = kv.key;
+			const String tags = kv.value;
+
+			const String formatted_mapping = "[" + mapping + "]";
+			// some code based on https://github.com/godotengine/godot/pull/106651/
+			const String formatted_mapping_end = "[/" + mapping + "]";
+
+			const PackedStringArray tag_list = tags.strip_escapes().remove_char('[').split("]");
+			String closing_tags = "";
+			for (const String &tag : tag_list) {
+				if (!tag.is_empty()) {
+					// Take the first "word" of the tag before any parameters to form the closing tag.
+					// For example, `[font slant=0.3 emb=1.0]`'s closing tag is just `[/font]`.
+					closing_tags = "[/" + tag.get_slicec('=', 0).get_slicec(' ', 0) + "]" + closing_tags;
+				}
+			}
+
+			if (bbcode.contains(formatted_mapping)) {
+				bbcode = bbcode.replace(formatted_mapping, tags);
+			}
+			if (bbcode.contains(formatted_mapping_end)) {
+				bbcode = bbcode.replace(formatted_mapping_end, closing_tags);
+			}
+		}
+	}
+
 	while (pos <= bbcode.length()) {
 		int brk_pos = bbcode.find_char('[', pos);
 
@@ -8005,6 +8038,9 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_menu_visible"), &RichTextLabel::is_menu_visible);
 	ClassDB::bind_method(D_METHOD("menu_option", "option"), &RichTextLabel::menu_option);
 
+	ClassDB::bind_method(D_METHOD("set_bbcode_mapping", "mapping"), &RichTextLabel::set_bbcode_mapping);
+	ClassDB::bind_method(D_METHOD("get_bbcode_mapping"), &RichTextLabel::get_bbcode_mapping);
+
 	// Note: set "bbcode_enabled" first, to avoid unnecessary "text" resets.
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bbcode_enabled"), "set_use_bbcode", "is_using_bbcode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
@@ -8026,6 +8062,7 @@ void RichTextLabel::_bind_methods() {
 
 	ADD_GROUP("Markup", "");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "custom_effects", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("RichTextEffect"), (PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE)), "set_effects", "get_effects");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "bbcode_mapping", PROPERTY_HINT_TYPE_STRING, "String;String"), "set_bbcode_mapping", "get_bbcode_mapping");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "meta_underlined"), "set_meta_underline", "is_meta_underlined");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hint_underlined"), "set_hint_underline", "is_hint_underlined");
 
@@ -8396,6 +8433,19 @@ void RichTextLabel::menu_option(int p_option) {
 			select_all();
 		} break;
 	}
+}
+
+void RichTextLabel::set_bbcode_mapping(const TypedDictionary<String, String> &p_mapping) {
+	if (p_mapping == bbcode_mapping) {
+		return;
+	}
+
+	bbcode_mapping = p_mapping;
+	_apply_translation();
+}
+
+TypedDictionary<String, String> RichTextLabel::get_bbcode_mapping() const {
+	return bbcode_mapping;
 }
 
 Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_identifier) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -32,6 +32,8 @@
 
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
+#include "core/variant/dictionary.h"
+#include "core/variant/typed_dictionary.h"
 #include "scene/gui/control.h"
 #include "scene/resources/text_paragraph.h"
 
@@ -569,6 +571,8 @@ private:
 
 	HashMap<RID, Rect2> ac_element_bounds_cache;
 
+	TypedDictionary<String, String> bbcode_mapping;
+
 	void _update_follow_vc();
 	void _invalidate_accessibility();
 	void _invalidate_current_line(ItemFrame *p_frame);
@@ -586,6 +590,9 @@ private:
 	void _remove_frame(HashSet<Item *> &r_erase_list, ItemFrame *p_frame, int p_line, bool p_erase, int p_char_offset, int p_line_offset);
 
 	void _texture_changed(RID p_item);
+
+	void set_bbcode_mapping(const TypedDictionary<String, String> &p_mapping);
+	TypedDictionary<String, String> get_bbcode_mapping() const;
 
 	static inline RID_PtrOwner<Item, true> items{ 65536, 1048576 };
 	List<String> tag_stack;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13923, and effectively closes https://github.com/godotengine/godot-proposals/issues/12328 (which I based some code on).

This introduces a new ~~simple resource~~ property which allows you to map simple strings to BBCodes in a RichTextLabel. This makes it much easier to use repeated combinations of tags.

For example, if you frequently use, say, `[color=red][wave amp=15]` you can create a mapping which lets you write `[cw15]`, and it gets replaced in the text. This also accounts for closing tags, though it doesn't currently account for tags which have already been closed outside of the mapping. (For example, if you wrote `[cw15]Test[/color] text[/cw15] you would have issues.)

Additionally, due to its simple implementation, if the substitution is fully self closing (for example, `[wave][img="res://icon.svg"][img="res://images/test.png"][/wave]`, then there's no issue just using the "opening" version of the tag and never closing it. This also means that you can use it for string replacements, such as `[color=pink]The Queen[/color]`, which, if combined with localization, could make it much easier to have special nouns that are formatted in a certain way without worrying about the formatting every time.

I'm not excellent at C++ (or git, I think I might've messed up the proper commit format), so the code is likely a bit messy, but if people give me pointers on how to improve it I'm more than happy to implement them.

The documentation is lacking, but I'm not quite sure how to explain the feature despite how simple it is. If anyone has ideas on how to help clarify it that'd be great.

UPDATE: Removed the resource and replaced it with a dictionary property in the RichTextLabel itself

Here's a demo project:
[bbcode-mapping-test-revamp.zip](https://github.com/user-attachments/files/27234181/bbcode-mapping-test-revamp.zip)