### PR TITLE
Buildsystem: Simplify `format_buffer` utility method

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -66,7 +66,7 @@ def encryption_key_builder(target, source, env):
 #include <cstdint>
 
 uint8_t script_encryption_key[32] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};"""
         )
 
@@ -87,7 +87,7 @@ def make_certs_header(target, source, env):
 inline constexpr int _certs_compressed_size = {len(buffer)};
 inline constexpr int _certs_uncompressed_size = {decomp_size};
 inline constexpr unsigned char _certs_compressed[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -17,7 +17,7 @@ def run(target, source, env):
 inline constexpr int _gdextension_interface_data_compressed_size = {len(buffer)};
 inline constexpr int _gdextension_interface_data_uncompressed_size = {decomp_size};
 inline constexpr unsigned char _gdextension_interface_data_compressed[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 
 class GDExtensionInterfaceDump {{

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -63,7 +63,7 @@ inline constexpr const char *_doc_data_hash = "{hash(buffer)}";
 inline constexpr int _doc_data_compressed_size = {len(buffer)};
 inline constexpr int _doc_data_uncompressed_size = {decomp_size};
 inline constexpr const unsigned char _doc_data_compressed[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 
@@ -114,7 +114,7 @@ def make_translations(target, source, env):
 
             file.write(f"""\
 inline constexpr const unsigned char _{category}_translation_{name}_compressed[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 
 """)

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -13,7 +13,7 @@ def make_splash(target, source, env):
 
 static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);
 inline constexpr const unsigned char boot_splash_png[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 
@@ -29,7 +29,7 @@ def make_splash_editor(target, source, env):
 
 static const Color boot_splash_editor_bg_color = Color(0.125, 0.145, 0.192);
 inline constexpr const unsigned char boot_splash_editor_png[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 
@@ -41,6 +41,6 @@ def make_app_icon(target, source, env):
         # Use a neutral gray color to better fit various kinds of projects.
         file.write(f"""\
 inline constexpr const unsigned char app_icon_png[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)

--- a/methods.py
+++ b/methods.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import sys
-import textwrap
 import zlib
 from collections import OrderedDict
 from io import StringIO
@@ -1596,14 +1595,8 @@ def compress_buffer(buffer: bytes) -> bytes:
     return zlib.compress(buffer, zlib.Z_BEST_COMPRESSION)
 
 
-def format_buffer(buffer: bytes, indent: int = 0, width: int = 120, initial_indent: bool = False) -> str:
-    return textwrap.fill(
-        ", ".join(str(byte) for byte in buffer),
-        width=width,
-        initial_indent="\t" * indent if initial_indent else "",
-        subsequent_indent="\t" * indent,
-        tabsize=4,
-    )
+def format_buffer(buffer: bytes, indent: int = 0, width: int = 120) -> str:
+    return re.sub(f"(.{{0,{width - indent - 1}}},) ", ("\t" * indent) + "\\g<1>\n", ", ".join(map(str, buffer)))
 
 
 ############################################################

--- a/modules/text_server_adv/text_server_adv_builders.py
+++ b/modules/text_server_adv/text_server_adv_builders.py
@@ -16,6 +16,6 @@ def make_icu_data(target, source, env):
 
 extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = {len(buffer)};
 extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -15,7 +15,7 @@ def make_fonts_header(target, source, env):
             file.write(f"""\
 inline constexpr int _font_{name}_size = {len(buffer)};
 inline constexpr unsigned char _font_{name}[] = {{
-	{methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 
 """)

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -33,7 +33,7 @@ def areatex_builder(target, source, env):
 #define AREATEX_SIZE (AREATEX_HEIGHT * AREATEX_PITCH)
 
 inline constexpr const unsigned char area_tex_png[] = {{
-    {methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 
@@ -52,7 +52,7 @@ def searchtex_builder(target, source, env):
 #define SEARCHTEX_SIZE (SEARCHTEX_HEIGHT * SEARCHTEX_PITCH)
 
 inline constexpr const unsigned char search_tex_png[] = {{
-    {methods.format_buffer(buffer, 1)}
+{methods.format_buffer(buffer, 1)}
 }};
 """)
 


### PR DESCRIPTION
Buildsystem: Simplify `format_buffer` utility method 

This method is used to generate headers for embedding files into the binary (think about the new `#embed` feature in C23 and C++26). 

While the stringification step itself was plenty fast, it then proceeded to wrap everything using the `textwrap` module. `textwrap` is *very* slow, as it's apparently optimized for human text. 

This patch reimplements the wrapping logic using a simple regex, resulting in a tremendous speed improvement (~6x), and switches to `map` for the stringification itself (thanks Rémi!) 

It also removes a (practically) unused argument, `initial_indent`. 

The generated files are pretty much the same, with a tiny difference in line length (for some reason the old logic overshot the requested line length) 

## Context

I daily drive the experimental ninja backend. It's very fast in lots of cases but it has to sometimes defer to SCons for some custom logic and this deferring is unfortunately single-threaded. I've talked with the SCons maintainers on Discord and they're looking into this too, but in the meantime I figured out that we could optimize what we got already.

I started with this method as it's used in quite a lot of places and quite simple overall.

Initially I tried passing two extra arguments to `textwrap.fill` (`break_long_words=False` and `break_on_hyphens=False`) [as it's apparently faster](https://stackoverflow.com/questions/11781261/why-are-textwrap-wrap-and-textwrap-fill-so-slow/11781870#11781870) but after some more investigations I found that the `re` (RegEx) module is even faster for our usecase.

I don't usually do lots of RegEx so please correct me if I did something stupid/slow.

## Benchmarks

Did some benchmarks on my laptop, sporting an AMD Ryzen 7 5825U, SSD and 32GB of RAM. Kept `amd_pstate` on `active` but set both the EPP and scheduler to `performance`, turned off boost, and forced the frequency to 2GHz (the max non-turbo speed).

I tried my best to get consistent and reasonable results but I'm not experienced in benchmarking. Please double-check this if you can.

### Synthetic test

First of all, the raw methods, using Python's `timeit` module. Ran this script from the source dir twice:

<details> <summary>benchmark.sh</summary>

```
#!/bin/sh

python -m timeit -s '
import re
import textwrap
width = 120
indent = 1

with open("thirdparty/icu4c/icudt_godot.dat", "rb") as f:
    buffer = f.read()' \
're.sub(
    f"(.{{0,{width - indent - 1}}},) ", ("\t" * indent) + "\\g<1>\n", ", ".join(str(byte) for byte in buffer)
)'

python -m timeit -s '
import re
import textwrap
width = 120
indent = 1
initial_indent = False

with open("thirdparty/icu4c/icudt_godot.dat", "rb") as f:
    buffer = f.read()' \
'textwrap.fill(
    ", ".join(str(byte) for byte in buffer),
    width=width,
    initial_indent="\t" * indent if initial_indent else "",
    subsequent_indent="\t" * indent,
    tabsize=4,
)'
```

</details>

Outputs:
```
1 loop, best of 5: 1.4 sec per loop #EDIT: regex
1 loop, best of 5: 8.02 sec per loop #EDIT: textwrap

1 loop, best of 5: 1.41 sec per loop #EDIT: regex
1 loop, best of 5: 7.89 sec per loop #EDIT: texwrap
```

_(Oops forgot to also test the "no wrap" tweaks here. Imagine them being somewhat in the middle.)_

That said I was more interested in the cumulative results for a whole build.

### Build container

Part of my workflow is now building the whole thing into a [Godot build container](https://github.com/godotengine/build-containers), so that I can load it up into a VM or other computer, as my laptop uses an unusual libc (musl). This is also why I was interested in making everything faster.

For this next benchmark I made use of some pretty heavily modified [Godot build scripts](https://github.com/godotengine/godot-build-scripts), with some additions to the container for ninja and ccache.

The times here include everything done by the `build.sh` script: updating the local repository, making it a tarball, entering into a container and starting the build. Containers have access to a host directory for the scons cache and another for ccache's... cache.

I've used hyperfine, with a warmup run and two regular ones.

Here are the results:

<details> <summary>Results</summary>

```
Benchmark 1: master (scons cache)
  Time (mean ± σ):     276.660 s ±  2.037 s    [User: 24.647 s, System: 6.153 s]
  Range (min … max):   275.220 s … 278.101 s    2 runs
 
Benchmark 2: textwrap no break (scons cache)
  Time (mean ± σ):     260.121 s ±  1.303 s    [User: 24.524 s, System: 6.218 s]
  Range (min … max):   259.200 s … 261.042 s    2 runs
 
Benchmark 3: RegEx (scons cache)
  Time (mean ± σ):     236.420 s ±  0.419 s    [User: 25.113 s, System: 6.254 s]
  Range (min … max):   236.123 s … 236.716 s    2 runs
 
Benchmark 4: master (ninja + ccache)
  Time (mean ± σ):     247.878 s ±  1.580 s    [User: 24.836 s, System: 6.300 s]
  Range (min … max):   246.760 s … 248.995 s    2 runs
 
Benchmark 5: textwrap no break (ninja + ccache)
  Time (mean ± σ):     229.962 s ±  4.292 s    [User: 24.795 s, System: 6.287 s]
  Range (min … max):   226.927 s … 232.997 s    2 runs
 
Benchmark 6: RegEx (ninja + ccache)
  Time (mean ± σ):     210.142 s ±  4.389 s    [User: 24.793 s, System: 6.240 s]
  Range (min … max):   207.038 s … 213.245 s    2 runs
 
Summary
  RegEx (ninja + ccache) ran
    1.09 ± 0.03 times faster than textwrap no break (ninja + ccache)
    1.13 ± 0.02 times faster than RegEx (scons cache)
    1.18 ± 0.03 times faster than master (ninja + ccache)
    1.24 ± 0.03 times faster than textwrap no break (scons cache)
    1.32 ± 0.03 times faster than master (scons cache)
```

</details>

So this change seems to bring some non-negligible improvements overall.

---

(Yes this patch is indeed `8 files changed, 15 insertions(+), 20 deletions(-)`. Sorry for the wall of text xD)