### PR TITLE
[Windows] Dynamically load `coremessaging`.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -427,7 +427,6 @@ def configure_msvc(env: "SConsEnvironment"):
         "ntdll",
         "hid",
         "mincore",
-        "coremessaging",
     ]
 
     if env.debug_features:
@@ -825,7 +824,6 @@ def configure_mingw(env: "SConsEnvironment"):
             "ntdll",
             "hid",
             "mincore",
-            "coremessaging",
         ]
     )
 

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -66,7 +66,8 @@ struct DispatcherQueueOptions {
 	DISPATCHERQUEUE_THREAD_APARTMENTTYPE apartmentType;
 };
 
-extern "C" HRESULT __declspec(dllexport) WINAPI CreateDispatcherQueueController(DispatcherQueueOptions options, void *dispatcherQueueController);
+typedef HRESULT(WINAPI *CreateDispatcherQueueControllerPtr)(DispatcherQueueOptions options, void *dispatcherQueueController);
+CreateDispatcherQueueControllerPtr CreateDispatcherQueueController;
 
 #ifndef E_BOUNDS
 #define E_BOUNDS _HRESULT_TYPEDEF_(0x8000000B)
@@ -126,6 +127,15 @@ class WinRTWindowData {
 };
 
 bool WinRTUtils::create_queue() {
+	HMODULE coremessaging = LoadLibraryW(L"coremessaging.dll");
+	if (!coremessaging) {
+		return false;
+	}
+	CreateDispatcherQueueController = (CreateDispatcherQueueControllerPtr)(void *)GetProcAddress(coremessaging, "CreateDispatcherQueueController");
+	if (!CreateDispatcherQueueController) {
+		return false;
+	}
+
 	DispatcherQueueOptions options{ sizeof(options), DQTYPE_THREAD_CURRENT, DQTAT_COM_NONE };
 	HRESULT res = CreateDispatcherQueueController(options, winrt::put_abi(controller));
 	return SUCCEEDED(res);


### PR DESCRIPTION
Only relevant for Windows 10 1607 LTS version, since this function is available only since 1709. This version is ancient and unlikely used by anyone, but seems like it just got ESUs until October 2029.