### PR TITLE
Do not use empty string as editor locale.

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -59,7 +59,6 @@
 #include "scene/gui/file_dialog.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/animation.h"
 #include "servers/display/display_server.h"
 
@@ -2024,7 +2023,7 @@ float EditorSettings::get_auto_display_scale() {
 
 String EditorSettings::get_language() const {
 	const String language = has_setting("interface/editor/localization/editor_language") ? get("interface/editor/localization/editor_language") : "auto";
-	if (language != "auto") {
+	if (language != "auto" && !language.is_empty()) {
 		return language;
 	}
 


### PR DESCRIPTION
Not sure what exact conditions can trigger it (probably using old builds of editor), but `interface/editor/localization/editor_language` can be set to empty string and spam `Locale cannot be an empty string.` on start.