### PR TITLE
Fix MSAA 3D internal buffer being recreated every frame

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -381,6 +381,10 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 			glGenFramebuffers(1, &msaa3d.fbo);
 			glBindFramebuffer(GL_FRAMEBUFFER, msaa3d.fbo);
 
+			// Initialize msaa3d.color to fit check in already setup.
+			// Without this, the MSAA buffer path will recreate resources every frame.
+			glGenRenderbuffers(1, &msaa3d.color);
+
 			_rt_attach_textures(internal3d.color, internal3d.depth, msaa3d.samples, view_count, true);
 
 			GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -198,7 +198,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 		_clear_intermediate_buffers();
 	}
 
-	if ((!use_internal_buffer || internal3d.color != 0) && (msaa3d.mode == RSE::VIEWPORT_MSAA_DISABLED || msaa3d.color != 0)) {
+	if ((!use_internal_buffer || internal3d.color != 0) && (msaa3d.mode == RSE::VIEWPORT_MSAA_DISABLED || msaa3d.fbo != 0)) {
 		// already setup!
 		return;
 	}
@@ -268,7 +268,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 	}
 
-	if (msaa3d.mode != RSE::VIEWPORT_MSAA_DISABLED && msaa3d.color == 0) {
+	if (msaa3d.mode != RSE::VIEWPORT_MSAA_DISABLED && msaa3d.fbo == 0) {
 		// Setup MSAA.
 		const GLsizei samples[] = { 1, 2, 4, 8 };
 		msaa3d.samples = samples[msaa3d.mode];

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -371,7 +371,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 			// hence we'll use our FBO cache here.
 			msaa3d.needs_resolve = false;
 			msaa3d.check_fbo_cache = true;
-		} else if (use_internal_buffer) {
+		} else if (use_internal_buffer && msaa3d.fbo != 0) {
 			// We can combine MSAA and scaling/effects.
 			msaa3d.needs_resolve = false;
 			msaa3d.check_fbo_cache = false;
@@ -380,10 +380,6 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 			// On mobile this means MSAA never leaves tile memory = efficiency!
 			glGenFramebuffers(1, &msaa3d.fbo);
 			glBindFramebuffer(GL_FRAMEBUFFER, msaa3d.fbo);
-
-			// Initialize msaa3d.color to fit check in already setup.
-			// Without this, the MSAA buffer path will recreate resources every frame.
-			glGenRenderbuffers(1, &msaa3d.color);
 
 			_rt_attach_textures(internal3d.color, internal3d.depth, msaa3d.samples, view_count, true);
 

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -371,7 +371,7 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 			// hence we'll use our FBO cache here.
 			msaa3d.needs_resolve = false;
 			msaa3d.check_fbo_cache = true;
-		} else if (use_internal_buffer && msaa3d.fbo != 0) {
+		} else if (use_internal_buffer) {
 			// We can combine MSAA and scaling/effects.
 			msaa3d.needs_resolve = false;
 			msaa3d.check_fbo_cache = false;


### PR DESCRIPTION
## What this PR does

Initializes `msaa3d.color` in the internal buffer path when setting up 3D MSAA.

Without this, the setup check will treat the MSAA buffer as uninitialized and recreate it every frame. This causes unnecessary resource recreation and lead to leaks on android platform.

## Why

In the `use_internal_buffer` path, `msaa3d.fbo` is created, but `msaa3d.color` was not initialized before the setup state was checked again later.

Generating the renderbuffer here makes the MSAA state consistent with the rest of the setup flow and prevents repeated recreation.

## Testing

- Built and ran the affected renderer path
- Verified the framebuffer setup still completes successfully
- Verified the MSAA 3D internal buffer is no longer recreated every frame

## Acknowledgments

Thanks to [陈晨阳](https://github.com/Chency1126) and [李宇飞](https://github.com/Liyufei1).
