### PR TITLE
Fix `disable_xr=yes` disabling the WebXR module

### DIFF
--- a/modules/webxr/config.py
+++ b/modules/webxr/config.py
@@ -1,7 +1,7 @@
 def can_build(env, platform):
-    if platform == "web":
+    if platform == "web" and env["proxy_to_pthread"]:
         # WebXR is incompatible with proxy_to_pthread.
-        return not env["proxy_to_pthread"]
+        return False
 
     return env["opengl3"] and not env["disable_xr"]
 


### PR DESCRIPTION
It occurred to me over night that I got the logic wrong in https://github.com/godotengine/godot/pull/118780 and that it breaks `disable_xr=yes` disabling the WebXR module. Sorry about that!

This PR should fix it :-)