### PR TITLE
Add support for `gl_NumWorkGroups` in D3D12.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -4794,6 +4794,9 @@ void RenderingDeviceDriverD3D12::command_bind_render_pipeline(CommandBufferID p_
 
 		cmd_buf_info->graphics_pso = pipeline_info->pso.Get();
 		cmd_buf_info->compute_pso = nullptr;
+
+		cmd_buf_info->nir_graphics_runtime_data_root_param_idx = shader_info_in->nir_runtime_data_root_param_idx;
+		cmd_buf_info->nir_compute_runtime_data_root_param_idx = UINT32_MAX;
 	}
 
 	if (cmd_buf_info->graphics_root_signature_crc != shader_info_in->root_signature_crc) {
@@ -5376,6 +5379,9 @@ void RenderingDeviceDriverD3D12::command_bind_compute_pipeline(CommandBufferID p
 
 		cmd_buf_info->compute_pso = pipeline_info->pso.Get();
 		cmd_buf_info->graphics_pso = nullptr;
+
+		cmd_buf_info->nir_compute_runtime_data_root_param_idx = shader_info_in->nir_runtime_data_root_param_idx;
+		cmd_buf_info->nir_graphics_runtime_data_root_param_idx = UINT32_MAX;
 	}
 
 	if (cmd_buf_info->compute_root_signature_crc != shader_info_in->root_signature_crc) {
@@ -5430,6 +5436,14 @@ void RenderingDeviceDriverD3D12::command_compute_dispatch(CommandBufferID p_cmd_
 	CommandBufferInfo *cmd_buf_info = (CommandBufferInfo *)p_cmd_buffer.id;
 	if (!barrier_capabilities.enhanced_barriers_supported) {
 		_resource_transitions_flush(cmd_buf_info);
+	}
+
+	if (cmd_buf_info->nir_compute_runtime_data_root_param_idx != UINT32_MAX) {
+		dxil_spirv_compute_runtime_data runtime_data = {};
+		runtime_data.group_count_x = p_x_groups;
+		runtime_data.group_count_y = p_y_groups;
+		runtime_data.group_count_z = p_z_groups;
+		cmd_buf_info->cmd_list->SetComputeRoot32BitConstants(cmd_buf_info->nir_compute_runtime_data_root_param_idx, sizeof(dxil_spirv_compute_runtime_data) / sizeof(uint32_t), &runtime_data, 0);
 	}
 
 	cmd_buf_info->cmd_list->Dispatch(p_x_groups, p_y_groups, p_z_groups);

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -491,6 +491,9 @@ private:
 		ID3D12PipelineState *graphics_pso = nullptr;
 		ID3D12PipelineState *compute_pso = nullptr;
 
+		uint32_t nir_graphics_runtime_data_root_param_idx = UINT32_MAX;
+		uint32_t nir_compute_runtime_data_root_param_idx = UINT32_MAX;
+
 		DynParams dyn_params;
 		bool pending_dyn_params = true;
 

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -539,14 +539,17 @@ bool RenderingShaderContainerD3D12::_generate_root_signature(BitField<RenderingD
 
 	// NIR-DXIL runtime data.
 	if (reflection_data_d3d12.nir_runtime_data_root_param_idx == 1) { // Set above to 1 when discovering runtime data is needed.
-		DEV_ASSERT(reflection_data.pipeline_type != RDC::PIPELINE_TYPE_COMPUTE); // Could be supported if needed, but it's pointless as of now.
+		bool is_compute = (reflection_data.pipeline_type == RDC::PIPELINE_TYPE_COMPUTE);
+		uint32_t runtime_data_size = (is_compute ? sizeof(dxil_spirv_compute_runtime_data) : sizeof(dxil_spirv_vertex_runtime_data));
+		D3D12_SHADER_VISIBILITY visibility = (is_compute ? D3D12_SHADER_VISIBILITY_ALL : D3D12_SHADER_VISIBILITY_VERTEX);
+
 		reflection_data_d3d12.nir_runtime_data_root_param_idx = root_params.size();
 		CD3DX12_ROOT_PARAMETER1 nir_runtime_data;
 		nir_runtime_data.InitAsConstants(
-				sizeof(dxil_spirv_vertex_runtime_data) / sizeof(uint32_t),
+				runtime_data_size / sizeof(uint32_t),
 				RUNTIME_DATA_REGISTER,
 				0,
-				D3D12_SHADER_VISIBILITY_VERTEX);
+				visibility);
 		root_params.push_back(nir_runtime_data);
 	}
 


### PR DESCRIPTION
Fixes #118113.