### PR TITLE
Fix GPUParticles3D/CPUParticles3D shadows freezing when off-screen or in "Shadows Only" mode

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2430,6 +2430,16 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 							if (instance->mesh_instance.is_valid()) {
 								RSG::mesh_storage->mesh_instance_check_for_update(instance->mesh_instance);
 							}
+
+							if (instance->base_type == RSE::INSTANCE_PARTICLES) {
+								RSG::particles_storage->particles_request_process(instance->base);
+								RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(instance->base, -p_cam_transform.basis.get_column(2).normalized(), p_cam_transform.basis.get_column(1).normalized()));
+								animated_material_found = true;
+							}
+
+							if (instance->redraw_if_visible) {
+								animated_material_found = true;
+							}
 						}
 
 						shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
@@ -2512,6 +2522,16 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 							if (instance->mesh_instance.is_valid()) {
 								RSG::mesh_storage->mesh_instance_check_for_update(instance->mesh_instance);
 							}
+
+							if (instance->base_type == RSE::INSTANCE_PARTICLES) {
+								RSG::particles_storage->particles_request_process(instance->base);
+								RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(instance->base, -p_cam_transform.basis.get_column(2).normalized(), p_cam_transform.basis.get_column(1).normalized()));
+								animated_material_found = true;
+							}
+
+							if (instance->redraw_if_visible) {
+								animated_material_found = true;
+							}
 						}
 
 						shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
@@ -2581,6 +2601,16 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 					if (instance->mesh_instance.is_valid()) {
 						RSG::mesh_storage->mesh_instance_check_for_update(instance->mesh_instance);
 					}
+
+					if (instance->base_type == RSE::INSTANCE_PARTICLES) {
+						RSG::particles_storage->particles_request_process(instance->base);
+						RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(instance->base, -p_cam_transform.basis.get_column(2).normalized(), p_cam_transform.basis.get_column(1).normalized()));
+						animated_material_found = true;
+					}
+
+					if (instance->redraw_if_visible) {
+						animated_material_found = true;
+					}
 				}
 				shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
 			}
@@ -2646,6 +2676,16 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 
 					if (instance->mesh_instance.is_valid()) {
 						RSG::mesh_storage->mesh_instance_check_for_update(instance->mesh_instance);
+					}
+
+					if (instance->base_type == RSE::INSTANCE_PARTICLES) {
+						RSG::particles_storage->particles_request_process(instance->base);
+						RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(instance->base, -p_cam_transform.basis.get_column(2).normalized(), p_cam_transform.basis.get_column(1).normalized()));
+						animated_material_found = true;
+					}
+
+					if (instance->redraw_if_visible) {
+						animated_material_found = true;
 					}
 				}
 
@@ -3230,6 +3270,21 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 					if (keep) {
 						cull_result.geometry_instances.push_back(idata.instance_geometry);
 					}
+				} else if (((1 << base_type) & RSE::INSTANCE_GEOMETRY_MASK) && (idata.flags & InstanceData::FLAG_CAST_SHADOWS_ONLY)) {
+					bool request_redraw = (idata.flags & InstanceData::FLAG_REDRAW_IF_VISIBLE);
+
+					if (base_type == RSE::INSTANCE_PARTICLES && !RSG::particles_storage->particles_is_inactive(idata.base_rid)) {
+						cull_data.cull->lock.lock();
+						RSG::particles_storage->particles_request_process(idata.base_rid);
+						cull_data.cull->lock.unlock();
+
+						RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(idata.base_rid, -cull_data.cam_transform.basis.get_column(2).normalized(), cull_data.cam_transform.basis.get_column(1).normalized()));
+						request_redraw = true;
+					}
+
+					if (request_redraw) {
+						RenderingServerDefault::redraw_request();
+					}
 				}
 			}
 
@@ -3244,6 +3299,22 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 						if (((1 << base_type) & RSE::INSTANCE_GEOMETRY_MASK) && idata.flags & InstanceData::FLAG_CAST_SHADOWS && (LAYER_CHECK & cull_data.cull->shadows[j].caster_mask)) {
 							cull_result.directional_shadows[j].cascade_geometry_instances[k].push_back(idata.instance_geometry);
 							mesh_visible = true;
+
+							bool request_redraw = (idata.flags & InstanceData::FLAG_REDRAW_IF_VISIBLE);
+
+							// Drive particle simulation for emitters in directional shadow but outside main camera frustum (GH-17267).
+							if (base_type == RSE::INSTANCE_PARTICLES) {
+								cull_data.cull->lock.lock();
+								RSG::particles_storage->particles_request_process(idata.base_rid);
+								cull_data.cull->lock.unlock();
+
+								RS::get_singleton()->call_on_render_thread(callable_mp_static(&RendererSceneCull::_scene_particles_set_view_axis).bind(idata.base_rid, -cull_data.cam_transform.basis.get_column(2).normalized(), cull_data.cam_transform.basis.get_column(1).normalized()));
+								request_redraw = true;
+							}
+
+							if (request_redraw) {
+								RenderingServerDefault::redraw_request();
+							}
 						}
 					}
 				}
@@ -3630,6 +3701,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 				RENDER_TIMESTAMP("> Render Light3D " + itos(i));
 				if (_light_instance_update_shadow(ins, p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect, p_shadow_atlas, scenario, p_screen_mesh_lod_threshold, p_visible_layers)) {
 					light->make_shadow_dirty();
+					RenderingServerDefault::redraw_request();
 				}
 				RENDER_TIMESTAMP("< Render Light3D " + itos(i));
 			} else {


### PR DESCRIPTION
This PR fixes an issue where GPUParticles3D and CPUParticles3D would stop simulating when entirely outside the main camera frustum or set to "Shadow Only" mode, causing their cast shadows to appear frozen on screen.

### Changes
- **Positional Shadows (_render_scene)**: Add `particles_request_process()` calls to `_light_instance_update_shadow` to keep particles in Omni/Spot light shadows simulating off-screen.
- **Directional & Shadows-Only (_scene_cull)**: Add `particles_request_process()` and `redraw_request()` during directional shadow cascade evaluation and within the `FLAG_CAST_SHADOWS_ONLY` culling loop.
- **Billboard Particles**: Pass the main camera's view direction to off-screen particles to ensure that the orientation of billboard particles continues to update.

Fixes #77139 
Fixes #17267 

Fix: Shadows Only Mode

https://github.com/user-attachments/assets/55de24c2-0790-45d4-913a-872ee8bcc6be


Fix: Off-screen Particles

https://github.com/user-attachments/assets/02a2a1f6-4ebe-48d6-b9fd-f46a85bc0954

### Was generative AI (LLM AI) used to create a portion of this PR?

I used Codex and Gemini to research the relevant particle shadow functionalities, review my final code, and help me draft the PR description. The changes were mainly made by me, with AI assistance for clarity.
