### PR TITLE
Fix subpixel positioning.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1426,10 +1426,10 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 						hb_raster_paint_reset(p_font_data->hb_rdr);
 						hb_raster_paint_set_scale_factor(p_font_data->hb_rdr, 64.0, 64.0);
 						if (Math::is_equal_approx(p_font_data->transform[0][0], (real_t)1.f) && Math::is_equal_approx(p_font_data->transform[1][0], (real_t)0.f) && Math::is_equal_approx(p_font_data->transform[1][1], (real_t)1.f)) {
-							hb_raster_paint_set_transform(p_font_data->hb_rdr, 1.f, 0.f, 0.f, -1.f, xshift, 0.f);
+							hb_raster_paint_set_transform(p_font_data->hb_rdr, 1.f, 0.f, 0.f, -1.f, -xshift, 0.f);
 						} else {
 							Transform2D tr = p_font_data->transform * Transform2D::FLIP_Y;
-							hb_raster_paint_set_transform(p_font_data->hb_rdr, tr[0][0], tr[1][0], tr[0][1], tr[1][1], xshift, 0.f);
+							hb_raster_paint_set_transform(p_font_data->hb_rdr, tr[0][0], tr[1][0], tr[0][1], tr[1][1], -xshift, 0.f);
 						}
 						hb_raster_paint_clear_custom_palette_colors(p_font_data->hb_rdr);
 						if (!p_font_data->palette_custom_colors_hb.is_empty()) {
@@ -4293,10 +4293,10 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -4344,13 +4344,12 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 				Point2 cpos = p_pos;
 				double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
 				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-					cpos.x = cpos.x + 0.125;
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
 				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-					cpos.x = cpos.x + 0.25;
-				}
-				if (scale == 1.0) {
-					cpos.y = Math::floor(cpos.y);
-					cpos.x = Math::floor(cpos.x);
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+				} else if (scale == 1.0) {
+					cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+					cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 				}
 				Vector2 gpos = fgl.rect.position;
 				Size2 csize = fgl.rect.size;
@@ -4436,10 +4435,10 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -4483,13 +4482,12 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 				Point2 cpos = p_pos;
 				double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
 				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-					cpos.x = cpos.x + 0.125;
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
 				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-					cpos.x = cpos.x + 0.25;
-				}
-				if (scale == 1.0) {
-					cpos.y = Math::floor(cpos.y);
-					cpos.x = Math::floor(cpos.x);
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+				} else if (scale == 1.0) {
+					cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+					cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 				}
 				Vector2 gpos = fgl.rect.position;
 				Size2 csize = fgl.rect.size;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2937,10 +2937,10 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -2987,14 +2987,13 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 			} else {
 				Point2 cpos = p_pos;
 				double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
-				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-					cpos.x = cpos.x + 0.125;
-				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-					cpos.x = cpos.x + 0.25;
-				}
-				if (scale == 1.0) {
-					cpos.y = Math::floor(cpos.y);
-					cpos.x = Math::floor(cpos.x);
+				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
+				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+				} else if (scale == 1.0) {
+					cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+					cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 				}
 				Vector2 gpos = fgl.rect.position;
 				Size2 csize = fgl.rect.size;
@@ -3080,10 +3079,10 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -3126,14 +3125,13 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 			} else {
 				Point2 cpos = p_pos;
 				double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
-				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-					cpos.x = cpos.x + 0.125;
-				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-					cpos.x = cpos.x + 0.25;
-				}
-				if (scale == 1.0) {
-					cpos.y = Math::floor(cpos.y);
-					cpos.x = Math::floor(cpos.x);
+				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
+				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
+					cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+				} else if (scale == 1.0) {
+					cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+					cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 				}
 				Vector2 gpos = fgl.rect.position;
 				Size2 csize = fgl.rect.size;


### PR DESCRIPTION
Related https://github.com/godotengine/godot/issues/117338 (I'll check what's going on in FT rasterize in 4.6 and older separately, it might be wrong as well).

`dev5 (Advanced text server/HarfBuzz)`
<img width="584" height="55" alt="Screenshot 2026-04-21 at 19 34 54" src="https://github.com/user-attachments/assets/a3e88dca-9456-46b1-9e43-6b027d660e5d" />

`this PR (Advanced text server/HarfBuzz)`
<img width="584" height="55" alt="dev_1_4" src="https://github.com/user-attachments/assets/30a6e8a0-e4fb-4098-8c7b-2e2261606a59" />
