### PR TITLE
Fill some gaps in QoL & utility for Vectors & AABBs

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -416,6 +416,50 @@ void AABB::get_edge(int p_edge, Vector3 &r_from, Vector3 &r_to) const {
 	}
 }
 
+AABB AABB::translated(const Vector3 & p_amount) const
+{
+	AABB bbox = *this;
+	bbox.position += p_amount;
+	return bbox;
+}
+
+AABB AABB::scaled(const Vector3 & p_amount) const
+{
+	AABB bbox = *this;
+	bbox.position *= p_amount;
+	bbox.size *= p_amount;
+	return bbox;
+}
+
+void AABB::extrude(const Vector3 & v)
+{
+	#ifdef MATH_CHECKS
+	if (unlikely(size.x < 0 || size.y < 0 || size.z < 0)) {
+		ERR_PRINT("AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size.");
+	}
+	#endif
+	auto p0 = position;
+	auto p1 = position + size;
+	const auto x = v.x;
+	const auto y = v.y;
+	const auto z = v.z;
+	if (x < 0) { p0.x += x; }
+	if (y < 0) { p0.y += y; }
+	if (z < 0) { p0.z += z; }
+	if (x > 0) { p1.x += x; }
+	if (y > 0) { p1.y += y; }
+	if (z > 0) { p1.z += z; }
+	position = p0;
+	size = p1-p0;
+}
+
+AABB AABB::extruded(const Vector3 & v) const
+{
+	AABB bbox = *this;
+	bbox.extrude(v);
+	return bbox;
+}
+
 Variant AABB::intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const {
 	Vector3 inters;
 	if (intersects_segment(p_from, p_to, &inters)) {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -128,9 +128,32 @@ struct [[nodiscard]] AABB {
 		return position + size;
 	}
 
+	_FORCE_INLINE_ void set_start(const Vector3 &p_start) {
+		Vector3 pev = position;
+		position = p_start;
+		size += pev-position;
+	}
+
+	_FORCE_INLINE_ Vector3 get_start() const {
+		return position;
+	}
+
 	_FORCE_INLINE_ Vector3 get_center() const {
 		return position + (size * 0.5f);
 	}
+
+	_FORCE_INLINE_ bool is_point() const {
+		return ((size.x+0)==0) && ((size.y+0)==0) && ((size.z+0)==0);
+	}
+	_FORCE_INLINE_ bool is_point_approx() const {
+		return Math::is_zero_approx(size.x) && Math::is_zero_approx(size.y) && Math::is_zero_approx(size.z);
+	}
+
+	AABB translated (const Vector3& p_amount) const;
+	AABB scaled (const Vector3& p_amount) const;
+
+	void extrude(const Vector3 & v);
+	AABB extruded(const Vector3& v) const;
 
 	uint32_t hash() const {
 		uint32_t h = hash_murmur3_one_real(position.x);

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -119,6 +119,34 @@ Vector2 Vector2::round() const {
 	return Vector2(Math::round(x), Math::round(y));
 }
 
+Vector2i Vector2::floori () const {
+	return Vector2i {
+		static_cast<int32_t>(Math::floor(x)),
+		static_cast<int32_t>(Math::floor(y)),
+	};
+}
+
+Vector2i Vector2::ceili () const {
+	return Vector2i {
+		static_cast<int32_t>(Math::ceil(x)),
+		static_cast<int32_t>(Math::ceil(y)),
+	};
+}
+
+Vector2 Vector2::wrapped(const Vector2 & p_min, const Vector2 & p_max) const {
+	return Vector2 {
+		Math::wrapf(x, p_min.x, p_max.x),
+		Math::wrapf(y, p_min.y, p_max.y),
+	};
+}
+
+Vector2 Vector2::wrappedf(real_t p_min, real_t p_max) const {
+	return Vector2 {
+		Math::wrapf(x, p_min, p_max),
+		Math::wrapf(y, p_min, p_max),
+	};
+}
+
 Vector2 Vector2::rotated(real_t p_by) const {
 	real_t sine = Math::sin(p_by);
 	real_t cosi = Math::cos(p_by);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -189,6 +189,11 @@ struct [[nodiscard]] Vector2 {
 	Vector2 clamp(const Vector2 &p_min, const Vector2 &p_max) const;
 	Vector2 clampf(real_t p_min, real_t p_max) const;
 	real_t aspect() const { return width / height; }
+	Vector2i floori () const;
+	Vector2i ceili () const;
+
+	Vector2 wrapped (const Vector2& p_min, const Vector2& p_max) const;
+	Vector2 wrappedf (real_t p_min, real_t p_max) const;
 
 	explicit operator String() const;
 	operator Vector2i() const;

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -107,6 +107,10 @@ struct [[nodiscard]] Vector2i {
 		return (p_to - *this).length_squared();
 	}
 
+	int64_t dot (const Vector2i& p_with) const {
+		return x*p_with.x+y*p_with.y;
+	}
+
 	constexpr Vector2i operator+(const Vector2i &p_v) const;
 	constexpr void operator+=(const Vector2i &p_v);
 	constexpr Vector2i operator-(const Vector2i &p_v) const;
@@ -123,6 +127,30 @@ struct [[nodiscard]] Vector2i {
 	constexpr Vector2i operator%(const Vector2i &p_v1) const;
 	constexpr Vector2i operator%(int32_t p_rvalue) const;
 	constexpr void operator%=(int32_t p_rvalue);
+
+	constexpr Vector2i &operator>>=(int32_t p_i);
+	constexpr Vector2i operator>>(int32_t p_i) const;
+	constexpr Vector2i &operator<<=(int32_t p_i);
+	constexpr Vector2i operator<<(int32_t p_i) const;
+	constexpr Vector2i &operator&=(int32_t p_i);
+	constexpr Vector2i operator&(int32_t p_i) const;
+	constexpr Vector2i &operator|=(int32_t p_i);
+	constexpr Vector2i operator|(int32_t p_i) const;
+	constexpr Vector2i &operator^=(int32_t p_i);
+	constexpr Vector2i operator^(int32_t p_i) const;
+
+	constexpr Vector2i &operator>>=(const Vector2i& p_v);
+	constexpr Vector2i operator>>(const Vector2i& p_v) const;
+	constexpr Vector2i &operator<<=(const Vector2i& p_v);
+	constexpr Vector2i operator<<(const Vector2i& p_v) const;
+	constexpr Vector2i &operator&=(const Vector2i& p_v);
+	constexpr Vector2i operator&(const Vector2i& p_v) const;
+	constexpr Vector2i &operator|=(const Vector2i& p_v);
+	constexpr Vector2i operator|(const Vector2i& p_v) const;
+	constexpr Vector2i &operator^=(const Vector2i& p_v);
+	constexpr Vector2i operator^(const Vector2i& p_v) const;
+
+	constexpr Vector2i operator~() const;
 
 	constexpr Vector2i operator-() const;
 	constexpr bool operator<(const Vector2i &p_vec2) const { return (x == p_vec2.x) ? (y < p_vec2.y) : (x < p_vec2.x); }
@@ -253,6 +281,105 @@ constexpr Vector2i operator*(float p_scalar, const Vector2i &p_vector) {
 constexpr Vector2i operator*(double p_scalar, const Vector2i &p_vector) {
 	return p_vector * p_scalar;
 }
+
+// v bitwise int
+inline constexpr Vector2i & Vector2i::operator>>=(int32_t p_i)
+{
+	x >>= p_i;
+	y >>= p_i;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator>>(int32_t p_i) const {
+	return Vector2i(x >> p_i, y >> p_i);
+}
+inline constexpr Vector2i & Vector2i::operator<<=(int32_t p_i)
+{
+	x <<= p_i;
+	y <<= p_i;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator<<(int32_t p_i) const {
+	return Vector2i(x << p_i, y << p_i);
+}
+inline constexpr Vector2i & Vector2i::operator&=(int32_t p_i)
+{
+	x &= p_i;
+	y &= p_i;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator&(int32_t p_i) const {
+	return Vector2i(x & p_i, y & p_i);
+}
+inline constexpr Vector2i & Vector2i::operator|=(int32_t p_i)
+{
+	x |= p_i;
+	y |= p_i;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator|(int32_t p_i) const {
+	return Vector2i(x | p_i, y | p_i);
+}
+inline constexpr Vector2i & Vector2i::operator^=(int32_t p_i)
+{
+	x ^= p_i;
+	y ^= p_i;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator^(int32_t p_i) const {
+	return Vector2i(x ^ p_i, y ^ p_i);
+}
+
+// v bitwise v
+inline constexpr Vector2i & Vector2i::operator>>=(const Vector2i& p_v)
+{
+	x >>= p_v.x;
+	y >>= p_v.y;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator>>(const Vector2i& p_v) const {
+	return Vector2i(x >> p_v.x, y >> p_v.y);
+}
+inline constexpr Vector2i & Vector2i::operator<<=(const Vector2i& p_v)
+{
+	x <<= p_v.x;
+	y <<= p_v.y;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator<<(const Vector2i& p_v) const {
+	return Vector2i(x << p_v.x, y << p_v.y);
+}
+inline constexpr Vector2i & Vector2i::operator&=(const Vector2i& p_v)
+{
+	x &= p_v.x;
+	y &= p_v.y;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator&(const Vector2i& p_v) const {
+	return Vector2i(x & p_v.x, y & p_v.y);
+}
+inline constexpr Vector2i & Vector2i::operator|=(const Vector2i& p_v)
+{
+	x |= p_v.x;
+	y |= p_v.y;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator|(const Vector2i& p_v) const {
+	return Vector2i(x | p_v.x, y | p_v.y);
+}
+inline constexpr Vector2i & Vector2i::operator^=(const Vector2i& p_v)
+{
+	x ^= p_v.x;
+	y ^= p_v.y;
+	return *this;
+}
+constexpr Vector2i Vector2i::operator^(const Vector2i& p_v) const {
+	return Vector2i(x ^ p_v.x, y ^ p_v.y);
+}
+
+constexpr Vector2i Vector2i::operator~() const {
+	return Vector2i(~x, ~y);
+}
+
 
 typedef Vector2i Size2i;
 typedef Vector2i Point2i;

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -154,6 +154,39 @@ bool Vector3::is_finite() const {
 	return Math::is_finite(x) && Math::is_finite(y) && Math::is_finite(z);
 }
 
+Vector3 Vector3::wrapped(const Vector3 & p_min, const Vector3 & p_max) const {
+	return Vector3{
+		Math::wrapf(x, p_min.x, p_max.x),
+		Math::wrapf(y, p_min.y, p_max.y),
+		Math::wrapf(z, p_min.z, p_max.z),
+	};
+}
+
+Vector3 Vector3::wrappedf(real_t p_min, real_t p_max) const
+{
+	return Vector3 {
+		Math::wrapf(x, p_min, p_max),
+		Math::wrapf(y, p_min, p_max),
+		Math::wrapf(z, p_min, p_max),
+	};
+}
+
+Vector3i Vector3::floori () const {
+	return Vector3i {
+		static_cast<int32_t>(Math::floor(x)),
+		static_cast<int32_t>(Math::floor(y)),
+		static_cast<int32_t>(Math::floor(z)),
+	};
+}
+
+Vector3i Vector3::ceili () const {
+	return Vector3i {
+		static_cast<int32_t>(Math::ceil(x)),
+		static_cast<int32_t>(Math::ceil(y)),
+		static_cast<int32_t>(Math::ceil(z)),
+	};
+}
+
 Vector3::operator String() const {
 	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ")";
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -165,6 +165,8 @@ struct [[nodiscard]] Vector3 {
 	_FORCE_INLINE_ Vector3 sign() const;
 	_FORCE_INLINE_ Vector3 ceil() const;
 	_FORCE_INLINE_ Vector3 round() const;
+	Vector3i floori() const;
+	Vector3i ceili() const;
 
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
@@ -185,6 +187,9 @@ struct [[nodiscard]] Vector3 {
 	bool is_same(const Vector3 &p_v) const;
 	bool is_zero_approx() const;
 	bool is_finite() const;
+
+	Vector3 wrapped (const Vector3& p_min, const Vector3& p_max) const;
+	Vector3 wrappedf (real_t p_min, real_t p_max) const;
 
 	/* Operators */
 

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -94,6 +94,10 @@ struct [[nodiscard]] Vector3i {
 		return Vector3i(MAX(x, p_scalar), MAX(y, p_scalar), MAX(z, p_scalar));
 	}
 
+	int64_t dot (const Vector3i &p_with) const {
+		return x*p_with.x+y*p_with.y+z*p_with.z;
+	}
+
 	_FORCE_INLINE_ int64_t length_squared() const;
 	_FORCE_INLINE_ double length() const;
 
@@ -129,6 +133,29 @@ struct [[nodiscard]] Vector3i {
 	constexpr Vector3i &operator%=(int32_t p_scalar);
 	constexpr Vector3i operator%(int32_t p_scalar) const;
 
+	constexpr Vector3i &operator>>=(int32_t p_i);
+	constexpr Vector3i operator>>(int32_t p_i) const;
+	constexpr Vector3i &operator<<=(int32_t p_i);
+	constexpr Vector3i operator<<(int32_t p_i) const;
+	constexpr Vector3i &operator&=(int32_t p_i);
+	constexpr Vector3i operator&(int32_t p_i) const;
+	constexpr Vector3i &operator|=(int32_t p_i);
+	constexpr Vector3i operator|(int32_t p_i) const;
+	constexpr Vector3i &operator^=(int32_t p_i);
+	constexpr Vector3i operator^(int32_t p_i) const;
+
+	constexpr Vector3i &operator>>=(const Vector3i& p_v);
+	constexpr Vector3i operator>>(const Vector3i& p_v) const;
+	constexpr Vector3i &operator<<=(const Vector3i& p_v);
+	constexpr Vector3i operator<<(const Vector3i& p_v) const;
+	constexpr Vector3i &operator&=(const Vector3i& p_v);
+	constexpr Vector3i operator&(const Vector3i& p_v) const;
+	constexpr Vector3i &operator|=(const Vector3i& p_v);
+	constexpr Vector3i operator|(const Vector3i& p_v) const;
+	constexpr Vector3i &operator^=(const Vector3i& p_v);
+	constexpr Vector3i operator^(const Vector3i& p_v) const;
+
+	constexpr Vector3i operator~() const;
 	constexpr Vector3i operator-() const;
 
 	constexpr bool operator==(const Vector3i &p_v) const;
@@ -293,9 +320,118 @@ constexpr Vector3i Vector3i::operator%(int32_t p_scalar) const {
 	return Vector3i(x % p_scalar, y % p_scalar, z % p_scalar);
 }
 
+// v bitwise int
+inline constexpr Vector3i & Vector3i::operator>>=(int32_t p_i)
+{
+	x >>= p_i;
+	y >>= p_i;
+	z >>= p_i;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator>>(int32_t p_i) const {
+	return Vector3i(x >> p_i, y >> p_i, z >> p_i);
+}
+inline constexpr Vector3i & Vector3i::operator<<=(int32_t p_i)
+{
+	x <<= p_i;
+	y <<= p_i;
+	z <<= p_i;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator<<(int32_t p_i) const {
+	return Vector3i(x << p_i, y << p_i, z << p_i);
+}
+inline constexpr Vector3i & Vector3i::operator&=(int32_t p_i)
+{
+	x &= p_i;
+	y &= p_i;
+	z &= p_i;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator&(int32_t p_i) const {
+	return Vector3i(x & p_i, y & p_i, z & p_i);
+}
+inline constexpr Vector3i & Vector3i::operator|=(int32_t p_i)
+{
+	x |= p_i;
+	y |= p_i;
+	z |= p_i;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator|(int32_t p_i) const {
+	return Vector3i(x | p_i, y | p_i, z | p_i);
+}
+inline constexpr Vector3i & Vector3i::operator^=(int32_t p_i)
+{
+	x ^= p_i;
+	y ^= p_i;
+	z ^= p_i;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator^(int32_t p_i) const {
+	return Vector3i(x ^ p_i, y ^ p_i, z ^ p_i);
+}
+
+// v bitwise v
+inline constexpr Vector3i & Vector3i::operator>>=(const Vector3i& p_v)
+{
+	x >>= p_v.x;
+	y >>= p_v.y;
+	z >>= p_v.z;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator>>(const Vector3i& p_v) const {
+	return Vector3i(x >> p_v.x, y >> p_v.y, z >> p_v.z);
+}
+inline constexpr Vector3i & Vector3i::operator<<=(const Vector3i& p_v)
+{
+	x <<= p_v.x;
+	y <<= p_v.y;
+	z <<= p_v.z;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator<<(const Vector3i& p_v) const {
+	return Vector3i(x << p_v.x, y << p_v.y, z << p_v.z);
+}
+inline constexpr Vector3i & Vector3i::operator&=(const Vector3i& p_v)
+{
+	x &= p_v.x;
+	y &= p_v.y;
+	z &= p_v.z;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator&(const Vector3i& p_v) const {
+	return Vector3i(x & p_v.x, y & p_v.y, z & p_v.z);
+}
+inline constexpr Vector3i & Vector3i::operator|=(const Vector3i& p_v)
+{
+	x |= p_v.x;
+	y |= p_v.y;
+	z |= p_v.z;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator|(const Vector3i& p_v) const {
+	return Vector3i(x | p_v.x, y | p_v.y, z | p_v.z);
+}
+inline constexpr Vector3i & Vector3i::operator^=(const Vector3i& p_v)
+{
+	x ^= p_v.x;
+	y ^= p_v.y;
+	z ^= p_v.z;
+	return *this;
+}
+constexpr Vector3i Vector3i::operator^(const Vector3i& p_v) const {
+	return Vector3i(x ^ p_v.x, y ^ p_v.y, z ^ p_v.z);
+}
+
+constexpr Vector3i Vector3i::operator~() const {
+	return Vector3i(~x, ~y, ~z);
+}
+
 constexpr Vector3i Vector3i::operator-() const {
 	return Vector3i(-x, -y, -z);
 }
+
 
 constexpr bool Vector3i::operator==(const Vector3i &p_v) const {
 	return (x == p_v.x && y == p_v.y && z == p_v.z);

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -224,6 +224,24 @@ Vector4 Vector4::clampf(real_t p_min, real_t p_max) const {
 			CLAMP(w, p_min, p_max));
 }
 
+Vector4i Vector4::floori () const {
+	return Vector4i {
+		static_cast<int32_t>(Math::floor(x)),
+		static_cast<int32_t>(Math::floor(y)),
+		static_cast<int32_t>(Math::floor(z)),
+		static_cast<int32_t>(Math::floor(w)),
+	};
+}
+
+Vector4i Vector4::ceili () const {
+	return Vector4i {
+		static_cast<int32_t>(Math::ceil(x)),
+		static_cast<int32_t>(Math::ceil(y)),
+		static_cast<int32_t>(Math::ceil(z)),
+		static_cast<int32_t>(Math::ceil(w)),
+	};
+}
+
 Vector4::operator String() const {
 	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ", " + String::num_real(w, true) + ")";
 }

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -112,6 +112,8 @@ struct [[nodiscard]] Vector4 {
 	Vector4 lerp(const Vector4 &p_to, real_t p_weight) const;
 	Vector4 cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight) const;
 	Vector4 cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, real_t p_weight, real_t p_b_t, real_t p_pre_a_t, real_t p_post_b_t) const;
+	Vector4i floori() const;
+	Vector4i ceili() const;
 
 	Vector4 posmod(real_t p_mod) const;
 	Vector4 posmodv(const Vector4 &p_modv) const;

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -124,6 +124,30 @@ struct [[nodiscard]] Vector4i {
 	constexpr Vector4i &operator%=(int32_t p_scalar);
 	constexpr Vector4i operator%(int32_t p_scalar) const;
 
+	constexpr Vector4i &operator>>=(int32_t p_i);
+	constexpr Vector4i operator>>(int32_t p_i) const;
+	constexpr Vector4i &operator<<=(int32_t p_i);
+	constexpr Vector4i operator<<(int32_t p_i) const;
+	constexpr Vector4i &operator&=(int32_t p_i);
+	constexpr Vector4i operator&(int32_t p_i) const;
+	constexpr Vector4i &operator|=(int32_t p_i);
+	constexpr Vector4i operator|(int32_t p_i) const;
+	constexpr Vector4i &operator^=(int32_t p_i);
+	constexpr Vector4i operator^(int32_t p_i) const;
+
+	constexpr Vector4i &operator>>=(const Vector4i& p_v);
+	constexpr Vector4i operator>>(const Vector4i& p_v) const;
+	constexpr Vector4i &operator<<=(const Vector4i& p_v);
+	constexpr Vector4i operator<<(const Vector4i& p_v) const;
+	constexpr Vector4i &operator&=(const Vector4i& p_v);
+	constexpr Vector4i operator&(const Vector4i& p_v) const;
+	constexpr Vector4i &operator|=(const Vector4i& p_v);
+	constexpr Vector4i operator|(const Vector4i& p_v) const;
+	constexpr Vector4i &operator^=(const Vector4i& p_v);
+	constexpr Vector4i operator^(const Vector4i& p_v) const;
+
+	constexpr Vector4i operator~() const;
+
 	constexpr Vector4i operator-() const;
 
 	constexpr bool operator==(const Vector4i &p_v) const;
@@ -289,6 +313,124 @@ constexpr Vector4i &Vector4i::operator%=(int32_t p_scalar) {
 
 constexpr Vector4i Vector4i::operator%(int32_t p_scalar) const {
 	return Vector4i(x % p_scalar, y % p_scalar, z % p_scalar, w % p_scalar);
+}
+
+// v bitwise int
+inline constexpr Vector4i & Vector4i::operator>>=(int32_t p_i)
+{
+	x >>= p_i;
+	y >>= p_i;
+	z >>= p_i;
+	w >>= p_i;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator>>(int32_t p_i) const {
+	return Vector4i(x >> p_i, y >> p_i, z >> p_i, w >> p_i);
+}
+inline constexpr Vector4i & Vector4i::operator<<=(int32_t p_i)
+{
+	x <<= p_i;
+	y <<= p_i;
+	z <<= p_i;
+	w <<= p_i;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator<<(int32_t p_i) const {
+	return Vector4i(x << p_i, y << p_i, z << p_i, w << p_i);
+}
+inline constexpr Vector4i & Vector4i::operator&=(int32_t p_i)
+{
+	x &= p_i;
+	y &= p_i;
+	z &= p_i;
+	w &= p_i;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator&(int32_t p_i) const {
+	return Vector4i(x & p_i, y & p_i, z & p_i, w & p_i);
+}
+inline constexpr Vector4i & Vector4i::operator|=(int32_t p_i)
+{
+	x |= p_i;
+	y |= p_i;
+	z |= p_i;
+	w |= p_i;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator|(int32_t p_i) const {
+	return Vector4i(x | p_i, y | p_i, z | p_i, w | p_i);
+}
+inline constexpr Vector4i & Vector4i::operator^=(int32_t p_i)
+{
+	x ^= p_i;
+	y ^= p_i;
+	z ^= p_i;
+	w ^= p_i;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator^(int32_t p_i) const {
+	return Vector4i(x ^ p_i, y ^ p_i, z ^ p_i, w ^ p_i);
+}
+
+// v bitwise v
+inline constexpr Vector4i & Vector4i::operator>>=(const Vector4i& p_v)
+{
+	x >>= p_v.x;
+	y >>= p_v.y;
+	z >>= p_v.z;
+	w >>= p_v.w;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator>>(const Vector4i& p_v) const {
+	return Vector4i(x >> p_v.x, y >> p_v.y, z >> p_v.z, w >> p_v.w);
+}
+inline constexpr Vector4i & Vector4i::operator<<=(const Vector4i& p_v)
+{
+	x <<= p_v.x;
+	y <<= p_v.y;
+	z <<= p_v.z;
+	w <<= p_v.w;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator<<(const Vector4i& p_v) const {
+	return Vector4i(x << p_v.x, y << p_v.y, z << p_v.z, w << p_v.w);
+}
+inline constexpr Vector4i & Vector4i::operator&=(const Vector4i& p_v)
+{
+	x &= p_v.x;
+	y &= p_v.y;
+	z &= p_v.z;
+	w &= p_v.w;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator&(const Vector4i& p_v) const {
+	return Vector4i(x & p_v.x, y & p_v.y, z & p_v.z, w & p_v.w);
+}
+inline constexpr Vector4i & Vector4i::operator|=(const Vector4i& p_v)
+{
+	x |= p_v.x;
+	y |= p_v.y;
+	z |= p_v.z;
+	w |= p_v.w;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator|(const Vector4i& p_v) const {
+	return Vector4i(x | p_v.x, y | p_v.y, z | p_v.z, w | p_v.w);
+}
+inline constexpr Vector4i & Vector4i::operator^=(const Vector4i& p_v)
+{
+	x ^= p_v.x;
+	y ^= p_v.y;
+	z ^= p_v.z;
+	w ^= p_v.w;
+	return *this;
+}
+constexpr Vector4i Vector4i::operator^(const Vector4i& p_v) const {
+	return Vector4i(x ^ p_v.x, y ^ p_v.y, z ^ p_v.z, w ^ p_v.w);
+}
+
+constexpr Vector4i Vector4i::operator~() const {
+	return Vector4i(~x, ~y, ~z, ~w);
 }
 
 constexpr Vector4i Vector4i::operator-() const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2218,6 +2218,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2i, mini, sarray("with"), varray());
 	bind_method(Vector2i, max, sarray("with"), varray());
 	bind_method(Vector2i, maxi, sarray("with"), varray());
+	bind_method(Vector2i, dot, sarray("with"), varray());
 
 	/* Rect2 */
 
@@ -2327,6 +2328,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3i, mini, sarray("with"), varray());
 	bind_method(Vector3i, max, sarray("with"), varray());
 	bind_method(Vector3i, maxi, sarray("with"), varray());
+	bind_method(Vector3i, dot, sarray("with"), varray());
 
 	/* Vector4 */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2176,6 +2176,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2, floor, sarray(), varray());
 	bind_method(Vector2, ceil, sarray(), varray());
 	bind_method(Vector2, round, sarray(), varray());
+	bind_method(Vector2, floori, sarray(), varray());
+	bind_method(Vector2, ceili, sarray(), varray());
 	bind_method(Vector2, aspect, sarray(), varray());
 	bind_method(Vector2, dot, sarray("with"), varray());
 	bind_method(Vector2, slide, sarray("n"), varray());
@@ -2192,6 +2194,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2, minf, sarray("with"), varray());
 	bind_method(Vector2, max, sarray("with"), varray());
 	bind_method(Vector2, maxf, sarray("with"), varray());
+	bind_method(Vector2, wrapped, sarray("min", "max"), varray());
+	bind_method(Vector2, wrappedf, sarray("min", "max"), varray());
 
 	bind_static_method(Vector2, from_angle, sarray("angle"), varray());
 
@@ -2287,6 +2291,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3, floor, sarray(), varray());
 	bind_method(Vector3, ceil, sarray(), varray());
 	bind_method(Vector3, round, sarray(), varray());
+	bind_method(Vector3, floori, sarray(), varray());
+	bind_method(Vector3, ceili, sarray(), varray());
 	bind_method(Vector3, posmod, sarray("mod"), varray());
 	bind_method(Vector3, posmodv, sarray("modv"), varray());
 	bind_method(Vector3, project, sarray("b"), varray());
@@ -2299,6 +2305,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3, minf, sarray("with"), varray());
 	bind_method(Vector3, max, sarray("with"), varray());
 	bind_method(Vector3, maxf, sarray("with"), varray());
+	bind_method(Vector3, wrapped, sarray("min", "max"), varray());
+	bind_method(Vector3, wrappedf, sarray("min", "max"), varray());
 	bind_static_method(Vector3, octahedron_decode, sarray("uv"), varray());
 
 	/* Vector3i */
@@ -2331,6 +2339,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector4, floor, sarray(), varray());
 	bind_method(Vector4, ceil, sarray(), varray());
 	bind_method(Vector4, round, sarray(), varray());
+	bind_method(Vector4, floori, sarray(), varray());
+	bind_method(Vector4, ceili, sarray(), varray());
 	bind_method(Vector4, lerp, sarray("to", "weight"), varray());
 	bind_method(Vector4, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Vector4, cubic_interpolate_in_time, sarray("b", "pre_a", "post_b", "weight", "b_t", "pre_a_t", "post_b_t"), varray());
@@ -2582,6 +2592,11 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(AABB, get_endpoint, sarray("idx"), varray());
 	bind_methodv(AABB, intersects_segment, &AABB::intersects_segment_bind, sarray("from", "to"), varray());
 	bind_methodv(AABB, intersects_ray, &AABB::intersects_ray_bind, sarray("from", "dir"), varray());
+	bind_method(AABB, is_point, sarray(), varray());
+	bind_method(AABB, is_point_approx, sarray(), varray());
+	bind_method(AABB, translated, sarray("by"), varray());
+	bind_method(AABB, scaled, sarray("scale"), varray());
+	bind_method(AABB, extruded, sarray("v"), varray());
 
 	/* Transform3D */
 

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -483,6 +483,54 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorBitAnd<int64_t, int64_t, int64_t>>(Variant::OP_BIT_AND, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorBitXor<int64_t, int64_t, int64_t>>(Variant::OP_BIT_XOR, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorBitNeg<int64_t, int64_t>>(Variant::OP_BIT_NEGATE, Variant::INT, Variant::NIL);
+	
+	// v2 bit
+	register_op<OperatorEvaluatorShiftLeft<Vector2i, Vector2i, int64_t>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR2I, Variant::INT);
+	register_op<OperatorEvaluatorShiftRight<Vector2i, Vector2i, int64_t>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR2I, Variant::INT);
+	register_op<OperatorEvaluatorBitOr<Vector2i, Vector2i, int64_t>>(Variant::OP_BIT_OR, Variant::VECTOR2I, Variant::INT);
+	register_op<OperatorEvaluatorBitAnd<Vector2i, Vector2i, int64_t>>(Variant::OP_BIT_AND, Variant::VECTOR2I, Variant::INT);
+	register_op<OperatorEvaluatorBitXor<Vector2i, Vector2i, int64_t>>(Variant::OP_BIT_XOR, Variant::VECTOR2I, Variant::INT);
+	
+	register_op<OperatorEvaluatorShiftLeft<Vector2i, Vector2i, Vector2i>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorShiftRight<Vector2i, Vector2i, Vector2i>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorBitOr<Vector2i, Vector2i, Vector2i>>(Variant::OP_BIT_OR, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorBitAnd<Vector2i, Vector2i, Vector2i>>(Variant::OP_BIT_AND, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorBitXor<Vector2i, Vector2i, Vector2i>>(Variant::OP_BIT_XOR, Variant::VECTOR2I, Variant::VECTOR2I);
+	
+	register_op<OperatorEvaluatorBitNeg<Vector2i, Vector2i>>(Variant::OP_BIT_NEGATE, Variant::VECTOR2I, Variant::NIL);
+
+
+	// v3 bit
+	register_op<OperatorEvaluatorShiftLeft<Vector3i, Vector3i, int64_t>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR3I, Variant::INT);
+	register_op<OperatorEvaluatorShiftRight<Vector3i, Vector3i, int64_t>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR3I, Variant::INT);
+	register_op<OperatorEvaluatorBitOr<Vector3i, Vector3i, int64_t>>(Variant::OP_BIT_OR, Variant::VECTOR3I, Variant::INT);
+	register_op<OperatorEvaluatorBitAnd<Vector3i, Vector3i, int64_t>>(Variant::OP_BIT_AND, Variant::VECTOR3I, Variant::INT);
+	register_op<OperatorEvaluatorBitXor<Vector3i, Vector3i, int64_t>>(Variant::OP_BIT_XOR, Variant::VECTOR3I, Variant::INT);
+	
+	register_op<OperatorEvaluatorShiftLeft<Vector3i, Vector3i, Vector3i>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorShiftRight<Vector3i, Vector3i, Vector3i>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorBitOr<Vector3i, Vector3i, Vector3i>>(Variant::OP_BIT_OR, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorBitAnd<Vector3i, Vector3i, Vector3i>>(Variant::OP_BIT_AND, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorBitXor<Vector3i, Vector3i, Vector3i>>(Variant::OP_BIT_XOR, Variant::VECTOR3I, Variant::VECTOR3I);
+	
+	register_op<OperatorEvaluatorBitNeg<Vector3i, Vector3i>>(Variant::OP_BIT_NEGATE, Variant::VECTOR3I, Variant::NIL);
+
+
+	// v4 bit
+	register_op<OperatorEvaluatorShiftLeft<Vector4i, Vector4i, int64_t>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR4I, Variant::INT);
+	register_op<OperatorEvaluatorShiftRight<Vector4i, Vector4i, int64_t>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR4I, Variant::INT);
+	register_op<OperatorEvaluatorBitOr<Vector4i, Vector4i, int64_t>>(Variant::OP_BIT_OR, Variant::VECTOR4I, Variant::INT);
+	register_op<OperatorEvaluatorBitAnd<Vector4i, Vector4i, int64_t>>(Variant::OP_BIT_AND, Variant::VECTOR4I, Variant::INT);
+	register_op<OperatorEvaluatorBitXor<Vector4i, Vector4i, int64_t>>(Variant::OP_BIT_XOR, Variant::VECTOR4I, Variant::INT);
+	
+	register_op<OperatorEvaluatorShiftLeft<Vector4i, Vector4i, Vector4i>>(Variant::OP_SHIFT_LEFT, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorShiftRight<Vector4i, Vector4i, Vector4i>>(Variant::OP_SHIFT_RIGHT, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorBitOr<Vector4i, Vector4i, Vector4i>>(Variant::OP_BIT_OR, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorBitAnd<Vector4i, Vector4i, Vector4i>>(Variant::OP_BIT_AND, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorBitXor<Vector4i, Vector4i, Vector4i>>(Variant::OP_BIT_XOR, Variant::VECTOR4I, Variant::VECTOR4I);
+	
+	register_op<OperatorEvaluatorBitNeg<Vector4i, Vector4i>>(Variant::OP_BIT_NEGATE, Variant::VECTOR4I, Variant::NIL);
+
 
 	register_op<OperatorEvaluatorAlwaysTrue>(Variant::OP_EQUAL, Variant::NIL, Variant::NIL);
 	register_op<OperatorEvaluatorEqual<bool, bool>>(Variant::OP_EQUAL, Variant::BOOL, Variant::BOOL);

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -408,6 +408,325 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
+// v2 shifting
+template <>
+class OperatorEvaluatorShiftLeft<Vector2i, Vector2i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) << VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) << PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector2i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftLeft<Vector2i, Vector2i, Vector2i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const Vector2i &b = VariantInternalAccessor<Vector2i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) << VariantInternalAccessor<Vector2i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) << PtrToArg<Vector2i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector2i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector2i, Vector2i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) >> VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) >> PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector2i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector2i, Vector2i, Vector2i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector2i &a = VariantInternalAccessor<Vector2i>::get(&p_left);
+		const Vector2i &b = VariantInternalAccessor<Vector2i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector2i>::get(r_ret) = VariantInternalAccessor<Vector2i>::get(left) >> VariantInternalAccessor<Vector2i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) >> PtrToArg<Vector2i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector2i>::VARIANT_TYPE; }
+};
+
+
+
+// v3 shifting
+template <>
+class OperatorEvaluatorShiftLeft<Vector3i, Vector3i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) << VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) << PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector3i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftLeft<Vector3i, Vector3i, Vector3i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const Vector3i &b = VariantInternalAccessor<Vector3i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0 || b.z < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) << VariantInternalAccessor<Vector3i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) << PtrToArg<Vector3i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector3i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector3i, Vector3i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) >> VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) >> PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector3i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector3i, Vector3i, Vector3i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector3i &a = VariantInternalAccessor<Vector3i>::get(&p_left);
+		const Vector3i &b = VariantInternalAccessor<Vector3i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0 || b.z < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector3i>::get(r_ret) = VariantInternalAccessor<Vector3i>::get(left) >> VariantInternalAccessor<Vector3i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector3i>::encode(PtrToArg<Vector3i>::convert(left) >> PtrToArg<Vector3i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector3i>::VARIANT_TYPE; }
+};
+
+// v4 shifting
+template <>
+class OperatorEvaluatorShiftLeft<Vector4i, Vector4i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) << VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) << PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftLeft<Vector4i, Vector4i, Vector4i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const Vector4i &b = VariantInternalAccessor<Vector4i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0 || b.z < 0 || b.w < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a << b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) << VariantInternalAccessor<Vector4i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) << PtrToArg<Vector4i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector4i, Vector4i, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) >> VariantInternalAccessor<int64_t>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) >> PtrToArg<int64_t>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorShiftRight<Vector4i, Vector4i, Vector4i> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const Vector4i &a = VariantInternalAccessor<Vector4i>::get(&p_left);
+		const Vector4i &b = VariantInternalAccessor<Vector4i>::get(&p_right);
+
+#if defined(DEBUG_ENABLED)
+		if (b.x < 0 || b.y < 0 || b.z < 0 || b.w < 0) {
+			*r_ret = "Invalid operands for bit shifting. Only positive operands are supported.";
+			r_valid = false;
+			return;
+		}
+#endif
+		*r_ret = a >> b;
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		VariantInternalAccessor<Vector4i>::get(r_ret) = VariantInternalAccessor<Vector4i>::get(left) >> VariantInternalAccessor<Vector4i>::get(right);
+	}
+	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
+		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(left) >> PtrToArg<Vector4i>::convert(right), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
+};
+
+
+
 template <typename R, typename A, typename B>
 class OperatorEvaluatorBitOr : public CommonEvaluate<OperatorEvaluatorBitOr<R, A, B>> {
 public:

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -101,6 +101,7 @@ void register_named_setters_getters() {
 
 	REGISTER_MEMBER(AABB, position);
 	REGISTER_MEMBER(AABB, size);
+	REGISTER_MEMBER(AABB, start);
 	REGISTER_MEMBER(AABB, end);
 
 	REGISTER_MEMBER(Transform2D, x);

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -310,6 +310,7 @@ SETGET_STRUCT_FUNC(Rect2i, Vector2i, end, set_end, get_end)
 
 SETGET_STRUCT(AABB, Vector3, position)
 SETGET_STRUCT(AABB, Vector3, size)
+SETGET_STRUCT_FUNC(AABB, Vector3, start, set_start, get_start)
 SETGET_STRUCT_FUNC(AABB, Vector3, end, set_end, get_end)
 
 SETGET_STRUCT_CUSTOM(Transform2D, Vector2, x, columns[0])

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -117,6 +117,26 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="extruded" qualifiers="const">
+			<return type="AABB" />
+			<param index="0" name="by" type="Vector3" />
+			<description>
+				Returns a copy of this bounding box to be "extruded" by the given [param by].
+				If a component of the vector is negative, the minimum end of the AABB will be moved. If positive, the maximum end is moved.
+				This can be useful for algorithms involving "swept" AABBs.
+				[codeblocks]
+				[gdscript]
+				var box = AABB(Vector3(0, 0, 2), Vector3(5, 2, 5))
+				var speed = Vector3(1, 2, -3)
+				
+				box = box.extruded(speed)
+				print(box.position) # Prints (0.0, 0.0, -1.0)
+				print(box.size)     # Prints (6.0, 4.0, 5.0)
+				
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_center" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -344,6 +364,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="start" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+			The starting point. Get-wise, this is the same as [member position]. Setting to this value affects both [member position] and [member size], keeping [member end] where it is in space.
+		</member>
 		<member name="end" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
 			The ending point. This is usually the corner on the top-right and back of the bounding box, and is equivalent to [code]position + size[/code]. Setting this point affects the [member size].
 		</member>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -303,6 +303,90 @@
 				Divides each component of the [Vector2i] by the given [int].
 			</description>
 		</operator>
+		
+		<operator name="operator &amp;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ANDs each component of the [Vector2i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &amp;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+				Bitwise-ANDs each component of the [Vector2i] by the components of the given [Vector2i].
+			</description>
+		</operator>
+
+		<operator name="operator |">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ORs each component of the [Vector2i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator |">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+				Bitwise-ORs each component of the [Vector2i] by the components of the given [Vector2i].
+			</description>
+		</operator>
+
+		<operator name="operator ^">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-XORs each component of the [Vector2i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator ^">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+				Bitwise-XORs each component of the [Vector2i] by the components of the given [Vector2i].
+			</description>
+		</operator>
+
+		<operator name="operator &gt;&gt;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts right each component of the [Vector2i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &gt;&gt;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+				Bitwise-shifts right each component of the [Vector2i] by the components of the given [Vector2i].
+			</description>
+		</operator>
+
+		<operator name="operator &lt;&lt;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts left each component of the [Vector2i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &lt;&lt;">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+				Bitwise-shifts left each component of the [Vector2i] by the components of the given [Vector2i].
+			</description>
+		</operator>
+
+		<operator name="~">
+			<return type="Vector2i" />
+			<description>
+				Returns the bitwise-NOT value of the [Vector2i]. This is the same as writing [code]Vector2i(~v.x, ~v.y)[/code].
+			</description>
+		</operator>
+		
+
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2i" />

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -310,6 +310,89 @@
 				Divides each component of the [Vector3i] by the given [int].
 			</description>
 		</operator>
+		
+		<operator name="operator &amp;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ANDs each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &amp;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+				Bitwise-ANDs each component of the [Vector3i] by the components of the given [Vector3i].
+			</description>
+		</operator>
+
+		<operator name="operator |">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ORs each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator |">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+				Bitwise-ORs each component of the [Vector3i] by the components of the given [Vector3i].
+			</description>
+		</operator>
+
+		<operator name="operator ^">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-XORs each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator ^">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+				Bitwise-XORs each component of the [Vector3i] by the components of the given [Vector3i].
+			</description>
+		</operator>
+
+		<operator name="operator &gt;&gt;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts right each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &gt;&gt;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+				Bitwise-shifts right each component of the [Vector3i] by the components of the given [Vector3i].
+			</description>
+		</operator>
+
+		<operator name="operator &lt;&lt;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts left each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &lt;&lt;">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+				Bitwise-shifts left each component of the [Vector3i] by the components of the given [Vector3i].
+			</description>
+		</operator>
+
+		<operator name="~">
+			<return type="Vector3i" />
+			<description>
+				Returns the bitwise-NOT value of the [Vector3i]. This is the same as writing [code]Vector3i(~v.x, ~v.y, ~v.z)[/code].
+			</description>
+		</operator>
+
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3i" />

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -298,6 +298,89 @@
 				Divides each component of the [Vector4i] by the given [int].
 			</description>
 		</operator>
+
+		<operator name="operator &amp;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ANDs each component of the [Vector4i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &amp;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+				Bitwise-ANDs each component of the [Vector4i] by the components of the given [Vector4i].
+			</description>
+		</operator>
+
+		<operator name="operator |">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-ORs each component of the [Vector4i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator |">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+				Bitwise-ORs each component of the [Vector4i] by the components of the given [Vector4i].
+			</description>
+		</operator>
+
+		<operator name="operator ^">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-XORs each component of the [Vector4i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator ^">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+				Bitwise-XORs each component of the [Vector4i] by the components of the given [Vector4i].
+			</description>
+		</operator>
+
+		<operator name="operator &gt;&gt;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts right each component of the [Vector4i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &gt;&gt;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+				Bitwise-shifts right each component of the [Vector4i] by the components of the given [Vector4i].
+			</description>
+		</operator>
+
+		<operator name="operator &lt;&lt;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+				Bitwise-shifts left each component of the [Vector4i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator &lt;&lt;">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+				Bitwise-shifts left each component of the [Vector4i] by the components of the given [Vector4i].
+			</description>
+		</operator>
+
+		<operator name="~">
+			<return type="Vector4i" />
+			<description>
+				Returns the bitwise-NOT value of the [Vector4i]. This is the same as writing [code]Vector4i(~v.x, ~v.y, ~v.z, ~v.w)[/code].
+			</description>
+		</operator>
+
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector4i" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14707

These are all things ive added to my own build of the engine because I use them commonly
some variations are missing (like wrapped for ivecs, or repeating the AABB additions for rects) as well as most of the docs bc i dont want to do those prematurely in case they get rejected

`Vector*.floori` and `Vector*.ceili`: returns the floor/ceil of the vector as its int counterpart.
same as `Vectori(v.floor())`

`Vector*i.dot`: it has some niche uses but bugged me that it wasnt a thing. would be fine with this one being cut.

`Vector*.wrapped` and `Vector*.wrappedf`: component wise wrapping of vector members

`Vector*i` bitwise ops: self explanatory. The template copy-pasting probably couldve been done better but whatever it works. That whole file is already alphabet soup anyway.
Comes in the flavors of `Vector x Int` and `Vector x Vector`. Also `~Vector`.
I considered having `Int x Vector -> Vector` ops but that might be a little *too* silly.

`AABB.extruded(v)`: not the same as "expanding". This is basically like moving the AABB by v and drawing an AABB around it pre and post move. I'm not sure if it should be called `extruded` or `extrude`. 

`AABB.start`: counterpart to `AABB.end`. Getting `start` is the same as `position`, but setting `start` will change `size` so that `end` stays in the same place in space.
basically the same as this
```gdscript
var pev := bb.end
bb.position = newStart
bb.end = pev
```
unsure about my implementation as to if it has any numeric stability issues. maybe doesnt matter

`AABB.translated(v)`: returns a copy of the `AABB` with its position moved. shorthand of `AABB(bb.position+v, bb.size)`

`AABB.scaled(v)`: returns a copy of the `AABB` with its `position` and `size` multiplied by `v`. shorthand of `AABB(bb.position*v, bb.size*v)`. Would be fine with this one getting cut.

`AABB.is_point()` and `AABB.is_point_approx()`: different to `has_volume` in that all axises of `size` must be 0 to be true. example use case is that for my Funny Block Models i consider an AABB that has no volume but is a flat plane to still be valid
could also be one function called something like `AABB.is_degenerate(DegenType)` and `AABB.is_degenerate_approx(DegenType)` with `DegenType.POINT` (all size axises are 0) `DegenType.LINE` (two size axises are 0) and `DegenType.PLANE` (one size axis is 0) being the options