### PR TITLE
Defer resolving node path properties until inherited scene is fully instantiated

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -153,6 +153,10 @@ static Node *_find_node_by_id(Node *p_owner, Node *p_node, int32_t p_id) {
 }
 
 Node *SceneState::instantiate(GenEditState p_edit_state) const {
+	return _instantiate(p_edit_state, nullptr);
+}
+
+Node *SceneState::_instantiate(GenEditState p_edit_state, LocalVector<DeferredNodePathProperties> *r_parent_deferred_node_paths) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
 
@@ -230,7 +234,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			// Scene inheritance on root node.
 			Ref<PackedScene> sdata = props[base_scene_idx];
 			ERR_FAIL_COND_V(sdata.is_null(), nullptr);
-			node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE); //only main gets main edit state
+			node = sdata->_instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE, &deferred_node_paths); //only main gets main edit state
 			ERR_FAIL_NULL_V(node, nullptr);
 			if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
 				node->set_scene_inherited_state(sdata->get_state());
@@ -594,49 +598,57 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		}
 	}
 
-	for (const DeferredNodePathProperties &dnp : deferred_node_paths) {
-		// Replace properties stored as NodePaths with actual Nodes.
-		Node *base = ObjectDB::get_instance<Node>(dnp.base);
-		ERR_CONTINUE_EDMSG(!base, vformat("Failed to set deferred property '%s' as the base node disappeared.", dnp.property));
-		if (dnp.value.get_type() == Variant::ARRAY) {
-			Array paths = dnp.value;
+	if (r_parent_deferred_node_paths != nullptr) {
+		// Bubble deferred paths to the caller to be resolved after
+		// all nodes in scene inheritance have been instantiated.
+		for (const DeferredNodePathProperties &dnp : deferred_node_paths) {
+			r_parent_deferred_node_paths->push_back(dnp);
+		}
+	} else {
+		for (const DeferredNodePathProperties &dnp : deferred_node_paths) {
+			// Replace properties stored as NodePaths with actual Nodes.
+			Node *base = ObjectDB::get_instance<Node>(dnp.base);
+			ERR_CONTINUE_EDMSG(!base, vformat("Failed to set deferred property '%s' as the base node disappeared.", dnp.property));
+			if (dnp.value.get_type() == Variant::ARRAY) {
+				Array paths = dnp.value;
 
-			bool valid;
-			Array array = base->get(dnp.property, &valid);
-			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			array = array.duplicate();
+				bool valid;
+				Array array = base->get(dnp.property, &valid);
+				ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
+				array = array.duplicate();
 
-			array.resize(paths.size());
-			for (int i = 0; i < array.size(); i++) {
-				array.set(i, base->get_node_or_null(paths[i]));
-			}
-			base->set(dnp.property, array);
-		} else if (dnp.value.get_type() == Variant::DICTIONARY) {
-			Dictionary paths = dnp.value;
-
-			bool valid;
-			Dictionary dict = base->get(dnp.property, &valid);
-			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			dict = dict.duplicate();
-			bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
-					ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
-			bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
-					ClassDB::is_parent_class(dict.get_typed_value_class_name(), "Node");
-
-			for (const KeyValue<Variant, Variant> &kv : paths) {
-				Variant key = kv.key;
-				if (convert_key) {
-					key = base->get_node_or_null(key);
+				array.resize(paths.size());
+				for (int i = 0; i < array.size(); i++) {
+					array.set(i, base->get_node_or_null(paths[i]));
 				}
-				Variant value = kv.value;
-				if (convert_value) {
-					value = base->get_node_or_null(value);
+				base->set(dnp.property, array);
+			} else if (dnp.value.get_type() == Variant::DICTIONARY) {
+				Dictionary paths = dnp.value;
+
+				bool valid;
+				Dictionary dict = base->get(dnp.property, &valid);
+				ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
+				dict = dict.duplicate();
+				bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
+						ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
+				bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
+						ClassDB::is_parent_class(dict.get_typed_value_class_name(), "Node");
+
+				for (const KeyValue<Variant, Variant> &kv : paths) {
+					Variant key = kv.key;
+					if (convert_key) {
+						key = base->get_node_or_null(key);
+					}
+					Variant value = kv.value;
+					if (convert_value) {
+						value = base->get_node_or_null(value);
+					}
+					dict[key] = value;
 				}
-				dict[key] = value;
+				base->set(dnp.property, dict);
+			} else {
+				base->set(dnp.property, base->get_node_or_null(dnp.value));
 			}
-			base->set(dnp.property, dict);
-		} else {
-			base->set(dnp.property, base->get_node_or_null(dnp.value));
 		}
 	}
 
@@ -2505,11 +2517,15 @@ bool PackedScene::can_instantiate() const {
 }
 
 Node *PackedScene::instantiate(GenEditState p_edit_state) const {
+	return _instantiate(p_edit_state, nullptr);
+}
+
+Node *PackedScene::_instantiate(GenEditState p_edit_state, LocalVector<SceneState::DeferredNodePathProperties> *r_parent_deferred_node_paths) const {
 #ifndef TOOLS_ENABLED
 	ERR_FAIL_COND_V_MSG(p_edit_state != GEN_EDIT_STATE_DISABLED, nullptr, "Edit state is only for editors, does not work without tools compiled.");
 #endif
 
-	Node *s = state->instantiate((SceneState::GenEditState)p_edit_state);
+	Node *s = state->_instantiate((SceneState::GenEditState)p_edit_state, r_parent_deferred_node_paths);
 	if (!s) {
 		return nullptr;
 	}

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -31,12 +31,14 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "core/templates/local_vector.h"
 #include "scene/main/node.h"
 
 class PackedScene;
 
 class SceneState : public RefCounted {
 	GDCLASS(SceneState, RefCounted);
+	friend class PackedScene;
 
 	Vector<StringName> names;
 	Vector<Variant> variants;
@@ -161,6 +163,7 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
+	Node *_instantiate(GenEditState p_edit_state, LocalVector<DeferredNodePathProperties> *r_parent_deferred_node_paths) const;
 
 	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Dictionary setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
@@ -271,6 +274,7 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
+	Node *_instantiate(GenEditState p_edit_state, LocalVector<SceneState::DeferredNodePathProperties> *r_parent_deferred_node_paths) const;
 
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/86970

If the node path properties are resolved before the scene if fully initialized, it sets the node path properties before the node instances have their script attached. In C#, this creates node instances that are later disposed when the script is attached. By deferring this to the outer `instantiate` call, we ensure the properties are set after the script has already been attached, so the C# scripts reference the correct instance instead of the disposed one.