### PR TITLE
Add `allow_focus_shadow` for `ScrollContainer`

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -39,12 +39,16 @@
 		</method>
 	</methods>
 	<members>
+		<member name="allow_focus_shadow" type="bool" setter="set_allow_focus_shadow" getter="is_allowing_focus_shadow" default="false">
+			If [code]true[/code], allows finding descendant controls that are not displayed in the visible area as focus neighbors.
+		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="draw_focus_border" type="bool" setter="set_draw_focus_border" getter="get_draw_focus_border" default="false">
 			If [code]true[/code], [theme_item focus] is drawn when the ScrollContainer or one of its descendant nodes is focused.
 		</member>
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" default="false">
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
+			[b]Note:[/b] Disabling it requires custom scrolling logic to correctly display descendant focus controls outside the visible area when [member allow_focus_shadow] is enabled.
 		</member>
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
 			Controls whether horizontal scrollbar can be used and when it should be visible.

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3382,9 +3382,9 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 
 		if (sc) {
 			Rect2 sc_r = sc->get_global_rect();
-			bool follow_focus = sc->is_following_focus();
+			const bool allow_focus_shadow = sc->is_allowing_focus_shadow();
 
-			if (result && !follow_focus && !sc_r.intersects(result_rect)) {
+			if (result && !allow_focus_shadow && !sc_r.intersects(result_rect)) {
 				result = nullptr; // Skip invisible control.
 			}
 
@@ -3398,13 +3398,13 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 					sc_mind = sc_begin_d;
 				}
 
-				if (!follow_focus && maxd < sc_mind) {
+				if (!allow_focus_shadow && maxd < sc_mind) {
 					// Reposition to find visible control.
 					maxd = sc_mind;
 					r.set_position(r.get_position() + (sc_mind - maxd) * vdir);
 				}
 
-				if (follow_focus || sc_maxd > maxd) {
+				if (allow_focus_shadow || sc_maxd > maxd) {
 					_window_find_focus_neighbor(vdir, base, r, clamp, maxd, square_of_dist, &result);
 				}
 
@@ -3414,7 +3414,7 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 					r.set_position(r.get_position() + (sc_maxd - maxd) * vdir);
 				} else {
 					result_rect = result->get_global_rect();
-					if (follow_focus) {
+					if (allow_focus_shadow) {
 						real_t r_begin_d = vdir.dot(result_rect.get_position());
 						real_t r_end_d = vdir.dot(result_rect.get_end());
 						real_t r_maxd = r_begin_d;
@@ -3531,7 +3531,7 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 	ScrollContainer *sc = Object::cast_to<ScrollContainer>(c);
 	Rect2 intersection = p_clamp;
 	if (sc) {
-		if (!sc->is_following_focus() || !in_container) {
+		if (!in_container || !sc->is_allowing_focus_shadow()) {
 			intersection = p_clamp.intersection(sc->get_global_rect());
 			if (!intersection.has_area()) {
 				return;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -910,6 +910,14 @@ bool ScrollContainer::is_scroll_hint_tiled() {
 	return tile_scroll_hint;
 }
 
+bool ScrollContainer::is_allowing_focus_shadow() const {
+	return allow_focus_shadow;
+}
+
+void ScrollContainer::set_allow_focus_shadow(bool p_allow) {
+	allow_focus_shadow = p_allow;
+}
+
 bool ScrollContainer::is_following_focus() const {
 	return follow_focus;
 }
@@ -982,6 +990,9 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tile_scroll_hint", "tile_scroll_hint"), &ScrollContainer::set_tile_scroll_hint);
 	ClassDB::bind_method(D_METHOD("is_scroll_hint_tiled"), &ScrollContainer::is_scroll_hint_tiled);
 
+	ClassDB::bind_method(D_METHOD("set_allow_focus_shadow", "enabled"), &ScrollContainer::set_allow_focus_shadow);
+	ClassDB::bind_method(D_METHOD("is_allowing_focus_shadow"), &ScrollContainer::is_allowing_focus_shadow);
+
 	ClassDB::bind_method(D_METHOD("set_follow_focus", "enabled"), &ScrollContainer::set_follow_focus);
 	ClassDB::bind_method(D_METHOD("is_following_focus"), &ScrollContainer::is_following_focus);
 
@@ -995,6 +1006,7 @@ void ScrollContainer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("scroll_started"));
 	ADD_SIGNAL(MethodInfo("scroll_ended"));
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_focus_shadow"), "set_allow_focus_shadow", "is_allowing_focus_shadow");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "follow_focus"), "set_follow_focus", "is_following_focus");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_focus_border"), "set_draw_focus_border", "get_draw_focus_border");
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -85,6 +85,7 @@ private:
 
 	int deadzone = 0;
 	bool follow_focus = false;
+	bool allow_focus_shadow = false;
 	int scroll_border = 20;
 	int scroll_speed = 12;
 	bool scroll_horizontal_by_default = false;
@@ -177,6 +178,9 @@ public:
 
 	void set_tile_scroll_hint(bool p_enable);
 	bool is_scroll_hint_tiled();
+
+	void set_allow_focus_shadow(bool p_allow);
+	bool is_allowing_focus_shadow() const;
 
 	bool is_following_focus() const;
 	void set_follow_focus(bool p_follow);


### PR DESCRIPTION
If enabled, it allows finding descendant controls outside the visible area as focus neighbors.

In this case, the logic for scrolling to the focused descendant control depends on `follow_focus`.

Disabling `follow_focus` allows and requires custom scrolling logic.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Close #103726.
