### PR TITLE
[4.6] Fix subpixel positioning.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4022,10 +4022,10 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -4075,13 +4075,12 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-						cpos.x = cpos.x + 0.125;
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-						cpos.x = cpos.x + 0.25;
-					}
-					if (scale == 1.0) {
-						cpos.y = Math::floor(cpos.y);
-						cpos.x = Math::floor(cpos.x);
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+					} else if (scale == 1.0) {
+						cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+						cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 					}
 					Vector2 gpos = fgl.rect.position;
 					Size2 csize = fgl.rect.size;
@@ -4168,10 +4167,10 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -4217,13 +4216,12 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-						cpos.x = cpos.x + 0.125;
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-						cpos.x = cpos.x + 0.25;
-					}
-					if (scale == 1.0) {
-						cpos.y = Math::floor(cpos.y);
-						cpos.x = Math::floor(cpos.x);
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+					} else if (scale == 1.0) {
+						cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+						cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 					}
 					Vector2 gpos = fgl.rect.position;
 					Size2 csize = fgl.rect.size;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2908,10 +2908,10 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -2960,14 +2960,13 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 				} else {
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
-					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-						cpos.x = cpos.x + 0.125;
-					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-						cpos.x = cpos.x + 0.25;
-					}
-					if (scale == 1.0) {
-						cpos.y = Math::floor(cpos.y);
-						cpos.x = Math::floor(cpos.x);
+					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
+					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+					} else if (scale == 1.0) {
+						cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+						cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 					}
 					Vector2 gpos = fgl.rect.position;
 					Size2 csize = fgl.rect.size;
@@ -3054,10 +3053,10 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		}
 		// Subpixel X-shift, bits 27, 28
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
+			int xshift = (int)(Math::floor(4 * (p_pos.x * oversampling_factor + 0.125)) - 4 * Math::floor(p_pos.x * oversampling_factor + 0.125));
 			index = index | (xshift << 27);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
-			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
+			int xshift = (int)(Math::floor(2 * (p_pos.x * oversampling_factor + 0.25)) - 2 * Math::floor(p_pos.x * oversampling_factor + 0.25));
 			index = index | (xshift << 27);
 		}
 	}
@@ -3102,14 +3101,13 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 				} else {
 					Point2 cpos = p_pos;
 					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
-					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-						cpos.x = cpos.x + 0.125;
-					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-						cpos.x = cpos.x + 0.25;
-					}
-					if (scale == 1.0) {
-						cpos.y = Math::floor(cpos.y);
-						cpos.x = Math::floor(cpos.x);
+					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.125) / oversampling_factor;
+					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
+						cpos.x = Math::floor(cpos.x * oversampling_factor + 0.25) / oversampling_factor;
+					} else if (scale == 1.0) {
+						cpos.y = Math::floor(cpos.y * oversampling_factor) / oversampling_factor;
+						cpos.x = Math::floor(cpos.x * oversampling_factor) / oversampling_factor;
 					}
 					Vector2 gpos = fgl.rect.position;
 					Size2 csize = fgl.rect.size;


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/118818 for 4.6

`4.6.2`:
<img width="584" height="55" alt="4 6 2" src="https://github.com/user-attachments/assets/f2c8206d-9313-4a52-adbf-84ffce6c3ede" />

`this PR:`
<img width="584" height="55" alt="pr" src="https://github.com/user-attachments/assets/59ab4125-6422-456f-88f2-bda4a0b8a8a5" />
