### PR TITLE
Fix IME window position calculation in LineEdit and TextEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -136,7 +136,16 @@ void LineEdit::_update_ime_window_position() {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);
-	Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + theme_cache.font->get_height(theme_cache.font_size)) / 2) + get_global_position();
+
+	Ref<StyleBox> style = theme_cache.normal;
+	if (!is_editable()) {
+		style = theme_cache.read_only;
+	}
+	const float text_height = TS->shaped_text_get_size(text_rid).y;
+	const int y_area = get_size().y - style->get_minimum_size().height;
+	const float text_top = style->get_offset().y + (y_area - text_height) / 2.0f;
+	const Vector2 caret_pixel_pos = get_caret_pixel_pos();
+	Point2 pos = Point2(caret_pixel_pos.x, text_top) + get_global_position();
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -144,8 +144,7 @@ void LineEdit::_update_ime_window_position() {
 	const float text_height = TS->shaped_text_get_size(text_rid).y;
 	const int y_area = get_size().y - style->get_minimum_size().height;
 	const float text_top = style->get_offset().y + (y_area - text_height) / 2.0f;
-	const Vector2 caret_pixel_pos = get_caret_pixel_pos();
-	Point2 pos = Point2(caret_pixel_pos.x, text_top) + get_global_position();
+	Point2 pos = Point2(get_caret_pixel_pos().x, text_top) + get_global_position();
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3459,16 +3459,8 @@ void TextEdit::_update_ime_window_position() {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);
-
-	const int caret_index = 0;
-	const int caret_line = get_caret_line(caret_index);
-	const int caret_wrap_index = get_caret_wrap_index(caret_index);
-	const Ref<TextParagraph> ldata = text.get_line_data(caret_line);
-	const RID text_rid = ldata->get_line_rid(caret_wrap_index);
-	const float text_height = TS->shaped_text_get_size(text_rid).y;
-	const Point2 caret_draw_pos = get_caret_draw_pos(caret_index);
-
-	Point2 pos = get_global_position() + Point2(caret_draw_pos.x, caret_draw_pos.y - text_height);
+	Point2 pos = get_global_position() + get_caret_draw_pos();
+	pos.y -= TS->shaped_text_get_size(text.get_line_data(get_caret_line())->get_line_rid(get_caret_wrap_index())).y;
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3459,7 +3459,16 @@ void TextEdit::_update_ime_window_position() {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);
-	Point2 pos = get_global_position() + get_caret_draw_pos();
+
+	const int caret_index = 0;
+	const int caret_line = get_caret_line(caret_index);
+	const int caret_wrap_index = get_caret_wrap_index(caret_index);
+	const Ref<TextParagraph> ldata = text.get_line_data(caret_line);
+	const RID text_rid = ldata->get_line_rid(caret_wrap_index);
+	const float text_height = TS->shaped_text_get_size(text_rid).y;
+	const Point2 caret_draw_pos = get_caret_draw_pos(caret_index);
+
+	Point2 pos = get_global_position() + Point2(caret_draw_pos.x, caret_draw_pos.y - text_height);
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}


### PR DESCRIPTION
Fixes #118838

I use the the actual position for drawing.
And we may need retire `caret_index` for `TextEdit` to move the IME window on it.

*Test on Windows 11 with Microsoft Pinyin*

Before

<img width="607" height="303" alt="Image" src="https://github.com/user-attachments/assets/8e4d9bc1-f65b-4a5f-abbb-f0b2dbf4eaf8" />

After

<img width="316" height="271" alt="image" src="https://github.com/user-attachments/assets/8c000cc6-5cf8-41e7-8a3c-51f9b02ffd8d" />
