### PR TITLE
Fix `PopupMenu` using the wrong separation when searching/filtering

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -915,13 +915,15 @@ void PopupMenu::_draw_items() {
 	Point2 ofs;
 
 	// Loop through all items and draw each.
+	bool first_visible = true;
 	for (int i = 0; i < items.size(); i++) {
 		if (!items[i].visible) {
 			continue;
 		}
 
-		// For the first item only add half a separation. For all other items, add a whole separation to the offset.
-		ofs.y += i > 0 ? theme_cache.v_separation : theme_cache.v_separation / 2;
+		// For the first visible item only add half a separation. For all other items, add a whole separation to the offset.
+		ofs.y += first_visible ? theme_cache.v_separation / 2 : theme_cache.v_separation;
+		first_visible = false;
 
 		_shape_item(i);
 


### PR DESCRIPTION
Fixes #118847.

#114236 changed `PopupMenu::_draw_items` to skip invisible items in its loop, but missed the `i > 0` check for the separation of the first item, causing it to be inconsistent if the actual first item (i.e. `i == 0`) was filtered out.

This fixes that by applying the half separation for the first _visible_ item.

---
_Disclaimer: AI tooling was used to triage this issue as part of #118571, prompting this seemingly straight-forward change, which I've reviewed to the best of my ability._