### PR TITLE
Fix OOB writes in D3D12 when setting vertex arrays.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -464,7 +464,7 @@ private:
 		LocalVector<AttachmentLayout> attachment_layouts;
 
 		const VertexFormatInfo *vf_info = nullptr;
-		D3D12_VERTEX_BUFFER_VIEW vertex_buffer_views[8] = {};
+		D3D12_VERTEX_BUFFER_VIEW vertex_buffer_views[D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT] = {};
 		uint32_t vertex_buffer_count = 0;
 	};
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117009.
Fixes https://github.com/godotengine/godot/issues/117667.

The MRP sets 9 vertex buffers, but the D3D12 driver allowed 8 maximum, despite D3D12's actual limit being 32.