### PR TITLE
Change `StringName` -> `String` conversion from `operator String()` to `string()`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -298,13 +298,13 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 	if (p_value.get_type() == Variant::NIL) {
 		props.erase(p_name);
-		if (p_name.operator String().begins_with("autoload/")) {
-			String node_name = p_name.operator String().get_slicec('/', 1);
+		if (p_name.string().begins_with("autoload/")) {
+			String node_name = p_name.string().get_slicec('/', 1);
 			if (autoloads.has(node_name)) {
 				remove_autoload(node_name);
 			}
-		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slicec('/', 1);
+		} else if (p_name.string().begins_with("global_group/")) {
+			String group_name = p_name.string().get_slicec('/', 1);
 			if (global_groups.has(group_name)) {
 				remove_global_group(group_name);
 			}
@@ -322,9 +322,9 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 		}
 
 		{ // Feature overrides.
-			int dot = p_name.operator String().find_char('.');
+			int dot = p_name.string().find_char('.');
 			if (dot != -1) {
-				Vector<String> s = p_name.operator String().split(".");
+				Vector<String> s = p_name.string().split(".");
 
 				for (int i = 1; i < s.size(); i++) {
 					String feature = s[i].strip_edges();
@@ -344,8 +344,8 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 		} else {
 			props[p_name] = VariantContainer(p_value, last_order++);
 		}
-		if (p_name.operator String().begins_with("autoload_prepend/")) {
-			String node_name = p_name.operator String().get_slicec('/', 1);
+		if (p_name.string().begins_with("autoload_prepend/")) {
+			String node_name = p_name.string().get_slicec('/', 1);
 			AutoloadInfo autoload;
 			autoload.name = node_name;
 			String path = p_value;
@@ -356,8 +356,8 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 				autoload.path = path.simplify_path();
 			}
 			add_autoload(autoload, true);
-		} else if (p_name.operator String().begins_with("autoload/")) {
-			String node_name = p_name.operator String().get_slicec('/', 1);
+		} else if (p_name.string().begins_with("autoload/")) {
+			String node_name = p_name.string().get_slicec('/', 1);
 			AutoloadInfo autoload;
 			autoload.name = node_name;
 			String path = p_value;
@@ -368,8 +368,8 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 				autoload.path = path.simplify_path();
 			}
 			add_autoload(autoload);
-		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slicec('/', 1);
+		} else if (p_name.string().begins_with("global_group/")) {
+			String group_name = p_name.string().get_slicec('/', 1);
 			add_global_group(group_name, p_value);
 		}
 	}

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1831,7 +1831,7 @@ void ClassDB::get_argument_options(const StringName &p_function, int p_idx, List
 		::ClassDB::get_class_list(classes);
 		for (const StringName &E : classes) {
 			if (::ClassDB::is_class_exposed(E)) {
-				r_options->push_back(E.operator String().quote());
+				r_options->push_back(E.string().quote());
 			}
 		}
 	}

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -404,7 +404,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			List<StringName> snames;
 
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
-				String name = F.key.operator String();
+				String name = F.key.string();
 
 				ERR_CONTINUE(name.is_empty());
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -276,9 +276,9 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 				*r_valid = true;
 			}
 			return;
-		} else if (p_name.operator String().begins_with("metadata/")) {
+		} else if (p_name.string().begins_with("metadata/")) {
 			// Must exist, otherwise duplicate() will not work.
-			set_meta(p_name.operator String().replace_first("metadata/", ""), p_value);
+			set_meta(p_name.string().replace_first("metadata/", ""), p_value);
 			if (r_valid) {
 				*r_valid = true;
 			}
@@ -522,7 +522,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	}
 
 	for (const KeyValue<StringName, Variant> &K : metadata) {
-		PropertyInfo pi = PropertyInfo(K.value.get_type(), "metadata/" + K.key.operator String());
+		PropertyInfo pi = PropertyInfo(K.value.get_type(), "metadata/" + K.key.string());
 		if (K.value.get_type() == Variant::OBJECT) {
 			pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
 			Object *obj = K.value;
@@ -1033,7 +1033,7 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (E) {
 		E->value = p_value;
 	} else {
-		ERR_FAIL_COND_MSG(!p_name.operator String().is_valid_ascii_identifier(), vformat("Invalid metadata identifier: '%s'.", p_name));
+		ERR_FAIL_COND_MSG(!p_name.string().is_valid_ascii_identifier(), vformat("Invalid metadata identifier: '%s'.", p_name));
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 
 		const String &sname = p_name;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -41,7 +41,7 @@ void NodePath::_update_hash_cache() const {
 }
 
 void NodePath::prepend_period() {
-	if (data->path.size() && data->path[0].operator String() != ".") {
+	if (data->path.size() && data->path[0].string() != ".") {
 		_copy_on_write();
 		data->path.insert(0, ".");
 		data->concatenated_path = StringName();
@@ -236,7 +236,7 @@ StringName NodePath::get_concatenated_names() const {
 			if (i > 0) {
 				concatenated += "/";
 			}
-			concatenated += sn[i].operator String();
+			concatenated += sn[i].string();
 		}
 		data->concatenated_path = concatenated;
 	}
@@ -254,7 +254,7 @@ StringName NodePath::get_concatenated_subnames() const {
 			if (i > 0) {
 				concatenated += ":";
 			}
-			concatenated += ssn[i].operator String();
+			concatenated += ssn[i].string();
 		}
 		data->concatenated_subpath = concatenated;
 	}
@@ -361,10 +361,10 @@ void NodePath::simplify() {
 		if (data->path.size() == 1) {
 			break;
 		}
-		if (data->path[i].operator String() == ".") {
+		if (data->path[i].string() == ".") {
 			data->path.remove_at(i);
 			i--;
-		} else if (i > 0 && data->path[i].operator String() == ".." && data->path[i - 1].operator String() != "." && data->path[i - 1].operator String() != "..") {
+		} else if (i > 0 && data->path[i].string() == ".." && data->path[i - 1].string() != "." && data->path[i - 1].string() != "..") {
 			//remove both
 			data->path.remove_at(i - 1);
 			data->path.remove_at(i - 1);

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -56,7 +56,7 @@ bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		p_from->get_message_list(&raw_keys);
 
 		for (const StringName &key : raw_keys) {
-			const String key_str = key.operator String();
+			const String key_str = key.string();
 			int p = key_str.find_char(0x04);
 			if (p == -1) {
 				keys.push_back(key);
@@ -85,7 +85,7 @@ bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 
 	for (const StringName &E : keys) {
 		//hash string
-		CharString cs = E.operator String().utf8();
+		CharString cs = E.string().utf8();
 		uint32_t h = hash(0, cs.get_data());
 		Pair<int, CharString> p;
 		p.first = idx;
@@ -93,7 +93,7 @@ bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		buckets.write[h % size].push_back(p);
 
 		//compress string
-		CharString src_s = p_from->get_message(E).operator String().utf8();
+		CharString src_s = p_from->get_message(E).string().utf8();
 		CompressedString ps;
 		ps.orig_len = src_s.size();
 		ps.offset = total_compression_size;
@@ -200,7 +200,7 @@ bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 }
 
 bool OptimizedTranslation::_set(const StringName &p_name, const Variant &p_value) {
-	String prop_name = p_name.operator String();
+	String prop_name = p_name.string();
 	if (prop_name == "hash_table") {
 		hash_table = p_value;
 	} else if (prop_name == "bucket_table") {
@@ -217,7 +217,7 @@ bool OptimizedTranslation::_set(const StringName &p_name, const Variant &p_value
 }
 
 bool OptimizedTranslation::_get(const StringName &p_name, Variant &r_ret) const {
-	String prop_name = p_name.operator String();
+	String prop_name = p_name.string();
 	if (prop_name == "hash_table") {
 		r_ret = hash_table;
 	} else if (prop_name == "bucket_table") {
@@ -240,7 +240,7 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 		return StringName();
 	}
 
-	CharString str = p_src_text.operator String().utf8();
+	CharString str = p_src_text.string().utf8();
 	uint32_t h = hash(0, str.get_data());
 
 	const int *htr = hash_table.ptr();

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -125,12 +125,13 @@ public:
 		return (void *)_data;
 	}
 
-	_FORCE_INLINE_ operator String() const {
-		if (_data) {
-			return _data->name;
-		}
+	_FORCE_INLINE_ const String &string() const {
+		static const String EMPTY;
+		return _data ? _data->name : EMPTY;
+	}
 
-		return String();
+	_FORCE_INLINE_ operator const String &() const {
+		return string();
 	}
 
 	struct AlphCompare {

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -1129,11 +1129,11 @@ class OperatorEvaluatorInStringFind<Left, StringName> : public CommonEvaluate<Op
 public:
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Left &str_a = VariantInternalAccessor<Left>::get(left);
-		const String str_b = VariantInternalAccessor<StringName>::get(right).operator String();
+		const String str_b = VariantInternalAccessor<StringName>::get(right).string();
 		VariantInternalAccessor<bool>::get(r_ret) = str_b.find(str_a) != -1;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
-		PtrToArg<bool>::encode(PtrToArg<StringName>::convert(right).operator String().find(PtrToArg<Left>::convert(left)) != -1, r_ret);
+		PtrToArg<bool>::encode(PtrToArg<StringName>::convert(right).string().find(PtrToArg<Left>::convert(left)) != -1, r_ret);
 	}
 	using ReturnType = bool;
 };

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -1181,7 +1181,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 
 	//change editors accordingly
 	for (int i = 0; i < visible_properties.size(); i++) {
-		String pname = visible_properties[i]->get_edited_property().operator String();
+		String pname = visible_properties[i]->get_edited_property().string();
 		if (pname.begins_with(base_path + prev_name)) {
 			String new_name2 = pname.replace_first(base_path + prev_name, base_path + name);
 			visible_properties[i]->set_object_and_property(visible_properties[i]->get_edited_object(), new_name2);

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1160,7 +1160,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 			continue;
 		}
 
-		String name = E.operator String().replace("AudioEffect", "");
+		String name = E.string().replace("AudioEffect", "");
 		effect_options->add_item(name);
 		effect_options->set_item_metadata(-1, E);
 	}

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -498,7 +498,7 @@ void EditorDebuggerInspector::clear_stack_variables() {
 
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {
 	for (KeyValue<StringName, TypedDictionary<uint64_t, Variant>> &E : variables->prop_values) {
-		String v = E.key.operator String();
+		String v = E.key.string();
 		if (v.get_slicec('/', 1) == p_var) {
 			return variables->get_variant(v);
 		}

--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -69,7 +69,7 @@ static bool can_edit(Node *p_node, const String &p_group) {
 
 struct _GroupInfoComparator {
 	bool operator()(const Node::GroupInfo &p_a, const Node::GroupInfo &p_b) const {
-		return p_a.name.operator String() < p_b.name.operator String();
+		return p_a.name.string() < p_b.name.string();
 	}
 };
 

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -597,7 +597,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 											Vector<StringName> names = anim->track_get_path(i).get_names();
 											names.remove_at(0);
 											for (int j = 0; j < names.size(); j++) {
-												path_string += "/" + names[j].operator String();
+												path_string += "/" + names[j].string();
 											}
 										}
 										if (anim->track_get_path(i).get_subname_count() > 0) {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4782,7 +4782,7 @@ void EditorInspector::update_tree() {
 
 				HashMap<String, DocData::ClassDoc>::ConstIterator F = dd->class_list.find(classname);
 				while (F) {
-					Vector<String> slices = propname.operator String().split("/");
+					Vector<String> slices = propname.string().split("/");
 					// Check if it's a theme item first.
 					if (slices.size() == 2 && slices[0].begins_with("theme_override_")) {
 						for (int i = 0; i < F->value.theme_properties.size(); i++) {
@@ -4795,7 +4795,7 @@ void EditorInspector::update_tree() {
 					} else {
 						for (int i = 0; i < F->value.properties.size(); i++) {
 							String doc_path_current = "class_property:" + F->value.name + ":" + F->value.properties[i].name;
-							if (F->value.properties[i].name == propname.operator String()) {
+							if (F->value.properties[i].name == propname.string()) {
 								doc_path = doc_path_current;
 							}
 						}

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1243,7 +1243,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &p_item) {
 	cd.method = ConnectDialog::generate_method_callback_name(cd.source, signal_name, cd.target);
 	connect_dialog->init(cd, signal_args);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
-	connect_dialog->popup_dialog(signal_name.operator String() + "(" + String(", ").join(signal_args) + ")");
+	connect_dialog->popup_dialog(signal_name.string() + "(" + String(", ").join(signal_args) + ")");
 }
 
 /*
@@ -1265,7 +1265,7 @@ void ConnectionsDock::_open_edit_connection_dialog(TreeItem &p_item) {
 
 		connect_dialog->init(cd, signal_args, true);
 		connect_dialog->set_title(vformat(TTR("Edit Connection: '%s'"), cd.signal));
-		connect_dialog->popup_dialog(signal_name.operator String() + "(" + String(", ").join(signal_args) + ")");
+		connect_dialog->popup_dialog(signal_name.string() + "(" + String(", ").join(signal_args) + ")");
 	}
 }
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -966,7 +966,7 @@ void _save_text_editor_theme_as(const String &p_file) {
 	text_colors.sort();
 	for (const KeyValue<StringName, Color> &text_color : text_colors) {
 		const Color val = EditorSettings::get_singleton()->get_setting(text_color.key);
-		const String &key = text_color.key.operator String().replace("text_editor/theme/highlighting/", "");
+		const String &key = text_color.key.string().replace("text_editor/theme/highlighting/", "");
 		cf->set_value(theme_section, key, val.to_html());
 	}
 

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -305,7 +305,7 @@ String GDScriptDocGen::docvalue_from_expression(const GDP::ExpressionNode *p_exp
 		case GDP::Node::CALL: {
 			const GDP::CallNode *call = static_cast<const GDP::CallNode *>(p_expression);
 			if (call->get_callee_type() == GDP::Node::IDENTIFIER) {
-				return call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
+				return call->function_name.string() + (call->arguments.is_empty() ? "()" : "(...)");
 			}
 		} break;
 		case GDP::Node::DICTIONARY: {

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -947,7 +947,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			HashMap<StringName, Variant> scr_constant_list;
 			scr_class->get_constants(&scr_constant_list);
 			for (const KeyValue<StringName, Variant> &E : scr_constant_list) {
-				member_keywords[E.key.operator String()] = member_variable_color;
+				member_keywords[E.key.string()] = member_variable_color;
 			}
 			scr_class = scr_class->get_base_script();
 		}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2553,8 +2553,8 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			p_return->void_return = true;
 			const GDScriptParser::DataType &return_type = p_return->return_value->datatype;
 			if (is_call && !return_type.is_hard_type()) {
-				String function_name = parser->current_function->identifier ? parser->current_function->identifier->name.operator String() : String("<anonymous function>");
-				String called_function_name = static_cast<GDScriptParser::CallNode *>(p_return->return_value)->function_name.operator String();
+				String function_name = parser->current_function->identifier ? parser->current_function->identifier->name.string() : String("<anonymous function>");
+				String called_function_name = static_cast<GDScriptParser::CallNode *>(p_return->return_value)->function_name.string();
 #ifdef DEBUG_ENABLED
 				parser->push_warning(p_return, GDScriptWarning::UNSAFE_VOID_RETURN, function_name, called_function_name);
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2889,7 +2889,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 							} else {
 								enum_hint_string += ",";
 							}
-							enum_hint_string += E.key.operator String().capitalize().xml_escape();
+							enum_hint_string += E.key.string().capitalize().xml_escape();
 							enum_hint_string += ":";
 							enum_hint_string += String::num_int64(E.value).xml_escape();
 						}

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -753,7 +753,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " = ";
 				text += Variant::get_type_name(type);
 				text += ".";
-				text += _global_names_ptr[_code_ptr[ip + 2 + instr_var_args]].operator String();
+				text += _global_names_ptr[_code_ptr[ip + 2 + instr_var_args]].string();
 				text += "(";
 
 				for (int i = 0; i < argc; i++) {
@@ -1004,7 +1004,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += DADDR(1 + captures_count);
 				text += "create lambda from ";
-				text += lambda->name.operator String();
+				text += lambda->name.string();
 				text += "function, captures (";
 
 				for (int i = 0; i < captures_count; i++) {
@@ -1024,7 +1024,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += DADDR(1 + captures_count);
 				text += "create self lambda from ";
-				text += lambda->name.operator String();
+				text += lambda->name.string();
 				text += "function, captures (";
 
 				for (int i = 0; i < captures_count; i++) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -324,7 +324,7 @@ String GDScriptLanguage::debug_get_stack_level_function(int p_level) const {
 
 	ERR_FAIL_INDEX_V(p_level, (int)_call_stack_size, "");
 	GDScriptFunction *func = _get_stack_level(p_level)->function;
-	return func ? func->get_name().operator String() : "";
+	return func ? func->get_name().string() : "";
 }
 
 String GDScriptLanguage::debug_get_stack_level_source(int p_level) const {
@@ -827,9 +827,9 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 		}
 		const GDScriptParser::ParameterNode *par = p_function->parameters[i];
 		if (!par->get_datatype().is_hard_type()) {
-			arghint += par->identifier->name.operator String() + ": Variant";
+			arghint += par->identifier->name.string() + ": Variant";
 		} else {
-			arghint += par->identifier->name.operator String() + ": " + par->get_datatype().to_string();
+			arghint += par->identifier->name.string() + ": " + par->get_datatype().to_string();
 		}
 
 		if (par->initializer) {
@@ -841,14 +841,14 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 				} break;
 				case GDScriptParser::Node::IDENTIFIER: {
 					const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(par->initializer);
-					def_val = id->name.operator String();
+					def_val = id->name.string();
 				} break;
 				case GDScriptParser::Node::CALL: {
 					const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(par->initializer);
 					if (call->is_constant && call->reduced) {
 						def_val = call->reduced_value.get_construct_string();
 					} else if (call->get_callee_type() == GDScriptParser::Node::IDENTIFIER) {
-						def_val = call->function_name.operator String() + (call->arguments.is_empty() ? "()" : "(...)");
+						def_val = call->function_name.string() + (call->arguments.is_empty() ? "()" : "(...)");
 					}
 				} break;
 				case GDScriptParser::Node::ARRAY: {
@@ -1264,7 +1264,7 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						option = ScriptLanguage::CodeCompletionOption(member.m_enum->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, location);
 						break;
 					case GDScriptParser::ClassNode::Member::FUNCTION:
-						if (p_types_only || outer || (p_static && !member.function->is_static) || member.function->identifier->name.operator String().begins_with("@")) {
+						if (p_types_only || outer || (p_static && !member.function->is_static) || member.function->identifier->name.string().begins_with("@")) {
 							continue;
 						}
 						option = ScriptLanguage::CodeCompletionOption(member.function->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
@@ -1366,7 +1366,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						scr->get_constants(&constants);
 						for (const KeyValue<StringName, Variant> &E : constants) {
 							int location = p_recursion_depth + _get_constant_location(scr, E.key);
-							ScriptLanguage::CodeCompletionOption option(E.key.operator String(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+							ScriptLanguage::CodeCompletionOption option(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
 							r_result.insert(option.display, option);
 						}
 					}
@@ -1691,9 +1691,9 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	for (const KeyValue<StringName, int> &E : GDScriptLanguage::get_singleton()->get_global_map()) {
 		ScriptLanguage::CodeCompletionOption option;
 		if (GDScriptAnalyzer::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
-			option = ScriptLanguage::CodeCompletionOption(E.key.operator String(), ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
+			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
 		} else {
-			option = ScriptLanguage::CodeCompletionOption(E.key.operator String(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
 		}
 		r_result.insert(option.display, option);
 	}
@@ -2106,7 +2106,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 
 					// Insert example values for functions which a structured dictionary response.
 					if (!base.type.is_meta_type) {
-						const Dictionary *example = structure_examples.getptr(base.type.native_type.operator String() + "::" + call->function_name);
+						const Dictionary *example = structure_examples.getptr(base.type.native_type.string() + "::" + call->function_name);
 						if (example != nullptr) {
 							r_type = _type_from_variant(*example, p_context);
 							found = true;
@@ -3185,7 +3185,7 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 				}
 
-				if (p_argidx == 0 && method_args > 0 && ClassDB::is_parent_class(class_name, SNAME("InputEvent")) && method.operator String().contains("action")) {
+				if (p_argidx == 0 && method_args > 0 && ClassDB::is_parent_class(class_name, SNAME("InputEvent")) && method.string().contains("action")) {
 					// Get input actions
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -59,7 +59,7 @@ String GDScriptLambdaCallable::get_as_text() const {
 		return "<invalid lambda>";
 	}
 	if (function->get_name() != StringName()) {
-		return function->get_name().operator String() + "(lambda)";
+		return function->get_name().string() + "(lambda)";
 	}
 	return "(anonymous lambda)";
 }
@@ -183,7 +183,7 @@ String GDScriptLambdaSelfCallable::get_as_text() const {
 		return "<invalid self lambda>";
 	}
 	if (function->get_name() != StringName()) {
-		return function->get_name().operator String() + "(self lambda)";
+		return function->get_name().string() + "(self lambda)";
 	}
 	return "(anonymous self lambda)";
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2821,7 +2821,7 @@ GDScriptParser::IdentifierNode *GDScriptParser::parse_identifier() {
 #ifdef DEBUG_ENABLED
 	// Check for spoofing here (if available in TextServer) since this isn't called inside expressions. This is only relevant for declarations.
 	if (identifier && TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier->name)) {
-		push_warning(identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier->name.operator String());
+		push_warning(identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier->name.string());
 	}
 #endif
 	return identifier;
@@ -2834,7 +2834,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode 
 	IdentifierNode *identifier = alloc_node<IdentifierNode>();
 	complete_extents(identifier);
 	identifier->name = previous.get_identifier();
-	if (identifier->name.operator String().is_empty()) {
+	if (identifier->name.string().is_empty()) {
 		print_line("Empty identifier found.");
 	}
 	identifier->suite = current_suite;
@@ -4837,7 +4837,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 						} else {
 							enum_hint_string += ",";
 						}
-						enum_hint_string += E.key.operator String().capitalize().xml_escape();
+						enum_hint_string += E.key.string().capitalize().xml_escape();
 						enum_hint_string += ":";
 						enum_hint_string += String::num_int64(E.value).xml_escape();
 					}
@@ -4914,7 +4914,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 							} else {
 								enum_hint_string += ",";
 							}
-							enum_hint_string += E.key.operator String().capitalize().xml_escape();
+							enum_hint_string += E.key.string().capitalize().xml_escape();
 							enum_hint_string += ":";
 							enum_hint_string += String::num_int64(E.value).xml_escape();
 						}
@@ -5352,15 +5352,15 @@ String GDScriptParser::DataType::to_string() const {
 			if (is_meta_type) {
 				return GDScriptNativeClass::get_class_static();
 			}
-			return native_type.operator String();
+			return native_type.string();
 		case CLASS:
 			if (class_type->identifier != nullptr) {
-				return class_type->identifier->name.operator String();
+				return class_type->identifier->name.string();
 			}
 			return class_type->fqcn;
 		case SCRIPT: {
 			if (is_meta_type) {
-				return script_type.is_valid() ? script_type->get_class_name().operator String() : "";
+				return script_type.is_valid() ? script_type->get_class_name().string() : "";
 			}
 			String name = script_type.is_valid() ? script_type->get_name() : "";
 			if (!name.is_empty()) {
@@ -5370,7 +5370,7 @@ String GDScriptParser::DataType::to_string() const {
 			if (!name.is_empty()) {
 				return name;
 			}
-			return native_type.operator String();
+			return native_type.string();
 		}
 		case ENUM: {
 			// native_type contains either the native class defining the enum
@@ -6106,7 +6106,7 @@ void GDScriptParser::TreePrinter::print_lambda(LambdaNode *p_lambda) {
 		if (i > 0) {
 			push_text(" , ");
 		}
-		push_text(p_lambda->captures[i]->name.operator String());
+		push_text(p_lambda->captures[i]->name.string());
 	}
 	push_line(" ]");
 }

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -300,7 +300,7 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code,
 
 	// Save identifiers.
 	for (const StringName &id : rev_identifier_map) {
-		String s = id.operator String();
+		String s = id.string();
 		int len = s.length();
 
 		contents.resize(buf_pos + (len + 1) * 4);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -53,7 +53,7 @@ static String _get_element_type(Variant::Type builtin_type, const StringName &na
 	if (script_type.is_valid() && script_type->is_valid()) {
 		return GDScript::debug_get_script_name(script_type);
 	} else if (native_type != StringName()) {
-		return native_type.operator String();
+		return native_type.string();
 	} else {
 		return Variant::get_type_name(builtin_type);
 	}
@@ -517,7 +517,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 		String err_func = name;
 		if (!_script->local_name.is_empty()) {
-			err_func = String(_script->local_name) + "." + err_func;
+			err_func = _script->local_name.string() + "." + err_func;
 		}
 		int err_line = _initial_line;
 		const char *err_text = "Stack overflow. Check for infinite recursion in your script.";
@@ -1273,7 +1273,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 #ifdef DEBUG_ENABLED
 				if (!valid) {
-					err_text = "Invalid access to property or key '" + index->operator String() + "' on a base object of type '" + _get_var_type(src) + "'.";
+					err_text = "Invalid access to property or key '" + index->string() + "' on a base object of type '" + _get_var_type(src) + "'.";
 					OPCODE_BREAK;
 				}
 				*dst = ret;
@@ -2135,7 +2135,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {
-					err_text = _get_call_error("static function '" + methodname->operator String() + "' in type '" + Variant::get_type_name(builtin_type) + "'", argptrs, argc, *ret, err);
+					err_text = _get_call_error("static function '" + methodname->string() + "' in type '" + Variant::get_type_name(builtin_type) + "'", argptrs, argc, *ret, err);
 					OPCODE_BREAK;
 				}
 #endif
@@ -2181,7 +2181,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 				if (err.error != Callable::CallError::CALL_OK) {
-					err_text = _get_call_error("static function '" + method->get_name().operator String() + "' in type '" + method->get_instance_class().operator String() + "'", argptrs, argc, *ret, err);
+					err_text = _get_call_error("static function '" + method->get_name().string() + "' in type '" + method->get_instance_class().string() + "'", argptrs, argc, *ret, err);
 					OPCODE_BREAK;
 				}
 
@@ -3967,7 +3967,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 		String err_func = name;
 		if (!_script->local_name.is_empty()) {
-			err_func = String(_script->local_name) + "." + err_func;
+			err_func = _script->local_name.string() + "." + err_func;
 		}
 		int err_line = line;
 		if (err_text.is_empty()) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6547,7 +6547,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 		// First, check if it's a Blend Shape track.
 		const Vector<StringName> subnames = track_path.get_subnames();
 		Animation::TrackType track_type = animation->track_get_type(track_index);
-		if (animation->track_get_type(track_index) == Animation::TYPE_BLEND_SHAPE || (subnames.size() == 1 && subnames[0].operator String().begins_with("blend_shapes/") && track_type == Animation::TYPE_VALUE)) {
+		if (animation->track_get_type(track_index) == Animation::TYPE_BLEND_SHAPE || (subnames.size() == 1 && subnames[0].string().begins_with("blend_shapes/") && track_type == Animation::TYPE_VALUE)) {
 			const MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(animated_node);
 			ERR_CONTINUE_MSG(!mesh_instance, "glTF: Animation had a Blend Shape track, but the node wasn't a MeshInstance3D. Ignoring this track.");
 			Ref<Mesh> mesh = mesh_instance->get_mesh();

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -59,7 +59,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 			List<StringName> snames;
 
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
-				String name = F.key.operator String();
+				String name = F.key.string();
 
 				ERR_CONTINUE(name.is_empty());
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2221,7 +2221,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 				output.append(CS_SINGLETON_INSTANCE_SUFFIX);
 			}
 		} else {
-			ERR_PRINT("Base type '" + itype.base_name.operator String() + "' does not exist, for class '" + itype.name + "'.");
+			ERR_PRINT("Base type '" + itype.base_name.string() + "' does not exist, for class '" + itype.name + "'.");
 			return ERR_INVALID_DATA;
 		}
 	}
@@ -2319,7 +2319,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	for (const PropertyInterface &iprop : itype.properties) {
 		Error prop_err = _generate_cs_property(itype, iprop, output);
 		ERR_FAIL_COND_V_MSG(prop_err != OK, prop_err,
-				"Failed to generate property '" + iprop.cname.operator String() +
+				"Failed to generate property '" + iprop.cname.string() +
 						"' for class '" + itype.name + "'.");
 	}
 
@@ -4355,7 +4355,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		for (const KeyValue<StringName, const GDType::EnumInfo *> &kv : enum_map) {
 			StringName enum_proxy_cname = kv.key;
-			String enum_proxy_name = pascal_to_pascal_case(enum_proxy_cname.operator String());
+			String enum_proxy_name = pascal_to_pascal_case(enum_proxy_cname.string());
 			if (itype.find_property_by_proxy_name(enum_proxy_name) || itype.find_method_by_proxy_name(enum_proxy_name) || itype.find_signal_by_proxy_name(enum_proxy_name)) {
 				// In case the enum name conflicts with other PascalCase members,
 				// we append 'Enum' to the enum name in those cases.
@@ -4365,7 +4365,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			}
 			EnumInterface ienum(enum_proxy_cname, enum_proxy_name, kv.value->is_bitfield);
 			for (const KeyValue<StringName, int64_t> &kv_case : kv.value->values) {
-				String constant_name = kv_case.key.operator String();
+				String constant_name = kv_case.key.string();
 				constants.erase(kv_case.key);
 
 				ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), kv_case.value);
@@ -5095,7 +5095,7 @@ void BindingsGenerator::_populate_global_constants() {
 			iconstant.const_doc = const_doc;
 
 			if (enum_name != StringName()) {
-				EnumInterface ienum(enum_name, pascal_to_pascal_case(enum_name.operator String()), CoreConstants::is_global_constant_bitfield(i));
+				EnumInterface ienum(enum_name, pascal_to_pascal_case(enum_name.string()), CoreConstants::is_global_constant_bitfield(i));
 				List<EnumInterface>::Element *enum_match = global_enums.find(ienum);
 				if (enum_match) {
 					enum_match->get().constants.push_back(iconstant);
@@ -5111,7 +5111,7 @@ void BindingsGenerator::_populate_global_constants() {
 		for (EnumInterface &ienum : global_enums) {
 			TypeInterface enum_itype;
 			enum_itype.is_enum = true;
-			enum_itype.name = ienum.cname.operator String();
+			enum_itype.name = ienum.cname.string();
 			enum_itype.cname = ienum.cname;
 			enum_itype.proxy_name = ienum.proxy_name;
 			TypeInterface::postsetup_enum_type(enum_itype);

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -391,7 +391,7 @@ void godotsharp_node_path_new_from_string(NodePath *r_dest, const String *p_name
 }
 
 void godotsharp_string_name_as_string(String *r_dest, const StringName *p_name) {
-	memnew_placement(r_dest, String(p_name->operator String()));
+	memnew_placement(r_dest, String(p_name->string()));
 }
 
 void godotsharp_node_path_as_string(String *r_dest, const NodePath *p_np) {

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -520,7 +520,7 @@ Error SceneReplicationInterface::_make_spawn_packet(Node *p_node, MultiplayerSpa
 
 	// Encode scene ID, path ID, net ID, node name.
 	int path_id = multiplayer_cache->make_object_cache(p_spawner);
-	CharString cname = p_node->get_name().operator String().utf8();
+	CharString cname = p_node->get_name().string().utf8();
 	int nlen = encode_cstring(cname.get_data(), nullptr);
 	MAKE_ROOM(1 + 1 + 4 + 4 + 4 + 4 * sync_ids.size() + 4 + nlen + (is_custom ? 4 + spawn_arg_size : 0) + state_size);
 	uint8_t *ptr = packet_cache.ptrw();

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -4885,7 +4885,7 @@ void VisualShaderEditor::_delete_nodes_request(const TypedArray<StringName> &p_n
 			int id = String(graph_element->get_name()).to_int();
 			Ref<VisualShaderNode> vsnode = visual_shader->get_node(type, id);
 			if (vsnode->is_deletable() && graph_element->is_selected()) {
-				to_erase.push_back(graph_element->get_name().operator String().to_int());
+				to_erase.push_back(graph_element->get_name().string().to_int());
 			}
 		}
 	} else {
@@ -5419,7 +5419,7 @@ void VisualShaderEditor::_nodes_linked_to_frame_request(const TypedArray<StringN
 	for (int i = 0; i < p_nodes.size(); i++) {
 		node_ids.push_back(p_nodes[i].operator String().to_int());
 	}
-	frame_node_id_to_link_to = p_frame.operator String().to_int();
+	frame_node_id_to_link_to = p_frame.string().to_int();
 	nodes_link_to_frame_buffer = node_ids;
 }
 

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -116,7 +116,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 					}
 				} break;
 				case ARG_TYPE_CLASS: {
-					String cn = E.param_sigs[i].operator String();
+					String cn = E.param_sigs[i].string();
 					if (cn.begins_with("L") && cn.ends_with(";")) {
 						cn = cn.substr(1, cn.length() - 2);
 					}
@@ -227,7 +227,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 						if (arr.is_typed() && arr.get_typed_builtin() != Variant::OBJECT) {
 							arg_expected = Variant::ARRAY;
 						} else {
-							String cn = E.param_sigs[i].operator String();
+							String cn = E.param_sigs[i].string();
 							if (cn.begins_with("[L") && cn.ends_with(";")) {
 								cn = cn.substr(2, cn.length() - 3);
 							}
@@ -586,7 +586,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				argv[i].l = jarr;
 			} break;
 			case ARG_ARRAY_BIT | ARG_TYPE_CLASS: {
-				String cn = method->param_sigs[i].operator String();
+				String cn = method->param_sigs[i].string();
 				if (cn.begins_with("[L") && cn.ends_with(";")) {
 					cn = cn.substr(2, cn.length() - 3);
 				}

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -70,8 +70,8 @@ bool MeshInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (p_name.operator String().begins_with("surface_material_override/")) {
-		int idx = p_name.operator String().get_slicec('/', 1).to_int();
+	if (p_name.string().begins_with("surface_material_override/")) {
+		int idx = p_name.string().get_slicec('/', 1).to_int();
 
 		if (idx >= surface_override_materials.size() || idx < 0) {
 			return false;
@@ -95,8 +95,8 @@ bool MeshInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 
-	if (p_name.operator String().begins_with("surface_material_override/")) {
-		int idx = p_name.operator String().get_slicec('/', 1).to_int();
+	if (p_name.string().begins_with("surface_material_override/")) {
+		int idx = p_name.string().get_slicec('/', 1).to_int();
 		if (idx >= surface_override_materials.size() || idx < 0) {
 			return false;
 		}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -302,9 +302,9 @@ Error AnimationMixer::add_animation_library(const StringName &p_name, const Ref<
 
 	for (const AnimationLibraryData &lib : animation_libraries) {
 		ERR_FAIL_COND_V_MSG(lib.name == p_name, ERR_ALREADY_EXISTS, "Can't add animation library twice with name: " + String(p_name));
-		ERR_FAIL_COND_V_MSG(lib.library == p_animation_library, ERR_ALREADY_EXISTS, "Can't add animation library twice (adding as '" + p_name.operator String() + "', exists as '" + lib.name.operator String() + "'.");
+		ERR_FAIL_COND_V_MSG(lib.library == p_animation_library, ERR_ALREADY_EXISTS, "Can't add animation library twice (adding as '" + p_name.string() + "', exists as '" + lib.name.string() + "'.");
 
-		if (lib.name.operator String() >= p_name.operator String()) {
+		if (lib.name.string() >= p_name.string()) {
 			break;
 		}
 

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -72,7 +72,7 @@ public:
 	struct AnimationLibraryData {
 		StringName name;
 		Ref<AnimationLibrary> library;
-		bool operator<(const AnimationLibraryData &p_data) const { return name.operator String() < p_data.name.operator String(); }
+		bool operator<(const AnimationLibraryData &p_data) const { return name.string() < p_data.name.string(); }
 	};
 
 	struct AnimationData {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -632,7 +632,7 @@ void AnimationPlayer::set_assigned_animation(const StringName &p_animation) {
 		float speed = playback.current.speed_scale;
 		play(p_animation, -1.0, speed, std::signbit(speed));
 	} else {
-		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation.operator String()));
+		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation.string()));
 		playback.current.pos = 0;
 		playback.current.is_enabled = true;
 		playback.current.animation_name = p_animation;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1553,7 +1553,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 			// Optimized version of the code below:
 			// String name = "@" + String(p_child->get_name()) + "@" + itos(node_hrcr_count.get());
 			uint32_t c = node_hrcr_count.get();
-			String cn = p_child->get_class_name().operator String();
+			String cn = p_child->get_class_name().string();
 			const char32_t *cn_ptr = cn.ptr();
 			uint32_t cn_length = cn.length();
 			uint32_t c_chars = String::num_characters(c);
@@ -1996,7 +1996,7 @@ Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) 
 		if (p_owned && !cptr[i]->data.owner) {
 			continue;
 		}
-		if (cptr[i]->data.name.operator String().match(p_pattern)) {
+		if (cptr[i]->data.name.string().match(p_pattern)) {
 			return cptr[i];
 		}
 
@@ -2027,7 +2027,7 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 			continue;
 		}
 
-		if (p_pattern.is_empty() || cptr[i]->data.name.operator String().match(p_pattern)) {
+		if (p_pattern.is_empty() || cptr[i]->data.name.string().match(p_pattern)) {
 			if (p_type.is_empty() || cptr[i]->is_class(p_type)) {
 				ret.append(cptr[i]);
 			} else if (cptr[i]->get_script_instance()) {
@@ -2105,7 +2105,7 @@ Node *Node::find_parent(const String &p_pattern) const {
 	ERR_THREAD_GUARD_V(nullptr);
 	Node *p = data.parent;
 	while (p) {
-		if (p->data.name.operator String().match(p_pattern)) {
+		if (p->data.name.string().match(p_pattern)) {
 			return p;
 		}
 		p = p->data.parent;
@@ -2223,7 +2223,7 @@ void Node::_set_owner_nocheck(Node *p_owner) {
 
 void Node::_release_unique_name_in_owner() {
 	ERR_FAIL_NULL(data.owner); // Safety check.
-	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
+	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.string());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which == nullptr || *which != this) {
 		return; // Ignore.
@@ -2233,7 +2233,7 @@ void Node::_release_unique_name_in_owner() {
 
 void Node::_acquire_unique_name_in_owner() {
 	ERR_FAIL_NULL(data.owner); // Safety check.
-	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
+	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.string());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which != nullptr && *which != this) {
 		String which_path = String(is_inside_tree() ? (*which)->get_path() : data.owner->get_path_to(*which));
@@ -3493,7 +3493,7 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 	} else if (p_idx == 0 && (pf == "add_to_group" || pf == "remove_from_group" || pf == "is_in_group")) {
 		HashMap<StringName, String> global_groups(ProjectSettings::get_singleton()->get_global_groups_list());
 		for (const KeyValue<StringName, String> &E : global_groups) {
-			r_options->push_back(E.key.operator String().quote());
+			r_options->push_back(E.key.string().quote());
 		}
 	}
 	Object::get_argument_options(p_function, p_idx, r_options);

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -80,7 +80,7 @@ void ResourcePreloader::add_resource(const StringName &p_name, const Ref<Resourc
 		int idx = 2;
 
 		while (true) {
-			new_name = p_name.operator String() + " " + itos(idx);
+			new_name = p_name.string() + " " + itos(idx);
 			if (resources.has(new_name)) {
 				idx++;
 				continue;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2036,7 +2036,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 	if (add_options) {
 		HashMap<StringName, String> global_groups(ProjectSettings::get_singleton()->get_global_groups_list());
 		for (const KeyValue<StringName, String> &E : global_groups) {
-			r_options->push_back(E.key.operator String().quote());
+			r_options->push_back(E.key.string().quote());
 		}
 	}
 	MainLoop::get_argument_options(p_function, p_idx, r_options);

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -151,7 +151,7 @@ void AnimationLibrary::get_argument_options(const StringName &p_function, int p_
 		LocalVector<StringName> names;
 		get_animation_list(&names);
 		for (const StringName &E : names) {
-			r_options->push_back(E.operator String().quote());
+			r_options->push_back(E.string().quote());
 		}
 	}
 	Resource::get_argument_options(p_function, p_idx, r_options);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1103,7 +1103,7 @@ void FontFile::_validate_property(PropertyInfo &p_property) const {
 }
 
 bool FontFile::_set(const StringName &p_name, const Variant &p_value) {
-	Vector<String> tokens = p_name.operator String().split("/");
+	Vector<String> tokens = p_name.string().split("/");
 
 #ifndef DISABLE_DEPRECATED
 	if (tokens.size() == 1 && tokens[0] == "font_path") {
@@ -1281,7 +1281,7 @@ bool FontFile::_set(const StringName &p_name, const Variant &p_value) {
 }
 
 bool FontFile::_get(const StringName &p_name, Variant &r_ret) const {
-	Vector<String> tokens = p_name.operator String().split("/");
+	Vector<String> tokens = p_name.string().split("/");
 	if (tokens.size() == 2 && tokens[0] == "language_support_override") {
 		const String &lang_code = tokens[1];
 		r_ret = get_language_support_override(lang_code);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -427,7 +427,7 @@ void ShaderMaterial::set_shader_parameter(const StringName &p_param, const Varia
 		Variant *v = param_cache.getptr(p_param);
 		if (!v) {
 			// Never assigned, also update the remap cache.
-			remap_cache["shader_parameter/" + p_param.operator String()] = p_param;
+			remap_cache["shader_parameter/" + p_param.string()] = p_param;
 			param_cache.insert(p_param, p_value);
 		} else {
 			*v = p_value;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1633,7 +1633,7 @@ Variant SceneState::get_property_value(int p_node, const StringName &p_property,
 		// Compatibility: In 4.5 and earlier, AnimationMixer used a single "libraries" Dictionary property.
 		// In 4.6+, each library is stored as a separate "libraries/<name>" property.
 		// If we're looking for "libraries/<name>" and didn't find it, check the old format.
-		String prop_str = p_property.operator String();
+		String prop_str = p_property.string();
 		if (prop_str.begins_with("libraries/")) {
 			StringName node_type = get_node_type(p_node);
 			if (node_type != StringName() && ClassDB::is_parent_class(node_type, SNAME("AnimationMixer"))) {

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2236,7 +2236,7 @@ void RenderingServer::get_argument_options(const StringName &p_function, int p_i
 		if (pf == "global_shader_parameter_set" || pf == "global_shader_parameter_set_override" ||
 				pf == "global_shader_parameter_get" || pf == "global_shader_parameter_get_type" || pf == "global_shader_parameter_remove") {
 			for (const StringName &E : global_shader_parameter_get_list()) {
-				r_options->push_back(E.operator String().quote());
+				r_options->push_back(E.string().quote());
 			}
 		} else if (pf == "has_os_feature") {
 			for (const String E : { "\"rgtc\"", "\"s3tc\"", "\"bptc\"", "\"etc\"", "\"etc2\"", "\"astc\"" }) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3603,8 +3603,8 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 
 	ERR_FAIL_COND_V(p_func->arguments[0]->type != Node::NODE_TYPE_VARIABLE, false);
 
-	StringName name = static_cast<VariableNode *>(p_func->arguments[0])->name.operator String();
-	StringName rname = static_cast<VariableNode *>(p_func->arguments[0])->rname.operator String();
+	StringName name = static_cast<VariableNode *>(p_func->arguments[0])->name.string();
+	StringName rname = static_cast<VariableNode *>(p_func->arguments[0])->rname.string();
 
 	for (int i = 1; i < p_func->arguments.size(); i++) {
 		args.push_back(p_func->arguments[i]->get_datatype());
@@ -5422,7 +5422,7 @@ bool ShaderLanguage::_get_completable_identifier(BlockNode *p_block, CompletionT
 		tk = _get_token();
 
 		if (tk.type == TK_IDENTIFIER) {
-			identifier = identifier.operator String() + tk.text.operator String();
+			identifier = identifier.string() + tk.text.string();
 		} else {
 			_set_tkpos(pos);
 		}

--- a/tests/core/object/test_class_db.cpp
+++ b/tests/core/object/test_class_db.cpp
@@ -497,7 +497,7 @@ void validate_class(const Context &p_context, const ExposedClass &p_exposed_clas
 	}
 
 	TEST_FAIL_COND((is_derived_type && !p_context.exposed_classes.has(p_exposed_class.base)),
-			"Base type '", p_exposed_class.base.operator String(), "' does not exist, for class '", p_exposed_class.name, "'.");
+			"Base type '", p_exposed_class.base.string(), "' does not exist, for class '", p_exposed_class.name, "'.");
 
 	for (const PropertyData &F : p_exposed_class.properties) {
 		validate_property(p_context, p_exposed_class, F);


### PR DESCRIPTION
Simple interface improvement for `StringName` -> `String`.

Mainly, this avoids the `atomic` reference+unreference inherent to `operator String()`, where almost all callers need a view instead of a copy. (my measurements from a few months ago indicated that reference+unreference are almost as costly as a full allocation)

The alternative would have been to use `const operator String &()`, which is unreadably long, so I changed it to a named method `string()`.

`operator const String &()` is kept for implicit conversion, since the implicit conversion to `Variant` also still exists, and otherwise passing an argument to a function that accepts both `String` and `Variant` overloads suddenly starts selecting the `Variant` overload. This can be removed if/when we remove the implicit -> `Variant` conversion, but the PR is a strict improvement over the status quo anyway.

This is only possible since https://github.com/godotengine/godot/pull/104985.