### PR TITLE
Fix and clean up clearcoat reflection probe process

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2032,7 +2032,7 @@ void fragment_shader(in SceneData scene_data) {
 		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
 		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
 #ifdef LIGHT_CLEARCOAT_USED
-		vec3 cc_reflection_accum = vec3(0.0, 0.0, 0.0);
+		vec4 cc_reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
 #endif
 
 		uint cluster_reflection_offset = cluster_offset + implementation_data.cluster_type_size * 4;
@@ -2079,13 +2079,19 @@ void fragment_shader(in SceneData scene_data) {
 					continue; //not masked
 				}
 
+#ifndef LIGHT_CLEARCOAT_USED
 				if (reflection_accum.a >= 1.0 && ambient_accum.a >= 1.0) {
 					break;
 				}
+#else
+				if (reflection_accum.a >= 1.0 && cc_reflection_accum.a >= 1.0 && ambient_accum.a >= 1.0) {
+					break;
+				}
+#endif // LIGHT_CLEARCOAT_USED
 
-				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, indirect_specular_light,
+				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light,
 #ifdef LIGHT_CLEARCOAT_USED
-						cc_specular_light, cc_ref_vec, mix(0.001, 0.1, clearcoat_roughness), cc_reflection_accum,
+						cc_ref_vec, mix(0.001, 0.1, clearcoat_roughness), cc_reflection_accum,
 #endif
 						ambient_accum, reflection_accum);
 			}
@@ -2099,12 +2105,21 @@ void fragment_shader(in SceneData scene_data) {
 			reflection_accum.rgb = indirect_specular_light * (1.0 - reflection_accum.a) + reflection_accum.rgb;
 		}
 
+#ifdef LIGHT_CLEARCOAT_USED
+		if (cc_reflection_accum.a < 1.0) {
+			cc_reflection_accum.rgb = cc_specular_light * (1.0 - cc_reflection_accum.a) + cc_reflection_accum.rgb;
+		}
+#endif
+
 		if (reflection_accum.a > 0.0) {
 			indirect_specular_light = reflection_accum.rgb;
-#ifdef LIGHT_CLEARCOAT_USED
-			cc_specular_light = cc_reflection_accum.rgb;
-#endif
 		}
+
+#ifdef LIGHT_CLEARCOAT_USED
+		if (cc_reflection_accum.a > 0.0) {
+			cc_specular_light = cc_reflection_accum.rgb;
+		}
+#endif
 
 #if !defined(USE_LIGHTMAP)
 		if (ambient_accum.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1769,7 +1769,7 @@ void main() {
 		hvec4 reflection_accum = hvec4(0.0);
 		hvec4 ambient_accum = hvec4(0.0);
 #ifdef LIGHT_CLEARCOAT_USED
-		hvec3 cc_reflection_accum = hvec3(0.0);
+		hvec4 cc_reflection_accum = hvec4(0.0);
 #endif
 
 #ifdef LIGHT_ANISOTROPY_USED
@@ -1792,13 +1792,19 @@ void main() {
 				break;
 			}
 
+#ifndef LIGHT_CLEARCOAT_USED
 			if (reflection_accum.a >= half(1.0) && ambient_accum.a >= half(1.0)) {
 				break;
 			}
+#else
+			if (reflection_accum.a >= half(1.0) && cc_reflection_accum.a >= half(1.0) && ambient_accum.a >= half(1.0)) {
+				break;
+			}
+#endif // LIGHT_CLEARCOAT_USED
 
-			reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, indirect_specular_light,
+			reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light,
 #ifdef LIGHT_CLEARCOAT_USED
-					cc_specular_light, cc_ref_vec, mix(half(0.001), half(0.1), clearcoat_roughness), cc_reflection_accum,
+					cc_ref_vec, mix(half(0.001), half(0.1), clearcoat_roughness), cc_reflection_accum,
 #endif
 					ambient_accum, reflection_accum);
 		}
@@ -1811,12 +1817,21 @@ void main() {
 			reflection_accum.rgb = indirect_specular_light * (half(1.0) - reflection_accum.a) + reflection_accum.rgb;
 		}
 
+#ifdef LIGHT_CLEARCOAT_USED
+		if (cc_reflection_accum.a < half(1.0)) {
+			cc_reflection_accum.rgb = cc_specular_light * (half(1.0) - reflection_accum.a) + cc_reflection_accum.rgb;
+		}
+#endif
+
 		if (reflection_accum.a > half(0.0)) {
 			indirect_specular_light = reflection_accum.rgb;
-#ifdef LIGHT_CLEARCOAT_USED
-			cc_specular_light = cc_reflection_accum.rgb;
-#endif
 		}
+
+#ifdef LIGHT_CLEARCOAT_USED
+		if (cc_reflection_accum.a > half(0.0)) {
+			cc_specular_light = cc_reflection_accum.rgb;
+		}
+#endif
 
 #if !defined(USE_LIGHTMAP)
 		if (ambient_accum.a > half(0.0)) {

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -1312,9 +1312,9 @@ void light_process_area(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 #endif // LIGHT_CODE_USED
 }
 
-void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal, half roughness, hvec3 ambient_light, hvec3 specular_light,
+void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal, half roughness, hvec3 ambient_light,
 #ifdef LIGHT_CLEARCOAT_USED
-		hvec3 cc_specular_light, hvec3 cc_ref_vec, half cc_roughness, inout hvec3 cc_reflection_accum,
+		hvec3 cc_ref_vec, half cc_roughness, inout hvec4 cc_reflection_accum,
 #endif
 		inout hvec4 ambient_accum, inout hvec4 reflection_accum) {
 	vec3 box_extents = reflections.data[ref_index].box_extents;
@@ -1367,30 +1367,36 @@ void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal
 	}
 
 #ifdef LIGHT_CLEARCOAT_USED
-	vec3 local_cc_ref_vec = (reflections.data[ref_index].local_matrix * vec4(cc_ref_vec, 0.0)).xyz;
+	if (reflections.data[ref_index].intensity > 0.0 && cc_reflection_accum.a < half(1.0)) { // compute clearcoat reflection
+		vec3 local_cc_ref_vec = (reflections.data[ref_index].local_matrix * vec4(cc_ref_vec, 0.0)).xyz;
 
-	if (reflections.data[ref_index].box_project) { // Box project.
+		if (reflections.data[ref_index].box_project) { // Box project.
 
-		vec3 nrdir = normalize(local_cc_ref_vec);
-		vec3 rbmax = (box_extents - local_pos) / nrdir;
-		vec3 rbmin = (-box_extents - local_pos) / nrdir;
+			vec3 nrdir = normalize(local_cc_ref_vec);
+			vec3 rbmax = (box_extents - local_pos) / nrdir;
+			vec3 rbmin = (-box_extents - local_pos) / nrdir;
 
-		vec3 rbminmax = mix(rbmin, rbmax, greaterThan(nrdir, vec3(0.0, 0.0, 0.0)));
+			vec3 rbminmax = mix(rbmin, rbmax, greaterThan(nrdir, vec3(0.0, 0.0, 0.0)));
 
-		float fa = min(min(rbminmax.x, rbminmax.y), rbminmax.z);
-		vec3 posonbox = local_pos + nrdir * fa;
-		local_cc_ref_vec = posonbox - reflections.data[ref_index].box_offset;
+			float fa = min(min(rbminmax.x, rbminmax.y), rbminmax.z);
+			vec3 posonbox = local_pos + nrdir * fa;
+			local_cc_ref_vec = posonbox - reflections.data[ref_index].box_offset;
+		}
+
+		hvec4 cc_reflection;
+		half cc_reflection_blend = max(half(0.0), blend - cc_reflection_accum.a);
+
+		float cc_roughness_lod = sqrt(cc_roughness) * MAX_ROUGHNESS_LOD;
+		vec2 cc_reflection_uv = vec3_to_oct_with_border(local_cc_ref_vec, border_size);
+		cc_reflection.rgb = hvec3(textureLod(sampler2DArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(cc_reflection_uv, reflections.data[ref_index].index), cc_roughness_lod).rgb) * REFLECTION_MULTIPLIER;
+		cc_reflection.rgb *= half(reflections.data[ref_index].exposure_normalization);
+		cc_reflection.a = cc_reflection_blend;
+
+		cc_reflection.rgb *= half(reflections.data[ref_index].intensity);
+		cc_reflection.rgb *= cc_reflection.a;
+
+		cc_reflection_accum += cc_reflection;
 	}
-
-	float cc_roughness_lod = sqrt(cc_roughness) * MAX_ROUGHNESS_LOD;
-	vec2 cc_reflection_uv = vec3_to_oct_with_border(local_cc_ref_vec, border_size);
-	hvec3 cc_reflection = hvec3(textureLod(sampler2DArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(cc_reflection_uv, reflections.data[ref_index].index), cc_roughness_lod).rgb) * REFLECTION_MULTIPLIER;
-	cc_reflection *= half(reflections.data[ref_index].exposure_normalization);
-	if (reflections.data[ref_index].exterior) {
-		cc_reflection = mix(cc_specular_light, cc_reflection, blend);
-	}
-	cc_reflection *= half(reflections.data[ref_index].intensity) * blend;
-	cc_reflection_accum += cc_reflection;
 #endif // LIGHT_CLEARCOAT_USED
 
 	if (ambient_accum.a >= half(1.0)) {


### PR DESCRIPTION
This PR implements the following changes that were missed in PR #111464:

- Removed the `specular_light` parameter from the reflection_process() function, as it became obsolete in PR #100241.
- Removed the `cc_specular_light` parameter as well.
- Removed the `if (reflections.data[ref_index].exterior)` check for the clearcoat, following its removal in PR #100241.
- Replaced the `blend` variable in clearcoat reflections with `cc_reflection.a` to maintain consistency with the main reflection implementation.
-  Changed value type for `cc_reflection_accum` and `cc_reflection` from vec3 to vec4.
- Moved the clearcoat reflection operations inside their own conditionals: `if (reflections.data[ref_index].intensity > 0.0 && cc_reflection_accum.a < half(1.0))`, `if (cc_reflection_accum.a < 1.0)`, and `if (cc_reflection_accum.a > 0.0)`.
- Added the operation `cc_reflection_accum.rgb = cc_specular_light * (1.0 - cc_reflection_accum.a) + cc_reflection_accum.rgb;` to prevent seams artifacts in the reflection.

Here are some before-and-after comparisons.
|Before|After|
|--------|--------|
|<img width="890" height="829" alt="before" src="https://github.com/user-attachments/assets/2f4f0faf-7b96-4742-a293-ba8b35af8c24" />|<img width="859" height="831" alt="after" src="https://github.com/user-attachments/assets/381897ec-21f9-40bd-86cd-a2cbc2c257da" />|
|<img width="791" height="797" alt="before2" src="https://github.com/user-attachments/assets/aa64d6c5-7ca3-45af-b5e0-4fbf1a01971b" />|<img width="791" height="797" alt="after2" src="https://github.com/user-attachments/assets/d446f9c9-cb49-4c47-a838-3f99ec124932" />|