### PR TITLE
Revert Android Editor minSdk bump to 24

### DIFF
--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -81,7 +81,7 @@ android {
         applicationId "org.godotengine.editor.v4"
         versionCode generateVersionCode()
         versionName generateVersionName()
-        minSdkVersion 29 // Minimum recommended sdk version for Vulkan 1.1 support. See https://developer.android.com/games/develop/vulkan/native-engine-support#recommendations
+        minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
 
         missingDimensionStrategy 'products', 'editor'
@@ -187,6 +187,7 @@ android {
             }
             applicationIdSuffix ".pico"
             versionNameSuffix "-pico"
+            minSdkVersion 29
             targetSdkVersion 32
         }
     }

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -18,11 +18,11 @@
         android:required="true" />
     <uses-feature
         android:name="android.hardware.vulkan.version"
-        android:required="true"
+        android:required="false"
         android:version="0x401000" />
     <uses-feature
         android:name="android.hardware.vulkan.level"
-        android:required="true"
+        android:required="false"
         android:version="1" />
     <uses-feature
         android:name="android.hardware.camera"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -256,7 +256,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 		// Skip permissions request if running in a device farm (e.g. firebase test lab) or if requested via the launch
 		// intent (e.g. instrumentation tests).
-		val skipPermissionsRequest = isRunningInInstrumentation() || ActivityManager.isRunningInUserTestHarness()
+		val skipPermissionsRequest = isRunningInInstrumentation() ||
+			Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ActivityManager.isRunningInUserTestHarness()
 		if (!skipPermissionsRequest) {
 			// We exclude certain permissions from the set we request at startup, as they'll be
 			// requested on demand based on use cases.
@@ -804,7 +805,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			}
 
 			PermissionsUtil.REQUEST_INSTALL_PACKAGES_REQ_CODE -> {
-				if (!packageManager.canRequestPackageInstalls()) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
 					Toast.makeText(
 						this,
 						R.string.denied_install_packages_permission_error_msg,

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
@@ -31,6 +31,7 @@
 package org.godotengine.editor.embed
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.view.LayoutInflater
@@ -185,7 +186,9 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 		PopupMenu(context, optionsButton).apply {
 			setOnMenuItemClickListener(this@GameMenuFragment)
 			inflate(R.menu.options_menu)
-			menu.setGroupDividerEnabled(true)
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+				menu.setGroupDividerEnabled(true)
+			}
 		}
 	}
 


### PR DESCRIPTION
partially reverts https://github.com/godotengine/godot/pull/117355 (the editor part only)

Resolves https://github.com/godotengine/godot/issues/118753