### PR TITLE
Fix clearcoat intensity for area lights

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1871,7 +1871,7 @@ void light_process_area(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 	float cc_specular_ltc = 0.0;
 	vec2 cc_fresnel = vec2(0.0);
 	ltc_evaluate_specular(vertex_normal, eye_vec, sqrt(mix(0.001, 0.1, float(clearcoat_roughness))), points, ltc_lut1, ltc_lut2, cc_specular_ltc, cc_fresnel);
-	float Fr = 0.04 * max(cc_fresnel.x, 0.0) + (1.0 - 0.04) * max(cc_fresnel.y, 0.0) * clearcoat;
+	float Fr = (0.04 * max(cc_fresnel.x, 0.0) + (1.0 - 0.04) * max(cc_fresnel.y, 0.0)) * clearcoat;
 	cc_attenuation = 1.0 - Fr;
 	specular_light += cc_specular_ltc * Fr * light_color * light_attenuation_ltc * specular_amount;
 #endif // LIGHT_CLEARCOAT_USED

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -1265,7 +1265,7 @@ void light_process_area(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 	float cc_specular_ltc = 0.0;
 	vec2 cc_fresnel;
 	ltc_evaluate_specular(vec3(vertex_normal), vec3(eye_vec), sqrt(mix(0.001, 0.1, float(clearcoat_roughness))), points, area_lights.data[idx].projector_rect, max_mipmap, area_light_atlas, SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP, ltc_lut1, ltc_lut2, cc_specular_ltc, cc_fresnel, cc_specular_tex_color);
-	half Fr = half(0.04) * max(half(cc_fresnel.x), half(0.0)) + half(1.0 - 0.04) * max(half(cc_fresnel.y), half(0.0)) * clearcoat;
+	half Fr = (half(0.04) * max(half(cc_fresnel.x), half(0.0)) + half(1.0 - 0.04) * max(half(cc_fresnel.y), half(0.0))) * clearcoat;
 	cc_attenuation = half(1.0) - Fr;
 	specular_light += half(cc_specular_ltc) * hvec3(cc_specular_tex_color) * Fr * color * light_attenuation_ltc * specular_amount;
 #endif // LIGHT_CLEARCOAT_USED


### PR DESCRIPTION
During the development of #108219, I mentioned that parentheses should be added when multiplying by the clearcoat variable see [#108219](https://github.com/godotengine/godot/pull/108219/changes#r2855284347), but it was overlooked. No worries, though I have nothing against the author, and it’s an easy fix.

Here is the before and after.
|Before|After|
|--------|--------|
|<video src=https://github.com/user-attachments/assets/6ceabd6d-d2de-4dd1-b9c3-e25560b7abb0></video>|<video src=https://github.com/user-attachments/assets/f967bbaa-6b8a-472c-8557-f691f65c09cc></video>|