### PR TITLE
In editor properties, capitalize "androidxr" as "AndroidXR" (with uppercase "XR")

### DIFF
--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -150,6 +150,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["adb"] = "ADB";
 	capitalize_string_remaps["actool"] = "actool";
 	capitalize_string_remaps["ao"] = "AO";
+	capitalize_string_remaps["androidxr"] = "AndroidXR";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";
 	capitalize_string_remaps["arm32"] = "arm32";


### PR DESCRIPTION
Currently, Project Settings with "androidxr" in the name will become "Androidxr":

<img width="786" height="361" alt="Selection_453" src="https://github.com/user-attachments/assets/eb56502b-1c11-4f78-8843-cfcc8911bcde" />

However, the platform is actually called "AndroidXR" (with uppercase "XR"). This PR fixes that!

We have a similar mapping for "macos" -> "macOS".