### PR TITLE
Remove constructors from MP3 and Ogg Vorbis streams

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -357,10 +357,3 @@ void AudioStreamMP3::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "loop_offset"), "set_loop_offset", "get_loop_offset");
 }
-
-AudioStreamMP3::AudioStreamMP3() {
-}
-
-AudioStreamMP3::~AudioStreamMP3() {
-	clear_data();
-}

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -146,7 +146,4 @@ public:
 	virtual Ref<AudioSample> generate_sample() const override;
 
 	virtual void get_parameter_list(List<Parameter> *r_parameters) override;
-
-	AudioStreamMP3();
-	virtual ~AudioStreamMP3();
 };

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -737,7 +737,3 @@ void AudioStreamOggVorbis::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "loop_offset"), "set_loop_offset", "get_loop_offset");
 }
-
-AudioStreamOggVorbis::AudioStreamOggVorbis() {}
-
-AudioStreamOggVorbis::~AudioStreamOggVorbis() {}

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -176,7 +176,4 @@ public:
 		return true;
 	}
 	virtual Ref<AudioSample> generate_sample() const override;
-
-	AudioStreamOggVorbis();
-	virtual ~AudioStreamOggVorbis();
 };


### PR DESCRIPTION
Both constructors are empty, so they're redundant.

One destructor is empty, and the other clears a `TightLocalVector`, which is already done on destruction anyway, so also redundant.

For reference, `AudioStreamWAV` used constructor and destructor too in the past, but they eventually became redundant and were removed.