### PR TITLE
Add script editor toggle for folding all comment blocks in script file

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -408,8 +408,12 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 		}
 
 		seb->validate_script();
-	}
 
+		if (ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(teb)) {
+			ste->apply_doc_comment_fold_state(EDITOR_GET("text_editor/behavior/documentation/fold_doc_comments"));
+			ste->apply_comment_fold_state(EDITOR_GET("text_editor/behavior/general/fold_comments"));
+		}
+	}
 	if (EditorHelp *eh = Object::cast_to<EditorHelp>(c)) {
 		script_name_button->set_text(eh->get_class());
 		_calculate_script_name_button_size();
@@ -2746,6 +2750,10 @@ void ScriptEditor::_apply_editor_settings() {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(tab_container->get_tab_control(i))) {
 			teb->update_settings();
+			if (ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(teb)) {
+				ste->apply_doc_comment_fold_state(EDITOR_GET("text_editor/behavior/documentation/fold_doc_comments"));
+				ste->apply_comment_fold_state(EDITOR_GET("text_editor/behavior/general/fold_comments"));
+			}
 		}
 	}
 }

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -190,6 +190,8 @@ ScriptTextEditor::EditMenusSTE::EditMenusSTE() {
 	_popup_move_item(SEARCH_GOTO_LINE, goto_menu->get_popup());
 
 	edit_menu_fold->add_shortcut(ED_GET_SHORTCUT("script_text_editor/create_code_region"), EDIT_CREATE_CODE_REGION);
+	edit_menu_fold->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_doc_comments"), EDIT_TOGGLE_FOLD_DOC_COMMENTS);
+	edit_menu_fold->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_fold_comments"), EDIT_TOGGLE_FOLD_COMMENTS);
 	edit_menu_convert_indent->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
 
 	search_menu->get_popup()->add_separator();
@@ -1689,6 +1691,12 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 		case EDIT_CREATE_CODE_REGION: {
 			tx->create_code_region();
 		} break;
+		case EDIT_TOGGLE_FOLD_DOC_COMMENTS: {
+			toggle_fold_doc_comments_for_active_script();
+		} break;
+		case EDIT_TOGGLE_FOLD_COMMENTS: {
+			toggle_fold_comments_for_active_script();
+		} break;
 		case EDIT_TOGGLE_COMMENT: {
 			_edit_option_toggle_inline_comment();
 		} break;
@@ -1867,6 +1875,117 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 		}
 	}
 	return true;
+}
+
+static bool _is_comment_block_line(CodeEdit *p_text_edit, int p_line) {
+	if (p_line < 0 || p_line >= p_text_edit->get_line_count()) {
+		return false;
+	}
+
+	const String stripped_line = p_text_edit->get_line(p_line).strip_edges();
+
+	return stripped_line.begins_with("#") &&
+			!stripped_line.begins_with("##") &&
+			stripped_line != "#region" &&
+			stripped_line != "#endregion";
+}
+
+bool ScriptTextEditor::_is_comment_block_start(CodeEdit *p_text_edit, int p_line) const {
+	ERR_FAIL_NULL_V(p_text_edit, false);
+
+	if (!_is_comment_block_line(p_text_edit, p_line)) {
+		return false;
+	}
+
+	return p_line == 0 || !_is_comment_block_line(p_text_edit, p_line - 1);
+}
+
+bool ScriptTextEditor::_is_doc_comment_block_start(CodeEdit *p_text_edit, int p_line) const {
+	const int delimiter_idx = p_text_edit->is_in_comment(p_line);
+	if (delimiter_idx == -1) {
+		return false;
+	}
+
+	if (p_text_edit->get_delimiter_start_key(delimiter_idx) != "##") {
+		return false;
+	}
+
+	if (p_line == 0) {
+		return true;
+	}
+
+	const int prev_delimiter_idx = p_text_edit->is_in_comment(p_line - 1);
+	if (prev_delimiter_idx == -1) {
+		return true;
+	}
+
+	return p_text_edit->get_delimiter_start_key(prev_delimiter_idx) != "##";
+}
+
+void ScriptTextEditor::toggle_fold_comments_for_active_script() {
+	const bool fold = !bool(EDITOR_GET("text_editor/behavior/general/fold_comments"));
+	EditorSettings::get_singleton()->set("text_editor/behavior/general/fold_comments", fold);
+	apply_comment_fold_state(fold);
+}
+
+void ScriptTextEditor::toggle_fold_doc_comments_for_active_script() {
+	const bool fold = !bool(EDITOR_GET("text_editor/behavior/documentation/fold_doc_comments"));
+	EditorSettings::get_singleton()->set("text_editor/behavior/documentation/fold_doc_comments", fold);
+	apply_doc_comment_fold_state(fold);
+}
+
+void ScriptTextEditor::apply_comment_fold_state(bool p_fold) {
+	CodeEdit *text_edit = code_editor->get_text_editor();
+	ERR_FAIL_NULL(text_edit);
+
+	const int line_count = text_edit->get_line_count();
+	LocalVector<int> comment_headers;
+	comment_headers.reserve(line_count / 4);
+
+	for (int line = 0; line < line_count; line++) {
+		if (_is_comment_block_start(text_edit, line)) {
+			comment_headers.push_back(line);
+		}
+	}
+
+	for (uint32_t i = 0; i < comment_headers.size(); i++) {
+		const int line = comment_headers[i];
+
+		if (p_fold) {
+			if (text_edit->can_fold_line(line)) {
+				text_edit->fold_line(line);
+			}
+		} else if (text_edit->is_line_folded(line)) {
+			text_edit->unfold_line(line);
+		}
+	}
+}
+
+void ScriptTextEditor::apply_doc_comment_fold_state(bool p_fold) {
+	CodeEdit *text_edit = code_editor->get_text_editor();
+	ERR_FAIL_NULL(text_edit);
+
+	const int line_count = text_edit->get_line_count();
+	LocalVector<int> doc_comment_headers;
+	doc_comment_headers.reserve(line_count / 4);
+
+	for (int line = 0; line < line_count; line++) {
+		if (_is_doc_comment_block_start(text_edit, line)) {
+			doc_comment_headers.push_back(line);
+		}
+	}
+
+	for (uint32_t i = 0; i < doc_comment_headers.size(); i++) {
+		const int line = doc_comment_headers[i];
+
+		if (p_fold) {
+			if (text_edit->can_fold_line(line)) {
+				text_edit->fold_line(line);
+			}
+		} else if (text_edit->is_line_folded(line)) {
+			text_edit->unfold_line(line);
+		}
+	}
 }
 
 void ScriptTextEditor::_edit_option_toggle_inline_comment() {
@@ -2632,6 +2751,8 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/fold_all_lines", TTRC("Fold All Lines"), Key::NONE);
 	ED_SHORTCUT("script_text_editor/create_code_region", TTRC("Create Code Region"), KeyModifierMask::ALT | Key::R);
 	ED_SHORTCUT("script_text_editor/unfold_all_lines", TTRC("Unfold All Lines"), Key::NONE);
+	ED_SHORTCUT("script_text_editor/toggle_fold_doc_comments", TTRC("Toggle Fold Documentation Comments"), Key::NONE);
+	ED_SHORTCUT("script_text_editor/toggle_fold_comments", TTRC("Toggle Fold Comments"), Key::NONE);
 	ED_SHORTCUT("script_text_editor/duplicate_selection", TTRC("Duplicate Selection"), KeyModifierMask::SHIFT | KeyModifierMask::CTRL | Key::D);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/duplicate_selection", "macos", KeyModifierMask::SHIFT | KeyModifierMask::META | Key::C);
 	ED_SHORTCUT("script_text_editor/duplicate_lines", TTRC("Duplicate Lines"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::DOWN);

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -107,6 +107,8 @@ class ScriptTextEditor : public CodeEditorBase {
 		EDIT_PICK_COLOR,
 		EDIT_EVALUATE,
 		EDIT_CREATE_CODE_REGION,
+		EDIT_TOGGLE_FOLD_DOC_COMMENTS,
+		EDIT_TOGGLE_FOLD_COMMENTS,
 
 		SEARCH_LOCATE_FUNCTION,
 
@@ -213,6 +215,9 @@ protected:
 	virtual void _load_theme_settings() override;
 	virtual void _validate_script() override;
 
+	bool _is_doc_comment_block_start(CodeEdit *p_text_edit, int p_line) const;
+	bool _is_comment_block_start(CodeEdit *p_text_edit, int p_line) const;
+
 public:
 	void _update_connected_methods();
 
@@ -239,6 +244,12 @@ public:
 
 	Variant get_previous_state();
 	void store_previous_state();
+
+	void toggle_fold_doc_comments_for_active_script();
+	void apply_doc_comment_fold_state(bool p_fold);
+
+	void toggle_fold_comments_for_active_script();
+	void apply_comment_fold_state(bool p_fold);
 
 	ScriptTextEditor();
 	~ScriptTextEditor();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -813,6 +813,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior
 	// Behavior: General
 	_initial_set("text_editor/behavior/general/empty_selection_clipboard", true);
+	_initial_set("text_editor/behavior/general/fold_comments", false, true);
 
 	// Behavior: Navigation
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true, true);
@@ -845,6 +846,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Behavior: Documentation
 	_initial_set("text_editor/behavior/documentation/enable_tooltips", true, true);
+	_initial_set("text_editor/behavior/documentation/fold_doc_comments", false, true);
 
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true, true);


### PR DESCRIPTION
### Summary of Changes

**1.** Documentation Comment folding through **a)** editor settings, **b)** Script editor menu, Edit -> Folding -> Toggle Fold Documentation Comments.
**2.** Regular Comment folding through  **a)** editor settings, **b)**  Script editor menu, Edit -> Folding -> Toggle Fold Comments.

### Motivation

This PR is meant to be a working example the proposal found [**here**](https://github.com/godotengine/godot-proposals/discussions/14712).  The working example is being provided to allow me to showcase the idea as well as practice development within the Godot guidelines and specifications.  It is intended to be fully ready for merge if the community decides it should be.

### Related Work

[This Discussion thread]( https://github.com/godotengine/godot-proposals/discussions/14712)

### Technical Overview

These changes stay at the script editor level and build on top of existing CodeEdit folding rather than changing the parser or folding system itself. It adds two separate fold paths in ScriptTextEditor: one for documentation comment blocks and one for regular comment blocks, each with its own toggle and persisted editor setting.

Doc comment folding uses CodeEdit’s comment delimiter state so it only targets documentation comment blocks. Regular comment folding follows the same flow, but identifies full-line comment blocks separately through a simple logical block which excludes ##, #region, and #endregion, resulting in keeping all three folding behaviors independent.

Both update their stored editor setting and immediately reapply the fold state to the active script. ScriptEditor also reapplies both saved states when switching tabs and when editor settings refresh so that open editors remain consistent with the current setting state.

### Testing

I tested by creating as many various forms of comment and documentation comment as I could come up with.  This included inline comments, comments with tabs, comments with spaces, blank comments, and other styling choices developers may prefer in their workflow.  I tested the persistence of the editor setting, toggling off and on again through the edit menu folding options, and added a hotkey temporarily to both to ensure that would function as expected.  

### Discussion

I see this pull request as a low-risk feature proposal.  It is intentionally small in scope and I did my best to limit any interactions that would lead to immediately identifiable issues.  

The major caveats I have identified are:

1. Potentially adding hotkeys risks polluting an already low availability mapping.
1a. Mitigation is possible by keeping the hotkeys unassigned as these toggles aren't likely to be toggled often enough for the lack of a hotkey to be inconvenient.

2. The editor settings have been added to the best fitting categories I could identify - but they may not have been placed ideally.
2a. This can be mitigated by community input, this is just a working example and therefore is not intended to be proposed as "final states".

This proposal is highly unlikely to cause any compatibility breakages or regressions.  The caveat being if the delimiters are changed substantially for Documentation Comments in the future or if the underlying structure of comments or documentation comments are changed to no longer resolve folding the same way.

### Additional Work

I strongly desire community discussion on this feature proposal to decide if it would benefit enough users by improving readability of script files after extensive documentation or commenting blocks are added.  

There is follow-up work needed to ensure that the communities views of this feature are that it is wanted and that all implementations live up to the Godot Contributor specifications and guidelines.

Performance testing has not been done at this time but can be if there are concerns over the implementations.