### PR TITLE
Rewrite HashMap and AHashMap around SwissTable probing

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2682,89 +2682,31 @@ double String::to_float() const {
 }
 
 uint32_t String::hash(const char *p_cstr) {
-	// static_cast: avoid negative values on platforms where char is signed.
-	uint32_t hashv = 5381;
-	uint32_t c = static_cast<uint8_t>(*p_cstr++);
-
-	while (c) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
-		c = static_cast<uint8_t>(*p_cstr++);
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr);
 }
 
 uint32_t String::hash(const char *p_cstr, int p_len) {
-	uint32_t hashv = 5381;
-	for (int i = 0; i < p_len; i++) {
-		// static_cast: avoid negative values on platforms where char is signed.
-		hashv = ((hashv << 5) + hashv) + static_cast<uint8_t>(p_cstr[i]); /* hash * 33 + c */
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr, p_len);
 }
 
 uint32_t String::hash(const wchar_t *p_cstr, int p_len) {
-	// Avoid negative values on platforms where wchar_t is signed. Account for different sizes.
-	using wide_unsigned = std::conditional<sizeof(wchar_t) == 2, uint16_t, uint32_t>::type;
-
-	uint32_t hashv = 5381;
-	for (int i = 0; i < p_len; i++) {
-		hashv = ((hashv << 5) + hashv) + static_cast<wide_unsigned>(p_cstr[i]); /* hash * 33 + c */
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr, p_len);
 }
 
 uint32_t String::hash(const wchar_t *p_cstr) {
-	// Avoid negative values on platforms where wchar_t is signed. Account for different sizes.
-	using wide_unsigned = std::conditional<sizeof(wchar_t) == 2, uint16_t, uint32_t>::type;
-
-	uint32_t hashv = 5381;
-	uint32_t c = static_cast<wide_unsigned>(*p_cstr++);
-
-	while (c) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
-		c = static_cast<wide_unsigned>(*p_cstr++);
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr);
 }
 
 uint32_t String::hash(const char32_t *p_cstr, int p_len) {
-	uint32_t hashv = 5381;
-	for (int i = 0; i < p_len; i++) {
-		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr, p_len);
 }
 
 uint32_t String::hash(const char32_t *p_cstr) {
-	uint32_t hashv = 5381;
-	uint32_t c = *p_cstr++;
-
-	while (c) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
-		c = *p_cstr++;
-	}
-
-	return hashv;
+	return hash_foldhash(p_cstr);
 }
 
 uint32_t String::hash() const {
-	/* simple djb2 hashing */
-
-	const char32_t *chr = get_data();
-	uint32_t hashv = 5381;
-	uint32_t c = *chr++;
-
-	while (c) {
-		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
-		c = *chr++;
-	}
-
-	return hashv;
+	return hash_foldhash(get_data(), length());
 }
 
 uint64_t String::hash64() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -228,7 +228,7 @@ public:
 		return *this;
 	}
 
-	uint32_t hash() const { return hash_djb2(get_data()); }
+	uint32_t hash() const { return hash_foldhash(get_data(), length()); }
 
 protected:
 	void copy_from(const T *p_cstr) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -703,6 +703,16 @@ public:
 template <>
 struct is_zero_constructible<String> : std::true_type {};
 
+template <>
+struct HashMapComparatorDefault<String> {
+	static _FORCE_INLINE_ bool compare(const String &p_lhs, const String &p_rhs) {
+		// HashMap hit lookups often probe with keys that share the same COW
+		// buffer as the stored String, so bypass the span/memcmp path when the
+		// underlying storage is identical.
+		return (p_lhs.ptr() == p_rhs.ptr() && p_lhs.length() == p_rhs.length()) || (p_lhs == p_rhs);
+	}
+};
+
 bool operator==(const char *p_chr, const String &p_str);
 bool operator==(const wchar_t *p_chr, const String &p_str);
 bool operator!=(const char *p_chr, const String &p_str);

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -706,9 +706,7 @@ struct is_zero_constructible<String> : std::true_type {};
 template <>
 struct HashMapComparatorDefault<String> {
 	static _FORCE_INLINE_ bool compare(const String &p_lhs, const String &p_rhs) {
-		// HashMap hit lookups often probe with keys that share the same COW
-		// buffer as the stored String, so bypass the span/memcmp path when the
-		// underlying storage is identical.
+		// Fast path for shared storage.
 		return (p_lhs.ptr() == p_rhs.ptr() && p_lhs.length() == p_rhs.length()) || (p_lhs == p_rhs);
 	}
 };

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -91,6 +91,11 @@ private:
 
 	// Dense entries store (insertion order is NOT preserved on erase).
 	KV *_elements = nullptr;
+	// Parallel cached 32-bit hashes, sized identically to _elements. Stored
+	// at insert time so probes can short-circuit before a (potentially
+	// expensive) key compare and so rehashing on grow doesn't have to re-run
+	// Hasher on the key.
+	uint32_t *_hashes = nullptr;
 	uint32_t _elements_capacity = 0;
 
 	uint32_t _capacity = 0; // Power of two, or 0 if unallocated.
@@ -100,7 +105,13 @@ private:
 	uint32_t _deleted = 0; // Tombstones currently in the index table.
 
 	static _FORCE_INLINE_ uint32_t _hash(const TKey &p_key) {
-		return Hasher::hash(p_key);
+		// Apply a SwissTable-friendly bit mixer at the boundary so callers
+		// don't have to. Several Godot hashers (notably String/DJB2) leave
+		// the high bits weakly mixed; splitting them into h1/h2 directly
+		// would cluster fingerprints and inflate probe chains. The same
+		// mixed value is what we cache in _hashes[i], so that grow and the
+		// hash short-circuit in _lookup keep working consistently.
+		return SwissTable::mix(Hasher::hash(p_key));
 	}
 
 	// Round up to a power of two no smaller than min, and at least kGroupWidth.
@@ -114,7 +125,8 @@ private:
 
 	// Find the slot containing p_key. Returns true if found, with r_slot_idx
 	// set to the slot index in _ctrl/_slots and r_element_idx to the index in
-	// _elements.
+	// _elements. Uses the cached 32-bit hash on each candidate to short-
+	// circuit before the (potentially expensive) key compare.
 	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx, uint32_t &r_element_idx) const {
 		if (_capacity == 0) {
 			return false;
@@ -131,7 +143,7 @@ private:
 				uint32_t i = it.next();
 				uint32_t slot_idx = (group_idx + i) & _capacity_mask;
 				uint32_t elem_idx = _slots[slot_idx];
-				if (Comparator::compare(_elements[elem_idx].key, p_key)) {
+				if (_hashes[elem_idx] == p_hash && Comparator::compare(_elements[elem_idx].key, p_key)) {
 					r_slot_idx = slot_idx;
 					r_element_idx = elem_idx;
 					return true;
@@ -145,6 +157,52 @@ private:
 			probe_dist += kGroupWidth;
 			// Quadratic probing across groups; bounded by capacity (always succeeds
 			// because we maintain at least one empty slot in the table).
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
+		}
+	}
+
+	// Combined "lookup if present, otherwise pick insert slot" probe used
+	// by insert and operator[]. Returns true if the key is already in the
+	// table (with r_slot_idx / r_element_idx set to the existing entry);
+	// returns false with r_slot_idx pointing at a kEmpty/kDeleted slot
+	// where the new entry should be placed.
+	//
+	// Caller must ensure _capacity > 0 and _growth_left > 0.
+	bool _find_or_prepare_insert(const TKey &p_key, uint32_t p_hash,
+			uint32_t &r_slot_idx, uint32_t &r_element_idx) const {
+		const uint8_t h2 = SwissTable::h2(p_hash);
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
+		uint32_t insert_slot = 0;
+		bool have_insert_slot = false;
+
+		while (true) {
+			SwissTable::Group g(_ctrl + group_idx);
+			Mask m = g.match(h2);
+			auto it = m.iter();
+			while (it.has_next()) {
+				const uint32_t i = it.next();
+				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
+				const uint32_t elem_idx = _slots[slot_idx];
+				if (_hashes[elem_idx] == p_hash && Comparator::compare(_elements[elem_idx].key, p_key)) {
+					r_slot_idx = slot_idx;
+					r_element_idx = elem_idx;
+					return true;
+				}
+			}
+			if (!have_insert_slot) {
+				Mask ed = g.match_empty_or_deleted();
+				if (ed) {
+					const uint32_t i = ed.lowest_set_bit();
+					insert_slot = (group_idx + i) & _capacity_mask;
+					have_insert_slot = true;
+				}
+			}
+			if (g.match_empty()) {
+				r_slot_idx = insert_slot;
+				return false;
+			}
+			probe_dist += kGroupWidth;
 			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
 	}
@@ -240,9 +298,10 @@ private:
 		_growth_left = SwissTable::capacity_to_growth(new_capacity);
 		_deleted = 0;
 
-		// Reinsert all live elements (entries themselves don't move).
+		// Reinsert all live elements (entries themselves don't move). We
+		// reuse the cached hashes so grow doesn't have to re-run Hasher.
 		for (uint32_t i = 0; i < _size; i++) {
-			const uint32_t hash = _hash(_elements[i].key);
+			const uint32_t hash = _hashes[i];
 			const uint32_t slot = _find_insert_slot(hash);
 			_set_ctrl(slot, SwissTable::h2(hash));
 			_slots[slot] = i;
@@ -261,6 +320,8 @@ private:
 		}
 		_elements = reinterpret_cast<KV *>(
 				Memory::realloc_static(_elements, sizeof(KV) * p_new_capacity));
+		_hashes = reinterpret_cast<uint32_t *>(
+				Memory::realloc_static(_hashes, sizeof(uint32_t) * p_new_capacity));
 		_elements_capacity = p_new_capacity;
 	}
 
@@ -283,25 +344,32 @@ private:
 		_grow_entries(_entries_capacity_for(_capacity));
 	}
 
-	// Insert with the assumption that p_key does not already exist.
-	uint32_t _insert_new(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
-		if (_growth_left == 0) {
-			_grow();
-		}
-		const uint32_t slot = _find_insert_slot(p_hash);
-		// If we picked a deleted slot, we don't lose growth (deleted slots do
-		// count against growth_left already through _deleted accounting).
-		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
-		_set_ctrl(slot, SwissTable::h2(p_hash));
+	// Place a new element at the given (already chosen) slot. The slot must
+	// currently be kEmpty or kDeleted, and the caller must have already
+	// guaranteed _growth_left > 0 and that the entries array has room.
+	_FORCE_INLINE_ uint32_t _emplace_at_slot(const TKey &p_key, const TValue &p_value,
+			uint32_t p_hash, uint32_t p_slot) {
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[p_slot]);
+		_set_ctrl(p_slot, SwissTable::h2(p_hash));
 		const uint32_t element_idx = _size;
-		_slots[slot] = element_idx;
+		_slots[p_slot] = element_idx;
 		memnew_placement(&_elements[element_idx], KV(p_key, p_value));
+		_hashes[element_idx] = p_hash;
 		_size++;
 		if (was_deleted) {
 			_deleted--;
 		}
 		_growth_left--;
 		return element_idx;
+	}
+
+	// Insert with the assumption that p_key does not already exist.
+	uint32_t _insert_new(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
+		if (_growth_left == 0) {
+			_grow();
+		}
+		const uint32_t slot = _find_insert_slot(p_hash);
+		return _emplace_at_slot(p_key, p_value, p_hash, slot);
 	}
 
 	void _init_from(const AHashMap &p_other) {
@@ -323,6 +391,8 @@ private:
 				memnew_placement(&_elements[i], KV(p_other._elements[i]));
 			}
 		}
+		// Copy parallel hash array.
+		memcpy(_hashes, p_other._hashes, sizeof(uint32_t) * p_other._size);
 		_size = p_other._size;
 		// Copy ctrl table verbatim, including mirror bytes.
 		memcpy(_ctrl, p_other._ctrl, p_other._capacity + kGroupWidth);
@@ -419,15 +489,18 @@ public:
 		// Swap-with-tail to keep entries dense. We need to update the moved
 		// entry's slot mapping BEFORE doing the actual move, because a
 		// post-move lookup would find the slot but read the (now-garbage)
-		// data at the old tail index when comparing keys.
+		// data at the old tail index when comparing keys. We use the cached
+		// hash on the tail entry to drive the lookup so we don't re-run
+		// Hasher on the moved key.
 		if (element_idx < _size) {
 			uint32_t moved_slot = 0;
 			uint32_t moved_idx = 0;
-			bool found = _lookup(_elements[_size].key, _hash(_elements[_size].key), moved_slot, moved_idx);
+			bool found = _lookup(_elements[_size].key, _hashes[_size], moved_slot, moved_idx);
 			(void)found;
 			DEV_ASSERT(found && moved_idx == _size);
 			_slots[moved_slot] = element_idx;
 			memcpy(static_cast<void *>(&_elements[element_idx]), static_cast<const void *>(&_elements[_size]), sizeof(KV));
+			_hashes[element_idx] = _hashes[_size];
 		}
 
 		return true;
@@ -455,15 +528,16 @@ public:
 		}
 		_set_ctrl(old_slot, new_ctrl);
 
-		// Mutate the key in place.
+		// Mutate the key in place and update the cached hash.
 		const_cast<TKey &>(_elements[element_idx].key) = p_new_key;
+		const uint32_t new_hash = _hash(p_new_key);
+		_hashes[element_idx] = new_hash;
 
 		// Insert into the new position. We may need to grow if the deleted slot
 		// converted to empty consumed our growth budget; check growth_left.
 		if (_growth_left == 0) {
 			_grow();
 		}
-		const uint32_t new_hash = _hash(p_new_key);
 		const uint32_t slot = _find_insert_slot(new_hash);
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
 		_set_ctrl(slot, SwissTable::h2(new_hash));
@@ -611,13 +685,19 @@ public:
 
 	TValue &operator[](const TKey &p_key) {
 		const uint32_t hash = _hash(p_key);
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
 		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		if (_capacity != 0 && _lookup(p_key, hash, slot, element_idx)) {
+		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot, element_idx)) {
 			return _elements[element_idx].value;
 		}
-		_ensure_allocated();
-		element_idx = _insert_new(p_key, TValue(), hash);
+		if (_size == 0) {
+			slot = _find_insert_slot(hash);
+		}
+		element_idx = _emplace_at_slot(p_key, TValue(), hash, slot);
 		return _elements[element_idx].value;
 	}
 
@@ -625,14 +705,20 @@ public:
 
 	Iterator insert(const TKey &p_key, const TValue &p_value) {
 		const uint32_t hash = _hash(p_key);
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
 		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		if (_capacity != 0 && _lookup(p_key, hash, slot, element_idx)) {
+		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot, element_idx)) {
 			_elements[element_idx].value = p_value;
 			return Iterator(_elements + element_idx, _elements, _elements + _size);
 		}
-		_ensure_allocated();
-		element_idx = _insert_new(p_key, p_value, hash);
+		if (_size == 0) {
+			slot = _find_insert_slot(hash);
+		}
+		element_idx = _emplace_at_slot(p_key, p_value, hash, slot);
 		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
@@ -680,6 +766,7 @@ public:
 		_ctrl = p_other._ctrl;
 		_slots = p_other._slots;
 		_elements = p_other._elements;
+		_hashes = p_other._hashes;
 		_elements_capacity = p_other._elements_capacity;
 		_capacity = p_other._capacity;
 		_capacity_mask = p_other._capacity_mask;
@@ -690,6 +777,7 @@ public:
 		p_other._ctrl = nullptr;
 		p_other._slots = nullptr;
 		p_other._elements = nullptr;
+		p_other._hashes = nullptr;
 		p_other._elements_capacity = 0;
 		p_other._capacity = 0;
 		p_other._capacity_mask = 0;
@@ -734,6 +822,10 @@ public:
 			Memory::free_static(_elements);
 			_elements = nullptr;
 			_elements_capacity = 0;
+		}
+		if (_hashes != nullptr) {
+			Memory::free_static(_hashes);
+			_hashes = nullptr;
 		}
 		if (_ctrl != nullptr) {
 			Memory::free_static(_ctrl);

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -30,11 +30,11 @@
 
 #pragma once
 
-#include "core/math/math_funcs_binary.h"
 #include "core/os/memory.h"
-#include "core/string/print_string.h"
+#include "core/string/print_string.h" // IWYU pragma: keep. `WARN_VERBOSE` macro.
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
+#include "core/templates/swiss_table_simd.h"
 
 #include <initializer_list>
 
@@ -43,243 +43,298 @@ class StringName;
 class Variant;
 
 /**
- * An array-based implementation of a hash map. It is very efficient in terms of performance and
- * memory usage. Works like a dynamic array, adding elements to the end of the array, and
- * allows you to access array elements by their index by using `get_by_index` method.
- * Example:
- * ```
- *  AHashMap<int, Object *> map;
+ * An array-based implementation of a hash map. Very efficient in performance
+ * and memory usage. Uses a SwissTable-style control-byte index (SIMD-scanned)
+ * pointing into a contiguous packed entries array. Insertion order is NOT
+ * preserved across erases: erase swaps the removed element with the last one
+ * in the entries array (constant-time erase, dense storage).
  *
- *  int get_object_id_by_number(int p_number) {
- *		int id = map.get_index(p_number);
- *		return id;
- *  }
+ * Element pointers and indices are NOT stable across erases that move the
+ * tail. Pointers/iterators may also be invalidated by inserts that grow the
+ * table. If you need pointer stability or insertion-order preservation across
+ * erases, use HashMap instead.
  *
- *  Object *get_object_by_id(int p_id) {
- *		map.get_by_index(p_id).value;
- *  }
- * ```
- * Still, don`t erase the elements because ID can break.
- *
- * When an element erase, its place is taken by the element from the end.
- *
- *        <-------------
- *      |               |
- *  6 8 X 9 32 -1 5 -10 7 X X X
- *  6 8 7 9 32 -1 5 -10 X X X X
- *
+ * Public API mirrors the older Robin-Hood implementation:
+ *   - get / getptr / has / find
+ *   - insert / insert_new / operator[]
+ *   - erase / erase_by_index / replace_key
+ *   - get_index (key -> entry index) / get_by_index (entry index -> KeyValue)
+ *   - get_elements_ptr (raw pointer to dense entries array)
+ *   - reserve / clear / reset
  *
  * Use RBMap if you need to iterate over sorted elements.
  *
  * Use HashMap if:
- *   - You need to keep an iterator or const pointer to Key and you intend to add/remove elements in the meantime.
+ *   - You need to keep an iterator or const pointer to Key and you intend to
+ *     add/remove elements in the meantime.
  *   - You need to preserve the insertion order when using erase.
- *
- * It is recommended to use `HashMap` if `KeyValue` size is very large.
  */
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>>
 class AHashMap {
 public:
-	// Must be a power of two.
+	// Power of two; must be at least kGroupWidth (16 for SSE2/WASM, 8 otherwise).
 	static constexpr uint32_t INITIAL_CAPACITY = 16;
-	static constexpr uint32_t EMPTY_HASH = 0;
-	static_assert(EMPTY_HASH == 0, "EMPTY_HASH must always be 0 for the memcpy() optimization.");
+	using KV = KeyValue<TKey, TValue>;
 
 private:
-	struct Metadata {
-		uint32_t hash;
-		uint32_t element_idx;
-	};
+	using Mask = typename SwissTable::Group::Mask;
+	static constexpr uint32_t kGroupWidth = SwissTable::Group::kWidth;
 
-	static_assert(sizeof(Metadata) == 8);
+	// Index table:
+	//   _ctrl: capacity + kGroupWidth control bytes (the trailing bytes mirror
+	//          the leading ones so group probing can wrap-overshoot safely).
+	//   _slots: capacity entry indices (uint32_t each), parallel to _ctrl[0..capacity).
+	uint8_t *_ctrl = nullptr;
+	uint32_t *_slots = nullptr;
 
-	typedef KeyValue<TKey, TValue> MapKeyValue;
-	MapKeyValue *_elements = nullptr;
-	Metadata *_metadata = nullptr;
+	// Dense entries store (insertion order is NOT preserved on erase).
+	KV *_elements = nullptr;
+	uint32_t _elements_capacity = 0;
 
-	// Due to optimization, this is `capacity - 1`. Use + 1 to get normal capacity.
-	uint32_t _capacity_mask = 0;
+	uint32_t _capacity = 0; // Power of two, or 0 if unallocated.
+	uint32_t _capacity_mask = 0; // _capacity - 1.
 	uint32_t _size = 0;
+	uint32_t _growth_left = 0; // Number of inserts allowed before next grow/rehash.
+	uint32_t _deleted = 0; // Tombstones currently in the index table.
 
-	uint32_t _hash(const TKey &p_key) const {
-		uint32_t hash = Hasher::hash(p_key);
-
-		if (unlikely(hash == EMPTY_HASH)) {
-			hash = EMPTY_HASH + 1;
-		}
-
-		return hash;
+	static _FORCE_INLINE_ uint32_t _hash(const TKey &p_key) {
+		return Hasher::hash(p_key);
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_resize_count(uint32_t p_capacity_mask) {
-		return p_capacity_mask ^ (p_capacity_mask + 1) >> 2; // = get_capacity() * 0.75 - 1; Works only if p_capacity_mask = 2^n - 1.
+	// Round up to a power of two no smaller than min, and at least kGroupWidth.
+	static _FORCE_INLINE_ uint32_t _round_up_capacity(uint32_t p_min) {
+		uint32_t cap = kGroupWidth;
+		while (cap < p_min) {
+			cap <<= 1;
+		}
+		return cap;
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_meta_idx, uint32_t p_hash, uint32_t p_capacity) {
-		const uint32_t original_idx = p_hash & p_capacity;
-		return (p_meta_idx - original_idx + p_capacity + 1) & p_capacity;
-	}
-
-	bool _lookup_idx(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
-		}
-		return _lookup_idx_with_hash(p_key, r_element_idx, r_meta_idx, _hash(p_key));
-	}
-
-	bool _lookup_idx_with_hash(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx, uint32_t p_hash) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
-		}
-
-		uint32_t meta_idx = p_hash & _capacity_mask;
-		Metadata metadata = _metadata[meta_idx];
-		if (metadata.hash == p_hash && Comparator::compare(_elements[metadata.element_idx].key, p_key)) {
-			r_element_idx = metadata.element_idx;
-			r_meta_idx = meta_idx;
-			return true;
-		}
-
-		if (metadata.hash == EMPTY_HASH) {
+	// Find the slot containing p_key. Returns true if found, with r_slot_idx
+	// set to the slot index in _ctrl/_slots and r_element_idx to the index in
+	// _elements.
+	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx, uint32_t &r_element_idx) const {
+		if (_capacity == 0) {
 			return false;
 		}
-
-		// A collision occurred.
-		meta_idx = (meta_idx + 1) & _capacity_mask;
-		uint32_t distance = 1;
-		while (true) {
-			metadata = _metadata[meta_idx];
-			if (metadata.hash == p_hash && Comparator::compare(_elements[metadata.element_idx].key, p_key)) {
-				r_element_idx = metadata.element_idx;
-				r_meta_idx = meta_idx;
-				return true;
-			}
-
-			if (metadata.hash == EMPTY_HASH) {
-				return false;
-			}
-
-			if (distance > _get_probe_length(meta_idx, metadata.hash, _capacity_mask)) {
-				return false;
-			}
-
-			meta_idx = (meta_idx + 1) & _capacity_mask;
-			distance++;
-		}
-	}
-
-	uint32_t _insert_metadata(uint32_t p_hash, uint32_t p_element_idx) {
-		uint32_t meta_idx = p_hash & _capacity_mask;
-
-		if (_metadata[meta_idx].hash == EMPTY_HASH) {
-			_metadata[meta_idx] = Metadata{ p_hash, p_element_idx };
-			return meta_idx;
-		}
-
-		uint32_t distance = 1;
-		meta_idx = (meta_idx + 1) & _capacity_mask;
-		Metadata metadata;
-		metadata.hash = p_hash;
-		metadata.element_idx = p_element_idx;
+		const uint8_t h2 = SwissTable::h2(p_hash);
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
 
 		while (true) {
-			if (_metadata[meta_idx].hash == EMPTY_HASH) {
-#ifdef DEV_ENABLED
-				if (unlikely(distance > 12)) {
-					WARN_PRINT("Excessive collision count, is the right hash function being used?");
+			SwissTable::Group g(_ctrl + group_idx);
+			Mask m = g.match(h2);
+			auto it = m.iter();
+			while (it.has_next()) {
+				uint32_t i = it.next();
+				uint32_t slot_idx = (group_idx + i) & _capacity_mask;
+				uint32_t elem_idx = _slots[slot_idx];
+				if (Comparator::compare(_elements[elem_idx].key, p_key)) {
+					r_slot_idx = slot_idx;
+					r_element_idx = elem_idx;
+					return true;
 				}
-#endif
-				_metadata[meta_idx] = metadata;
-				return meta_idx;
 			}
-
-			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(meta_idx, _metadata[meta_idx].hash, _capacity_mask);
-			if (existing_probe_len < distance) {
-				SWAP(metadata, _metadata[meta_idx]);
-				distance = existing_probe_len;
+			// If this group has any empty slot, the key cannot be further along
+			// the probe sequence (deletes are tombstones, empties are not).
+			if (g.match_empty()) {
+				return false;
 			}
-
-			meta_idx = (meta_idx + 1) & _capacity_mask;
-			distance++;
+			probe_dist += kGroupWidth;
+			// Quadratic probing across groups; bounded by capacity (always succeeds
+			// because we maintain at least one empty slot in the table).
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
 	}
 
-	void _resize_and_rehash(uint32_t p_new_capacity) {
-		uint32_t real_old_capacity = _capacity_mask + 1;
-		// Capacity can't be 0 and must be 2^n - 1.
-		_capacity_mask = MAX(4u, p_new_capacity);
-		uint32_t real_capacity = Math::next_power_of_2(_capacity_mask);
-		_capacity_mask = real_capacity - 1;
-
-		Metadata *old_map_data = _metadata;
-
-		_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static_zeroed(sizeof(Metadata) * real_capacity));
-		_elements = reinterpret_cast<MapKeyValue *>(Memory::realloc_static(_elements, sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
-
-		if (_size != 0) {
-			for (uint32_t i = 0; i < real_old_capacity; i++) {
-				Metadata metadata = old_map_data[i];
-				if (metadata.hash != EMPTY_HASH) {
-					_insert_metadata(metadata.hash, metadata.element_idx);
-				}
+	// Find the first empty-or-deleted slot where a new element with p_hash can
+	// be inserted. Caller is responsible for ensuring growth_left > 0.
+	uint32_t _find_insert_slot(uint32_t p_hash) const {
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
+		while (true) {
+			SwissTable::Group g(_ctrl + group_idx);
+			Mask m = g.match_empty_or_deleted();
+			if (m) {
+				uint32_t i = m.lowest_set_bit();
+				return (group_idx + i) & _capacity_mask;
 			}
+			probe_dist += kGroupWidth;
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
-
-		Memory::free_static(old_map_data);
 	}
 
-	int32_t _insert_element(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
-		if (unlikely(_elements == nullptr)) {
-			// Allocate on demand to save memory.
+	// Decide whether an erased slot can become kEmpty (so it doesn't
+	// permanently consume probe-chain length) or must remain a kDeleted
+	// tombstone. With unaligned probing, the promotion to kEmpty is only
+	// safe when no probe sequence could ever have been forced to skip past
+	// this slot while it was full -- approximated by requiring an empty in
+	// both the kGroupWidth-window immediately after AND immediately before
+	// the slot, with no run of kGroupWidth full bytes in between. This
+	// matches absl::container_internal::WasNeverFull.
+	_FORCE_INLINE_ uint8_t _ctrl_after_erase(uint32_t p_slot_idx) const {
+		// Single-group tables: no probe sequence ever leaves the group, so
+		// converting an erased slot to empty is always safe.
+		if (_capacity <= kGroupWidth) {
+			return SwissTable::kEmpty;
+		}
+		// Trailing: number of consecutive non-empty bytes starting AT the
+		// slot (looking forward). We scan up to kGroupWidth bytes; the
+		// trailing-mirror region of _ctrl makes the read safe even if the
+		// slot is near the end of the index table.
+		uint32_t trailing = 0;
+		while (trailing < kGroupWidth && _ctrl[p_slot_idx + trailing] != SwissTable::kEmpty) {
+			trailing++;
+		}
+		if (trailing == kGroupWidth) {
+			return SwissTable::kDeleted;
+		}
+		// Leading: number of consecutive non-empty bytes ending JUST BEFORE
+		// the slot (looking backward, with wrap).
+		uint32_t leading = 0;
+		while (leading < kGroupWidth) {
+			const uint32_t idx = (p_slot_idx + _capacity - 1 - leading) & _capacity_mask;
+			if (_ctrl[idx] == SwissTable::kEmpty) {
+				break;
+			}
+			leading++;
+		}
+		// Promote to empty only when the run of non-empties surrounding the
+		// slot is shorter than one full group window -- meaning no probe
+		// could have been forced to scan a full group through this slot.
+		if (trailing + leading < kGroupWidth) {
+			return SwissTable::kEmpty;
+		}
+		return SwissTable::kDeleted;
+	}
 
-			uint32_t real_capacity = _capacity_mask + 1;
-			_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static_zeroed(sizeof(Metadata) * real_capacity));
-			_elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
+	// Set the control byte and the trailing mirror byte (if applicable).
+	_FORCE_INLINE_ void _set_ctrl(uint32_t p_slot_idx, uint8_t p_value) {
+		_ctrl[p_slot_idx] = p_value;
+		// Mirror the first (kGroupWidth - 1) control bytes at the tail so that
+		// group probing can read past the end without bounds checks.
+		const uint32_t mirrored = ((p_slot_idx - (kGroupWidth - 1)) & _capacity_mask) + (kGroupWidth - 1);
+		_ctrl[mirrored] = p_value;
+	}
+
+	// (Re)allocate the index table to the given capacity (power of two), then
+	// reinsert all existing elements.
+	void _resize_table(uint32_t p_new_capacity) {
+		const uint32_t new_capacity = MAX(p_new_capacity, kGroupWidth);
+		// Allocate ctrl with kGroupWidth-1 trailing mirror bytes.
+		uint8_t *new_ctrl = reinterpret_cast<uint8_t *>(
+				Memory::alloc_static(sizeof(uint8_t) * (new_capacity + kGroupWidth)));
+		uint32_t *new_slots = reinterpret_cast<uint32_t *>(
+				Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		memset(new_ctrl, SwissTable::kEmpty, new_capacity + kGroupWidth);
+
+		uint8_t *old_ctrl = _ctrl;
+		uint32_t *old_slots = _slots;
+
+		_ctrl = new_ctrl;
+		_slots = new_slots;
+		_capacity = new_capacity;
+		_capacity_mask = new_capacity - 1;
+		_growth_left = SwissTable::capacity_to_growth(new_capacity);
+		_deleted = 0;
+
+		// Reinsert all live elements (entries themselves don't move).
+		for (uint32_t i = 0; i < _size; i++) {
+			const uint32_t hash = _hash(_elements[i].key);
+			const uint32_t slot = _find_insert_slot(hash);
+			_set_ctrl(slot, SwissTable::h2(hash));
+			_slots[slot] = i;
+			_growth_left--;
 		}
 
-		if (unlikely(_size > _get_resize_count(_capacity_mask))) {
-			_resize_and_rehash(_capacity_mask * 2);
+		if (old_ctrl != nullptr) {
+			Memory::free_static(old_ctrl);
+			Memory::free_static(old_slots);
 		}
+	}
 
-		memnew_placement(&_elements[_size], MapKeyValue(p_key, p_value));
+	void _grow_entries(uint32_t p_new_capacity) {
+		if (p_new_capacity <= _elements_capacity) {
+			return;
+		}
+		_elements = reinterpret_cast<KV *>(
+				Memory::realloc_static(_elements, sizeof(KV) * p_new_capacity));
+		_elements_capacity = p_new_capacity;
+	}
 
-		_insert_metadata(p_hash, _size);
+	// Compute the entry-array capacity needed to support a given index-table
+	// capacity (we hold up to growth-left elements).
+	static _FORCE_INLINE_ uint32_t _entries_capacity_for(uint32_t p_index_capacity) {
+		return SwissTable::capacity_to_growth(p_index_capacity);
+	}
+
+	void _ensure_allocated() {
+		if (_capacity == 0) {
+			_resize_table(MAX((uint32_t)INITIAL_CAPACITY, kGroupWidth));
+			_grow_entries(_entries_capacity_for(_capacity));
+		}
+	}
+
+	void _grow() {
+		const uint32_t new_capacity = _capacity == 0 ? MAX((uint32_t)INITIAL_CAPACITY, kGroupWidth) : (_capacity * 2);
+		_resize_table(new_capacity);
+		_grow_entries(_entries_capacity_for(_capacity));
+	}
+
+	// Insert with the assumption that p_key does not already exist.
+	uint32_t _insert_new(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
+		if (_growth_left == 0) {
+			_grow();
+		}
+		const uint32_t slot = _find_insert_slot(p_hash);
+		// If we picked a deleted slot, we don't lose growth (deleted slots do
+		// count against growth_left already through _deleted accounting).
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
+		_set_ctrl(slot, SwissTable::h2(p_hash));
+		const uint32_t element_idx = _size;
+		_slots[slot] = element_idx;
+		memnew_placement(&_elements[element_idx], KV(p_key, p_value));
 		_size++;
-		return _size - 1;
+		if (was_deleted) {
+			_deleted--;
+		}
+		_growth_left--;
+		return element_idx;
 	}
 
 	void _init_from(const AHashMap &p_other) {
-		_capacity_mask = p_other._capacity_mask;
-		uint32_t real_capacity = _capacity_mask + 1;
-		_size = p_other._size;
-
 		if (p_other._size == 0) {
 			return;
 		}
-
-		_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static(sizeof(Metadata) * real_capacity));
-		_elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
-
+		_resize_table(p_other._capacity);
+		// Match the source's full entries-array capacity, not just its current
+		// size. The index table copied below was sized for `p_other._capacity`
+		// and still has growth_left slots available without rehashing; if we
+		// only allocate `p_other._size` entries here, subsequent inserts will
+		// happily write past the entries array before the next grow.
+		_grow_entries(MAX(p_other._size, _entries_capacity_for(_capacity)));
+		// Copy entries.
 		if constexpr (std::is_trivially_copyable_v<TKey> && std::is_trivially_copyable_v<TValue>) {
-			void *destination = _elements;
-			const void *source = p_other._elements;
-			memcpy(destination, source, sizeof(MapKeyValue) * _size);
+			memcpy(static_cast<void *>(_elements), static_cast<const void *>(p_other._elements), sizeof(KV) * p_other._size);
 		} else {
-			for (uint32_t i = 0; i < _size; i++) {
-				memnew_placement(&_elements[i], MapKeyValue(p_other._elements[i]));
+			for (uint32_t i = 0; i < p_other._size; i++) {
+				memnew_placement(&_elements[i], KV(p_other._elements[i]));
 			}
 		}
-
-		memcpy(_metadata, p_other._metadata, sizeof(Metadata) * real_capacity);
+		_size = p_other._size;
+		// Copy ctrl table verbatim, including mirror bytes.
+		memcpy(_ctrl, p_other._ctrl, p_other._capacity + kGroupWidth);
+		memcpy(_slots, p_other._slots, sizeof(uint32_t) * p_other._capacity);
+		_growth_left = p_other._growth_left;
+		_deleted = p_other._deleted;
 	}
 
 public:
 	/* Standard Godot Container API */
 
-	_FORCE_INLINE_ uint32_t get_capacity() const { return _capacity_mask + 1; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return _capacity; }
 	_FORCE_INLINE_ uint32_t size() const { return _size; }
 
 	_FORCE_INLINE_ bool is_empty() const {
@@ -287,255 +342,223 @@ public:
 	}
 
 	void clear() {
-		if (_elements == nullptr || _size == 0) {
+		if (_capacity == 0 || _size == 0) {
 			return;
 		}
-
-		memset(_metadata, EMPTY_HASH, (_capacity_mask + 1) * sizeof(Metadata));
 		if constexpr (!(std::is_trivially_destructible_v<TKey> && std::is_trivially_destructible_v<TValue>)) {
 			for (uint32_t i = 0; i < _size; i++) {
 				_elements[i].key.~TKey();
 				_elements[i].value.~TValue();
 			}
 		}
-
+		memset(_ctrl, SwissTable::kEmpty, _capacity + kGroupWidth);
 		_size = 0;
+		_deleted = 0;
+		_growth_left = SwissTable::capacity_to_growth(_capacity);
 	}
 
 	TValue &get(const TKey &p_key) {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
+		bool exists = _lookup(p_key, _hash(p_key), slot, element_idx);
 		CRASH_COND_MSG(!exists, "AHashMap key not found.");
 		return _elements[element_idx].value;
 	}
 
 	const TValue &get(const TKey &p_key) const {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
+		bool exists = _lookup(p_key, _hash(p_key), slot, element_idx);
 		CRASH_COND_MSG(!exists, "AHashMap key not found.");
 		return _elements[element_idx].value;
 	}
 
 	const TValue *getptr(const TKey &p_key) const {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-
-		if (exists) {
+		if (_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return &_elements[element_idx].value;
 		}
 		return nullptr;
 	}
 
 	TValue *getptr(const TKey &p_key) {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-
-		if (exists) {
+		if (_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return &_elements[element_idx].value;
 		}
 		return nullptr;
 	}
 
 	bool has(const TKey &p_key) const {
-		uint32_t _idx = 0;
-		uint32_t meta_idx = 0;
-		return _lookup_idx(p_key, _idx, meta_idx);
+		uint32_t slot = 0;
+		uint32_t element_idx = 0;
+		return _lookup(p_key, _hash(p_key), slot, element_idx);
 	}
 
 	bool erase(const TKey &p_key) {
-		uint32_t meta_idx = 0;
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-
-		if (!exists) {
+		if (!_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return false;
 		}
-
-		uint32_t next_meta_idx = (meta_idx + 1) & _capacity_mask;
-		while (_metadata[next_meta_idx].hash != EMPTY_HASH && _get_probe_length(next_meta_idx, _metadata[next_meta_idx].hash, _capacity_mask) != 0) {
-			SWAP(_metadata[next_meta_idx], _metadata[meta_idx]);
-
-			meta_idx = next_meta_idx;
-			next_meta_idx = (next_meta_idx + 1) & _capacity_mask;
+		const uint8_t new_ctrl = _ctrl_after_erase(slot);
+		if (new_ctrl == SwissTable::kEmpty) {
+			_growth_left++;
+		} else {
+			_deleted++;
 		}
+		_set_ctrl(slot, new_ctrl);
 
-		_metadata[meta_idx].hash = EMPTY_HASH;
+		// Destroy the element.
 		_elements[element_idx].key.~TKey();
 		_elements[element_idx].value.~TValue();
 		_size--;
 
+		// Swap-with-tail to keep entries dense. We need to update the moved
+		// entry's slot mapping BEFORE doing the actual move, because a
+		// post-move lookup would find the slot but read the (now-garbage)
+		// data at the old tail index when comparing keys.
 		if (element_idx < _size) {
-			memcpy((void *)&_elements[element_idx], (const void *)&_elements[_size], sizeof(MapKeyValue));
-			uint32_t moved_element_idx = 0;
-			uint32_t moved_meta_idx = 0;
-			_lookup_idx(_elements[_size].key, moved_element_idx, moved_meta_idx);
-			_metadata[moved_meta_idx].element_idx = element_idx;
+			uint32_t moved_slot = 0;
+			uint32_t moved_idx = 0;
+			bool found = _lookup(_elements[_size].key, _hash(_elements[_size].key), moved_slot, moved_idx);
+			(void)found;
+			DEV_ASSERT(found && moved_idx == _size);
+			_slots[moved_slot] = element_idx;
+			memcpy(static_cast<void *>(&_elements[element_idx]), static_cast<const void *>(&_elements[_size]), sizeof(KV));
 		}
 
 		return true;
 	}
 
-	// Replace the key of an entry in-place, without invalidating iterators or changing the entries position during iteration.
-	// p_old_key must exist in the map and p_new_key must not, unless it is equal to p_old_key.
+	// Replace the key of an entry in-place, without invalidating its index in
+	// the entries array. p_old_key must exist; p_new_key must not unless equal
+	// to p_old_key.
 	bool replace_key(const TKey &p_old_key, const TKey &p_new_key) {
 		if (p_old_key == p_new_key) {
 			return true;
 		}
-		uint32_t meta_idx = 0;
+		uint32_t old_slot = 0;
 		uint32_t element_idx = 0;
-		ERR_FAIL_COND_V(_lookup_idx(p_new_key, element_idx, meta_idx), false);
-		ERR_FAIL_COND_V(!_lookup_idx(p_old_key, element_idx, meta_idx), false);
-		MapKeyValue &element = _elements[element_idx];
-		const_cast<TKey &>(element.key) = p_new_key;
+		ERR_FAIL_COND_V(!_lookup(p_old_key, _hash(p_old_key), old_slot, element_idx), false);
+		uint32_t new_slot_check = 0;
+		uint32_t check_idx = 0;
+		ERR_FAIL_COND_V(_lookup(p_new_key, _hash(p_new_key), new_slot_check, check_idx), false);
 
-		uint32_t next_meta_idx = (meta_idx + 1) & _capacity_mask;
-		while (_metadata[next_meta_idx].hash != EMPTY_HASH && _get_probe_length(next_meta_idx, _metadata[next_meta_idx].hash, _capacity_mask) != 0) {
-			SWAP(_metadata[next_meta_idx], _metadata[meta_idx]);
-
-			meta_idx = next_meta_idx;
-			next_meta_idx = (next_meta_idx + 1) & _capacity_mask;
+		const uint8_t new_ctrl = _ctrl_after_erase(old_slot);
+		if (new_ctrl == SwissTable::kEmpty) {
+			_growth_left++;
+		} else {
+			_deleted++;
 		}
+		_set_ctrl(old_slot, new_ctrl);
 
-		_metadata[meta_idx].hash = EMPTY_HASH;
+		// Mutate the key in place.
+		const_cast<TKey &>(_elements[element_idx].key) = p_new_key;
 
-		uint32_t hash = _hash(p_new_key);
-		_insert_metadata(hash, element_idx);
+		// Insert into the new position. We may need to grow if the deleted slot
+		// converted to empty consumed our growth budget; check growth_left.
+		if (_growth_left == 0) {
+			_grow();
+		}
+		const uint32_t new_hash = _hash(p_new_key);
+		const uint32_t slot = _find_insert_slot(new_hash);
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
+		_set_ctrl(slot, SwissTable::h2(new_hash));
+		_slots[slot] = element_idx;
+		if (was_deleted) {
+			_deleted--;
+		}
+		_growth_left--;
 
 		return true;
 	}
 
-	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
-	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		if (_elements == nullptr) {
-			_capacity_mask = MAX(4u, p_new_capacity);
-			_capacity_mask = Math::next_power_of_2(_capacity_mask) - 1;
-			return; // Unallocated yet.
-		}
-		if (p_new_capacity <= get_capacity()) {
-			if (p_new_capacity < size()) {
+		if (p_new_capacity <= _entries_capacity_for(_capacity)) {
+			if (_capacity != 0 && p_new_capacity < _size) {
 				WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 			}
 			return;
 		}
-		_resize_and_rehash(p_new_capacity);
+		// Choose smallest power-of-two index capacity that fits p_new_capacity
+		// elements at 7/8 load factor.
+		uint32_t needed_index_capacity = SwissTable::growth_to_lower_bound_capacity(p_new_capacity);
+		uint32_t cap = _round_up_capacity(needed_index_capacity);
+		_resize_table(cap);
+		_grow_entries(MAX(p_new_capacity, _entries_capacity_for(_capacity)));
 	}
 
 	/** Iterator API **/
 
 	struct ConstIterator {
-		_FORCE_INLINE_ const MapKeyValue &operator*() const {
-			return *pair;
-		}
-		_FORCE_INLINE_ const MapKeyValue *operator->() const {
-			return pair;
-		}
+		_FORCE_INLINE_ const KV &operator*() const { return *pair; }
+		_FORCE_INLINE_ const KV *operator->() const { return pair; }
 		_FORCE_INLINE_ ConstIterator &operator++() {
 			pair++;
 			return *this;
 		}
-
 		_FORCE_INLINE_ ConstIterator &operator--() {
 			pair--;
-			if (pair < begin) {
-				pair = end;
+			if (pair < begin_ptr) {
+				pair = end_ptr;
 			}
 			return *this;
 		}
-
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return pair == b.pair; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return pair != b.pair; }
+		_FORCE_INLINE_ explicit operator bool() const { return pair != end_ptr; }
 
-		_FORCE_INLINE_ explicit operator bool() const {
-			return pair != end;
-		}
-
-		_FORCE_INLINE_ ConstIterator(MapKeyValue *p_key, MapKeyValue *p_begin, MapKeyValue *p_end) {
-			pair = p_key;
-			begin = p_begin;
-			end = p_end;
-		}
+		_FORCE_INLINE_ ConstIterator(const KV *p_pair, const KV *p_begin, const KV *p_end) :
+				pair(p_pair), begin_ptr(p_begin), end_ptr(p_end) {}
 		_FORCE_INLINE_ ConstIterator() {}
-		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_it) {
-			pair = p_it.pair;
-			begin = p_it.begin;
-			end = p_it.end;
-		}
-		_FORCE_INLINE_ void operator=(const ConstIterator &p_it) {
-			pair = p_it.pair;
-			begin = p_it.begin;
-			end = p_it.end;
-		}
+		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_it) = default;
+		_FORCE_INLINE_ ConstIterator &operator=(const ConstIterator &p_it) = default;
 
 	private:
-		MapKeyValue *pair = nullptr;
-		MapKeyValue *begin = nullptr;
-		MapKeyValue *end = nullptr;
+		const KV *pair = nullptr;
+		const KV *begin_ptr = nullptr;
+		const KV *end_ptr = nullptr;
 	};
 
 	struct Iterator {
-		_FORCE_INLINE_ MapKeyValue &operator*() const {
-			return *pair;
-		}
-		_FORCE_INLINE_ MapKeyValue *operator->() const {
-			return pair;
-		}
+		_FORCE_INLINE_ KV &operator*() const { return *pair; }
+		_FORCE_INLINE_ KV *operator->() const { return pair; }
 		_FORCE_INLINE_ Iterator &operator++() {
 			pair++;
 			return *this;
 		}
 		_FORCE_INLINE_ Iterator &operator--() {
 			pair--;
-			if (pair < begin) {
-				pair = end;
+			if (pair < begin_ptr) {
+				pair = end_ptr;
 			}
 			return *this;
 		}
-
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return pair == b.pair; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return pair != b.pair; }
+		_FORCE_INLINE_ explicit operator bool() const { return pair != end_ptr; }
 
-		_FORCE_INLINE_ explicit operator bool() const {
-			return pair != end;
-		}
-
-		_FORCE_INLINE_ Iterator(MapKeyValue *p_key, MapKeyValue *p_begin, MapKeyValue *p_end) {
-			pair = p_key;
-			begin = p_begin;
-			end = p_end;
-		}
+		_FORCE_INLINE_ Iterator(KV *p_pair, KV *p_begin, KV *p_end) :
+				pair(p_pair), begin_ptr(p_begin), end_ptr(p_end) {}
 		_FORCE_INLINE_ Iterator() {}
-		_FORCE_INLINE_ Iterator(const Iterator &p_it) {
-			pair = p_it.pair;
-			begin = p_it.begin;
-			end = p_it.end;
-		}
-		_FORCE_INLINE_ void operator=(const Iterator &p_it) {
-			pair = p_it.pair;
-			begin = p_it.begin;
-			end = p_it.end;
-		}
+		_FORCE_INLINE_ Iterator(const Iterator &p_it) = default;
+		_FORCE_INLINE_ Iterator &operator=(const Iterator &p_it) = default;
 
 		operator ConstIterator() const {
-			return ConstIterator(pair, begin, end);
+			return ConstIterator(pair, begin_ptr, end_ptr);
 		}
 
 	private:
-		MapKeyValue *pair = nullptr;
-		MapKeyValue *begin = nullptr;
-		MapKeyValue *end = nullptr;
+		KV *pair = nullptr;
+		KV *begin_ptr = nullptr;
+		KV *end_ptr = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(_elements, _elements, _elements + _size);
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(_elements + _size, _elements, _elements + _size);
-	}
+	_FORCE_INLINE_ Iterator begin() { return Iterator(_elements, _elements, _elements + _size); }
+	_FORCE_INLINE_ Iterator end() { return Iterator(_elements + _size, _elements, _elements + _size); }
 	_FORCE_INLINE_ Iterator last() {
 		if (unlikely(_size == 0)) {
 			return Iterator(nullptr, nullptr, nullptr);
@@ -544,10 +567,9 @@ public:
 	}
 
 	Iterator find(const TKey &p_key) {
-		uint32_t meta_idx = 0;
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-		if (!exists) {
+		if (!_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return end();
 		}
 		return Iterator(_elements + element_idx, _elements, _elements + _size);
@@ -559,12 +581,8 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(_elements, _elements, _elements + _size);
-	}
-	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(_elements + _size, _elements, _elements + _size);
-	}
+	_FORCE_INLINE_ ConstIterator begin() const { return ConstIterator(_elements, _elements, _elements + _size); }
+	_FORCE_INLINE_ ConstIterator end() const { return ConstIterator(_elements + _size, _elements, _elements + _size); }
 	_FORCE_INLINE_ ConstIterator last() const {
 		if (unlikely(_size == 0)) {
 			return ConstIterator(nullptr, nullptr, nullptr);
@@ -573,10 +591,9 @@ public:
 	}
 
 	ConstIterator find(const TKey &p_key) const {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-		if (!exists) {
+		if (!_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return end();
 		}
 		return ConstIterator(_elements + element_idx, _elements, _elements + _size);
@@ -585,76 +602,73 @@ public:
 	/* Indexing */
 
 	const TValue &operator[](const TKey &p_key) const {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
+		bool exists = _lookup(p_key, _hash(p_key), slot, element_idx);
 		CRASH_COND(!exists);
 		return _elements[element_idx].value;
 	}
 
 	TValue &operator[](const TKey &p_key) {
+		const uint32_t hash = _hash(p_key);
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		uint32_t hash = _hash(p_key);
-		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
-
-		if (exists) {
-			return _elements[element_idx].value;
-		} else {
-			element_idx = _insert_element(p_key, TValue(), hash);
+		if (_capacity != 0 && _lookup(p_key, hash, slot, element_idx)) {
 			return _elements[element_idx].value;
 		}
+		_ensure_allocated();
+		element_idx = _insert_new(p_key, TValue(), hash);
+		return _elements[element_idx].value;
 	}
 
 	/* Insert */
 
 	Iterator insert(const TKey &p_key, const TValue &p_value) {
+		const uint32_t hash = _hash(p_key);
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		uint32_t hash = _hash(p_key);
-		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
-
-		if (!exists) {
-			element_idx = _insert_element(p_key, p_value, hash);
-		} else {
+		if (_capacity != 0 && _lookup(p_key, hash, slot, element_idx)) {
 			_elements[element_idx].value = p_value;
+			return Iterator(_elements + element_idx, _elements, _elements + _size);
 		}
+		_ensure_allocated();
+		element_idx = _insert_new(p_key, p_value, hash);
 		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	// Inserts an element without checking if it already exists.
 	Iterator insert_new(const TKey &p_key, const TValue &p_value) {
 		DEV_ASSERT(!has(p_key));
-		uint32_t hash = _hash(p_key);
-		uint32_t element_idx = _insert_element(p_key, p_value, hash);
+		_ensure_allocated();
+		const uint32_t element_idx = _insert_new(p_key, p_value, _hash(p_key));
 		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	/* Array methods. */
 
-	// Unsafe. Changing keys and going outside the bounds of an array can lead to undefined behavior.
-	KeyValue<TKey, TValue> *get_elements_ptr() {
+	// Unsafe. Pointer is invalidated by any reserve/insert that grows the
+	// entries array, and by erases that swap with the tail.
+	KV *get_elements_ptr() {
 		return _elements;
 	}
 
 	// Returns the element index. If not found, returns -1.
 	int get_index(const TKey &p_key) {
+		uint32_t slot = 0;
 		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
-		if (!exists) {
+		if (!_lookup(p_key, _hash(p_key), slot, element_idx)) {
 			return -1;
 		}
-		return element_idx;
+		return static_cast<int>(element_idx);
 	}
 
-	KeyValue<TKey, TValue> &get_by_index(uint32_t p_index) {
+	KV &get_by_index(uint32_t p_index) {
 		CRASH_BAD_UNSIGNED_INDEX(p_index, _size);
 		return _elements[p_index];
 	}
 
 	bool erase_by_index(uint32_t p_index) {
-		if (p_index >= size()) {
+		if (p_index >= _size) {
 			return false;
 		}
 		return erase(_elements[p_index].key);
@@ -663,15 +677,25 @@ public:
 	/* Constructors */
 
 	AHashMap(AHashMap &&p_other) {
+		_ctrl = p_other._ctrl;
+		_slots = p_other._slots;
 		_elements = p_other._elements;
-		_metadata = p_other._metadata;
+		_elements_capacity = p_other._elements_capacity;
+		_capacity = p_other._capacity;
 		_capacity_mask = p_other._capacity_mask;
 		_size = p_other._size;
+		_growth_left = p_other._growth_left;
+		_deleted = p_other._deleted;
 
+		p_other._ctrl = nullptr;
+		p_other._slots = nullptr;
 		p_other._elements = nullptr;
-		p_other._metadata = nullptr;
+		p_other._elements_capacity = 0;
+		p_other._capacity = 0;
 		p_other._capacity_mask = 0;
 		p_other._size = 0;
+		p_other._growth_left = 0;
+		p_other._deleted = 0;
 	}
 
 	explicit AHashMap(const AHashMap &p_other) {
@@ -680,26 +704,21 @@ public:
 
 	void operator=(const AHashMap &p_other) {
 		if (this == &p_other) {
-			return; // Ignore self assignment.
+			return;
 		}
-
 		reset();
-
 		_init_from(p_other);
 	}
 
 	AHashMap(uint32_t p_initial_capacity) {
-		// Capacity can't be 0 and must be 2^n - 1.
-		_capacity_mask = MAX(4u, p_initial_capacity);
-		_capacity_mask = Math::next_power_of_2(_capacity_mask) - 1;
-	}
-	AHashMap() :
-			_capacity_mask(INITIAL_CAPACITY - 1) {
+		reserve(p_initial_capacity);
 	}
 
-	AHashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
+	AHashMap() {}
+
+	AHashMap(std::initializer_list<KV> p_init) {
 		reserve(p_init.size());
-		for (const KeyValue<TKey, TValue> &E : p_init) {
+		for (const KV &E : p_init) {
 			insert(E.key, E.value);
 		}
 	}
@@ -713,11 +732,20 @@ public:
 				}
 			}
 			Memory::free_static(_elements);
-			Memory::free_static(_metadata);
 			_elements = nullptr;
+			_elements_capacity = 0;
 		}
-		_capacity_mask = INITIAL_CAPACITY - 1;
+		if (_ctrl != nullptr) {
+			Memory::free_static(_ctrl);
+			Memory::free_static(_slots);
+			_ctrl = nullptr;
+			_slots = nullptr;
+		}
+		_capacity = 0;
+		_capacity_mask = 0;
 		_size = 0;
+		_growth_left = 0;
+		_deleted = 0;
 	}
 
 	~AHashMap() {

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -105,13 +105,11 @@ private:
 	uint32_t _deleted = 0; // Tombstones currently in the index table.
 
 	static _FORCE_INLINE_ uint32_t _hash(const TKey &p_key) {
-		// Apply a SwissTable-friendly bit mixer at the boundary so callers
-		// don't have to. Several Godot hashers (notably String/DJB2) leave
-		// the high bits weakly mixed; splitting them into h1/h2 directly
-		// would cluster fingerprints and inflate probe chains. The same
-		// mixed value is what we cache in _hashes[i], so that grow and the
-		// hash short-circuit in _lookup keep working consistently.
-		return SwissTable::mix(Hasher::hash(p_key));
+		// Hashers are expected to return SwissTable-ready 32-bit hashes now.
+		// We cache that exact value in _hashes[i] so grow and the hash short-
+		// circuit in _lookup stay consistent without paying a second boundary
+		// mix on every insert/lookup/erase.
+		return Hasher::hash(p_key);
 	}
 
 	// Round up to a power of two no smaller than min, and at least kGroupWidth.

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/os/memory.h"
-#include "core/string/print_string.h" // IWYU pragma: keep. `WARN_VERBOSE` macro.
+#include "core/string/print_string.h" // IWYU pragma: keep
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
 #include "core/templates/swiss_table_simd.h"
@@ -82,19 +82,13 @@ private:
 	using Mask = typename SwissTable::Group::Mask;
 	static constexpr uint32_t kGroupWidth = SwissTable::Group::kWidth;
 
-	// Index table:
-	//   _ctrl: capacity + kGroupWidth control bytes (the trailing bytes mirror
-	//          the leading ones so group probing can wrap-overshoot safely).
-	//   _slots: capacity entry indices (uint32_t each), parallel to _ctrl[0..capacity).
+	// Index table.
 	uint8_t *_ctrl = nullptr;
 	uint32_t *_slots = nullptr;
 
-	// Dense entries store (insertion order is NOT preserved on erase).
+	// Dense entries (insertion order is not preserved on erase).
 	KV *_elements = nullptr;
-	// Parallel cached 32-bit hashes, sized identically to _elements. Stored
-	// at insert time so probes can short-circuit before a (potentially
-	// expensive) key compare and so rehashing on grow doesn't have to re-run
-	// Hasher on the key.
+	// Parallel cached 32-bit hashes.
 	uint32_t *_hashes = nullptr;
 	uint32_t _elements_capacity = 0;
 
@@ -105,14 +99,10 @@ private:
 	uint32_t _deleted = 0; // Tombstones currently in the index table.
 
 	static _FORCE_INLINE_ uint32_t _hash(const TKey &p_key) {
-		// Hashers are expected to return SwissTable-ready 32-bit hashes now.
-		// We cache that exact value in _hashes[i] so grow and the hash short-
-		// circuit in _lookup stay consistent without paying a second boundary
-		// mix on every insert/lookup/erase.
 		return Hasher::hash(p_key);
 	}
 
-	// Round up to a power of two no smaller than min, and at least kGroupWidth.
+	// Round up to a power of two no smaller than min.
 	static _FORCE_INLINE_ uint32_t _round_up_capacity(uint32_t p_min) {
 		uint32_t cap = kGroupWidth;
 		while (cap < p_min) {
@@ -121,10 +111,7 @@ private:
 		return cap;
 	}
 
-	// Find the slot containing p_key. Returns true if found, with r_slot_idx
-	// set to the slot index in _ctrl/_slots and r_element_idx to the index in
-	// _elements. Uses the cached 32-bit hash on each candidate to short-
-	// circuit before the (potentially expensive) key compare.
+	// Find the slot containing p_key. Returns true if found.
 	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx, uint32_t &r_element_idx) const {
 		if (_capacity == 0) {
 			return false;
@@ -147,24 +134,15 @@ private:
 					return true;
 				}
 			}
-			// If this group has any empty slot, the key cannot be further along
-			// the probe sequence (deletes are tombstones, empties are not).
 			if (g.match_empty()) {
 				return false;
 			}
 			probe_dist += kGroupWidth;
-			// Quadratic probing across groups; bounded by capacity (always succeeds
-			// because we maintain at least one empty slot in the table).
 			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
 	}
 
-	// Combined "lookup if present, otherwise pick insert slot" probe used
-	// by insert and operator[]. Returns true if the key is already in the
-	// table (with r_slot_idx / r_element_idx set to the existing entry);
-	// returns false with r_slot_idx pointing at a kEmpty/kDeleted slot
-	// where the new entry should be placed.
-	//
+	// Find an existing key or the slot to insert into.
 	// Caller must ensure _capacity > 0 and _growth_left > 0.
 	bool _find_or_prepare_insert(const TKey &p_key, uint32_t p_hash,
 			uint32_t &r_slot_idx, uint32_t &r_element_idx) const {
@@ -222,26 +200,11 @@ private:
 		}
 	}
 
-	// Decide whether an erased slot can become kEmpty (so it doesn't
-	// permanently consume probe-chain length) or must remain a kDeleted
-	// tombstone. With unaligned probing, the promotion to kEmpty is only
-	// safe when no probe sequence could ever have been forced to skip past
-	// this slot while it was full -- approximated by requiring an empty in
-	// both the kGroupWidth-window immediately after AND immediately before
-	// the slot, with no run of kGroupWidth full bytes in between. This
-	// matches absl::container_internal::WasNeverFull.
+	// Decide whether an erased slot can become kEmpty or must remain a tombstone.
 	_FORCE_INLINE_ uint8_t _ctrl_after_erase(uint32_t p_slot_idx) const {
-		// Single-group tables: no probe sequence ever leaves the group, so
-		// converting an erased slot to empty is always safe.
 		if (_capacity <= kGroupWidth) {
 			return SwissTable::kEmpty;
 		}
-		// SIMD-scan the kGroupWidth-byte windows AFTER and BEFORE p_slot_idx
-		// for kEmpty. Both reads are single unaligned loads -- the trailing
-		// read stays in-bounds because of the mirror tail past _capacity, and
-		// the leading read of the kGroupWidth bytes ending at p_slot_idx - 1
-		// is in-bounds for any p_slot_idx since the wrap case
-		// (p_slot_idx < kGroupWidth) lands its tail in that same mirror.
 		const SwissTable::Group g_after(_ctrl + p_slot_idx);
 		const Mask after_empty = g_after.match_empty();
 		if (!after_empty) {
@@ -252,9 +215,6 @@ private:
 		const uint32_t lead_start = (p_slot_idx - kGroupWidth) & _capacity_mask;
 		const SwissTable::Group g_before(_ctrl + lead_start);
 		const Mask before_empty = g_before.match_empty();
-		// Slot at position k within g_before is (kGroupWidth - 1 - k) bytes
-		// before p_slot_idx, so the closest kEmpty corresponds to the highest
-		// set bit. No empty -> full kGroupWidth-byte run, force kDeleted.
 		const uint32_t leading = before_empty
 				? ((kGroupWidth - 1u) - before_empty.highest_set_bit())
 				: kGroupWidth;
@@ -373,15 +333,10 @@ private:
 			return;
 		}
 		_resize_table(p_other._capacity);
-		// Match the source's full entries-array capacity, not just its current
-		// size. The index table copied below was sized for `p_other._capacity`
-		// and still has growth_left slots available without rehashing; if we
-		// only allocate `p_other._size` entries here, subsequent inserts will
-		// happily write past the entries array before the next grow.
 		_grow_entries(MAX(p_other._size, _entries_capacity_for(_capacity)));
 		// Copy entries.
 		if constexpr (std::is_trivially_copyable_v<TKey> && std::is_trivially_copyable_v<TValue>) {
-			memcpy(static_cast<void *>(_elements), static_cast<const void *>(p_other._elements), sizeof(KV) * p_other._size);
+			memcpy(_elements, p_other._elements, sizeof(KV) * p_other._size);
 		} else {
 			for (uint32_t i = 0; i < p_other._size; i++) {
 				memnew_placement(&_elements[i], KV(p_other._elements[i]));
@@ -482,12 +437,7 @@ public:
 		_elements[element_idx].value.~TValue();
 		_size--;
 
-		// Swap-with-tail to keep entries dense. We need to update the moved
-		// entry's slot mapping BEFORE doing the actual move, because a
-		// post-move lookup would find the slot but read the (now-garbage)
-		// data at the old tail index when comparing keys. We use the cached
-		// hash on the tail entry to drive the lookup so we don't re-run
-		// Hasher on the moved key.
+		// Swap with the tail to keep entries dense.
 		if (element_idx < _size) {
 			uint32_t moved_slot = 0;
 			uint32_t moved_idx = 0;

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -90,6 +90,7 @@ private:
 	KV *_elements = nullptr;
 	// Parallel cached 32-bit hashes.
 	uint32_t *_hashes = nullptr;
+	uint32_t *_reverse_slots = nullptr;
 	uint32_t _elements_capacity = 0;
 
 	uint32_t _capacity = 0; // Power of two, or 0 if unallocated.
@@ -261,6 +262,7 @@ private:
 			const uint32_t slot = _find_insert_slot(hash);
 			_set_ctrl(slot, SwissTable::h2(hash));
 			_slots[slot] = i;
+			_reverse_slots[i] = slot;
 			_growth_left--;
 		}
 
@@ -278,6 +280,8 @@ private:
 				Memory::realloc_static(_elements, sizeof(KV) * p_new_capacity));
 		_hashes = reinterpret_cast<uint32_t *>(
 				Memory::realloc_static(_hashes, sizeof(uint32_t) * p_new_capacity));
+		_reverse_slots = reinterpret_cast<uint32_t *>(
+				Memory::realloc_static(_reverse_slots, sizeof(uint32_t) * p_new_capacity));
 		_elements_capacity = p_new_capacity;
 	}
 
@@ -300,6 +304,16 @@ private:
 		_grow_entries(_entries_capacity_for(_capacity));
 	}
 
+	void _prepare_insert() {
+		if (_growth_left == 0) {
+			if (_deleted != 0) {
+				_resize_table(_capacity);
+			} else {
+				_grow();
+			}
+		}
+	}
+
 	// Place a new element at the given (already chosen) slot. The slot must
 	// currently be kEmpty or kDeleted, and the caller must have already
 	// guaranteed _growth_left > 0 and that the entries array has room.
@@ -311,6 +325,7 @@ private:
 		_slots[p_slot] = element_idx;
 		memnew_placement(&_elements[element_idx], KV(p_key, p_value));
 		_hashes[element_idx] = p_hash;
+		_reverse_slots[element_idx] = p_slot;
 		_size++;
 		if (was_deleted) {
 			_deleted--;
@@ -321,9 +336,7 @@ private:
 
 	// Insert with the assumption that p_key does not already exist.
 	uint32_t _insert_new(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
-		if (_growth_left == 0) {
-			_grow();
-		}
+		_prepare_insert();
 		const uint32_t slot = _find_insert_slot(p_hash);
 		return _emplace_at_slot(p_key, p_value, p_hash, slot);
 	}
@@ -344,6 +357,7 @@ private:
 		}
 		// Copy parallel hash array.
 		memcpy(_hashes, p_other._hashes, sizeof(uint32_t) * p_other._size);
+		memcpy(_reverse_slots, p_other._reverse_slots, sizeof(uint32_t) * p_other._size);
 		_size = p_other._size;
 		// Copy ctrl table verbatim, including mirror bytes.
 		memcpy(_ctrl, p_other._ctrl, p_other._capacity + kGroupWidth);
@@ -363,7 +377,7 @@ public:
 	}
 
 	void clear() {
-		if (_capacity == 0 || _size == 0) {
+		if (_capacity == 0 || (_size == 0 && _deleted == 0)) {
 			return;
 		}
 		if constexpr (!(std::is_trivially_destructible_v<TKey> && std::is_trivially_destructible_v<TValue>)) {
@@ -439,14 +453,11 @@ public:
 
 		// Swap with the tail to keep entries dense.
 		if (element_idx < _size) {
-			uint32_t moved_slot = 0;
-			uint32_t moved_idx = 0;
-			bool found = _lookup(_elements[_size].key, _hashes[_size], moved_slot, moved_idx);
-			(void)found;
-			DEV_ASSERT(found && moved_idx == _size);
+			const uint32_t moved_slot = _reverse_slots[_size];
 			_slots[moved_slot] = element_idx;
 			memcpy(static_cast<void *>(&_elements[element_idx]), static_cast<const void *>(&_elements[_size]), sizeof(KV));
 			_hashes[element_idx] = _hashes[_size];
+			_reverse_slots[element_idx] = moved_slot;
 		}
 
 		return true;
@@ -481,13 +492,12 @@ public:
 
 		// Insert into the new position. We may need to grow if the deleted slot
 		// converted to empty consumed our growth budget; check growth_left.
-		if (_growth_left == 0) {
-			_grow();
-		}
+		_prepare_insert();
 		const uint32_t slot = _find_insert_slot(new_hash);
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
 		_set_ctrl(slot, SwissTable::h2(new_hash));
 		_slots[slot] = element_idx;
+		_reverse_slots[element_idx] = slot;
 		if (was_deleted) {
 			_deleted--;
 		}
@@ -632,9 +642,7 @@ public:
 	TValue &operator[](const TKey &p_key) {
 		const uint32_t hash = _hash(p_key);
 		_ensure_allocated();
-		if (_growth_left == 0) {
-			_grow();
-		}
+		_prepare_insert();
 		uint32_t slot = 0;
 		uint32_t element_idx = 0;
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot, element_idx)) {
@@ -652,9 +660,7 @@ public:
 	Iterator insert(const TKey &p_key, const TValue &p_value) {
 		const uint32_t hash = _hash(p_key);
 		_ensure_allocated();
-		if (_growth_left == 0) {
-			_grow();
-		}
+		_prepare_insert();
 		uint32_t slot = 0;
 		uint32_t element_idx = 0;
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot, element_idx)) {
@@ -713,6 +719,7 @@ public:
 		_slots = p_other._slots;
 		_elements = p_other._elements;
 		_hashes = p_other._hashes;
+		_reverse_slots = p_other._reverse_slots;
 		_elements_capacity = p_other._elements_capacity;
 		_capacity = p_other._capacity;
 		_capacity_mask = p_other._capacity_mask;
@@ -724,6 +731,7 @@ public:
 		p_other._slots = nullptr;
 		p_other._elements = nullptr;
 		p_other._hashes = nullptr;
+		p_other._reverse_slots = nullptr;
 		p_other._elements_capacity = 0;
 		p_other._capacity = 0;
 		p_other._capacity_mask = 0;
@@ -772,6 +780,10 @@ public:
 		if (_hashes != nullptr) {
 			Memory::free_static(_hashes);
 			_hashes = nullptr;
+		}
+		if (_reverse_slots != nullptr) {
+			Memory::free_static(_reverse_slots);
+			_reverse_slots = nullptr;
 		}
 		if (_ctrl != nullptr) {
 			Memory::free_static(_ctrl);

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -238,30 +238,28 @@ private:
 		if (_capacity <= kGroupWidth) {
 			return SwissTable::kEmpty;
 		}
-		// Trailing: number of consecutive non-empty bytes starting AT the
-		// slot (looking forward). We scan up to kGroupWidth bytes; the
-		// trailing-mirror region of _ctrl makes the read safe even if the
-		// slot is near the end of the index table.
-		uint32_t trailing = 0;
-		while (trailing < kGroupWidth && _ctrl[p_slot_idx + trailing] != SwissTable::kEmpty) {
-			trailing++;
-		}
-		if (trailing == kGroupWidth) {
+		// SIMD-scan the kGroupWidth-byte windows AFTER and BEFORE p_slot_idx
+		// for kEmpty. Both reads are single unaligned loads -- the trailing
+		// read stays in-bounds because of the mirror tail past _capacity, and
+		// the leading read of the kGroupWidth bytes ending at p_slot_idx - 1
+		// is in-bounds for any p_slot_idx since the wrap case
+		// (p_slot_idx < kGroupWidth) lands its tail in that same mirror.
+		const SwissTable::Group g_after(_ctrl + p_slot_idx);
+		const Mask after_empty = g_after.match_empty();
+		if (!after_empty) {
 			return SwissTable::kDeleted;
 		}
-		// Leading: number of consecutive non-empty bytes ending JUST BEFORE
-		// the slot (looking backward, with wrap).
-		uint32_t leading = 0;
-		while (leading < kGroupWidth) {
-			const uint32_t idx = (p_slot_idx + _capacity - 1 - leading) & _capacity_mask;
-			if (_ctrl[idx] == SwissTable::kEmpty) {
-				break;
-			}
-			leading++;
-		}
-		// Promote to empty only when the run of non-empties surrounding the
-		// slot is shorter than one full group window -- meaning no probe
-		// could have been forced to scan a full group through this slot.
+		const uint32_t trailing = after_empty.lowest_set_bit();
+
+		const uint32_t lead_start = (p_slot_idx - kGroupWidth) & _capacity_mask;
+		const SwissTable::Group g_before(_ctrl + lead_start);
+		const Mask before_empty = g_before.match_empty();
+		// Slot at position k within g_before is (kGroupWidth - 1 - k) bytes
+		// before p_slot_idx, so the closest kEmpty corresponds to the highest
+		// set bit. No empty -> full kGroupWidth-byte run, force kDeleted.
+		const uint32_t leading = before_empty
+				? ((kGroupWidth - 1u) - before_empty.highest_set_bit())
+				: kGroupWidth;
 		if (trailing + leading < kGroupWidth) {
 			return SwissTable::kEmpty;
 		}

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -47,12 +47,12 @@
  *   - _ctrl[capacity + kGroupWidth]: control bytes (h2 / kEmpty / kDeleted),
  *     with the leading kGroupWidth bytes mirrored at the tail so groups can
  *     overshoot safely.
- *   - _slots[capacity]: handle per slot to the owning HashMapElement
- *     (kInvalidHandle if empty/deleted).
+ *   - _slots[capacity]: adaptive-width handle per slot to the owning
+ *     HashMapElement (kInvalidHandle if empty/deleted).
  *   - Entry payload storage lives in stable arena pages. Handles index into
  *     those pages and remain valid until that specific entry is erased.
- *   - Per-handle metadata (cached hash, prev/next insertion-order links,
- *     alive/free-list state) lives in dense side arrays, so lookup and
+ *   - Per-handle metadata (cached hash plus prev/next insertion-order or
+ *     free-list links) lives in one co-allocated dense block, so lookup and
  *     unlinking do not have to touch the full key/value payload unless a
  *     candidate slot survives the hash/fingerprint filters.
  *
@@ -103,15 +103,15 @@ private:
 
 	// Index table.
 	uint8_t *_ctrl = nullptr;
-	uint32_t *_slots = nullptr;
+	void *_slots = nullptr;
+	uint8_t _slot_width = sizeof(uint32_t);
 
-	// Stable entry payload arena and dense per-handle metadata.
+	// Stable entry payload arena and co-allocated dense per-handle metadata.
 	void **_payload_pages = nullptr;
-	uint8_t *_entry_alive = nullptr;
+	uint8_t *_entry_meta_block = nullptr;
 	uint32_t *_entry_hashes = nullptr;
 	uint32_t *_next_handles = nullptr;
 	uint32_t *_prev_handles = nullptr;
-	uint32_t *_free_next = nullptr;
 	uint32_t _entry_page_count = 0;
 	uint32_t _entry_capacity = 0;
 	uint32_t _entry_count = 0;
@@ -141,7 +141,54 @@ private:
 	}
 
 	_FORCE_INLINE_ Payload *_payload_from_slot(uint32_t p_slot_idx) const {
-		return _payload_from_handle(_slots[p_slot_idx]);
+		return _payload_from_handle(_get_slot(p_slot_idx));
+	}
+
+	_FORCE_INLINE_ static uint8_t _slot_width_for_handle_count(uint32_t p_handle_count) {
+		if (p_handle_count <= UINT8_MAX) {
+			return sizeof(uint8_t);
+		}
+		if (p_handle_count <= UINT16_MAX) {
+			return sizeof(uint16_t);
+		}
+		return sizeof(uint32_t);
+	}
+
+	_FORCE_INLINE_ uint8_t _slot_width_for_capacity(uint32_t p_capacity) const {
+		return _slot_width_for_handle_count(MAX(_entry_count, SwissTable::capacity_to_growth(p_capacity)));
+	}
+
+	_FORCE_INLINE_ uint32_t _get_slot(uint32_t p_slot_idx) const {
+		switch (_slot_width) {
+			case sizeof(uint8_t): {
+				const uint8_t handle = static_cast<const uint8_t *>(_slots)[p_slot_idx];
+				return handle == UINT8_MAX ? kInvalidHandle : handle;
+			}
+			case sizeof(uint16_t): {
+				const uint16_t handle = static_cast<const uint16_t *>(_slots)[p_slot_idx];
+				return handle == UINT16_MAX ? kInvalidHandle : handle;
+			}
+			default: {
+				const uint32_t handle = static_cast<const uint32_t *>(_slots)[p_slot_idx];
+				return handle == UINT32_MAX ? kInvalidHandle : handle;
+			}
+		}
+	}
+
+	_FORCE_INLINE_ void _set_slot(uint32_t p_slot_idx, uint32_t p_handle) {
+		switch (_slot_width) {
+			case sizeof(uint8_t): {
+				CRASH_COND(p_handle != kInvalidHandle && p_handle >= UINT8_MAX);
+				static_cast<uint8_t *>(_slots)[p_slot_idx] = p_handle == kInvalidHandle ? UINT8_MAX : static_cast<uint8_t>(p_handle);
+			} break;
+			case sizeof(uint16_t): {
+				CRASH_COND(p_handle != kInvalidHandle && p_handle >= UINT16_MAX);
+				static_cast<uint16_t *>(_slots)[p_slot_idx] = p_handle == kInvalidHandle ? UINT16_MAX : static_cast<uint16_t>(p_handle);
+			} break;
+			default: {
+				static_cast<uint32_t *>(_slots)[p_slot_idx] = p_handle;
+			} break;
+		}
 	}
 
 	void _ensure_entry_metadata_capacity(uint32_t p_min_capacity) {
@@ -153,35 +200,26 @@ private:
 			new_capacity <<= 1;
 		}
 
-		uint8_t *new_entry_alive = reinterpret_cast<uint8_t *>(Memory::alloc_static(sizeof(uint8_t) * new_capacity));
-		uint32_t *new_entry_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
-		uint32_t *new_next_handles = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
-		uint32_t *new_prev_handles = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
-		uint32_t *new_free_next = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		uint8_t *new_entry_meta_block = reinterpret_cast<uint8_t *>(
+				Memory::alloc_static(sizeof(uint32_t) * new_capacity * 3));
+		uint32_t *new_entry_hashes = reinterpret_cast<uint32_t *>(new_entry_meta_block);
+		uint32_t *new_next_handles = new_entry_hashes + new_capacity;
+		uint32_t *new_prev_handles = new_next_handles + new_capacity;
 		if (_entry_capacity > 0) {
-			memcpy(new_entry_alive, _entry_alive, sizeof(uint8_t) * _entry_capacity);
 			memcpy(new_entry_hashes, _entry_hashes, sizeof(uint32_t) * _entry_capacity);
 			memcpy(new_next_handles, _next_handles, sizeof(uint32_t) * _entry_capacity);
 			memcpy(new_prev_handles, _prev_handles, sizeof(uint32_t) * _entry_capacity);
-			memcpy(new_free_next, _free_next, sizeof(uint32_t) * _entry_capacity);
-			Memory::free_static(_entry_alive);
-			Memory::free_static(_entry_hashes);
-			Memory::free_static(_next_handles);
-			Memory::free_static(_prev_handles);
-			Memory::free_static(_free_next);
+			Memory::free_static(_entry_meta_block);
 		}
-		memset(new_entry_alive + _entry_capacity, 0, sizeof(uint8_t) * (new_capacity - _entry_capacity));
 		for (uint32_t i = _entry_capacity; i < new_capacity; i++) {
 			new_entry_hashes[i] = 0;
 			new_next_handles[i] = kInvalidHandle;
 			new_prev_handles[i] = kInvalidHandle;
-			new_free_next[i] = kInvalidHandle;
 		}
-		_entry_alive = new_entry_alive;
+		_entry_meta_block = new_entry_meta_block;
 		_entry_hashes = new_entry_hashes;
 		_next_handles = new_next_handles;
 		_prev_handles = new_prev_handles;
-		_free_next = new_free_next;
 		_entry_capacity = new_capacity;
 	}
 
@@ -206,8 +244,8 @@ private:
 	uint32_t _allocate_handle() {
 		if (_free_head != kInvalidHandle) {
 			const uint32_t handle = _free_head;
-			_free_head = _free_next[handle];
-			_free_next[handle] = kInvalidHandle;
+			_free_head = _next_handles[handle];
+			_next_handles[handle] = kInvalidHandle;
 			return handle;
 		}
 
@@ -219,39 +257,19 @@ private:
 
 	void _destroy_entry(uint32_t p_handle) {
 		_payload_from_handle(p_handle)->~Payload();
-		_entry_alive[p_handle] = 0;
 		_entry_hashes[p_handle] = 0;
-		_next_handles[p_handle] = kInvalidHandle;
 		_prev_handles[p_handle] = kInvalidHandle;
-		_free_next[p_handle] = _free_head;
+		_next_handles[p_handle] = _free_head;
 		_free_head = p_handle;
 	}
 
 	void _free_all_entry_storage() {
-		if (_entry_alive != nullptr) {
-			for (uint32_t handle = 0; handle < _entry_count; handle++) {
-				if (_entry_alive[handle] != 0) {
-					_payload_from_handle(handle)->~Payload();
-				}
-			}
-			Memory::free_static(_entry_alive);
-			_entry_alive = nullptr;
-		}
-		if (_entry_hashes != nullptr) {
-			Memory::free_static(_entry_hashes);
+		if (_entry_meta_block != nullptr) {
+			Memory::free_static(_entry_meta_block);
+			_entry_meta_block = nullptr;
 			_entry_hashes = nullptr;
-		}
-		if (_next_handles != nullptr) {
-			Memory::free_static(_next_handles);
 			_next_handles = nullptr;
-		}
-		if (_prev_handles != nullptr) {
-			Memory::free_static(_prev_handles);
 			_prev_handles = nullptr;
-		}
-		if (_free_next != nullptr) {
-			Memory::free_static(_free_next);
-			_free_next = nullptr;
 		}
 		if (_payload_pages != nullptr) {
 			for (uint32_t i = 0; i < _entry_page_count; i++) {
@@ -299,7 +317,7 @@ private:
 			while (it.has_next()) {
 				const uint32_t i = it.next();
 				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
-				const uint32_t handle = _slots[slot_idx];
+				const uint32_t handle = _get_slot(slot_idx);
 				Payload *payload = _payload_from_handle(handle);
 				if (_entry_hashes[handle] == p_hash && Comparator::compare(payload->key, p_key)) {
 					r_slot_idx = slot_idx;
@@ -331,7 +349,7 @@ private:
 			while (it.has_next()) {
 				const uint32_t i = it.next();
 				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
-				const uint32_t handle = _slots[slot_idx];
+				const uint32_t handle = _get_slot(slot_idx);
 				Payload *payload = _payload_from_handle(handle);
 				if (_entry_hashes[handle] == p_hash && Comparator::compare(payload->key, p_key)) {
 					r_slot_idx = slot_idx;
@@ -380,18 +398,17 @@ private:
 		const uint32_t new_capacity = MAX(p_new_capacity, kGroupWidth);
 		uint8_t *new_ctrl = reinterpret_cast<uint8_t *>(
 				Memory::alloc_static(sizeof(uint8_t) * (new_capacity + kGroupWidth)));
-		uint32_t *new_slots = reinterpret_cast<uint32_t *>(
-				Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		const uint8_t new_slot_width = _slot_width_for_capacity(new_capacity);
+		void *new_slots = Memory::alloc_static(size_t(new_slot_width) * new_capacity);
 		memset(new_ctrl, SwissTable::kEmpty, new_capacity + kGroupWidth);
-		for (uint32_t i = 0; i < new_capacity; i++) {
-			new_slots[i] = kInvalidHandle;
-		}
+		memset(new_slots, 0xFF, size_t(new_slot_width) * new_capacity);
 
 		uint8_t *old_ctrl = _ctrl;
-		uint32_t *old_slots = _slots;
+		void *old_slots = _slots;
 
 		_ctrl = new_ctrl;
 		_slots = new_slots;
+		_slot_width = new_slot_width;
 		_capacity = new_capacity;
 		_capacity_mask = new_capacity - 1;
 		_growth_left = SwissTable::capacity_to_growth(new_capacity);
@@ -405,7 +422,7 @@ private:
 			const uint32_t hash = _entry_hashes[handle];
 			const uint32_t slot = _find_insert_slot(hash);
 			_set_ctrl(slot, SwissTable::h2(hash));
-			_slots[slot] = handle;
+			_set_slot(slot, handle);
 			_growth_left--;
 		}
 
@@ -498,10 +515,9 @@ private:
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[p_slot]);
 		const uint32_t handle = _allocate_handle();
 		Payload *payload = memnew_placement(_payload_from_handle(handle), Payload(p_key, p_value));
-		_entry_alive[handle] = 1;
 		_entry_hashes[handle] = p_hash;
 		_set_ctrl(p_slot, SwissTable::h2(p_hash));
-		_slots[p_slot] = handle;
+		_set_slot(p_slot, handle);
 		_link_after_alloc(handle, p_front_insert);
 		_size++;
 		if (was_deleted) {
@@ -659,7 +675,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return false;
 		}
-		const uint32_t handle = _slots[slot];
+		const uint32_t handle = _get_slot(slot);
 		const uint8_t new_ctrl = _ctrl_after_erase(slot);
 		if (new_ctrl == SwissTable::kEmpty) {
 			_growth_left++;
@@ -667,9 +683,9 @@ public:
 			_deleted++;
 		}
 		_set_ctrl(slot, new_ctrl);
-		// Leave _slots[slot] dangling: any subsequent reader (lookup,
+		// Leave the slot payload dangling: any subsequent reader (lookup,
 		// resize, iteration) gates on _ctrl[slot] being kEmpty/kDeleted
-		// before consulting _slots, so this write is dead and skipping it
+		// before consulting the slot array, so this write is dead and skipping it
 		// shaves a small amount off the erase hot path.
 		_unlink(handle);
 		_destroy_entry(handle);
@@ -690,7 +706,7 @@ public:
 		ERR_FAIL_COND_V(_lookup(p_new_key, new_hash, check_slot), false);
 		uint32_t old_slot = 0;
 		ERR_FAIL_COND_V(!_lookup(p_old_key, _hash(p_old_key), old_slot), false);
-		const uint32_t handle = _slots[old_slot];
+		const uint32_t handle = _get_slot(old_slot);
 		Payload *payload = _payload_from_handle(handle);
 
 		// Vacate the old slot.
@@ -701,7 +717,7 @@ public:
 			_deleted++;
 		}
 		_set_ctrl(old_slot, new_ctrl);
-		_slots[old_slot] = kInvalidHandle;
+		_set_slot(old_slot, kInvalidHandle);
 
 		// KeyValue::key is const TKey.
 		const_cast<TKey &>(payload->key) = p_new_key;
@@ -711,7 +727,7 @@ public:
 		const uint32_t target = _find_insert_slot(new_hash);
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[target]);
 		_set_ctrl(target, SwissTable::h2(new_hash));
-		_slots[target] = handle;
+		_set_slot(target, handle);
 		if (was_deleted) {
 			_deleted--;
 		} else {
@@ -849,7 +865,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return Iterator(this, _slots[slot]);
+		return Iterator(this, _get_slot(slot));
 	}
 
 	_FORCE_INLINE_ void remove(const Iterator &p_iter) {
@@ -873,7 +889,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return ConstIterator(this, _slots[slot]);
+		return ConstIterator(this, _get_slot(slot));
 	}
 
 	/* Indexing */
@@ -912,13 +928,13 @@ public:
 		uint32_t slot = 0;
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
 			_payload_from_slot(slot)->value = p_value;
-			return Iterator(this, _slots[slot]);
+			return Iterator(this, _get_slot(slot));
 		}
 		if (_size == 0) {
 			slot = _find_insert_slot(hash);
 		}
 		_emplace_at_slot(p_key, p_value, hash, slot, p_front_insert);
-		return Iterator(this, _slots[slot]);
+		return Iterator(this, _get_slot(slot));
 	}
 
 	/* Constructors */
@@ -942,12 +958,12 @@ public:
 	HashMap(HashMap &&p_other) {
 		_ctrl = p_other._ctrl;
 		_slots = p_other._slots;
+		_slot_width = p_other._slot_width;
 		_payload_pages = p_other._payload_pages;
-		_entry_alive = p_other._entry_alive;
+		_entry_meta_block = p_other._entry_meta_block;
 		_entry_hashes = p_other._entry_hashes;
 		_next_handles = p_other._next_handles;
 		_prev_handles = p_other._prev_handles;
-		_free_next = p_other._free_next;
 		_entry_page_count = p_other._entry_page_count;
 		_entry_capacity = p_other._entry_capacity;
 		_entry_count = p_other._entry_count;
@@ -963,12 +979,12 @@ public:
 
 		p_other._ctrl = nullptr;
 		p_other._slots = nullptr;
+		p_other._slot_width = sizeof(uint32_t);
 		p_other._payload_pages = nullptr;
-		p_other._entry_alive = nullptr;
+		p_other._entry_meta_block = nullptr;
 		p_other._entry_hashes = nullptr;
 		p_other._next_handles = nullptr;
 		p_other._prev_handles = nullptr;
-		p_other._free_next = nullptr;
 		p_other._entry_page_count = 0;
 		p_other._entry_capacity = 0;
 		p_other._entry_count = 0;
@@ -1010,12 +1026,12 @@ public:
 
 		_ctrl = p_other._ctrl;
 		_slots = p_other._slots;
+		_slot_width = p_other._slot_width;
 		_payload_pages = p_other._payload_pages;
-		_entry_alive = p_other._entry_alive;
+		_entry_meta_block = p_other._entry_meta_block;
 		_entry_hashes = p_other._entry_hashes;
 		_next_handles = p_other._next_handles;
 		_prev_handles = p_other._prev_handles;
-		_free_next = p_other._free_next;
 		_entry_page_count = p_other._entry_page_count;
 		_entry_capacity = p_other._entry_capacity;
 		_entry_count = p_other._entry_count;
@@ -1031,12 +1047,12 @@ public:
 
 		p_other._ctrl = nullptr;
 		p_other._slots = nullptr;
+		p_other._slot_width = sizeof(uint32_t);
 		p_other._payload_pages = nullptr;
-		p_other._entry_alive = nullptr;
+		p_other._entry_meta_block = nullptr;
 		p_other._entry_hashes = nullptr;
 		p_other._next_handles = nullptr;
 		p_other._prev_handles = nullptr;
-		p_other._free_next = nullptr;
 		p_other._entry_page_count = 0;
 		p_other._entry_capacity = 0;
 		p_other._entry_count = 0;
@@ -1069,7 +1085,7 @@ public:
 		if (c == SwissTable::kEmpty || c == SwissTable::kDeleted) {
 			return 0;
 		}
-		const uint32_t handle = _slots[p_idx];
+		const uint32_t handle = _get_slot(p_idx);
 		return handle != kInvalidHandle ? _entry_hashes[handle] : 0;
 	}
 	Iterator debug_get_element(uint32_t p_idx) {
@@ -1077,7 +1093,7 @@ public:
 			return Iterator();
 		}
 		ERR_FAIL_INDEX_V(p_idx, _capacity, Iterator());
-		const uint32_t handle = _slots[p_idx];
+		const uint32_t handle = _get_slot(p_idx);
 		if (handle == kInvalidHandle) {
 			return Iterator();
 		}

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -119,13 +119,11 @@ private:
 	uint32_t _pending_capacity = 0;
 
 	_FORCE_INLINE_ static uint32_t _hash(const TKey &p_key) {
-		// Apply a SwissTable-friendly bit mixer at the boundary so callers
-		// don't have to. Several Godot hashers (notably String/DJB2) leave
-		// the high bits weakly mixed; splitting them into h1/h2 directly
-		// would cluster fingerprints and inflate probe chains. The same
-		// mixed value is what we cache on Element::hash, so that grow and
-		// the hash short-circuit in _lookup keep working consistently.
-		return SwissTable::mix(Hasher::hash(p_key));
+		// Hashers are expected to return SwissTable-ready 32-bit hashes now.
+		// We cache that exact value on the element so grow and the hash
+		// short-circuit in _lookup stay consistent without paying a second
+		// boundary mix on every insert/lookup/erase.
+		return Hasher::hash(p_key);
 	}
 
 	static _FORCE_INLINE_ uint32_t _round_up_capacity(uint32_t p_min) {

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -33,8 +33,8 @@
 #include "core/os/memory.h"
 #include "core/string/print_string.h" // IWYU pragma: keep. `WARN_VERBOSE` macro.
 #include "core/templates/hashfuncs.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
-#include "core/templates/sort_list.h"
 #include "core/templates/swiss_table_simd.h"
 
 #include <initializer_list>
@@ -47,12 +47,14 @@
  *   - _ctrl[capacity + kGroupWidth]: control bytes (h2 / kEmpty / kDeleted),
  *     with the leading kGroupWidth bytes mirrored at the tail so groups can
  *     overshoot safely.
- *   - _slots[capacity]: pointer per slot to the owning HashMapElement (or null
- *     if empty/deleted).
- *   - HashMapElement holds key/value plus prev/next pointers for the
- *     intrusive insertion-order doubly linked list (rooted at _head_element /
- *     _tail_element). The physical placement of HashMapElement in memory is
- *     independent of its position in the index table.
+ *   - _slots[capacity]: handle per slot to the owning HashMapElement
+ *     (kInvalidHandle if empty/deleted).
+ *   - Entry payload storage lives in stable arena pages. Handles index into
+ *     those pages and remain valid until that specific entry is erased.
+ *   - Per-handle metadata (cached hash, prev/next insertion-order links,
+ *     alive/free-list state) lives in dense side arrays, so lookup and
+ *     unlinking do not have to touch the full key/value payload unless a
+ *     candidate slot survives the hash/fingerprint filters.
  *
  * Properties:
  *   - Pointer stability: once inserted, KeyValue addresses (and iterators
@@ -64,21 +66,21 @@
  *   - Lookups SIMD-scan a group at a time, then run a full key compare only
  *     on slots whose 7-bit fingerprint matches.
  *
- * The Allocator template parameter manages HashMapElement allocation. The
- * default uses the heap; PagedAllocator may be passed for pool-based storage.
- *
  * Use AHashMap if you don't need order preservation or pointer stability and
  * want the densest possible memory layout.
  */
 
 template <typename TKey, typename TValue>
 struct HashMapElement {
-	HashMapElement *next = nullptr;
-	HashMapElement *prev = nullptr;
+	// Preserved for source compatibility with existing Allocator template
+	// arguments. Ordered HashMap now stores KeyValue payloads in a stable arena
+	// and keeps hash/order metadata in side arrays keyed by handle.
 	// Cached full 32-bit hash. Stored at insert time so probes can
 	// short-circuit before a (potentially expensive) key compare, and so
 	// rehashing on grow doesn't have to re-run Hasher on the key.
 	uint32_t hash = 0;
+	uint32_t next = UINT32_MAX;
+	uint32_t prev = UINT32_MAX;
 	KeyValue<TKey, TValue> data;
 	HashMapElement() {}
 	HashMapElement(const TKey &p_key, const TValue &p_value, uint32_t p_hash) :
@@ -94,18 +96,33 @@ public:
 	static constexpr uint32_t INITIAL_CAPACITY = 16;
 	using KV = KeyValue<TKey, TValue>;
 	using Element = HashMapElement<TKey, TValue>;
+	using Payload = KV;
 
 private:
 	using Mask = typename SwissTable::Group::Mask;
 	static constexpr uint32_t kGroupWidth = SwissTable::Group::kWidth;
+	static constexpr uint32_t kInvalidHandle = UINT32_MAX;
+	static constexpr uint32_t kEntriesPerPage = 128;
 
 	// Index table.
 	uint8_t *_ctrl = nullptr;
-	Element **_slots = nullptr;
+	uint32_t *_slots = nullptr;
+
+	// Stable entry payload arena and dense per-handle metadata.
+	void **_payload_pages = nullptr;
+	uint8_t *_entry_alive = nullptr;
+	uint32_t *_entry_hashes = nullptr;
+	uint32_t *_next_handles = nullptr;
+	uint32_t *_prev_handles = nullptr;
+	uint32_t *_free_next = nullptr;
+	uint32_t _entry_page_count = 0;
+	uint32_t _entry_capacity = 0;
+	uint32_t _entry_count = 0;
+	uint32_t _free_head = kInvalidHandle;
 
 	// Insertion-order linked list head/tail.
-	Element *_head_element = nullptr;
-	Element *_tail_element = nullptr;
+	uint32_t _head_handle = kInvalidHandle;
+	uint32_t _tail_handle = kInvalidHandle;
 
 	uint32_t _capacity = 0; // Power of two, or 0 if unallocated.
 	uint32_t _capacity_mask = 0; // _capacity - 1.
@@ -117,6 +134,140 @@ private:
 	// reserve() before any actual allocation has happened. Once _ctrl is
 	// allocated this is no longer consulted.
 	uint32_t _pending_capacity = 0;
+
+	_FORCE_INLINE_ Payload *_payload_from_handle(uint32_t p_handle) const {
+		CRASH_COND(p_handle == kInvalidHandle || p_handle >= _entry_count);
+		const uint32_t page_idx = p_handle / kEntriesPerPage;
+		const uint32_t page_offset = p_handle % kEntriesPerPage;
+		uint8_t *page = static_cast<uint8_t *>(_payload_pages[page_idx]);
+		return reinterpret_cast<Payload *>(page + (sizeof(Payload) * page_offset));
+	}
+
+	_FORCE_INLINE_ Payload *_payload_from_slot(uint32_t p_slot_idx) const {
+		return _payload_from_handle(_slots[p_slot_idx]);
+	}
+
+	void _ensure_entry_metadata_capacity(uint32_t p_min_capacity) {
+		if (p_min_capacity <= _entry_capacity) {
+			return;
+		}
+		uint32_t new_capacity = MAX((uint32_t)16, _entry_capacity);
+		while (new_capacity < p_min_capacity) {
+			new_capacity <<= 1;
+		}
+
+		uint8_t *new_entry_alive = reinterpret_cast<uint8_t *>(Memory::alloc_static(sizeof(uint8_t) * new_capacity));
+		uint32_t *new_entry_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		uint32_t *new_next_handles = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		uint32_t *new_prev_handles = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		uint32_t *new_free_next = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * new_capacity));
+		if (_entry_capacity > 0) {
+			memcpy(new_entry_alive, _entry_alive, sizeof(uint8_t) * _entry_capacity);
+			memcpy(new_entry_hashes, _entry_hashes, sizeof(uint32_t) * _entry_capacity);
+			memcpy(new_next_handles, _next_handles, sizeof(uint32_t) * _entry_capacity);
+			memcpy(new_prev_handles, _prev_handles, sizeof(uint32_t) * _entry_capacity);
+			memcpy(new_free_next, _free_next, sizeof(uint32_t) * _entry_capacity);
+			Memory::free_static(_entry_alive);
+			Memory::free_static(_entry_hashes);
+			Memory::free_static(_next_handles);
+			Memory::free_static(_prev_handles);
+			Memory::free_static(_free_next);
+		}
+		memset(new_entry_alive + _entry_capacity, 0, sizeof(uint8_t) * (new_capacity - _entry_capacity));
+		for (uint32_t i = _entry_capacity; i < new_capacity; i++) {
+			new_entry_hashes[i] = 0;
+			new_next_handles[i] = kInvalidHandle;
+			new_prev_handles[i] = kInvalidHandle;
+			new_free_next[i] = kInvalidHandle;
+		}
+		_entry_alive = new_entry_alive;
+		_entry_hashes = new_entry_hashes;
+		_next_handles = new_next_handles;
+		_prev_handles = new_prev_handles;
+		_free_next = new_free_next;
+		_entry_capacity = new_capacity;
+	}
+
+	void _ensure_entry_page(uint32_t p_handle) {
+		const uint32_t required_pages = (p_handle / kEntriesPerPage) + 1;
+		if (required_pages <= _entry_page_count) {
+			return;
+		}
+		void **new_pages = reinterpret_cast<void **>(
+				Memory::alloc_static(sizeof(void *) * required_pages));
+		if (_entry_page_count > 0) {
+			memcpy(new_pages, _payload_pages, sizeof(void *) * _entry_page_count);
+			Memory::free_static(_payload_pages);
+		}
+		for (uint32_t i = _entry_page_count; i < required_pages; i++) {
+			new_pages[i] = Memory::alloc_static(sizeof(Payload) * kEntriesPerPage);
+		}
+		_payload_pages = new_pages;
+		_entry_page_count = required_pages;
+	}
+
+	uint32_t _allocate_handle() {
+		if (_free_head != kInvalidHandle) {
+			const uint32_t handle = _free_head;
+			_free_head = _free_next[handle];
+			_free_next[handle] = kInvalidHandle;
+			return handle;
+		}
+
+		const uint32_t handle = _entry_count++;
+		_ensure_entry_metadata_capacity(_entry_count);
+		_ensure_entry_page(handle);
+		return handle;
+	}
+
+	void _destroy_entry(uint32_t p_handle) {
+		_payload_from_handle(p_handle)->~Payload();
+		_entry_alive[p_handle] = 0;
+		_entry_hashes[p_handle] = 0;
+		_next_handles[p_handle] = kInvalidHandle;
+		_prev_handles[p_handle] = kInvalidHandle;
+		_free_next[p_handle] = _free_head;
+		_free_head = p_handle;
+	}
+
+	void _free_all_entry_storage() {
+		if (_entry_alive != nullptr) {
+			for (uint32_t handle = 0; handle < _entry_count; handle++) {
+				if (_entry_alive[handle] != 0) {
+					_payload_from_handle(handle)->~Payload();
+				}
+			}
+			Memory::free_static(_entry_alive);
+			_entry_alive = nullptr;
+		}
+		if (_entry_hashes != nullptr) {
+			Memory::free_static(_entry_hashes);
+			_entry_hashes = nullptr;
+		}
+		if (_next_handles != nullptr) {
+			Memory::free_static(_next_handles);
+			_next_handles = nullptr;
+		}
+		if (_prev_handles != nullptr) {
+			Memory::free_static(_prev_handles);
+			_prev_handles = nullptr;
+		}
+		if (_free_next != nullptr) {
+			Memory::free_static(_free_next);
+			_free_next = nullptr;
+		}
+		if (_payload_pages != nullptr) {
+			for (uint32_t i = 0; i < _entry_page_count; i++) {
+				Memory::free_static(_payload_pages[i]);
+			}
+			Memory::free_static(_payload_pages);
+			_payload_pages = nullptr;
+		}
+		_entry_page_count = 0;
+		_entry_capacity = 0;
+		_entry_count = 0;
+		_free_head = kInvalidHandle;
+	}
 
 	_FORCE_INLINE_ static uint32_t _hash(const TKey &p_key) {
 		// Hashers are expected to return SwissTable-ready 32-bit hashes now.
@@ -155,8 +306,9 @@ private:
 			while (it.has_next()) {
 				const uint32_t i = it.next();
 				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
-				Element *elem = _slots[slot_idx];
-				if (elem->hash == p_hash && Comparator::compare(elem->data.key, p_key)) {
+				const uint32_t handle = _slots[slot_idx];
+				Payload *payload = _payload_from_handle(handle);
+				if (_entry_hashes[handle] == p_hash && Comparator::compare(payload->key, p_key)) {
 					r_slot_idx = slot_idx;
 					return true;
 				}
@@ -196,8 +348,9 @@ private:
 			while (it.has_next()) {
 				const uint32_t i = it.next();
 				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
-				Element *elem = _slots[slot_idx];
-				if (elem->hash == p_hash && Comparator::compare(elem->data.key, p_key)) {
+				const uint32_t handle = _slots[slot_idx];
+				Payload *payload = _payload_from_handle(handle);
+				if (_entry_hashes[handle] == p_hash && Comparator::compare(payload->key, p_key)) {
 					r_slot_idx = slot_idx;
 					return true;
 				}
@@ -250,12 +403,15 @@ private:
 		const uint32_t new_capacity = MAX(p_new_capacity, kGroupWidth);
 		uint8_t *new_ctrl = reinterpret_cast<uint8_t *>(
 				Memory::alloc_static(sizeof(uint8_t) * (new_capacity + kGroupWidth)));
-		Element **new_slots = reinterpret_cast<Element **>(
-				Memory::alloc_static(sizeof(Element *) * new_capacity));
+		uint32_t *new_slots = reinterpret_cast<uint32_t *>(
+				Memory::alloc_static(sizeof(uint32_t) * new_capacity));
 		memset(new_ctrl, SwissTable::kEmpty, new_capacity + kGroupWidth);
+		for (uint32_t i = 0; i < new_capacity; i++) {
+			new_slots[i] = kInvalidHandle;
+		}
 
 		uint8_t *old_ctrl = _ctrl;
-		Element **old_slots = _slots;
+		uint32_t *old_slots = _slots;
 
 		_ctrl = new_ctrl;
 		_slots = new_slots;
@@ -268,11 +424,11 @@ private:
 		// preserves order while letting us drop the old index table. We
 		// reuse the cached hash on each Element so grow doesn't have to
 		// re-run Hasher (a real win for non-trivial keys like String).
-		for (Element *e = _head_element; e != nullptr; e = e->next) {
-			const uint32_t hash = e->hash;
+		for (uint32_t handle = _head_handle; handle != kInvalidHandle; handle = _next_handles[handle]) {
+			const uint32_t hash = _entry_hashes[handle];
 			const uint32_t slot = _find_insert_slot(hash);
 			_set_ctrl(slot, SwissTable::h2(hash));
-			_slots[slot] = e;
+			_slots[slot] = handle;
 			_growth_left--;
 		}
 
@@ -335,18 +491,20 @@ private:
 		return SwissTable::kDeleted;
 	}
 
-	void _link_after_alloc(Element *p_elem, bool p_front_insert) {
-		if (_tail_element == nullptr) {
-			_head_element = p_elem;
-			_tail_element = p_elem;
+	void _link_after_alloc(uint32_t p_handle, bool p_front_insert) {
+		_prev_handles[p_handle] = kInvalidHandle;
+		_next_handles[p_handle] = kInvalidHandle;
+		if (_tail_handle == kInvalidHandle) {
+			_head_handle = p_handle;
+			_tail_handle = p_handle;
 		} else if (p_front_insert) {
-			_head_element->prev = p_elem;
-			p_elem->next = _head_element;
-			_head_element = p_elem;
+			_prev_handles[_head_handle] = p_handle;
+			_next_handles[p_handle] = _head_handle;
+			_head_handle = p_handle;
 		} else {
-			_tail_element->next = p_elem;
-			p_elem->prev = _tail_element;
-			_tail_element = p_elem;
+			_next_handles[_tail_handle] = p_handle;
+			_prev_handles[p_handle] = _tail_handle;
+			_tail_handle = p_handle;
 		}
 	}
 
@@ -354,42 +512,45 @@ private:
 	// either delete p_elem immediately afterwards or re-link it before any
 	// further iteration -- we deliberately leave p_elem->{prev,next} dangling
 	// to avoid two pointless writes on the erase hot path.
-	void _unlink(Element *p_elem) {
-		Element *const prev = p_elem->prev;
-		Element *const next = p_elem->next;
-		if (prev) {
-			prev->next = next;
+	void _unlink(uint32_t p_handle) {
+		const uint32_t prev = _prev_handles[p_handle];
+		const uint32_t next = _next_handles[p_handle];
+		if (prev != kInvalidHandle) {
+			_next_handles[prev] = next;
 		} else {
 			// p_elem was the head.
-			_head_element = next;
+			_head_handle = next;
 		}
-		if (next) {
-			next->prev = prev;
+		if (next != kInvalidHandle) {
+			_prev_handles[next] = prev;
 		} else {
 			// p_elem was the tail.
-			_tail_element = prev;
+			_tail_handle = prev;
 		}
 	}
 
 	// Place a brand-new element at the given (already chosen) slot. The slot
 	// must currently be kEmpty or kDeleted, and the caller must have already
 	// guaranteed _growth_left > 0.
-	_FORCE_INLINE_ Element *_emplace_at_slot(const TKey &p_key, const TValue &p_value,
+	_FORCE_INLINE_ Payload *_emplace_at_slot(const TKey &p_key, const TValue &p_value,
 			uint32_t p_hash, uint32_t p_slot, bool p_front_insert) {
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[p_slot]);
-		Element *elem = Allocator::new_allocation(Element(p_key, p_value, p_hash));
+		const uint32_t handle = _allocate_handle();
+		Payload *payload = memnew_placement(_payload_from_handle(handle), Payload(p_key, p_value));
+		_entry_alive[handle] = 1;
+		_entry_hashes[handle] = p_hash;
 		_set_ctrl(p_slot, SwissTable::h2(p_hash));
-		_slots[p_slot] = elem;
-		_link_after_alloc(elem, p_front_insert);
+		_slots[p_slot] = handle;
+		_link_after_alloc(handle, p_front_insert);
 		_size++;
 		if (was_deleted) {
 			_deleted--;
 		}
 		_growth_left--;
-		return elem;
+		return payload;
 	}
 
-	Element *_insert_internal(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert) {
+	Payload *_insert_internal(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert) {
 		_ensure_allocated();
 		if (_growth_left == 0) {
 			_grow();
@@ -399,15 +560,60 @@ private:
 	}
 
 	void _clear_data() {
-		Element *current = _tail_element;
-		while (current != nullptr) {
-			Element *prev = current->prev;
-			Allocator::delete_allocation(current);
+		uint32_t current = _tail_handle;
+		while (current != kInvalidHandle) {
+			const uint32_t prev = _prev_handles[current];
+			_destroy_entry(current);
 			current = prev;
 		}
-		_head_element = nullptr;
-		_tail_element = nullptr;
+		_head_handle = kInvalidHandle;
+		_tail_handle = kInvalidHandle;
 		_size = 0;
+	}
+
+	template <typename C>
+	_FORCE_INLINE_ bool _handle_less(uint32_t p_lhs, uint32_t p_rhs, C &p_compare) const {
+		return p_compare(*_payload_from_handle(p_lhs), *_payload_from_handle(p_rhs));
+	}
+
+	template <typename C>
+	void _merge_sort_handles(uint32_t *p_handles, uint32_t *p_buffer, uint32_t p_begin, uint32_t p_end, C &p_compare) {
+		if (p_end - p_begin <= 1) {
+			return;
+		}
+		const uint32_t mid = p_begin + ((p_end - p_begin) >> 1);
+		_merge_sort_handles(p_handles, p_buffer, p_begin, mid, p_compare);
+		_merge_sort_handles(p_handles, p_buffer, mid, p_end, p_compare);
+
+		uint32_t left = p_begin;
+		uint32_t right = mid;
+		uint32_t out = p_begin;
+		while (left < mid && right < p_end) {
+			if (_handle_less(p_handles[right], p_handles[left], p_compare)) {
+				p_buffer[out++] = p_handles[right++];
+			} else {
+				p_buffer[out++] = p_handles[left++];
+			}
+		}
+		while (left < mid) {
+			p_buffer[out++] = p_handles[left++];
+		}
+		while (right < p_end) {
+			p_buffer[out++] = p_handles[right++];
+		}
+		for (uint32_t i = p_begin; i < p_end; i++) {
+			p_handles[i] = p_buffer[i];
+		}
+	}
+
+	void _rebuild_order_from_handles(const uint32_t *p_handles, uint32_t p_count) {
+		_head_handle = p_count > 0 ? p_handles[0] : kInvalidHandle;
+		_tail_handle = p_count > 0 ? p_handles[p_count - 1] : kInvalidHandle;
+		for (uint32_t i = 0; i < p_count; i++) {
+			const uint32_t handle = p_handles[i];
+			_prev_handles[handle] = (i > 0) ? p_handles[i - 1] : kInvalidHandle;
+			_next_handles[handle] = (i + 1 < p_count) ? p_handles[i + 1] : kInvalidHandle;
+		}
 	}
 
 public:
@@ -439,28 +645,37 @@ public:
 		if (size() < 2) {
 			return;
 		}
-		SortList<Element, KeyValue<TKey, TValue>, &Element::data, &Element::prev, &Element::next, C> sorter;
-		sorter.sort(_head_element, _tail_element);
+		LocalVector<uint32_t> handles;
+		handles.resize(_size);
+		uint32_t idx = 0;
+		for (uint32_t handle = _head_handle; handle != kInvalidHandle; handle = _next_handles[handle]) {
+			handles[idx++] = handle;
+		}
+		LocalVector<uint32_t> scratch;
+		scratch.resize(_size);
+		C compare;
+		_merge_sort_handles(handles.ptr(), scratch.ptr(), 0, _size, compare);
+		_rebuild_order_from_handles(handles.ptr(), _size);
 	}
 
 	TValue &get(const TKey &p_key) {
 		uint32_t slot = 0;
 		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return _slots[slot]->data.value;
+		return _payload_from_slot(slot)->value;
 	}
 
 	const TValue &get(const TKey &p_key) const {
 		uint32_t slot = 0;
 		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return _slots[slot]->data.value;
+		return _payload_from_slot(slot)->value;
 	}
 
 	const TValue *getptr(const TKey &p_key) const {
 		uint32_t slot = 0;
 		if (_lookup(p_key, _hash(p_key), slot)) {
-			return &_slots[slot]->data.value;
+			return &_payload_from_slot(slot)->value;
 		}
 		return nullptr;
 	}
@@ -468,7 +683,7 @@ public:
 	TValue *getptr(const TKey &p_key) {
 		uint32_t slot = 0;
 		if (_lookup(p_key, _hash(p_key), slot)) {
-			return &_slots[slot]->data.value;
+			return &_payload_from_slot(slot)->value;
 		}
 		return nullptr;
 	}
@@ -483,7 +698,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return false;
 		}
-		Element *elem = _slots[slot];
+		const uint32_t handle = _slots[slot];
 		const uint8_t new_ctrl = _ctrl_after_erase(slot);
 		if (new_ctrl == SwissTable::kEmpty) {
 			_growth_left++;
@@ -495,8 +710,8 @@ public:
 		// resize, iteration) gates on _ctrl[slot] being kEmpty/kDeleted
 		// before consulting _slots, so this write is dead and skipping it
 		// shaves a small amount off the erase hot path.
-		_unlink(elem);
-		Allocator::delete_allocation(elem);
+		_unlink(handle);
+		_destroy_entry(handle);
 		_size--;
 		return true;
 	}
@@ -514,7 +729,8 @@ public:
 		ERR_FAIL_COND_V(_lookup(p_new_key, new_hash, check_slot), false);
 		uint32_t old_slot = 0;
 		ERR_FAIL_COND_V(!_lookup(p_old_key, _hash(p_old_key), old_slot), false);
-		Element *elem = _slots[old_slot];
+		const uint32_t handle = _slots[old_slot];
+		Payload *payload = _payload_from_handle(handle);
 
 		// Vacate the old slot.
 		const uint8_t new_ctrl = _ctrl_after_erase(old_slot);
@@ -524,19 +740,19 @@ public:
 			_deleted++;
 		}
 		_set_ctrl(old_slot, new_ctrl);
-		_slots[old_slot] = nullptr;
+		_slots[old_slot] = kInvalidHandle;
 
 		// Mutate the key in place. KeyValue::key is `const TKey`; the cast is
 		// safe because the entry is uniquely owned and no caller may hold a
 		// concurrent reference to it. Update the cached hash to match.
-		const_cast<TKey &>(elem->data.key) = p_new_key;
-		elem->hash = new_hash;
+		const_cast<TKey &>(payload->key) = p_new_key;
+		_entry_hashes[handle] = new_hash;
 
 		// Reinsert into a fresh slot under the new hash.
 		const uint32_t target = _find_insert_slot(new_hash);
 		const bool was_deleted = SwissTable::is_deleted(_ctrl[target]);
 		_set_ctrl(target, SwissTable::h2(new_hash));
-		_slots[target] = elem;
+		_slots[target] = handle;
 		if (was_deleted) {
 			_deleted--;
 		} else {
@@ -566,81 +782,107 @@ public:
 	/** Iterator API **/
 
 	struct ConstIterator {
-		_FORCE_INLINE_ const KeyValue<TKey, TValue> &operator*() const { return E->data; }
-		_FORCE_INLINE_ const KeyValue<TKey, TValue> *operator->() const { return &E->data; }
+		_FORCE_INLINE_ const KeyValue<TKey, TValue> &operator*() const { return *map->_payload_from_handle(handle); }
+		_FORCE_INLINE_ const KeyValue<TKey, TValue> *operator->() const { return map->_payload_from_handle(handle); }
 		_FORCE_INLINE_ ConstIterator &operator++() {
-			if (E) {
-				E = E->next;
+			if (handle != kInvalidHandle) {
+				handle = map->_next_handles[handle];
 			}
 			return *this;
 		}
 		_FORCE_INLINE_ ConstIterator &operator--() {
-			if (E) {
-				E = E->prev;
+			if (handle != kInvalidHandle) {
+				handle = map->_prev_handles[handle];
 			}
 			return *this;
 		}
 
-		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
+		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return map == b.map && handle == b.handle; }
+		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return !(*this == b); }
+		_FORCE_INLINE_ bool operator==(std::nullptr_t) const { return handle == kInvalidHandle; }
+		_FORCE_INLINE_ bool operator!=(std::nullptr_t) const { return handle != kInvalidHandle; }
 
-		_FORCE_INLINE_ explicit operator bool() const { return E != nullptr; }
+		_FORCE_INLINE_ explicit operator bool() const { return handle != kInvalidHandle; }
 
-		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
+		_FORCE_INLINE_ ConstIterator(const HashMap *p_map, uint32_t p_handle) {
+			map = p_map;
+			handle = p_handle;
+		}
 		_FORCE_INLINE_ ConstIterator() {}
-		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_it) { E = p_it.E; }
+		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_it) {
+			map = p_it.map;
+			handle = p_it.handle;
+		}
 		_FORCE_INLINE_ void operator=(const ConstIterator &p_it) {
-			E = p_it.E;
+			map = p_it.map;
+			handle = p_it.handle;
+		}
+		_FORCE_INLINE_ void operator=(std::nullptr_t) {
+			handle = kInvalidHandle;
 		}
 
 	private:
-		const Element *E = nullptr;
+		const HashMap *map = nullptr;
+		uint32_t handle = kInvalidHandle;
 	};
 
 	struct Iterator {
-		_FORCE_INLINE_ KeyValue<TKey, TValue> &operator*() const { return E->data; }
-		_FORCE_INLINE_ KeyValue<TKey, TValue> *operator->() const { return &E->data; }
+		_FORCE_INLINE_ KeyValue<TKey, TValue> &operator*() const { return *map->_payload_from_handle(handle); }
+		_FORCE_INLINE_ KeyValue<TKey, TValue> *operator->() const { return map->_payload_from_handle(handle); }
 		_FORCE_INLINE_ Iterator &operator++() {
-			if (E) {
-				E = E->next;
+			if (handle != kInvalidHandle) {
+				handle = map->_next_handles[handle];
 			}
 			return *this;
 		}
 		_FORCE_INLINE_ Iterator &operator--() {
-			if (E) {
-				E = E->prev;
+			if (handle != kInvalidHandle) {
+				handle = map->_prev_handles[handle];
 			}
 			return *this;
 		}
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
+		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return map == b.map && handle == b.handle; }
+		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return !(*this == b); }
+		_FORCE_INLINE_ bool operator==(std::nullptr_t) const { return handle == kInvalidHandle; }
+		_FORCE_INLINE_ bool operator!=(std::nullptr_t) const { return handle != kInvalidHandle; }
 
-		_FORCE_INLINE_ explicit operator bool() const { return E != nullptr; }
+		_FORCE_INLINE_ explicit operator bool() const { return handle != kInvalidHandle; }
 
-		_FORCE_INLINE_ Iterator(Element *p_E) { E = p_E; }
+		_FORCE_INLINE_ Iterator(HashMap *p_map, uint32_t p_handle) {
+			map = p_map;
+			handle = p_handle;
+		}
 		_FORCE_INLINE_ Iterator() {}
-		_FORCE_INLINE_ Iterator(const Iterator &p_it) { E = p_it.E; }
+		_FORCE_INLINE_ Iterator(const Iterator &p_it) {
+			map = p_it.map;
+			handle = p_it.handle;
+		}
 		_FORCE_INLINE_ void operator=(const Iterator &p_it) {
-			E = p_it.E;
+			map = p_it.map;
+			handle = p_it.handle;
+		}
+		_FORCE_INLINE_ void operator=(std::nullptr_t) {
+			handle = kInvalidHandle;
 		}
 
 		operator ConstIterator() const {
-			return ConstIterator(E);
+			return ConstIterator(map, handle);
 		}
 
 	private:
-		Element *E = nullptr;
+		HashMap *map = nullptr;
+		uint32_t handle = kInvalidHandle;
 	};
 
 	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(_head_element);
+		return Iterator(this, _head_handle);
 	}
 	_FORCE_INLINE_ Iterator end() {
-		return Iterator(nullptr);
+		return Iterator(this, kInvalidHandle);
 	}
 	_FORCE_INLINE_ Iterator last() {
-		return Iterator(_tail_element);
+		return Iterator(this, _tail_handle);
 	}
 
 	_FORCE_INLINE_ Iterator find(const TKey &p_key) {
@@ -648,7 +890,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return Iterator(_slots[slot]);
+		return Iterator(this, _slots[slot]);
 	}
 
 	_FORCE_INLINE_ void remove(const Iterator &p_iter) {
@@ -658,13 +900,13 @@ public:
 	}
 
 	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(_head_element);
+		return ConstIterator(this, _head_handle);
 	}
 	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(nullptr);
+		return ConstIterator(this, kInvalidHandle);
 	}
 	_FORCE_INLINE_ ConstIterator last() const {
-		return ConstIterator(_tail_element);
+		return ConstIterator(this, _tail_handle);
 	}
 
 	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const {
@@ -672,7 +914,7 @@ public:
 		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return ConstIterator(_slots[slot]);
+		return ConstIterator(this, _slots[slot]);
 	}
 
 	/* Indexing */
@@ -681,7 +923,7 @@ public:
 		uint32_t slot = 0;
 		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND(!exists);
-		return _slots[slot]->data.value;
+		return _payload_from_slot(slot)->value;
 	}
 
 	TValue &operator[](const TKey &p_key) {
@@ -692,7 +934,7 @@ public:
 		}
 		uint32_t slot = 0;
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
-			return _slots[slot]->data.value;
+			return _payload_from_slot(slot)->value;
 		}
 		// Single-pass path: when the table is empty we still need to pick a
 		// slot. _find_or_prepare_insert handles that, but only when called;
@@ -700,7 +942,7 @@ public:
 		if (_size == 0) {
 			slot = _find_insert_slot(hash);
 		}
-		return _emplace_at_slot(p_key, TValue(), hash, slot, false)->data.value;
+		return _emplace_at_slot(p_key, TValue(), hash, slot, false)->value;
 	}
 
 	/* Insert */
@@ -713,13 +955,14 @@ public:
 		}
 		uint32_t slot = 0;
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
-			_slots[slot]->data.value = p_value;
-			return Iterator(_slots[slot]);
+			_payload_from_slot(slot)->value = p_value;
+			return Iterator(this, _slots[slot]);
 		}
 		if (_size == 0) {
 			slot = _find_insert_slot(hash);
 		}
-		return Iterator(_emplace_at_slot(p_key, p_value, hash, slot, p_front_insert));
+		_emplace_at_slot(p_key, p_value, hash, slot, p_front_insert);
+		return Iterator(this, _slots[slot]);
 	}
 
 	/* Constructors */
@@ -743,8 +986,18 @@ public:
 	HashMap(HashMap &&p_other) {
 		_ctrl = p_other._ctrl;
 		_slots = p_other._slots;
-		_head_element = p_other._head_element;
-		_tail_element = p_other._tail_element;
+		_payload_pages = p_other._payload_pages;
+		_entry_alive = p_other._entry_alive;
+		_entry_hashes = p_other._entry_hashes;
+		_next_handles = p_other._next_handles;
+		_prev_handles = p_other._prev_handles;
+		_free_next = p_other._free_next;
+		_entry_page_count = p_other._entry_page_count;
+		_entry_capacity = p_other._entry_capacity;
+		_entry_count = p_other._entry_count;
+		_free_head = p_other._free_head;
+		_head_handle = p_other._head_handle;
+		_tail_handle = p_other._tail_handle;
 		_capacity = p_other._capacity;
 		_capacity_mask = p_other._capacity_mask;
 		_size = p_other._size;
@@ -754,8 +1007,18 @@ public:
 
 		p_other._ctrl = nullptr;
 		p_other._slots = nullptr;
-		p_other._head_element = nullptr;
-		p_other._tail_element = nullptr;
+		p_other._payload_pages = nullptr;
+		p_other._entry_alive = nullptr;
+		p_other._entry_hashes = nullptr;
+		p_other._next_handles = nullptr;
+		p_other._prev_handles = nullptr;
+		p_other._free_next = nullptr;
+		p_other._entry_page_count = 0;
+		p_other._entry_capacity = 0;
+		p_other._entry_count = 0;
+		p_other._free_head = kInvalidHandle;
+		p_other._head_handle = kInvalidHandle;
+		p_other._tail_handle = kInvalidHandle;
 		p_other._capacity = 0;
 		p_other._capacity_mask = 0;
 		p_other._size = 0;
@@ -783,6 +1046,7 @@ public:
 			return *this;
 		}
 		_clear_data();
+		_free_all_entry_storage();
 		if (_ctrl != nullptr) {
 			Memory::free_static(_ctrl);
 			Memory::free_static(_slots);
@@ -790,8 +1054,18 @@ public:
 
 		_ctrl = p_other._ctrl;
 		_slots = p_other._slots;
-		_head_element = p_other._head_element;
-		_tail_element = p_other._tail_element;
+		_payload_pages = p_other._payload_pages;
+		_entry_alive = p_other._entry_alive;
+		_entry_hashes = p_other._entry_hashes;
+		_next_handles = p_other._next_handles;
+		_prev_handles = p_other._prev_handles;
+		_free_next = p_other._free_next;
+		_entry_page_count = p_other._entry_page_count;
+		_entry_capacity = p_other._entry_capacity;
+		_entry_count = p_other._entry_count;
+		_free_head = p_other._free_head;
+		_head_handle = p_other._head_handle;
+		_tail_handle = p_other._tail_handle;
 		_capacity = p_other._capacity;
 		_capacity_mask = p_other._capacity_mask;
 		_size = p_other._size;
@@ -801,8 +1075,18 @@ public:
 
 		p_other._ctrl = nullptr;
 		p_other._slots = nullptr;
-		p_other._head_element = nullptr;
-		p_other._tail_element = nullptr;
+		p_other._payload_pages = nullptr;
+		p_other._entry_alive = nullptr;
+		p_other._entry_hashes = nullptr;
+		p_other._next_handles = nullptr;
+		p_other._prev_handles = nullptr;
+		p_other._free_next = nullptr;
+		p_other._entry_page_count = 0;
+		p_other._entry_capacity = 0;
+		p_other._entry_count = 0;
+		p_other._free_head = kInvalidHandle;
+		p_other._head_handle = kInvalidHandle;
+		p_other._tail_handle = kInvalidHandle;
 		p_other._capacity = 0;
 		p_other._capacity_mask = 0;
 		p_other._size = 0;
@@ -829,23 +1113,24 @@ public:
 		if (c == SwissTable::kEmpty || c == SwissTable::kDeleted) {
 			return 0;
 		}
-		Element *e = _slots[p_idx];
-		return e != nullptr ? e->hash : 0;
+		const uint32_t handle = _slots[p_idx];
+		return handle != kInvalidHandle ? _entry_hashes[handle] : 0;
 	}
 	Iterator debug_get_element(uint32_t p_idx) {
 		if (_size == 0 || _capacity == 0) {
 			return Iterator();
 		}
 		ERR_FAIL_INDEX_V(p_idx, _capacity, Iterator());
-		Element *e = _slots[p_idx];
-		if (e == nullptr) {
+		const uint32_t handle = _slots[p_idx];
+		if (handle == kInvalidHandle) {
 			return Iterator();
 		}
-		return Iterator(e);
+		return Iterator(this, handle);
 	}
 
 	~HashMap() {
 		_clear_data();
+		_free_all_entry_storage();
 		if (_ctrl != nullptr) {
 			Memory::free_static(_ctrl);
 			Memory::free_static(_slots);

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/os/memory.h"
-#include "core/string/print_string.h" // IWYU pragma: keep. `WARN_VERBOSE` macro.
+#include "core/string/print_string.h" // IWYU pragma: keep
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
@@ -73,11 +73,8 @@
 template <typename TKey, typename TValue>
 struct HashMapElement {
 	// Preserved for source compatibility with existing Allocator template
-	// arguments. Ordered HashMap now stores KeyValue payloads in a stable arena
-	// and keeps hash/order metadata in side arrays keyed by handle.
-	// Cached full 32-bit hash. Stored at insert time so probes can
-	// short-circuit before a (potentially expensive) key compare, and so
-	// rehashing on grow doesn't have to re-run Hasher on the key.
+	// arguments.
+	// Cached full 32-bit hash.
 	uint32_t hash = 0;
 	uint32_t next = UINT32_MAX;
 	uint32_t prev = UINT32_MAX;
@@ -285,12 +282,8 @@ private:
 		return cap;
 	}
 
-	// Find the slot containing p_key. Returns true if found, with r_slot_idx
-	// set to the slot index in _ctrl/_slots. Uses the cached 32-bit hash on
-	// each candidate element to short-circuit before the (potentially
-	// expensive) key compare; with a 7-bit fingerprint we expect a false
-	// match every ~128 slots, and with a stored 32-bit hash false matches
-	// almost never escalate to a real key compare.
+	// Find the slot containing p_key. Returns true if found and sets
+	// r_slot_idx to the slot index in _ctrl/_slots.
 	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx) const {
 		if (_capacity == 0 || _size == 0) {
 			return false;
@@ -321,17 +314,9 @@ private:
 		}
 	}
 
-	// Find the slot containing p_key OR the first empty/deleted slot the
-	// probe sequence visits. Single-pass replacement for "_lookup then
-	// _find_insert_slot"; saves one probe walk per insert miss.
-	//
-	// Returns true if the key was found at r_slot_idx; r_slot_idx is the
-	// existing slot. Returns false if the key was not found; r_slot_idx
-	// is the slot where a new entry should be placed (always either kEmpty
-	// or kDeleted -- caller must pass through to _set_ctrl / accounting).
-	//
-	// Caller must ensure _capacity > 0 and _growth_left > 0 before calling
-	// (an empty/full table cannot satisfy both halves of the contract).
+	// Find the slot containing p_key or the first empty/deleted slot in the
+	// probe sequence. Returns true if found, false if r_slot_idx should be
+	// used for insertion. Caller must ensure _capacity > 0 and _growth_left > 0.
 	bool _find_or_prepare_insert(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx) const {
 		const uint8_t h2 = SwissTable::h2(p_hash);
 		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
@@ -341,8 +326,6 @@ private:
 
 		while (true) {
 			SwissTable::Group g(_ctrl + group_idx);
-			// Look for a matching fingerprint first; if any candidate's full
-			// hash matches and key compares equal, we've found the entry.
 			Mask m = g.match(h2);
 			auto it = m.iter();
 			while (it.has_next()) {
@@ -355,9 +338,6 @@ private:
 					return true;
 				}
 			}
-			// Record the first kEmpty/kDeleted slot we encounter so we have
-			// somewhere to put the new entry once we conclude the key isn't
-			// present anywhere along the probe chain.
 			if (!have_insert_slot) {
 				Mask ed = g.match_empty_or_deleted();
 				if (ed) {
@@ -366,9 +346,6 @@ private:
 					have_insert_slot = true;
 				}
 			}
-			// kEmpty terminates the probe chain: the key cannot appear past
-			// this group, so the recorded insert slot (which exists, since
-			// this group has at least one empty byte) is the answer.
 			if (g.match_empty()) {
 				r_slot_idx = insert_slot;
 				return false;
@@ -451,24 +428,11 @@ private:
 		_resize_table(new_capacity);
 	}
 
-	// Decide whether an erased slot can become kEmpty (so it doesn't
-	// permanently consume probe-chain length) or must remain a kDeleted
-	// tombstone. With unaligned probing, the promotion to kEmpty is only
-	// safe when no probe sequence could ever have been forced to skip past
-	// this slot while it was full -- approximated by requiring an empty in
-	// both the kGroupWidth-window immediately after AND immediately before
-	// the slot, with no run of kGroupWidth full bytes in between. This
-	// matches absl::container_internal::WasNeverFull.
+	// Decide whether an erased slot can become kEmpty or must remain a tombstone.
 	_FORCE_INLINE_ uint8_t _ctrl_after_erase(uint32_t p_slot) const {
 		if (_capacity <= kGroupWidth) {
 			return SwissTable::kEmpty;
 		}
-		// SIMD-scan the kGroupWidth-byte windows AFTER and BEFORE p_slot for
-		// kEmpty. Both reads are single unaligned loads -- the trailing read
-		// stays in-bounds because of the mirror tail past _capacity, and the
-		// leading read of the kGroupWidth bytes ending at p_slot - 1 is also
-		// in-bounds for any p_slot since the wrap case (p_slot < kGroupWidth)
-		// lands its tail in that same mirror region.
 		const SwissTable::Group g_after(_ctrl + p_slot);
 		const Mask after_empty = g_after.match_empty();
 		if (!after_empty) {
@@ -479,9 +443,6 @@ private:
 		const uint32_t lead_start = (p_slot - kGroupWidth) & _capacity_mask;
 		const SwissTable::Group g_before(_ctrl + lead_start);
 		const Mask before_empty = g_before.match_empty();
-		// Slot at position k within g_before is (kGroupWidth - 1 - k) bytes
-		// before p_slot, so the closest kEmpty corresponds to the highest set
-		// bit. No empty -> full kGroupWidth-byte run, force kDeleted.
 		const uint32_t leading = before_empty
 				? ((kGroupWidth - 1u) - before_empty.highest_set_bit())
 				: kGroupWidth;
@@ -742,9 +703,7 @@ public:
 		_set_ctrl(old_slot, new_ctrl);
 		_slots[old_slot] = kInvalidHandle;
 
-		// Mutate the key in place. KeyValue::key is `const TKey`; the cast is
-		// safe because the entry is uniquely owned and no caller may hold a
-		// concurrent reference to it. Update the cached hash to match.
+		// KeyValue::key is const TKey.
 		const_cast<TKey &>(payload->key) = p_new_key;
 		_entry_hashes[handle] = new_hash;
 
@@ -936,9 +895,6 @@ public:
 		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
 			return _payload_from_slot(slot)->value;
 		}
-		// Single-pass path: when the table is empty we still need to pick a
-		// slot. _find_or_prepare_insert handles that, but only when called;
-		// when _size == 0 we skip it and fall back to the simpler probe.
 		if (_size == 0) {
 			slot = _find_insert_slot(hash);
 		}

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -75,10 +75,14 @@ template <typename TKey, typename TValue>
 struct HashMapElement {
 	HashMapElement *next = nullptr;
 	HashMapElement *prev = nullptr;
+	// Cached full 32-bit hash. Stored at insert time so probes can
+	// short-circuit before a (potentially expensive) key compare, and so
+	// rehashing on grow doesn't have to re-run Hasher on the key.
+	uint32_t hash = 0;
 	KeyValue<TKey, TValue> data;
 	HashMapElement() {}
-	HashMapElement(const TKey &p_key, const TValue &p_value) :
-			data(p_key, p_value) {}
+	HashMapElement(const TKey &p_key, const TValue &p_value, uint32_t p_hash) :
+			hash(p_hash), data(p_key, p_value) {}
 };
 
 template <typename TKey, typename TValue,
@@ -115,7 +119,13 @@ private:
 	uint32_t _pending_capacity = 0;
 
 	_FORCE_INLINE_ static uint32_t _hash(const TKey &p_key) {
-		return Hasher::hash(p_key);
+		// Apply a SwissTable-friendly bit mixer at the boundary so callers
+		// don't have to. Several Godot hashers (notably String/DJB2) leave
+		// the high bits weakly mixed; splitting them into h1/h2 directly
+		// would cluster fingerprints and inflate probe chains. The same
+		// mixed value is what we cache on Element::hash, so that grow and
+		// the hash short-circuit in _lookup keep working consistently.
+		return SwissTable::mix(Hasher::hash(p_key));
 	}
 
 	static _FORCE_INLINE_ uint32_t _round_up_capacity(uint32_t p_min) {
@@ -127,7 +137,11 @@ private:
 	}
 
 	// Find the slot containing p_key. Returns true if found, with r_slot_idx
-	// set to the slot index in _ctrl/_slots.
+	// set to the slot index in _ctrl/_slots. Uses the cached 32-bit hash on
+	// each candidate element to short-circuit before the (potentially
+	// expensive) key compare; with a 7-bit fingerprint we expect a false
+	// match every ~128 slots, and with a stored 32-bit hash false matches
+	// almost never escalate to a real key compare.
 	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx) const {
 		if (_capacity == 0 || _size == 0) {
 			return false;
@@ -144,12 +158,68 @@ private:
 				const uint32_t i = it.next();
 				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
 				Element *elem = _slots[slot_idx];
-				if (Comparator::compare(elem->data.key, p_key)) {
+				if (elem->hash == p_hash && Comparator::compare(elem->data.key, p_key)) {
 					r_slot_idx = slot_idx;
 					return true;
 				}
 			}
 			if (g.match_empty()) {
+				return false;
+			}
+			probe_dist += kGroupWidth;
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
+		}
+	}
+
+	// Find the slot containing p_key OR the first empty/deleted slot the
+	// probe sequence visits. Single-pass replacement for "_lookup then
+	// _find_insert_slot"; saves one probe walk per insert miss.
+	//
+	// Returns true if the key was found at r_slot_idx; r_slot_idx is the
+	// existing slot. Returns false if the key was not found; r_slot_idx
+	// is the slot where a new entry should be placed (always either kEmpty
+	// or kDeleted -- caller must pass through to _set_ctrl / accounting).
+	//
+	// Caller must ensure _capacity > 0 and _growth_left > 0 before calling
+	// (an empty/full table cannot satisfy both halves of the contract).
+	bool _find_or_prepare_insert(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx) const {
+		const uint8_t h2 = SwissTable::h2(p_hash);
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
+		uint32_t insert_slot = 0;
+		bool have_insert_slot = false;
+
+		while (true) {
+			SwissTable::Group g(_ctrl + group_idx);
+			// Look for a matching fingerprint first; if any candidate's full
+			// hash matches and key compares equal, we've found the entry.
+			Mask m = g.match(h2);
+			auto it = m.iter();
+			while (it.has_next()) {
+				const uint32_t i = it.next();
+				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
+				Element *elem = _slots[slot_idx];
+				if (elem->hash == p_hash && Comparator::compare(elem->data.key, p_key)) {
+					r_slot_idx = slot_idx;
+					return true;
+				}
+			}
+			// Record the first kEmpty/kDeleted slot we encounter so we have
+			// somewhere to put the new entry once we conclude the key isn't
+			// present anywhere along the probe chain.
+			if (!have_insert_slot) {
+				Mask ed = g.match_empty_or_deleted();
+				if (ed) {
+					const uint32_t i = ed.lowest_set_bit();
+					insert_slot = (group_idx + i) & _capacity_mask;
+					have_insert_slot = true;
+				}
+			}
+			// kEmpty terminates the probe chain: the key cannot appear past
+			// this group, so the recorded insert slot (which exists, since
+			// this group has at least one empty byte) is the answer.
+			if (g.match_empty()) {
+				r_slot_idx = insert_slot;
 				return false;
 			}
 			probe_dist += kGroupWidth;
@@ -197,9 +267,11 @@ private:
 		_deleted = 0;
 
 		// Reinsert by walking the existing insertion-order linked list. This
-		// preserves order while letting us drop the old index table.
+		// preserves order while letting us drop the old index table. We
+		// reuse the cached hash on each Element so grow doesn't have to
+		// re-run Hasher (a real win for non-trivial keys like String).
 		for (Element *e = _head_element; e != nullptr; e = e->next) {
-			const uint32_t hash = _hash(e->data.key);
+			const uint32_t hash = e->hash;
 			const uint32_t slot = _find_insert_slot(hash);
 			_set_ctrl(slot, SwissTable::h2(hash));
 			_slots[slot] = e;
@@ -290,16 +362,15 @@ private:
 		p_elem->next = nullptr;
 	}
 
-	Element *_insert_internal(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert) {
-		_ensure_allocated();
-		if (_growth_left == 0) {
-			_grow();
-		}
-		const uint32_t slot = _find_insert_slot(p_hash);
-		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
-		Element *elem = Allocator::new_allocation(Element(p_key, p_value));
-		_set_ctrl(slot, SwissTable::h2(p_hash));
-		_slots[slot] = elem;
+	// Place a brand-new element at the given (already chosen) slot. The slot
+	// must currently be kEmpty or kDeleted, and the caller must have already
+	// guaranteed _growth_left > 0.
+	_FORCE_INLINE_ Element *_emplace_at_slot(const TKey &p_key, const TValue &p_value,
+			uint32_t p_hash, uint32_t p_slot, bool p_front_insert) {
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[p_slot]);
+		Element *elem = Allocator::new_allocation(Element(p_key, p_value, p_hash));
+		_set_ctrl(p_slot, SwissTable::h2(p_hash));
+		_slots[p_slot] = elem;
 		_link_after_alloc(elem, p_front_insert);
 		_size++;
 		if (was_deleted) {
@@ -307,6 +378,15 @@ private:
 		}
 		_growth_left--;
 		return elem;
+	}
+
+	Element *_insert_internal(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert) {
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
+		const uint32_t slot = _find_insert_slot(p_hash);
+		return _emplace_at_slot(p_key, p_value, p_hash, slot, p_front_insert);
 	}
 
 	void _clear_data() {
@@ -436,8 +516,9 @@ public:
 
 		// Mutate the key in place. KeyValue::key is `const TKey`; the cast is
 		// safe because the entry is uniquely owned and no caller may hold a
-		// concurrent reference to it.
+		// concurrent reference to it. Update the cached hash to match.
 		const_cast<TKey &>(elem->data.key) = p_new_key;
+		elem->hash = new_hash;
 
 		// Reinsert into a fresh slot under the new hash.
 		const uint32_t target = _find_insert_slot(new_hash);
@@ -593,23 +674,40 @@ public:
 
 	TValue &operator[](const TKey &p_key) {
 		const uint32_t hash = _hash(p_key);
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
 		uint32_t slot = 0;
-		if (_capacity > 0 && _size > 0 && _lookup(p_key, hash, slot)) {
+		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
 			return _slots[slot]->data.value;
 		}
-		return _insert_internal(p_key, TValue(), hash, false)->data.value;
+		// Single-pass path: when the table is empty we still need to pick a
+		// slot. _find_or_prepare_insert handles that, but only when called;
+		// when _size == 0 we skip it and fall back to the simpler probe.
+		if (_size == 0) {
+			slot = _find_insert_slot(hash);
+		}
+		return _emplace_at_slot(p_key, TValue(), hash, slot, false)->data.value;
 	}
 
 	/* Insert */
 
 	Iterator insert(const TKey &p_key, const TValue &p_value, bool p_front_insert = false) {
 		const uint32_t hash = _hash(p_key);
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
 		uint32_t slot = 0;
-		if (_capacity > 0 && _size > 0 && _lookup(p_key, hash, slot)) {
+		if (_size > 0 && _find_or_prepare_insert(p_key, hash, slot)) {
 			_slots[slot]->data.value = p_value;
 			return Iterator(_slots[slot]);
 		}
-		return Iterator(_insert_internal(p_key, p_value, hash, p_front_insert));
+		if (_size == 0) {
+			slot = _find_insert_slot(hash);
+		}
+		return Iterator(_emplace_at_slot(p_key, p_value, hash, slot, p_front_insert));
 	}
 
 	/* Constructors */
@@ -719,9 +817,8 @@ public:
 		if (c == SwissTable::kEmpty || c == SwissTable::kDeleted) {
 			return 0;
 		}
-		// Reconstruction of the full hash isn't possible from h2; expose the
-		// fingerprint byte instead, which is what callers need for diagnostics.
-		return c;
+		Element *e = _slots[p_idx];
+		return e != nullptr ? e->hash : 0;
 	}
 	Iterator debug_get_element(uint32_t p_idx) {
 		if (_size == 0 || _capacity == 0) {

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -309,21 +309,28 @@ private:
 		if (_capacity <= kGroupWidth) {
 			return SwissTable::kEmpty;
 		}
-		uint32_t trailing = 0;
-		while (trailing < kGroupWidth && _ctrl[p_slot + trailing] != SwissTable::kEmpty) {
-			trailing++;
-		}
-		if (trailing == kGroupWidth) {
+		// SIMD-scan the kGroupWidth-byte windows AFTER and BEFORE p_slot for
+		// kEmpty. Both reads are single unaligned loads -- the trailing read
+		// stays in-bounds because of the mirror tail past _capacity, and the
+		// leading read of the kGroupWidth bytes ending at p_slot - 1 is also
+		// in-bounds for any p_slot since the wrap case (p_slot < kGroupWidth)
+		// lands its tail in that same mirror region.
+		const SwissTable::Group g_after(_ctrl + p_slot);
+		const Mask after_empty = g_after.match_empty();
+		if (!after_empty) {
 			return SwissTable::kDeleted;
 		}
-		uint32_t leading = 0;
-		while (leading < kGroupWidth) {
-			const uint32_t idx = (p_slot + _capacity - 1 - leading) & _capacity_mask;
-			if (_ctrl[idx] == SwissTable::kEmpty) {
-				break;
-			}
-			leading++;
-		}
+		const uint32_t trailing = after_empty.lowest_set_bit();
+
+		const uint32_t lead_start = (p_slot - kGroupWidth) & _capacity_mask;
+		const SwissTable::Group g_before(_ctrl + lead_start);
+		const Mask before_empty = g_before.match_empty();
+		// Slot at position k within g_before is (kGroupWidth - 1 - k) bytes
+		// before p_slot, so the closest kEmpty corresponds to the highest set
+		// bit. No empty -> full kGroupWidth-byte run, force kDeleted.
+		const uint32_t leading = before_empty
+				? ((kGroupWidth - 1u) - before_empty.highest_set_bit())
+				: kGroupWidth;
 		if (trailing + leading < kGroupWidth) {
 			return SwissTable::kEmpty;
 		}
@@ -345,21 +352,25 @@ private:
 		}
 	}
 
+	// Remove p_elem from the insertion-order list. Caller is expected to
+	// either delete p_elem immediately afterwards or re-link it before any
+	// further iteration -- we deliberately leave p_elem->{prev,next} dangling
+	// to avoid two pointless writes on the erase hot path.
 	void _unlink(Element *p_elem) {
-		if (_head_element == p_elem) {
-			_head_element = p_elem->next;
+		Element *const prev = p_elem->prev;
+		Element *const next = p_elem->next;
+		if (prev) {
+			prev->next = next;
+		} else {
+			// p_elem was the head.
+			_head_element = next;
 		}
-		if (_tail_element == p_elem) {
-			_tail_element = p_elem->prev;
+		if (next) {
+			next->prev = prev;
+		} else {
+			// p_elem was the tail.
+			_tail_element = prev;
 		}
-		if (p_elem->prev) {
-			p_elem->prev->next = p_elem->next;
-		}
-		if (p_elem->next) {
-			p_elem->next->prev = p_elem->prev;
-		}
-		p_elem->prev = nullptr;
-		p_elem->next = nullptr;
 	}
 
 	// Place a brand-new element at the given (already chosen) slot. The slot
@@ -482,7 +493,10 @@ public:
 			_deleted++;
 		}
 		_set_ctrl(slot, new_ctrl);
-		_slots[slot] = nullptr;
+		// Leave _slots[slot] dangling: any subsequent reader (lookup,
+		// resize, iteration) gates on _ctrl[slot] being kEmpty/kDeleted
+		// before consulting _slots, so this write is dead and skipping it
+		// shaves a small amount off the erase hot path.
 		_unlink(elem);
 		Allocator::delete_allocation(elem);
 		_size--;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -35,21 +35,40 @@
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_list.h"
+#include "core/templates/swiss_table_simd.h"
 
 #include <initializer_list>
 
 /**
- * A HashMap implementation that uses open addressing with Robin Hood hashing.
- * Robin Hood hashing swaps out entries that have a smaller probing distance
- * than the to-be-inserted entry, that evens out the average probing distance
- * and enables faster lookups. Backward shift deletion is employed to further
- * improve the performance and to avoid infinite loops in rare cases.
+ * An insertion-ordered, pointer-stable hash map. Uses a SwissTable-style
+ * SIMD-scanned control-byte index over a separately allocated entries store.
  *
- * Keys and values are stored in a double linked list by insertion order. This
- * has a slight performance overhead on lookup, which can be mostly compensated
- * using a paged allocator if required.
+ * Layout:
+ *   - _ctrl[capacity + kGroupWidth]: control bytes (h2 / kEmpty / kDeleted),
+ *     with the leading kGroupWidth bytes mirrored at the tail so groups can
+ *     overshoot safely.
+ *   - _slots[capacity]: pointer per slot to the owning HashMapElement (or null
+ *     if empty/deleted).
+ *   - HashMapElement holds key/value plus prev/next pointers for the
+ *     intrusive insertion-order doubly linked list (rooted at _head_element /
+ *     _tail_element). The physical placement of HashMapElement in memory is
+ *     independent of its position in the index table.
  *
- * The assignment operator copy the pairs from one map to the other.
+ * Properties:
+ *   - Pointer stability: once inserted, KeyValue addresses (and iterators
+ *     pointing to them) are valid until that specific entry is erased or the
+ *     entire map is destroyed. Inserts/erases of OTHER keys never invalidate
+ *     them, even when the index table is rehashed.
+ *   - Insertion order is preserved across erases, and iteration follows the
+ *     intrusive linked list. `front_insert` prepends instead of appending.
+ *   - Lookups SIMD-scan a group at a time, then run a full key compare only
+ *     on slots whose 7-bit fingerprint matches.
+ *
+ * The Allocator template parameter manages HashMapElement allocation. The
+ * default uses the heap; PagedAllocator may be passed for pool-based storage.
+ *
+ * Use AHashMap if you don't need order preservation or pointer stability and
+ * want the densest possible memory layout.
  */
 
 template <typename TKey, typename TValue>
@@ -68,204 +87,258 @@ template <typename TKey, typename TValue,
 		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
 class HashMap : private Allocator {
 public:
-	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
-	static constexpr float MAX_OCCUPANCY = 0.75;
-	static constexpr uint32_t EMPTY_HASH = 0;
-	using KV = KeyValue<TKey, TValue>; // Type alias for easier access to KeyValue.
+	static constexpr uint32_t INITIAL_CAPACITY = 16;
+	using KV = KeyValue<TKey, TValue>;
+	using Element = HashMapElement<TKey, TValue>;
 
 private:
-	HashMapElement<TKey, TValue> **_elements = nullptr;
-	uint32_t *_hashes = nullptr;
-	HashMapElement<TKey, TValue> *_head_element = nullptr;
-	HashMapElement<TKey, TValue> *_tail_element = nullptr;
+	using Mask = typename SwissTable::Group::Mask;
+	static constexpr uint32_t kGroupWidth = SwissTable::Group::kWidth;
 
-	uint32_t _capacity_idx = 0;
+	// Index table.
+	uint8_t *_ctrl = nullptr;
+	Element **_slots = nullptr;
+
+	// Insertion-order linked list head/tail.
+	Element *_head_element = nullptr;
+	Element *_tail_element = nullptr;
+
+	uint32_t _capacity = 0; // Power of two, or 0 if unallocated.
+	uint32_t _capacity_mask = 0; // _capacity - 1.
 	uint32_t _size = 0;
+	uint32_t _growth_left = 0;
+	uint32_t _deleted = 0;
+
+	// Initial capacity hint requested via the (uint32_t) constructor or
+	// reserve() before any actual allocation has happened. Once _ctrl is
+	// allocated this is no longer consulted.
+	uint32_t _pending_capacity = 0;
 
 	_FORCE_INLINE_ static uint32_t _hash(const TKey &p_key) {
-		uint32_t hash = Hasher::hash(p_key);
+		return Hasher::hash(p_key);
+	}
 
-		if (unlikely(hash == EMPTY_HASH)) {
-			hash = EMPTY_HASH + 1;
+	static _FORCE_INLINE_ uint32_t _round_up_capacity(uint32_t p_min) {
+		uint32_t cap = kGroupWidth;
+		while (cap < p_min) {
+			cap <<= 1;
 		}
-
-		return hash;
+		return cap;
 	}
 
-	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {
-		r_idx++;
-		// `if` is faster than both fastmod and mod.
-		if (unlikely(r_idx == p_capacity)) {
-			r_idx = 0;
+	// Find the slot containing p_key. Returns true if found, with r_slot_idx
+	// set to the slot index in _ctrl/_slots.
+	bool _lookup(const TKey &p_key, uint32_t p_hash, uint32_t &r_slot_idx) const {
+		if (_capacity == 0 || _size == 0) {
+			return false;
 		}
-	}
-
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
-		const uint32_t distance_idx = p_idx - original_idx + p_capacity;
-		// At most p_capacity over 0, so we can use an if (faster than fastmod).
-		return distance_idx >= p_capacity ? distance_idx - p_capacity : distance_idx;
-	}
-
-	bool _lookup_idx(const TKey &p_key, uint32_t &r_idx) const {
-		return _elements != nullptr && _size > 0 && _lookup_idx_unchecked(p_key, _hash(p_key), r_idx);
-	}
-
-	/// Note: Assumes that _elements != nullptr
-	bool _lookup_idx_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_idx) const {
-		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t idx = fastmod(p_hash, capacity_inv, capacity);
-		uint32_t distance = 0;
+		const uint8_t h2 = SwissTable::h2(p_hash);
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
 
 		while (true) {
-			if (_hashes[idx] == EMPTY_HASH) {
+			SwissTable::Group g(_ctrl + group_idx);
+			Mask m = g.match(h2);
+			auto it = m.iter();
+			while (it.has_next()) {
+				const uint32_t i = it.next();
+				const uint32_t slot_idx = (group_idx + i) & _capacity_mask;
+				Element *elem = _slots[slot_idx];
+				if (Comparator::compare(elem->data.key, p_key)) {
+					r_slot_idx = slot_idx;
+					return true;
+				}
+			}
+			if (g.match_empty()) {
 				return false;
 			}
-
-			if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
-				return false;
-			}
-
-			if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
-				r_idx = idx;
-				return true;
-			}
-
-			_increment_mod(idx, capacity);
-			distance++;
+			probe_dist += kGroupWidth;
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
 	}
 
-	void _insert_element(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
-		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t hash = p_hash;
-		HashMapElement<TKey, TValue> *value = p_value;
-		uint32_t distance = 0;
-		uint32_t idx = fastmod(hash, capacity_inv, capacity);
-
+	uint32_t _find_insert_slot(uint32_t p_hash) const {
+		uint32_t group_idx = SwissTable::h1(p_hash) & _capacity_mask;
+		uint32_t probe_dist = 0;
 		while (true) {
-			if (_hashes[idx] == EMPTY_HASH) {
-				_elements[idx] = value;
-				_hashes[idx] = hash;
-
-				_size++;
-
-				return;
+			SwissTable::Group g(_ctrl + group_idx);
+			Mask m = g.match_empty_or_deleted();
+			if (m) {
+				const uint32_t i = m.lowest_set_bit();
+				return (group_idx + i) & _capacity_mask;
 			}
-
-			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
-			if (existing_probe_len < distance) {
-				SWAP(hash, _hashes[idx]);
-				SWAP(value, _elements[idx]);
-				distance = existing_probe_len;
-			}
-
-			_increment_mod(idx, capacity);
-			distance++;
+			probe_dist += kGroupWidth;
+			group_idx = (group_idx + probe_dist) & _capacity_mask;
 		}
 	}
 
-	void _resize_and_rehash(uint32_t p_new_capacity_idx) {
-		uint32_t old_capacity = hash_table_size_primes[_capacity_idx];
-
-		// Capacity can't be 0.
-		_capacity_idx = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_idx);
-
-		uint32_t capacity = hash_table_size_primes[_capacity_idx];
-
-		HashMapElement<TKey, TValue> **old_elements = _elements;
-		uint32_t *old_hashes = _hashes;
-
-		_size = 0;
-		static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-
-		_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-		_elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * capacity));
-
-		if (old_capacity == 0) {
-			// Nothing to do.
-			return;
-		}
-
-		for (uint32_t i = 0; i < old_capacity; i++) {
-			if (old_hashes[i] == EMPTY_HASH) {
-				continue;
-			}
-
-			_insert_element(old_hashes[i], old_elements[i]);
-		}
-
-		Memory::free_static(old_elements);
-		Memory::free_static(old_hashes);
+	_FORCE_INLINE_ void _set_ctrl(uint32_t p_slot_idx, uint8_t p_value) {
+		_ctrl[p_slot_idx] = p_value;
+		const uint32_t mirrored = ((p_slot_idx - (kGroupWidth - 1)) & _capacity_mask) + (kGroupWidth - 1);
+		_ctrl[mirrored] = p_value;
 	}
 
-	_FORCE_INLINE_ HashMapElement<TKey, TValue> *_insert(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert = false) {
-		uint32_t capacity = hash_table_size_primes[_capacity_idx];
-		if (unlikely(_elements == nullptr)) {
-			// Allocate on demand to save memory.
+	void _resize_table(uint32_t p_new_capacity) {
+		const uint32_t new_capacity = MAX(p_new_capacity, kGroupWidth);
+		uint8_t *new_ctrl = reinterpret_cast<uint8_t *>(
+				Memory::alloc_static(sizeof(uint8_t) * (new_capacity + kGroupWidth)));
+		Element **new_slots = reinterpret_cast<Element **>(
+				Memory::alloc_static(sizeof(Element *) * new_capacity));
+		memset(new_ctrl, SwissTable::kEmpty, new_capacity + kGroupWidth);
 
-			static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-			_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-			_elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static(sizeof(HashMapElement<TKey, TValue> *) * capacity));
+		uint8_t *old_ctrl = _ctrl;
+		Element **old_slots = _slots;
+
+		_ctrl = new_ctrl;
+		_slots = new_slots;
+		_capacity = new_capacity;
+		_capacity_mask = new_capacity - 1;
+		_growth_left = SwissTable::capacity_to_growth(new_capacity);
+		_deleted = 0;
+
+		// Reinsert by walking the existing insertion-order linked list. This
+		// preserves order while letting us drop the old index table.
+		for (Element *e = _head_element; e != nullptr; e = e->next) {
+			const uint32_t hash = _hash(e->data.key);
+			const uint32_t slot = _find_insert_slot(hash);
+			_set_ctrl(slot, SwissTable::h2(hash));
+			_slots[slot] = e;
+			_growth_left--;
 		}
 
-		if (_size + 1 > MAX_OCCUPANCY * capacity) {
-			ERR_FAIL_COND_V_MSG(_capacity_idx + 1 == HASH_TABLE_SIZE_MAX, nullptr, "Hash table maximum capacity reached, aborting insertion.");
-			_resize_and_rehash(_capacity_idx + 1);
+		if (old_ctrl != nullptr) {
+			Memory::free_static(old_ctrl);
+			Memory::free_static(old_slots);
 		}
+	}
 
-		HashMapElement<TKey, TValue> *elem = Allocator::new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
+	void _ensure_allocated() {
+		if (_capacity == 0) {
+			const uint32_t initial = MAX(_pending_capacity, MAX((uint32_t)INITIAL_CAPACITY, kGroupWidth));
+			_resize_table(_round_up_capacity(initial));
+			_pending_capacity = 0;
+		}
+	}
 
+	void _grow() {
+		const uint32_t new_capacity = _capacity == 0 ? MAX((uint32_t)INITIAL_CAPACITY, kGroupWidth) : (_capacity * 2);
+		_resize_table(new_capacity);
+	}
+
+	// Decide whether an erased slot can become kEmpty (so it doesn't
+	// permanently consume probe-chain length) or must remain a kDeleted
+	// tombstone. With unaligned probing, the promotion to kEmpty is only
+	// safe when no probe sequence could ever have been forced to skip past
+	// this slot while it was full -- approximated by requiring an empty in
+	// both the kGroupWidth-window immediately after AND immediately before
+	// the slot, with no run of kGroupWidth full bytes in between. This
+	// matches absl::container_internal::WasNeverFull.
+	_FORCE_INLINE_ uint8_t _ctrl_after_erase(uint32_t p_slot) const {
+		if (_capacity <= kGroupWidth) {
+			return SwissTable::kEmpty;
+		}
+		uint32_t trailing = 0;
+		while (trailing < kGroupWidth && _ctrl[p_slot + trailing] != SwissTable::kEmpty) {
+			trailing++;
+		}
+		if (trailing == kGroupWidth) {
+			return SwissTable::kDeleted;
+		}
+		uint32_t leading = 0;
+		while (leading < kGroupWidth) {
+			const uint32_t idx = (p_slot + _capacity - 1 - leading) & _capacity_mask;
+			if (_ctrl[idx] == SwissTable::kEmpty) {
+				break;
+			}
+			leading++;
+		}
+		if (trailing + leading < kGroupWidth) {
+			return SwissTable::kEmpty;
+		}
+		return SwissTable::kDeleted;
+	}
+
+	void _link_after_alloc(Element *p_elem, bool p_front_insert) {
 		if (_tail_element == nullptr) {
-			_head_element = elem;
-			_tail_element = elem;
+			_head_element = p_elem;
+			_tail_element = p_elem;
 		} else if (p_front_insert) {
-			_head_element->prev = elem;
-			elem->next = _head_element;
-			_head_element = elem;
+			_head_element->prev = p_elem;
+			p_elem->next = _head_element;
+			_head_element = p_elem;
 		} else {
-			_tail_element->next = elem;
-			elem->prev = _tail_element;
-			_tail_element = elem;
+			_tail_element->next = p_elem;
+			p_elem->prev = _tail_element;
+			_tail_element = p_elem;
 		}
+	}
 
-		_insert_element(p_hash, elem);
+	void _unlink(Element *p_elem) {
+		if (_head_element == p_elem) {
+			_head_element = p_elem->next;
+		}
+		if (_tail_element == p_elem) {
+			_tail_element = p_elem->prev;
+		}
+		if (p_elem->prev) {
+			p_elem->prev->next = p_elem->next;
+		}
+		if (p_elem->next) {
+			p_elem->next->prev = p_elem->prev;
+		}
+		p_elem->prev = nullptr;
+		p_elem->next = nullptr;
+	}
+
+	Element *_insert_internal(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert) {
+		_ensure_allocated();
+		if (_growth_left == 0) {
+			_grow();
+		}
+		const uint32_t slot = _find_insert_slot(p_hash);
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[slot]);
+		Element *elem = Allocator::new_allocation(Element(p_key, p_value));
+		_set_ctrl(slot, SwissTable::h2(p_hash));
+		_slots[slot] = elem;
+		_link_after_alloc(elem, p_front_insert);
+		_size++;
+		if (was_deleted) {
+			_deleted--;
+		}
+		_growth_left--;
 		return elem;
 	}
 
 	void _clear_data() {
-		HashMapElement<TKey, TValue> *current = _tail_element;
+		Element *current = _tail_element;
 		while (current != nullptr) {
-			HashMapElement<TKey, TValue> *prev = current->prev;
+			Element *prev = current->prev;
 			Allocator::delete_allocation(current);
 			current = prev;
 		}
+		_head_element = nullptr;
+		_tail_element = nullptr;
+		_size = 0;
 	}
 
 public:
-	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[_capacity_idx]; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return _capacity; }
 	_FORCE_INLINE_ uint32_t size() const { return _size; }
-
-	/* Standard Godot Container API */
 
 	bool is_empty() const {
 		return _size == 0;
 	}
 
 	void clear() {
-		if (_elements == nullptr || _size == 0) {
+		if (_size == 0 && _deleted == 0) {
 			return;
 		}
-
 		_clear_data();
-		memset(_hashes, EMPTY_HASH, get_capacity() * sizeof(uint32_t));
-
-		_tail_element = nullptr;
-		_head_element = nullptr;
-		_size = 0;
+		if (_ctrl != nullptr) {
+			memset(_ctrl, SwissTable::kEmpty, _capacity + kGroupWidth);
+		}
+		_deleted = 0;
+		_growth_left = (_capacity > 0) ? SwissTable::capacity_to_growth(_capacity) : 0;
 	}
 
 	void sort() {
@@ -277,159 +350,130 @@ public:
 		if (size() < 2) {
 			return;
 		}
-
-		using E = HashMapElement<TKey, TValue>;
-		SortList<E, KeyValue<TKey, TValue>, &E::data, &E::prev, &E::next, C> sorter;
+		SortList<Element, KeyValue<TKey, TValue>, &Element::data, &Element::prev, &Element::next, C> sorter;
 		sorter.sort(_head_element, _tail_element);
 	}
 
 	TValue &get(const TKey &p_key) {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
+		uint32_t slot = 0;
+		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return _elements[idx]->data.value;
+		return _slots[slot]->data.value;
 	}
 
 	const TValue &get(const TKey &p_key) const {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
+		uint32_t slot = 0;
+		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return _elements[idx]->data.value;
+		return _slots[slot]->data.value;
 	}
 
 	const TValue *getptr(const TKey &p_key) const {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
-
-		if (exists) {
-			return &_elements[idx]->data.value;
+		uint32_t slot = 0;
+		if (_lookup(p_key, _hash(p_key), slot)) {
+			return &_slots[slot]->data.value;
 		}
 		return nullptr;
 	}
 
 	TValue *getptr(const TKey &p_key) {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
-
-		if (exists) {
-			return &_elements[idx]->data.value;
+		uint32_t slot = 0;
+		if (_lookup(p_key, _hash(p_key), slot)) {
+			return &_slots[slot]->data.value;
 		}
 		return nullptr;
 	}
 
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
-		uint32_t _idx = 0;
-		return _lookup_idx(p_key, _idx);
+		uint32_t slot = 0;
+		return _lookup(p_key, _hash(p_key), slot);
 	}
 
 	bool erase(const TKey &p_key) {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
-
-		if (!exists) {
+		uint32_t slot = 0;
+		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return false;
 		}
-
-		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
-			SWAP(_hashes[next_idx], _hashes[idx]);
-			SWAP(_elements[next_idx], _elements[idx]);
-			idx = next_idx;
-			_increment_mod(next_idx, capacity);
+		Element *elem = _slots[slot];
+		const uint8_t new_ctrl = _ctrl_after_erase(slot);
+		if (new_ctrl == SwissTable::kEmpty) {
+			_growth_left++;
+		} else {
+			_deleted++;
 		}
-
-		_hashes[idx] = EMPTY_HASH;
-
-		if (_head_element == _elements[idx]) {
-			_head_element = _elements[idx]->next;
-		}
-
-		if (_tail_element == _elements[idx]) {
-			_tail_element = _elements[idx]->prev;
-		}
-
-		if (_elements[idx]->prev) {
-			_elements[idx]->prev->next = _elements[idx]->next;
-		}
-
-		if (_elements[idx]->next) {
-			_elements[idx]->next->prev = _elements[idx]->prev;
-		}
-
-		Allocator::delete_allocation(_elements[idx]);
-
+		_set_ctrl(slot, new_ctrl);
+		_slots[slot] = nullptr;
+		_unlink(elem);
+		Allocator::delete_allocation(elem);
 		_size--;
 		return true;
 	}
 
-	// Replace the key of an entry in-place, without invalidating iterators or changing the entries position during iteration.
-	// p_old_key must exist in the map and p_new_key must not, unless it is equal to p_old_key.
+	// Replace the key of an entry in-place, without invalidating iterators or
+	// changing the entry's position in the insertion-order list. p_old_key
+	// must exist; p_new_key must not, unless equal to p_old_key.
 	bool replace_key(const TKey &p_old_key, const TKey &p_new_key) {
-		ERR_FAIL_COND_V(_elements == nullptr || _size == 0, false);
+		ERR_FAIL_COND_V(_capacity == 0 || _size == 0, false);
 		if (p_old_key == p_new_key) {
 			return true;
 		}
 		const uint32_t new_hash = _hash(p_new_key);
-		uint32_t idx = 0;
-		ERR_FAIL_COND_V(_lookup_idx_unchecked(p_new_key, new_hash, idx), false);
-		ERR_FAIL_COND_V(!_lookup_idx(p_old_key, idx), false);
-		HashMapElement<TKey, TValue> *element = _elements[idx];
+		uint32_t check_slot = 0;
+		ERR_FAIL_COND_V(_lookup(p_new_key, new_hash, check_slot), false);
+		uint32_t old_slot = 0;
+		ERR_FAIL_COND_V(!_lookup(p_old_key, _hash(p_old_key), old_slot), false);
+		Element *elem = _slots[old_slot];
 
-		// Delete the old entries in _hashes and _elements.
-		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
-			SWAP(_hashes[next_idx], _hashes[idx]);
-			SWAP(_elements[next_idx], _elements[idx]);
-			idx = next_idx;
-			_increment_mod(next_idx, capacity);
+		// Vacate the old slot.
+		const uint8_t new_ctrl = _ctrl_after_erase(old_slot);
+		if (new_ctrl == SwissTable::kEmpty) {
+			_growth_left++;
+		} else {
+			_deleted++;
 		}
+		_set_ctrl(old_slot, new_ctrl);
+		_slots[old_slot] = nullptr;
 
-		_hashes[idx] = EMPTY_HASH;
+		// Mutate the key in place. KeyValue::key is `const TKey`; the cast is
+		// safe because the entry is uniquely owned and no caller may hold a
+		// concurrent reference to it.
+		const_cast<TKey &>(elem->data.key) = p_new_key;
 
-		// _insert_element will increment this again.
-		_size--;
-
-		// Update the HashMapElement with the new key and reinsert it.
-		const_cast<TKey &>(element->data.key) = p_new_key;
-		_insert_element(new_hash, element);
-
+		// Reinsert into a fresh slot under the new hash.
+		const uint32_t target = _find_insert_slot(new_hash);
+		const bool was_deleted = SwissTable::is_deleted(_ctrl[target]);
+		_set_ctrl(target, SwissTable::h2(new_hash));
+		_slots[target] = elem;
+		if (was_deleted) {
+			_deleted--;
+		} else {
+			_growth_left--;
+		}
 		return true;
 	}
 
-	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
-	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
+	// Reserve at least p_new_capacity *entries*. Sized so the index table
+	// can host that many keys without triggering another grow.
 	void reserve(uint32_t p_new_capacity) {
-		uint32_t new_idx = _capacity_idx;
-
-		while (hash_table_size_primes[new_idx] < p_new_capacity) {
-			ERR_FAIL_COND_MSG(new_idx + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
-			new_idx++;
+		const uint32_t needed_index_capacity = _round_up_capacity(
+				MAX(SwissTable::growth_to_lower_bound_capacity(p_new_capacity), kGroupWidth));
+		if (_capacity == 0) {
+			_pending_capacity = MAX(_pending_capacity, needed_index_capacity);
+			return;
 		}
-
-		if (new_idx == _capacity_idx) {
+		if (needed_index_capacity <= _capacity) {
 			if (p_new_capacity < _size) {
 				WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 			}
 			return;
 		}
-
-		if (_elements == nullptr) {
-			_capacity_idx = new_idx;
-			return; // Unallocated yet.
-		}
-		_resize_and_rehash(new_idx);
+		_resize_table(needed_index_capacity);
 	}
 
 	/** Iterator API **/
 
 	struct ConstIterator {
-		_FORCE_INLINE_ const KeyValue<TKey, TValue> &operator*() const {
-			return E->data;
-		}
+		_FORCE_INLINE_ const KeyValue<TKey, TValue> &operator*() const { return E->data; }
 		_FORCE_INLINE_ const KeyValue<TKey, TValue> *operator->() const { return &E->data; }
 		_FORCE_INLINE_ ConstIterator &operator++() {
 			if (E) {
@@ -447,11 +491,9 @@ public:
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
 
-		_FORCE_INLINE_ explicit operator bool() const {
-			return E != nullptr;
-		}
+		_FORCE_INLINE_ explicit operator bool() const { return E != nullptr; }
 
-		_FORCE_INLINE_ ConstIterator(const HashMapElement<TKey, TValue> *p_E) { E = p_E; }
+		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}
 		_FORCE_INLINE_ ConstIterator(const ConstIterator &p_it) { E = p_it.E; }
 		_FORCE_INLINE_ void operator=(const ConstIterator &p_it) {
@@ -459,13 +501,11 @@ public:
 		}
 
 	private:
-		const HashMapElement<TKey, TValue> *E = nullptr;
+		const Element *E = nullptr;
 	};
 
 	struct Iterator {
-		_FORCE_INLINE_ KeyValue<TKey, TValue> &operator*() const {
-			return E->data;
-		}
+		_FORCE_INLINE_ KeyValue<TKey, TValue> &operator*() const { return E->data; }
 		_FORCE_INLINE_ KeyValue<TKey, TValue> *operator->() const { return &E->data; }
 		_FORCE_INLINE_ Iterator &operator++() {
 			if (E) {
@@ -483,11 +523,9 @@ public:
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
 
-		_FORCE_INLINE_ explicit operator bool() const {
-			return E != nullptr;
-		}
+		_FORCE_INLINE_ explicit operator bool() const { return E != nullptr; }
 
-		_FORCE_INLINE_ Iterator(HashMapElement<TKey, TValue> *p_E) { E = p_E; }
+		_FORCE_INLINE_ Iterator(Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ Iterator() {}
 		_FORCE_INLINE_ Iterator(const Iterator &p_it) { E = p_it.E; }
 		_FORCE_INLINE_ void operator=(const Iterator &p_it) {
@@ -499,7 +537,7 @@ public:
 		}
 
 	private:
-		HashMapElement<TKey, TValue> *E = nullptr;
+		Element *E = nullptr;
 	};
 
 	_FORCE_INLINE_ Iterator begin() {
@@ -513,12 +551,11 @@ public:
 	}
 
 	_FORCE_INLINE_ Iterator find(const TKey &p_key) {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
-		if (!exists) {
+		uint32_t slot = 0;
+		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return Iterator(_elements[idx]);
+		return Iterator(_slots[slot]);
 	}
 
 	_FORCE_INLINE_ void remove(const Iterator &p_iter) {
@@ -538,92 +575,94 @@ public:
 	}
 
 	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
-		if (!exists) {
+		uint32_t slot = 0;
+		if (!_lookup(p_key, _hash(p_key), slot)) {
 			return end();
 		}
-		return ConstIterator(_elements[idx]);
+		return ConstIterator(_slots[slot]);
 	}
 
 	/* Indexing */
 
 	const TValue &operator[](const TKey &p_key) const {
-		uint32_t idx = 0;
-		bool exists = _lookup_idx(p_key, idx);
+		uint32_t slot = 0;
+		const bool exists = _lookup(p_key, _hash(p_key), slot);
 		CRASH_COND(!exists);
-		return _elements[idx]->data.value;
+		return _slots[slot]->data.value;
 	}
 
 	TValue &operator[](const TKey &p_key) {
 		const uint32_t hash = _hash(p_key);
-		uint32_t idx = 0;
-		bool exists = _elements && _size > 0 && _lookup_idx_unchecked(p_key, hash, idx);
-		if (!exists) {
-			return _insert(p_key, TValue(), hash)->data.value;
-		} else {
-			return _elements[idx]->data.value;
+		uint32_t slot = 0;
+		if (_capacity > 0 && _size > 0 && _lookup(p_key, hash, slot)) {
+			return _slots[slot]->data.value;
 		}
+		return _insert_internal(p_key, TValue(), hash, false)->data.value;
 	}
 
 	/* Insert */
 
 	Iterator insert(const TKey &p_key, const TValue &p_value, bool p_front_insert = false) {
 		const uint32_t hash = _hash(p_key);
-		uint32_t idx = 0;
-		bool exists = _elements && _size > 0 && _lookup_idx_unchecked(p_key, hash, idx);
-		if (!exists) {
-			return Iterator(_insert(p_key, p_value, hash, p_front_insert));
-		} else {
-			_elements[idx]->data.value = p_value;
-			return Iterator(_elements[idx]);
+		uint32_t slot = 0;
+		if (_capacity > 0 && _size > 0 && _lookup(p_key, hash, slot)) {
+			_slots[slot]->data.value = p_value;
+			return Iterator(_slots[slot]);
 		}
+		return Iterator(_insert_internal(p_key, p_value, hash, p_front_insert));
 	}
 
 	/* Constructors */
 
-	explicit HashMap(const HashMap &p_other) {
-		reserve(hash_table_size_primes[p_other._capacity_idx]);
+	HashMap() {}
 
+	explicit HashMap(uint32_t p_initial_capacity) {
+		reserve(p_initial_capacity);
+	}
+
+	HashMap(const HashMap &p_other) {
 		if (p_other._size == 0) {
 			return;
 		}
-
+		reserve(p_other._size);
 		for (const KeyValue<TKey, TValue> &E : p_other) {
 			insert(E.key, E.value);
 		}
 	}
 
 	HashMap(HashMap &&p_other) {
-		_elements = p_other._elements;
-		_hashes = p_other._hashes;
+		_ctrl = p_other._ctrl;
+		_slots = p_other._slots;
 		_head_element = p_other._head_element;
 		_tail_element = p_other._tail_element;
-		_capacity_idx = p_other._capacity_idx;
+		_capacity = p_other._capacity;
+		_capacity_mask = p_other._capacity_mask;
 		_size = p_other._size;
+		_growth_left = p_other._growth_left;
+		_deleted = p_other._deleted;
+		_pending_capacity = p_other._pending_capacity;
 
-		p_other._elements = nullptr;
-		p_other._hashes = nullptr;
+		p_other._ctrl = nullptr;
+		p_other._slots = nullptr;
 		p_other._head_element = nullptr;
 		p_other._tail_element = nullptr;
-		p_other._capacity_idx = MIN_CAPACITY_INDEX;
+		p_other._capacity = 0;
+		p_other._capacity_mask = 0;
 		p_other._size = 0;
+		p_other._growth_left = 0;
+		p_other._deleted = 0;
+		p_other._pending_capacity = 0;
 	}
 
 	void operator=(const HashMap &p_other) {
 		if (this == &p_other) {
-			return; // Ignore self assignment.
+			return;
 		}
-		if (_size != 0) {
-			clear();
+		clear();
+		if (p_other._size == 0) {
+			return;
 		}
-
-		reserve(hash_table_size_primes[p_other._capacity_idx]);
-
-		if (p_other._elements == nullptr) {
-			return; // Nothing to copy.
-		}
-
+		reserve(p_other._size);
 		for (const KeyValue<TKey, TValue> &E : p_other) {
 			insert(E.key, E.value);
 		}
@@ -633,39 +672,35 @@ public:
 		if (this == &p_other) {
 			return *this;
 		}
-
-		if (_size != 0) {
-			clear();
-		}
-		if (_elements != nullptr) {
-			Memory::free_static(_elements);
-			Memory::free_static(_hashes);
+		_clear_data();
+		if (_ctrl != nullptr) {
+			Memory::free_static(_ctrl);
+			Memory::free_static(_slots);
 		}
 
-		_elements = p_other._elements;
-		_hashes = p_other._hashes;
+		_ctrl = p_other._ctrl;
+		_slots = p_other._slots;
 		_head_element = p_other._head_element;
 		_tail_element = p_other._tail_element;
-		_capacity_idx = p_other._capacity_idx;
+		_capacity = p_other._capacity;
+		_capacity_mask = p_other._capacity_mask;
 		_size = p_other._size;
+		_growth_left = p_other._growth_left;
+		_deleted = p_other._deleted;
+		_pending_capacity = p_other._pending_capacity;
 
-		p_other._elements = nullptr;
-		p_other._hashes = nullptr;
+		p_other._ctrl = nullptr;
+		p_other._slots = nullptr;
 		p_other._head_element = nullptr;
 		p_other._tail_element = nullptr;
-		p_other._capacity_idx = MIN_CAPACITY_INDEX;
+		p_other._capacity = 0;
+		p_other._capacity_mask = 0;
 		p_other._size = 0;
+		p_other._growth_left = 0;
+		p_other._deleted = 0;
+		p_other._pending_capacity = 0;
 
 		return *this;
-	}
-
-	HashMap(uint32_t p_initial_capacity) {
-		// Capacity can't be 0.
-		_capacity_idx = 0;
-		reserve(p_initial_capacity);
-	}
-	HashMap() {
-		_capacity_idx = MIN_CAPACITY_INDEX;
 	}
 
 	HashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
@@ -676,26 +711,35 @@ public:
 	}
 
 	uint32_t debug_get_hash(uint32_t p_idx) {
-		if (_size == 0) {
+		if (_size == 0 || _capacity == 0) {
 			return 0;
 		}
-		ERR_FAIL_INDEX_V(p_idx, get_capacity(), 0);
-		return _hashes[p_idx];
+		ERR_FAIL_INDEX_V(p_idx, _capacity, 0);
+		const uint8_t c = _ctrl[p_idx];
+		if (c == SwissTable::kEmpty || c == SwissTable::kDeleted) {
+			return 0;
+		}
+		// Reconstruction of the full hash isn't possible from h2; expose the
+		// fingerprint byte instead, which is what callers need for diagnostics.
+		return c;
 	}
 	Iterator debug_get_element(uint32_t p_idx) {
-		if (_size == 0) {
+		if (_size == 0 || _capacity == 0) {
 			return Iterator();
 		}
-		ERR_FAIL_INDEX_V(p_idx, get_capacity(), Iterator());
-		return Iterator(_elements[p_idx]);
+		ERR_FAIL_INDEX_V(p_idx, _capacity, Iterator());
+		Element *e = _slots[p_idx];
+		if (e == nullptr) {
+			return Iterator();
+		}
+		return Iterator(e);
 	}
 
 	~HashMap() {
 		_clear_data();
-
-		if (_elements != nullptr) {
-			Memory::free_static(_elements);
-			Memory::free_static(_hashes);
+		if (_ctrl != nullptr) {
+			Memory::free_static(_ctrl);
+			Memory::free_static(_slots);
 		}
 	}
 };

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -45,6 +45,133 @@ struct Pair;
  * Hashing functions
  */
 
+// Deterministic folded-multiply hasher derived from foldhash's core mixing
+// primitive. We hash string code units by numeric value (rather than their
+// in-memory byte layout) so `char *`, `wchar_t *`, and `char32_t *` overloads
+// stay consistent for the same code points on the current platform.
+inline constexpr uint64_t HASH_FOLD_SEED0 = 0x243f6a8885a308d3ULL;
+inline constexpr uint64_t HASH_FOLD_SEED1 = 0x13198a2e03707344ULL;
+inline constexpr uint64_t HASH_FOLD_SEED2 = 0xa4093822299f31d0ULL;
+inline constexpr uint64_t HASH_FOLD_SEED3 = 0x082efa98ec4e6c89ULL;
+inline constexpr uint64_t HASH_FOLD_SEED4 = 0x452821e638d01377ULL;
+
+_FORCE_INLINE_ uint32_t hash_fmix32(uint32_t h);
+
+_FORCE_INLINE_ uint64_t hash_folded_multiply(uint64_t p_x, uint64_t p_y) {
+#if defined(_MSC_VER) && defined(_M_X64)
+	uint64_t hi = 0;
+	const uint64_t lo = _umul128(p_x, p_y, &hi);
+	return lo ^ hi;
+#elif defined(_MSC_VER) && defined(_M_ARM64)
+	const uint64_t lo = p_x * p_y;
+	const uint64_t hi = __umulh(p_x, p_y);
+	return lo ^ hi;
+#elif defined(__SIZEOF_INT128__)
+	__extension__ typedef unsigned __int128 uint128;
+	const uint128 full = static_cast<uint128>(p_x) * static_cast<uint128>(p_y);
+	return static_cast<uint64_t>(full) ^ static_cast<uint64_t>(full >> 64);
+#else
+	const uint32_t lx = uint32_t(p_x);
+	const uint32_t ly = uint32_t(p_y);
+	const uint32_t hx = uint32_t(p_x >> 32);
+	const uint32_t hy = uint32_t(p_y >> 32);
+
+	const uint64_t ll = uint64_t(lx) * uint64_t(ly);
+	const uint64_t lh = uint64_t(lx) * uint64_t(hy);
+	const uint64_t hl = uint64_t(hx) * uint64_t(ly);
+	const uint64_t hh = uint64_t(hx) * uint64_t(hy);
+	return (hh ^ ll) ^ ((hl ^ lh) >> 32) ^ ((hl ^ lh) << 32);
+#endif
+}
+
+template <typename T>
+_FORCE_INLINE_ uint64_t hash_foldhash_pack_units(const T *p_data, int p_count) {
+	static_assert(std::is_integral_v<T>, "Foldhash packer requires integral code units.");
+	static_assert(sizeof(T) <= sizeof(uint32_t), "Foldhash packer requires code units up to 32 bits.");
+	ERR_FAIL_COND_V(p_count > 2, 0);
+
+	using U = std::make_unsigned_t<T>;
+	uint64_t word = 0;
+	for (int i = 0; i < p_count; i++) {
+		// Normalize every code unit to a 32-bit lane so equivalent logical
+		// strings hash the same regardless of whether they entered as char*,
+		// wchar_t*, char16_t*, char32_t*, or String.
+		word |= uint64_t(uint32_t(U(p_data[i]))) << (i * 32);
+	}
+	return word;
+}
+
+template <typename T>
+_FORCE_INLINE_ int hash_foldhash_cstr_len(const T *p_cstr) {
+	int len = 0;
+	while (p_cstr[len] != 0) {
+		len++;
+	}
+	return len;
+}
+
+template <typename T>
+_FORCE_INLINE_ uint32_t hash_foldhash_units(const T *p_data, int p_len) {
+	static_assert(std::is_integral_v<T>, "Foldhash unit hasher requires integral code units.");
+	constexpr int kLaneUnits = 2;
+
+	uint64_t acc = HASH_FOLD_SEED3 ^ (uint64_t(uint32_t(MAX(p_len, 0))) * HASH_FOLD_SEED4);
+	int i = 0;
+	while (i + 2 * kLaneUnits <= p_len) {
+		const uint64_t lo = hash_foldhash_pack_units(p_data + i, kLaneUnits);
+		const uint64_t hi = hash_foldhash_pack_units(p_data + i + kLaneUnits, kLaneUnits);
+		acc = hash_folded_multiply(lo ^ acc, hi ^ HASH_FOLD_SEED0);
+		i += 2 * kLaneUnits;
+	}
+
+	const int remaining = p_len - i;
+	if (remaining > 0) {
+		const int lo_count = MIN(remaining, kLaneUnits);
+		const int hi_count = remaining - lo_count;
+		const uint64_t lo = hash_foldhash_pack_units(p_data + i, lo_count);
+		const uint64_t hi = (hi_count > 0)
+				? hash_foldhash_pack_units(p_data + i + lo_count, hi_count)
+				: ((uint64_t(uint32_t(p_len)) << 32) | uint64_t(lo_count));
+		acc = hash_folded_multiply(lo ^ acc, hi ^ HASH_FOLD_SEED1);
+	}
+
+	const uint64_t final = hash_folded_multiply(acc ^ HASH_FOLD_SEED2,
+			(uint64_t(uint32_t(p_len)) << 32) ^ HASH_FOLD_SEED4);
+	return uint32_t(final) ^ uint32_t(final >> 32);
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char *p_cstr) {
+	return hash_foldhash_units(reinterpret_cast<const uint8_t *>(p_cstr), hash_foldhash_cstr_len(p_cstr));
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char *p_cstr, int p_len) {
+	return hash_foldhash_units(reinterpret_cast<const uint8_t *>(p_cstr), p_len);
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const wchar_t *p_cstr, int p_len) {
+	return hash_foldhash_units(p_cstr, p_len);
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const wchar_t *p_cstr) {
+	return hash_foldhash_units(p_cstr, hash_foldhash_cstr_len(p_cstr));
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char16_t *p_cstr, int p_len) {
+	return hash_foldhash_units(p_cstr, p_len);
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char16_t *p_cstr) {
+	return hash_foldhash_units(p_cstr, hash_foldhash_cstr_len(p_cstr));
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char32_t *p_cstr, int p_len) {
+	return hash_foldhash_units(p_cstr, p_len);
+}
+
+_FORCE_INLINE_ uint32_t hash_foldhash(const char32_t *p_cstr) {
+	return hash_foldhash_units(p_cstr, hash_foldhash_cstr_len(p_cstr));
+}
+
 /**
  * DJB2 Hash function
  * @param C String
@@ -204,7 +331,12 @@ struct HashMapHasherDefaultImpl<T, std::enable_if_t<std::is_enum_v<T>>> {
 
 template <>
 struct HashMapHasherDefaultImpl<char *> {
-	static _FORCE_INLINE_ uint32_t hash(const char *p_cstr) { return hash_djb2(p_cstr); }
+	static _FORCE_INLINE_ uint32_t hash(const char *p_cstr) { return hash_foldhash(p_cstr); }
+};
+
+template <>
+struct HashMapHasherDefaultImpl<const char *> {
+	static _FORCE_INLINE_ uint32_t hash(const char *p_cstr) { return hash_foldhash(p_cstr); }
 };
 
 template <>

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -46,9 +46,7 @@ struct Pair;
  */
 
 // Deterministic folded-multiply hasher derived from foldhash's core mixing
-// primitive. We hash string code units by numeric value (rather than their
-// in-memory byte layout) so `char *`, `wchar_t *`, and `char32_t *` overloads
-// stay consistent for the same code points on the current platform.
+// primitive.
 inline constexpr uint64_t HASH_FOLD_SEED0 = 0x243f6a8885a308d3ULL;
 inline constexpr uint64_t HASH_FOLD_SEED1 = 0x13198a2e03707344ULL;
 inline constexpr uint64_t HASH_FOLD_SEED2 = 0xa4093822299f31d0ULL;
@@ -93,9 +91,7 @@ _FORCE_INLINE_ uint64_t hash_foldhash_pack_units(const T *p_data, int p_count) {
 	using U = std::make_unsigned_t<T>;
 	uint64_t word = 0;
 	for (int i = 0; i < p_count; i++) {
-		// Normalize every code unit to a 32-bit lane so equivalent logical
-		// strings hash the same regardless of whether they entered as char*,
-		// wchar_t*, char16_t*, char32_t*, or String.
+		// Pack code units into 32-bit lanes before mixing.
 		word |= uint64_t(uint32_t(U(p_data[i]))) << (i * 32);
 	}
 	return word;

--- a/core/templates/swiss_table_simd.h
+++ b/core/templates/swiss_table_simd.h
@@ -1,0 +1,389 @@
+/**************************************************************************/
+/*  swiss_table_simd.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/typedefs.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/**
+ * SwissTable-style control-byte group scanning primitives, shared by HashMap
+ * and AHashMap.
+ *
+ * Each control byte describes one slot in the index table:
+ *   - kEmpty   (0x80) -- never used or rehashed-out.
+ *   - kDeleted (0xFE) -- tombstone left by erase, may still be probed past.
+ *   - 0..0x7F (kFull) -- 7-bit fingerprint (h2) of the contained key's hash.
+ *
+ * H1 (top bits) selects the starting probe group; H2 (low 7 bits, top bit
+ * cleared) is stored in the control byte. Lookup loads a group of bytes,
+ * SIMD-compares them against H2, and only follows up with a full key compare
+ * on slots whose fingerprint matches.
+ *
+ * Group widths:
+ *   - SSE2 / WASM SIMD128: 16 bytes
+ *   - NEON: 8 bytes (we use the vshrn-pack trick to produce a 64-bit mask
+ *     where each match byte is 0xF, and then condense to a 32-bit bitmask
+ *     with one set bit per match)
+ *   - SWAR scalar fallback: 8 bytes
+ *
+ * The Match return type (BitMask) abstracts the per-platform mask shape so
+ * that callers can iterate set bits uniformly via lowest_set_bit() / next().
+ */
+
+namespace SwissTable {
+
+inline constexpr uint8_t kEmpty = 0x80;
+inline constexpr uint8_t kDeleted = 0xFE;
+inline constexpr uint8_t kSentinel = 0xFF; // Reserved, currently unused.
+
+// True if the control byte represents an empty slot.
+static _FORCE_INLINE_ bool is_empty(uint8_t ctrl) {
+	return ctrl == kEmpty;
+}
+
+// True if the control byte represents a tombstone.
+static _FORCE_INLINE_ bool is_deleted(uint8_t ctrl) {
+	return ctrl == kDeleted;
+}
+
+// True if the control byte represents either empty or a tombstone.
+static _FORCE_INLINE_ bool is_empty_or_deleted(uint8_t ctrl) {
+	return (ctrl & 0x80) != 0;
+}
+
+// True if the control byte represents a full slot (top bit cleared).
+static _FORCE_INLINE_ bool is_full(uint8_t ctrl) {
+	return (ctrl & 0x80) == 0;
+}
+
+// Derive the 7-bit fingerprint to store in a control byte from a 32-bit hash.
+// We use the top 7 bits of the 32-bit hash to spread the fingerprint across
+// keys whose H1 (low bits) collide. Top bit is masked off so the value never
+// collides with kEmpty/kDeleted.
+static _FORCE_INLINE_ uint8_t h2(uint32_t hash) {
+	return static_cast<uint8_t>((hash >> 25) & 0x7F);
+}
+
+// "Probe sequence" group index. The fast path uses the low bits of the hash
+// to select the starting group; the caller is responsible for masking by
+// (capacity - 1). See the comment in BitMask for how H1 is consumed.
+static _FORCE_INLINE_ uint32_t h1(uint32_t hash) {
+	return hash >> 7;
+}
+
+// Iterate set bits in a SIMD match bitmask. Each call to next() returns the
+// slot index of the next match (0..Width-1). The mask layout differs per
+// backend:
+//   - SSE2 / WASM SIMD128: 1 bit per matched byte (Shift = 0).
+//   - NEON: 4 bits per matched byte (Shift = 2).
+//   - SWAR: 8 bits per matched byte (Shift = 3).
+//
+// `next()` clears ALL bits belonging to the lowest match before returning, so
+// that the iteration step correctly advances past the per-match bit group.
+template <uint32_t Width, uint32_t Shift>
+struct BitMask {
+	uint64_t mask;
+
+	// Bits belonging to one match. 1 for SSE2/WASM, 0xF for NEON, 0xFF for SWAR.
+	static constexpr uint64_t kMatchBits = (1ULL << (1u << Shift)) - 1;
+
+	_FORCE_INLINE_ explicit operator bool() const { return mask != 0; }
+
+	static _FORCE_INLINE_ uint32_t ctz64(uint64_t v) {
+#if defined(__GNUC__) || defined(__clang__)
+		return static_cast<uint32_t>(__builtin_ctzll(v));
+#elif defined(_MSC_VER)
+		unsigned long idx;
+		_BitScanForward64(&idx, v);
+		return static_cast<uint32_t>(idx);
+#else
+		uint32_t result = 0;
+		while ((v & 1) == 0) {
+			v >>= 1;
+			++result;
+		}
+		return result;
+#endif
+	}
+
+	_FORCE_INLINE_ uint32_t lowest_set_bit() const {
+		return ctz64(mask) >> Shift;
+	}
+
+	struct Iterator {
+		uint64_t m;
+		_FORCE_INLINE_ Iterator(uint64_t p_m) :
+				m(p_m) {}
+		_FORCE_INLINE_ bool has_next() const { return m != 0; }
+		_FORCE_INLINE_ uint32_t next() {
+			const uint32_t bit = ctz64(m);
+			const uint32_t idx = bit >> Shift;
+			// Clear all bits belonging to this match (one bit, one nibble, or
+			// one byte depending on Shift). The base aligns to the per-match
+			// stride (1, 4, or 8 bits).
+			const uint32_t base = bit & ~((1u << Shift) - 1u);
+			m &= ~(kMatchBits << base);
+			return idx;
+		}
+	};
+
+	_FORCE_INLINE_ Iterator iter() const { return Iterator(mask); }
+
+	static constexpr uint32_t width() { return Width; }
+};
+
+} // namespace SwissTable
+
+// =============================================================================
+// SSE2 implementation (x86_64 always-on, x86 with -msse2)
+// =============================================================================
+
+#if defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86) && defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
+#define SWISS_TABLE_HAS_SSE2 1
+#include <emmintrin.h>
+
+namespace SwissTable {
+
+struct GroupSSE2 {
+	static constexpr uint32_t kWidth = 16;
+	using Mask = BitMask<kWidth, 0>;
+
+	__m128i ctrl;
+
+	_FORCE_INLINE_ explicit GroupSSE2(const uint8_t *p_ctrl) {
+		// Use unaligned load -- callers may probe across group boundaries.
+		ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i *>(p_ctrl));
+	}
+
+	// Slots whose control byte equals h2.
+	_FORCE_INLINE_ Mask match(uint8_t p_h2) const {
+		__m128i needle = _mm_set1_epi8(static_cast<char>(p_h2));
+		__m128i eq = _mm_cmpeq_epi8(ctrl, needle);
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(eq))) };
+	}
+
+	// Slots whose control byte is kEmpty.
+	_FORCE_INLINE_ Mask match_empty() const {
+		__m128i needle = _mm_set1_epi8(static_cast<char>(kEmpty));
+		__m128i eq = _mm_cmpeq_epi8(ctrl, needle);
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(eq))) };
+	}
+
+	// Slots whose control byte has the high bit set (empty OR deleted).
+	_FORCE_INLINE_ Mask match_empty_or_deleted() const {
+		// (ctrl & 0x80) != 0 is true for kEmpty and kDeleted.
+		// _mm_movemask_epi8 returns the high bit of each byte directly.
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(ctrl))) };
+	}
+};
+
+} // namespace SwissTable
+#endif
+
+// =============================================================================
+// NEON implementation (ARM64 / ARMv7 with NEON)
+// =============================================================================
+
+#if (defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(_M_ARM64)) && !defined(SWISS_TABLE_HAS_SSE2)
+#define SWISS_TABLE_HAS_NEON 1
+#include <arm_neon.h>
+
+namespace SwissTable {
+
+struct GroupNEON {
+	static constexpr uint32_t kWidth = 8;
+	// Each matched byte produces 4 bits in the mask; shift right by 2 to get
+	// the slot index from a trailing-zero count.
+	using Mask = BitMask<kWidth, 2>;
+
+	uint8x8_t ctrl;
+
+	_FORCE_INLINE_ explicit GroupNEON(const uint8_t *p_ctrl) {
+		ctrl = vld1_u8(p_ctrl);
+	}
+
+	// Convert an 8-byte vector of all-ones-or-all-zeros bytes into a 32-bit
+	// mask with 4 bits per matched byte.
+	static _FORCE_INLINE_ uint64_t to_bitmask(uint8x8_t v) {
+		// vshrn_n_u16 with shift 4 on a 16x4 reinterpretation packs each
+		// nibble; the resulting 32-bit value has 4 bits set per matched byte.
+		uint16x8_t v16 = vreinterpretq_u16_u8(vcombine_u8(v, vdup_n_u8(0)));
+		uint8x8_t packed = vshrn_n_u16(v16, 4);
+		return static_cast<uint64_t>(vget_lane_u64(vreinterpret_u64_u8(packed), 0));
+	}
+
+	_FORCE_INLINE_ Mask match(uint8_t p_h2) const {
+		uint8x8_t needle = vdup_n_u8(p_h2);
+		uint8x8_t eq = vceq_u8(ctrl, needle);
+		return Mask{ to_bitmask(eq) };
+	}
+
+	_FORCE_INLINE_ Mask match_empty() const {
+		uint8x8_t needle = vdup_n_u8(kEmpty);
+		uint8x8_t eq = vceq_u8(ctrl, needle);
+		return Mask{ to_bitmask(eq) };
+	}
+
+	_FORCE_INLINE_ Mask match_empty_or_deleted() const {
+		// Top bit set -> empty or deleted. Test with sign extension.
+		uint8x8_t signbit = vdup_n_u8(0x80);
+		uint8x8_t masked = vand_u8(ctrl, signbit);
+		uint8x8_t eq = vceq_u8(masked, signbit);
+		return Mask{ to_bitmask(eq) };
+	}
+};
+
+} // namespace SwissTable
+#endif
+
+// =============================================================================
+// WASM SIMD128 implementation
+// =============================================================================
+
+#if defined(__wasm_simd128__) && !defined(SWISS_TABLE_HAS_SSE2) && !defined(SWISS_TABLE_HAS_NEON)
+#define SWISS_TABLE_HAS_WASM_SIMD 1
+#include <wasm_simd128.h>
+
+namespace SwissTable {
+
+struct GroupWASM {
+	static constexpr uint32_t kWidth = 16;
+	using Mask = BitMask<kWidth, 0>;
+
+	v128_t ctrl;
+
+	_FORCE_INLINE_ explicit GroupWASM(const uint8_t *p_ctrl) {
+		ctrl = wasm_v128_load(p_ctrl);
+	}
+
+	_FORCE_INLINE_ Mask match(uint8_t p_h2) const {
+		v128_t needle = wasm_i8x16_splat(static_cast<int8_t>(p_h2));
+		v128_t eq = wasm_i8x16_eq(ctrl, needle);
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(wasm_i8x16_bitmask(eq))) };
+	}
+
+	_FORCE_INLINE_ Mask match_empty() const {
+		v128_t needle = wasm_i8x16_splat(static_cast<int8_t>(kEmpty));
+		v128_t eq = wasm_i8x16_eq(ctrl, needle);
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(wasm_i8x16_bitmask(eq))) };
+	}
+
+	_FORCE_INLINE_ Mask match_empty_or_deleted() const {
+		// High bit of each byte -> empty or deleted.
+		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(wasm_i8x16_bitmask(ctrl))) };
+	}
+};
+
+} // namespace SwissTable
+#endif
+
+// =============================================================================
+// SWAR scalar fallback (always available)
+// =============================================================================
+
+namespace SwissTable {
+
+struct GroupSWAR {
+	static constexpr uint32_t kWidth = 8;
+	// Each matched byte produces 8 bits in the mask; shift right by 3 to get
+	// the slot index from a trailing-zero count.
+	using Mask = BitMask<kWidth, 3>;
+
+	uint64_t ctrl;
+
+	_FORCE_INLINE_ explicit GroupSWAR(const uint8_t *p_ctrl) {
+		memcpy(&ctrl, p_ctrl, sizeof(ctrl));
+	}
+
+	// Standard "find equal byte" SWAR trick:
+	//   v = ctrl XOR broadcast(p_h2)
+	//   matches are bytes equal to 0
+	//   has_zero(v) = (v - 0x01010101...) AND ~v AND 0x80808080...
+	_FORCE_INLINE_ Mask match(uint8_t p_h2) const {
+		uint64_t broadcast = 0x0101010101010101ULL * static_cast<uint64_t>(p_h2);
+		uint64_t v = ctrl ^ broadcast;
+		uint64_t hi = (v - 0x0101010101010101ULL) & ~v & 0x8080808080808080ULL;
+		return Mask{ hi };
+	}
+
+	_FORCE_INLINE_ Mask match_empty() const {
+		// kEmpty == 0x80. A byte equals 0x80 iff it has only the high bit set:
+		// (b & 0x80) != 0 AND (b & 0x7F) == 0.
+		// We compute this as (ctrl & ((~ctrl << 1) | ~0x7F-line)). Easier:
+		// match against the broadcast of 0x80 using the generic trick.
+		return match(kEmpty);
+	}
+
+	_FORCE_INLINE_ Mask match_empty_or_deleted() const {
+		// Any byte with the high bit set -> kEmpty or kDeleted.
+		return Mask{ ctrl & 0x8080808080808080ULL };
+	}
+};
+
+} // namespace SwissTable
+
+// =============================================================================
+// Default Group selection
+// =============================================================================
+
+namespace SwissTable {
+
+#if defined(SWISS_TABLE_HAS_SSE2)
+using Group = GroupSSE2;
+#elif defined(SWISS_TABLE_HAS_NEON)
+using Group = GroupNEON;
+#elif defined(SWISS_TABLE_HAS_WASM_SIMD)
+using Group = GroupWASM;
+#else
+using Group = GroupSWAR;
+#endif
+
+inline constexpr uint32_t kGroupWidth = Group::kWidth;
+
+// Round capacity up so it is large enough to host (size + 1) entries with at
+// most 7/8 occupancy. Capacities are always powers of two with a minimum of
+// kGroupWidth.
+static _FORCE_INLINE_ uint32_t capacity_to_growth(uint32_t capacity) {
+	// 7/8 of capacity, rounded down. capacity is always a power of two >= 8.
+	return capacity - (capacity / 8);
+}
+
+static _FORCE_INLINE_ uint32_t growth_to_lower_bound_capacity(uint32_t growth) {
+	// We want capacity >= growth * 8 / 7. Round up.
+	if (growth == 0) {
+		return 0;
+	}
+	return growth + ((growth - 1) / 7) + 1;
+}
+
+} // namespace SwissTable

--- a/core/templates/swiss_table_simd.h
+++ b/core/templates/swiss_table_simd.h
@@ -159,8 +159,31 @@ struct BitMask {
 #endif
 	}
 
+	static _FORCE_INLINE_ uint32_t clz64(uint64_t v) {
+#if defined(__GNUC__) || defined(__clang__)
+		return static_cast<uint32_t>(__builtin_clzll(v));
+#elif defined(_MSC_VER)
+		unsigned long idx;
+		_BitScanReverse64(&idx, v);
+		return static_cast<uint32_t>(63 - idx);
+#else
+		uint32_t result = 0;
+		while ((v & (1ULL << 63)) == 0) {
+			v <<= 1;
+			++result;
+		}
+		return result;
+#endif
+	}
+
 	_FORCE_INLINE_ uint32_t lowest_set_bit() const {
 		return ctz64(mask) >> Shift;
+	}
+
+	// Slot index of the highest set match in the mask. Caller must ensure
+	// mask != 0. Symmetric to lowest_set_bit but walks from the top.
+	_FORCE_INLINE_ uint32_t highest_set_bit() const {
+		return (63u - clz64(mask)) >> Shift;
 	}
 
 	struct Iterator {

--- a/core/templates/swiss_table_simd.h
+++ b/core/templates/swiss_table_simd.h
@@ -86,6 +86,29 @@ static _FORCE_INLINE_ bool is_full(uint8_t ctrl) {
 	return (ctrl & 0x80) == 0;
 }
 
+// Bit avalanche / "finalizer" applied to user hashes before splitting them
+// into H1 (group selector) and H2 (fingerprint).
+//
+// SwissTable selects buckets and fingerprints from disjoint bit ranges of a
+// 32-bit hash. Several Godot keys use hash functions whose bits are not well
+// mixed -- DJB2 String hashing in particular leaves the high bits highly
+// correlated when keys share a common prefix (e.g. "key_0".."key_N"). That
+// causes both probe-chain pile-ups (poor H1) and frequent fingerprint
+// collisions (poor H2), which in turn force cache-missing Element derefs to
+// do real key compares.
+//
+// We mix once at the public boundary (just before h1/h2) so callers don't
+// have to know about it. This is the splitmix32-style finalizer; cheap (a
+// few cycles) and breaks low-entropy correlations across all 32 bits.
+static _FORCE_INLINE_ uint32_t mix(uint32_t hash) {
+	hash ^= hash >> 16;
+	hash *= 0x7feb352dU;
+	hash ^= hash >> 15;
+	hash *= 0x846ca68bU;
+	hash ^= hash >> 16;
+	return hash;
+}
+
 // Derive the 7-bit fingerprint to store in a control byte from a 32-bit hash.
 // We use the top 7 bits of the 32-bit hash to spread the fingerprint across
 // keys whose H1 (low bits) collide. Top bit is masked off so the value never

--- a/core/templates/swiss_table_simd.h
+++ b/core/templates/swiss_table_simd.h
@@ -39,25 +39,9 @@
  * SwissTable-style control-byte group scanning primitives, shared by HashMap
  * and AHashMap.
  *
- * Each control byte describes one slot in the index table:
- *   - kEmpty   (0x80) -- never used or rehashed-out.
- *   - kDeleted (0xFE) -- tombstone left by erase, may still be probed past.
- *   - 0..0x7F (kFull) -- 7-bit fingerprint (h2) of the contained key's hash.
- *
- * H1 (top bits) selects the starting probe group; H2 (low 7 bits, top bit
- * cleared) is stored in the control byte. Lookup loads a group of bytes,
- * SIMD-compares them against H2, and only follows up with a full key compare
- * on slots whose fingerprint matches.
- *
- * Group widths:
- *   - SSE2 / WASM SIMD128: 16 bytes
- *   - NEON: 8 bytes (we use the vshrn-pack trick to produce a 64-bit mask
- *     where each match byte is 0xF, and then condense to a 32-bit bitmask
- *     with one set bit per match)
- *   - SWAR scalar fallback: 8 bytes
- *
- * The Match return type (BitMask) abstracts the per-platform mask shape so
- * that callers can iterate set bits uniformly via lowest_set_bit() / next().
+ * Control bytes store empty, deleted, or a 7-bit hash fingerprint. Probing
+ * compares a group of control bytes against h2 and only does a full key
+ * comparison on matching slots.
  */
 
 namespace SwissTable {
@@ -66,40 +50,23 @@ inline constexpr uint8_t kEmpty = 0x80;
 inline constexpr uint8_t kDeleted = 0xFE;
 inline constexpr uint8_t kSentinel = 0xFF; // Reserved, currently unused.
 
-// True if the control byte represents an empty slot.
 static _FORCE_INLINE_ bool is_empty(uint8_t ctrl) {
 	return ctrl == kEmpty;
 }
 
-// True if the control byte represents a tombstone.
 static _FORCE_INLINE_ bool is_deleted(uint8_t ctrl) {
 	return ctrl == kDeleted;
 }
 
-// True if the control byte represents either empty or a tombstone.
 static _FORCE_INLINE_ bool is_empty_or_deleted(uint8_t ctrl) {
 	return (ctrl & 0x80) != 0;
 }
 
-// True if the control byte represents a full slot (top bit cleared).
 static _FORCE_INLINE_ bool is_full(uint8_t ctrl) {
 	return (ctrl & 0x80) == 0;
 }
 
-// Bit avalanche / "finalizer" applied to user hashes before splitting them
-// into H1 (group selector) and H2 (fingerprint).
-//
-// SwissTable selects buckets and fingerprints from disjoint bit ranges of a
-// 32-bit hash. Several Godot keys use hash functions whose bits are not well
-// mixed -- DJB2 String hashing in particular leaves the high bits highly
-// correlated when keys share a common prefix (e.g. "key_0".."key_N"). That
-// causes both probe-chain pile-ups (poor H1) and frequent fingerprint
-// collisions (poor H2), which in turn force cache-missing Element derefs to
-// do real key compares.
-//
-// We mix once at the public boundary (just before h1/h2) so callers don't
-// have to know about it. This is the splitmix32-style finalizer; cheap (a
-// few cycles) and breaks low-entropy correlations across all 32 bits.
+// Finalizer applied before splitting a 32-bit hash into h1 and h2.
 static _FORCE_INLINE_ uint32_t mix(uint32_t hash) {
 	hash ^= hash >> 16;
 	hash *= 0x7feb352dU;
@@ -109,35 +76,21 @@ static _FORCE_INLINE_ uint32_t mix(uint32_t hash) {
 	return hash;
 }
 
-// Derive the 7-bit fingerprint to store in a control byte from a 32-bit hash.
-// We use the top 7 bits of the 32-bit hash to spread the fingerprint across
-// keys whose H1 (low bits) collide. Top bit is masked off so the value never
-// collides with kEmpty/kDeleted.
+// Derive the 7-bit fingerprint stored in the control byte.
 static _FORCE_INLINE_ uint8_t h2(uint32_t hash) {
 	return static_cast<uint8_t>((hash >> 25) & 0x7F);
 }
 
-// "Probe sequence" group index. The fast path uses the low bits of the hash
-// to select the starting group; the caller is responsible for masking by
-// (capacity - 1). See the comment in BitMask for how H1 is consumed.
+// Starting group for the probe sequence.
 static _FORCE_INLINE_ uint32_t h1(uint32_t hash) {
 	return hash >> 7;
 }
 
-// Iterate set bits in a SIMD match bitmask. Each call to next() returns the
-// slot index of the next match (0..Width-1). The mask layout differs per
-// backend:
-//   - SSE2 / WASM SIMD128: 1 bit per matched byte (Shift = 0).
-//   - NEON: 4 bits per matched byte (Shift = 2).
-//   - SWAR: 8 bits per matched byte (Shift = 3).
-//
-// `next()` clears ALL bits belonging to the lowest match before returning, so
-// that the iteration step correctly advances past the per-match bit group.
+// Iterate set bits in a backend-specific SIMD match bitmask.
 template <uint32_t Width, uint32_t Shift>
 struct BitMask {
 	uint64_t mask;
 
-	// Bits belonging to one match. 1 for SSE2/WASM, 0xF for NEON, 0xFF for SWAR.
 	static constexpr uint64_t kMatchBits = (1ULL << (1u << Shift)) - 1;
 
 	_FORCE_INLINE_ explicit operator bool() const { return mask != 0; }
@@ -180,8 +133,6 @@ struct BitMask {
 		return ctz64(mask) >> Shift;
 	}
 
-	// Slot index of the highest set match in the mask. Caller must ensure
-	// mask != 0. Symmetric to lowest_set_bit but walks from the top.
 	_FORCE_INLINE_ uint32_t highest_set_bit() const {
 		return (63u - clz64(mask)) >> Shift;
 	}
@@ -194,9 +145,6 @@ struct BitMask {
 		_FORCE_INLINE_ uint32_t next() {
 			const uint32_t bit = ctz64(m);
 			const uint32_t idx = bit >> Shift;
-			// Clear all bits belonging to this match (one bit, one nibble, or
-			// one byte depending on Shift). The base aligns to the per-match
-			// stride (1, 4, or 8 bits).
 			const uint32_t base = bit & ~((1u << Shift) - 1u);
 			m &= ~(kMatchBits << base);
 			return idx;
@@ -210,9 +158,7 @@ struct BitMask {
 
 } // namespace SwissTable
 
-// =============================================================================
-// SSE2 implementation (x86_64 always-on, x86 with -msse2)
-// =============================================================================
+// SSE2 implementation.
 
 #if defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86) && defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
 #define SWISS_TABLE_HAS_SSE2 1
@@ -227,28 +173,22 @@ struct GroupSSE2 {
 	__m128i ctrl;
 
 	_FORCE_INLINE_ explicit GroupSSE2(const uint8_t *p_ctrl) {
-		// Use unaligned load -- callers may probe across group boundaries.
 		ctrl = _mm_loadu_si128(reinterpret_cast<const __m128i *>(p_ctrl));
 	}
 
-	// Slots whose control byte equals h2.
 	_FORCE_INLINE_ Mask match(uint8_t p_h2) const {
 		__m128i needle = _mm_set1_epi8(static_cast<char>(p_h2));
 		__m128i eq = _mm_cmpeq_epi8(ctrl, needle);
 		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(eq))) };
 	}
 
-	// Slots whose control byte is kEmpty.
 	_FORCE_INLINE_ Mask match_empty() const {
 		__m128i needle = _mm_set1_epi8(static_cast<char>(kEmpty));
 		__m128i eq = _mm_cmpeq_epi8(ctrl, needle);
 		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(eq))) };
 	}
 
-	// Slots whose control byte has the high bit set (empty OR deleted).
 	_FORCE_INLINE_ Mask match_empty_or_deleted() const {
-		// (ctrl & 0x80) != 0 is true for kEmpty and kDeleted.
-		// _mm_movemask_epi8 returns the high bit of each byte directly.
 		return Mask{ static_cast<uint64_t>(static_cast<uint16_t>(_mm_movemask_epi8(ctrl))) };
 	}
 };
@@ -256,9 +196,7 @@ struct GroupSSE2 {
 } // namespace SwissTable
 #endif
 
-// =============================================================================
-// NEON implementation (ARM64 / ARMv7 with NEON)
-// =============================================================================
+// NEON implementation.
 
 #if (defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(_M_ARM64)) && !defined(SWISS_TABLE_HAS_SSE2)
 #define SWISS_TABLE_HAS_NEON 1

--- a/tests/core/templates/test_a_hash_map.cpp
+++ b/tests/core/templates/test_a_hash_map.cpp
@@ -34,7 +34,25 @@ TEST_FORCE_LINK(test_a_hash_map)
 
 #include "core/templates/a_hash_map.h"
 
+#include <unordered_map>
+
 namespace TestAHashMap {
+
+// Hasher that funnels every key into the same H1 group (low bits all zero)
+// to exercise quadratic probing under adversarial collisions.
+struct AHM_SameGroupHasher {
+	static _FORCE_INLINE_ uint32_t hash(int p_key) {
+		return (static_cast<uint32_t>(p_key) << 7);
+	}
+};
+
+// Hasher whose H1 AND H2 are constant -- forces full key compares for every
+// probe step.
+struct AHM_SameSlotHasher {
+	static _FORCE_INLINE_ uint32_t hash(int /*p_key*/) {
+		return 0;
+	}
+};
 
 TEST_CASE("[AHashMap] List initialization") {
 	AHashMap<int, String> map{ { 0, "A" }, { 1, "B" }, { 2, "C" }, { 3, "D" }, { 4, "E" } };
@@ -309,6 +327,152 @@ TEST_CASE("[AHashMap] Array methods") {
 	CHECK(map.erase_by_index(index));
 	CHECK(!map.erase_by_index(index));
 	CHECK(map.get_index(1) == -1);
+}
+
+TEST_CASE("[AHashMap] Swap-on-erase keeps tail key reachable") {
+	AHashMap<int, int> map;
+	for (int i = 0; i < 32; i++) {
+		map.insert(i, i + 1000);
+	}
+	// Erase from the middle and head; check that all the surviving keys are
+	// still reachable and that the dense entries array stays packed.
+	map.erase(0);
+	map.erase(15);
+	map.erase(31);
+	CHECK(map.size() == 29);
+	for (int i = 1; i < 31; i++) {
+		if (i == 15) {
+			continue;
+		}
+		REQUIRE(map.has(i));
+		CHECK(map[i] == i + 1000);
+	}
+
+	// All entries returned by get_by_index() must reflect what get() returns
+	// for that key (i.e. the swap-on-erase didn't desync the slot mapping).
+	for (uint32_t i = 0; i < map.size(); i++) {
+		const KeyValue<int, int> &kv = map.get_by_index(i);
+		CHECK(map.get(kv.key) == kv.value);
+		CHECK((uint32_t)map.get_index(kv.key) == i);
+	}
+}
+
+TEST_CASE("[AHashMap] Adversarial same-group collisions") {
+	AHashMap<int, int, AHM_SameGroupHasher> map;
+	const int N = 200;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i * 7);
+	}
+	CHECK(map.size() == (uint32_t)N);
+	for (int i = 0; i < N; i++) {
+		REQUIRE(map.has(i));
+		CHECK(map[i] == i * 7);
+	}
+	for (int i = 1; i < N; i += 2) {
+		map.erase(i);
+	}
+	for (int i = 0; i < N; i++) {
+		if (i & 1) {
+			CHECK(!map.has(i));
+		} else {
+			CHECK(map[i] == i * 7);
+		}
+	}
+}
+
+TEST_CASE("[AHashMap] Adversarial same-slot collisions") {
+	AHashMap<int, int, AHM_SameSlotHasher> map;
+	const int N = 64;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i * 3);
+	}
+	for (int i = 0; i < N; i++) {
+		CHECK(map[i] == i * 3);
+	}
+	for (int i = 0; i < N; i++) {
+		map.erase(i);
+		CHECK(!map.has(i));
+	}
+	CHECK(map.size() == 0);
+}
+
+TEST_CASE("[AHashMap] std::unordered_map oracle fuzz") {
+	AHashMap<int, int> map;
+	std::unordered_map<int, int> oracle;
+	uint32_t rng = 0xDEADBEEFu;
+	auto next = [&]() {
+		rng ^= rng << 13;
+		rng ^= rng >> 17;
+		rng ^= rng << 5;
+		return rng;
+	};
+	for (int step = 0; step < 4000; step++) {
+		const int key = static_cast<int>(next() % 200);
+		const uint32_t op = next() % 4;
+		if (op == 0) {
+			const int v = static_cast<int>(next());
+			map.insert(key, v);
+			oracle[key] = v;
+		} else if (op == 1) {
+			map.erase(key);
+			oracle.erase(key);
+		} else if (op == 2) {
+			const int *p = map.getptr(key);
+			auto it = oracle.find(key);
+			if (it == oracle.end()) {
+				CHECK(p == nullptr);
+			} else {
+				REQUIRE(p != nullptr);
+				CHECK(*p == it->second);
+			}
+		} else {
+			CHECK(map.has(key) == (oracle.count(key) > 0));
+		}
+		CHECK(map.size() == (uint32_t)oracle.size());
+	}
+	for (const auto &kv : oracle) {
+		const int *p = map.getptr(kv.first);
+		REQUIRE(p != nullptr);
+		CHECK(*p == kv.second);
+	}
+}
+
+TEST_CASE("[AHashMap] Memory recycling across churn") {
+	AHashMap<int, int> map;
+	const int N = 1024;
+	for (int cycle = 0; cycle < 5; cycle++) {
+		for (int i = 0; i < N; i++) {
+			map.insert(i, i + cycle);
+		}
+		CHECK(map.size() == (uint32_t)N);
+		for (int i = 0; i < N; i++) {
+			CHECK(map[i] == i + cycle);
+		}
+		for (int i = 0; i < N; i++) {
+			map.erase(i);
+		}
+		CHECK(map.size() == 0);
+	}
+}
+
+TEST_CASE("[AHashMap] get_elements_ptr stays packed after erase") {
+	AHashMap<int, int> map;
+	const int N = 50;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i);
+	}
+	for (int i = 0; i < N; i += 3) {
+		map.erase(i);
+	}
+	const uint32_t live = map.size();
+	const KeyValue<int, int> *raw = map.get_elements_ptr();
+	REQUIRE(raw != nullptr);
+	for (uint32_t i = 0; i < live; i++) {
+		// Each entry must be reachable by both index AND key, and they must
+		// agree.
+		CHECK(raw[i].value == map.get(raw[i].key));
+		CHECK((uint32_t)map.get_index(raw[i].key) == i);
+	}
 }
 
 } // namespace TestAHashMap

--- a/tests/core/templates/test_a_hash_map.cpp
+++ b/tests/core/templates/test_a_hash_map.cpp
@@ -475,4 +475,47 @@ TEST_CASE("[AHashMap] get_elements_ptr stays packed after erase") {
 	}
 }
 
+TEST_CASE("[AHashMap] Tombstone-heavy churn keeps slot mapping in sync") {
+	AHashMap<int, int> map;
+	const int N = 256;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i);
+	}
+	const uint32_t steady_capacity = map.get_capacity();
+	for (int cycle = 0; cycle < 4096; cycle++) {
+		const int key = cycle & (N - 1);
+		CHECK(map.erase(key));
+		map.insert(key, cycle + 1000);
+		CHECK(map.get(key) == cycle + 1000);
+		if ((cycle & 127) == 0) {
+			CHECK(map.get_capacity() == steady_capacity);
+			for (int i = 0; i < N; i++) {
+				const int index = map.get_index(i);
+				REQUIRE(index >= 0);
+				const KeyValue<int, int> &kv = map.get_by_index(index);
+				CHECK(kv.key == i);
+				CHECK(kv.value == map.get(i));
+			}
+		}
+	}
+}
+
+TEST_CASE("[AHashMap] Clear resets tombstones after full erase") {
+	AHashMap<int, int> map;
+	for (int i = 0; i < 128; i++) {
+		map.insert(i, i * 4);
+	}
+	for (int i = 0; i < 128; i++) {
+		CHECK(map.erase(i));
+	}
+	CHECK(map.size() == 0);
+	map.clear();
+	for (int i = 0; i < 128; i++) {
+		map.insert(i, i * 8);
+	}
+	for (int i = 0; i < 128; i++) {
+		CHECK(map.get(i) == i * 8);
+	}
+}
+
 } // namespace TestAHashMap

--- a/tests/core/templates/test_hash_map.cpp
+++ b/tests/core/templates/test_hash_map.cpp
@@ -423,4 +423,60 @@ TEST_CASE("[HashMap] Reserve avoids subsequent rehash") {
 	}
 }
 
+TEST_CASE("[HashMap] Reserve tiers keep ordered semantics under churn") {
+	{
+		HashMap<int, int> small_map;
+		small_map.reserve(200);
+		for (int i = 0; i < 200; i++) {
+			small_map.insert(i, i * 2);
+		}
+		for (int i = 0; i < 200; i++) {
+			CHECK(small_map[i] == i * 2);
+		}
+	}
+
+	HashMap<int, int> map;
+	map.reserve(300);
+	for (int i = 0; i < 300; i++) {
+		map.insert(i, i * 10);
+	}
+
+	int *replaced_ptr = map.getptr(151);
+	REQUIRE(replaced_ptr != nullptr);
+
+	for (int i = 0; i < 300; i += 3) {
+		CHECK(map.erase(i));
+	}
+
+	for (int i = 1000; i < 1032; i++) {
+		map.insert(i, i, /*p_front_insert=*/true);
+	}
+
+	CHECK(map.replace_key(151, 1151));
+	CHECK(map.getptr(1151) == replaced_ptr);
+	CHECK(map[1151] == 1510);
+
+	int idx = 0;
+	for (const KeyValue<int, int> &kv : map) {
+		if (idx < 32) {
+			CHECK(kv.key == 1031 - idx);
+		} else {
+			int original = 1;
+			int live_index = idx - 32;
+			while ((original % 3) == 0) {
+				original++;
+			}
+			for (int skip = 0; skip < live_index; skip++) {
+				original++;
+				while ((original % 3) == 0) {
+					original++;
+				}
+			}
+			CHECK(kv.key == (original == 151 ? 1151 : original));
+		}
+		idx++;
+	}
+	CHECK(idx == 232);
+}
+
 } // namespace TestHashMap

--- a/tests/core/templates/test_hash_map.cpp
+++ b/tests/core/templates/test_hash_map.cpp
@@ -34,7 +34,28 @@ TEST_FORCE_LINK(test_hash_map)
 
 #include "core/templates/hash_map.h"
 
+#include <unordered_map>
+
 namespace TestHashMap {
+
+// A hasher that funnels every key into the same H1 group (low bits all zero)
+// so that we exercise quadratic probing and adversarial-collision behavior.
+struct SameGroupHasher {
+	static _FORCE_INLINE_ uint32_t hash(int p_key) {
+		// Spread fingerprints across the high bits so h2 still varies, but
+		// keep the low bits zero so h1 is constant and every probe starts at
+		// group 0.
+		return (static_cast<uint32_t>(p_key) << 7);
+	}
+};
+
+// A hasher whose H2 fingerprint is also constant -- every key collides on
+// both group AND fingerprint, forcing full key compares all the way through.
+struct SameSlotHasher {
+	static _FORCE_INLINE_ uint32_t hash(int /*p_key*/) {
+		return 0;
+	}
+};
 
 TEST_CASE("[HashMap] List initialization") {
 	HashMap<int, String> map{ { 0, "A" }, { 1, "B" }, { 2, "C" }, { 3, "D" }, { 4, "E" } };
@@ -171,6 +192,234 @@ TEST_CASE("[HashMap] Sort") {
 	for (const KeyValue<int, int> &kv : hashmap) {
 		i--;
 		CHECK_EQ(kv.key, i);
+	}
+}
+
+TEST_CASE("[HashMap] Insertion order preserved across erases") {
+	HashMap<int, int> map;
+	for (int i = 0; i < 32; i++) {
+		map.insert(i, i * 10);
+	}
+	// Erase every other key.
+	for (int i = 0; i < 32; i += 2) {
+		map.erase(i);
+	}
+	int expected = 1;
+	for (const KeyValue<int, int> &kv : map) {
+		CHECK(kv.key == expected);
+		CHECK(kv.value == expected * 10);
+		expected += 2;
+	}
+	CHECK(expected == 33);
+}
+
+TEST_CASE("[HashMap] front_insert prepends to iteration order") {
+	HashMap<int, int> map;
+	map.insert(2, 20);
+	map.insert(3, 30);
+	map.insert(1, 10, /*p_front_insert=*/true);
+	map.insert(0, 0, /*p_front_insert=*/true);
+
+	int expected[] = { 0, 1, 2, 3 };
+	int idx = 0;
+	for (const KeyValue<int, int> &kv : map) {
+		CHECK(kv.key == expected[idx]);
+		idx++;
+	}
+	CHECK(idx == 4);
+}
+
+TEST_CASE("[HashMap] Pointer stability across many inserts and erases") {
+	HashMap<int, int> map;
+	const int N = 256;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i + 1000);
+	}
+	// Capture pointers to a subset of values.
+	int *anchors[N];
+	for (int i = 0; i < N; i++) {
+		anchors[i] = map.getptr(i);
+		REQUIRE(anchors[i] != nullptr);
+		CHECK(*anchors[i] == i + 1000);
+	}
+	// Insert a bunch more entries; existing pointers must remain valid.
+	for (int i = N; i < N * 4; i++) {
+		map.insert(i, i + 1000);
+	}
+	for (int i = 0; i < N; i++) {
+		CHECK(*anchors[i] == i + 1000);
+		CHECK(map.getptr(i) == anchors[i]);
+	}
+	// Erase a disjoint set; remaining anchored pointers must remain valid.
+	for (int i = N; i < N * 4; i += 3) {
+		map.erase(i);
+	}
+	for (int i = 0; i < N; i++) {
+		CHECK(*anchors[i] == i + 1000);
+		CHECK(map.getptr(i) == anchors[i]);
+	}
+}
+
+TEST_CASE("[HashMap] Adversarial same-group collisions") {
+	HashMap<int, int, SameGroupHasher> map;
+	const int N = 200;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i * 7);
+	}
+	CHECK(map.size() == (uint32_t)N);
+	for (int i = 0; i < N; i++) {
+		REQUIRE(map.has(i));
+		CHECK(map[i] == i * 7);
+	}
+	// Erase odd keys, then look up everything.
+	for (int i = 1; i < N; i += 2) {
+		map.erase(i);
+	}
+	for (int i = 0; i < N; i++) {
+		if (i & 1) {
+			CHECK(!map.has(i));
+		} else {
+			CHECK(map[i] == i * 7);
+		}
+	}
+}
+
+TEST_CASE("[HashMap] Adversarial same-slot collisions (h1 and h2 collide)") {
+	HashMap<int, int, SameSlotHasher> map;
+	const int N = 64;
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i * 3);
+	}
+	for (int i = 0; i < N; i++) {
+		CHECK(map[i] == i * 3);
+	}
+	for (int i = 0; i < N; i++) {
+		map.erase(i);
+		CHECK(!map.has(i));
+	}
+	CHECK(map.size() == 0);
+}
+
+TEST_CASE("[HashMap] std::unordered_map oracle fuzz") {
+	HashMap<int, int> map;
+	std::unordered_map<int, int> oracle;
+	// Deterministic pseudo-random sequence (xorshift) so the test reproduces.
+	uint32_t rng = 0xCAFEBABEu;
+	auto next = [&]() {
+		rng ^= rng << 13;
+		rng ^= rng >> 17;
+		rng ^= rng << 5;
+		return rng;
+	};
+	for (int step = 0; step < 4000; step++) {
+		const int key = static_cast<int>(next() % 200);
+		const uint32_t op = next() % 4;
+		if (op == 0) {
+			const int v = static_cast<int>(next());
+			map.insert(key, v);
+			oracle[key] = v;
+		} else if (op == 1) {
+			map.erase(key);
+			oracle.erase(key);
+		} else if (op == 2) {
+			const int *p = map.getptr(key);
+			auto it = oracle.find(key);
+			if (it == oracle.end()) {
+				CHECK(p == nullptr);
+			} else {
+				REQUIRE(p != nullptr);
+				CHECK(*p == it->second);
+			}
+		} else {
+			CHECK(map.has(key) == (oracle.count(key) > 0));
+		}
+		CHECK(map.size() == (uint32_t)oracle.size());
+	}
+	// Final equality check: every oracle entry must be present with the
+	// expected value, and the map must contain no extras.
+	for (const auto &kv : oracle) {
+		const int *p = map.getptr(kv.first);
+		REQUIRE(p != nullptr);
+		CHECK(*p == kv.second);
+	}
+	uint32_t counted = 0;
+	for (const KeyValue<int, int> &kv : map) {
+		auto it = oracle.find(kv.key);
+		REQUIRE(it != oracle.end());
+		CHECK(it->second == kv.value);
+		counted++;
+	}
+	CHECK(counted == (uint32_t)oracle.size());
+}
+
+TEST_CASE("[HashMap] Memory recycling across churn") {
+	HashMap<int, int> map;
+	const int N = 1024;
+	// Fill, drain, refill several times. Verifies that erase + insert reuses
+	// slots without leaking state across cycles.
+	for (int cycle = 0; cycle < 5; cycle++) {
+		for (int i = 0; i < N; i++) {
+			map.insert(i, i + cycle);
+		}
+		CHECK(map.size() == (uint32_t)N);
+		for (int i = 0; i < N; i++) {
+			CHECK(map[i] == i + cycle);
+		}
+		for (int i = 0; i < N; i++) {
+			map.erase(i);
+		}
+		CHECK(map.size() == 0);
+	}
+	// Re-fill one more time and walk insertion order.
+	for (int i = 0; i < N; i++) {
+		map.insert(i, i);
+	}
+	int expected = 0;
+	for (const KeyValue<int, int> &kv : map) {
+		CHECK(kv.key == expected);
+		expected++;
+	}
+	CHECK(expected == N);
+}
+
+TEST_CASE("[HashMap] replace_key preserves iteration position and pointer") {
+	HashMap<int, int> map;
+	for (int i = 0; i < 8; i++) {
+		map.insert(i, i * 11);
+	}
+	int *p = map.getptr(3);
+	REQUIRE(p != nullptr);
+	CHECK(map.replace_key(3, 100));
+	CHECK(!map.has(3));
+	CHECK(map.has(100));
+	CHECK(map[100] == 33);
+	// Pointer to the old slot should now read as the same entry under new key
+	// (KeyValue at the same address; only the key was mutated).
+	CHECK(map.getptr(100) == p);
+
+	// Iteration order: 0, 1, 2, 100, 4, 5, 6, 7
+	int expected[] = { 0, 1, 2, 100, 4, 5, 6, 7 };
+	int idx = 0;
+	for (const KeyValue<int, int> &kv : map) {
+		CHECK(kv.key == expected[idx]);
+		idx++;
+	}
+	CHECK(idx == 8);
+}
+
+TEST_CASE("[HashMap] Reserve avoids subsequent rehash") {
+	HashMap<int, int> map;
+	map.reserve(1000);
+	// Reservation is allowed to be lazy; force the index table to actually
+	// materialize by inserting a single element, then snapshot the capacity.
+	map.insert(0, 0);
+	const uint32_t cap_before = map.get_capacity();
+	for (int i = 1; i < 700; i++) {
+		map.insert(i, i);
+	}
+	CHECK(map.get_capacity() == cap_before);
+	for (int i = 0; i < 700; i++) {
+		CHECK(map[i] == i);
 	}
 }
 

--- a/tests/core/templates/test_hash_map_bench.cpp
+++ b/tests/core/templates/test_hash_map_bench.cpp
@@ -40,12 +40,7 @@ TEST_FORCE_LINK(test_hash_map_bench)
 #include "core/variant/variant.h"
 
 // Benchmarks for the SwissTable HashMap / AHashMap rewrites.
-//
-// These cases run only when the user explicitly opts in with
-// `--test-case=*HashMapBench*`, since they take seconds and would slow down
-// the regular CI sweep. The numbers printed here are absolute throughput; to
-// compare against the legacy Robin-Hood implementation, check out the parent
-// commit of this rewrite, build with the same flags, and re-run.
+// Run explicitly with `--test-case=*HashMapBench*`.
 
 namespace TestHashMapBench {
 
@@ -115,7 +110,7 @@ static void _bench_int_workload(const char *p_label, Make make_map) {
 	_report("iterate    ", iter_us, kElems * kIters);
 	_report("erase      ", erase_us, kElems * kIters);
 
-	// Keep results live so the optimizer can't elide.
+	// Keep results live.
 	CHECK((hit_sink + miss_sink + iter_sink) != INT64_MIN);
 }
 

--- a/tests/core/templates/test_hash_map_bench.cpp
+++ b/tests/core/templates/test_hash_map_bench.cpp
@@ -219,6 +219,38 @@ TEST_CASE("[HashMapBench] HashMap<StringName,Variant>") {
 	CHECK(hit_sink != INT64_MIN);
 }
 
+TEST_CASE("[HashMapBench] HashMap<StringName,Variant> churn") {
+	print_line(vformat("[HashMap] StringName->Variant churn (%d cycles of erase+insert, table size 1024):", kElems));
+
+	Vector<StringName> keys;
+	keys.resize(1024);
+	for (int i = 0; i < 1024; i++) {
+		keys.write[i] = StringName("churn_" + itos(i));
+	}
+
+	uint64_t churn_us = 0;
+	int64_t sink = 0;
+	for (int rep = 0; rep < kIters; rep++) {
+		HashMap<StringName, Variant> m;
+		for (int i = 0; i < 1024; i++) {
+			m.insert(keys[i], Variant(i));
+		}
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const int k = i & 1023;
+			m.erase(keys[k]);
+			m.insert(keys[k], Variant(i));
+			const Variant *p = m.getptr(keys[k]);
+			if (p) {
+				sink += int64_t(*p);
+			}
+		}
+		churn_us += OS::get_singleton()->get_ticks_usec() - t0;
+	}
+	_report("churn (erase+insert)", churn_us, kElems * kIters);
+	CHECK(sink != INT64_MIN);
+}
+
 TEST_CASE("[HashMapBench] AHashMap<int,int> churn") {
 	print_line(vformat("[AHashMap] int->int churn (%d cycles of insert+erase, table size 1024):", kElems));
 

--- a/tests/core/templates/test_hash_map_bench.cpp
+++ b/tests/core/templates/test_hash_map_bench.cpp
@@ -269,4 +269,36 @@ TEST_CASE("[HashMapBench] AHashMap<int,int> churn") {
 	CHECK(sink != INT64_MIN);
 }
 
+TEST_CASE("[HashMapBench] AHashMap<StringName,Variant> churn") {
+	print_line(vformat("[AHashMap] StringName->Variant churn (%d cycles of erase+insert, table size 1024):", kElems));
+
+	Vector<StringName> keys;
+	keys.resize(1024);
+	for (int i = 0; i < 1024; i++) {
+		keys.write[i] = StringName("achurn_" + itos(i));
+	}
+
+	uint64_t churn_us = 0;
+	int64_t sink = 0;
+	for (int rep = 0; rep < kIters; rep++) {
+		AHashMap<StringName, Variant> m;
+		for (int i = 0; i < 1024; i++) {
+			m.insert(keys[i], Variant(i));
+		}
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const int k = i & 1023;
+			m.erase(keys[k]);
+			m.insert(keys[k], Variant(i));
+			const Variant *p = m.getptr(keys[k]);
+			if (p) {
+				sink += int64_t(*p);
+			}
+		}
+		churn_us += OS::get_singleton()->get_ticks_usec() - t0;
+	}
+	_report("churn (erase+insert)", churn_us, kElems * kIters);
+	CHECK(sink != INT64_MIN);
+}
+
 } // namespace TestHashMapBench

--- a/tests/core/templates/test_hash_map_bench.cpp
+++ b/tests/core/templates/test_hash_map_bench.cpp
@@ -1,0 +1,245 @@
+/**************************************************************************/
+/*  test_hash_map_bench.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_hash_map_bench)
+
+#include "core/os/os.h"
+#include "core/string/string_name.h"
+#include "core/string/ustring.h"
+#include "core/templates/a_hash_map.h"
+#include "core/templates/hash_map.h"
+#include "core/variant/variant.h"
+
+// Benchmarks for the SwissTable HashMap / AHashMap rewrites.
+//
+// These cases run only when the user explicitly opts in with
+// `--test-case=*HashMapBench*`, since they take seconds and would slow down
+// the regular CI sweep. The numbers printed here are absolute throughput; to
+// compare against the legacy Robin-Hood implementation, check out the parent
+// commit of this rewrite, build with the same flags, and re-run.
+
+namespace TestHashMapBench {
+
+static constexpr int kElems = 200'000;
+static constexpr int kIters = 5;
+
+// Print a one-line result row in microseconds-per-op, plus megaops/sec.
+static void _report(const char *p_workload, uint64_t p_total_usec, int p_ops) {
+	const double per_op_ns = static_cast<double>(p_total_usec) * 1000.0 / static_cast<double>(p_ops);
+	const double mops = static_cast<double>(p_ops) / static_cast<double>(p_total_usec);
+	print_line(vformat("  %s: %.1f ns/op  (%.2f Mops/s, %d ops in %d us)",
+			p_workload, per_op_ns, mops, p_ops, (int)p_total_usec));
+}
+
+template <typename TMap, typename Make>
+static void _bench_int_workload(const char *p_label, Make make_map) {
+	print_line(vformat("[%s] int->int (%d entries):", p_label, kElems));
+
+	uint64_t insert_us = 0, hit_us = 0, miss_us = 0, iter_us = 0, erase_us = 0;
+	int64_t hit_sink = 0, miss_sink = 0, iter_sink = 0;
+
+	for (int rep = 0; rep < kIters; rep++) {
+		TMap m = make_map();
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.insert(i, i + 1);
+		}
+		const uint64_t t1 = OS::get_singleton()->get_ticks_usec();
+		insert_us += t1 - t0;
+
+		const uint64_t t2 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const int *p = m.getptr(i);
+			if (p) {
+				hit_sink += *p;
+			}
+		}
+		const uint64_t t3 = OS::get_singleton()->get_ticks_usec();
+		hit_us += t3 - t2;
+
+		const uint64_t t4 = OS::get_singleton()->get_ticks_usec();
+		for (int i = kElems; i < 2 * kElems; i++) {
+			const int *p = m.getptr(i);
+			miss_sink += p ? 1 : 0;
+		}
+		const uint64_t t5 = OS::get_singleton()->get_ticks_usec();
+		miss_us += t5 - t4;
+
+		const uint64_t t6 = OS::get_singleton()->get_ticks_usec();
+		for (const auto &kv : m) {
+			iter_sink += kv.value;
+		}
+		const uint64_t t7 = OS::get_singleton()->get_ticks_usec();
+		iter_us += t7 - t6;
+
+		const uint64_t t8 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.erase(i);
+		}
+		const uint64_t t9 = OS::get_singleton()->get_ticks_usec();
+		erase_us += t9 - t8;
+	}
+
+	_report("insert", insert_us, kElems * kIters);
+	_report("lookup-hit ", hit_us, kElems * kIters);
+	_report("lookup-miss", miss_us, kElems * kIters);
+	_report("iterate    ", iter_us, kElems * kIters);
+	_report("erase      ", erase_us, kElems * kIters);
+
+	// Keep results live so the optimizer can't elide.
+	CHECK((hit_sink + miss_sink + iter_sink) != INT64_MIN);
+}
+
+TEST_CASE("[HashMapBench] HashMap<int,int>") {
+	_bench_int_workload<HashMap<int, int>>("HashMap", []() { return HashMap<int, int>(); });
+}
+
+TEST_CASE("[HashMapBench] AHashMap<int,int>") {
+	_bench_int_workload<AHashMap<int, int>>("AHashMap", []() { return AHashMap<int, int>(); });
+}
+
+TEST_CASE("[HashMapBench] HashMap<String,int>") {
+	print_line(vformat("[HashMap] String->int (%d entries):", kElems));
+
+	Vector<String> keys;
+	keys.resize(kElems);
+	for (int i = 0; i < kElems; i++) {
+		keys.write[i] = "key_" + itos(i);
+	}
+
+	uint64_t insert_us = 0, hit_us = 0, miss_us = 0, erase_us = 0;
+	int64_t hit_sink = 0;
+
+	for (int rep = 0; rep < kIters; rep++) {
+		HashMap<String, int> m;
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.insert(keys[i], i);
+		}
+		insert_us += OS::get_singleton()->get_ticks_usec() - t0;
+
+		const uint64_t t2 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const int *p = m.getptr(keys[i]);
+			if (p) {
+				hit_sink += *p;
+			}
+		}
+		hit_us += OS::get_singleton()->get_ticks_usec() - t2;
+
+		const String missing = "missing_key_xxx";
+		const uint64_t t4 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			hit_sink += m.has(missing) ? 1 : 0;
+		}
+		miss_us += OS::get_singleton()->get_ticks_usec() - t4;
+
+		const uint64_t t6 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.erase(keys[i]);
+		}
+		erase_us += OS::get_singleton()->get_ticks_usec() - t6;
+	}
+
+	_report("insert     ", insert_us, kElems * kIters);
+	_report("lookup-hit ", hit_us, kElems * kIters);
+	_report("lookup-miss", miss_us, kElems * kIters);
+	_report("erase      ", erase_us, kElems * kIters);
+	CHECK(hit_sink != INT64_MIN);
+}
+
+TEST_CASE("[HashMapBench] HashMap<StringName,Variant>") {
+	print_line(vformat("[HashMap] StringName->Variant (%d entries):", kElems));
+
+	Vector<StringName> keys;
+	keys.resize(kElems);
+	for (int i = 0; i < kElems; i++) {
+		keys.write[i] = StringName("k_" + itos(i));
+	}
+
+	uint64_t insert_us = 0, hit_us = 0, erase_us = 0;
+	int64_t hit_sink = 0;
+
+	for (int rep = 0; rep < kIters; rep++) {
+		HashMap<StringName, Variant> m;
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.insert(keys[i], Variant(i));
+		}
+		insert_us += OS::get_singleton()->get_ticks_usec() - t0;
+
+		const uint64_t t2 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const Variant *p = m.getptr(keys[i]);
+			if (p) {
+				hit_sink += (int64_t)(*p);
+			}
+		}
+		hit_us += OS::get_singleton()->get_ticks_usec() - t2;
+
+		const uint64_t t6 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			m.erase(keys[i]);
+		}
+		erase_us += OS::get_singleton()->get_ticks_usec() - t6;
+	}
+
+	_report("insert    ", insert_us, kElems * kIters);
+	_report("lookup-hit", hit_us, kElems * kIters);
+	_report("erase     ", erase_us, kElems * kIters);
+	CHECK(hit_sink != INT64_MIN);
+}
+
+TEST_CASE("[HashMapBench] AHashMap<int,int> churn") {
+	print_line(vformat("[AHashMap] int->int churn (%d cycles of insert+erase, table size 1024):", kElems));
+
+	uint64_t churn_us = 0;
+	int64_t sink = 0;
+	for (int rep = 0; rep < kIters; rep++) {
+		AHashMap<int, int> m;
+		for (int i = 0; i < 1024; i++) {
+			m.insert(i, i);
+		}
+		const uint64_t t0 = OS::get_singleton()->get_ticks_usec();
+		for (int i = 0; i < kElems; i++) {
+			const int k = i & 1023;
+			m.erase(k);
+			m.insert(k, i);
+			sink += m[k];
+		}
+		churn_us += OS::get_singleton()->get_ticks_usec() - t0;
+	}
+	_report("churn (erase+insert)", churn_us, kElems * kIters);
+	CHECK(sink != INT64_MIN);
+}
+
+} // namespace TestHashMapBench

--- a/tests/core/templates/test_swiss_table_simd.cpp
+++ b/tests/core/templates/test_swiss_table_simd.cpp
@@ -1,0 +1,164 @@
+/**************************************************************************/
+/*  test_swiss_table_simd.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_swiss_table_simd)
+
+#include "core/templates/swiss_table_simd.h"
+
+namespace TestSwissTableSIMD {
+
+// Reference: brute-force compute the expected match bitmask, where bit i is
+// set if buf[i] satisfies the predicate.
+static uint32_t reference_match(const uint8_t *buf, uint32_t width, uint8_t needle) {
+	uint32_t out = 0;
+	for (uint32_t i = 0; i < width; i++) {
+		if (buf[i] == needle) {
+			out |= (1u << i);
+		}
+	}
+	return out;
+}
+
+static uint32_t reference_match_empty(const uint8_t *buf, uint32_t width) {
+	return reference_match(buf, width, SwissTable::kEmpty);
+}
+
+static uint32_t reference_match_empty_or_deleted(const uint8_t *buf, uint32_t width) {
+	uint32_t out = 0;
+	for (uint32_t i = 0; i < width; i++) {
+		if ((buf[i] & 0x80) != 0) {
+			out |= (1u << i);
+		}
+	}
+	return out;
+}
+
+template <typename Group>
+static uint32_t mask_to_bits(typename Group::Mask m) {
+	uint32_t out = 0;
+	auto it = m.iter();
+	while (it.has_next()) {
+		out |= (1u << it.next());
+	}
+	return out;
+}
+
+template <typename Group>
+static void check_group_against_reference(const uint8_t *buf, uint8_t needle) {
+	Group g(buf);
+	CHECK_EQ(mask_to_bits<Group>(g.match(needle)), reference_match(buf, Group::kWidth, needle));
+	CHECK_EQ(mask_to_bits<Group>(g.match_empty()), reference_match_empty(buf, Group::kWidth));
+	CHECK_EQ(mask_to_bits<Group>(g.match_empty_or_deleted()), reference_match_empty_or_deleted(buf, Group::kWidth));
+}
+
+static void fill_pattern(uint8_t *buf, uint32_t width, uint32_t seed) {
+	uint32_t s = seed;
+	for (uint32_t i = 0; i < width; i++) {
+		s = s * 1664525u + 1013904223u;
+		uint32_t bucket = s & 7;
+		if (bucket == 0) {
+			buf[i] = SwissTable::kEmpty;
+		} else if (bucket == 1) {
+			buf[i] = SwissTable::kDeleted;
+		} else {
+			buf[i] = static_cast<uint8_t>((s >> 24) & 0x7F);
+		}
+	}
+}
+
+template <typename Group>
+static void exercise_group() {
+	alignas(16) uint8_t buf[16] = {};
+
+	// All empty.
+	memset(buf, SwissTable::kEmpty, sizeof(buf));
+	check_group_against_reference<Group>(buf, 0x00);
+	check_group_against_reference<Group>(buf, SwissTable::kEmpty);
+
+	// All same fingerprint.
+	memset(buf, 0x42, sizeof(buf));
+	check_group_against_reference<Group>(buf, 0x42);
+	check_group_against_reference<Group>(buf, 0x43);
+
+	// Patterned mix of empty / deleted / full.
+	const uint32_t seeds[] = { 0x12345678u, 0xdeadbeefu, 0xfeedfaceu, 0xcafebabeu, 0x00000001u, 0xffffffffu };
+	for (uint32_t seed : seeds) {
+		fill_pattern(buf, Group::kWidth, seed);
+		uint8_t needles[] = { 0x00, 0x42, 0x7F, SwissTable::kEmpty, SwissTable::kDeleted, buf[0], buf[Group::kWidth / 2] };
+		for (uint8_t needle : needles) {
+			check_group_against_reference<Group>(buf, needle);
+		}
+	}
+}
+
+TEST_CASE("[SwissTable][SIMD] SWAR group matches reference") {
+	exercise_group<SwissTable::GroupSWAR>();
+}
+
+#if defined(SWISS_TABLE_HAS_SSE2)
+TEST_CASE("[SwissTable][SIMD] SSE2 group matches reference") {
+	exercise_group<SwissTable::GroupSSE2>();
+}
+#endif
+
+#if defined(SWISS_TABLE_HAS_NEON)
+TEST_CASE("[SwissTable][SIMD] NEON group matches reference") {
+	exercise_group<SwissTable::GroupNEON>();
+}
+#endif
+
+#if defined(SWISS_TABLE_HAS_WASM_SIMD)
+TEST_CASE("[SwissTable][SIMD] WASM group matches reference") {
+	exercise_group<SwissTable::GroupWASM>();
+}
+#endif
+
+TEST_CASE("[SwissTable] H1/H2 derivation") {
+	// h2 should always have the top bit cleared so it never collides with kEmpty/kDeleted.
+	for (uint32_t hash = 0; hash < 1024; hash++) {
+		uint8_t h2 = SwissTable::h2(hash);
+		CHECK((h2 & 0x80) == 0);
+		CHECK(h2 != SwissTable::kEmpty);
+		CHECK(h2 != SwissTable::kDeleted);
+	}
+	// Different high bits should give different fingerprints.
+	CHECK_NE(SwissTable::h2(0x00000000u), SwissTable::h2(0x80000000u));
+	CHECK_NE(SwissTable::h2(0xFE000000u), SwissTable::h2(0x00000000u));
+}
+
+TEST_CASE("[SwissTable] capacity_to_growth") {
+	for (uint32_t cap : { 8u, 16u, 32u, 64u, 128u, 256u, 1024u }) {
+		CHECK_EQ(SwissTable::capacity_to_growth(cap), cap - cap / 8);
+	}
+}
+
+} // namespace TestSwissTableSIMD

--- a/tests/core/variant/test_dictionary.cpp
+++ b/tests/core/variant/test_dictionary.cpp
@@ -406,6 +406,27 @@ TEST_CASE("[Dictionary] Hash dictionary") {
 	CHECK_EQ(d2.hash(), original_hash);
 }
 
+TEST_CASE("[Dictionary] Hash follows iteration order") {
+	Dictionary ordered_a;
+	ordered_a[1] = "one";
+	ordered_a[2] = "two";
+	ordered_a[3] = "three";
+
+	Dictionary ordered_b;
+	ordered_b[3] = "three";
+	ordered_b[1] = "one";
+	ordered_b[2] = "two";
+
+	CHECK_EQ(ordered_a, ordered_b);
+	CHECK_NE(ordered_a.keys(), ordered_b.keys());
+	CHECK_NE(ordered_a.hash(), ordered_b.hash());
+
+	ordered_a.sort();
+	ordered_b.sort();
+	CHECK_EQ(ordered_a.keys(), ordered_b.keys());
+	CHECK_EQ(ordered_a.hash(), ordered_b.hash());
+}
+
 TEST_CASE("[Dictionary] Hash recursive dictionary") {
 	Dictionary d;
 	d[1] = d;


### PR DESCRIPTION
## Motivation

HashMaps are everywhere in Godot, no matter in the engine or the game logics. The Swiss-table family of designs (Abseil [flat_hash_map](https://abseil.io/blog/20180927-swisstables), Rust [hashbrown](https://github.com/rust-lang/hashbrown)) addresses with a 1-byte-per-slot control array that lets a single SIMD/SWAR comparison reject or short-list 8 slots at once. We borrow that idea to improve the performance of Godot's hashmap. We adopted SwissTable as the probing/index mechanism, but we bent the storage layer around Godot’s stronger API guarantees and existing container behavior.

## What changed
- rewrite `HashMap` and `AHashMap` to use a SwissTable-style control-byte index with SIMD-scanned probe groups
- preserve `HashMap`'s insertion-order iteration and live-entry pointer stability while keeping `AHashMap` dense and swap-on-erase
- introduce cached full hashes, SIMD erase tombstone handling, foldhash-based string hashing, a stable-handle ordered arena, and a metadata/payload split for ordered entries
- add focused tests and benchmarks for `HashMap`, `AHashMap`, SwissTable SIMD helpers, and `Dictionary` order/hash behavior
- compact ordered HashMap index and metadata, learned from Ruby's [patch 1](https://bugs.ruby-lang.org/issues/22011) and [patch 2](https://bugs.ruby-lang.org/issues/12142).

## Benchmark (running on Macbook Pro M4)


Workload | Legacy | New | Delta | Change
-- | -- | -- | -- | --
HashMap<int,int> insert | 47.7 | 24.1 | -23.6 | -49.5%
HashMap<int,int> lookup-hit | 7.3 | 4.5 | -2.8 | -38.4%
HashMap<int,int> lookup-miss | 11.3 | 8.0 | -3.3 | -29.2%
HashMap<int,int> erase | 27.3 | 17.6 | -9.7 | -35.5%
AHashMap<int,int> insert | 31.2 | 8.1 | -23.1 | -74.0%
AHashMap<int,int> lookup-hit | 4.9 | 3.1 | -1.8 | -36.7%
AHashMap<int,int> erase | 11.5 | 13.8 | +2.3 | +20.0%
AHashMap<int,int> churn | 8.5 | 8.5 | +0.0 | +0.0%
HashMap<String,int> insert | 54.3 | 28.9 | -25.4 | -46.8%
HashMap<String,int> lookup-hit | 12.5 | 10.0 | -2.5 | -20.0%
HashMap<String,int> erase | 26.6 | 24.7 | -1.9 | -7.1%
HashMap<StringName,Variant> insert | 82.8 | 26.5 | -56.3 | -68.0%
HashMap<StringName,Variant> lookup-hit | 7.5 | 6.0 | -1.5 | -20.0%
HashMap<StringName,Variant> erase | 19.3 | 17.8 | -1.5 | -7.8%


## Notes

Tests and docs are written by AI, some of the code are rewritten by AI with some of my proven working code in Rust.