### PR TITLE
Do not show popups before setting edited scene root.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4591,9 +4591,6 @@ void EditorNode::set_edited_scene_root(Node *p_scene, bool p_auto_add) {
 	}
 	get_editor_data().set_edited_scene_root(p_scene);
 
-	if (Object::cast_to<Popup>(p_scene)) {
-		Object::cast_to<Popup>(p_scene)->show();
-	}
 	SceneTreeDock::get_singleton()->set_edited_scene(p_scene);
 	if (get_tree()) {
 		get_tree()->set_edited_scene_root(p_scene);
@@ -4601,6 +4598,10 @@ void EditorNode::set_edited_scene_root(Node *p_scene, bool p_auto_add) {
 
 	if (p_auto_add && p_scene) {
 		scene_root->add_child(p_scene, true);
+	}
+
+	if (Object::cast_to<Popup>(p_scene)) {
+		Object::cast_to<Popup>(p_scene)->show();
 	}
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3507,7 +3507,8 @@ void PopupMenu::_native_popup(const Rect2i &p_rect) {
 		}
 		popup_pos += DisplayServer::get_singleton()->window_get_position(wid);
 	}
-	float win_scale = get_parent_visible_window()->get_content_scale_factor();
+	Window *parent_window = get_parent_visible_window();
+	float win_scale = parent_window ? parent_window->get_content_scale_factor() : 1.0;
 	NativeMenu::get_singleton()->set_minimum_width(global_menu, p_rect.size.x * win_scale);
 	NativeMenu::get_singleton()->popup(global_menu, popup_pos);
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118866

Prevents native menus and popups from opening in editor when Window control is scene root.