### PR TITLE
Add support for time editing of multiple keyframes

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -53,7 +53,6 @@
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/separator.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/image_texture.h"
 #include "servers/display/display_server.h"
@@ -2520,6 +2519,29 @@ AnimationTrackKeyEditEditorPlugin::AnimationTrackKeyEditEditorPlugin() {
 
 bool AnimationTrackKeyEditEditorPlugin::handles(Object *p_object) const {
 	return p_object->is_class("AnimationTrackKeyEdit");
+}
+
+// AnimationMultiTrackKeyEditEditorPlugin
+
+bool EditorInspectorPluginAnimationMultiTrackKeyEdit::can_handle(Object *p_object) {
+	return Object::cast_to<AnimationMultiTrackKeyEdit>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginAnimationMultiTrackKeyEdit::parse_begin(Object *p_object) {
+	AnimationMultiTrackKeyEdit *amtk = Object::cast_to<AnimationMultiTrackKeyEdit>(p_object);
+	ERR_FAIL_NULL(amtk);
+
+	amtk_editor = memnew(AnimationMultiTrackKeyEditEditor(amtk->animation, amtk->base_map, amtk->key_ofs_map, amtk->use_fps));
+	add_custom_control(amtk_editor);
+}
+
+AnimationMultiTrackKeyEditEditorPlugin::AnimationMultiTrackKeyEditEditorPlugin() {
+	amtk_plugin = memnew(EditorInspectorPluginAnimationMultiTrackKeyEdit);
+	EditorInspector::add_inspector_plugin(amtk_plugin);
+}
+
+bool AnimationMultiTrackKeyEditEditorPlugin::handles(Object *p_object) const {
+	return p_object->is_class("AnimationMultiTrackKeyEdit");
 }
 
 bool EditorInspectorPluginAnimationMarkerKeyEdit::can_handle(Object *p_object) {

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -341,6 +341,31 @@ public:
 	AnimationTrackKeyEditEditorPlugin();
 };
 
+// AnimationMultiTrackKeyEditEditorPlugin
+
+class EditorInspectorPluginAnimationMultiTrackKeyEdit : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginAnimationMultiTrackKeyEdit, EditorInspectorPlugin);
+
+	AnimationMultiTrackKeyEditEditor *amtk_editor = nullptr;
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class AnimationMultiTrackKeyEditEditorPlugin : public EditorPlugin {
+	GDCLASS(AnimationMultiTrackKeyEditEditorPlugin, EditorPlugin);
+
+	Ref<EditorInspectorPluginAnimationMultiTrackKeyEdit> amtk_plugin;
+
+public:
+	virtual bool handles(Object *p_object) const override;
+
+	virtual String get_plugin_name() const override { return "AnimationMultiTrackKeyEdit"; }
+
+	AnimationMultiTrackKeyEditEditorPlugin();
+};
+
 // AnimationMarkerKeyEditEditorPlugin
 
 class EditorInspectorPluginAnimationMarkerKeyEdit : public EditorInspectorPlugin {

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8822,6 +8822,150 @@ AnimationTrackKeyEditEditor::AnimationTrackKeyEditEditor(Ref<Animation> p_animat
 	spinner->connect("value_focus_exited", callable_mp(this, &AnimationTrackKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
 }
 
+// AnimationMultiTrackKeyEditEditor
+
+void AnimationMultiTrackKeyEditEditor::_time_edit_spun() {
+	_time_edit_entered();
+	_time_edit_exited();
+}
+
+void AnimationMultiTrackKeyEditEditor::_time_edit_entered() {
+	original_spinner_value = spinner->get_value();
+	key_data_caches.clear();
+	for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+		int track = E.key;
+		for (const float &F : E.value) {
+			float key_ofs = F;
+			int key = animation->track_find_key(track, key_ofs, Animation::FIND_MODE_APPROX);
+			if (key == -1) {
+				return;
+			}
+			real_t time = animation->track_get_key_time(track, key);
+			key_data_caches[track][time].transition = animation->track_get_key_transition(track, key);
+			key_data_caches[track][time].value = animation->track_get_key_value(track, key);
+		}
+	}
+}
+
+void AnimationMultiTrackKeyEditEditor::_time_edit_exited() {
+	real_t new_time = spinner->get_value();
+
+	if (Math::is_equal_approx(new_time, original_spinner_value)) {
+		return; // No change.
+	}
+
+	if (use_fps) {
+		real_t fps = animation->get_step();
+		if (fps > 0) {
+			fps = 1.0 / fps;
+		}
+		new_time /= fps;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	undo_redo->create_action(TTR("Animation Change Keyframe Time"));
+	for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+		int track = E.key;
+		int existing = animation->track_find_key(track, new_time, Animation::FIND_MODE_APPROX);
+
+		if (existing != -1) {
+			undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track, animation->track_get_key_time(track, existing));
+		}
+
+		for (int i = 0; i < E.value.size(); ++i) {
+			real_t old_time = E.value.get(i);
+
+			Variant value = key_data_caches[track][old_time].value;
+			float transition = key_data_caches[track][old_time].transition;
+
+			if (i == 0) {
+				// only insert for the first key found in the track, the rest are discarded as they will be merged into the same time
+				undo_redo->add_do_method(animation.ptr(), "track_insert_key", track, new_time, value, transition);
+				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", track, new_time);
+			}
+
+			if (!Math::is_equal_approx(old_time, new_time)) { // already removed
+				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track, old_time);
+				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, old_time, value, transition);
+			}
+		}
+
+		if (existing != -1) {
+			undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track, animation->track_get_key_time(track, existing), animation->track_get_key_value(track, existing), animation->track_get_key_transition(track, existing));
+		}
+	}
+
+	// Reselect key.
+	AnimationPlayerEditor *ape = AnimationPlayerEditor::get_singleton();
+	if (ape) {
+		AnimationTrackEditor *ate = ape->get_track_editor();
+		if (ate) {
+			undo_redo->add_do_method(ate, "_clear_selection_for_anim", animation);
+			undo_redo->add_undo_method(ate, "_clear_selection_for_anim", animation);
+			for (const KeyValue<int, List<float>> &E : key_ofs_map) {
+				int track = E.key;
+				undo_redo->add_do_method(ate, "_select_at_anim", animation, track, new_time);
+				for (const float &F : E.value) {
+					undo_redo->add_undo_method(ate, "_select_at_anim", animation, track, F);
+				}
+			}
+		}
+
+		undo_redo->add_do_method(ape, "_animation_update_key_frame");
+		undo_redo->add_undo_method(ape, "_animation_update_key_frame");
+	}
+
+	undo_redo->commit_action();
+}
+
+AnimationMultiTrackKeyEditEditor::AnimationMultiTrackKeyEditEditor(Ref<Animation> p_animation, const RBMap<int, NodePath> &p_base_map, const RBMap<int, List<float>> &p_key_ofs_map, bool p_use_fps) {
+	if (p_animation.is_null()) {
+		return;
+	}
+
+	animation = p_animation;
+	base_map = p_base_map;
+	key_ofs_map = p_key_ofs_map;
+	use_fps = p_use_fps;
+
+	set_label("Time");
+
+	spinner = memnew(EditorSpinSlider);
+	spinner->set_focus_mode(Control::FOCUS_CLICK);
+	spinner->set_min(0);
+	spinner->set_allow_greater(true);
+	spinner->set_allow_lesser(true);
+	add_child(spinner);
+
+	// when there are multiple different time values, use the first one
+	// since the internal spinner doesn't have an indeterminate state
+	float default_ofs = 0;
+	if (base_map.size() > 0) {
+		float first_track = base_map.begin()->key;
+		default_ofs = key_ofs_map[first_track].get(0);
+	}
+	if (use_fps) {
+		spinner->set_step(FPS_DECIMAL);
+		real_t fps = animation->get_step();
+		if (fps > 0) {
+			fps = 1.0 / fps;
+		}
+		spinner->set_value(default_ofs * fps);
+		spinner->set_max(animation->get_length() * fps);
+		spinner->connect("updown_pressed", callable_mp(this, &AnimationMultiTrackKeyEditEditor::_time_edit_spun), CONNECT_DEFERRED);
+	} else {
+		spinner->set_step(SECOND_DECIMAL);
+		spinner->set_value(default_ofs);
+		spinner->set_max(animation->get_length());
+	}
+
+	spinner->connect("grabbed", callable_mp(this, &AnimationMultiTrackKeyEditEditor::_time_edit_entered), CONNECT_DEFERRED);
+	spinner->connect("ungrabbed", callable_mp(this, &AnimationMultiTrackKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
+	spinner->connect("value_focus_entered", callable_mp(this, &AnimationMultiTrackKeyEditEditor::_time_edit_entered), CONNECT_DEFERRED);
+	spinner->connect("value_focus_exited", callable_mp(this, &AnimationMultiTrackKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
+}
+
 void AnimationMarkerEdit::_zoom_changed() {
 	queue_redraw();
 	play_position->queue_redraw();

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -1060,3 +1060,30 @@ class AnimationMarkerKeyEditEditor : public EditorProperty {
 public:
 	AnimationMarkerKeyEditEditor(Ref<Animation> p_animation, const StringName &p_name, bool p_use_fps);
 };
+
+// AnimationMultiTrackKeyEditEditorPlugin
+
+class AnimationMultiTrackKeyEditEditor : public EditorProperty {
+	GDCLASS(AnimationMultiTrackKeyEditEditor, EditorProperty);
+
+	Ref<Animation> animation;
+	RBMap<int, List<float>> key_ofs_map;
+	RBMap<int, NodePath> base_map;
+	bool use_fps = false;
+
+	EditorSpinSlider *spinner = nullptr;
+
+	struct KeyDataCache {
+		float transition = 0.0;
+		Variant value;
+	};
+	RBMap<int, RBMap<real_t, KeyDataCache>> key_data_caches;
+	real_t original_spinner_value = 0.0;
+
+	void _time_edit_spun();
+	void _time_edit_entered();
+	void _time_edit_exited();
+
+public:
+	AnimationMultiTrackKeyEditEditor(Ref<Animation> p_animation, const RBMap<int, NodePath> &p_base_map, const RBMap<int, List<float>> &p_key_ofs_map, bool p_use_fps);
+};

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9398,6 +9398,7 @@ EditorNode::EditorNode() {
 	// More visually meaningful to have this later.
 	add_editor_plugin(memnew(AnimationPlayerEditorPlugin));
 	add_editor_plugin(memnew(AnimationTrackKeyEditEditorPlugin));
+	add_editor_plugin(memnew(AnimationMultiTrackKeyEditEditorPlugin));
 	add_editor_plugin(memnew(AnimationMarkerKeyEditEditorPlugin));
 
 	add_editor_plugin(VersionControlEditorPlugin::get_singleton());


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14713

This PR lets you edit the time of keyframes when multiple are selected at once. The intended use case is for users to select multiple keyframes across different tracks and adjust their time at once.

### Implementation
The implementation is mostly a copy of the `AnimationTrackKeyEditEditor`, but with the edit action being applied in a loop for all key values, and adding a few checks for cases where there are conflicts in the undo/redo.

I had considered consolidating both into a single plugin (since the same logic still works for a single track), but I think keeping them separate (1 plugin per 1 resource type) is ultimately easier to maintain.

### Edge Cases
There are a few unintuitive edge cases:
1. When multiple keyframes are selected with different time values, the "Time" field will show the value of the first one. This is because the internal `EditorSpinSlider` doesn't support indeterminate states.
2. When multiple keyframes are selected with different time values, and the user inputs the same time value that is shown on the editor, no changes will be applied. This is because it's not possible to tell whether the user intends to edit the time of *all* values or not. Without this edge-case check, if the user simply selects multiple keyframes, clicks the spinner without editing anything, and defocuses, the time value of the first keyframe will be applied to all even though the user likely intended to 'cancel' the action. The downside is that if the user actually intended to adjust all the time values, it will simply do nothing. I believe this is an acceptable edge case because it's not really the intended usage; if the user wants to mass delete all but one keyframe, there are easier ways to achieve that.
3. When multiple keyframes are selected **from the same track** and the time is edited, all but the first keyframe will be removed. Not unintuitive as it sounds, the existing single keyframe time editor already has destructive behavior if you change a keyframe's time to one that is already taken by another keyframe.

Edge cases 1 and 2 could be resolved if an "indeterminate state" is added for the `EditorSpinSlider` (inspector float editor), such that when multiple keyframe with different time values are selected, the "Time" field will be empty as opposed to defaulting to the time of the first keyframe in the selection.

### QA Video

https://github.com/user-attachments/assets/545205a2-af1f-4df2-9e6e-31ba9d22656c

- Full undo/redo support tested
- Multiple track / multiple keyframes / multiple track type tested
- See 0:14 for edge case 1
- See 0:34 for edge case 2
- See 0:42 for edge case 3

----------------

Turns out there's a bit more edge cases in the implementation than I had originally anticipated, so maintainers feel free to close the PR if you feel it's a bit too unintuitive. Most of these edge cases stem from the inability to display a partial/indeterminate time value, which will be a much bigger effort to implement since it's a core engine control type.