### PR TITLE
Editor: Fix Tag Container Clipping Project Title and Breaking Project Manager UI

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -46,6 +46,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/popup_menu.h"
@@ -471,11 +472,12 @@ ProjectListItemControl::ProjectListItemControl() {
 		project_title = memnew(Label);
 		project_title->set_focus_mode(FOCUS_ACCESSIBILITY);
 		project_title->set_name("ProjectName");
-		project_title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		project_title->set_clip_text(true);
+		project_title->set_h_size_flags(Control::SIZE_FILL);
 		title_hb->add_child(project_title);
 
-		tag_container = memnew(HBoxContainer);
+		tag_container = memnew(HFlowContainer);
+		tag_container->set_alignment(FlowContainer::ALIGNMENT_END);
+		tag_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		title_hb->add_child(tag_container);
 	}
 

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -36,6 +36,7 @@
 
 class AcceptDialog;
 class Button;
+class HFlowContainer;
 class Label;
 class PopupMenu;
 class ProjectList;
@@ -56,7 +57,7 @@ class ProjectListItemControl : public HBoxContainer {
 	Label *project_version = nullptr;
 	TextureRect *project_unsupported_features = nullptr;
 	TextureRect *project_different_version = nullptr;
-	HBoxContainer *tag_container = nullptr;
+	HFlowContainer *tag_container = nullptr;
 	Button *touch_menu_button = nullptr;
 
 	Color favorite_focus_color;

--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -69,9 +69,11 @@ ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
 	add_child(button);
 	button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	button->set_text(p_text.capitalize());
+	button->set_tooltip_text(p_text.capitalize());
 	button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button->set_accessibility_name(vformat(TTR("Project Tag: %s"), p_text));
 	button->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	button->set_theme_type_variation(SNAME("ProjectTagButton"));
+	button->set_custom_maximum_size(Vector2(334 * EDSCALE, -1));
 	button->set_mouse_filter(MOUSE_FILTER_PASS);
 }


### PR DESCRIPTION
Closes #118871
Closes #113566
Currently, a project with a lot of tags causes the project title text to clip and also pushes the sidebar beyond the Project Manager window size.
<img width="866" height="163" alt="tag_unwrapped" src="https://github.com/user-attachments/assets/d39a8e82-0ce7-4c56-b7ab-63366d738e79" />


This wraps the tags by having them inside an HFlowContainer instead of the default HBoxContainer.
<img width="866" height="193" alt="tag_wrapped" src="https://github.com/user-attachments/assets/71a2ac0c-f8ee-4a1d-b6a5-ddb51793f913" />


It also works properly with longer project titles
<img width="711" height="87" alt="long_project_title" src="https://github.com/user-attachments/assets/8d93e1e8-cf49-4aa3-96c4-5d55a663e8a0" />

Edit 1: This fix won't work for long tag names (or a combination of an overly long project title and tag name), though it is unlikely to encounter such an issue.
Edit 2: The above has been resolved via a maximum size for tags and tooltips that show full tag name.