### PR TITLE
Fix wrong `_get()` code in class reference

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -43,6 +43,7 @@
 					if property == "fake_property":
 						print("Getting my property!")
 						return 4
+					return null
 
 				func _get_property_list():
 					return [
@@ -113,6 +114,7 @@
 					if property.begins_with("number_"):
 						var index = property.get_slice("_", 1).to_int()
 						return numbers[index]
+					return null
 
 				func _set(property, value):
 					if property.begins_with("number_"):


### PR DESCRIPTION
Seems like `_get()` with no default return is an error in 4.7.
<img width="688" height="258" alt="image" src="https://github.com/user-attachments/assets/61ddbcc3-df98-487a-9567-606371e32427" />
Interestingly, you can also do `return` instead of `return null` and it also works.

Note that the example does not fully work even with this change, due to #118877