### PR TITLE
Capitalize ARM in editor properties

### DIFF
--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -152,10 +152,10 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";
-	capitalize_string_remaps["arm32"] = "arm32";
-	capitalize_string_remaps["arm64"] = "arm64";
-	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
-	capitalize_string_remaps["armeabi-v7a"] = "armeabi-v7a";
+	capitalize_string_remaps["arm32"] = "ARM32";
+	capitalize_string_remaps["arm64"] = "ARM64";
+	capitalize_string_remaps["arm64-v8a"] = "ARM64-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "ARMeabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["astc"] = "ASTC";
 	capitalize_string_remaps["bbcode"] = "BBCode";


### PR DESCRIPTION
In the file editor_property_name_processor.cpp, the variable is called capitalize_string_remaps and it makes more sense to use the capital ARM as it's an acronym. So I have changed arm32, arm64, arm64-v8a, armeabi-v7a to be ARM.