### PR TITLE
Use borderless window for drag preview outside viewport bounds

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1471,14 +1471,18 @@ bool TabBar::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
 	}
 
 	bool drop_override = Control::can_drop_data(p_point, p_data);
-	if (drop_override) {
-		return drop_override;
+	if (!drop_override && drag_to_rearrange_enabled) {
+		drop_override = _handle_can_drop_data("tab_bar_tab", p_point, p_data);
 	}
 
-	if (drag_to_rearrange_enabled) {
-		return _handle_can_drop_data("tab_bar_tab", p_point, p_data);
+	if(drop_override){
+		if(!dragging_valid_tab) {
+			const_cast<TabBar *>(this)->dragging_valid_tab = true;
+		}
+		const_cast<TabBar *>(this)->queue_redraw();
 	}
-	return false;
+
+	return drop_override;
 }
 
 void TabBar::drop_data(const Point2 &p_point, const Variant &p_data) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2075,11 +2075,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 								gui.dragging = true;
 								break;
 							} else {
-								Control *drag_preview = _gui_get_drag_preview();
-								if (drag_preview) {
+								if (_gui_get_drag_preview()) {
 									ERR_PRINT("Don't set a drag preview and return null data. Preview was deleted and drag request ignored.");
-									memdelete(drag_preview);
-									gui.drag_preview_id = ObjectID();
+									_gui_delete_drag_preview();
 								}
 								section_root->gui.global_dragging = false;
 							}
@@ -2196,8 +2194,11 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (gui.dragging) {
 			// Handle drag & drop. This happens in the viewport where dragging started.
 
+			Window *drag_preview_window = _gui_get_drag_preview_window();
 			Control *drag_preview = _gui_get_drag_preview();
-			if (drag_preview) {
+			if (drag_preview_window) {
+				drag_preview_window->set_position(DisplayServer::get_singleton()->mouse_get_position());
+			} else if (drag_preview) {
 				Vector2 pos = drag_preview->get_canvas_transform().affine_inverse().xform(mpos);
 				drag_preview->set_position(pos);
 			}
@@ -2454,11 +2455,7 @@ void Viewport::gui_perform_drop_at(const Point2 &p_pos, Control *p_control) {
 		gui.drag_successful = false;
 	}
 
-	Control *drag_preview = _gui_get_drag_preview();
-	if (drag_preview) {
-		memdelete(drag_preview);
-		gui.drag_preview_id = ObjectID();
-	}
+	_gui_delete_drag_preview();
 
 	Viewport *section_root = get_section_root_viewport();
 	section_root->gui.drag_data = Variant();
@@ -2524,13 +2521,46 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	ERR_FAIL_COND(p_control->is_inside_tree());
 	ERR_FAIL_COND(p_control->get_parent() != nullptr);
 
-	Control *drag_preview = _gui_get_drag_preview();
-	if (drag_preview) {
-		memdelete(drag_preview);
+	_gui_delete_drag_preview();
+
+	Control *root_parent = p_base->get_root_parent_control();
+
+	// Try hosting the preview in a borderless top-level Window so it can render outside the host window.
+	// Requires native subwindows and window transparency; embedded (SubViewport) fallbacks use an in-viewport Control.
+	DisplayServer *ds = DisplayServer::get_singleton();
+	bool try_window = ds && ds->has_feature(DisplayServerEnums::FEATURE_SUBWINDOWS) && ds->has_feature(DisplayServerEnums::FEATURE_WINDOW_TRANSPARENCY);
+
+	if (try_window) {
+		Window *preview_window = memnew(Window);
+		preview_window->set_flag(Window::FLAG_BORDERLESS, true);
+		preview_window->set_flag(Window::FLAG_TRANSPARENT, true);
+		preview_window->set_flag(Window::FLAG_NO_FOCUS, true);
+		preview_window->set_flag(Window::FLAG_ALWAYS_ON_TOP, true);
+		preview_window->set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
+		preview_window->set_flag(Window::FLAG_POPUP, false);
+		preview_window->set_wrap_controls(true);
+		preview_window->set_force_native(true); // Escape embedded-subwindow containers (e.g., editor).
+
+		preview_window->add_child(p_control);
+		root_parent->add_child(preview_window);
+
+		if (preview_window->is_embedded()) {
+			// Embedded subwindows clip to the parent viewport, which is the problem we're trying to avoid.
+			preview_window->remove_child(p_control);
+			memdelete(preview_window);
+		} else {
+			Vector2i screen_pos = ds->mouse_get_position();
+			preview_window->set_position(screen_pos);
+			gui.drag_preview_window_id = preview_window->get_instance_id();
+			gui.drag_preview_id = p_control->get_instance_id();
+			return;
+		}
 	}
+
+	// Fallback: in-viewport Control (clips at window edge).
 	p_control->set_as_top_level(true);
 	p_control->set_position(gui.last_mouse_pos);
-	p_base->get_root_parent_control()->add_child(p_control); // Add as child of viewport.
+	root_parent->add_child(p_control);
 	p_control->move_to_front();
 
 	gui.drag_preview_id = p_control->get_instance_id();
@@ -2546,6 +2576,33 @@ Control *Viewport::_gui_get_drag_preview() {
 			gui.drag_preview_id = ObjectID();
 		}
 		return drag_preview;
+	}
+}
+
+Window *Viewport::_gui_get_drag_preview_window() {
+	if (gui.drag_preview_window_id.is_null()) {
+		return nullptr;
+	}
+	Window *w = ObjectDB::get_instance<Window>(gui.drag_preview_window_id);
+	if (!w) {
+		gui.drag_preview_window_id = ObjectID();
+	}
+	return w;
+}
+
+void Viewport::_gui_delete_drag_preview() {
+	Window *preview_window = _gui_get_drag_preview_window();
+	if (preview_window) {
+		// Deleting the Window also deletes the preview Control which is its child.
+		memdelete(preview_window);
+		gui.drag_preview_window_id = ObjectID();
+		gui.drag_preview_id = ObjectID();
+		return;
+	}
+	Control *drag_preview = _gui_get_drag_preview();
+	if (drag_preview) {
+		memdelete(drag_preview);
+		gui.drag_preview_id = ObjectID();
 	}
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -398,6 +398,7 @@ private:
 		bool drag_attempted = false;
 		Variant drag_data; // Only used in root-Viewport and SubViewports, that are not children of a SubViewportContainer.
 		ObjectID drag_preview_id;
+		ObjectID drag_preview_window_id;
 		String drag_description;
 		Ref<SceneTreeTimer> tooltip_timer;
 		double tooltip_delay = 0.0;
@@ -471,6 +472,8 @@ private:
 	void _gui_force_drag(Control *p_base, const Variant &p_data, Control *p_control);
 	void _gui_set_drag_preview(Control *p_base, Control *p_control);
 	Control *_gui_get_drag_preview();
+	Window *_gui_get_drag_preview_window();
+	void _gui_delete_drag_preview();
 
 	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_unfocus_control(Control *p_control);


### PR DESCRIPTION
We have been working on a solution to allow tab drag previews to render outside the bounds of the main window by utilizing a borderless window.

Fixes #116577 

While the drag functionality and window positioning are working as intended, we are currently encountering an issue where the new window renders with a solid black background instead of being transparent (as shown in the attached video). We were wondering if there is specific window flag or viewport setting required in the Godot core to make the borderless window transparent? Any info or pointers would be greatly appreciated.




https://github.com/user-attachments/assets/bba37d7a-a592-49ef-aa3d-8ccf06d83708

