### PR TITLE
Fix typo "subresorces" -> "subresources" in DEEP_DUPLICATE_NONE doc

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -186,7 +186,7 @@
 	</signals>
 	<constants>
 		<constant name="DEEP_DUPLICATE_NONE" value="0" enum="DeepDuplicateMode">
-			No subresorces at all are duplicated. This is useful even in a deep duplication to have all the arrays and dictionaries duplicated but still pointing to the original resources.
+			No subresources at all are duplicated. This is useful even in a deep duplication to have all the arrays and dictionaries duplicated but still pointing to the original resources.
 		</constant>
 		<constant name="DEEP_DUPLICATE_INTERNAL" value="1" enum="DeepDuplicateMode">
 			Only subresources without a path or with a scene-local path will be duplicated.


### PR DESCRIPTION
Fixes godotengine/godot-docs#11945.

The doc string for `DEEP_DUPLICATE_NONE` in `doc/classes/Resource.xml` had `subresorces` (missing the `u`). The other constants in the same enum (`DEEP_DUPLICATE_INTERNAL`, `DEEP_DUPLICATE_ALL`) and the `duplicate_deep` parameter use the correct spelling `subresources`, so this is just a one-character fix.

Filed against the `4.6` branch since master already has the correct spelling. The published 4.5 docs at https://docs.godotengine.org/en/stable/classes/class_resource.html#enum-resource-deepduplicatemode currently show the typo (screenshot in the linked issue).