### PR TITLE
Add Addons tab to project settings editor

### DIFF
--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -844,13 +844,18 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	group_settings->connect("group_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	globals_container->add_child(group_settings);
 
+	TabContainer *addons_container = memnew(TabContainer);
+	addons_container->set_theme_type_variation("TabContainerInner");
+	addons_container->set_name(TTRC("Addons"));
+	tab_container->add_child(addons_container);
+
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTRC("Plugins"));
-	tab_container->add_child(plugin_settings);
+	addons_container->add_child(plugin_settings);
 
 	gdextension_settings = memnew(ProjectSettingsGDExtension);
 	gdextension_settings->set_name(TTRC("GDExtension"));
-	tab_container->add_child(gdextension_settings);
+	addons_container->add_child(gdextension_settings);
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);


### PR DESCRIPTION
Similar to #92770, this PR moves Plugins and GDExtension tabs under a new Addons supertab.
|Before|After|
|-|-|
|<img width="693" height="97" alt="image" src="https://github.com/user-attachments/assets/c8819ee6-3a24-4bce-9e2d-cda450e501b0" />|<img width="586" height="135" alt="image" src="https://github.com/user-attachments/assets/7bc8cb1d-3bf5-49ec-b853-b5a03cd3ce20" />|