### PR TITLE
Fix `PopupMenu` input handling when scaled/padded

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1195,7 +1195,7 @@ void PopupMenu::_close_or_suspend() {
 	if (this_submenu_index != -1) { // Is a submenu.
 		PopupMenu *parent_popup = Object::cast_to<PopupMenu>(get_parent());
 		ERR_FAIL_NULL(parent_popup);
-		Point2 mouse_pos = is_embedded() ? parent_popup->get_mouse_position() : Point2(DisplayServer::get_singleton()->mouse_get_position() - parent_popup->get_position());
+		Point2 mouse_pos = is_embedded() ? parent_popup->get_mouse_position() * parent_popup->get_content_scale_factor() : Point2(DisplayServer::get_singleton()->mouse_get_position() - parent_popup->get_position());
 		if (parent_popup->_get_mouse_over(mouse_pos) == this_submenu_index) {
 			parent_popup->submenu_mouse_exited_ticks_msec = -1;
 			parent_popup->mouse_movement_was_tested = false;
@@ -2446,7 +2446,7 @@ void PopupMenu::_submenu_hidden() {
 	queue_accessibility_update();
 	control->queue_redraw();
 	if (!activated_by_keyboard) {
-		Point2 mouse_pos = is_embedded() ? get_mouse_position() : Point2(DisplayServer::get_singleton()->mouse_get_position() - get_position());
+		Point2 mouse_pos = is_embedded() ? get_mouse_position() * get_content_scale_factor() : Point2(DisplayServer::get_singleton()->mouse_get_position() - get_position());
 		_mouse_over_update(mouse_pos);
 	}
 }
@@ -3271,19 +3271,6 @@ bool PopupMenu::get_allow_search() const {
 	return allow_search;
 }
 
-String PopupMenu::get_tooltip(const Point2 &p_pos) const {
-	Point2 pos = p_pos;
-	// Adjust for the top style margin and search bar.
-	pos.y += scroll_container->get_global_position().y;
-
-	int over = _get_mouse_over(pos);
-	if (over < 0 || over >= items.size()) {
-		return "";
-	}
-
-	return items[over].tooltip;
-}
-
 void PopupMenu::set_search_bar_enabled(bool p_enabled) {
 	search_bar_enabled = p_enabled;
 	_update_search_bar_visibility();
@@ -3836,4 +3823,12 @@ PopupMenu::PopupMenu() {
 
 PopupMenu::~PopupMenu() {
 	unbind_global_menu();
+}
+
+String PopupMenuItems::get_tooltip(const Point2 &p_pos) const {
+	int over = popup->_get_mouse_over(get_global_transform_with_canvas().xform(p_pos) * popup->get_content_scale_factor());
+	if (over < 0 || over >= popup->items.size()) {
+		return "";
+	}
+	return popup->items[over].tooltip;
 }

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -423,8 +423,6 @@ public:
 
 	void clear(bool p_free_submenus = true);
 
-	virtual String get_tooltip(const Point2 &p_pos) const;
-
 #ifdef TOOLS_ENABLED
 	PackedStringArray get_configuration_warnings() const override;
 #endif
@@ -469,4 +467,5 @@ public:
 
 	virtual RID get_focused_accessibility_element() const override;
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual String get_tooltip(const Point2 &p_pos) const override;
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -44,7 +44,6 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup.h"
-#include "scene/gui/popup_menu.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/scene_tree.h"
@@ -1567,14 +1566,9 @@ void Viewport::_gui_cancel_tooltip() {
 String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Control **r_tooltip_owner) {
 	Vector2 pos = p_pos;
 	String tooltip;
-	PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 
 	while (p_control) {
-		if (menu) {
-			tooltip = menu->get_tooltip(pos);
-		} else {
-			tooltip = p_control->get_tooltip(pos);
-		}
+		tooltip = p_control->get_tooltip(pos);
 
 		if (r_tooltip_owner) {
 			*r_tooltip_owner = p_control;


### PR DESCRIPTION
Fixes #118840.
Fixes #118885.

`PopupMenu::_get_mouse_over` (and `PopupMenu::_mouse_over_update` as a result) seemingly expects the mouse position to be scaled by `get_content_scale_factor()`, as seen here:

https://github.com/godotengine/godot/blob/583596cd50bbdd29c5ee033d944410035eeb87fb/scene/gui/popup_menu.cpp#L342-L344

... because it's presumably meant to be called from `_input_from_window`, which unlike the events propagated by `push_input` are seemingly not made local using the stretch transform.

This became a problem for the `is_embedded()` case in `_close_or_suspend` and `_submenu_hidden`, as `get_mouse_position()` will effectively return the mouse position local to the `PopupMenu`, causing a coordinate space mismatch between them and the `InputEventMouseMotion` handler.

Now they have their mouse positions scaled by `get_content_scale_factor()`, to match what `_get_mouse_over` expects.

~~Similarly, the usage of `_get_mouse_over` in `PopupMenu::get_tooltip` was also broken, as we were passing in a position not only fully local to the `PopupMenu`, but local to whatever `Control` you happened to be hovering over, which is doubly broken now that we have a `LineEdit` in there as well. On top of that there seem to have been a hack introduced in #90922 to accommodate for top margins specifically, which shifted the position down in such a case, which was stacked on top of another "temporary" hack introduced in #51906.~~

~~I've scrapped both of these hacks in favor of a more self-contained approach, by changing `PopupMenu::control` into a new the `PopupMenuItems` class, which can then appropriately override `get_tooltip` and actually transform `p_pos` into `PopupMenu` space correctly, which can then be scaled by `get_content_scale_factor()` to match what `_get_mouse_over` expects.~~

EDIT: The tooltip fix in #119412 conflicted with what's struck through above, but similar problems still remain, so I'm replacing it with a `PopupMenuItems::get_tooltip` instead, to correctly handle the space conversion, without needing to deal with a bunch of offsets and scales.

---
_Disclaimer: AI tooling was used to help triage this, but the code was all written by me._