### PR TITLE
Remove redraw timer for theme previews

### DIFF
--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -58,8 +58,6 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/theme/theme_db.h"
 
-constexpr double REFRESH_TIMER = 1.5;
-
 void ThemeEditorPreview::set_preview_theme(const Ref<Theme> &p_theme) {
 	preview_content->set_theme(p_theme);
 }
@@ -67,30 +65,6 @@ void ThemeEditorPreview::set_preview_theme(const Ref<Theme> &p_theme) {
 void ThemeEditorPreview::add_preview_overlay(Control *p_overlay) {
 	preview_overlay->add_child(p_overlay);
 	p_overlay->hide();
-}
-
-void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
-	p_at->notification(NOTIFICATION_THEME_CHANGED);
-	p_at->update_minimum_size();
-	p_at->queue_redraw();
-	for (int i = 0; i < p_at->get_child_count(); i++) {
-		Control *a = Object::cast_to<Control>(p_at->get_child(i));
-		if (a) {
-			_propagate_redraw(a);
-		}
-	}
-}
-
-void ThemeEditorPreview::_refresh_interval() {
-	// In case the project settings have changed.
-	preview_bg->set_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
-
-	_propagate_redraw(preview_bg);
-	_propagate_redraw(preview_content);
-}
-
-void ThemeEditorPreview::_preview_visibility_changed() {
-	set_process(is_visible_in_tree());
 }
 
 void ThemeEditorPreview::_picker_button_cbk() {
@@ -202,18 +176,14 @@ void ThemeEditorPreview::_reset_picker_overlay() {
 	picker_overlay->queue_redraw();
 }
 
+void ThemeEditorPreview::_update_preview_bg() {
+	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/environment/defaults/default_clear_color")) {
+		preview_bg->set_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+	}
+}
+
 void ThemeEditorPreview::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_POSTINITIALIZE: {
-			connect(SceneStringName(visibility_changed), callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
-		} break;
-
-		case NOTIFICATION_ENTER_TREE: {
-			if (is_visible_in_tree()) {
-				set_process(true);
-			}
-		} break;
-
 		// Due to NOTIFICATION_READY being called only once, and theme contexts being destroyed on node removal,
 		// this is the notification needed, as it can be triggered indefinitely.
 		case NOTIFICATION_POST_ENTER_TREE: {
@@ -230,14 +200,6 @@ void ThemeEditorPreview::_notification(int p_what) {
 			theme_cache.preview_picker_label = get_theme_stylebox(SNAME("preview_picker_label"), SNAME("ThemeEditor"));
 			theme_cache.preview_picker_font = get_theme_font(SNAME("status_source"), EditorStringName(EditorFonts));
 			theme_cache.font_size = get_theme_default_font_size();
-		} break;
-
-		case NOTIFICATION_PROCESS: {
-			time_left -= get_process_delta_time();
-			if (time_left < 0) {
-				time_left = REFRESH_TIMER;
-				_refresh_interval();
-			}
 		} break;
 	}
 }
@@ -293,6 +255,8 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_overlay->connect(SceneStringName(draw), callable_mp(this, &ThemeEditorPreview::_draw_picker_overlay));
 	picker_overlay->connect(SceneStringName(gui_input), callable_mp(this, &ThemeEditorPreview::_gui_input_picker_overlay));
 	picker_overlay->connect(SceneStringName(mouse_exited), callable_mp(this, &ThemeEditorPreview::_reset_picker_overlay));
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ThemeEditorPreview::_update_preview_bg));
 }
 
 void DefaultThemeEditorPreview::_notification(int p_what) {

--- a/editor/scene/gui/theme_editor_preview.h
+++ b/editor/scene/gui/theme_editor_preview.h
@@ -58,18 +58,14 @@ class ThemeEditorPreview : public VBoxContainer {
 		int font_size = 16;
 	} theme_cache;
 
-	double time_left = 0;
-
-	void _propagate_redraw(Control *p_at);
-	void _refresh_interval();
-	void _preview_visibility_changed();
-
 	void _picker_button_cbk();
 	Control *_find_hovered_control(Control *p_parent, Vector2 p_mouse_position);
 
 	void _draw_picker_overlay();
 	void _gui_input_picker_overlay(const Ref<InputEvent> &p_event);
 	void _reset_picker_overlay();
+
+	void _update_preview_bg();
 
 protected:
 	HBoxContainer *preview_toolbar = nullptr;


### PR DESCRIPTION
The `Theme` editor preview has had for several years a refresh timer to manually trigger redrawing for the `Control` nodes inside. The problem is that it not only feels like it's totally pointless (since I didn't see anything toggled to disable the automatic redrawing), but also breaks stuff. So this PR outright removes that stuff.

Fixes #118255.