### PR TITLE
Fix EditorDock accessibility properties

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -82,6 +82,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_region" type="bool" setter="set_accessibility_region" getter="is_accessibility_region" overrides="Container" default="true" />
 		<member name="available_layouts" type="int" setter="set_available_layouts" getter="get_available_layouts" enum="EditorDock.DockLayout" is_bitfield="true" default="5">
 			The available layouts for this dock, as a bitmask. By default, the dock allows vertical and floating layouts.
 		</member>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -45,10 +45,15 @@ void EditorDock::_emit_changed() {
 	emit_signal(SNAME("_tab_style_changed"));
 }
 
+void EditorDock::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "accessibility_name") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
 void EditorDock::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			set_accessibility_region(true);
 			set_accessibility_name(get_display_title());
 		} break;
 
@@ -321,4 +326,8 @@ Ref<Texture2D> EditorDock::get_effective_icon(const Callable &p_icon_fetch) {
 		icon = p_icon_fetch.call(icon_name);
 	}
 	return icon;
+}
+
+EditorDock::EditorDock() {
+	set_accessibility_region(true);
 }

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -98,6 +98,8 @@ private:
 	void _emit_changed();
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 
@@ -160,6 +162,8 @@ public:
 
 	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const { GDVIRTUAL_CALL(_save_layout_to_config, p_layout, p_section); }
 	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) { GDVIRTUAL_CALL(_load_layout_from_config, p_layout, p_section); }
+
+	EditorDock();
 };
 
 VARIANT_BITFIELD_CAST(EditorDock::DockLayout);


### PR DESCRIPTION
I noticed EditorDock sets some accessibility settings in `NOTIFICATION_READY`. This results in redundant properties saved in a scene using EditorDock.

This PR fixes it by:
- Setting `accessibility_region` in the constructor, so it becomes a default value instead of override.
- Hiding `accessibility_name` property. The title overwrites it anyway, so no reason to have it editable.