### PR TITLE
Fix script editor guideline colors

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -528,7 +528,9 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/selection_color"] = p_config.selection_color;
 			colors["text_editor/theme/highlighting/brace_mismatch_color"] = p_config.dark_icon_and_font ? p_config.error_color : Color(1, 0.08, 0, 1);
 			colors["text_editor/theme/highlighting/current_line_color"] = alpha1;
-			colors["text_editor/theme/highlighting/line_length_guideline_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.dark_color_2;
+			// Contrast is positive in dark themes and negative in light themes. Lerping with a negative weight
+			// gives us lighter lines than base_color in dark themes and darker lines in light themes.
+			colors["text_editor/theme/highlighting/line_length_guideline_color"] = p_config.base_color.lerp(Color(0, 0, 0), p_config.contrast * -1.25).clamp();
 			colors["text_editor/theme/highlighting/word_highlighted_color"] = alpha1;
 			colors["text_editor/theme/highlighting/number_color"] = p_config.dark_icon_and_font ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
 			colors["text_editor/theme/highlighting/function_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -455,7 +455,7 @@ void CodeEdit::_draw_guidelines() {
 		const int column_pos = theme_cache.font->get_string_size(String("0").repeat((int)line_length_guideline_columns[i]), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
 		const int xoffset = xmargin_beg + column_pos - get_h_scroll();
 		if (xoffset > xmargin_beg && xoffset < xmargin_end) {
-			Color guideline_color = (i == 0) ? theme_cache.line_length_guideline_color : theme_cache.line_length_guideline_color * Color(1, 1, 1, 0.5);
+			Color guideline_color = (i == 0) ? theme_cache.line_length_guideline_color : theme_cache.line_length_guideline_color * Color(1, 1, 1, 0.6);
 			if (rtl) {
 				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(size.width - xoffset, 0), Point2(size.width - xoffset, size.height), guideline_color);
 				continue;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/118817

| Old | New |
|--------|--------|
| <img width="1659" height="880" alt="1" src="https://github.com/user-attachments/assets/e08cbea7-9c06-4ff3-a1ee-5e6ac3578881" /> | <img width="1659" height="880" alt="2" src="https://github.com/user-attachments/assets/10a38f14-6b23-4811-97e4-4f1d03294402" /> |
| <img width="1659" height="880" alt="3" src="https://github.com/user-attachments/assets/8a98fe15-6acc-4219-84fc-4a6f14c46c8e" /> | <img width="1659" height="880" alt="4" src="https://github.com/user-attachments/assets/62bbf4bf-22da-482a-8762-f919674f36e3" /> |
| <img width="1659" height="880" alt="5" src="https://github.com/user-attachments/assets/6981b622-2f24-4c84-b89b-f0c1f9a43abf" /> | <img width="1659" height="880" alt="6" src="https://github.com/user-attachments/assets/4c77975c-6fb9-406b-a616-6391962e45b2" /> | 









