### PR TITLE
[Windows] Fix IME candidate window misalignment by setting composition font

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -136,6 +136,13 @@ static void update_ime_form_positions(HIMC p_himc, const Point2i &p_pos) {
 	cps.ptCurrentPos.y = p_pos.y;
 	ImmSetCompositionWindow(p_himc, &cps);
 
+	LOGFONT logFont = {};
+
+	logFont.lfHeight = 1; // em height
+	logFont.lfQuality = CLEARTYPE_QUALITY;
+
+	ImmSetCompositionFontA(p_himc, &logFont);
+
 	CANDIDATEFORM cf = {};
 	cf.dwIndex = 0;
 


### PR DESCRIPTION
Fixes #118892

See https://github.com/godotengine/godot/pull/118843#issuecomment-4303773928

https://learn.microsoft.com/en-us/windows/win32/api/immdev/nf-immdev-immsetcompositionfonta

Use `ImmSetCompositionFont` might resolves this issue and works on Pinyin IME

This change seems not affect `Microsoft Japanese IME`.

`lfHeight` grow the value will effect on Pinyin IME.

Related code in web IME:
https://github.com/godotengine/godot/blob/583596cd50bbdd29c5ee033d944410035eeb87fb/platform/web/js/libs/library_godot_input.js#L133

*Testest on  Windows 11 with `Microsoft Pinyin` and `Google Pinyin` 3.0.1.98*

Before:

<img width="607" height="303" alt="Image" src="https://github.com/user-attachments/assets/8e4d9bc1-f65b-4a5f-abbb-f0b2dbf4eaf8" />

<img width="353" height="113" alt="Image" src="https://github.com/user-attachments/assets/d3840ec3-0a8b-46f3-b295-42d01537ffc2" />

After:
<img width="179" height="124" alt="image" src="https://github.com/user-attachments/assets/54937ee8-a0d7-47b0-8e72-f5edbb5e6d8c" />

<img width="179" height="124" alt="image" src="https://github.com/user-attachments/assets/25035592-4b12-4481-8195-dcf95d43ddba" />

