### PR TITLE
Fix inspector tooltips after focus changes

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -513,9 +513,7 @@ Error SceneDebugger::_msg_report_window_focused(const Array &p_args) {
 
 	bool focused = p_args[0];
 	Input::get_singleton()->embedder_focused = focused;
-	if (Input::get_singleton()->_should_ignore_joypad_events()) {
-		Input::get_singleton()->release_pressed_events();
-	}
+	Input::get_singleton()->release_pressed_events();
 	return OK;
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -932,9 +932,10 @@ void SceneTree::_notification(int p_notification) {
 			if (Input::get_singleton()) {
 				Input::get_singleton()->application_focused = p_notification == NOTIFICATION_APPLICATION_FOCUS_IN;
 
-				if (Input::get_singleton()->_should_ignore_joypad_events()) {
-					Input::get_singleton()->release_pressed_events();
-				}
+				// `release_pressed_events()` already preserves joypad state when the
+				// unfocused joypad setting is disabled, but keyboard state still needs
+				// to be released after focus loss.
+				Input::get_singleton()->release_pressed_events();
 			}
 
 			// Pass these to nodes, since they are mirrored.


### PR DESCRIPTION
## Summary
- release pressed input state when app focus changes so stale keyboard state does not block inspector tooltips
- do the same for embedded debugger focus changes while keeping joypad handling in `Input::release_pressed_events()`

Fixes #118826.
- *Bugsquad edit:* This PR also fixes https://github.com/godotengine/godot/issues/118341