### PR TITLE
Jolt: Fix extra area events on same-frame re-enter

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -55,7 +55,12 @@ JPH::ObjectLayer JoltArea3D::_get_object_layer() const {
 }
 
 void JoltArea3D::_add_to_space() {
-	jolt_shape = build_shapes(true);
+	const bool can_reuse_current_shape = jolt_body != nullptr && cached_body_space == space &&
+			space->get_body_iface().IsAdded(jolt_body->GetID()) && !shapes_dirty;
+	if (!can_reuse_current_shape) {
+		jolt_shape = build_shapes(true);
+		shapes_dirty = false;
+	}
 
 	JPH::CollisionGroup::GroupID group_id = 0;
 	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
@@ -135,10 +140,6 @@ bool JoltArea3D::_remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p
 }
 
 void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callback) {
-	// Jolt body IDs can change when the same Godot object leaves and re-enters a space in one frame.
-	// Coalesce by stable Godot identity before reporting monitor events.
-	HashMap<EventKey, int, EventKey> event_states;
-
 	for (OverlapsById::Iterator E = p_objects.begin(); E;) {
 		Overlap &overlap = E->value;
 
@@ -146,7 +147,7 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 			for (const ShapeIndexPair &shape_indices : overlap.pending_added) {
 				int &ref_count = overlap.ref_counts[shape_indices];
 				if (ref_count++ == 0) {
-					event_states[EventKey(overlap.rid, overlap.instance_id, shape_indices)]++;
+					_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
 				}
 			}
 
@@ -154,7 +155,7 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 				HashMap<ShapeIndexPair, int, ShapeIndexPair>::Iterator ref_count = overlap.ref_counts.find(shape_indices);
 				ERR_CONTINUE(ref_count == overlap.ref_counts.end() || ref_count->value <= 0);
 				if (--ref_count->value == 0) {
-					event_states[EventKey(overlap.rid, overlap.instance_id, shape_indices)]--;
+					_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
 					overlap.ref_counts.remove(ref_count);
 				}
 			}
@@ -171,16 +172,6 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 		}
 
 		E = next;
-	}
-
-	if (p_callback.is_valid()) {
-		for (const KeyValue<EventKey, int> &E : event_states) {
-			if (E.value > 0) {
-				_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, E.key.rid, E.key.instance_id, E.key.other_shape, E.key.self_shape);
-			} else if (E.value < 0) {
-				_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, E.key.rid, E.key.instance_id, E.key.other_shape, E.key.self_shape);
-			}
-		}
 	}
 }
 

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -135,6 +135,10 @@ bool JoltArea3D::_remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p
 }
 
 void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callback) {
+	// Jolt body IDs can change when the same Godot object leaves and re-enters a space in one frame.
+	// Coalesce by stable Godot identity before reporting monitor events.
+	HashMap<EventKey, int, EventKey> event_states;
+
 	for (OverlapsById::Iterator E = p_objects.begin(); E;) {
 		Overlap &overlap = E->value;
 
@@ -142,16 +146,16 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 			for (const ShapeIndexPair &shape_indices : overlap.pending_added) {
 				int &ref_count = overlap.ref_counts[shape_indices];
 				if (ref_count++ == 0) {
-					_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
+					event_states[EventKey(overlap.rid, overlap.instance_id, shape_indices)]++;
 				}
 			}
 
 			for (const ShapeIndexPair &shape_indices : overlap.pending_removed) {
-				int &ref_count = overlap.ref_counts[shape_indices];
-				ERR_CONTINUE(ref_count <= 0);
-				if (--ref_count == 0) {
-					_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
-					overlap.ref_counts.erase(shape_indices);
+				HashMap<ShapeIndexPair, int, ShapeIndexPair>::Iterator ref_count = overlap.ref_counts.find(shape_indices);
+				ERR_CONTINUE(ref_count == overlap.ref_counts.end() || ref_count->value <= 0);
+				if (--ref_count->value == 0) {
+					event_states[EventKey(overlap.rid, overlap.instance_id, shape_indices)]--;
+					overlap.ref_counts.remove(ref_count);
 				}
 			}
 		}
@@ -167,6 +171,16 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 		}
 
 		E = next;
+	}
+
+	if (p_callback.is_valid()) {
+		for (const KeyValue<EventKey, int> &E : event_states) {
+			if (E.value > 0) {
+				_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, E.key.rid, E.key.instance_id, E.key.other_shape, E.key.self_shape);
+			} else if (E.value < 0) {
+				_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, E.key.rid, E.key.instance_id, E.key.other_shape, E.key.self_shape);
+			}
+		}
 	}
 }
 
@@ -514,8 +528,9 @@ void JoltArea3D::body_exited(const JPH::BodyID &p_body_id, bool p_notify) {
 	}
 
 	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		overlap->pending_added.erase(E.value);
-		overlap->pending_removed.push_back(E.value);
+		if (!overlap->pending_added.erase(E.value)) {
+			overlap->pending_removed.push_back(E.value);
+		}
 	}
 
 	_events_changed();
@@ -538,8 +553,9 @@ void JoltArea3D::area_exited(const JPH::BodyID &p_body_id) {
 	}
 
 	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		overlap->pending_added.erase(E.value);
-		overlap->pending_removed.push_back(E.value);
+		if (!overlap->pending_added.erase(E.value)) {
+			overlap->pending_removed.push_back(E.value);
+		}
 	}
 
 	_events_changed();

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -84,34 +84,6 @@ private:
 		}
 	};
 
-	struct EventKey {
-		RID rid;
-		ObjectID instance_id;
-		int other_shape = -1;
-		int self_shape = -1;
-
-		EventKey() = default;
-
-		EventKey(const RID &p_rid, ObjectID p_instance_id, const ShapeIndexPair &p_shape_indices) :
-				rid(p_rid),
-				instance_id(p_instance_id),
-				other_shape(p_shape_indices.other),
-				self_shape(p_shape_indices.self) {}
-
-		static uint32_t hash(const EventKey &p_key) {
-			uint32_t hash = hash_one_uint64(p_key.rid.get_id());
-			hash = hash_murmur3_one_64(p_key.instance_id, hash);
-			hash = hash_murmur3_one_32(p_key.other_shape, hash);
-			hash = hash_murmur3_one_32(p_key.self_shape, hash);
-			return hash_fmix32(hash);
-		}
-
-		friend bool operator==(const EventKey &p_lhs, const EventKey &p_rhs) {
-			return p_lhs.rid == p_rhs.rid && p_lhs.instance_id == p_rhs.instance_id &&
-					p_lhs.other_shape == p_rhs.other_shape && p_lhs.self_shape == p_rhs.self_shape;
-		}
-	};
-
 	struct Overlap {
 		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
 		HashMap<ShapeIndexPair, int, ShapeIndexPair> ref_counts;

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -84,6 +84,34 @@ private:
 		}
 	};
 
+	struct EventKey {
+		RID rid;
+		ObjectID instance_id;
+		int other_shape = -1;
+		int self_shape = -1;
+
+		EventKey() = default;
+
+		EventKey(const RID &p_rid, ObjectID p_instance_id, const ShapeIndexPair &p_shape_indices) :
+				rid(p_rid),
+				instance_id(p_instance_id),
+				other_shape(p_shape_indices.other),
+				self_shape(p_shape_indices.self) {}
+
+		static uint32_t hash(const EventKey &p_key) {
+			uint32_t hash = hash_one_uint64(p_key.rid.get_id());
+			hash = hash_murmur3_one_64(p_key.instance_id, hash);
+			hash = hash_murmur3_one_32(p_key.other_shape, hash);
+			hash = hash_murmur3_one_32(p_key.self_shape, hash);
+			return hash_fmix32(hash);
+		}
+
+		friend bool operator==(const EventKey &p_lhs, const EventKey &p_rhs) {
+			return p_lhs.rid == p_rhs.rid && p_lhs.instance_id == p_rhs.instance_id &&
+					p_lhs.other_shape == p_rhs.other_shape && p_lhs.self_shape == p_rhs.self_shape;
+		}
+	};
+
 	struct Overlap {
 		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
 		HashMap<ShapeIndexPair, int, ShapeIndexPair> ref_counts;

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -88,7 +88,12 @@ JPH::EMotionType JoltBody3D::_get_motion_type() const {
 }
 
 void JoltBody3D::_add_to_space() {
-	jolt_shape = build_shapes(true);
+	const bool can_reuse_current_shape = jolt_body != nullptr && cached_body_space == space &&
+			space->get_body_iface().IsAdded(jolt_body->GetID()) && !shapes_dirty;
+	if (!can_reuse_current_shape) {
+		jolt_shape = build_shapes(true);
+		shapes_dirty = false;
+	}
 
 	JPH::CollisionGroup::GroupID group_id = 0;
 	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
@@ -413,6 +418,10 @@ void JoltBody3D::_exit_all_areas() {
 	areas.clear();
 }
 
+void JoltBody3D::_clear_areas() {
+	areas.clear();
+}
+
 void JoltBody3D::_update_group_filter() {
 	JPH::GroupFilter *group_filter = !exceptions.is_empty() ? JoltGroupFilter::instance : nullptr;
 
@@ -443,9 +452,12 @@ void JoltBody3D::_space_changing() {
 	JoltShapedObject3D::_space_changing();
 
 	sleep_initially = is_sleeping();
+	const bool deferring_removal = space != nullptr && space_changing_to == nullptr && space->will_defer_object_destruction(*this);
 
 	_destroy_joint_constraints();
-	_exit_all_areas();
+	if (!deferring_removal) {
+		_exit_all_areas();
+	}
 	_dequeue_call_queries();
 }
 
@@ -457,6 +469,10 @@ void JoltBody3D::_space_changed() {
 	_update_joint_constraints();
 	_update_sleep_allowed();
 	_areas_changed();
+}
+
+void JoltBody3D::_jolt_body_destroying() {
+	_clear_areas();
 }
 
 void JoltBody3D::_areas_changed() {
@@ -502,6 +518,8 @@ JoltBody3D::JoltBody3D() :
 }
 
 JoltBody3D::~JoltBody3D() {
+	_clear_areas();
+
 	if (direct_state != nullptr) {
 		memdelete(direct_state);
 		direct_state = nullptr;

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -136,11 +136,13 @@ private:
 	void _destroy_joint_constraints();
 
 	void _exit_all_areas();
+	void _clear_areas();
 
 	void _mode_changed();
 	virtual void _shapes_committed() override;
 	virtual void _space_changing() override;
 	virtual void _space_changed() override;
+	virtual void _jolt_body_destroying() override;
 	void _areas_changed();
 	void _joints_changed();
 	void _transform_changed();

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -39,17 +39,18 @@ void JoltObject3D::_remove_from_space() {
 		return;
 	}
 
-	space->remove_object(jolt_body->GetID());
-	jolt_body = nullptr;
+	space->remove_object(*this);
 }
 
 void JoltObject3D::_reset_space() {
 	ERR_FAIL_NULL(space);
 
+	space_changing_to = space;
 	_space_changing();
 	_remove_from_space();
 	_add_to_space();
 	_space_changed();
+	space_changing_to = nullptr;
 }
 
 void JoltObject3D::_update_object_layer() {
@@ -69,10 +70,16 @@ void JoltObject3D::_collision_mask_changed() {
 }
 
 JoltObject3D::JoltObject3D(ObjectType p_object_type) :
+		needs_destruction_element(this),
 		object_type(p_object_type) {
 }
 
-JoltObject3D::~JoltObject3D() = default;
+JoltObject3D::~JoltObject3D() {
+	JoltSpace3D *body_space = cached_body_space != nullptr ? cached_body_space : space;
+	if (jolt_body != nullptr && body_space != nullptr) {
+		destroy_jolt_body(body_space, false);
+	}
+}
 
 Object *JoltObject3D::get_instance() const {
 	return ObjectDB::get_instance(instance_id);
@@ -83,6 +90,7 @@ void JoltObject3D::set_space(JoltSpace3D *p_space) {
 		return;
 	}
 
+	space_changing_to = p_space;
 	_space_changing();
 
 	if (space != nullptr) {
@@ -96,6 +104,7 @@ void JoltObject3D::set_space(JoltSpace3D *p_space) {
 	}
 
 	_space_changed();
+	space_changing_to = nullptr;
 }
 
 void JoltObject3D::set_collision_layer(uint32_t p_layer) {
@@ -132,6 +141,40 @@ bool JoltObject3D::can_interact_with(const JoltObject3D &p_other) const {
 	} else {
 		ERR_FAIL_V_MSG(false, vformat("Unhandled object type: '%d'. This should not happen. Please report this.", p_other.get_type()));
 	}
+}
+
+void JoltObject3D::enqueue_needs_destruction(JoltSpace3D *p_space) {
+	if (p_space != nullptr) {
+		p_space->enqueue_needs_destruction(&needs_destruction_element);
+	}
+}
+
+void JoltObject3D::dequeue_needs_destruction(JoltSpace3D *p_space) {
+	if (p_space != nullptr) {
+		p_space->dequeue_needs_destruction(&needs_destruction_element);
+	}
+}
+
+void JoltObject3D::destroy_jolt_body(JoltSpace3D *p_space, bool p_notify) {
+	if (jolt_body == nullptr || p_space == nullptr) {
+		return;
+	}
+
+	dequeue_needs_destruction(p_space);
+
+	if (p_notify) {
+		_jolt_body_destroying();
+	}
+
+	JPH::BodyInterface &body_iface = p_space->get_body_iface();
+	const JPH::BodyID jolt_id = jolt_body->GetID();
+	if (body_iface.IsAdded(jolt_id)) {
+		body_iface.RemoveBody(jolt_id);
+	}
+	body_iface.DestroyBody(jolt_id);
+
+	jolt_body = nullptr;
+	cached_body_space = nullptr;
 }
 
 String JoltObject3D::to_string() const {

--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -36,6 +36,7 @@
 #include "core/object/object.h"
 #include "core/string/ustring.h"
 #include "core/templates/rid.h"
+#include "core/templates/self_list.h"
 
 #include <Jolt/Jolt.h>
 
@@ -60,9 +61,13 @@ public:
 	};
 
 protected:
+	SelfList<JoltObject3D> needs_destruction_element;
+
 	RID rid;
 	ObjectID instance_id;
 	JoltSpace3D *space = nullptr;
+	JoltSpace3D *space_changing_to = nullptr;
+	JoltSpace3D *cached_body_space = nullptr;
 	JPH::Body *jolt_body = nullptr;
 
 	uint32_t collision_layer = 1;
@@ -87,6 +92,7 @@ protected:
 
 	virtual void _space_changing() {}
 	virtual void _space_changed() {}
+	virtual void _jolt_body_destroying() {}
 
 public:
 	explicit JoltObject3D(ObjectType p_object_type);
@@ -124,6 +130,8 @@ public:
 	JoltSpace3D *get_space() const { return space; }
 	void set_space(JoltSpace3D *p_space);
 	bool in_space() const { return space != nullptr && jolt_body != nullptr; }
+	bool is_being_removed_from_space() const { return space != nullptr && space_changing_to == nullptr; }
+	JoltSpace3D *get_cached_body_space() const { return cached_body_space; }
 
 	uint32_t get_collision_layer() const { return collision_layer; }
 	void set_collision_layer(uint32_t p_layer);
@@ -144,6 +152,11 @@ public:
 	virtual bool can_interact_with(const JoltArea3D &p_other) const = 0;
 
 	virtual bool reports_contacts() const = 0;
+
+	void enqueue_needs_destruction(JoltSpace3D *p_space);
+	void dequeue_needs_destruction(JoltSpace3D *p_space);
+	void destroy_jolt_body(JoltSpace3D *p_space, bool p_notify = true);
+	void set_cached_body_space(JoltSpace3D *p_space) { cached_body_space = p_space; }
 
 	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) {}
 

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -296,6 +296,7 @@ JPH::ShapeRefC JoltShapedObject3D::build_shapes(bool p_optimize_compound) {
 
 void JoltShapedObject3D::commit_shapes(bool p_optimize_compound) {
 	if (!in_space()) {
+		shapes_dirty = true;
 		_shapes_committed();
 		return;
 	}
@@ -320,6 +321,8 @@ void JoltShapedObject3D::commit_shapes(bool p_optimize_compound) {
 	} else {
 		_dequeue_needs_optimization();
 	}
+
+	shapes_dirty = false;
 
 	_shapes_committed();
 }

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -54,6 +54,7 @@ protected:
 	JPH::ShapeRefC previous_jolt_shape;
 
 	JPH::BodyCreationSettings *jolt_settings = new JPH::BodyCreationSettings();
+	bool shapes_dirty = false;
 
 	virtual JPH::EMotionType _get_motion_type() const = 0;
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -421,6 +421,14 @@ void JoltSoftBody3D::_areas_changed() {
 	wake_up();
 }
 
+void JoltSoftBody3D::_clear_areas() {
+	areas.clear();
+}
+
+void JoltSoftBody3D::_jolt_body_destroying() {
+	_clear_areas();
+}
+
 JoltSoftBody3D::JoltSoftBody3D() :
 		JoltObject3D(OBJECT_TYPE_SOFT_BODY) {
 	jolt_settings->mRestitution = 0.0f;
@@ -430,6 +438,8 @@ JoltSoftBody3D::JoltSoftBody3D() :
 }
 
 JoltSoftBody3D::~JoltSoftBody3D() {
+	_clear_areas();
+
 	if (jolt_settings != nullptr) {
 		delete jolt_settings;
 		jolt_settings = nullptr;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -93,6 +93,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 	void _motion_changed();
 	void _transform_changed();
 	void _areas_changed();
+	void _clear_areas();
+	virtual void _jolt_body_destroying() override;
 
 public:
 	JoltSoftBody3D();

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -63,7 +63,80 @@ constexpr double SPACE_DEFAULT_SOLVER_ITERATIONS = 8;
 
 } // namespace
 
+void JoltSpace3D::_apply_body_settings(JPH::Body &p_jolt_body, const JPH::BodyCreationSettings &p_settings) {
+	JPH::BodyInterface &body_iface = get_body_iface();
+	const JPH::BodyID &jolt_id = p_jolt_body.GetID();
+
+	p_jolt_body.SetUserData(p_settings.mUserData);
+	p_jolt_body.SetFriction(p_settings.mFriction);
+	p_jolt_body.SetRestitution(p_settings.mRestitution);
+	p_jolt_body.SetCollisionGroup(p_settings.mCollisionGroup);
+	p_jolt_body.SetIsSensor(p_settings.mIsSensor);
+	p_jolt_body.SetCollideKinematicVsNonDynamic(p_settings.mCollideKinematicVsNonDynamic);
+	p_jolt_body.SetUseManifoldReduction(p_settings.mUseManifoldReduction);
+	p_jolt_body.SetApplyGyroscopicForce(p_settings.mApplyGyroscopicForce);
+	p_jolt_body.SetEnhancedInternalEdgeRemoval(p_settings.mEnhancedInternalEdgeRemoval);
+
+	body_iface.SetMotionType(jolt_id, p_settings.mMotionType, JPH::EActivation::DontActivate);
+	body_iface.SetObjectLayer(jolt_id, p_settings.mObjectLayer);
+	body_iface.SetShape(jolt_id, p_settings.GetShape(), false, JPH::EActivation::DontActivate);
+
+	JPH::MotionProperties *motion_properties = p_jolt_body.GetMotionPropertiesUnchecked();
+	if (motion_properties != nullptr) {
+		motion_properties->SetMassProperties(p_settings.mAllowedDOFs, p_settings.GetMassProperties());
+		motion_properties->SetLinearDamping(p_settings.mLinearDamping);
+		motion_properties->SetAngularDamping(p_settings.mAngularDamping);
+		motion_properties->SetMaxLinearVelocity(p_settings.mMaxLinearVelocity);
+		motion_properties->SetMaxAngularVelocity(p_settings.mMaxAngularVelocity);
+		motion_properties->SetGravityFactor(p_settings.mGravityFactor);
+		motion_properties->SetNumVelocityStepsOverride(p_settings.mNumVelocityStepsOverride);
+		motion_properties->SetNumPositionStepsOverride(p_settings.mNumPositionStepsOverride);
+		p_jolt_body.SetAllowSleeping(p_settings.mAllowSleeping);
+		body_iface.SetMotionQuality(jolt_id, p_settings.mMotionQuality);
+	}
+
+	body_iface.SetPositionAndRotationWhenChanged(jolt_id, p_settings.mPosition, p_settings.mRotation, JPH::EActivation::DontActivate);
+	if (motion_properties != nullptr && (motion_properties->GetLinearVelocity() != p_settings.mLinearVelocity ||
+			motion_properties->GetAngularVelocity() != p_settings.mAngularVelocity)) {
+		body_iface.SetLinearAndAngularVelocity(jolt_id, p_settings.mLinearVelocity, p_settings.mAngularVelocity);
+	}
+}
+
+JPH::Body *JoltSpace3D::_try_reuse_body(JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings) {
+	JoltSpace3D *cached_space = p_object.get_cached_body_space();
+	if (cached_space == nullptr) {
+		return nullptr;
+	}
+
+	JPH::Body *cached_body = p_object.get_jolt_body();
+	if (cached_body == nullptr) {
+		p_object.set_cached_body_space(nullptr);
+		return nullptr;
+	}
+
+	if (cached_space != this) {
+		p_object.destroy_jolt_body(cached_space);
+		return nullptr;
+	}
+
+	p_object.dequeue_needs_destruction(this);
+	p_object.set_cached_body_space(nullptr);
+	_apply_body_settings(*cached_body, p_settings);
+	return cached_body;
+}
+
+void JoltSpace3D::_flush_needs_destruction() {
+	while (needs_destruction_list.first()) {
+		SelfList<JoltObject3D> *element = needs_destruction_list.first();
+		JoltObject3D *object = element->self();
+		needs_destruction_list.remove(element);
+		object->destroy_jolt_body(this);
+	}
+}
+
 void JoltSpace3D::_pre_step(float p_step) {
+	_flush_needs_destruction();
+
 	flush_pending_objects();
 
 	while (needs_optimization_list.first()) {
@@ -161,6 +234,8 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system, JPH::TempAllocator *p_tem
 }
 
 JoltSpace3D::~JoltSpace3D() {
+	_flush_needs_destruction();
+
 	if (direct_state != nullptr) {
 		memdelete(direct_state);
 		direct_state = nullptr;
@@ -384,9 +459,19 @@ JoltPhysicsDirectSpaceState3D *JoltSpace3D::get_direct_state() {
 	return direct_state;
 }
 
-JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::Body *JoltSpace3D::add_object(JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
 	JPH::BodyInterface &body_iface = get_body_iface();
-	JPH::Body *jolt_body = body_iface.CreateBody(p_settings);
+	JPH::Body *jolt_body = _try_reuse_body(p_object, p_settings);
+
+	if (jolt_body == nullptr) {
+		jolt_body = body_iface.CreateBody(p_settings);
+	}
+
+	if (jolt_body == nullptr && needs_destruction_list.first() != nullptr) {
+		_flush_needs_destruction();
+		jolt_body = body_iface.CreateBody(p_settings);
+	}
+
 	if (unlikely(jolt_body == nullptr)) {
 		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
 							   "Consider increasing maximum number of bodies in project settings. "
@@ -396,18 +481,30 @@ JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::Body
 		return nullptr;
 	}
 
-	if (p_sleeping) {
-		pending_objects_sleeping.push_back(jolt_body->GetID());
-	} else {
-		pending_objects_awake.push_back(jolt_body->GetID());
+	if (!body_iface.IsAdded(jolt_body->GetID())) {
+		if (p_sleeping) {
+			pending_objects_sleeping.push_back(jolt_body->GetID());
+		} else {
+			pending_objects_awake.push_back(jolt_body->GetID());
+		}
 	}
 
 	return jolt_body;
 }
 
-JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::Body *JoltSpace3D::add_object(JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
+	if (p_object.get_cached_body_space() != nullptr) {
+		p_object.destroy_jolt_body(p_object.get_cached_body_space());
+	}
+
 	JPH::BodyInterface &body_iface = get_body_iface();
 	JPH::Body *jolt_body = body_iface.CreateSoftBody(p_settings);
+
+	if (jolt_body == nullptr && needs_destruction_list.first() != nullptr) {
+		_flush_needs_destruction();
+		jolt_body = body_iface.CreateSoftBody(p_settings);
+	}
+
 	if (unlikely(jolt_body == nullptr)) {
 		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
 							   "Consider increasing maximum number of bodies in project settings. "
@@ -417,29 +514,43 @@ JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::Soft
 		return nullptr;
 	}
 
-	if (p_sleeping) {
-		pending_objects_sleeping.push_back(jolt_body->GetID());
-	} else {
-		pending_objects_awake.push_back(jolt_body->GetID());
+	if (!body_iface.IsAdded(jolt_body->GetID())) {
+		if (p_sleeping) {
+			pending_objects_sleeping.push_back(jolt_body->GetID());
+		} else {
+			pending_objects_awake.push_back(jolt_body->GetID());
+		}
 	}
 
 	return jolt_body;
 }
 
-void JoltSpace3D::remove_object(const JPH::BodyID &p_jolt_id) {
-	JPH::BodyInterface &body_iface = get_body_iface();
+void JoltSpace3D::remove_object(JoltObject3D &p_object) {
+	const JPH::BodyID jolt_id = p_object.get_jolt_id();
 
-	if (!pending_objects_sleeping.erase_unordered(p_jolt_id) && !pending_objects_awake.erase_unordered(p_jolt_id)) {
-		body_iface.RemoveBody(p_jolt_id);
+	const bool deferring_removal = will_defer_object_destruction(p_object);
+	const bool deferring_broadphase_removal = deferring_removal && p_object.is_being_removed_from_space();
+
+	if (!pending_objects_sleeping.erase_unordered(jolt_id) && !pending_objects_awake.erase_unordered(jolt_id) && !deferring_broadphase_removal) {
+		get_body_iface().RemoveBody(jolt_id);
 	}
 
-	body_iface.DestroyBody(p_jolt_id);
+	if (deferring_removal) {
+		p_object.set_cached_body_space(this);
+		p_object.enqueue_needs_destruction(this);
+	} else {
+		p_object.destroy_jolt_body(this);
+	}
 
 	// If we're never going to step this space, like in the editor viewport, we need to manually clean up Jolt's broad phase instead, otherwise performance can degrade when doing things like switching scenes.
 	// We'll never actually have zero bodies in any space though, since we always have the default area, so we check if there's one or fewer left instead.
 	if (!JoltPhysicsServer3D::get_singleton()->is_active() && physics_system->GetNumBodies() <= 1) {
 		physics_system->OptimizeBroadPhase();
 	}
+}
+
+bool JoltSpace3D::will_defer_object_destruction(const JoltObject3D &p_object) const {
+	return JoltPhysicsServer3D::get_singleton()->is_active() && !p_object.is_soft_body();
 }
 
 void JoltSpace3D::flush_pending_objects() {
@@ -533,6 +644,18 @@ void JoltSpace3D::enqueue_needs_optimization(SelfList<JoltShapedObject3D> *p_obj
 void JoltSpace3D::dequeue_needs_optimization(SelfList<JoltShapedObject3D> *p_object) {
 	if (p_object->in_list()) {
 		needs_optimization_list.remove(p_object);
+	}
+}
+
+void JoltSpace3D::enqueue_needs_destruction(SelfList<JoltObject3D> *p_object) {
+	if (!p_object->in_list()) {
+		needs_destruction_list.add(p_object);
+	}
+}
+
+void JoltSpace3D::dequeue_needs_destruction(SelfList<JoltObject3D> *p_object) {
+	if (p_object->in_list()) {
+		needs_destruction_list.remove(p_object);
 	}
 }
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -61,6 +61,7 @@ class JoltSpace3D {
 	SelfList<JoltArea3D>::List area_call_queries_list;
 	SelfList<JoltShapedObject3D>::List shapes_changed_list;
 	SelfList<JoltShapedObject3D>::List needs_optimization_list;
+	SelfList<JoltObject3D>::List needs_destruction_list;
 
 	LocalVector<JPH::BodyID> pending_objects_sleeping;
 	LocalVector<JPH::BodyID> pending_objects_awake;
@@ -80,6 +81,10 @@ class JoltSpace3D {
 
 	bool active = false;
 	bool stepping = false;
+
+	void _apply_body_settings(JPH::Body &p_jolt_body, const JPH::BodyCreationSettings &p_settings);
+	JPH::Body *_try_reuse_body(JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings);
+	void _flush_needs_destruction();
 
 	void _pre_step(float p_step);
 	void _post_step(float p_step);
@@ -131,10 +136,11 @@ public:
 
 	float get_last_step() const { return last_step; }
 
-	JPH::Body *add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
-	JPH::Body *add_object(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
-	void remove_object(const JPH::BodyID &p_jolt_id);
+	JPH::Body *add_object(JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
+	JPH::Body *add_object(JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
+	void remove_object(JoltObject3D &p_object);
 	void flush_pending_objects();
+	bool will_defer_object_destruction(const JoltObject3D &p_object) const;
 
 	void set_is_object_sleeping(const JPH::BodyID &p_jolt_id, bool p_enable);
 
@@ -148,6 +154,8 @@ public:
 
 	void enqueue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);
 	void dequeue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);
+	void enqueue_needs_destruction(SelfList<JoltObject3D> *p_object);
+	void dequeue_needs_destruction(SelfList<JoltObject3D> *p_object);
 
 	void add_joint(JPH::Constraint *p_jolt_ref);
 	void add_joint(JoltJoint3D *p_joint);


### PR DESCRIPTION
## Summary

Fixes #118714 

Fix redundant Jolt area monitor events when an overlapping body leaves and re-enters the scene tree in the same physics frame.

AI Disclosure: I have used an LLM to search Jolt related code and propose a fix for this particular issue.