### PR TITLE
OpenXR: Fix crash when using `XR_EXT_frame_synthesis` after Godot 4.7-dev5

### DIFF
--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
@@ -258,7 +258,7 @@ void OpenXRFrameSynthesisExtension::on_main_swapchains_created() {
 	}
 }
 
-void OpenXRFrameSynthesisExtension::on_pre_render() {
+void OpenXRFrameSynthesisExtension::on_pre_draw_viewport(RID p_render_target) {
 	if (!frame_synthesis_ext) {
 		return;
 	}
@@ -266,8 +266,7 @@ void OpenXRFrameSynthesisExtension::on_pre_render() {
 	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 	ERR_FAIL_NULL(openxr_api);
 
-	size_t view_count = render_state.config_views.size();
-	if (!enabled || view_count != 2 || render_state.skip_next_frame) {
+	if (!enabled || render_state.config_views.size() != 2 || render_state.frame_synthesis_info.size() != 2 || render_state.skip_next_frame) {
 		// Unset these just in case.
 		openxr_api->set_velocity_texture(RID());
 		openxr_api->set_velocity_depth_texture(RID());
@@ -319,7 +318,7 @@ void OpenXRFrameSynthesisExtension::on_pre_render() {
 
 void OpenXRFrameSynthesisExtension::on_post_draw_viewport(RID p_render_target) {
 	// Check if our extension is supported and enabled.
-	if (!frame_synthesis_ext || !enabled || render_state.config_views.size() != 2 || render_state.skip_next_frame) {
+	if (!frame_synthesis_ext || !enabled || render_state.config_views.size() != 2 || render_state.frame_synthesis_info.size() != 2 || render_state.skip_next_frame) {
 		return;
 	}
 
@@ -331,7 +330,7 @@ void OpenXRFrameSynthesisExtension::on_post_draw_viewport(RID p_render_target) {
 
 void *OpenXRFrameSynthesisExtension::set_projection_views_and_get_next_pointer(int p_view_index, void *p_next_pointer) {
 	// Check if our extension is supported and enabled.
-	if (!frame_synthesis_ext || !enabled || render_state.config_views.size() != 2) {
+	if (!frame_synthesis_ext || !enabled || render_state.config_views.size() != 2 || render_state.frame_synthesis_info.size() != 2) {
 		return nullptr;
 	}
 
@@ -344,14 +343,8 @@ void *OpenXRFrameSynthesisExtension::set_projection_views_and_get_next_pointer(i
 		return nullptr;
 	}
 
-	// Check if we can run frame synthesis.
-	size_t view_count = render_state.config_views.size();
-	if (enabled && view_count == 2) {
-		render_state.frame_synthesis_info[p_view_index].next = p_next_pointer;
-		return &render_state.frame_synthesis_info[p_view_index];
-	}
-
-	return nullptr;
+	render_state.frame_synthesis_info[p_view_index].next = p_next_pointer;
+	return &render_state.frame_synthesis_info[p_view_index];
 }
 
 bool OpenXRFrameSynthesisExtension::is_available() const {

--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.h
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.h
@@ -56,7 +56,7 @@ public:
 	virtual void on_session_destroyed() override;
 
 	virtual void on_main_swapchains_created() override;
-	virtual void on_pre_render() override;
+	virtual void on_pre_draw_viewport(RID p_render_target) override;
 	virtual void on_post_draw_viewport(RID p_render_target) override;
 	virtual void *set_projection_views_and_get_next_pointer(int p_view_index, void *p_next_pointer) override;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118902