### PR TITLE
Add lacked argument to bound method for curve in SpringBoneSimulator

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -669,7 +669,7 @@ void SpringBoneSimulator3D::set_radius_damping_curve(int p_index, const Ref<Curv
 	}
 	settings[p_index]->radius_damping_curve = p_damping_curve;
 	if (settings[p_index]->radius_damping_curve.is_valid()) {
-		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->radius_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -703,7 +703,7 @@ void SpringBoneSimulator3D::set_stiffness_damping_curve(int p_index, const Ref<C
 	}
 	settings[p_index]->stiffness_damping_curve = p_damping_curve;
 	if (settings[p_index]->stiffness_damping_curve.is_valid()) {
-		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->stiffness_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -737,7 +737,7 @@ void SpringBoneSimulator3D::set_drag_damping_curve(int p_index, const Ref<Curve>
 	}
 	settings[p_index]->drag_damping_curve = p_damping_curve;
 	if (settings[p_index]->drag_damping_curve.is_valid()) {
-		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->drag_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }
@@ -771,7 +771,7 @@ void SpringBoneSimulator3D::set_gravity_damping_curve(int p_index, const Ref<Cur
 	}
 	settings[p_index]->gravity_damping_curve = p_damping_curve;
 	if (settings[p_index]->gravity_damping_curve.is_valid()) {
-		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index));
+		settings[p_index]->gravity_damping_curve->connect_changed(callable_mp(this, &SpringBoneSimulator3D::_make_joints_dirty).bind(p_index, false));
 	}
 	_make_joints_dirty(p_index);
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/118199

Since `bind()` cannot recognize default arguments in c++, we must pass the arguments explicitly.