### PR TITLE
Fix SceneTree constructor not using VRS texture

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2149,10 +2149,7 @@ SceneTree::SceneTree() {
 		if (load_err) {
 			ERR_PRINT("Non-existing or invalid VRS texture at '" + vrs_texture_path + "'.");
 		} else {
-			Ref<ImageTexture> vrs_texture;
-			vrs_texture.instantiate();
-			vrs_texture->create_from_image(vrs_image);
-			root->set_vrs_texture(vrs_texture);
+			root->set_vrs_texture(ImageTexture::create_from_image(vrs_image));
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
`ImageTexture::create_from_image` is static method that returns an instance. In the `SceneTree` constructor, it is used as if it has side-effects on the instance. This likely means that the texture supplied was not reflected in the instance. 

This might fix https://github.com/godotengine/godot-docs-user-notes/discussions/524#discussioncomment-14371156