### PR TITLE
Fix infinite loop in GDScriptWorkspace::find_usages_in_file

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -438,6 +438,7 @@ Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::Document
 	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(p_file_path);
 	if (parser) {
 		const PackedStringArray &content = parser->get_lines();
+		String uri = get_file_uri(p_file_path);
 		for (int i = 0; i < content.size(); ++i) {
 			String line = content[i];
 
@@ -446,7 +447,7 @@ Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::Document
 				LSP::TextDocumentPositionParams params;
 
 				LSP::TextDocumentIdentifier text_doc;
-				text_doc.uri = get_file_uri(p_file_path);
+				text_doc.uri = uri;
 
 				params.textDocument = text_doc;
 				params.position.line = i;
@@ -468,7 +469,8 @@ Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::Document
 					}
 				}
 
-				character = line.find(identifier, range.end.character);
+				int next_search_index = MAX(character + 1, range.end.character);
+				character = line.find(identifier, next_search_index);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

This fixes issue #118912, but it's maybe not the correct fix, as I'm not so familiar with this part of the codebase. However I think that the guardrail to force next_search_index to be +1 makes sense, though it can hide bugs in the actual parsing?

Additionally I modified `get_file_uri` to be called once for the whole loop as I suspected that was the issue at first, but it wasn't. Still think it's a good idea to move it out of the loop. 

This closes #118912.

AI disclosure: I used Gemini to help with gdb and triaging the codepath, but wrote the fix myself.