### PR TITLE
dr_mp3: Update to 0.7.3

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -203,7 +203,7 @@ Patches:
 ## dr_libs
 
 - Upstream: https://github.com/mackron/dr_libs
-- Version: mp3-0.7.2 (547c211a87a06a42bf62c1366616aa14b57dd429, 2025)
+- Version: mp3-0.7.3 (5690d4671d7ad07ae6021756d7222eb159745f06, 2026)
 - License: Public Domain or Unlicense or MIT-0
 
 Files extracted from upstream source:

--- a/thirdparty/dr_libs/dr_mp3.h
+++ b/thirdparty/dr_libs/dr_mp3.h
@@ -1,6 +1,6 @@
 /*
 MP3 audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_mp3 - v0.7.2 - 2025-12-02
+dr_mp3 - v0.7.3 - 2026-01-17
 
 David Reid - mackron@gmail.com
 
@@ -72,7 +72,7 @@ extern "C" {
 
 #define DRMP3_VERSION_MAJOR     0
 #define DRMP3_VERSION_MINOR     7
-#define DRMP3_VERSION_REVISION  2
+#define DRMP3_VERSION_REVISION  3
 #define DRMP3_VERSION_STRING    DRMP3_XSTRINGIFY(DRMP3_VERSION_MAJOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_MINOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_REVISION)
 
 #include <stddef.h> /* For size_t. */
@@ -3170,7 +3170,6 @@ static drmp3_bool32 drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drm
         {
             drmp3_bs bs;
             drmp3_L3_gr_info grInfo[4];
-            const drmp3_uint8* pTagData = pFirstFrameData;
 
             drmp3_bs_init(&bs, pFirstFrameData + DRMP3_HDR_SIZE, firstFrameInfo.frame_bytes - DRMP3_HDR_SIZE);
 
@@ -3181,6 +3180,7 @@ static drmp3_bool32 drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drm
             if (drmp3_L3_read_side_info(&bs, grInfo, pFirstFrameData) >= 0) {
                 drmp3_bool32 isXing = DRMP3_FALSE;
                 drmp3_bool32 isInfo = DRMP3_FALSE;
+                const drmp3_uint8* pTagData;
                 const drmp3_uint8* pTagDataBeg;
 
                 pTagDataBeg = pFirstFrameData + DRMP3_HDR_SIZE + (bs.pos/8);
@@ -3330,8 +3330,6 @@ static drmp3_bool32 drmp3__on_seek_memory(void* pUserData, int byteOffset, drmp3
     drmp3_int64 newCursor;
 
     DRMP3_ASSERT(pMP3 != NULL);
-
-    newCursor = pMP3->memory.currentReadPos;
 
     if (origin == DRMP3_SEEK_SET) {
         newCursor = 0;
@@ -4804,6 +4802,8 @@ static float* drmp3__full_read_and_close_f32(drmp3* pMP3, drmp3_config* pConfig,
             pNewFrames = (float*)drmp3__realloc_from_callbacks(pFrames, (size_t)newFramesBufferSize, (size_t)oldFramesBufferSize, &pMP3->allocationCallbacks);
             if (pNewFrames == NULL) {
                 drmp3__free_from_callbacks(pFrames, &pMP3->allocationCallbacks);
+                pFrames = NULL;
+                totalFramesRead = 0;
                 break;
             }
 
@@ -4871,6 +4871,8 @@ static drmp3_int16* drmp3__full_read_and_close_s16(drmp3* pMP3, drmp3_config* pC
             pNewFrames = (drmp3_int16*)drmp3__realloc_from_callbacks(pFrames, (size_t)newFramesBufferSize, (size_t)oldFramesBufferSize, &pMP3->allocationCallbacks);
             if (pNewFrames == NULL) {
                 drmp3__free_from_callbacks(pFrames, &pMP3->allocationCallbacks);
+                pFrames = NULL;
+                totalFramesRead = 0;
                 break;
             }
 
@@ -5005,6 +5007,10 @@ DIFFERENCES BETWEEN minimp3 AND dr_mp3
 /*
 REVISION HISTORY
 ================
+v0.7.3 - 2026-01-17
+  - Fix an error in drmp3_open_and_read_pcm_frames_s16() and family when memory allocation fails.
+  - Fix some compilation warnings.
+
 v0.7.2 - 2025-12-02
   - Reduce stack space to improve robustness on embedded systems.
   - Fix a compilation error with MSVC Clang toolset relating to cpuid.


### PR DESCRIPTION
https://github.com/mackron/dr_libs/releases/tag/mp3-0.7.3

---

v0.7.3 - 2026-01-17
- Fix an `error in drmp3_open_and_read_pcm_frames_s16()` and family when memory allocation fails.
- Fix some compilation warnings.
