### PR TITLE
Stop clearing animation tracks cache on animation stop or empty queue

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -297,6 +297,9 @@
 		<member name="autoplay" type="StringName" setter="set_autoplay" getter="get_autoplay" default="&amp;&quot;&quot;">
 			The key of the animation to play when the scene loads.
 		</member>
+		<member name="clear_cache_on_stop" type="bool" setter="set_clear_cache_on_stop_enabled" getter="is_clear_cache_on_stop_enabled" default="true">
+			If [code]true[/code], the animation track cache is cleared when the animation is stopped or the playback queue becomes empty. If [code]false[/code], the track cache is preserved, which can improve performance when animations are frequently started and stopped.
+		</member>
 		<member name="current_animation" type="StringName" setter="set_current_animation" getter="get_current_animation" default="&amp;&quot;&quot;">
 			The key of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not restart the animation. See [method play] for more information on playing animations.
 			[b]Note:[/b] While this property appears in the Inspector, it's not meant to be edited, and it's not saved in the scene. This property is mainly used to get the currently playing animation, and internally for animation playback tracks. For more information, see [Animation].

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -583,18 +583,20 @@ bool AnimationMixer::is_dummy() const {
 /* -- Caches for blending --------------------- */
 /* -------------------------------------------- */
 
-void AnimationMixer::_clear_caches() {
+void AnimationMixer::_clear_caches(bool p_clear_track_cache) {
 	_init_root_motion_cache();
 	_clear_audio_streams();
 	_clear_playing_caches();
+	capture_cache.clear();
+	if (!p_clear_track_cache) {
+		return;
+	}
 	for (KeyValue<Animation::TrackCacheID, TrackCache *> &K : track_cache) {
 		memdelete(K.value);
 	}
 	track_cache.clear();
 	animation_track_num_to_track_cache.clear();
 	cache_valid = false;
-	capture_cache.clear();
-
 	emit_signal(SNAME("caches_cleared"));
 }
 
@@ -604,6 +606,15 @@ void AnimationMixer::_clear_audio_streams() {
 		playing_audio_stream_players[i]->call(SNAME("set_stream"), Ref<AudioStream>());
 	}
 	playing_audio_stream_players.clear();
+
+	// Unref the playback handle so it doesn't keep the AudioStreamPlaybackPolyphonic
+	// alive after the AudioStreamPlayer node may have been deleted while stopped.
+	// It is re-acquired lazily on the next play.
+	for (KeyValue<Animation::TrackCacheID, TrackCache *> &K : track_cache) {
+		if (K.value->type == Animation::TYPE_AUDIO) {
+			static_cast<TrackCacheAudio *>(K.value)->audio_stream_playback.unref();
+		}
+	}
 }
 
 void AnimationMixer::_clear_playing_caches() {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -310,7 +310,7 @@ protected:
 	Vector<Node *> playing_audio_stream_players;
 
 	// Helpers.
-	void _clear_caches();
+	void _clear_caches(bool p_clear_track_cache = true);
 	void _clear_audio_streams();
 	void _clear_playing_caches();
 	void _init_root_motion_cache();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -359,7 +359,7 @@ void AnimationPlayer::_blend_post_process() {
 					emit_signal(SceneStringName(animation_changed), old, new_name);
 				}
 			} else {
-				_clear_caches();
+				_clear_caches(clear_cache_on_stop);
 				playing = false;
 				_set_process(false);
 				if (end_notify) {
@@ -801,6 +801,14 @@ bool AnimationPlayer::is_movie_quit_on_finish_enabled() const {
 	return movie_quit_on_finish;
 }
 
+void AnimationPlayer::set_clear_cache_on_stop_enabled(bool p_enabled) {
+	clear_cache_on_stop = p_enabled;
+}
+
+bool AnimationPlayer::is_clear_cache_on_stop_enabled() const {
+	return clear_cache_on_stop;
+}
+
 void AnimationPlayer::_animation_changed(const StringName &p_name) {
 	AnimationMixer::_animation_changed(p_name);
 	if (playback.current.is_enabled && playback.current.animation_name == p_name && animation_set.has(p_name)) {
@@ -809,7 +817,7 @@ void AnimationPlayer::_animation_changed(const StringName &p_name) {
 }
 
 void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
-	_clear_caches();
+	_clear_caches(clear_cache_on_stop);
 	Playback &c = playback;
 	double start = c.current.is_enabled ? playback.current.get_start_time() : 0;
 	if (p_reset) {
@@ -1038,6 +1046,9 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_movie_quit_on_finish_enabled", "enabled"), &AnimationPlayer::set_movie_quit_on_finish_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_quit_on_finish_enabled"), &AnimationPlayer::is_movie_quit_on_finish_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_clear_cache_on_stop_enabled", "enabled"), &AnimationPlayer::set_clear_cache_on_stop_enabled);
+	ClassDB::bind_method(D_METHOD("is_clear_cache_on_stop_enabled"), &AnimationPlayer::is_clear_cache_on_stop_enabled);
+
 	ClassDB::bind_method(D_METHOD("get_current_animation_position"), &AnimationPlayer::get_current_animation_position);
 	ClassDB::bind_method(D_METHOD("get_current_animation_length"), &AnimationPlayer::get_current_animation_length);
 
@@ -1066,6 +1077,7 @@ void AnimationPlayer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clear_cache_on_stop"), "set_clear_cache_on_stop_enabled", "is_clear_cache_on_stop_enabled");
 
 	ADD_SIGNAL(MethodInfo("current_animation_changed", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -127,6 +127,7 @@ private:
 	StringName autoplay;
 
 	bool movie_quit_on_finish = false;
+	bool clear_cache_on_stop = true;
 
 	void _play(const StringName &p_name, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void _capture(const StringName &p_name, bool p_from_end = false, double p_duration = -1.0, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
@@ -230,6 +231,9 @@ public:
 
 	void set_movie_quit_on_finish_enabled(bool p_enabled);
 	bool is_movie_quit_on_finish_enabled() const;
+
+	void set_clear_cache_on_stop_enabled(bool p_enabled);
+	bool is_clear_cache_on_stop_enabled() const;
 
 	void seek_internal(double p_time, bool p_update = false, bool p_update_only = false, bool p_is_internal_seek = false);
 	void seek(double p_time, bool p_update = false, bool p_update_only = false);


### PR DESCRIPTION
As the title says, the engine was clearing the animation tracks cache every time AnimationPlayer was stopped or its queue would be empty.
This was unneeded and was creating huge performance problems when used with a custom "Animation Manager", causing AnimationMixer to constantly rebuild the tracks cache. The effect was especially noticeable with a lot of entities.

Full cache clearing was replaced with clearing of just the capture cache, playing cache, and audio streams.