### PR TITLE
Improve movie writer low disk space: check is specific to path instead of filesystem

### DIFF
--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -106,12 +106,11 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	print_line(vformat(U"Movie Maker mode enabled, recording movie in %s×%s @ %d FPS...", movie_size.width, movie_size.height, p_fps));
 
 	// Check for available disk space and warn the user if needed.
-	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String path = p_base_path.get_base_dir();
 	if (path.is_relative_path()) {
 		path = "res://" + path;
 	}
-	dir->open(path);
+	Ref<DirAccess> dir = DirAccess::open(path);
 	if (dir->get_space_left() < 10 * Math::pow(1024.0, 3.0)) {
 		// Less than 10 GiB available.
 		WARN_PRINT(vformat("Current available space on disk is low (%s). MovieWriter will fail during movie recording if the disk runs out of available space.", String::humanize_size(dir->get_space_left())));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
`DirAccess::open` is a static method with no side effects aside from object creation. In this context, the return value is unused. I believe this is a mistake and the intention was not to call this for the side-effects of checking if the path can be opened. 

As a result of the change, the space check will now be specific to the path.