### PR TITLE
Fix per-project overrides not working for language

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -91,10 +91,6 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 			}
 		}
 		emit_signal(SNAME("settings_changed"));
-
-		if (p_name == SNAME("interface/editor/localization/editor_language")) {
-			setup_language(false);
-		}
 	}
 	return true;
 }
@@ -2022,7 +2018,7 @@ float EditorSettings::get_auto_display_scale() {
 }
 
 String EditorSettings::get_language() const {
-	const String language = has_setting("interface/editor/localization/editor_language") ? get("interface/editor/localization/editor_language") : "auto";
+	const String language = has_setting("interface/editor/localization/editor_language") ? get_setting("interface/editor/localization/editor_language") : "auto";
 	if (language != "auto" && !language.is_empty()) {
 		return language;
 	}
@@ -2353,6 +2349,10 @@ void EditorSettings::notify_changes() {
 		return;
 	}
 	root->propagate_notification(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
+
+	if (check_changed_settings_in_group("interface/editor/localization/editor_language")) {
+		setup_language(false);
+	}
 }
 
 void EditorSettings::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {


### PR DESCRIPTION
Overriding editor language for a project was not working at all. The editor was always using the base setting.

This PR makes it correctly use the override and update the language when it changes.