### PR TITLE
Fix bug in DirAccessWindows::rename where 'to' file is deleted even if 'from' is invalid

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -300,10 +300,13 @@ bool DirAccessWindows::dir_exists(String p_dir) {
 Error DirAccessWindows::rename(String p_path, String p_new_path) {
 	String path = fix_path(p_path);
 	String new_path = fix_path(p_new_path);
+	bool does_dir_exist = dir_exists(path);
 
-	// If we're only changing file name case we need to do a little juggling
-	if (path.to_lower() == new_path.to_lower()) {
-		if (dir_exists(path)) {
+	if (!file_exists(path) && !does_dir_exist) {
+		return FAILED;
+	} else if (path.to_lower() == new_path.to_lower()) {
+		// If we're only changing file name case we need to do a little juggling
+		if (does_dir_exist) {
 			// The path is a dir; just rename
 			return MoveFileW((LPCWSTR)(path.utf16().get_data()), (LPCWSTR)(new_path.utf16().get_data())) != 0 ? OK : FAILED;
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/118858

I couldn't find any unit tests for `DirAccessWindows`, but if they do exist let me know and I'll add a case for this bugfix.

I just tested this change manually using this test project:
[DirAccess.rename.zip](https://github.com/user-attachments/files/27068472/DirAccess.rename.zip)

