### PR TITLE
Automatically open duplicated files in file system

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1619,7 +1619,11 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		Error err = EditorFileSystem::get_singleton()->copy_file(old_path, new_path);
 		if (err != OK) {
 			EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + U" → " + new_path + ": " + TTR(error_names[err]) + "\n");
+		} else {
+			// Open duplicated file.
+			EditorNode::get_singleton()->load_scene_or_resource(p_new_path);
 		}
+
 	} else {
 		Error err = EditorFileSystem::get_singleton()->copy_directory(old_path, new_path);
 		if (err != OK) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
When duplicating a file with a similar name, it may confuse to not automatically open it.

Moving a file also doesn't have that behavior, however.

A toggled on by default checkbox confirming to open the new duplicated file would be appreciated.

https://github.com/user-attachments/assets/e2299adf-477d-4bfc-bdfb-6bb69f53ba55