### PR TITLE
Fix bug #115368 Cmd stays pressed

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -377,6 +377,11 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 	snap_target[1] = SNAP_TARGET_NONE;
 
 	bool is_snap_active = smart_snap_active ^ Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
+	bool is_tab_pressed = Input::get_singleton()->is_key_pressed(Key::TAB);
+
+	if (is_tab_pressed) {
+		is_snap_active = false;
+	}
 
 	// Smart snap using the canvas position
 	Vector2 output = p_target;


### PR DESCRIPTION
Proposed fix to bug #115368. 

Inserts a check to see if tab button is pressed while Cmd button is being pressed. The idea is that pressing another button while Cmd is being held down for grid snapping should turn off grid snapping. This is because Cmd+TAB is a different shortcut, so Cmd shouldn't keep grid snapping on. 

This would also apply to pressing the 'S' key, #115616, and I found that pressing the 'A' key produces similar results. 

This fix was tested and does not fix the issue, but maybe it could help inspire other solutions to this problem. 