### PR TITLE
[Windows] - Extend_To_Title (Client Side Decorations)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1702,7 +1702,7 @@ void EditorNode::_titlebar_resized() {
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (title_bar) {
-		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y));
+		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y * 2));
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1700,7 +1700,7 @@ void EditorNode::_titlebar_resized() {
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (title_bar) {
-		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y));
+		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y * 2));
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8267,6 +8267,17 @@ void EditorNode::_add_to_main_menu(const String &p_name, PopupMenu *p_menu) {
 	main_menu_items.push_back(p_menu);
 }
 
+void EditorNode::add_control_to_toolbar(Control *p_control) {
+	title_bar->add_child(p_control);
+	if (right_menu_spacer) {
+		title_bar->move_child(p_control, right_menu_spacer->get_index());
+	}
+}
+
+void EditorNode::remove_control_from_toolbar(Control *p_control) {
+	title_bar->remove_child(p_control);
+}
+
 void EditorNode::_update_main_menu_type() {
 	bool can_expand = bool(EDITOR_GET("interface/editor/appearance/expand_to_title")) && DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EXTEND_TO_TITLE);
 	bool use_menu_button = EDITOR_GET("interface/editor/appearance/collapse_main_menu");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -773,6 +773,9 @@ public:
 	static EditorBottomPanel *get_bottom_panel() { return singleton->bottom_panel; }
 	static EditorMainScreen *get_editor_main_screen() { return singleton->editor_main_screen; }
 
+	void add_control_to_toolbar(Control *p_control);
+	void remove_control_from_toolbar(Control *p_control);
+
 	static Button *get_distraction_free_button() { return singleton->distraction_free; }
 
 	static String adjust_scene_name_casing(const String &p_root_name);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -144,7 +144,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 
 	switch (p_location) {
 		case CONTAINER_TOOLBAR: {
-			EditorNode::get_title_bar()->add_child(p_control);
+			EditorNode::get_singleton()->add_control_to_toolbar(p_control);
 		} break;
 
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
@@ -196,7 +196,7 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 
 	switch (p_location) {
 		case CONTAINER_TOOLBAR: {
-			EditorNode::get_title_bar()->remove_child(p_control);
+			EditorNode::get_singleton()->remove_control_from_toolbar(p_control);
 		} break;
 
 		case CONTAINER_SPATIAL_EDITOR_MENU: {

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -48,7 +48,6 @@
 #include "editor/export/editor_export_platform.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_bottom_panel.h"
-#include "editor/gui/editor_title_bar.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/inspector/editor_inspector.h"

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1320,11 +1320,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
-#ifdef WINDOWS_ENABLED
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(23, 22), DisplayServerEnums::MAIN_WINDOW_ID);
-#elif MACOS_ENABLED
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServerEnums::MAIN_WINDOW_ID);
-#endif
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServerEnums::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;
@@ -1335,7 +1331,7 @@ void ProjectManager::_titlebar_resized() {
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (title_bar) {
-		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y));
+		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y * 2));
 	}
 }
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1320,7 +1320,11 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
+#ifdef WINDOWS_ENABLED
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(23, 22), DisplayServerEnums::MAIN_WINDOW_ID);
+#elif MACOS_ENABLED
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServerEnums::MAIN_WINDOW_ID);
+#endif
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServerEnums::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1343,11 +1343,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
-#ifdef WINDOWS_ENABLED
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(23, 22), DisplayServerEnums::MAIN_WINDOW_ID);
-#elif MACOS_ENABLED
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServerEnums::MAIN_WINDOW_ID);
-#endif
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServerEnums::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;
@@ -1358,7 +1354,7 @@ void ProjectManager::_titlebar_resized() {
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
 	}
 	if (title_bar) {
-		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y));
+		title_bar->set_custom_minimum_size(Size2(0, margin.z - title_bar->get_global_position().y * 2));
 	}
 }
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1343,7 +1343,11 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
+#ifdef WINDOWS_ENABLED
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(23, 22), DisplayServerEnums::MAIN_WINDOW_ID);
+#elif MACOS_ENABLED
 	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServerEnums::MAIN_WINDOW_ID);
+#endif
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServerEnums::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2248,7 +2248,7 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	}
 
 	wd.caption_buttons_offset = p_offset;
-	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_CAPTION_BUTTONS_CHANGE);
 }
 
 void DisplayServerWindows::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -193,6 +193,11 @@ bool DisplayServerWindows::has_feature(DisplayServerEnums::Feature p_feature) co
 		case DisplayServerEnums::FEATURE_WINDOW_DRAG:
 		case DisplayServerEnums::FEATURE_HDR_OUTPUT:
 			return true;
+		case DisplayServerEnums::FEATURE_EXTEND_TO_TITLE:
+			// OpenGL3 cannot composite over the DWM sheet-of-glass surface,
+			// so the feature is unavailable on the compatibility renderer using opengl3
+			// opengl3_angle works, as it translates to Vulkan/D3D12 which can composite properly.
+			return rendering_driver != "opengl3";
 		case DisplayServerEnums::FEATURE_SCREEN_EXCLUDE_FROM_CAPTURE:
 			return (os_ver.dwBuildNumber >= 19041); // Fully supported on Windows 10 Vibranium R1 (2004)+ only, captured as black rect on older versions.
 		case DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER:
@@ -2200,6 +2205,52 @@ Size2i DisplayServerWindows::window_get_title_size(const String &p_title, Displa
 	return size;
 }
 
+Vector3i DisplayServerWindows::window_get_safe_title_margins(DisplayServerEnums::WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V(!windows.has(p_window), Vector3i());
+	const WindowData &wd = windows[p_window];
+
+	if (!wd.extend_to_title || wd.fullscreen || wd.minimized || wd.borderless) {
+		return Vector3i();
+	}
+
+	// Button dimensions are driven by caption_buttons_offset: each button is
+	// (offset.x * 2) × (offset.y * 2) logical pixels; three buttons make the cluster.
+	UINT dpi = GetDpiForWindow(wd.hWnd);
+	float scale = (float)dpi / 96.0f;
+	int bw = (int)Math::round(wd.caption_buttons_offset.x * 2 * scale);
+	int bh = (int)Math::round(wd.caption_buttons_offset.y * 2 * scale);
+	int cw = bw * 3;
+	int ch = bh;
+
+	bool rtl = (GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0;
+
+	// x = left margin, y = right margin, z = height (all in physical pixels).
+	if (rtl) {
+		return Vector3i(cw, 0, ch);
+	} else {
+		return Vector3i(0, cw, ch);
+	}
+}
+
+void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (!wd.extend_to_title) {
+		return;
+	}
+	if (wd.caption_buttons_offset == p_offset) {
+		return;
+	}
+
+	wd.caption_buttons_offset = p_offset;
+	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+}
+
 void DisplayServerWindows::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
@@ -2679,6 +2730,13 @@ void DisplayServerWindows::_update_window_style(DisplayServerEnums::WindowID p_w
 
 	SetWindowPos(wd.hWnd, _is_always_on_top_recursive(p_window) ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | ((wd.no_focus || wd.is_popup) ? SWP_NOACTIVATE : 0));
 
+	// Re-apply DWM frame extension if needed. Changing the window style (e.g. toggling
+	// borderless or returning from fullscreen) can silently reset the DWM frame state.
+	if (wd.extend_to_title && !wd.fullscreen && !wd.borderless) {
+		MARGINS margins = { -1, -1, -1, -1 };
+		DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+	}
+
 	if (p_repaint) {
 		RECT rect;
 		GetWindowRect(wd.hWnd, &rect);
@@ -2889,6 +2947,7 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 			_update_window_style(p_window);
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_BORDERLESS: {
+			bool prev_borderless = wd.borderless;
 			wd.borderless = p_enabled;
 			if (wd.fullscreen) {
 				return;
@@ -2896,6 +2955,9 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 			_update_window_mouse_passthrough(p_window);
 			_update_window_style(p_window);
 			ShowWindow(wd.hWnd, (wd.no_focus || wd.is_popup) ? SW_SHOWNOACTIVATE : SW_SHOW); // Show the window.
+			if (!p_enabled && wd.extend_to_title && prev_borderless != p_enabled) {
+				_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+			}
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_ALWAYS_ON_TOP: {
 			ERR_FAIL_COND_MSG(wd.transient_parent != DisplayServerEnums::INVALID_WINDOW_ID && p_enabled, "Transient windows can't become on top.");
@@ -2958,6 +3020,28 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 				SetWindowDisplayAffinity(wd.hWnd, WDA_NONE);
 			}
 		} break;
+		case DisplayServerEnums::WINDOW_FLAG_EXTEND_TO_TITLE: {
+			if (!has_feature(DisplayServerEnums::FEATURE_EXTEND_TO_TITLE)) {
+				return;
+			}
+			wd.extend_to_title = p_enabled;
+			if (wd.fullscreen || wd.borderless) {
+				// No need to apply DWM changes — they're meaningless
+				// on fullscreen/borderless windows. The state will be re-applied in
+				// _update_window_style() when leaving those modes.
+				break;
+			}
+			if (p_enabled) {
+				MARGINS margins = { -1, -1, -1, -1 };
+				DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+			} else {
+				MARGINS margins = { 0, 0, 0, 0 };
+				DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+			}
+			// Force a WM_NCCALCSIZE and redraw to apply the frame change.
+			SetWindowPos(wd.hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER);
+			_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+		} break;
 		case DisplayServerEnums::WINDOW_FLAG_POPUP: {
 			ERR_FAIL_COND_MSG(p_window == DisplayServerEnums::MAIN_WINDOW_ID, "Main window can't be popup.");
 			ERR_FAIL_COND_MSG(IsWindowVisible(wd.hWnd) && (wd.is_popup != p_enabled), "Popup flag can't changed while window is opened.");
@@ -3007,6 +3091,9 @@ bool DisplayServerWindows::window_get_flag(DisplayServerEnums::WindowFlags p_fla
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_EXCLUDE_FROM_CAPTURE: {
 			return wd.hide_from_capture;
+		} break;
+		case DisplayServerEnums::WINDOW_FLAG_EXTEND_TO_TITLE: {
+			return wd.extend_to_title;
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_POPUP: {
 			return wd.is_popup;
@@ -5672,9 +5759,81 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SendMessageW(windows[window_id].hWnd, WM_PAINT, 0, 0);
 			}
 		} break;
+		case WM_NCCALCSIZE: {
+			// When extend_to_title is active, make the entire window rect the client area
+			// so that game/engine content can draw over the entire window. DWM still technically draws
+			// the min/max/close buttons underneath, but we just ignore them by never returning hits on them in WM_NCHITTEST handling
+			// Removing them breaks features like snapping, shadows and maximize/restore animations
+			// Note that opengl3 can't draw over a full client area window - extend_to_title is feature flagged off
+			if (wParam == TRUE && windows.has(window_id)) {
+				const WindowData &ncwd = windows[window_id];
+				if (ncwd.extend_to_title && !ncwd.fullscreen && !ncwd.borderless) {
+					// use IsZoomed instead of ncwd.maximized, as we don't receive the WM_SIZE event before WM_NCCALCSIZE
+					if (IsZoomed(hWnd)) {
+						// When maximized, Windows positions the window with an invisible
+						// resize border (typically 8px) on each side that sits off-screen.
+						// Compensate for this so content starts at the visible screen edge.
+						int frame = GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER);
+						NCCALCSIZE_PARAMS *params = (NCCALCSIZE_PARAMS *)lParam;
+						params->rgrc[0].top += frame;
+						params->rgrc[0].left += frame;
+						params->rgrc[0].right -= frame;
+						params->rgrc[0].bottom -= frame;
+					}
+					return 0; // Full window rect = client area; no NC chrome.
+				}
+			}
+		} break;
 		case WM_NCHITTEST: {
 			if (windows[window_id].mpass) {
 				return HTTRANSPARENT;
+			}
+			if (windows[window_id].extend_to_title &&
+					!windows[window_id].fullscreen &&
+					!windows[window_id].borderless) {
+				POINT cursor = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+				RECT wnd_rect;
+				GetWindowRect(hWnd, &wnd_rect);
+
+				bool is_max = windows[window_id].maximized;
+				// Resize border thickness. Zero when maximized (can't resize from border).
+				int frame_x = is_max ? 0 : (GetSystemMetrics(SM_CXSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
+				int frame_y = is_max ? 0 : (GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
+
+				// --- Resize border hit zones ---
+				if (!is_max) {
+					bool at_top = cursor.y < wnd_rect.top + frame_y;
+					bool at_bottom = cursor.y >= wnd_rect.bottom - frame_y;
+					bool at_left = cursor.x < wnd_rect.left + frame_x;
+					bool at_right = cursor.x >= wnd_rect.right - frame_x;
+
+					if (at_top && at_left) {
+						return HTTOPLEFT;
+					}
+					if (at_top && at_right) {
+						return HTTOPRIGHT;
+					}
+					if (at_bottom && at_left) {
+						return HTBOTTOMLEFT;
+					}
+					if (at_bottom && at_right) {
+						return HTBOTTOMRIGHT;
+					}
+					if (at_top) {
+						return HTTOP;
+					}
+					if (at_bottom) {
+						return HTBOTTOM;
+					}
+					if (at_left) {
+						return HTLEFT;
+					}
+					if (at_right) {
+						return HTRIGHT;
+					}
+				}
+
+				return HTCLIENT;
 			}
 		} break;
 		case WM_MOUSEACTIVATE: {
@@ -6623,6 +6782,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			WINDOWPOS *window_pos_params = (WINDOWPOS *)lParam;
 
+			// Snapshot maximized state before the update block so we can detect transitions.
+			bool prev_maximized = window.maximized;
+
 			bool rect_changed = false;
 			if (!(window_pos_params->flags & SWP_NOSIZE) || window_pos_params->flags & SWP_FRAMECHANGED) {
 				int screen_id = window_get_current_screen(window_id);
@@ -6686,6 +6848,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 #endif
 #endif
+			}
+
+			// Notify the scene when maximized/minimized state changes so CaptionButtonOverlay updates its icon.
+			if (window.extend_to_title && window.maximized != prev_maximized) {
+				_send_window_event(window, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
 			}
 
 			if (!window.minimized && (!(window_pos_params->flags & SWP_NOMOVE) || window_pos_params->flags & SWP_FRAMECHANGED)) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2243,11 +2243,14 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	if (!wd.extend_to_title) {
 		return;
 	}
-	if (wd.caption_buttons_offset == p_offset) {
+	UINT dpi = GetDpiForWindow(wd.hWnd);
+	float scale = (float)dpi / 96.0f;
+	Vector2i offset = p_offset / scale;
+	if (wd.caption_buttons_offset == offset) {
 		return;
 	}
 
-	wd.caption_buttons_offset = p_offset;
+	wd.caption_buttons_offset = offset;
 	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_CAPTION_BUTTONS_CHANGE);
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2224,7 +2224,7 @@ Vector3i DisplayServerWindows::window_get_safe_title_margins(DisplayServerEnums:
 	int cw = bw * 3;
 	int ch = bh;
 
-	bool rtl = (GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0;
+	bool rtl = false;
 
 	// x = left margin, y = right margin, z = height (all in physical pixels).
 	if (rtl) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2981,6 +2981,10 @@ void DisplayServerWindows::window_set_mode(DisplayServerEnums::WindowMode p_mode
 		}
 	}
 	_update_window_mouse_passthrough(p_window);
+
+	if (wd.fullscreen != was_fullscreen) {
+		_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+	}
 }
 
 DisplayServerEnums::WindowMode DisplayServerWindows::window_get_mode(DisplayServerEnums::WindowID p_window) const {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2324,11 +2324,14 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	if (!wd.extend_to_title) {
 		return;
 	}
-	if (wd.caption_buttons_offset == p_offset) {
+	UINT dpi = GetDpiForWindow(wd.hWnd);
+	float scale = (float)dpi / 96.0f;
+	Vector2i offset = p_offset / scale;
+	if (wd.caption_buttons_offset == offset) {
 		return;
 	}
 
-	wd.caption_buttons_offset = p_offset;
+	wd.caption_buttons_offset = offset;
 	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_CAPTION_BUTTONS_CHANGE);
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2510,9 +2510,9 @@ void DisplayServerWindows::window_set_position(const Point2i &p_position, Displa
 	// AdjustWindowRectEx would incorrectly add space for the title bar and borders to the window, whose non-client area is removed.
 	if (!wd.extend_to_title) {
 		const DWORD style = GetWindowLongPtr(wd.hWnd, GWL_STYLE);
-		const DWORD exStyle = GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE);
+		const DWORD ex_style = GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE);
 
-		AdjustWindowRectEx(&rc, style, false, exStyle);
+		AdjustWindowRectEx(&rc, style, false, ex_style);
 	}
 	MoveWindow(wd.hWnd, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, TRUE);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2329,7 +2329,7 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	}
 
 	wd.caption_buttons_offset = p_offset;
-	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_CAPTION_BUTTONS_CHANGE);
 }
 
 void DisplayServerWindows::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2305,7 +2305,7 @@ Vector3i DisplayServerWindows::window_get_safe_title_margins(DisplayServerEnums:
 	int cw = bw * 3;
 	int ch = bh;
 
-	bool rtl = (GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0;
+	bool rtl = false;
 
 	// x = left margin, y = right margin, z = height (all in physical pixels).
 	if (rtl) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2326,7 +2326,9 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	}
 	UINT dpi = GetDpiForWindow(wd.hWnd);
 	float scale = (float)dpi / 96.0f;
-	Vector2i offset = p_offset / scale;
+	Vector2i offset(
+			(int)Math::round((float)p_offset.x / scale),
+			(int)Math::round((float)p_offset.y / scale));
 	if (wd.caption_buttons_offset == offset) {
 		return;
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -194,6 +194,11 @@ bool DisplayServerWindows::has_feature(DisplayServerEnums::Feature p_feature) co
 		case DisplayServerEnums::FEATURE_WINDOW_DRAG:
 		case DisplayServerEnums::FEATURE_HDR_OUTPUT:
 			return true;
+		case DisplayServerEnums::FEATURE_EXTEND_TO_TITLE:
+			// OpenGL3 cannot composite over the DWM sheet-of-glass surface,
+			// so the feature is unavailable on the compatibility renderer using opengl3
+			// opengl3_angle works, as it translates to Vulkan/D3D12 which can composite properly.
+			return rendering_driver != "opengl3";
 		case DisplayServerEnums::FEATURE_SCREEN_EXCLUDE_FROM_CAPTURE:
 			return (os_ver.dwBuildNumber >= 19041); // Fully supported on Windows 10 Vibranium R1 (2004)+ only, captured as black rect on older versions.
 		case DisplayServerEnums::FEATURE_EMOJI_AND_SYMBOL_PICKER:
@@ -2281,6 +2286,52 @@ Size2i DisplayServerWindows::window_get_title_size(const String &p_title, Displa
 	return size;
 }
 
+Vector3i DisplayServerWindows::window_get_safe_title_margins(DisplayServerEnums::WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V(!windows.has(p_window), Vector3i());
+	const WindowData &wd = windows[p_window];
+
+	if (!wd.extend_to_title || wd.fullscreen || wd.minimized || wd.borderless) {
+		return Vector3i();
+	}
+
+	// Button dimensions are driven by caption_buttons_offset: each button is
+	// (offset.x * 2) × (offset.y * 2) logical pixels; three buttons make the cluster.
+	UINT dpi = GetDpiForWindow(wd.hWnd);
+	float scale = (float)dpi / 96.0f;
+	int bw = (int)Math::round(wd.caption_buttons_offset.x * 2 * scale);
+	int bh = (int)Math::round(wd.caption_buttons_offset.y * 2 * scale);
+	int cw = bw * 3;
+	int ch = bh;
+
+	bool rtl = (GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE) & WS_EX_LAYOUTRTL) != 0;
+
+	// x = left margin, y = right margin, z = height (all in physical pixels).
+	if (rtl) {
+		return Vector3i(cw, 0, ch);
+	} else {
+		return Vector3i(0, cw, ch);
+	}
+}
+
+void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+
+	if (!wd.extend_to_title) {
+		return;
+	}
+	if (wd.caption_buttons_offset == p_offset) {
+		return;
+	}
+
+	wd.caption_buttons_offset = p_offset;
+	_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+}
+
 void DisplayServerWindows::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
@@ -2760,6 +2811,13 @@ void DisplayServerWindows::_update_window_style(DisplayServerEnums::WindowID p_w
 
 	SetWindowPos(wd.hWnd, _is_always_on_top_recursive(p_window) ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | ((wd.no_focus || wd.is_popup) ? SWP_NOACTIVATE : 0));
 
+	// Re-apply DWM frame extension if needed. Changing the window style (e.g. toggling
+	// borderless or returning from fullscreen) can silently reset the DWM frame state.
+	if (wd.extend_to_title && !wd.fullscreen && !wd.borderless) {
+		MARGINS margins = { -1, -1, -1, -1 };
+		DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+	}
+
 	if (p_repaint) {
 		RECT rect;
 		GetWindowRect(wd.hWnd, &rect);
@@ -2970,6 +3028,7 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 			_update_window_style(p_window);
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_BORDERLESS: {
+			bool prev_borderless = wd.borderless;
 			wd.borderless = p_enabled;
 			if (wd.fullscreen) {
 				return;
@@ -2977,6 +3036,9 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 			_update_window_mouse_passthrough(p_window);
 			_update_window_style(p_window);
 			ShowWindow(wd.hWnd, (wd.no_focus || wd.is_popup) ? SW_SHOWNOACTIVATE : SW_SHOW); // Show the window.
+			if (!p_enabled && wd.extend_to_title && prev_borderless != p_enabled) {
+				_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+			}
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_ALWAYS_ON_TOP: {
 			ERR_FAIL_COND_MSG(wd.transient_parent != DisplayServerEnums::INVALID_WINDOW_ID && p_enabled, "Transient windows can't become on top.");
@@ -3039,6 +3101,28 @@ void DisplayServerWindows::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 				SetWindowDisplayAffinity(wd.hWnd, WDA_NONE);
 			}
 		} break;
+		case DisplayServerEnums::WINDOW_FLAG_EXTEND_TO_TITLE: {
+			if (!has_feature(DisplayServerEnums::FEATURE_EXTEND_TO_TITLE)) {
+				return;
+			}
+			wd.extend_to_title = p_enabled;
+			if (wd.fullscreen || wd.borderless) {
+				// No need to apply DWM changes — they're meaningless
+				// on fullscreen/borderless windows. The state will be re-applied in
+				// _update_window_style() when leaving those modes.
+				break;
+			}
+			if (p_enabled) {
+				MARGINS margins = { -1, -1, -1, -1 };
+				DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+			} else {
+				MARGINS margins = { 0, 0, 0, 0 };
+				DwmExtendFrameIntoClientArea(wd.hWnd, &margins);
+			}
+			// Force a WM_NCCALCSIZE and redraw to apply the frame change.
+			SetWindowPos(wd.hWnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER);
+			_send_window_event(wd, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
+		} break;
 		case DisplayServerEnums::WINDOW_FLAG_POPUP: {
 			ERR_FAIL_COND_MSG(p_window == DisplayServerEnums::MAIN_WINDOW_ID, "Main window can't be popup.");
 			ERR_FAIL_COND_MSG(IsWindowVisible(wd.hWnd) && (wd.is_popup != p_enabled), "Popup flag can't changed while window is opened.");
@@ -3088,6 +3172,9 @@ bool DisplayServerWindows::window_get_flag(DisplayServerEnums::WindowFlags p_fla
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_EXCLUDE_FROM_CAPTURE: {
 			return wd.hide_from_capture;
+		} break;
+		case DisplayServerEnums::WINDOW_FLAG_EXTEND_TO_TITLE: {
+			return wd.extend_to_title;
 		} break;
 		case DisplayServerEnums::WINDOW_FLAG_POPUP: {
 			return wd.is_popup;
@@ -5773,9 +5860,81 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SendMessageW(windows[window_id].hWnd, WM_PAINT, 0, 0);
 			}
 		} break;
+		case WM_NCCALCSIZE: {
+			// When extend_to_title is active, make the entire window rect the client area
+			// so that game/engine content can draw over the entire window. DWM still technically draws
+			// the min/max/close buttons underneath, but we just ignore them by never returning hits on them in WM_NCHITTEST handling
+			// Removing them breaks features like snapping, shadows and maximize/restore animations
+			// Note that opengl3 can't draw over a full client area window - extend_to_title is feature flagged off
+			if (wParam == TRUE && windows.has(window_id)) {
+				const WindowData &ncwd = windows[window_id];
+				if (ncwd.extend_to_title && !ncwd.fullscreen && !ncwd.borderless) {
+					// use IsZoomed instead of ncwd.maximized, as we don't receive the WM_SIZE event before WM_NCCALCSIZE
+					if (IsZoomed(hWnd)) {
+						// When maximized, Windows positions the window with an invisible
+						// resize border (typically 8px) on each side that sits off-screen.
+						// Compensate for this so content starts at the visible screen edge.
+						int frame = GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER);
+						NCCALCSIZE_PARAMS *params = (NCCALCSIZE_PARAMS *)lParam;
+						params->rgrc[0].top += frame;
+						params->rgrc[0].left += frame;
+						params->rgrc[0].right -= frame;
+						params->rgrc[0].bottom -= frame;
+					}
+					return 0; // Full window rect = client area; no NC chrome.
+				}
+			}
+		} break;
 		case WM_NCHITTEST: {
 			if (windows[window_id].mpass) {
 				return HTTRANSPARENT;
+			}
+			if (windows[window_id].extend_to_title &&
+					!windows[window_id].fullscreen &&
+					!windows[window_id].borderless) {
+				POINT cursor = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+				RECT wnd_rect;
+				GetWindowRect(hWnd, &wnd_rect);
+
+				bool is_max = windows[window_id].maximized;
+				// Resize border thickness. Zero when maximized (can't resize from border).
+				int frame_x = is_max ? 0 : (GetSystemMetrics(SM_CXSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
+				int frame_y = is_max ? 0 : (GetSystemMetrics(SM_CYSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER));
+
+				// --- Resize border hit zones ---
+				if (!is_max) {
+					bool at_top = cursor.y < wnd_rect.top + frame_y;
+					bool at_bottom = cursor.y >= wnd_rect.bottom - frame_y;
+					bool at_left = cursor.x < wnd_rect.left + frame_x;
+					bool at_right = cursor.x >= wnd_rect.right - frame_x;
+
+					if (at_top && at_left) {
+						return HTTOPLEFT;
+					}
+					if (at_top && at_right) {
+						return HTTOPRIGHT;
+					}
+					if (at_bottom && at_left) {
+						return HTBOTTOMLEFT;
+					}
+					if (at_bottom && at_right) {
+						return HTBOTTOMRIGHT;
+					}
+					if (at_top) {
+						return HTTOP;
+					}
+					if (at_bottom) {
+						return HTBOTTOM;
+					}
+					if (at_left) {
+						return HTLEFT;
+					}
+					if (at_right) {
+						return HTRIGHT;
+					}
+				}
+
+				return HTCLIENT;
 			}
 		} break;
 		case WM_MOUSEACTIVATE: {
@@ -6724,6 +6883,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			WINDOWPOS *window_pos_params = (WINDOWPOS *)lParam;
 
+			// Snapshot maximized state before the update block so we can detect transitions.
+			bool prev_maximized = window.maximized;
+
 			bool rect_changed = false;
 			if (!(window_pos_params->flags & SWP_NOSIZE) || window_pos_params->flags & SWP_FRAMECHANGED) {
 				int screen_id = window_get_current_screen(window_id);
@@ -6787,6 +6949,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 #endif
 #endif
+			}
+
+			// Notify the scene when maximized/minimized state changes so CaptionButtonOverlay updates its icon.
+			if (window.extend_to_title && window.maximized != prev_maximized) {
+				_send_window_event(window, DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE);
 			}
 
 			if (!window.minimized && (!(window_pos_params->flags & SWP_NOMOVE) || window_pos_params->flags & SWP_FRAMECHANGED)) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2326,9 +2326,7 @@ void DisplayServerWindows::window_set_window_buttons_offset(const Vector2i &p_of
 	}
 	UINT dpi = GetDpiForWindow(wd.hWnd);
 	float scale = (float)dpi / 96.0f;
-	Vector2i offset(
-			(int)Math::round((float)p_offset.x / scale),
-			(int)Math::round((float)p_offset.y / scale));
+	Vector2i offset = (Vector2(p_offset) / scale).round();
 	if (wd.caption_buttons_offset == offset) {
 		return;
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2508,10 +2508,14 @@ void DisplayServerWindows::window_set_position(const Point2i &p_position, Displa
 	rc.bottom = p_position.y + wd.height + offset.y;
 	rc.top = p_position.y + offset.y;
 
-	const DWORD style = GetWindowLongPtr(wd.hWnd, GWL_STYLE);
-	const DWORD exStyle = GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE);
+	// extend_to_title windows make the entire window rect the client area.
+	// AdjustWindowRectEx would incorrectly add space for the title bar and borders to the window, whose non-client area is removed.
+	if (!wd.extend_to_title) {
+		const DWORD style = GetWindowLongPtr(wd.hWnd, GWL_STYLE);
+		const DWORD exStyle = GetWindowLongPtr(wd.hWnd, GWL_EXSTYLE);
 
-	AdjustWindowRectEx(&rc, style, false, exStyle);
+		AdjustWindowRectEx(&rc, style, false, exStyle);
+	}
 	MoveWindow(wd.hWnd, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, TRUE);
 
 	wd.last_pos = p_position;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -324,6 +324,8 @@ class DisplayServerWindows : public DisplayServer {
 		bool mpass = false;
 		bool sharp_corners = false;
 		bool hide_from_capture = false;
+		bool extend_to_title = false;
+		Vector2i caption_buttons_offset = Vector2i(23, 16);
 
 		// Used to transfer data between events using timer.
 		WPARAM saved_wparam;
@@ -660,6 +662,8 @@ public:
 
 	virtual void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual Vector3i window_get_safe_title_margins(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -663,6 +663,7 @@ public:
 	virtual void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
 	virtual Vector3i window_get_safe_title_margins(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual bool window_maximize_on_title_dbl_click() const override { return true; }
 	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -325,6 +325,8 @@ class DisplayServerWindows : public DisplayServer {
 		bool mpass = false;
 		bool sharp_corners = false;
 		bool hide_from_capture = false;
+		bool extend_to_title = false;
+		Vector2i caption_buttons_offset = Vector2i(23, 16);
 
 		// Used to transfer data between events using timer.
 		WPARAM saved_wparam;
@@ -667,6 +669,8 @@ public:
 
 	virtual void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual Vector3i window_get_safe_title_margins(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -670,6 +670,7 @@ public:
 	virtual void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_title_size(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
 	virtual Vector3i window_get_safe_title_margins(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	virtual bool window_maximize_on_title_dbl_click() const override { return true; }
 	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -100,7 +100,8 @@ void CaptionButtonOverlay::_draw_icon_minimize(const Rect2 &p_rect, const Color 
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 5.0f * scale;
-	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale);
+	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
+	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale, antiAliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_maximize(const Rect2 &p_rect, const Color &p_color) {
@@ -109,8 +110,9 @@ void CaptionButtonOverlay::_draw_icon_maximize(const Rect2 &p_rect, const Color 
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 4.5f * scale;
+	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
 	Rect2 sq(cx - half, cy - half, half * 2.0f, half * 2.0f);
-	draw_rect(sq, p_color, false, scale);
+	draw_rect(sq, p_color, false, scale, antiAliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &p_color) {
@@ -121,9 +123,11 @@ void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &
 	float sz = 7.0f * scale;
 	float offset = 2.0f * scale;
 
+	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
+
 	// Front square — shifted down by half the offset so the combined icon is vertically centered.
 	Rect2 front(cx - sz * 0.5f, cy - sz * 0.5f + offset * 0.5f, sz, sz);
-	draw_rect(front, p_color, false, scale);
+	draw_rect(front, p_color, false, scale, antiAliased);
 
 	// Back square — derived directly from front (off px right, off px up).
 	Rect2 back(front.position + Vector2(offset, -offset), Size2(sz, sz));
@@ -133,11 +137,11 @@ void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &
 	float by = back.position.y;
 
 	// Top edge — stop short of the corner by radius.
-	draw_line(Point2(bx, by), Point2(bx + sz - r, by), p_color, scale);
+	draw_line(Point2(bx, by), Point2(bx + sz - r, by), p_color, scale, antiAliased);
 	// Right edge — start below the corner by radius.
-	draw_line(Point2(bx + sz, by + r), Point2(bx + sz, by + sz), p_color, scale);
+	draw_line(Point2(bx + sz, by + r), Point2(bx + sz, by + sz), p_color, scale, antiAliased);
 	// Quarter-circle arc joining them at the top-right corner.
-	draw_arc(Vector2(bx + sz - r, by + r), r, -Math::PI * 0.5f, 0.0f, 4, p_color, scale);
+	draw_arc(Vector2(bx + sz - r, by + r), r, -Math::PI * 0.5f, 0.0f, 4, p_color, scale, antiAliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_close(const Rect2 &p_rect, const Color &p_color) {

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -1,0 +1,290 @@
+/**************************************************************************/
+/*  caption_button_overlay.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "caption_button_overlay.h"
+
+#include "core/object/class_db.h"
+#include "scene/gui/control.h"
+#include "scene/main/window.h"
+#include "servers/display/display_server.h"
+
+// -- Geometry helpers ------------------------------------------------
+
+// Maps logical zone indices to left-to-right column order.
+// LTR: minimize(0), maximize(1), close(2)
+// RTL: close(0),    maximize(1), minimize(2)  — cluster moves to top-left
+static CaptionButtonOverlay::ButtonZone _ltr_zone(int col, bool rtl) {
+	if (rtl) {
+		// Columns are: 0=close, 1=maximize, 2=minimize
+		switch (col) {
+			case 0:
+				return CaptionButtonOverlay::ZONE_CLOSE;
+			case 1:
+				return CaptionButtonOverlay::ZONE_MAXIMIZE;
+			default:
+				return CaptionButtonOverlay::ZONE_MINIMIZE;
+		}
+	} else {
+		return (CaptionButtonOverlay::ButtonZone)col;
+	}
+}
+
+Rect2 CaptionButtonOverlay::_zone_rect(ButtonZone p_zone) const {
+	bool rtl = is_layout_rtl();
+	int col = 0;
+	if (rtl) {
+		switch (p_zone) {
+			case ZONE_CLOSE:
+				col = 0;
+				break;
+			case ZONE_MAXIMIZE:
+				col = 1;
+				break;
+			default:
+				col = 2;
+				break;
+		}
+	} else {
+		col = (int)p_zone;
+	}
+	float bw = get_size().x / 3.0f;
+	float bh = get_size().y;
+	return Rect2(col * bw, 0, bw, bh);
+}
+
+CaptionButtonOverlay::ButtonZone CaptionButtonOverlay::_zone_at(const Vector2 &p_pos) const {
+	bool rtl = is_layout_rtl();
+	float bw = get_size().x / 3.0f;
+	float bh = get_size().y;
+	for (int col = 0; col < 3; col++) {
+		Rect2 r(col * bw, 0, bw, bh);
+		if (r.has_point(p_pos)) {
+			return _ltr_zone(col, rtl);
+		}
+	}
+	return ZONE_NONE;
+}
+
+// -- Icon drawing ------------------------------------------------
+
+void CaptionButtonOverlay::_draw_icon_minimize(const Rect2 &p_rect, const Color &p_color) {
+	// Horizontal line at vertical center.
+	float scale = _dpi_scale;
+	float cx = p_rect.get_center().x;
+	float cy = p_rect.get_center().y;
+	float half = 5.0f * scale;
+	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale);
+}
+
+void CaptionButtonOverlay::_draw_icon_maximize(const Rect2 &p_rect, const Color &p_color) {
+	// Square outline centered in the button.
+	float scale = _dpi_scale;
+	float cx = p_rect.get_center().x;
+	float cy = p_rect.get_center().y;
+	float half = 4.5f * scale;
+	Rect2 sq(cx - half, cy - half, half * 2.0f, half * 2.0f);
+	draw_rect(sq, p_color, false, scale);
+}
+
+void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &p_color) {
+	// Two overlapping square outlines — front (bottom-left, full) and back (top-right, L-shaped).
+	float scale = _dpi_scale;
+	float cx = p_rect.get_center().x;
+	float cy = p_rect.get_center().y;
+	float sz = 7.0f * scale;
+	float offset = 2.0f * scale;
+
+	// Front square — shifted down by half the offset so the combined icon is vertically centered.
+	Rect2 front(cx - sz * 0.5f, cy - sz * 0.5f + offset * 0.5f, sz, sz);
+	draw_rect(front, p_color, false, scale);
+
+	// Back square — derived directly from front (off px right, off px up).
+	Rect2 back(front.position + Vector2(offset, -offset), Size2(sz, sz));
+
+	float r = 1.5f * scale;
+	float bx = back.position.x;
+	float by = back.position.y;
+
+	// Top edge — stop short of the corner by radius.
+	draw_line(Point2(bx, by), Point2(bx + sz - r, by), p_color, scale);
+	// Right edge — start below the corner by radius.
+	draw_line(Point2(bx + sz, by + r), Point2(bx + sz, by + sz), p_color, scale);
+	// Quarter-circle arc joining them at the top-right corner.
+	draw_arc(Vector2(bx + sz - r, by + r), r, -Math::PI * 0.5f, 0.0f, 4, p_color, scale);
+}
+
+void CaptionButtonOverlay::_draw_icon_close(const Rect2 &p_rect, const Color &p_color) {
+	// × — two diagonal lines.
+	float scale = _dpi_scale;
+	float cx = p_rect.get_center().x;
+	float cy = p_rect.get_center().y;
+	float half = 5.0f * scale;
+	draw_line(Vector2(cx - half, cy - half), Vector2(cx + half, cy + half), p_color, scale, true);
+	draw_line(Vector2(cx + half, cy - half), Vector2(cx - half, cy + half), p_color, scale, true);
+}
+
+// -- Control overrides -----------------------------------------------
+
+CaptionButtonOverlay::CaptionButtonOverlay() {
+	set_mouse_filter(MOUSE_FILTER_STOP);
+}
+
+void CaptionButtonOverlay::set_window_focused(bool p_focused) {
+	if (window_focused == p_focused) {
+		return;
+	}
+	window_focused = p_focused;
+	queue_redraw();
+}
+
+void CaptionButtonOverlay::set_window_maximized(bool p_maximized) {
+	if (window_maximized == p_maximized) {
+		return;
+	}
+	window_maximized = p_maximized;
+	queue_redraw();
+}
+
+void CaptionButtonOverlay::set_minimize_disabled(bool p_disabled) {
+	if (minimize_disabled == p_disabled) {
+		return;
+	}
+	minimize_disabled = p_disabled;
+	queue_redraw();
+}
+
+void CaptionButtonOverlay::set_maximize_disabled(bool p_disabled) {
+	if (maximize_disabled == p_disabled) {
+		return;
+	}
+	maximize_disabled = p_disabled;
+	queue_redraw();
+}
+
+void CaptionButtonOverlay::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			// Background colour for hovered / pressed button
+			const Color close_hover_bg(0.769f, 0.169f, 0.110f, 1.0f); // Windows 11 red
+			const Color normal_hover_bg(1.0f, 1.0f, 1.0f, 0.08f);
+			const Color normal_press_bg(1.0f, 1.0f, 1.0f, 0.04f);
+
+			for (int z = 0; z < 3; z++) {
+				ButtonZone zone = (ButtonZone)z;
+				Rect2 r = _zone_rect(zone);
+				if (zone == hover_zone) {
+					Color bg = (zone == ZONE_CLOSE) ? close_hover_bg : (pressing ? normal_press_bg : normal_hover_bg);
+					draw_rect(r, bg);
+				}
+			}
+
+			Color icon_color = get_theme_color(SNAME("title_color"), SNAME("Window"));
+			Color disabled_color = icon_color * Color(1, 1, 1, 0.35f);
+
+			// When unfocused, dim icons that are not currently hovered.
+			auto icon_alpha = [&](ButtonZone p_zone) -> float {
+				return (!window_focused && hover_zone != p_zone) ? 0.4f : 1.0f;
+			};
+
+			// Close: white when hovered (always full opacity); otherwise dimmed when unfocused.
+			Color close_color = (hover_zone == ZONE_CLOSE)
+					? Color(1, 1, 1)
+					: Color(icon_color.r, icon_color.g, icon_color.b, icon_color.a * icon_alpha(ZONE_CLOSE));
+			_draw_icon_close(_zone_rect(ZONE_CLOSE), close_color);
+
+			Color min_color = minimize_disabled ? disabled_color : icon_color;
+			min_color.a *= icon_alpha(ZONE_MINIMIZE);
+			_draw_icon_minimize(_zone_rect(ZONE_MINIMIZE), min_color);
+
+			Color max_color = maximize_disabled ? disabled_color : icon_color;
+			max_color.a *= icon_alpha(ZONE_MAXIMIZE);
+			if (window_maximized) {
+				_draw_icon_restore(_zone_rect(ZONE_MAXIMIZE), max_color);
+			} else {
+				_draw_icon_maximize(_zone_rect(ZONE_MAXIMIZE), max_color);
+			}
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			hover_zone = ZONE_NONE;
+			pressing = false;
+			queue_redraw();
+		} break;
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_WM_DPI_CHANGE: {
+			_dpi_scale = DisplayServer::get_singleton()->screen_get_dpi(get_window()->get_current_screen()) / 96.0f;
+			queue_redraw();
+		} break;
+	}
+}
+
+void CaptionButtonOverlay::gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		ButtonZone new_zone = _zone_at(mm->get_position());
+		if (new_zone != hover_zone) {
+			hover_zone = new_zone;
+			queue_redraw();
+		}
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
+		if (mb->is_pressed()) {
+			pressing = true;
+			queue_redraw();
+		} else if (pressing) {
+			pressing = false;
+			queue_redraw();
+			ButtonZone zone = _zone_at(mb->get_position());
+			if (zone == ZONE_CLOSE) {
+				emit_signal(SNAME("close_pressed"));
+			} else if (zone == ZONE_MINIMIZE && !minimize_disabled) {
+				emit_signal(SNAME("minimize_pressed"));
+			} else if (zone == ZONE_MAXIMIZE && !maximize_disabled) {
+				emit_signal(SNAME("maximize_pressed"));
+			}
+		}
+		accept_event();
+	}
+}
+
+void CaptionButtonOverlay::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_window_focused", "focused"), &CaptionButtonOverlay::set_window_focused);
+	ClassDB::bind_method(D_METHOD("set_window_maximized", "maximized"), &CaptionButtonOverlay::set_window_maximized);
+	ClassDB::bind_method(D_METHOD("get_window_maximized"), &CaptionButtonOverlay::get_window_maximized);
+	ClassDB::bind_method(D_METHOD("set_minimize_disabled", "disabled"), &CaptionButtonOverlay::set_minimize_disabled);
+	ClassDB::bind_method(D_METHOD("set_maximize_disabled", "disabled"), &CaptionButtonOverlay::set_maximize_disabled);
+
+	ADD_SIGNAL(MethodInfo("close_pressed"));
+	ADD_SIGNAL(MethodInfo("minimize_pressed"));
+	ADD_SIGNAL(MethodInfo("maximize_pressed"));
+}

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -57,7 +57,7 @@ static CaptionButtonOverlay::ButtonZone _ltr_zone(int col, bool rtl) {
 }
 
 Rect2 CaptionButtonOverlay::_zone_rect(ButtonZone p_zone) const {
-	bool rtl = is_layout_rtl();
+	bool rtl = false;
 	int col = 0;
 	if (rtl) {
 		switch (p_zone) {
@@ -80,7 +80,7 @@ Rect2 CaptionButtonOverlay::_zone_rect(ButtonZone p_zone) const {
 }
 
 CaptionButtonOverlay::ButtonZone CaptionButtonOverlay::_zone_at(const Vector2 &p_pos) const {
-	bool rtl = is_layout_rtl();
+	bool rtl = false;
 	float bw = get_size().x / 3.0f;
 	float bh = get_size().y;
 	for (int col = 0; col < 3; col++) {

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -40,10 +40,10 @@
 // Maps logical zone indices to left-to-right column order.
 // LTR: minimize(0), maximize(1), close(2)
 // RTL: close(0),    maximize(1), minimize(2)  — cluster moves to top-left
-static CaptionButtonOverlay::ButtonZone _ltr_zone(int col, bool rtl) {
-	if (rtl) {
+static CaptionButtonOverlay::ButtonZone _ltr_zone(int p_col, bool p_rtl) {
+	if (p_rtl) {
 		// Columns are: 0=close, 1=maximize, 2=minimize
-		switch (col) {
+		switch (p_col) {
 			case 0:
 				return CaptionButtonOverlay::ZONE_CLOSE;
 			case 1:
@@ -52,7 +52,7 @@ static CaptionButtonOverlay::ButtonZone _ltr_zone(int col, bool rtl) {
 				return CaptionButtonOverlay::ZONE_MINIMIZE;
 		}
 	} else {
-		return (CaptionButtonOverlay::ButtonZone)col;
+		return (CaptionButtonOverlay::ButtonZone)p_col;
 	}
 }
 
@@ -96,38 +96,38 @@ CaptionButtonOverlay::ButtonZone CaptionButtonOverlay::_zone_at(const Vector2 &p
 
 void CaptionButtonOverlay::_draw_icon_minimize(const Rect2 &p_rect, const Color &p_color) {
 	// Horizontal line at vertical center.
-	float scale = _dpi_scale;
+	float scale = dpi_scale;
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 5.0f * scale;
 	bool anti_aliased = Math::abs(scale - Math::round(scale)) > 1e-6f;
-	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale, antiAliased);
+	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale, anti_aliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_maximize(const Rect2 &p_rect, const Color &p_color) {
 	// Square outline centered in the button.
-	float scale = _dpi_scale;
+	float scale = dpi_scale;
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 4.5f * scale;
-	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
+	bool anti_aliased = Math::abs(scale - Math::round(scale)) > 1e-6f;
 	Rect2 sq(cx - half, cy - half, half * 2.0f, half * 2.0f);
-	draw_rect(sq, p_color, false, scale, antiAliased);
+	draw_rect(sq, p_color, false, scale, anti_aliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &p_color) {
 	// Two overlapping square outlines — front (bottom-left, full) and back (top-right, L-shaped).
-	float scale = _dpi_scale;
+	float scale = dpi_scale;
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float sz = 7.0f * scale;
 	float offset = 2.0f * scale;
 
-	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
+	bool anti_aliased = Math::abs(scale - Math::round(scale)) > 1e-6f;
 
 	// Front square — shifted down by half the offset so the combined icon is vertically centered.
 	Rect2 front(cx - sz * 0.5f, cy - sz * 0.5f + offset * 0.5f, sz, sz);
-	draw_rect(front, p_color, false, scale, antiAliased);
+	draw_rect(front, p_color, false, scale, anti_aliased);
 
 	// Back square — derived directly from front (off px right, off px up).
 	Rect2 back(front.position + Vector2(offset, -offset), Size2(sz, sz));
@@ -137,16 +137,16 @@ void CaptionButtonOverlay::_draw_icon_restore(const Rect2 &p_rect, const Color &
 	float by = back.position.y;
 
 	// Top edge — stop short of the corner by radius.
-	draw_line(Point2(bx, by), Point2(bx + sz - r, by), p_color, scale, antiAliased);
+	draw_line(Point2(bx, by), Point2(bx + sz - r, by), p_color, scale, anti_aliased);
 	// Right edge — start below the corner by radius.
-	draw_line(Point2(bx + sz, by + r), Point2(bx + sz, by + sz), p_color, scale, antiAliased);
+	draw_line(Point2(bx + sz, by + r), Point2(bx + sz, by + sz), p_color, scale, anti_aliased);
 	// Quarter-circle arc joining them at the top-right corner.
-	draw_arc(Vector2(bx + sz - r, by + r), r, -Math::PI * 0.5f, 0.0f, 4, p_color, scale, antiAliased);
+	draw_arc(Vector2(bx + sz - r, by + r), r, -Math::PI * 0.5f, 0.0f, 4, p_color, scale, anti_aliased);
 }
 
 void CaptionButtonOverlay::_draw_icon_close(const Rect2 &p_rect, const Color &p_color) {
 	// × — two diagonal lines.
-	float scale = _dpi_scale;
+	float scale = dpi_scale;
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 5.0f * scale;
@@ -243,7 +243,7 @@ void CaptionButtonOverlay::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_WM_DPI_CHANGE: {
-			_dpi_scale = DisplayServer::get_singleton()->screen_get_dpi(get_window()->get_current_screen()) / 96.0f;
+			dpi_scale = DisplayServer::get_singleton()->screen_get_dpi(get_window()->get_current_screen()) / 96.0f;
 			queue_redraw();
 		} break;
 	}

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -37,56 +37,20 @@
 
 // -- Geometry helpers ------------------------------------------------
 
-// Maps logical zone indices to left-to-right column order.
-// LTR: minimize(0), maximize(1), close(2)
-// RTL: close(0),    maximize(1), minimize(2)  — cluster moves to top-left
-static CaptionButtonOverlay::ButtonZone _ltr_zone(int p_col, bool p_rtl) {
-	if (p_rtl) {
-		// Columns are: 0=close, 1=maximize, 2=minimize
-		switch (p_col) {
-			case 0:
-				return CaptionButtonOverlay::ZONE_CLOSE;
-			case 1:
-				return CaptionButtonOverlay::ZONE_MAXIMIZE;
-			default:
-				return CaptionButtonOverlay::ZONE_MINIMIZE;
-		}
-	} else {
-		return (CaptionButtonOverlay::ButtonZone)p_col;
-	}
-}
-
 Rect2 CaptionButtonOverlay::_zone_rect(ButtonZone p_zone) const {
-	bool rtl = false;
-	int col = 0;
-	if (rtl) {
-		switch (p_zone) {
-			case ZONE_CLOSE:
-				col = 0;
-				break;
-			case ZONE_MAXIMIZE:
-				col = 1;
-				break;
-			default:
-				col = 2;
-				break;
-		}
-	} else {
-		col = (int)p_zone;
-	}
+	int col = (int)p_zone;
 	float bw = get_size().x / 3.0f;
 	float bh = get_size().y;
 	return Rect2(col * bw, 0, bw, bh);
 }
 
 CaptionButtonOverlay::ButtonZone CaptionButtonOverlay::_zone_at(const Vector2 &p_pos) const {
-	bool rtl = false;
 	float bw = get_size().x / 3.0f;
 	float bh = get_size().y;
 	for (int col = 0; col < 3; col++) {
 		Rect2 r(col * bw, 0, bw, bh);
 		if (r.has_point(p_pos)) {
-			return _ltr_zone(col, rtl);
+			return (ButtonZone)col;
 		}
 	}
 	return ZONE_NONE;

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -100,7 +100,7 @@ void CaptionButtonOverlay::_draw_icon_minimize(const Rect2 &p_rect, const Color 
 	float cx = p_rect.get_center().x;
 	float cy = p_rect.get_center().y;
 	float half = 5.0f * scale;
-	bool antiAliased = std::abs(scale - std::round(scale)) > 1e-6f;
+	bool anti_aliased = Math::abs(scale - Math::round(scale)) > 1e-6f;
 	draw_line(Vector2(cx - half, cy), Vector2(cx + half, cy), p_color, scale, antiAliased);
 }
 
@@ -195,7 +195,7 @@ void CaptionButtonOverlay::set_maximize_disabled(bool p_disabled) {
 void CaptionButtonOverlay::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			// Background colour for hovered / pressed button
+			// Background color for hovered / pressed button.
 			const Color close_hover_bg(0.769f, 0.169f, 0.110f, 1.0f); // Windows 11 red
 			const Color normal_hover_bg(1.0f, 1.0f, 1.0f, 0.08f);
 			const Color normal_press_bg(1.0f, 1.0f, 1.0f, 0.04f);
@@ -220,7 +220,7 @@ void CaptionButtonOverlay::_notification(int p_what) {
 			// Close: white when hovered (always full opacity); otherwise dimmed when unfocused.
 			Color close_color = (hover_zone == ZONE_CLOSE)
 					? Color(1, 1, 1)
-					: Color(icon_color.r, icon_color.g, icon_color.b, icon_color.a * icon_alpha(ZONE_CLOSE));
+					: Color(icon_color, icon_color.a * icon_alpha(ZONE_CLOSE));
 			_draw_icon_close(_zone_rect(ZONE_CLOSE), close_color);
 
 			Color min_color = minimize_disabled ? disabled_color : icon_color;

--- a/scene/gui/caption_button_overlay.cpp
+++ b/scene/gui/caption_button_overlay.cpp
@@ -213,22 +213,20 @@ void CaptionButtonOverlay::_notification(int p_what) {
 			Color disabled_color = icon_color * Color(1, 1, 1, 0.35f);
 
 			// When unfocused, dim icons that are not currently hovered.
-			auto icon_alpha = [&](ButtonZone p_zone) -> float {
-				return (!window_focused && hover_zone != p_zone) ? 0.4f : 1.0f;
-			};
+			const float focus_alpha_modifier = window_focused ? 1.0f : 0.4f;
 
 			// Close: white when hovered (always full opacity); otherwise dimmed when unfocused.
 			Color close_color = (hover_zone == ZONE_CLOSE)
 					? Color(1, 1, 1)
-					: Color(icon_color, icon_color.a * icon_alpha(ZONE_CLOSE));
+					: Color(icon_color, icon_color.a * focus_alpha_modifier);
 			_draw_icon_close(_zone_rect(ZONE_CLOSE), close_color);
 
 			Color min_color = minimize_disabled ? disabled_color : icon_color;
-			min_color.a *= icon_alpha(ZONE_MINIMIZE);
+			min_color.a *= hover_zone == ZONE_MINIMIZE ? 1.0f : focus_alpha_modifier;
 			_draw_icon_minimize(_zone_rect(ZONE_MINIMIZE), min_color);
 
 			Color max_color = maximize_disabled ? disabled_color : icon_color;
-			max_color.a *= icon_alpha(ZONE_MAXIMIZE);
+			max_color.a *= hover_zone == ZONE_MAXIMIZE ? 1.0f : focus_alpha_modifier;
 			if (window_maximized) {
 				_draw_icon_restore(_zone_rect(ZONE_MAXIMIZE), max_color);
 			} else {

--- a/scene/gui/caption_button_overlay.h
+++ b/scene/gui/caption_button_overlay.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  caption_button_overlay.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/control.h"
+
+// Engine-drawn close/minimize/maximize button cluster rendered over the
+// title-bar area when WINDOW_FLAG_EXTEND_TO_TITLE is active on platforms that
+// do not provide native caption buttons (e.g. Windows).
+class CaptionButtonOverlay : public Control {
+	GDCLASS(CaptionButtonOverlay, Control);
+
+public:
+	enum ButtonZone {
+		ZONE_NONE = -1,
+		ZONE_MINIMIZE = 0,
+		ZONE_MAXIMIZE = 1,
+		ZONE_CLOSE = 2,
+	};
+
+private:
+	// DPI scale factor cached from the last NOTIFICATION_WM_DPI_CHANGE (1.0 = 96 DPI).
+	// Icon geometry is authored at 96 DPI (10 × 10 px) and multiplied by this value.
+	float _dpi_scale = 1.0f;
+
+	bool window_focused = true;
+	bool window_maximized = false;
+	bool minimize_disabled = false;
+	bool maximize_disabled = false;
+
+	ButtonZone hover_zone = ZONE_NONE;
+	bool pressing = false;
+
+	// Returns the local-space rect for a given zone, taking RTL into account.
+	Rect2 _zone_rect(ButtonZone p_zone) const;
+	ButtonZone _zone_at(const Vector2 &p_pos) const;
+
+	void _draw_icon_minimize(const Rect2 &p_rect, const Color &p_color);
+	void _draw_icon_maximize(const Rect2 &p_rect, const Color &p_color);
+	void _draw_icon_restore(const Rect2 &p_rect, const Color &p_color);
+	void _draw_icon_close(const Rect2 &p_rect, const Color &p_color);
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+public:
+	void set_window_focused(bool p_focused);
+	void set_window_maximized(bool p_maximized);
+	bool get_window_maximized() const { return window_maximized; }
+
+	void set_minimize_disabled(bool p_disabled);
+	void set_maximize_disabled(bool p_disabled);
+
+	CaptionButtonOverlay();
+};

--- a/scene/gui/caption_button_overlay.h
+++ b/scene/gui/caption_button_overlay.h
@@ -49,7 +49,7 @@ public:
 private:
 	// DPI scale factor cached from the last NOTIFICATION_WM_DPI_CHANGE (1.0 = 96 DPI).
 	// Icon geometry is authored at 96 DPI (10 × 10 px) and multiplied by this value.
-	float _dpi_scale = 1.0f;
+	float dpi_scale = 1.0f;
 
 	bool window_focused = true;
 	bool window_maximized = false;

--- a/scene/gui/caption_button_overlay.h
+++ b/scene/gui/caption_button_overlay.h
@@ -59,7 +59,7 @@ private:
 	ButtonZone hover_zone = ZONE_NONE;
 	bool pressing = false;
 
-	// Returns the local-space rect for a given zone, taking RTL into account.
+	// Returns the local-space rect for a given zone.
 	Rect2 _zone_rect(ButtonZone p_zone) const;
 	ButtonZone _zone_at(const Vector2 &p_pos) const;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1049,6 +1049,9 @@ void Window::_event_callback(DisplayServerEnums::WindowEvent p_event) {
 			_update_caption_overlay();
 			emit_signal(SNAME("titlebar_changed"));
 		} break;
+		case DisplayServerEnums::WINDOW_EVENT_CAPTION_BUTTONS_CHANGE: {
+			_update_caption_overlay();
+		} break;
 		case DisplayServerEnums::WINDOW_EVENT_FORCE_CLOSE: {
 			hide();
 		} break;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -638,7 +638,7 @@ void Window::_update_caption_overlay() {
 	// Use window_get_safe_title_margins as the authoritative DPI-scaled size.
 	// x = left cluster width (RTL), y = right cluster width (LTR), z = height
 	Vector3i margins = DisplayServer::get_singleton()->window_get_safe_title_margins(window_id);
-	bool rtl = is_layout_rtl();
+	bool rtl = false;
 	int w = rtl ? margins.x : margins.y;
 	int h = margins.z;
 	caption_overlay->set_size(Size2(w, h));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -39,7 +39,9 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
+#include "scene/gui/caption_button_overlay.h"
 #include "scene/gui/control.h"
+#include "scene/main/canvas_layer.h"
 #include "scene/main/scene_tree.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
@@ -542,6 +544,8 @@ void Window::set_mode(Mode p_mode) {
 	} else if (window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_mode(DisplayServerEnums::WindowMode(p_mode), window_id);
 	}
+
+	_update_caption_overlay_existence();
 }
 
 Window::Mode Window::get_mode() const {
@@ -560,6 +564,105 @@ bool Window::is_fullscreen_shortcut_enabled() const {
 	return fullscreen_shortcut_enabled;
 }
 
+static bool _needs_caption_overlay() {
+	// Create an engine-drawn overlay on platforms that support FEATURE_EXTEND_TO_TITLE
+	// but do not render native caption buttons (currently Windows only).
+#ifdef WINDOWS_ENABLED
+	return DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_EXTEND_TO_TITLE);
+#else
+	return false;
+#endif
+}
+
+void Window::_update_caption_overlay_existence() {
+	bool should_exist = flags[FLAG_EXTEND_TO_TITLE] &&
+			!flags[FLAG_BORDERLESS] &&
+			mode != MODE_FULLSCREEN &&
+			mode != MODE_EXCLUSIVE_FULLSCREEN &&
+			_needs_caption_overlay();
+	if (should_exist && !caption_overlay) {
+		_create_caption_overlay();
+	} else if (!should_exist && caption_overlay) {
+		_destroy_caption_overlay();
+	}
+}
+
+void Window::_create_caption_overlay() {
+	if (caption_overlay) {
+		return; // Already exists.
+	}
+
+	// Use a high CanvasLayer so the buttons render above all game content,
+	// including any CanvasLayers the developer has added.
+	caption_canvas_layer = memnew(CanvasLayer);
+	caption_canvas_layer->set_layer(4096);
+	add_child(caption_canvas_layer, false, Node::INTERNAL_MODE_BACK);
+
+	caption_overlay = memnew(CaptionButtonOverlay);
+	caption_canvas_layer->add_child(caption_overlay);
+
+	// Connect button signals.
+	caption_overlay->connect(SNAME("close_pressed"), callable_mp(this, &Window::_caption_close_pressed));
+	caption_overlay->connect(SNAME("minimize_pressed"), callable_mp(this, &Window::_caption_minimize_pressed));
+	caption_overlay->connect(SNAME("maximize_pressed"), callable_mp(this, &Window::_caption_maximize_pressed));
+
+	_update_caption_overlay();
+}
+
+void Window::_destroy_caption_overlay() {
+	if (!caption_overlay) {
+		return;
+	}
+	caption_overlay->queue_free();
+	caption_overlay = nullptr;
+	caption_canvas_layer->queue_free();
+	caption_canvas_layer = nullptr;
+}
+
+void Window::_update_caption_overlay() {
+	if (!caption_overlay) {
+		return;
+	}
+
+	// Sync disabled state with window flags.
+	caption_overlay->set_minimize_disabled(get_flag(FLAG_MINIMIZE_DISABLED));
+	caption_overlay->set_maximize_disabled(get_flag(FLAG_MAXIMIZE_DISABLED));
+	caption_overlay->set_window_maximized(get_mode() == MODE_MAXIMIZED);
+	caption_overlay->set_window_focused(focused);
+
+	DisplayServerEnums::WindowID current_window_id = get_window_id();
+	if (!is_inside_tree() || current_window_id != DisplayServerEnums::MAIN_WINDOW_ID) {
+		return;
+	}
+
+	// Use window_get_safe_title_margins as the authoritative DPI-scaled size.
+	// x = left cluster width (RTL), y = right cluster width (LTR), z = height
+	Vector3i margins = DisplayServer::get_singleton()->window_get_safe_title_margins(window_id);
+	bool rtl = is_layout_rtl();
+	int w = rtl ? margins.x : margins.y;
+	int h = margins.z;
+	caption_overlay->set_size(Size2(w, h));
+
+	if (rtl) {
+		caption_overlay->set_position(Vector2(0, 0));
+	} else {
+		caption_overlay->set_position(Vector2(get_size().x - w, 0));
+	}
+}
+
+void Window::_caption_close_pressed() {
+	_propagate_window_notification(this, NOTIFICATION_WM_CLOSE_REQUEST);
+	emit_signal(SNAME("close_requested"));
+}
+
+void Window::_caption_minimize_pressed() {
+	set_mode(MODE_MINIMIZED);
+}
+
+void Window::_caption_maximize_pressed() {
+	set_mode(mode == MODE_MAXIMIZED ? MODE_WINDOWED : MODE_MAXIMIZED);
+}
+
 void Window::set_flag(Flags p_flag, bool p_enabled) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_INDEX(p_flag, FLAG_MAX);
@@ -567,6 +670,14 @@ void Window::set_flag(Flags p_flag, bool p_enabled) {
 
 	if (p_flag == FLAG_TRANSPARENT) {
 		set_transparent_background(p_enabled);
+	}
+
+	if (p_flag == FLAG_EXTEND_TO_TITLE || p_flag == FLAG_BORDERLESS) {
+		_update_caption_overlay_existence();
+	}
+
+	if (p_flag == FLAG_MINIMIZE_DISABLED || p_flag == FLAG_MAXIMIZE_DISABLED) {
+		_update_caption_overlay();
 	}
 
 	if (embedder) {
@@ -889,6 +1000,9 @@ void Window::_event_callback(DisplayServerEnums::WindowEvent p_event) {
 		case DisplayServerEnums::WINDOW_EVENT_FOCUS_IN: {
 			focused = true;
 			focused_window = this;
+			if (caption_overlay) {
+				caption_overlay->set_window_focused(true);
+			}
 			_propagate_window_notification(this, NOTIFICATION_WM_WINDOW_FOCUS_IN);
 			emit_signal(SceneStringName(focus_entered));
 			if (get_tree() && get_tree()->is_accessibility_enabled()) {
@@ -908,6 +1022,9 @@ void Window::_event_callback(DisplayServerEnums::WindowEvent p_event) {
 			if (focused_window == this) {
 				focused_window = nullptr;
 			}
+			if (caption_overlay) {
+				caption_overlay->set_window_focused(false);
+			}
 			_propagate_window_notification(this, NOTIFICATION_WM_WINDOW_FOCUS_OUT);
 			emit_signal(SceneStringName(focus_exited));
 		} break;
@@ -924,10 +1041,12 @@ void Window::_event_callback(DisplayServerEnums::WindowEvent p_event) {
 		} break;
 		case DisplayServerEnums::WINDOW_EVENT_DPI_CHANGE: {
 			_update_viewport_size();
+			_update_caption_overlay();
 			_propagate_window_notification(this, NOTIFICATION_WM_DPI_CHANGE);
 			emit_signal(SNAME("dpi_changed"));
 		} break;
 		case DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE: {
+			_update_caption_overlay();
 			emit_signal(SNAME("titlebar_changed"));
 		} break;
 		case DisplayServerEnums::WINDOW_EVENT_FORCE_CLOSE: {
@@ -1452,6 +1571,8 @@ void Window::_update_viewport_size() {
 		RS::get_singleton()->viewport_set_size(get_viewport_rid(), s.width, s.height, 1);
 		embedder->_sub_window_update(this);
 	}
+
+	_update_caption_overlay();
 }
 
 void Window::_update_window_callbacks() {
@@ -1747,6 +1868,11 @@ void Window::_notification(int p_what) {
 
 			// Emits NOTIFICATION_THEME_CHANGED internally.
 			set_theme_context(ThemeDB::get_singleton()->get_nearest_theme_context(this));
+
+			// If extend_to_title was set before entering the tree, create the overlay now.
+			if (flags[FLAG_EXTEND_TO_TITLE] && !flags[FLAG_BORDERLESS] && _needs_caption_overlay()) {
+				_create_caption_overlay();
+			}
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -1778,6 +1904,8 @@ void Window::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			_destroy_caption_overlay();
+
 			if (ProjectSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &Window::_settings_changed))) {
 				ProjectSettings::get_singleton()->disconnect("settings_changed", callable_mp(this, &Window::_settings_changed));
 			}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -594,7 +594,7 @@ void Window::_create_caption_overlay() {
 	}
 
 	// Use a high CanvasLayer so the buttons render above all game content,
-	// including any CanvasLayers the developer has added.
+	// including any CanvasLayers the user has added.
 	caption_canvas_layer = memnew(CanvasLayer);
 	caption_canvas_layer->set_layer(4096);
 	add_child(caption_canvas_layer, false, Node::INTERNAL_MODE_BACK);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -641,6 +641,10 @@ void Window::_update_caption_overlay() {
 	bool rtl = false;
 	int w = rtl ? margins.x : margins.y;
 	int h = margins.z;
+
+	// Keep the caption overlay in native window coordinates, independently of
+	// the project's content scaling and global canvas transform.
+	caption_canvas_layer->set_transform(get_final_transform().affine_inverse());
 	caption_overlay->set_size(Size2(w, h));
 
 	if (rtl) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1876,10 +1876,8 @@ void Window::_notification(int p_what) {
 			// Emits NOTIFICATION_THEME_CHANGED internally.
 			set_theme_context(ThemeDB::get_singleton()->get_nearest_theme_context(this));
 
-			// If extend_to_title was set before entering the tree, create the overlay now.
-			if (flags[FLAG_EXTEND_TO_TITLE] && !flags[FLAG_BORDERLESS] && _needs_caption_overlay()) {
-				_create_caption_overlay();
-			}
+			// If extend_to_title was set before entering the tree, update the overlay now.
+			_update_caption_overlay_existence();
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -575,10 +575,11 @@ static bool _needs_caption_overlay() {
 }
 
 void Window::_update_caption_overlay_existence() {
+	Mode current_mode = get_mode();
 	bool should_exist = flags[FLAG_EXTEND_TO_TITLE] &&
 			!flags[FLAG_BORDERLESS] &&
-			mode != MODE_FULLSCREEN &&
-			mode != MODE_EXCLUSIVE_FULLSCREEN &&
+			current_mode != MODE_FULLSCREEN &&
+			current_mode != MODE_EXCLUSIVE_FULLSCREEN &&
 			_needs_caption_overlay();
 	if (should_exist && !caption_overlay) {
 		_create_caption_overlay();
@@ -676,10 +677,6 @@ void Window::set_flag(Flags p_flag, bool p_enabled) {
 		set_transparent_background(p_enabled);
 	}
 
-	if (p_flag == FLAG_EXTEND_TO_TITLE || p_flag == FLAG_BORDERLESS) {
-		_update_caption_overlay_existence();
-	}
-
 	if (p_flag == FLAG_MINIMIZE_DISABLED || p_flag == FLAG_MAXIMIZE_DISABLED) {
 		_update_caption_overlay();
 	}
@@ -690,6 +687,10 @@ void Window::set_flag(Flags p_flag, bool p_enabled) {
 		if (!is_in_edited_scene_root()) {
 			DisplayServer::get_singleton()->window_set_flag(DisplayServerEnums::WindowFlags(p_flag), p_enabled, window_id);
 		}
+	}
+
+	if (p_flag == FLAG_EXTEND_TO_TITLE || p_flag == FLAG_BORDERLESS) {
+		_update_caption_overlay_existence();
 	}
 }
 
@@ -1050,6 +1051,7 @@ void Window::_event_callback(DisplayServerEnums::WindowEvent p_event) {
 			emit_signal(SNAME("dpi_changed"));
 		} break;
 		case DisplayServerEnums::WINDOW_EVENT_TITLEBAR_CHANGE: {
+			_update_caption_overlay_existence();
 			_update_caption_overlay();
 			emit_signal(SNAME("titlebar_changed"));
 		} break;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -637,10 +637,9 @@ void Window::_update_caption_overlay() {
 	}
 
 	// Use window_get_safe_title_margins as the authoritative DPI-scaled size.
-	// x = left cluster width (RTL), y = right cluster width (LTR), z = height
+	// y = right cluster width, z = height.
 	Vector3i margins = DisplayServer::get_singleton()->window_get_safe_title_margins(window_id);
-	bool rtl = false;
-	int w = rtl ? margins.x : margins.y;
+	int w = margins.y;
 	int h = margins.z;
 
 	// Keep the caption overlay in native window coordinates, independently of
@@ -648,11 +647,7 @@ void Window::_update_caption_overlay() {
 	caption_canvas_layer->set_transform(get_final_transform().affine_inverse());
 	caption_overlay->set_size(Size2(w, h));
 
-	if (rtl) {
-		caption_overlay->set_position(Vector2(0, 0));
-	} else {
-		caption_overlay->set_position(Vector2(get_size().x - w, 0));
-	}
+	caption_overlay->set_position(Vector2(get_size().x - w, 0));
 }
 
 void Window::_caption_close_pressed() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -38,6 +38,8 @@ class Font;
 class StyleBox;
 class ThemeOwner;
 class ThemeContext;
+class CanvasLayer;
+class CaptionButtonOverlay;
 
 class Window : public Viewport {
 	GDCLASS(Window, Viewport);
@@ -180,6 +182,18 @@ private:
 	Size2i max_size_used;
 
 	Rect2i nonclient_area;
+
+	// Engine-drawn caption buttons (close/minimize/maximize) used on platforms
+	// that support FEATURE_EXTEND_TO_TITLE but not native caption buttons (e.g. Windows).
+	CanvasLayer *caption_canvas_layer = nullptr;
+	CaptionButtonOverlay *caption_overlay = nullptr;
+	void _create_caption_overlay();
+	void _destroy_caption_overlay();
+	void _update_caption_overlay();
+	void _update_caption_overlay_existence();
+	void _caption_close_pressed();
+	void _caption_minimize_pressed();
+	void _caption_maximize_pressed();
 
 	Size2i _clamp_limit_size(const Size2i &p_limit_size);
 	Size2i _clamp_window_size(const Size2i &p_size);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -50,6 +50,7 @@
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/gui/caption_button_overlay.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
@@ -474,6 +475,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Control);
 	GDREGISTER_VIRTUAL_CLASS(BaseButton);
 	GDREGISTER_CLASS(Button);
+	GDREGISTER_INTERNAL_CLASS(CaptionButtonOverlay);
 	GDREGISTER_CLASS(Label);
 	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -50,7 +50,6 @@
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
-#include "scene/gui/caption_button_overlay.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
@@ -475,7 +474,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Control);
 	GDREGISTER_VIRTUAL_CLASS(BaseButton);
 	GDREGISTER_CLASS(Button);
-	GDREGISTER_INTERNAL_CLASS(CaptionButtonOverlay);
 	GDREGISTER_CLASS(Label);
 	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -50,6 +50,7 @@
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/gui/caption_button_overlay.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
@@ -485,6 +486,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Control);
 	GDREGISTER_VIRTUAL_CLASS(BaseButton);
 	GDREGISTER_CLASS(Button);
+	GDREGISTER_INTERNAL_CLASS(CaptionButtonOverlay);
 	GDREGISTER_CLASS(Label);
 	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -50,7 +50,6 @@
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
-#include "scene/gui/caption_button_overlay.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
@@ -486,7 +485,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Control);
 	GDREGISTER_VIRTUAL_CLASS(BaseButton);
 	GDREGISTER_CLASS(Button);
-	GDREGISTER_INTERNAL_CLASS(CaptionButtonOverlay);
 	GDREGISTER_CLASS(Label);
 	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);

--- a/servers/display/display_server_enums.h
+++ b/servers/display/display_server_enums.h
@@ -246,6 +246,8 @@ enum WindowEvent {
 	WINDOW_EVENT_TITLEBAR_CHANGE,
 	WINDOW_EVENT_FORCE_CLOSE,
 	WINDOW_EVENT_OUTPUT_MAX_LINEAR_VALUE_CHANGED,
+	// Internal event used to update engine-drawn caption buttons without emitting a public event
+	WINDOW_EVENT_CAPTION_BUTTONS_CHANGE,
 };
 
 enum WindowResizeEdge {

--- a/servers/display/display_server_enums.h
+++ b/servers/display/display_server_enums.h
@@ -256,6 +256,8 @@ enum WindowEvent {
 	WINDOW_EVENT_TITLEBAR_CHANGE,
 	WINDOW_EVENT_FORCE_CLOSE,
 	WINDOW_EVENT_OUTPUT_MAX_LINEAR_VALUE_CHANGED,
+	// Internal event used to update engine-drawn caption buttons without emitting a public event
+	WINDOW_EVENT_CAPTION_BUTTONS_CHANGE,
 };
 
 enum WindowResizeEdge {


### PR DESCRIPTION
#### Summary

Implements `extend_to_title` on Windows, for Vulkan, D3D12 and OpenGL3_Angle.
OpenGL3 doesn't support drawing to a full client area window, so is feature flagged off.
This is only support for Windows in this PR. I plan to implement Linux support in a further PR.

#### Motivation
Closes https://github.com/godotengine/godot-proposals/issues/4846
Other similar unmerged PRs: https://github.com/godotengine/godot/pull/96310, https://github.com/godotengine/godot/pull/117086

#### Demos
Running project:

https://github.com/user-attachments/assets/c612f8a3-0b1a-4aa9-aab0-7f0724c11f94

Godot Project Manager:

<img width="1327" height="1013" alt="image" src="https://github.com/user-attachments/assets/dc4f91c7-72b7-48ce-bc08-7a524cc1d7d8" />

###

Godot Editor:

<img width="1747" height="1125" alt="image" src="https://github.com/user-attachments/assets/019bdf21-0172-41d5-b789-d24e235f13cb" />

### 

at 200% Windows Scaling: (Ignore the rest of UI being too small - my app is not auto DPI aware)

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/54cd0780-34dc-4bc0-8963-050d90ebc0d4" />

### 

Note that if you are attempting to test this with the godot project manager, you will need to run it with `--rendering-driver vulkan` or d3d12 or opengl3-angle, as the projet manager defaults to the compatibility renderer, which uses opengl3 by default.


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
