### PR TITLE
Fix Jolt integration not converting planes correctly

### DIFF
--- a/modules/jolt_physics/misc/jolt_type_conversions.h
+++ b/modules/jolt_physics/misc/jolt_type_conversions.h
@@ -125,7 +125,7 @@ _FORCE_INLINE_ JPH::AABox to_jolt(const AABB &p_aabb) {
 }
 
 _FORCE_INLINE_ JPH::Plane to_jolt(const Plane &p_plane) {
-	return JPH::Plane(to_jolt(p_plane.normal), (float)p_plane.d);
+	return JPH::Plane(to_jolt(p_plane.normal), (float)-p_plane.d);
 }
 
 _FORCE_INLINE_ JPH::RVec3 to_jolt_r(const Vector3 &p_vec) {


### PR DESCRIPTION
Fixes #118923.

It seems the conversion of Godot's `Plane` to Jolt's `JPH::Plane`, and `WorldBoundaryShape3D` as a result, was incorrectly implemented by me, as Godot expresses its planes as:

https://github.com/godotengine/godot/blob/6d6e822c689acb54bf86e19cc2bbbe3fa567b123/doc/classes/Plane.xml#L154-L157

... whereas Jolt expresses it as:

https://github.com/godotengine/godot/blob/6d6e822c689acb54bf86e19cc2bbbe3fa567b123/thirdparty/jolt_physics/Jolt/Geometry/Plane.h#L9-L10

... resulting in the plane distance effectively being negated when using Jolt.

This fixes that by negating said negation, which is a breaking change.