### PR TITLE
Prevent error message when try to get blend point name at first time

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -556,8 +556,8 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_
 	}
 
 	// Special case for discrete carry.
-	AnimationNodeInstance *instance_current_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(cur_closest));
 	if (new_closest != cur_closest && new_closest != -1 && cur_closest != -1 && blend_mode == BLEND_MODE_DISCRETE_CARRY && sync_mode < SYNC_MODE_CYCLIC_MUTABLE) {
+		AnimationNodeInstance *instance_current_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(cur_closest));
 		AnimationNodeInstance *instance_new_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(new_closest));
 		NodeTimeInfo from;
 		// For ping-pong loop.


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/118943

## Issue Description

When we try get blend point name at first time, the `cur_closest` is `-1`. So the assertion will report an error message.

https://github.com/godotengine/godot/blob/6d6e822c689acb54bf86e19cc2bbbe3fa567b123/scene/animation/animation_blend_space_1d.cpp#L231-L235

It won't break the flow, as `get_child_instance_by_path_or_null()` can handle the `null` situation.

https://github.com/godotengine/godot/blob/6d6e822c689acb54bf86e19cc2bbbe3fa567b123/scene/animation/animation_blend_space_1d.cpp#L559

## Solution

Checking `cur_closest` to consider whether calling `get_blend_point_name()`, then we can prevent the error message.