### PR TITLE
Remove various icons from scene tree context menu

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3917,7 +3917,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Add")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
 		}
-		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Collapse")), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
+		menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
 
 		existing_script = selected->get_script();
 
@@ -3990,12 +3990,12 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			}
 
 			if (existing_script.is_valid() && !existing_script->is_built_in()) {
-				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ScriptExtend")), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
+				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
 			}
 		}
 		if (existing_script.is_valid() && existing_script_removable) {
 			BEGIN_SECTION()
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ScriptRemove")), ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
+			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/detach_script"), TOOL_DETACH_SCRIPT);
 		} else if (full_selection.size() > 1) {
 			bool script_exists = false;
 			for (Node *E : full_selection) {
@@ -4020,19 +4020,19 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
 			}
 			if (can_replace) {
-				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Reload")), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_CHANGE_TYPE);
+				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_CHANGE_TYPE);
 			}
 			END_SECTION()
 		}
 
 		if (scene_tree->get_selected() != edited_scene) {
 			BEGIN_SECTION()
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveUp")), ED_GET_SHORTCUT("scene_tree/move_up"), TOOL_MOVE_UP);
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveDown")), ED_GET_SHORTCUT("scene_tree/move_down"), TOOL_MOVE_DOWN);
+			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/move_up"), TOOL_MOVE_UP);
+			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/move_down"), TOOL_MOVE_DOWN);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Reparent")), ED_GET_SHORTCUT("scene_tree/reparent"), TOOL_REPARENT);
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ReparentToNewNode")), ED_GET_SHORTCUT("scene_tree/reparent_to_new_node"), TOOL_REPARENT_TO_NEW_NODE);
+			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/reparent_to_new_node"), TOOL_REPARENT_TO_NEW_NODE);
 			if (selection.size() == 1) {
-				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("NewRoot")), ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
+				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/make_root"), TOOL_MAKE_ROOT);
 			}
 			END_SECTION()
 		}
@@ -4081,7 +4081,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (selection.size() == 1) {
 		if (full_selection.size() == 1) {
 			BEGIN_SECTION()
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("CopyNodePath")), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
+			menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
 			END_SECTION()
 		}
 	}
@@ -4117,11 +4117,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	BEGIN_SECTION()
 	// Group "open_in_editor" with "show_in_file_system", if it is available.
 	if (is_tool_scene_open_inherited_available) {
-		menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open in Editor"), TOOL_SCENE_OPEN_INHERITED);
-		menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/open_scene_in_editor"));
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Load")), ED_GET_SHORTCUT("scene_tree/open_inherited_scene_in_editor"), TOOL_SCENE_OPEN_INHERITED);
 	} else if (is_tool_scene_open_available) {
-		menu->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open in Editor"), TOOL_SCENE_OPEN);
-		menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/open_scene_in_editor"));
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Load")), ED_GET_SHORTCUT("scene_tree/open_scene_in_editor"), TOOL_SCENE_OPEN);
 	}
 
 	if (full_selection.size() == 1 && selection.front()->get()->is_instance()) {


### PR DESCRIPTION
Yo whaaat, look at me touching C++ files!!!! Genuinely my first time. Be gentle!

Anyway, it is my opinion that only features that are used often & emphasize 'the godot way' get icons so that, from a usability perspective, it is easier for users to spot common operations. I've been reviewing a few PRs where icons are added and / or removed, and was really bothered by the scene tree's context menu in particular. And so I dared to enter C++ land to make this PR!

| **Before** | **After** |
|--------|--------|
| <img width="494" height="643" alt="Screenshot 2026-04-25 at 14 12 35" src="https://github.com/user-attachments/assets/3052b866-0c78-4855-bff6-d61e959dc2a2" /> | <img width="497" height="640" alt="Screenshot 2026-04-25 at 14 11 20" src="https://github.com/user-attachments/assets/f67a356f-c5c7-4137-b791-d01fcd4e1c1c" /> |
| <img width="486" height="551" alt="Screenshot 2026-04-25 at 14 12 43" src="https://github.com/user-attachments/assets/dd5047d6-f1d5-44f2-b171-255b6917a5a7" /> | <img width="494" height="549" alt="Screenshot 2026-04-25 at 14 11 35" src="https://github.com/user-attachments/assets/66bee5e7-8c2c-4ab8-b5cc-85eec5e9c9d7" /> |

Open to feedback! Maybe I removed one icon too many? Should more icons go? Leave a comment.


