### PR TITLE
[macOS] Align menu items between separators.

### DIFF
--- a/platform/macos/godot_menu_item.h
+++ b/platform/macos/godot_menu_item.h
@@ -60,6 +60,7 @@ enum GlobalMenuCheckType {
 	bool enabled;
 	int max_states;
 	int state;
+	int indent;
 	Ref<Image> img;
 }
 

--- a/platform/macos/godot_menu_item.mm
+++ b/platform/macos/godot_menu_item.mm
@@ -42,6 +42,7 @@
 	self->checked = false;
 	self->max_states = 0;
 	self->state = 0;
+	self->indent = 0;
 	self->accel = Key::NONE;
 
 	return self;

--- a/platform/macos/native_menu_macos.h
+++ b/platform/macos/native_menu_macos.h
@@ -64,6 +64,8 @@ class NativeMenuMacOS : public NativeMenu {
 	RID help_menu;
 	RID dock_menu;
 
+	void _update_align(MenuData *p_md);
+
 	int _get_system_menu_start(const NSMenu *p_menu) const;
 	int _get_system_menu_count(const NSMenu *p_menu) const;
 	bool _is_menu_opened(NSMenu *p_menu) const;

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -196,6 +196,43 @@ int NativeMenuMacOS::_get_system_menu_count(const NSMenu *p_menu) const {
 	return [p_menu numberOfItems];
 }
 
+void NativeMenuMacOS::_update_align(MenuData *p_md) {
+	int item_start = _get_system_menu_start(p_md->menu);
+	int item_count = _get_system_menu_count(p_md->menu);
+
+	int block_start = item_start;
+	bool has_icon = false;
+	for (int i = item_start; i <= item_start + item_count; i++) {
+		bool end_block = false;
+		if (i < item_start + item_count) {
+			NSMenuItem *menu_item = [p_md->menu itemAtIndex:i];
+			if (!menu_item) {
+				continue;
+			}
+			const GodotMenuItem *obj = [menu_item representedObject];
+			if (obj) {
+				has_icon = has_icon || obj->img.is_valid();
+			}
+			end_block = [menu_item isSeparatorItem];
+		} else {
+			end_block = true;
+		}
+		if (end_block) {
+			for (int j = block_start; j < i; j++) {
+				NSMenuItem *menu_item_b = [p_md->menu itemAtIndex:j];
+				const GodotMenuItem *obj = [menu_item_b representedObject];
+				if (has_icon && obj && !obj->img.is_valid()) {
+					[menu_item_b setIndentationLevel:obj->indent + 2];
+				} else {
+					[menu_item_b setIndentationLevel:obj->indent];
+				}
+			}
+			block_start = i + 1;
+			has_icon = false;
+		}
+	}
+}
+
 bool NativeMenuMacOS::has_feature(Feature p_feature) const {
 	switch (p_feature) {
 		case FEATURE_GLOBAL_MENU:
@@ -423,6 +460,7 @@ int NativeMenuMacOS::add_submenu_item(const RID &p_rid, const String &p_label, c
 
 	[md_sub->menu setTitle:[NSString stringWithUTF8String:p_label.utf8().get_data()]];
 	[md->menu setSubmenu:md_sub->menu forItem:menu_item];
+	_update_align(md);
 
 	return p_index - item_start;
 }
@@ -460,6 +498,7 @@ int NativeMenuMacOS::add_item(const RID &p_rid, const String &p_label, const Cal
 		obj->accel = p_accel;
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -479,6 +518,7 @@ int NativeMenuMacOS::add_check_item(const RID &p_rid, const String &p_label, con
 		obj->accel = p_accel;
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -508,6 +548,7 @@ int NativeMenuMacOS::add_icon_item(const RID &p_rid, const Ref<Texture2D> &p_ico
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -538,6 +579,7 @@ int NativeMenuMacOS::add_icon_check_item(const RID &p_rid, const Ref<Texture2D> 
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -557,6 +599,7 @@ int NativeMenuMacOS::add_radio_check_item(const RID &p_rid, const String &p_labe
 		obj->accel = p_accel;
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -587,6 +630,7 @@ int NativeMenuMacOS::add_icon_radio_check_item(const RID &p_rid, const Ref<Textu
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -607,6 +651,7 @@ int NativeMenuMacOS::add_multistate_item(const RID &p_rid, const String &p_label
 		obj->accel = p_accel;
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
+		_update_align(md);
 	}
 	return out;
 }
@@ -627,6 +672,7 @@ int NativeMenuMacOS::add_separator(const RID &p_rid, int p_index) {
 		p_index = CLAMP(p_index, item_start, item_start + item_count);
 	}
 	[md->menu insertItem:[NSMenuItem separatorItem] atIndex:p_index];
+	_update_align(md);
 	return p_index - item_start;
 }
 
@@ -1302,6 +1348,7 @@ void NativeMenuMacOS::set_item_icon(const RID &p_rid, int p_idx, const Ref<Textu
 			obj->img = Ref<Image>();
 			[menu_item setImage:nil];
 		}
+		_update_align(md);
 	}
 }
 
@@ -1316,7 +1363,11 @@ void NativeMenuMacOS::set_item_indentation_level(const RID &p_rid, int p_idx, in
 	ERR_FAIL_COND(p_idx >= item_start + item_count);
 	NSMenuItem *menu_item = [md->menu itemAtIndex:p_idx];
 	if (menu_item) {
-		[menu_item setIndentationLevel:p_level];
+		GodotMenuItem *obj = [menu_item representedObject];
+		if (obj) {
+			obj->indent = p_level;
+			_update_align(md);
+		}
 	}
 }
 
@@ -1372,6 +1423,7 @@ void NativeMenuMacOS::remove_item(const RID &p_rid, int p_idx) {
 		return;
 	}
 	[md->menu removeItemAtIndex:p_idx];
+	_update_align(md);
 }
 
 void NativeMenuMacOS::clear(const RID &p_rid) {


### PR DESCRIPTION
Mostly relevant in combination with https://github.com/godotengine/godot/pull/65229, alternative version https://github.com/godotengine/godot/pull/119810

| Before | After |
|--|--|
| <img width="393" height="515" alt="Screenshot 2026-04-25 at 16 55 24" src="https://github.com/user-attachments/assets/659efb0e-590b-48b5-a5f0-e725764b70e9" /> | <img width="391" height="515" alt="Screenshot 2026-04-25 at 16 50 40" src="https://github.com/user-attachments/assets/1355105d-e270-4267-9ffa-2b35caf3e266" /> |

Built-in Godot menus align everything to an icon, but aligning only items between separators matches the way default macOS app handle it:
<img width="384" height="417" alt="Screenshot 2026-04-25 at 16 51 44" src="https://github.com/user-attachments/assets/89bd5dfb-911e-4e54-b1db-ec8d108c8ee6" />
