### PR TITLE
Improve 'Clear Output' button position

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -47,7 +47,6 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/flow_container.h"
-#include "scene/gui/separator.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"
 #include "servers/display/display_server.h"
@@ -110,7 +109,7 @@ void EditorLog::_update_theme() {
 	log->add_theme_font_size_override("mono_font_size", font_size);
 	log->end_bulk_theme_override();
 
-	const String wide_text = "MMM";
+	const String wide_text = "MM";
 
 	Button *button = type_filter_map[MSG_TYPE_STD]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Popup")));
@@ -513,46 +512,40 @@ EditorLog::EditorLog() {
 	vb_left->add_child(log);
 
 	HFlowContainer *bottom_hf = memnew(HFlowContainer);
+	bottom_hf->set_alignment(FlowContainer::ALIGNMENT_END);
 	vb_left->add_child(bottom_hf);
-
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	bottom_hf->add_child(hbox);
-
-	// Search box
-	search_box = memnew(LineEdit);
-	search_box->set_custom_minimum_size(Vector2(200 * EDSCALE, 0));
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	search_box->set_placeholder(TTRC("Filter Messages"));
-	search_box->set_accessibility_name(TTRC("Filter Messages"));
-	search_box->set_clear_button_enabled(true);
-	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
-	hbox->add_child(search_box);
 
 	// Clear.
 	clear_button = memnew(Button);
 	clear_button->set_accessibility_name(TTRC("Clear Log"));
-	clear_button->set_theme_type_variation(SceneStringName(FlatButton));
+	clear_button->set_theme_type_variation("BottomPanelButton");
 	clear_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTRC("Clear Output"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::K));
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorLog::_clear_request));
-	hbox->add_child(clear_button);
-
-	// Separate toggle buttons from normal buttons.
-	hbox->add_child(memnew(VSeparator));
-
-	hbox = memnew(HBoxContainer);
-	bottom_hf->add_child(hbox);
+	bottom_hf->add_child(clear_button);
 
 	// Collapse.
 	collapse_button = memnew(Button);
-	collapse_button->set_theme_type_variation(SceneStringName(FlatButton));
+	collapse_button->set_theme_type_variation("BottomPanelButton");
 	collapse_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	collapse_button->set_tooltip_text(TTR("Collapse duplicate messages into one log entry. Shows number of occurrences."));
 	collapse_button->set_toggle_mode(true);
 	collapse_button->set_pressed(false);
 	collapse_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_collapse));
-	hbox->add_child(collapse_button);
+	bottom_hf->add_child(collapse_button);
+
+	// Search box
+	search_box = memnew(LineEdit);
+	search_box->set_custom_minimum_size(Vector2(150 * EDSCALE, 0));
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_placeholder(TTRC("Filter Messages"));
+	search_box->set_accessibility_name(TTRC("Filter Messages"));
+	search_box->set_clear_button_enabled(true);
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
+	bottom_hf->add_child(search_box);
+
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	bottom_hf->add_child(hbox);
 
 	// Message Type Filters.
 	LogFilter *std_filter = memnew(LogFilter(MSG_TYPE_STD));


### PR DESCRIPTION
With https://github.com/godotengine/godot/pull/112690, the output panel's buttons were changed to show horizontally, looking cleaner and better. However, one complaint was that this change would mess with people's muscle memory to find the Clear button, which is arguably the most used button in that container. That complaint was met (also by me) with "we'll just have to get used to it" and the PR was merged.

Having played with the dev and beta version a bit, and having resized the editor docks a fair amount playing with various layouts, it does bother me more than I thought it would that the button "moves" and isn't stuck to a corner. 

| Clear button position (master) | Screenshot |
|--------|--------|
| The minimum-sized output dock positions it all the way to the right because the `HFlowContainer` wraps the rest of the buttons to the next lines: | <img width="625" height="272" alt="Screenshot 2026-04-25 at 16 17 39" src="https://github.com/user-attachments/assets/178145cf-df96-4b6f-8a5b-e046fb6af1b5" /> |
| A slightly larger output dock moves the button closer to the left than the right: | <img width="694" height="273" alt="Screenshot 2026-04-25 at 16 17 45" src="https://github.com/user-attachments/assets/99c4e0e9-a6a0-41bf-a53b-fb4fd8b9d0ff" /> |
| A wide output dock positions it closer to the right: | <img width="1232" height="273" alt="Screenshot 2026-04-25 at 16 17 52" src="https://github.com/user-attachments/assets/e1296208-8f1d-40d4-a2f8-a9eb5e76fd9c" /> | 

In conclusion, one can't grow any muscle memory for the button any longer. This PR attempts to fix that.

----

My first attempt to address this was to put the two buttons to the right. With this first attempt, the gestalt of the two buttons merges with the buttons below it, making a 2x2 grid of buttons, and... it's perhaps a bit awkward? Also, the Collapse and Expand Bottom Panel button icons look somewhat similar, which may pose a problem. So I concluded that perhaps we should move the clear button to the left instead? It doesn't look as sexy (in my opinion), but the button will always be on the left this way and will allow for muscle memory to grow again.

| Clear button position (this PR) | Screenshot |
|--------|--------|
| First iteration: right | <img width="624" height="274" alt="Screenshot 2026-04-25 at 15 56 45" src="https://github.com/user-attachments/assets/7ba2e804-1c71-4eea-b1cd-65ae2c8801c8" /> |
| Second iteration: left | <img width="625" height="274" alt="Screenshot 2026-04-25 at 15 59 29" src="https://github.com/user-attachments/assets/26a46e46-59ce-4aa0-9678-193ef43ad351" /> | 
| Third iteration: left (current state of this PR) | <img width="619" height="268" alt="Screenshot 2026-04-25 at 17 56 22" src="https://github.com/user-attachments/assets/570790d0-2726-40ff-bc59-0c59ec949dd5" /> | 

A few other small changes this PR does to improve the new output dock layout ever so slightly:
- applies the same theme variant to the clear and collapse buttons as the pin and keep open buttons in the bar below it.
- reduces the minimum size of the filter text field from 200 to 150 so that in theory the HFlowContainer never has to break the bar into two rows. I tried it with a few common languages and the text never seems to get cut off.
- reduces the minimum size of the output filter buttons from "MMM" to "MM".