### PR TITLE
Fix updating of closed script files

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -37,6 +37,7 @@
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
@@ -1125,6 +1126,14 @@ void FindInFilesPanel::_apply_replaces_in_file(const String &p_fpath, const Vect
 		Error err = f->reopen(p_fpath, FileAccess::WRITE);
 		ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + p_fpath + "'.");
 		f->store_string(final_text);
+		f->close();
+
+		Ref<Resource> res = ResourceCache::get_ref(p_fpath);
+		if (res.is_valid()) {
+			res->reload_from_file();
+		}
+
+		EditorFileSystem::get_singleton()->update_file(p_fpath);
 	}
 }
 


### PR DESCRIPTION
- Supersedes https://github.com/godotengine/godot/pull/114430
- Fixes https://github.com/godotengine/godot/issues/108960

Rebased version with my suggestions on top of mentioned PR (looks like @Kn1feKillz has been not available for several months).
I think this issue is quite critical (because users can _lose their changes and break files_ if they don't use VCS), especially when refactoring code, so no need to wait if we already have a properly working fix. 
Would be lovely to get it in next dev build!
