### PR TITLE
Remove redundant `ClearData` struct from `GDScript`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -41,6 +41,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/templates/rb_set.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -36,7 +36,6 @@
 #include "core/debugger/script_debugger.h"
 #include "core/doc_data.h"
 #include "core/object/script_language.h"
-#include "core/templates/rb_set.h"
 
 class GDScriptNativeClass : public RefCounted {
 	GDCLASS(GDScriptNativeClass, RefCounted);
@@ -68,15 +67,6 @@ class GDScript : public Script {
 		StringName getter;
 		GDScriptDataType data_type;
 		PropertyInfo property_info;
-	};
-
-	struct ClearData {
-		RBSet<GDScriptFunction *> functions;
-		RBSet<Ref<Script>> scripts;
-		void clear() {
-			functions.clear();
-			scripts.clear();
-		}
 	};
 
 	friend class GDScriptInstance;

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -37,6 +37,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/templates/rb_set.h"
 #include "core/templates/vector.h"
 
 GDScriptParserRef::Status GDScriptParserRef::get_status() const {


### PR DESCRIPTION
It was introduced in #71028, but its entire purpose was later removed in #114801, which likely missed this. It's not used anywhere and there's no `ClearData` in the codebase other than this sole definition.

The inclusion of `rb_set.h` gets moved from `gdscript.h` to `gdscript.cpp` and `gdscript_cache.cpp`, to make `clangd-tidy` happy.