### PR TITLE
Prevent `textureQueryLod` function from usage in vertex shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3588,6 +3588,7 @@ const ShaderLanguage::BuiltinEntry ShaderLanguage::frag_only_func_defs[] = {
 	{ "fwidth" },
 	{ "fwidthCoarse" },
 	{ "fwidthFine" },
+	{ "textureQueryLod" },
 	{ nullptr }
 };
 


### PR DESCRIPTION
This function leads to editor freeze when used in vertex shader function.

<img width="1666" height="204" alt="изображение" src="https://github.com/user-attachments/assets/3b91728d-a5e5-4dad-9502-82d6fca073c6" />
