### PR TITLE
Fix `get_version()` fallback for Android

### DIFF
--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -600,10 +600,14 @@ String EditorExportPreset::get_version(const StringName &p_preset_string, bool p
 		// Split and validate version number components.
 		const PackedStringArray result_split = result.split(".", false);
 		bool valid_version = !result_split.is_empty();
-		for (const String &E : result_split) {
-			if (!_check_digits(E)) {
-				valid_version = false;
-				break;
+
+		// Android supports non-numeric characters for version name.
+		if (!platform->is_class("EditorExportPlatformAndroid")) {
+			for (const String &E : result_split) {
+				if (!_check_digits(E)) {
+					valid_version = false;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently, if the version name is left empty in export preset, `preset->get_version("version/name")` falls back to `application/config/version` from Project Settings. However, the existing fallback logic only allows numeric char; otherwise, it defaults to 1.0.0.

This PR fixes the `get_version(...)` logic to not check for numeric char for Android because it allows non-numeric char in version names.