### PR TITLE
Allow selecting the interface for Multicast in `PacketPeerUDP`

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -117,6 +117,7 @@ public:
 	virtual void set_reuse_address_enabled(bool p_enabled) = 0;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
+	virtual Error set_multicast_send_interface(const String &p_if_name) = 0;
 
 	virtual ~NetSocket() {}
 };

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -68,6 +68,25 @@ Error PacketPeerUDP::leave_multicast_group(IPAddress p_multi_address, const Stri
 	return _sock->leave_multicast_group(p_multi_address, p_if_name);
 }
 
+Error PacketPeerUDP::set_multicast_send_interface(const String &p_if_name) {
+	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
+	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V(p_if_name.is_empty(), ERR_INVALID_PARAMETER);
+
+	if (!_sock->is_open()) {
+		IP::Type ip_type = IP::TYPE_ANY;
+		if (peer_addr.is_valid()) {
+			ip_type = peer_addr.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
+		}
+		Error open_err = _sock->open(NetSocket::Family::INET, NetSocket::TYPE_UDP, ip_type);
+		ERR_FAIL_COND_V_MSG(open_err != OK, ERR_CANT_CREATE, "Failed to open a new socket.");
+		_sock->set_blocking_enabled(false);
+		_sock->set_broadcasting_enabled(broadcast);
+	}
+
+	return _sock->set_multicast_send_interface(p_if_name);
+}
+
 String PacketPeerUDP::_get_packet_ip() const {
 	return String(get_packet_address());
 }
@@ -373,6 +392,7 @@ void PacketPeerUDP::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_broadcast_enabled", "enabled"), &PacketPeerUDP::set_broadcast_enabled);
 	ClassDB::bind_method(D_METHOD("join_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::join_multicast_group);
 	ClassDB::bind_method(D_METHOD("leave_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::leave_multicast_group);
+	ClassDB::bind_method(D_METHOD("set_multicast_send_interface", "interface_name"), &PacketPeerUDP::set_multicast_send_interface);
 }
 
 PacketPeerUDP::PacketPeerUDP() :

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -92,6 +92,7 @@ public:
 	void set_broadcast_enabled(bool p_enabled);
 	Error join_multicast_group(IPAddress p_multi_address, const String &p_if_name);
 	Error leave_multicast_group(IPAddress p_multi_address, const String &p_if_name);
+	Error set_multicast_send_interface(const String &p_if_name);
 
 	PacketPeerUDP();
 	~PacketPeerUDP();

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -127,6 +127,14 @@
 				[b]Note:[/b] [method set_broadcast_enabled] must be enabled before sending packets to a broadcast address (e.g. [code]255.255.255.255[/code]).
 			</description>
 		</method>
+		<method name="set_multicast_send_interface">
+			<return type="int" enum="Error" />
+			<param index="0" name="interface_name" type="String" />
+			<description>
+				Selects the interface that will be used to send multicast packets.
+				To get a list of available interfaces, use [method IP.get_local_interfaces].
+			</description>
+		</method>
 		<method name="wait">
 			<return type="int" enum="Error" />
 			<description>

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -853,4 +853,48 @@ Error NetSocketUnix::leave_multicast_group(const IPAddress &p_multi_address, con
 	return _change_multicast_group(p_multi_address, p_if_name, false);
 }
 
+Error NetSocketUnix::set_multicast_send_interface(const String &p_if_name) {
+	ERR_FAIL_COND_V(!is_open(), ERR_UNCONFIGURED);
+
+	HashMap<String, IP::Interface_Info> if_info_list;
+	IP::get_singleton()->get_local_interfaces(&if_info_list);
+
+	const IP::Interface_Info *match = nullptr;
+	for (const KeyValue<String, IP::Interface_Info> &E : if_info_list) {
+		if (E.value.name == p_if_name) {
+			match = &E.value;
+			break;
+		}
+	}
+	ERR_FAIL_NULL_V_MSG(match, ERR_INVALID_PARAMETER, vformat("Network interface %s not found.", p_if_name));
+
+	bool ipv6_success = true; // Using this variable allows attempting IPv4 even if this fails
+	if ((_ip_type == IP::TYPE_IPV6) || (_ip_type == IP::TYPE_ANY)) {
+		const int if_index = match->index.to_int();
+		if (setsockopt(_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &if_index, sizeof(if_index)) != 0) {
+			ERR_PRINT("Unable to set IPV6_MULTICAST_IF option.");
+			ipv6_success = false;
+		}
+	}
+
+	if ((_ip_type == IP::TYPE_IPV4) || (_ip_type == IP::TYPE_ANY)) {
+		IPAddress ipv4;
+		for (const IPAddress &ip : match->ip_addresses) {
+			if (ip.is_ipv4()) {
+				ipv4 = ip;
+				break;
+			}
+		}
+		ERR_FAIL_COND_V_MSG(!ipv4.is_valid(), FAILED, vformat("Unable to find the corresponding IPv4 address for interface %s.", p_if_name));
+
+		struct in_addr addr; // in_addr is 4 bytes (uint32_t)
+		memcpy(&addr.s_addr, ipv4.get_ipv4(), sizeof(addr.s_addr));
+		ERR_FAIL_COND_V_MSG(
+				setsockopt(_sock, IPPROTO_IP, IP_MULTICAST_IF, &addr, sizeof(addr)) != 0,
+				FAILED, "Unable to set IP_MULTICAST_IF option.");
+	}
+
+	return ipv6_success ? OK : FAILED;
+}
+
 #endif // UNIX_ENABLED && !UNIX_SOCKET_UNAVAILABLE

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -111,6 +111,7 @@ public:
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
+	virtual Error set_multicast_send_interface(const String &p_if_name) override;
 
 	NetSocketUnix();
 	~NetSocketUnix() override;

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -621,4 +621,38 @@ Error NetSocketWinSock::leave_multicast_group(const IPAddress &p_multi_address, 
 	return _change_multicast_group(p_multi_address, p_if_name, false);
 }
 
+Error NetSocketWinSock::set_multicast_send_interface(const String &p_if_name) {
+	ERR_FAIL_COND_V(!is_open(), ERR_UNCONFIGURED);
+
+	HashMap<String, IP::Interface_Info> if_info_list;
+	IP::get_singleton()->get_local_interfaces(&if_info_list);
+
+	const IP::Interface_Info *match = nullptr;
+	for (const KeyValue<String, IP::Interface_Info> &E : if_info_list) {
+		if (E.value.name == p_if_name) {
+			match = &E.value;
+			break;
+		}
+	}
+	ERR_FAIL_NULL_V_MSG(match, ERR_INVALID_PARAMETER, vformat("Network interface %s not found.", p_if_name));
+
+	bool ipv6_success = true; // Using this variable allows attempting IPv4 even if this fails
+	if (_ip_type == IP::TYPE_IPV6 || _ip_type == IP::TYPE_ANY) {
+		DWORD if_index = (DWORD)match->index.to_int();
+		if (setsockopt(_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char *)&if_index, sizeof(if_index)) != 0) {
+			ERR_PRINT("Unable to set IPV6_MULTICAST_IF option.");
+			ipv6_success = false;
+		}
+	}
+
+	if (_ip_type == IP::TYPE_IPV4 || _ip_type == IP::TYPE_ANY) {
+		DWORD if_index = htonl((u_long)match->index.to_int());
+		ERR_FAIL_COND_V_MSG(
+				setsockopt(_sock, IPPROTO_IP, IP_MULTICAST_IF, (const char *)&if_index, sizeof(if_index)) != 0,
+				FAILED, "Unable to set IP_MULTICAST_IF option.");
+	}
+
+	return ipv6_success ? OK : FAILED;
+}
+
 #endif // WINDOWS_ENABLED

--- a/drivers/windows/net_socket_winsock.h
+++ b/drivers/windows/net_socket_winsock.h
@@ -93,6 +93,7 @@ public:
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
+	virtual Error set_multicast_send_interface(const String &p_if_name) override;
 
 	NetSocketWinSock();
 	~NetSocketWinSock() override;

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -70,4 +70,5 @@ public:
 	virtual void set_reuse_address_enabled(bool p_enabled) override {}
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
+	virtual Error set_multicast_send_interface(const String &p_if_name) override { return ERR_UNAVAILABLE; }
 };

--- a/tests/core/io/test_stream_peer_tcp.cpp
+++ b/tests/core/io/test_stream_peer_tcp.cpp
@@ -67,6 +67,7 @@ public:
 	virtual void set_reuse_address_enabled(bool p_enabled) override;
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
+	virtual Error set_multicast_send_interface(const String &p_if_name) override;
 
 	Address host_addr;
 	Address dest_ip;
@@ -204,6 +205,10 @@ Error MockNetSocket::join_multicast_group(const IPAddress &p_multi_address, cons
 }
 
 Error MockNetSocket::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
+	return OK;
+}
+
+Error MockNetSocket::set_multicast_send_interface(const String &p_if_name) {
 	return OK;
 }
 


### PR DESCRIPTION
### Summary of changes
Added the function `set_multicast_send_interface(if_name)` to `PacketPeerUDP` and `NetSocket`.
This allows controlling the interface, through which a packet is sent to a multicast address.
Before, the OS would choose an interface, so that the packet can reach it, but since it is a multicast address, it would choose a random one (so for example localhost or dummy0), which is useless, because the address can be reached using any interface.
Internally, this sets `IPV6_MULTICAST_IF` and/or `IP_MULTICAST_IF` using `setsockopt(...)`.

### Example usage
This allows sending packets to multicast addresses using all interfaces:
<img width="771" height="661" alt="image" src="https://github.com/user-attachments/assets/5fe6194d-b878-4c0d-a573-cca0f440a1d4" />

### Motivation
This is an implementation of https://github.com/godotengine/godot-proposals/issues/3109
Also, I myself have had the same problem with multicast, so I decided to fix it.
Without this, functions like `join_mutlicast_group` in Godot are a bit (or a lot) useless, because the interface choices by the OS aren't consistent.

### Technical overview
The user calls set_mutlicast_send_interface(interface_name) on the PacketPeerUDP, which will pass the argument to the underlaying NetSocket. Each platform group (Unix, Windows), then defines that function in its own way, but the main priciple is the same:
If the socket ip_type covers IPv6, we find the interface index and call `setsockopt(_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, ...)` with it.
If the socket ip_type covers IPv4, we find the first IPv4 address in the interface and call `setsockopt(_sock, IPPROTO_IP, IP_MULTICAST_IF, ...)` with it.

### Testing
I have tested it, these connections worked first try (aside from firewall config):
1) Localhost (Almost any interface works locally)
2) Windows - WSL (Linux), using vEthernet (Hyper-V connection)
3) Windows - Windows, using Wi-Fi
4) Windows - Android, using Wi-Fi
5) Android - Android, using Wi-Fi
6) Windows - Ubuntu VM (VMWare Drivers)

### Discussion
I am not sure if it works on iOS and MacOS, so testing with it could be good.

### AI Self Disclosure
The `setsockopt(...)` lines were written by Claude. I made sure that the code makes sense, is readable and actually works, which means that I made changes to it.

EDIT: I have read the documentation for setsockopt parameters, and made changes according to it. It's a bit cleaner and safer now, and I can say that all code in this is written by a human (everything that AI originally wrote isn't in the code).