### PR TITLE
🤖 macOS: Discard OS-injected phantom mouseMoved events that break fullscreen UI clicks

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -524,6 +524,16 @@
 	NSPoint delta = NSMakePoint([event deltaX], [event deltaY]);
 	NSPoint mpos = [event locationInWindow];
 
+	// Workaround for a macOS regression (first observed on macOS 26 / Tahoe): synthetic
+	// mouseMoved events with stale coordinates are injected after every fullscreen mouseDown,
+	// corrupting BaseButton's pressing_inside state. These phantom events always carry
+	// subtype=NSEventSubtypeMouseEvent, deviceID=0, and delta=(0,0).
+	if (wd.fullscreen && [event deviceID] == 0 &&
+			[event subtype] == NSEventSubtypeMouseEvent &&
+			delta.x == 0.0 && delta.y == 0.0) {
+		return;
+	}
+
 	if (ds->update_mouse_wrap(wd, delta, mpos, [event timestamp])) {
 		return;
 	}


### PR DESCRIPTION
## Summary

On **macOS 26 (Tahoe)**, clicking any editor UI button (Run, Stop, 2D/3D/Script tabs, etc.) while the editor is in fullscreen mode silently fails. The button visually reacts to the press but does not activate on release. Keyboard shortcuts for the same actions work fine.

## Root cause

After every real `mouseDown:` in fullscreen, macOS injects one or two synthetic `NSEvent` `mouseMoved:` events with **stale, off-cursor coordinates**. These phantom events reach `BaseButton::gui_input` motion handling, which calls `has_point(position)` on the stale position — evaluating to `false` — and clears `pressing_inside`. On release, the guard `press_attempt && pressing_inside` then fails, so the button never activates.

Instrumentation confirmed that **Godot does not issue any `CGWarpMouseCursorPosition` call** on this code path; the events are purely OS-generated (a macOS Tahoe regression). The phantoms are reliably identified by: `subtype == NSEventSubtypeMouseEvent (0)`, `deviceID == 0`, `delta == (0, 0)`.

## Fix

Discard `mouseMoved:` events matching that signature when the window is in fullscreen mode. A stationary cursor never emits a real `mouseMoved` event, so the guard is safe.

## Testing

- Confirmed bug present on macOS 26 / M1 Max with Godot 4.6-stable and master.
- Confirmed fix resolves Run, Stop, 2D/3D/Script tabs, and ConfirmationDialog buttons in fullscreen.
- Windowed mode unaffected.

> [!INFO] *AI disclosure*: This contribution was authored by an autonomous AI agent (GitHub Copilot), on behalf of the user Gregor Pirolt, who reproduced the bug, guided the investigation, and verified the fix.