### PR TITLE
Improve conditionals across AnimationTree

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -576,12 +576,8 @@ void AnimationNodeBlendSpace1DEditor::_add_animation_type(int p_index) {
 }
 
 void AnimationNodeBlendSpace1DEditor::_tool_switch(int p_tool) {
-	if (p_tool == 0) {
-		tool_erase->show();
-		tool_erase_sep->show();
-	} else {
-		tool_erase->hide();
-		tool_erase_sep->hide();
+	if (p_tool != 0) {
+		_set_selected_point(-1);
 	}
 
 	_update_tool_erase();
@@ -985,14 +981,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_blend->set_tooltip_text(TTR("Set the blending position within the space."));
 	tool_blend->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(2));
 
-	tool_erase_sep = memnew(VSeparator);
-	top_hb->add_child(tool_erase_sep);
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_erase);
-	tool_erase->set_tooltip_text(TTR("Erase points."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
-
 	top_hb->add_child(memnew(VSeparator));
 
 	snap = memnew(Button);
@@ -1073,6 +1061,14 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->set_step(STEP_UNIT);
 	edit_value->set_accessibility_name(TTRC("Blend Value"));
 	edit_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
+
+	edit_hb->add_child(memnew(VSeparator));
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	top_hb->add_child(tool_erase);
+	tool_erase->set_tooltip_text(TTR("Erase points."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
+	tool_erase->set_disabled(true);
 
 	edit_hb->hide();
 	open_editor->hide();

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -421,12 +421,10 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 	min_value->set_value(blend_space->get_min_space());
 
 	sync->select(blend_space->get_sync_mode());
-	sync->set_fit_to_longest_item(false);
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
 	cyclic_length_value->set_visible(blend_space->get_sync_mode() == AnimationNodeBlendSpace1D::SYNC_MODE_CYCLIC_CONSTANT);
 
 	interpolation->select(blend_space->get_blend_mode());
-	interpolation->set_fit_to_longest_item(false);
 
 	label_value->set_text(blend_space->get_value_label());
 
@@ -579,12 +577,8 @@ void AnimationNodeBlendSpace1DEditor::_add_animation_type(int p_index) {
 }
 
 void AnimationNodeBlendSpace1DEditor::_tool_switch(int p_tool) {
-	if (p_tool == 0) {
-		tool_erase->show();
-		tool_erase_sep->show();
-	} else {
-		tool_erase->hide();
-		tool_erase_sep->hide();
+	if (p_tool != 0) {
+		_set_selected_point(-1);
 	}
 
 	_update_tool_erase();
@@ -639,12 +633,12 @@ void AnimationNodeBlendSpace1DEditor::_update_tool_erase() {
 		}
 
 		if (!read_only) {
-			edit_hb->show();
+			selected_hb->show();
 		} else {
-			edit_hb->hide();
+			selected_hb->hide();
 		}
 	} else {
-		edit_hb->hide();
+		selected_hb->hide();
 	}
 }
 
@@ -978,7 +972,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hf->add_child(tool_create);
-	tool_create->set_tooltip_text(TTR("Create points."));
+	tool_create->set_tooltip_text(TTR("Create point."));
 	tool_create->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(1));
 
 	tool_blend = memnew(Button);
@@ -988,14 +982,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hf->add_child(tool_blend);
 	tool_blend->set_tooltip_text(TTR("Set the blending position within the space."));
 	tool_blend->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(2));
-
-	tool_erase_sep = memnew(VSeparator);
-	top_hf->add_child(tool_erase_sep);
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hf->add_child(tool_erase);
-	tool_erase->set_tooltip_text(TTR("Erase points."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
 
 	top_hf->add_child(memnew(VSeparator));
 
@@ -1023,6 +1009,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	sync->add_item(TTR("Independent"));
 	sync->add_item(TTR("Cyclic Mutable"));
 	sync->add_item(TTR("Cyclic Constant"));
+	sync->set_fit_to_longest_item(false);
 	top_hf->add_child(sync);
 	sync->connect(SceneStringName(item_selected), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 
@@ -1041,6 +1028,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	top_hf->add_child(memnew(Label(TTR("Blend"))));
 	interpolation = memnew(OptionButton);
+	interpolation->set_fit_to_longest_item(false);
 	top_hf->add_child(interpolation);
 	interpolation->connect(SceneStringName(item_selected), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 
@@ -1048,21 +1036,22 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_hb->set_h_size_flags(SIZE_EXPAND_FILL);
 	top_hf->add_child(edit_hb);
 
-	Control *top_spacer = memnew(Control);
-	top_spacer->set_h_size_flags(SIZE_EXPAND_FILL);
-	edit_hb->add_child(top_spacer);
+	edit_hb->add_spacer();
+
+	selected_hb = memnew(HBoxContainer);
+	edit_hb->add_child(selected_hb);
 
 	open_editor = memnew(Button);
-	edit_hb->add_child(open_editor);
+	selected_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open"));
 	open_editor->set_tooltip_text(TTR("Open in editor."));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
-	edit_hb->add_child(open_editor_sep);
+	selected_hb->add_child(open_editor_sep);
 
-	edit_hb->add_child(memnew(Label(TTR("Index"))));
+	selected_hb->add_child(memnew(Label(TTR("Index"))));
 	index_edit = memnew(SpinBox);
-	edit_hb->add_child(index_edit);
+	selected_hb->add_child(index_edit);
 	index_edit->set_min(0);
 	index_edit->set_step(1);
 	index_edit->set_allow_greater(false);
@@ -1075,11 +1064,11 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_edit_focus_entered));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_exited), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_edit_focus_exited));
 
-	edit_hb->add_child(memnew(VSeparator));
+	selected_hb->add_child(memnew(VSeparator));
 
-	edit_hb->add_child(memnew(Label(TTR("Position"))));
+	selected_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_value = memnew(SpinBox);
-	edit_hb->add_child(edit_value);
+	selected_hb->add_child(edit_value);
 	edit_value->set_min(-ABS_MAX);
 	edit_value->set_max(ABS_MAX);
 	edit_value->set_step(STEP_UNIT);
@@ -1088,7 +1077,16 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
 
-	edit_hb->hide();
+	selected_hb->add_child(memnew(VSeparator));
+
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	edit_hb->add_child(tool_erase);
+	tool_erase->set_tooltip_text(TTR("Erase point."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
+	tool_erase->set_disabled(true);
+
+	selected_hb->hide();
 	open_editor->hide();
 	open_editor_sep->hide();
 

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -58,7 +58,6 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_blend = nullptr;
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
-	VSeparator *tool_erase_sep = nullptr;
 	Button *tool_erase = nullptr;
 	Button *snap = nullptr;
 	SpinBox *snap_value = nullptr;

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -58,7 +58,6 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_blend = nullptr;
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
-	VSeparator *tool_erase_sep = nullptr;
 	Button *tool_erase = nullptr;
 	Button *snap = nullptr;
 	SpinBox *snap_value = nullptr;
@@ -72,6 +71,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	OptionButton *interpolation = nullptr;
 
 	HBoxContainer *edit_hb = nullptr;
+	HBoxContainer *selected_hb = nullptr;
 	SpinBox *edit_value = nullptr;
 	Button *open_editor = nullptr;
 	VSeparator *open_editor_sep = nullptr;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -86,7 +86,7 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	edit_x->set_editable(!read_only);
 	edit_y->set_editable(!read_only);
 	index_edit->set_editable(!read_only);
-	tool_triangle->set_disabled(read_only);
+	tool_triangle->set_disabled(read_only || (blend_space.is_valid() && blend_space->get_auto_triangles()));
 	auto_triangles->set_disabled(read_only);
 	sync->set_disabled(read_only);
 	cyclic_length_value->set_editable(!read_only);
@@ -106,13 +106,19 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
-		if (k->get_keycode() == Key::ESCAPE && editing_point != -1) {
-			_cancel_inline_edit();
+		if (k->get_keycode() == Key::ESCAPE) {
+			if (editing_point != -1) {
+				_cancel_inline_edit();
+			}
+			if (making_triangle.size()) {
+				making_triangle.clear();
+				blend_space_draw->queue_redraw();
+			}
 			accept_event();
 			return;
 		}
 
-		if (tool_select->is_pressed() && k->get_keycode() == Key::KEY_DELETE) {
+		if ((tool_select->is_pressed() || tool_triangle->is_pressed()) && k->get_keycode() == Key::KEY_DELETE) {
 			if (selected_point != -1 || selected_triangle != -1) {
 				if (!read_only) {
 					_erase_selected();
@@ -274,6 +280,25 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 					making_triangle.clear();
 				}
 				return;
+			}
+		}
+
+		// Attempt triangles as well, in case the user wants to erase one.
+		if (!blend_space->get_auto_triangles()) { // Protecting state just in case.
+			for (int i = 0; i < blend_space->get_triangle_count(); i++) {
+				Vector<Vector2> triangle;
+
+				for (int j = 0; j < 3; j++) {
+					int idx = blend_space->get_triangle_point(i, j);
+					ERR_FAIL_INDEX(idx, points.size());
+					triangle.push_back(points[idx]);
+				}
+
+				if (Geometry2D::is_point_in_triangle(mb->get_position(), triangle[0], triangle[1], triangle[2])) {
+					selected_triangle = i;
+					_update_tool_erase();
+					return;
+				}
 			}
 		}
 	}
@@ -503,24 +528,13 @@ void AnimationNodeBlendSpace2DEditor::_update_tool_erase() {
 void AnimationNodeBlendSpace2DEditor::_tool_switch(int p_tool) {
 	making_triangle.clear();
 
-	if (p_tool == 3) {
-		Vector<Vector2> bl_points;
-		for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
-			bl_points.push_back(blend_space->get_blend_point_position(i));
-		}
-		Vector<Delaunay2D::Triangle> tr = Delaunay2D::triangulate(bl_points);
-		for (int i = 0; i < tr.size(); i++) {
-			blend_space->add_triangle(tr[i].points[0], tr[i].points[1], tr[i].points[2]);
+	if (p_tool != 0) {
+		_set_selected_point(-1);
+		if (p_tool != 3) {
+			selected_triangle = -1;
 		}
 	}
 
-	if (p_tool == 0) {
-		tool_erase->show();
-		tool_erase_sep->show();
-	} else {
-		tool_erase->hide();
-		tool_erase_sep->hide();
-	}
 	_update_tool_erase();
 	blend_space_draw->queue_redraw();
 }
@@ -755,12 +769,17 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 	updating = true;
 
 	if (blend_space->get_auto_triangles()) {
-		tool_triangle->hide();
+		tool_triangle->set_disabled(true);
+		if (tool_triangle->is_pressed()) {
+			tool_select->set_pressed(true);
+			_tool_switch(0);
+		}
 	} else {
-		tool_triangle->show();
+		tool_triangle->set_disabled(false);
 	}
 
 	auto_triangles->set_pressed(blend_space->get_auto_triangles());
+	reset_triangles->set_visible(!blend_space->get_auto_triangles());
 
 	sync->select(blend_space->get_sync_mode());
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
@@ -1020,6 +1039,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			snap->set_button_icon(get_editor_theme_icon(SNAME("SnapGrid")));
 			open_editor->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			auto_triangles->set_button_icon(get_editor_theme_icon(SNAME("AutoTriangle")));
+			reset_triangles->set_button_icon(get_editor_theme_icon(SNAME("Reload")));
 			interpolation->clear();
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
@@ -1071,6 +1091,18 @@ void AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled() {
 	undo_redo->create_action(TTR("Toggle Auto Triangles"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_auto_triangles", auto_triangles->is_pressed());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_auto_triangles", blend_space->get_auto_triangles());
+	undo_redo->add_do_method(this, "_update_space");
+	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->commit_action();
+}
+
+void AnimationNodeBlendSpace2DEditor::_reset_triangles() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Reset BlendSpace2D Triangles"));
+	for (int i = blend_space->get_triangle_count() - 1; i >= 0; i--) {
+		undo_redo->add_do_method(blend_space.ptr(), "remove_triangle", i);
+		undo_redo->add_undo_method(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(i, 0), blend_space->get_triangle_point(i, 1), blend_space->get_triangle_point(i, 2), i);
+	}
 	undo_redo->add_do_method(this, "_update_space");
 	undo_redo->add_undo_method(this, "_update_space");
 	undo_redo->commit_action();
@@ -1228,17 +1260,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_triangle->set_toggle_mode(true);
 	tool_triangle->set_button_group(bg);
 	top_hb->add_child(tool_triangle);
-	tool_triangle->set_tooltip_text(TTR("Create triangles by connecting points."));
+	tool_triangle->set_tooltip_text(TTR("Create triangles manually by connecting points."));
 	tool_triangle->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(3));
-
-	tool_erase_sep = memnew(VSeparator);
-	top_hb->add_child(tool_erase_sep);
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_erase);
-	tool_erase->set_tooltip_text(TTR("Erase points and triangles."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
-	tool_erase->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -1247,7 +1270,14 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(auto_triangles);
 	auto_triangles->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
 	auto_triangles->set_toggle_mode(true);
-	auto_triangles->set_tooltip_text(TTR("Generate blend triangles automatically (instead of manually)"));
+	auto_triangles->set_tooltip_text(TTR("Generate blend triangles automatically."));
+
+	reset_triangles = memnew(Button);
+	reset_triangles->set_theme_type_variation(SceneStringName(FlatButton));
+	top_hb->add_child(reset_triangles);
+	reset_triangles->set_tooltip_text(TTR("Reset triangles."));
+	reset_triangles->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_reset_triangles));
+	reset_triangles->set_visible(false);
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -1346,6 +1376,14 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_y->set_step(STEP_UNIT);
 	edit_y->set_accessibility_name(TTRC("Blend Y Value"));
 	edit_y->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
+
+	edit_hb->add_child(memnew(VSeparator));
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	top_hb->add_child(tool_erase);
+	tool_erase->set_tooltip_text(TTR("Erase points and triangles."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
+	tool_erase->set_disabled(true);
 
 	edit_hb->hide();
 	open_editor->hide();

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -87,7 +87,7 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	edit_x->set_editable(!read_only);
 	edit_y->set_editable(!read_only);
 	index_edit->set_editable(!read_only);
-	tool_triangle->set_disabled(read_only);
+	tool_triangle->set_disabled(read_only || (blend_space.is_valid() && blend_space->get_auto_triangles()));
 	auto_triangles->set_disabled(read_only);
 	sync->set_disabled(read_only);
 	cyclic_length_value->set_editable(!read_only);
@@ -107,13 +107,19 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
-		if (k->get_keycode() == Key::ESCAPE && editing_point != -1) {
-			_cancel_inline_edit();
+		if (k->get_keycode() == Key::ESCAPE) {
+			if (editing_point != -1) {
+				_cancel_inline_edit();
+			}
+			if (making_triangle.size()) {
+				making_triangle.clear();
+				blend_space_draw->queue_redraw();
+			}
 			accept_event();
 			return;
 		}
 
-		if (tool_select->is_pressed() && k->get_keycode() == Key::KEY_DELETE) {
+		if ((tool_select->is_pressed() || tool_triangle->is_pressed()) && k->get_keycode() == Key::KEY_DELETE) {
 			if (selected_point != -1 || selected_triangle != -1) {
 				if (!read_only) {
 					_erase_selected();
@@ -275,6 +281,25 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 					making_triangle.clear();
 				}
 				return;
+			}
+		}
+
+		// Attempt triangles as well, in case the user wants to erase one.
+		if (!blend_space->get_auto_triangles()) { // Protecting state just in case.
+			for (int i = 0; i < blend_space->get_triangle_count(); i++) {
+				Vector<Vector2> triangle;
+
+				for (int j = 0; j < 3; j++) {
+					int idx = blend_space->get_triangle_point(i, j);
+					ERR_FAIL_INDEX(idx, points.size());
+					triangle.push_back(points[idx]);
+				}
+
+				if (Geometry2D::is_point_in_triangle(mb->get_position(), triangle[0], triangle[1], triangle[2])) {
+					selected_triangle = i;
+					_update_tool_erase();
+					return;
+				}
 			}
 		}
 	}
@@ -492,36 +517,25 @@ void AnimationNodeBlendSpace2DEditor::_update_tool_erase() {
 			open_editor_sep->hide();
 		}
 		if (!read_only) {
-			edit_hb->show();
+			selected_hb->show();
 		} else {
-			edit_hb->hide();
+			selected_hb->hide();
 		}
 	} else {
-		edit_hb->hide();
+		selected_hb->hide();
 	}
 }
 
 void AnimationNodeBlendSpace2DEditor::_tool_switch(int p_tool) {
 	making_triangle.clear();
 
-	if (p_tool == 3) {
-		Vector<Vector2> bl_points;
-		for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
-			bl_points.push_back(blend_space->get_blend_point_position(i));
-		}
-		Vector<Delaunay2D::Triangle> tr = Delaunay2D::triangulate(bl_points);
-		for (int i = 0; i < tr.size(); i++) {
-			blend_space->add_triangle(tr[i].points[0], tr[i].points[1], tr[i].points[2]);
+	if (p_tool != 0) {
+		_set_selected_point(-1);
+		if (p_tool != 3) {
+			selected_triangle = -1;
 		}
 	}
 
-	if (p_tool == 0) {
-		tool_erase->show();
-		tool_erase_sep->show();
-	} else {
-		tool_erase->hide();
-		tool_erase_sep->hide();
-	}
 	_update_tool_erase();
 	blend_space_draw->queue_redraw();
 }
@@ -756,12 +770,17 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 	updating = true;
 
 	if (blend_space->get_auto_triangles()) {
-		tool_triangle->hide();
+		tool_triangle->set_disabled(true);
+		if (tool_triangle->is_pressed()) {
+			tool_select->set_pressed(true);
+			_tool_switch(0);
+		}
 	} else {
-		tool_triangle->show();
+		tool_triangle->set_disabled(false);
 	}
 
 	auto_triangles->set_pressed(blend_space->get_auto_triangles());
+	reset_triangles->set_visible(!blend_space->get_auto_triangles());
 
 	sync->select(blend_space->get_sync_mode());
 	sync->set_fit_to_longest_item(false);
@@ -1023,6 +1042,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			snap->set_button_icon(get_editor_theme_icon(SNAME("SnapGrid")));
 			open_editor->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			auto_triangles->set_button_icon(get_editor_theme_icon(SNAME("AutoTriangle")));
+			reset_triangles->set_button_icon(get_editor_theme_icon(SNAME("Reload")));
 			interpolation->clear();
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
@@ -1074,6 +1094,18 @@ void AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled() {
 	undo_redo->create_action(TTR("Toggle Auto Triangles"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_auto_triangles", auto_triangles->is_pressed());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_auto_triangles", blend_space->get_auto_triangles());
+	undo_redo->add_do_method(this, "_update_space");
+	undo_redo->add_undo_method(this, "_update_space");
+	undo_redo->commit_action();
+}
+
+void AnimationNodeBlendSpace2DEditor::_reset_triangles() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Reset BlendSpace2D Triangles"));
+	for (int i = blend_space->get_triangle_count() - 1; i >= 0; i--) {
+		undo_redo->add_do_method(blend_space.ptr(), "remove_triangle", i);
+		undo_redo->add_undo_method(blend_space.ptr(), "add_triangle", blend_space->get_triangle_point(i, 0), blend_space->get_triangle_point(i, 1), blend_space->get_triangle_point(i, 2), i);
+	}
 	undo_redo->add_do_method(this, "_update_space");
 	undo_redo->add_undo_method(this, "_update_space");
 	undo_redo->commit_action();
@@ -1216,7 +1248,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hf->add_child(tool_create);
-	tool_create->set_tooltip_text(TTR("Create points."));
+	tool_create->set_tooltip_text(TTR("Create point."));
 	tool_create->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(1));
 
 	tool_blend = memnew(Button);
@@ -1232,17 +1264,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_triangle->set_toggle_mode(true);
 	tool_triangle->set_button_group(bg);
 	top_hf->add_child(tool_triangle);
-	tool_triangle->set_tooltip_text(TTR("Create triangles by connecting points."));
+	tool_triangle->set_tooltip_text(TTR("Create triangles manually by connecting points."));
 	tool_triangle->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(3));
-
-	tool_erase_sep = memnew(VSeparator);
-	top_hf->add_child(tool_erase_sep);
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hf->add_child(tool_erase);
-	tool_erase->set_tooltip_text(TTR("Erase points and triangles."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
-	tool_erase->set_disabled(true);
 
 	top_hf->add_child(memnew(VSeparator));
 
@@ -1251,7 +1274,14 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hf->add_child(auto_triangles);
 	auto_triangles->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
 	auto_triangles->set_toggle_mode(true);
-	auto_triangles->set_tooltip_text(TTR("Generate blend triangles automatically (instead of manually)"));
+	auto_triangles->set_tooltip_text(TTR("Generate blend triangles automatically."));
+
+	reset_triangles = memnew(Button);
+	reset_triangles->set_theme_type_variation(SceneStringName(FlatButton));
+	top_hf->add_child(reset_triangles);
+	reset_triangles->set_tooltip_text(TTR("Reset triangles."));
+	reset_triangles->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_reset_triangles));
+	reset_triangles->set_visible(false);
 
 	top_hf->add_child(memnew(VSeparator));
 
@@ -1316,21 +1346,22 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_hb->set_h_size_flags(SIZE_EXPAND_FILL);
 	top_hf->add_child(edit_hb);
 
-	Control *top_spacer = memnew(Control);
-	top_spacer->set_h_size_flags(SIZE_EXPAND_FILL);
-	edit_hb->add_child(top_spacer);
+	edit_hb->add_spacer();
+
+	selected_hb = memnew(HBoxContainer);
+	edit_hb->add_child(selected_hb);
 
 	open_editor = memnew(Button);
-	edit_hb->add_child(open_editor);
+	selected_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open"));
 	open_editor->set_tooltip_text(TTR("Open in editor."));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
-	edit_hb->add_child(open_editor_sep);
+	selected_hb->add_child(open_editor_sep);
 
-	edit_hb->add_child(memnew(Label(TTR("Index"))));
+	selected_hb->add_child(memnew(Label(TTR("Index"))));
 	index_edit = memnew(SpinBox);
-	edit_hb->add_child(index_edit);
+	selected_hb->add_child(index_edit);
 	index_edit->set_min(0);
 	index_edit->set_step(1);
 	index_edit->set_allow_greater(false);
@@ -1343,11 +1374,11 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_edit_focus_entered));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_exited), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_edit_focus_exited));
 
-	edit_hb->add_child(memnew(VSeparator));
+	selected_hb->add_child(memnew(VSeparator));
 
-	edit_hb->add_child(memnew(Label(TTR("Position"))));
+	selected_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_x = memnew(SpinBox);
-	edit_hb->add_child(edit_x);
+	selected_hb->add_child(edit_x);
 	edit_x->set_min(-ABS_MAX);
 	edit_x->set_max(ABS_MAX);
 	edit_x->set_step(STEP_UNIT);
@@ -1356,7 +1387,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_x->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_x->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	edit_y = memnew(SpinBox);
-	edit_hb->add_child(edit_y);
+	selected_hb->add_child(edit_y);
 	edit_y->set_min(-ABS_MAX);
 	edit_y->set_max(ABS_MAX);
 	edit_y->set_step(STEP_UNIT);
@@ -1365,7 +1396,16 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_y->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_y->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 
-	edit_hb->hide();
+	selected_hb->add_child(memnew(VSeparator));
+
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	edit_hb->add_child(tool_erase);
+	tool_erase->set_tooltip_text(TTR("Erase point/triangle."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
+	tool_erase->set_disabled(true);
+
+	selected_hb->hide();
 	open_editor->hide();
 	open_editor_sep->hide();
 

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -59,7 +59,6 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
 	Button *tool_triangle = nullptr;
-	VSeparator *tool_erase_sep = nullptr;
 	Button *tool_erase = nullptr;
 	Button *snap = nullptr;
 	SpinBox *snap_x = nullptr;
@@ -69,6 +68,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	OptionButton *interpolation = nullptr;
 
 	Button *auto_triangles = nullptr;
+	Button *reset_triangles = nullptr;
 
 	LineEdit *label_x = nullptr;
 	LineEdit *label_y = nullptr;
@@ -148,6 +148,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	void _show_indices_with_cooldown();
 
 	void _auto_triangles_toggled();
+	void _reset_triangles();
 
 	StringName get_blend_position_path() const;
 	String _get_safe_name(const Ref<AnimationNodeBlendSpace2D> &p_blend_space, const String &p_name);

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -59,7 +59,6 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
 	Button *tool_triangle = nullptr;
-	VSeparator *tool_erase_sep = nullptr;
 	Button *tool_erase = nullptr;
 	Button *snap = nullptr;
 	SpinBox *snap_x = nullptr;
@@ -69,6 +68,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	OptionButton *interpolation = nullptr;
 
 	Button *auto_triangles = nullptr;
+	Button *reset_triangles = nullptr;
 
 	LineEdit *label_x = nullptr;
 	LineEdit *label_y = nullptr;
@@ -78,6 +78,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *min_y_value = nullptr;
 
 	HBoxContainer *edit_hb = nullptr;
+	HBoxContainer *selected_hb = nullptr;
 	SpinBox *edit_x = nullptr;
 	SpinBox *edit_y = nullptr;
 	Button *open_editor = nullptr;
@@ -148,6 +149,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	void _show_indices_with_cooldown();
 
 	void _auto_triangles_toggled();
+	void _reset_triangles();
 
 	StringName get_blend_position_path() const;
 	String _get_safe_name(const Ref<AnimationNodeBlendSpace2D> &p_blend_space, const String &p_name);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -281,7 +281,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				}
 			}
 
-			if (node_rects[i].edit.has_point(mb->get_position())) { //edit name
+			if (node_rects[i].edit.has_point(mb->get_position())) { // Open editor.
 				callable_mp(this, &AnimationNodeStateMachineEditor::_open_editor).call_deferred(node_rects[i].node_name);
 				return;
 			}
@@ -509,13 +509,13 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	}
 
 	// End box selecting
-	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed() && box_selecting) {
+	if (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && box_selecting) {
 		box_selecting = false;
 		state_machine_draw->queue_redraw();
 		_update_mode();
 	}
 
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+	if (mb.is_valid() && mb->is_pressed() && !tool_connect->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		StringName clicked_node;
 		for (int i = node_rects.size() - 1; i >= 0; i--) {
 			if (node_rects[i].node.has_point(mb->get_position())) {
@@ -705,7 +705,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		}
 
 		// Set transition tooltip or reconnection endpoint.
-		if (tool_select->is_pressed()) {
+		if (tool_select->is_pressed() && !reconnecting) {
 			int closest_for_highlight = -1;
 			int closest_for_tooltip = -1;
 			float closest_d_highlight = 1e20;
@@ -1055,7 +1055,9 @@ void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action
 			updating = false;
 		}
 
-		_select_transition(connecting_from, connecting_to_node);
+		if (tool_select->is_pressed()) {
+			_select_transition(connecting_from, connecting_to_node);
+		}
 
 		if (selected_transition_index >= 0) {
 			if (!state_machine->is_transition_across_group(selected_transition_index)) {
@@ -1966,12 +1968,17 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 
 void AnimationNodeStateMachineEditor::_update_mode() {
 	if (tool_select->is_pressed()) {
-		selection_tools_hb->show();
 		bool nothing_selected = selected_nodes.is_empty() && selected_transition_from == StringName() && selected_transition_to == StringName();
 		bool start_end_selected = selected_nodes.size() == 1 && (*selected_nodes.begin() == SceneStringName(Start) || *selected_nodes.begin() == SceneStringName(End));
 		tool_erase->set_disabled(nothing_selected || start_end_selected || read_only);
-	} else {
-		selection_tools_hb->hide();
+	} else { // Clear selection when not using select tool.
+		selected_transition_from = StringName();
+		selected_transition_to = StringName();
+		selected_transition_index = -1;
+		selected_node = StringName();
+		selected_nodes.clear();
+		connected_nodes.clear();
+		state_machine_draw->queue_redraw();
 	}
 
 	if (read_only) {
@@ -2079,18 +2086,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_connect->set_tooltip_text(TTR("Connect nodes."));
 	tool_connect->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), CONNECT_DEFERRED);
 
-	// Context-sensitive selection tools:
-	selection_tools_hb = memnew(HBoxContainer);
-	top_hb->add_child(selection_tools_hb);
-	selection_tools_hb->add_child(memnew(VSeparator));
-
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	tool_erase->set_tooltip_text(TTR("Remove selected node or transition."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected).bind(false));
-	tool_erase->set_disabled(true);
-	selection_tools_hb->add_child(tool_erase);
-
 	transition_tools_hb = memnew(HBoxContainer);
 	top_hb->add_child(transition_tools_hb);
 	transition_tools_hb->add_child(memnew(VSeparator));
@@ -2106,11 +2101,20 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	auto_advance->set_pressed(true);
 	transition_tools_hb->add_child(auto_advance);
 
-	top_hb->add_spacer();
+	top_hb->add_child(memnew(VSeparator));
 
 	top_hb->add_child(memnew(Label(TTR("Play Mode"))));
 	play_mode = memnew(OptionButton);
 	top_hb->add_child(play_mode);
+
+	top_hb->add_spacer();
+
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	tool_erase->set_tooltip_text(TTR("Remove selected node or transition."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected).bind(false));
+	tool_erase->set_disabled(true);
+	top_hb->add_child(tool_erase);
 
 	panel = memnew(PanelContainer);
 	panel->set_clip_contents(true);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -281,7 +281,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				}
 			}
 
-			if (node_rects[i].edit.has_point(mb->get_position())) { //edit name
+			if (node_rects[i].edit.has_point(mb->get_position())) { // Open editor.
 				callable_mp(this, &AnimationNodeStateMachineEditor::_open_editor).call_deferred(node_rects[i].node_name);
 				return;
 			}
@@ -509,13 +509,13 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	}
 
 	// End box selecting
-	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed() && box_selecting) {
+	if (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && box_selecting) {
 		box_selecting = false;
 		state_machine_draw->queue_redraw();
 		_update_mode();
 	}
 
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+	if (mb.is_valid() && mb->is_pressed() && !tool_connect->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		StringName clicked_node;
 		for (int i = node_rects.size() - 1; i >= 0; i--) {
 			if (node_rects[i].node.has_point(mb->get_position())) {
@@ -705,7 +705,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		}
 
 		// Set transition tooltip or reconnection endpoint.
-		if (tool_select->is_pressed()) {
+		if (tool_select->is_pressed() && !reconnecting) {
 			int closest_for_highlight = -1;
 			int closest_for_tooltip = -1;
 			float closest_d_highlight = 1e20;
@@ -1050,7 +1050,9 @@ void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action
 			updating = false;
 		}
 
-		_select_transition(connecting_from, connecting_to_node);
+		if (tool_select->is_pressed()) {
+			_select_transition(connecting_from, connecting_to_node);
+		}
 
 		if (selected_transition_index >= 0) {
 			if (!state_machine->is_transition_across_group(selected_transition_index)) {
@@ -1961,12 +1963,17 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 
 void AnimationNodeStateMachineEditor::_update_mode() {
 	if (tool_select->is_pressed()) {
-		selection_tools_hb->show();
 		bool nothing_selected = selected_nodes.is_empty() && selected_transition_from == StringName() && selected_transition_to == StringName();
 		bool start_end_selected = selected_nodes.size() == 1 && (*selected_nodes.begin() == SceneStringName(Start) || *selected_nodes.begin() == SceneStringName(End));
 		tool_erase->set_disabled(nothing_selected || start_end_selected || read_only);
-	} else {
-		selection_tools_hb->hide();
+	} else { // Clear selection when not using select tool.
+		selected_transition_from = StringName();
+		selected_transition_to = StringName();
+		selected_transition_index = -1;
+		selected_node = StringName();
+		selected_nodes.clear();
+		connected_nodes.clear();
+		state_machine_draw->queue_redraw();
 	}
 
 	if (read_only) {
@@ -2074,18 +2081,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_connect->set_tooltip_text(TTR("Connect nodes."));
 	tool_connect->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_update_mode), CONNECT_DEFERRED);
 
-	// Context-sensitive selection tools:
-	selection_tools_hb = memnew(HBoxContainer);
-	top_hb->add_child(selection_tools_hb);
-	selection_tools_hb->add_child(memnew(VSeparator));
-
-	tool_erase = memnew(Button);
-	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	tool_erase->set_tooltip_text(TTR("Remove selected node or transition."));
-	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected).bind(false));
-	tool_erase->set_disabled(true);
-	selection_tools_hb->add_child(tool_erase);
-
 	transition_tools_hb = memnew(HBoxContainer);
 	top_hb->add_child(transition_tools_hb);
 	transition_tools_hb->add_child(memnew(VSeparator));
@@ -2101,11 +2096,21 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	auto_advance->set_pressed(true);
 	transition_tools_hb->add_child(auto_advance);
 
-	top_hb->add_spacer();
+	top_hb->add_child(memnew(VSeparator));
 
 	top_hb->add_child(memnew(Label(TTR("Play Mode"))));
 	play_mode = memnew(OptionButton);
+	play_mode->set_fit_to_longest_item(false);
 	top_hb->add_child(play_mode);
+
+	top_hb->add_spacer();
+
+	tool_erase = memnew(Button);
+	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
+	tool_erase->set_tooltip_text(TTR("Remove selected node or transition."));
+	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeStateMachineEditor::_erase_selected).bind(false));
+	tool_erase->set_disabled(true);
+	top_hb->add_child(tool_erase);
 
 	panel = memnew(PanelContainer);
 	panel->set_clip_contents(true);

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -54,7 +54,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Popup *name_edit_popup = nullptr;
 	LineEdit *name_edit = nullptr;
 
-	HBoxContainer *selection_tools_hb = nullptr;
 	Button *tool_erase = nullptr;
 
 	HBoxContainer *transition_tools_hb = nullptr;


### PR DESCRIPTION
Follow up to #109792. Closes https://github.com/godotengine/godot/issues/122387.

The triangle tool in BlendSpace2D's editor has a few problems.
1. Its purpose is to allow the user to manually draw their triangles, but for some reason it attempts to autogenerate triangles when selected, and usually fails since they likely all exist already, throwing an error. This PR not only removes that triangulation code, but also offers a "Reset Triangles" button to allow users to clear all current triangles, and get to work drawing them.
> <img width="324" height="177" alt="image" src="https://github.com/user-attachments/assets/6a0e9146-040a-4f3d-8d5e-18582b4ff65d" />

2. The triangle tool is one of the four available, but is superseded by the auto toggle. However, that toggle hides the button, reducing general awareness of the tool, and, when toggled on, does not switch back to the select tool, which may leave the user in a suspended state, with no tool appearing to be selected. This PR disables the tool button rather than hiding it, and switches to select tool instead if auto triangles is toggled on.
> <img width="410" height="194" alt="image" src="https://github.com/user-attachments/assets/e2b50f08-8bc9-41c2-9eab-db5d576d5bdb" />

3. There doesn't appear to be a way to cancel triangle creation once started, which is unusual. This PR allows pressing Escape to do so.

The rest of the improvements serve as a succession of #110369, which moved editor-specific tools to the left side of the toolbar and edited item-specific tools to the right, only for BlendSpaces. This PR finishes that job, with some considerations.

4. The "Play Mode" setting, which was equivalent to BlendSpace's Blend Mode setting, has been moved to the left.
> <img width="427" height="169" alt="image" src="https://github.com/user-attachments/assets/3a27910f-c5c1-45c2-b3f3-460140f8d16f" />
5. The delete button's conditional disappearance has been removed across the board. Now, it is always seen on the right edge, and it is only disabled (not hidden) depending on context. Doing this allows reliably for muscle memory to be built, versus a button that would disappear often, and sat at a different x pos in BlendSpace2D, between two buttons with extremely linked functionality.
6. Doing this allows us to treat selection, which was previously exclusive to the select tool but unguarded, with a little more thoughtfulness; for BlendSpace2D, the triangle tool now allows selecting triangles, so that they can be both created and removed (with delete key, or the now visible delete button) with the tool. Conversely, selecting of neither points nor triangles is possible with the other two tools, and they will clear selection upon being chosen. Same for BlendSpace1D and StateMachine.
> <img width="421" height="265" alt="image" src="https://github.com/user-attachments/assets/f834e3cd-7576-4cbd-ac9d-5b456bd1dd5a" />
- Finally, there was a chunk of code in StateMachine's editor file that resided outside the ordinary left click selection block that was not functioning correctly: it was supposed to allow for holding shift to select multiple items. It was part of my first pair of pull requests, but I don't think I realised at the time that making that distinction on mousedown isn't possible. It also unnecessarily duplicated earlier code. The gate on that block was incorrect, and was responsible for a bug: when clicking over another node when in the create state tool, selection happened.
> <img width="624" height="268" alt="image" src="https://github.com/user-attachments/assets/0612ca6c-e119-42d8-8d79-6f3a7693e62c" />

While the last one has been fixed correctly, the whole block can't be removed yet. The broken feature that it tried to add is possible to fix with a refactor of selection in StateMachine that is ready to follow this PR, that will allow for both shift-clicking to add nodes to selection as well as shift-dragging to move them, by deferring to mouseup and mouse drag.