### PR TITLE
[.NET] Add support for web export using static LibGodot

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -132,6 +132,7 @@ env.__class__.add_shared_library = methods.add_shared_library
 env.__class__.add_library = methods.add_library
 env.__class__.add_program = methods.add_program
 env.__class__.CommandNoCache = methods.CommandNoCache
+env.__class__.add_configuration_file = methods.add_configuration_file
 env.__class__.Run = methods.Run
 env.__class__.disable_warnings = methods.disable_warnings
 env.__class__.force_optimization_on_debug = methods.force_optimization_on_debug
@@ -276,6 +277,7 @@ opts.Add(
         True,
     )
 )
+opts.Add(BoolVariable("disable_crash_handler", "Disable crash handler if it exists", False))
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
 opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
@@ -954,6 +956,11 @@ if env["disable_exceptions"]:
 elif env.msvc:
     env.Append(CXXFLAGS=["/EHsc"])
 
+# Disable crash handler. Mainly useful when using Godot as a library as some runtimes install
+# their own signal handlers, so they both will try to register their own signal handlers
+if env["disable_crash_handler"]:
+    env.AppendUnique(CPPDEFINES=["DISABLE_CRASH_HANDLER"])
+
 # Configure compiler warnings
 env.AppendUnique(CCFLAGS=["$WARNLEVEL"])
 if env.msvc and not methods.using_clang(env):  # MSVC
@@ -1169,6 +1176,7 @@ if env.editor_build:
         print_error("Not all modules required by editor builds are enabled.")
         Exit(255)
 
+env["RAWSUFFIX"] = suffix
 env["PROGSUFFIX_WRAP"] = suffix + env.module_version_string + ".console" + env["PROGSUFFIX"]
 env["PROGSUFFIX"] = suffix + env.module_version_string + env["PROGSUFFIX"]
 env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]

--- a/methods.py
+++ b/methods.py
@@ -609,6 +609,39 @@ def CommandNoCache(env, target, sources, command, **args):
     return result
 
 
+def add_configuration_file(env, name, opts=None, **args):
+    import json
+
+    from SCons.Node.FS import File
+    from SCons.Script import Flatten
+
+    libs = []
+    for lib in Flatten(env["LIBS"]):
+        if isinstance(lib, str) and not (lib.endswith(".a") or lib.endswith(".lib")):
+            libs.append(lib)
+        elif isinstance(lib, File):
+            path = lib.srcnode().abspath
+            if not (path.endswith(".a") or path.endswith(".lib")):
+                libs.append(path)
+
+    opts_default = {
+        "CFLAGS": env.subst("$CFLAGS"),
+        "CXXFLAGS": env.subst("$CXXFLAGS"),
+        "CCFLAGS": env.subst("$CCFLAGS"),
+        "LINKFLAGS": env.subst("$LINKFLAGS"),
+        "LIBS": ";".join(libs),
+    }
+    if isinstance(opts, dict):
+        opts_default.update(opts)
+        opts = opts_default
+    else:
+        opts = opts_default
+
+    config_file = env.Textfile(f"{name}{env['RAWSUFFIX']}.json", [env.Literal(json.dumps(opts, indent=4))], **args)
+    env.NoCache(config_file)
+    return config_file
+
+
 def Run(env, function, comstr="$GENCOMSTR"):
     from SCons.Script import Action
 

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -6,6 +6,15 @@ import build_scripts.mono_configure as mono_configure
 Import("env")
 Import("env_modules")
 
+if env["platform"] == "web":
+    if env["library_type"] == "shared_library":
+        # Shared library doesn't work right now.
+        env["EXPORTED_FUNCTIONS_SHARED"] += ["_set_load_from_executable_fn"]
+
+    env.AddJSLibraries(["web/setjmp_stub.js"])
+    env.AddJSPre(["web/callMain_stub.js"])
+    env["CUSTOM_GODOT_JS"] = env.File("web/mono_bridge.js")
+
 env_mono = env_modules.Clone()
 
 # Configure Mono

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -20,3 +20,6 @@ def configure(env, env_mono):
         if not module_supports_tools_on(env["platform"]):
             raise RuntimeError("This module does not currently support building for this platform for editor builds.")
         env_mono.Append(CPPDEFINES=["GD_MONO_HOT_RELOAD"])
+
+    if env["library_type"] != "executable":
+        env_mono.AppendUnique(CPPDEFINES=["GD_MONO_LIBGODOT_ENABLED"])

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,3 +1,8 @@
+import sys
+
+from methods import print_error
+
+
 def can_build(env, platform):
     if env.editor_build:
         env.module_add_dependencies("mono", ["regex"])
@@ -9,10 +14,32 @@ def configure(env):
     # Check if the platform has marked mono as supported.
     supported = env.get("supported", [])
     if "mono" not in supported:
-        import sys
-
         print("The 'mono' module does not currently support building for this platform. Aborting.")
         sys.exit(255)
+
+    if env["library_type"] != "executable" and not env["disable_crash_handler"]:
+        print_error(".NET installs its own crash handler.")
+        sys.exit(255)
+
+    if env["platform"] == "web":
+        if env["library_type"] == "executable":
+            print_error(".NET needs to be an entry point on web.")
+            sys.exit(255)
+
+        if env["library_type"] == "shared_library":
+            print_error("Can't build .NET with MAIN_MODULE, which would have made it possible to load shared library.")
+            sys.exit(255)
+
+        if env["threads"] and not env["proxy_to_pthread"]:
+            print_error(
+                '.NET runtime moves to worker thread when multi-threading is enabled, because of this godot needs to be compiled with "proxy_to_pthread" support.'
+            )
+            # https://github.com/dotnet/runtime/issues/126438.
+            sys.exit(255)
+
+        if env["lto"] != "none":
+            print_error(".NET can't work with lto library on web.")
+            sys.exit(255)
 
     env.add_module_version_string("mono")
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -36,8 +36,11 @@
       <Link>Sdk\SdkPackageVersions.props</Link>
     </None>
     <None Include="Sdk\Android.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Android.targets" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOS.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOS.targets" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Browser.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Browser.targets" Pack="true" PackagePath="Sdk" />
   </ItemGroup>
 
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Android.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Android.props
@@ -1,5 +1,2 @@
 <Project>
-  <PropertyGroup>
-    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' and '$(PublishAot)' != 'true' ">true</UseMonoRuntime>
-  </PropertyGroup>
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Android.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Android.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' and '$(PublishAot)' != 'true' ">true</UseMonoRuntime>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
@@ -1,0 +1,52 @@
+<Project>
+  <PropertyGroup>
+    <CustomLibGodotPath></CustomLibGodotPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> <!-- Currently needs unsafe. -->
+
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+
+    <WasmBuildNative>true</WasmBuildNative> <!-- required -->
+    <WasmAppDir>$([System.IO.Path]::Combine($(PublishDir), "AppBundle"))</WasmAppDir>
+
+    <WasmEnableSIMD>true</WasmEnableSIMD> <!-- -msimd128 -->
+    <WasmInitialHeapSize>32MB</WasmInitialHeapSize> <!-- -sINITIAL_MEMORY= -->
+    <EmccStackSize>5120KB</EmccStackSize> <!-- -sSTACK_SIZE= -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+    The Microsoft.NET.Sdk only understands of the Debug and Release configurations.
+    We need to set the following properties manually for ExportDebug and ExportRelease.
+    -->
+    <_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == '' and '$(Configuration)' != 'ExportRelease' and '$(WasmBuildingForNestedPublish)' != 'true'">-O1</_EmccOptimizationFlagDefault>
+    <_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == ''">-Oz</_EmccOptimizationFlagDefault>
+
+    <EmccCompileOptimizationFlag Condition="'$(EmccCompileOptimizationFlag)' == ''">$(_EmccOptimizationFlagDefault)</EmccCompileOptimizationFlag>
+    <WasmCompileOptimizationFlag>$(EmccCompileOptimizationFlag)</WasmCompileOptimizationFlag>
+    <WasmBitcodeCompileOptimizationFlag Condition="'$(WasmBitcodeCompileOptimizationFlag)' == '' and '$(Configuration)' == 'ExportRelease'">-O2</WasmBitcodeCompileOptimizationFlag>
+    <WasmBitcodeCompileOptimizationFlag Condition="'$(WasmBitcodeCompileOptimizationFlag)' == '' ">$(WasmCompileOptimizationFlag)</WasmBitcodeCompileOptimizationFlag>
+    <EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == '' and '$(Configuration)' == 'ExportRelease'">-O2</EmccLinkOptimizationFlag>
+    <EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == ''"   >$(WasmCompileOptimizationFlag)</EmccLinkOptimizationFlag>
+    <WasmLinkOptimizationFlag>$(EmccLinkOptimizationFlag)</WasmLinkOptimizationFlag>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <GodotEmccExtraLDFlag Include="-sMAX_WEBGL_VERSION=2" />
+    <GodotEmccExtraLDFlag Include="-sOFFSCREEN_FRAMEBUFFER=1" />
+    <GodotEmccExtraLDFlag Include="-sGL_ENABLE_GET_PROC_ADDRESS=0" />
+    <GodotEmccExtraLDFlag Include="-sWASM_BIGINT" />
+    <GodotEmccExtraLDFlag Include="-sMEMORY64=0" />
+    <GodotEmccExtraLDFlag Include="-sENVIRONMENT=web,worker" />
+    <GodotEmccExtraLDFlag Include="-sALLOW_MEMORY_GROWTH=1" />
+    <GodotEmccExtraLDFlag Include="-sINVOKE_RUN=0" />
+    <GodotEmccExtraLDFlag Include="-sEXIT_RUNTIME=1" />
+    <GodotEmccExtraLDFlag Include="-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0" />
+    <GodotEmccExtraLDFlag Include="-sTEXTDECODER=1" />
+    <GodotEmccExtraLDFlag Include="-lidbfs.js" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
@@ -1,0 +1,56 @@
+<Project>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);LIBGODOT_ENABLED</DefineConstants>
+
+    <_BaseLibGodotPath>$(BaseLibGodotPath)</_BaseLibGodotPath>
+    <_BaseLibGodotPath Condition=" '$(CustomLibGodotPath)' != '' ">$(CustomLibGodotPath)</_BaseLibGodotPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" Condition="'$(EnableGodotDotNetPreview)' != 'true' and '$(DisableImplicitGodotSharpReferences)' != 'true'" />
+    <TrimmerRootAssembly Include="Godot.Bindings" Condition="'$(EnableGodotDotNetPreview)' == 'true'" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+
+    <!--
+    Some scenarios need marshal-ilgen if marshaling is not disabled https://github.com/dotnet/android/issues/7276.
+    Despite it being for android the issue is still the same.
+    -->
+    <_MonoComponent Include="marshal-ilgen" Condition=" '$(GodotDisableRuntimeMarshalling)' != 'true' " />
+
+    <EmccExportedFunction Include="_malloc;_free" />
+    <EmccExportedRuntimeMethod Include="callMain;cwrap;HEAP8;HEAPU8;HEAP16;HEAPU16;HEAP32;HEAPU32;HEAP64;HEAPU64;HEAPF32;HEAPF64" />
+
+    <DirectPInvoke Include="libgodot" />
+    <NativeLibrary Include="$(_BaseLibGodotPath)\libgodot.a" />
+
+    <_GodotJsLibraries Include="$(_BaseLibGodotPath)\js_library\**\*.js" />
+    <_GodotPreJs Include="$(_BaseLibGodotPath)\pre_js\**\*.js" />
+    <_GodotPostJs Include="$(_BaseLibGodotPath)\post_js\**\*.js" />
+  </ItemGroup>
+
+  <Choose>
+      <When Condition=" '$([MSBuild]::IsOsPlatform(Windows))' ">
+          <ItemGroup>
+            <GodotEmccExtraLDFlag Include="@(_GodotJsLibraries->'--js-library &quot;%(FullPath)&quot;'->Replace('\', '/'))" />
+            <GodotEmccExtraLDFlag Include="@(_GodotPreJs->'--pre-js &quot;%(FullPath)&quot;'->Replace('\', '/'))" />
+            <GodotEmccExtraLDFlag Include="@(_GodotPostJs->'--post-js &quot;%(FullPath)&quot;'->Replace('\', '/'))" />
+          </ItemGroup>
+      </When>
+      <Otherwise>
+          <ItemGroup>
+            <GodotEmccExtraLDFlag Include="@(_GodotJsLibraries->'--js-library &quot;%(FullPath)&quot;')" />
+            <GodotEmccExtraLDFlag Include="@(_GodotPreJs->'--pre-js &quot;%(FullPath)&quot;')" />
+            <GodotEmccExtraLDFlag Include="@(_GodotPostJs->'--post-js &quot;%(FullPath)&quot;')" />
+          </ItemGroup>
+      </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <EmccExtraLDFlags>@(GodotEmccExtraLDFlag->'%(Identity)', ' ')</EmccExtraLDFlags>
+  </PropertyGroup>
+
+  <Target Name="GodotCheckLibGodotPath" BeforeTargets="Build">
+    <Error Text="Cannot build with empty 'BaseLibGodotPath'." Condition=" $(_BaseLibGodotPath) == '' " />
+    <Error Text="Cannot find 'libgodot.a' in expected placee." Condition=" !Exists('$(_BaseLibGodotPath)\libgodot.a') " />
+  </Target>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -84,6 +84,15 @@
     <GodotFloat64 Condition=" '$(GodotFloat64)' == '' ">false</GodotFloat64>
   </PropertyGroup>
 
+  <!--
+  Controls if Godot should automatically add 'DisableRuntimeMarshallingAttribute' to the user's assembly.
+  'GodotDisableRuntimeMarshalling' is used in GodotSharp/GodotSharp.props.
+  -->
+  <PropertyGroup Condition=" '$(GodotDisableRuntimeMarshalling)' == '' ">
+    <GodotDisableRuntimeMarshalling>false</GodotDisableRuntimeMarshalling>
+    <GodotDisableRuntimeMarshalling Condition=" '$(GodotTargetPlatform)' == 'web' ">true</GodotDisableRuntimeMarshalling>
+  </PropertyGroup>
+
   <!-- Godot DefineConstants. -->
   <PropertyGroup>
     <!-- Define constants to identify Godot builds. -->
@@ -103,6 +112,8 @@
     <_GodotDefineConstants>$(_GodotDefineConstants);$(_GodotPlatformConstants);$(_GodotVersionConstants)</_GodotDefineConstants>
   </PropertyGroup>
 
+  <!-- Platform-specific build properties. -->
   <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOS.props" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
+  <Import Project="$(MSBuildThisFileDirectory)\Browser.props" Condition=" '$(GodotTargetPlatform)' == 'web' " />
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -48,7 +48,8 @@
     <Error Text="The project or one of its dependencies references GodotSharp packages which is incompatible with the active Godot C# bindings. The active C# bindings is Godot .NET." Condition="$([System.String]::Copy('%(Reference.Identity)').Contains('GodotSharp.dll'))" />
   </Target>
 
-  <!-- iOS-specific build targets -->
+  <!-- Platform-specific build targets. -->
+  <Import Project="$(MSBuildThisFileDirectory)\Android.targets" Condition=" '$(GodotTargetPlatform)' == 'android' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOS.targets" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
-
+  <Import Project="$(MSBuildThisFileDirectory)\Browser.targets" Condition=" '$(GodotTargetPlatform)' == 'web' " />
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -52,6 +52,13 @@ namespace GodotPlugins.Game
                 return false.ToGodotBool();
             }
         }
+
+#if LIBGODOT_ENABLED
+        internal static unsafe IntPtr GetInitializePointer()
+        {
+            return (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, int, godot_bool>)&InitializeFromGameProject;
+        }
+#endif
     }
 }
 ";

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -30,7 +30,15 @@ namespace GodotTools.ProjectEditor
             var net9 = mainGroup.AddProperty("TargetFramework", "net9.0");
             net9.Condition = " '$(GodotTargetPlatform)' == 'android' ";
 
+            // Minimum possible version for web export.
+            var net9Web = mainGroup.AddProperty("TargetFramework", "net9.0");
+            net9Web.Condition = " '$(GodotTargetPlatform)' == 'web' ";
+
             mainGroup.AddProperty("EnableDynamicLoading", "true");
+
+            // Disable dynamic loading when building for web.
+            var dynLoad = mainGroup.AddProperty("EnableDynamicLoading", "false");
+            dynLoad.Condition = " '$(GodotTargetPlatform)' == 'web' ";
 
             string sanitizedName = IdentifierUtils.SanitizeQualifiedIdentifier(name, allowEmptyIdentifiers: true);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -293,7 +293,8 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            Godot.Collections.Array? customProperties = null
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
@@ -309,6 +310,9 @@ namespace GodotTools.Build
 
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
+
+            if (customProperties != null)
+                buildInfo.CustomProperties.AddRange(customProperties);
 
             return buildInfo;
         }
@@ -329,9 +333,10 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            Godot.Collections.Array? customProperties = null
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols, customProperties));
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/DisableRuntimeMarshalling.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/DisableRuntimeMarshalling.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute]

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -179,12 +179,6 @@ namespace GodotTools.Export
             if (!TryDeterminePlatformFromOSName(osName, out string? platform))
                 throw new NotSupportedException("Target platform not supported.");
 
-            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS }
-                    .Contains(platform))
-            {
-                throw new NotImplementedException("Target platform not yet implemented.");
-            }
-
             bool useAndroidLinuxBionic = (bool)GetOption("dotnet/android_use_linux_bionic");
             PublishConfig publishConfig = new()
             {
@@ -225,7 +219,15 @@ namespace GodotTools.Export
                 }
             }
 
+            if (features.Contains("wasm32"))
+            {
+                publishConfig.Archs.Add("wasm32");
+            }
+
             var targets = new List<PublishConfig> { publishConfig };
+
+            var baseDir = ProjectSettings.GlobalizePath(path.GetBaseDir());
+            var customProperties = new Godot.Collections.Array();
 
             if (platform == OS.Platforms.iOS)
             {
@@ -240,9 +242,21 @@ namespace GodotTools.Export
                 });
             }
 
+            if (platform == OS.Platforms.Web)
+            {
+                var configString = Godot.FileAccess.GetFileAsString(Path.Combine(baseDir, "libgodot", "config.json"));
+                var configDict = Godot.Json.ParseString(configString).AsGodotDictionary();
+                var linkFlags = configDict["LINKFLAGS"].As<string>();
+                if (linkFlags.Contains("-sUSE_PTHREADS=1") || linkFlags.Contains("-pthread"))
+                    customProperties.Add($"WasmEnableThreads=true");
+                else
+                    customProperties.Add($"WasmEnableThreads=false");
+                customProperties.Add($"BaseLibGodotPath=\"{Path.Combine(baseDir, "libgodot")}\"");
+            }
+
             List<string> outputPaths = new();
 
-            bool embedBuildResults = ((bool)GetOption("dotnet/embed_build_outputs") || platform == OS.Platforms.Android) && platform != OS.Platforms.MacOS;
+            bool embedBuildResults = ((bool)GetOption("dotnet/embed_build_outputs") || platform == OS.Platforms.Android) && (platform != OS.Platforms.MacOS || platform != OS.Platforms.Web);
 
             var exportedJars = new HashSet<string>();
 
@@ -284,7 +298,7 @@ namespace GodotTools.Export
 
                     // Execute dotnet publish.
                     if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
-                            runtimeIdentifier, publishOutputDir, includeDebugSymbols))
+                            runtimeIdentifier, publishOutputDir, includeDebugSymbols, customProperties))
                     {
                         throw new InvalidOperationException("Failed to build project. Check MSBuild panel for details.");
                     }
@@ -299,11 +313,20 @@ namespace GodotTools.Export
                     string assemblyPath = Path.Combine(publishOutputDir, $"{GodotSharpDirs.ProjectAssemblyName}.dll");
                     string nativeAotPath = Path.Combine(publishOutputDir,
                         $"{GodotSharpDirs.ProjectAssemblyName}.{soExt}");
+                    string webAppBundlePath = Path.Combine(publishOutputDir, "AppBundle");
 
-                    if (!File.Exists(assemblyPath) && !File.Exists(nativeAotPath))
+                    if (!File.Exists(assemblyPath) && !File.Exists(nativeAotPath) && !Directory.Exists(webAppBundlePath))
                     {
                         throw new NotSupportedException(
-                            $"Publish succeeded but project assembly not found at '{assemblyPath}' or '{nativeAotPath}'.");
+                            $"Publish succeeded but project assembly not found at '{assemblyPath}' or '{nativeAotPath}' or '{webAppBundlePath}'.");
+                    }
+
+                    if (platform == OS.Platforms.Web)
+                    {
+                        // AddSharedObject also populates gdextensionLibs, which we don't want, so move it manually.
+                        Directory.CopyDirectory(webAppBundlePath, baseDir, true);
+                        File.Move(Path.Combine(baseDir, "_framework", "dotnet.native.wasm"), $"{path.GetBaseName()}.wasm");
+                        continue;
                     }
 
                     // For ios simulator builds, skip packaging the build outputs.
@@ -510,6 +533,7 @@ namespace GodotTools.Export
                 "arm64-v8a" => "arm64",
                 "arm32" => "arm",
                 "arm64" => "arm64",
+                "wasm32" => "wasm",
                 _ => throw new ArgumentOutOfRangeException(nameof(arch), arch, "Unexpected architecture")
             };
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/Directory.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/Directory.cs
@@ -26,6 +26,33 @@ namespace GodotTools.Utils
             System.IO.Directory.Delete(path.GlobalizePath(), recursive);
         }
 
+        public static void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
+        {
+            // Check if the source directory exists
+            if (!Exists(sourceDir))
+                throw new DirectoryNotFoundException($"Source directory not found: {sourceDir.GlobalizePath()}");
+
+            // Cache directories before we start copying
+            string[] dirs = GetDirectories(sourceDir, "*", SearchOption.TopDirectoryOnly);
+
+            // Create the destination directory
+            CreateDirectory(destinationDir);
+
+            // Get the files in the source directory and copy to the destination directory
+            foreach (string file in GetFiles(sourceDir, "*", SearchOption.TopDirectoryOnly))
+            {
+                GodotTools.Utils.File.Copy(file, Path.Combine(destinationDir, file.GetFile()));
+            }
+
+            // If recursive and copying subdirectories, recursively call this method
+            if (recursive)
+            {
+                foreach (string subDir in dirs)
+                {
+                    CopyDirectory(subDir, Path.Combine(destinationDir, new DirectoryInfo(subDir).Name), true);
+                }
+            }
+        }
 
         public static string[] GetDirectories(string path, string searchPattern, SearchOption searchOption)
         {

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/File.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/File.cs
@@ -35,6 +35,11 @@ namespace GodotTools.Utils
             System.IO.File.Copy(sourceFileName.GlobalizePath(), destFileName.GlobalizePath(), overwrite: true);
         }
 
+        public static void Move(string sourceFileName, string destFileName)
+        {
+            System.IO.File.Move(sourceFileName.GlobalizePath(), destFileName.GlobalizePath(), overwrite: true);
+        }
+
         public static byte[] ReadAllBytes(string path)
         {
             return System.IO.File.ReadAllBytes(path.GlobalizePath());

--- a/modules/mono/glue/GodotSharp/GodotPlugins/DisableRuntimeMarshalling.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/DisableRuntimeMarshalling.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -245,7 +245,7 @@ namespace Godot.NativeInterop
 
         public static partial double godotsharp_variant_as_float(scoped in godot_variant p_self);
 
-        public static partial godot_string godotsharp_variant_as_string(scoped in godot_variant p_self);
+        public static partial void godotsharp_variant_as_string(scoped in godot_variant p_self, out godot_string r_dest);
 
         public static partial Vector2 godotsharp_variant_as_vector2(scoped in godot_variant p_self);
 
@@ -279,11 +279,11 @@ namespace Godot.NativeInterop
 
         public static partial Color godotsharp_variant_as_color(scoped in godot_variant p_self);
 
-        public static partial godot_string_name godotsharp_variant_as_string_name(scoped in godot_variant p_self);
+        public static partial void godotsharp_variant_as_string_name(scoped in godot_variant p_self, out godot_string_name r_dest);
 
-        public static partial godot_node_path godotsharp_variant_as_node_path(scoped in godot_variant p_self);
+        public static partial void godotsharp_variant_as_node_path(scoped in godot_variant p_self, out godot_node_path r_dest);
 
-        public static partial Rid godotsharp_variant_as_rid(scoped in godot_variant p_self);
+        public static partial void godotsharp_variant_as_rid(scoped in godot_variant p_self, out Rid r_dest);
 
         public static partial godot_callable godotsharp_variant_as_callable(scoped in godot_variant p_self);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -101,5 +101,29 @@ namespace Godot.NativeInterop
             godotsharp_node_path_new_from_string(out godot_node_path ret, src);
             return ret;
         }
+
+        public static godot_string godotsharp_variant_as_string(scoped in godot_variant p_self)
+        {
+            godotsharp_variant_as_string(p_self, out godot_string ret);
+            return ret;
+        }
+
+        public static godot_string_name godotsharp_variant_as_string_name(scoped in godot_variant p_self)
+        {
+            godotsharp_variant_as_string_name(p_self, out godot_string_name ret);
+            return ret;
+        }
+
+        public static godot_node_path godotsharp_variant_as_node_path(scoped in godot_variant p_self)
+        {
+            godotsharp_variant_as_node_path(p_self, out godot_node_path ret);
+            return ret;
+        }
+
+        public static Rid godotsharp_variant_as_rid(scoped in godot_variant p_self)
+        {
+            godotsharp_variant_as_rid(p_self, out Rid ret);
+            return ret;
+        }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/DisableRuntimeMarshalling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/DisableRuntimeMarshalling.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute]

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -148,6 +148,22 @@
     <Compile Include="Compat.cs" />
   </ItemGroup>
 
+  <!-- Disable runtime marshaling for this assembly. -->
+  <ItemGroup>
+    <Compile Include="DisableRuntimeMarshalling.cs" />
+  </ItemGroup>
+
+  <!-- Pack source-only files. -->
+  <ItemGroup>
+    <Compile Remove="SourceFiles\**\*.cs" />
+    <None Include="SourceFiles\**\*.cs" PackagePath="contentFiles/cs/netstandard2.0/GodotSharp/" Pack="true" BuildAction="Compile" />
+  </ItemGroup>
+
+  <!-- Pack props file that will be auto-included with GodotSharp. -->
+  <ItemGroup>
+    <None Include="GodotSharp.props" PackagePath="build/GodotSharp.props" Pack="true" />
+  </ItemGroup>
+
   <!--
   We import a props file with auto-generated includes. This works well with Rider.
   However, Visual Studio and MonoDevelop won't list them in the solution explorer.

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.props
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.props
@@ -1,0 +1,13 @@
+<Project>
+  <ItemGroup>
+    <!-- Hide source-only content files. -->
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'GodotSharp'">false</Visible>
+    </Compile>
+
+    <!-- Don't add 'DisableRuntimeMarshallingAttribute' to assembly if GodotDisableRuntimeMarshalling is false. -->
+    <Compile
+      Remove="$(MSBuildThisFileDirectory)\..\contentFiles\cs\netstandard2.0\GodotSharp\DisableRuntimeMarshalling.cs"
+      Condition=" '$(GodotDisableRuntimeMarshalling)' != 'true' " />
+  </ItemGroup>
+</Project>

--- a/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/DisableRuntimeMarshalling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/DisableRuntimeMarshalling.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute]

--- a/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/LibGodotBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/LibGodotBridge.cs
@@ -1,0 +1,388 @@
+#if LIBGODOT_ENABLED
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace GodotPlugins.Game
+{
+    // Wrapper for Marshal.StringToHGlobalAnsi/Marshal.FreeHGlobal.
+    public sealed class AnsiString : IDisposable
+    {
+        public nint Ptr { get; private set; } = nint.Zero;
+
+        public AnsiString(string value)
+        {
+            Ptr = Marshal.StringToHGlobalAnsi(value);
+        }
+
+        ~AnsiString()
+        {
+            Dispose(false);
+        }
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        void Dispose(bool _)
+        {
+            if (Ptr != nint.Zero)
+            {
+                Marshal.FreeHGlobal(Ptr);
+                Ptr = nint.Zero;
+            }
+        }
+
+        public override string ToString()
+        {
+            return Marshal.PtrToStringAnsi(Ptr) ?? "Error";
+        }
+
+        public static implicit operator nint(AnsiString ansiString) => ansiString.Ptr;
+    }
+
+    public unsafe class GodotLibrary
+    {
+        public nint GetProcAddress { get; }
+        public nint Token { get; }
+        private delegate* unmanaged<nint, nint> GetProcAddressDelegate { get; }
+
+        public GodotLibrary(nint getProcAddress, nint token)
+        {
+            GetProcAddress = getProcAddress;
+            Token = token;
+            GetProcAddressDelegate = (delegate* unmanaged<nint, nint>)getProcAddress;
+        }
+
+        public nint LoadFunction(string name)
+        {
+            using AnsiString ansiName = new(name);
+            nint fnPtr = GetProcAddressDelegate(ansiName);
+            // Console.WriteLine($"Loaded {name}");
+            return fnPtr;
+        }
+    }
+
+    public enum GDExtensionInitializationLevel
+    {
+        Core,
+        Servers,
+        Scene,
+        Editor,
+        Max,
+    }
+
+    public enum GDExtensionVariantType
+    {
+        Nil = 0,
+        Bool = 1,
+        Int = 2,
+        Float = 3,
+        String = 4,
+        Vector2 = 5,
+        Vector2I = 6,
+        Rect2 = 7,
+        Rect2I = 8,
+        Vector3 = 9,
+        Vector3I = 10,
+        TRANSFORM2D = 11,
+        Vector4 = 12,
+        Vector4I = 13,
+        Plane = 14,
+        Quaternion = 15,
+        Aabb = 16,
+        Basis = 17,
+        TRANSFORM3D = 18,
+        Projection = 19,
+        Color = 20,
+        StringName = 21,
+        NodePath = 22,
+        Rid = 23,
+        Object = 24,
+        Callable = 25,
+        Signal = 26,
+        Dictionary = 27,
+        Array = 28,
+        PackedByteArray = 29,
+        PackedInt32Array = 30,
+        PackedInt64Array = 31,
+        PackedFloat32Array = 32,
+        PackedFloat64Array = 33,
+        PackedStringArray = 34,
+        PackedVector2Array = 35,
+        PackedVector3Array = 36,
+        PackedColorArray = 37,
+        PackedVECTOR4Array = 38,
+        VariantMax = 39,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct GDExtensionInitialization
+    {
+        public GDExtensionInitializationLevel MinimumInitializationLevel;
+        public nint Userdata;
+        public delegate* unmanaged<nint, GDExtensionInitializationLevel, void> Initialize;
+        public delegate* unmanaged<nint, GDExtensionInitializationLevel, void> Deinitialize;
+    }
+
+    public class StringName : IDisposable
+    {
+        private unsafe static class Bindings
+        {
+            public static delegate* unmanaged<nint, nint, byte, void> string_name_new_with_latin1_chars;
+            public static delegate* unmanaged<nint, void> destructor;
+
+            public static void Initialize()
+            {
+                string_name_new_with_latin1_chars = (delegate* unmanaged<nint, nint, byte, void>)SimpleInterface.Library.LoadFunction("string_name_new_with_latin1_chars");
+                destructor = SimpleInterface.variant_get_ptr_destructor(GDExtensionVariantType.StringName);
+            }
+        }
+        public nint Ptr { get; private set; }
+
+        public unsafe StringName(string content)
+        {
+            using AnsiString ansiString = new(content);
+            Ptr = Marshal.AllocHGlobal(Unsafe.SizeOf<nint>());
+            Bindings.string_name_new_with_latin1_chars(Ptr, ansiString.Ptr, 0);
+        }
+
+        ~StringName()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private unsafe void Dispose(bool _)
+        {
+            if (Ptr != nint.Zero)
+            {
+                Bindings.destructor(Ptr);
+                Marshal.FreeHGlobal(Ptr);
+                Ptr = nint.Zero;
+            }
+        }
+
+        public static void InitializeBindings()
+        {
+            Bindings.Initialize();
+        }
+    }
+
+    // GodotInstance implementation.
+    public unsafe partial class GodotInstance : IDisposable
+    {
+        // Import LibGodot functions.
+        [LibraryImport("libgodot")]
+        private static partial nint libgodot_create_godot_instance(int argc, nint* argv, nint initFunc);
+        [LibraryImport("libgodot")]
+        private static partial void libgodot_destroy_godot_instance(nint godotInstance);
+
+        private static class Bindings
+        {
+            public static nint mbStart;
+            public static nint mbIsStarted;
+            public static nint mbIteration;
+            public static nint mbFocusIn;
+            public static nint mbFocusOut;
+            public static nint mbPause;
+            public static nint mbResume;
+
+            public static void Initialize()
+            {
+                using StringName nativeName = new("GodotInstance");
+
+                using StringName startName = new("start");
+                // Console.WriteLine("GodotInstance before start");
+                mbStart = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, startName.Ptr, 2240911060L);
+
+                using StringName isStartedName = new("is_started");
+                // Console.WriteLine("GodotInstance before is_started");
+                mbIsStarted = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, isStartedName.Ptr, 2240911060L);
+
+                using StringName iteratiomName = new("iteration");
+                // Console.WriteLine("GodotInstance before iteration");
+                mbIteration = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, iteratiomName.Ptr, 2240911060L);
+
+                using StringName focusInName = new("focus_in");
+                // Console.WriteLine("GodotInstance before focus_in");
+                mbFocusIn = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, focusInName.Ptr, 3218959716L);
+
+                using StringName focusOutName = new("focus_out");
+                // Console.WriteLine("GodotInstance before focus_out");
+                mbFocusOut = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, focusOutName.Ptr, 3218959716L);
+
+                using StringName pauseName = new("pause");
+                // Console.WriteLine("GodotInstance before pause");
+                mbPause = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, pauseName.Ptr, 3218959716L);
+
+                using StringName resumeName = new("resume");
+                // Console.WriteLine("GodotInstance before resume");
+                mbResume = SimpleInterface.classdb_get_method_bind(nativeName.Ptr, resumeName.Ptr, 3218959716L);
+            }
+        }
+
+        private nint owner;
+
+        private GodotInstance(nint owner)
+        {
+            this.owner = owner;
+        }
+
+        public static GodotInstance? CreateInstance(string[] args, delegate* unmanaged<nint, nint, GDExtensionInitialization*, byte> gdExtensionInit)
+        {
+            AnsiString[] argsAnsi = [.. args.Select(arg => new AnsiString(arg))];
+            nint[] argsPtrs = [.. argsAnsi.Select(arg => arg.Ptr)];
+            try
+            {
+                fixed (nint* argsBegin = argsPtrs)
+                {
+                    // Console.WriteLine($"Before libgodot_create_godot_instance {argsPtrs.Length}");
+                    nint instance = libgodot_create_godot_instance(argsPtrs.Length, argsBegin, (nint)gdExtensionInit);
+                    // Console.WriteLine("After libgodot_create_godot_instance");
+                    if (instance == nint.Zero) { return null; }
+                    return new GodotInstance(instance);
+                }
+            }
+            finally
+            {
+                foreach (var arg in argsAnsi)
+                {
+                    arg.Dispose();
+                }
+            }
+        }
+
+        ~GodotInstance()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool _)
+        {
+            if (owner != nint.Zero)
+            {
+                libgodot_destroy_godot_instance(owner);
+                owner = nint.Zero;
+            }
+        }
+
+        public static void InitializeBindings()
+        {
+            Bindings.Initialize();
+        }
+
+        public bool Start()
+        {
+            nint* args = stackalloc nint[0];
+            byte ret = 0;
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbStart, owner, args, (nint)(void*)&ret);
+            return ret != 0;
+        }
+        public bool IsStarted()
+        {
+            nint* args = stackalloc nint[0];
+            byte ret = 0;
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbIsStarted, owner, args, (nint)(void*)&ret);
+            return ret != 0;
+        }
+        public bool Iteration()
+        {
+            nint* args = stackalloc nint[0];
+            byte ret = 0;
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbIteration, owner, args, (nint)(void*)&ret);
+            return ret != 0;
+        }
+        public void FocusIn()
+        {
+            nint* args = stackalloc nint[0];
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbFocusIn, owner, args, nint.Zero);
+        }
+        public void FocusOut()
+        {
+            nint* args = stackalloc nint[0];
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbFocusOut, owner, args, nint.Zero);
+        }
+        public void Pause()
+        {
+            nint* args = stackalloc nint[0];
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbPause, owner, args, nint.Zero);
+        }
+        public void Resume()
+        {
+            nint* args = stackalloc nint[0];
+            SimpleInterface.object_method_bind_ptrcall(Bindings.mbResume, owner, args, nint.Zero);
+        }
+    }
+
+    // Simple GDExtension interface. Loads only what is needed for GodotInstance
+    public unsafe static class SimpleInterface
+    {
+        private static GodotLibrary? library = null;
+        public static GodotLibrary Library => library ?? throw new NullReferenceException(nameof(library));
+
+        public static delegate* unmanaged<GDExtensionVariantType, delegate* unmanaged<nint, void>> variant_get_ptr_destructor;
+        public static delegate* unmanaged<nint, nint, long, nint> classdb_get_method_bind;
+        public static delegate* unmanaged<nint, nint, nint*, nint, void> object_method_bind_ptrcall;
+
+        public static void Initialize(nint getProcAddress, nint token)
+        {
+            // Console.WriteLine("Inside SimpleInterface.Initialize");
+            library = new(getProcAddress, token);
+            // Console.WriteLine("Create library wrapper");
+            variant_get_ptr_destructor = (delegate* unmanaged<GDExtensionVariantType, delegate* unmanaged<nint, void>>)library.LoadFunction("variant_get_ptr_destructor");
+            classdb_get_method_bind = (delegate* unmanaged<nint, nint, long, nint>)library.LoadFunction("classdb_get_method_bind");
+            object_method_bind_ptrcall = (delegate* unmanaged<nint, nint, nint*, nint, void>)library.LoadFunction("object_method_bind_ptrcall");
+
+            StringName.InitializeBindings();
+            // Console.WriteLine("StringName after init");
+
+            GodotInstance.InitializeBindings();
+            // Console.WriteLine("GodotInstance after init");
+        }
+    }
+
+    // GDExtensions related init
+    public static partial class LibGodot
+    {
+        [UnmanagedCallersOnly]
+        private static void Initialize(nint userdata, GDExtensionInitializationLevel level) { }
+
+        [UnmanagedCallersOnly]
+        private static void Deinitialize(nint userdata, GDExtensionInitializationLevel level) { }
+
+        [UnmanagedCallersOnly]
+        private static unsafe byte GDExtensionInit(nint getProcAddress, nint token, GDExtensionInitialization* initialization)
+        {
+            // Console.WriteLine("Inside GDExtensionInit");
+            initialization->MinimumInitializationLevel = GDExtensionInitializationLevel.Scene;
+            initialization->Initialize = &Initialize;
+            initialization->Deinitialize = &Deinitialize;
+            initialization->Userdata = nint.Zero;
+
+            SimpleInterface.Initialize(getProcAddress, token);
+            return 1;
+        }
+
+        public static unsafe GodotInstance? CreateGodotInstance(string[] args)
+        {
+            return GodotInstance.CreateInstance(args, &GDExtensionInit);
+        }
+    }
+}
+#endif

--- a/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/LibGodotMain.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/LibGodotMain.cs
@@ -1,0 +1,169 @@
+#if LIBGODOT_ENABLED
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#if GODOT_WEB
+using System.Runtime.InteropServices.JavaScript;
+// Silence web build warnings for [JSImport]/[JSExport]
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("browser")]
+#endif
+
+namespace GodotPlugins.Game
+{
+    internal static partial class Initializer
+    {
+        // Set initialization getter, it needs to be this roundabout for godot as dll to work.
+        // Static library could access [UnmanagedCallersOnly] with entry point directly.
+        [LibraryImport("libgodot")]
+        private static partial void set_load_from_executable_fn(nint callback);
+
+        [UnmanagedCallersOnly]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static nint LoadFromExecutable()
+        {
+            // Console.WriteLine("LoadFromExecutable called");
+#if TOOLS
+            // Use builtin dotnet loading for editor.
+            return nint.Zero;
+#else
+            // Use NativeAOT loader for export build.s
+            return global::GodotPlugins.Game.Main.GetInitializePointer();
+#endif
+        }
+
+#if !GODOT_WEB
+        static unsafe int Main()
+        {
+            // Console.WriteLine("LibGodot static main begin");
+            List<string> args = [.. Environment.GetCommandLineArgs()];
+
+            // Console.WriteLine($"Environment.CurrentDirectory: {Environment.CurrentDirectory}");
+            var instance = LibGodot.CreateGodotInstance([.. args]);
+            if (instance is null)
+            {
+                Console.Error.WriteLine("Error creating Godot instance");
+                return 1;
+            }
+
+            set_load_from_executable_fn((nint)(delegate* unmanaged<nint>)&LoadFromExecutable);
+
+            // Console.WriteLine("LibGodot before start");
+
+            instance.Start();
+
+            // Console.WriteLine("LibGodot before first iteration");
+            while (!instance.Iteration()) { }
+
+            // Console.WriteLine("LibGodot before destroy");
+            instance.Dispose();
+
+            return 0;
+        }
+
+#else // GODOT_WEB
+
+        // Load emscriptens functions.
+        [DllImport("*")]
+        private static extern void emscripten_set_main_loop(nint func, int fps, byte simulate_infinite_loop);
+        // [DllImport("*")]
+        // private static extern byte emscripten_is_main_browser_thread();
+        [DllImport("*")]
+        private static extern void emscripten_cancel_main_loop();
+        [DllImport("*")]
+        private static extern void emscripten_force_exit(int status);
+
+        // Load godot js libraries.
+        [DllImport("*")]
+        private static unsafe extern void godot_js_os_finish_async(nint func);
+
+        // Custom web iteration.
+        [LibraryImport("libgodot")]
+        private static partial byte libgodot_web_iteration();
+
+        private static GodotInstance? instance = null;
+        private static bool shutdownComplete = false;
+
+        [UnmanagedCallersOnly]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ExitCallback()
+        {
+            if (!shutdownComplete)
+            {
+                return; // Still waiting.
+            }
+            if (instance is not null)
+            {
+                // Console.WriteLine("LibGodot before destroy");
+                instance.Dispose();
+                instance = null;
+            }
+            emscripten_cancel_main_loop();
+            emscripten_force_exit(0);
+        }
+
+        [UnmanagedCallersOnly]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void CleanupAfterSync()
+        {
+            shutdownComplete = true;
+        }
+
+        private static unsafe void SetupExit()
+        {
+            emscripten_cancel_main_loop();
+            emscripten_set_main_loop((nint)(delegate* unmanaged<void>)&ExitCallback, -1, 0);
+            godot_js_os_finish_async((nint)(delegate* unmanaged<void>)&CleanupAfterSync);
+        }
+
+
+        [UnmanagedCallersOnly]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void MainLoopCallback()
+        {
+            if (libgodot_web_iteration() != 0)
+            {
+                SetupExit();
+            }
+        }
+
+        static unsafe int Main()
+        {
+            // Checking that we are not in the actual browser thread inside multithreaded main.
+            // This makes it similar to enabled PROXY_TO_PTHREAD, which godot supports, so it's fine.
+            // The only bad thing is that there is no automatic support for transferring offscreen canvas
+            // to this main thread, which leads to a hack that adds support for it.
+            // Console.WriteLine($"LibGodot is main browser thread: {emscripten_is_main_browser_thread() != 0}");
+            // Console.WriteLine("LibGodot web main begin");
+            List<string> args = [.. Environment.GetCommandLineArgs()];
+            instance = LibGodot.CreateGodotInstance([.. args]);
+            if (instance is null)
+            {
+                Console.Error.WriteLine("Error creating Godot instance");
+                return 1;
+            }
+
+            set_load_from_executable_fn((nint)(delegate* unmanaged<nint>)&LoadFromExecutable);
+            // Console.WriteLine("LibGodot web before start");
+
+            instance.Start();
+            // Console.WriteLine("LibGodot web start");
+
+            emscripten_set_main_loop((nint)(delegate* unmanaged<void>)&MainLoopCallback, -1, 0);
+
+            // Console.WriteLine("LibGodot before first iteration");
+            if (libgodot_web_iteration() != 0)
+            {
+                SetupExit();
+                return 0;
+            }
+
+            return 0;
+        }
+#endif
+    }
+}
+#endif

--- a/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/WebTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/SourceFiles/WebTrampolines.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GodotPlugins.Game
+{
+    internal static partial class Initializer
+    {
+        // Generate web trampolines.
+        // C# doesn't automatically generate them if delegate is of type 'delegate* unmanaged<[contains long or ulong]>'.
+        // Should be updated when new function pointers with long or ulong argument type are added.
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate IntPtr classdb_get_method_bind_sig(IntPtr _1, IntPtr _2, long _3);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr godotsharp_method_bind_get_method_with_compatibility_sig(IntPtr _0, IntPtr _1, ulong _2);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate Godot.Color godotsharp_color_from_ok_hsl_sig(float _0, float _1, float _2, float _3);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate float godotsharp_color_get_ok_hsl_get_sig(IntPtr _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate long godotsharp_variant_as_int_sig(IntPtr _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate double godotsharp_variant_as_float_sig(IntPtr _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void godotsharp_packed_byte_array_decompress_sig(IntPtr _0, long _1, int _2, IntPtr _3);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void godotsharp_packed_byte_array_decompress_dynamic_sig(IntPtr _0, long _1, int _2, IntPtr _3);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        internal delegate IntPtr godotsharp_instance_from_id_sig(ulong _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        internal delegate uint godotsharp_rand_from_seed_sig(ulong _0, IntPtr _1);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void godotsharp_seed_sig(ulong _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate float godotsharp_randf_sig();
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate double godotsharp_randf_range_sig(double _0, double _1);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate long godotsharp_array_size_sig(IntPtr _0);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate Godot.Error godotsharp_stack_info_vector_resize_sig(IntPtr _0, int _1);
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate Godot.Error godotsharp_internal_signal_awaiter_connect_sig(IntPtr _0, IntPtr _1, IntPtr _3, IntPtr _4);
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/DisableRuntimeMarshalling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/DisableRuntimeMarshalling.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute]

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -39,6 +39,10 @@
   <ItemGroup Condition=" '$(GodotNoDeprecated)' == '' ">
     <Compile Include="Compat.cs" />
   </ItemGroup>
+  <!-- Disable runtime marshaling for this assembly. -->
+  <ItemGroup>
+    <Compile Include="DisableRuntimeMarshalling.cs" />
+  </ItemGroup>
   <!--
   We import a props file with auto-generated includes. This works well with Rider.
   However, Visual Studio and MonoDevelop won't list them in the solution explorer.

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -695,11 +695,8 @@ double godotsharp_variant_as_float(const Variant *p_self) {
 	return p_self->operator double();
 }
 
-godot_string godotsharp_variant_as_string(const Variant *p_self) {
-	godot_string raw_dest;
-	String *dest = (String *)&raw_dest;
-	memnew_placement(dest, String(p_self->operator String()));
-	return raw_dest;
+void godotsharp_variant_as_string(const Variant *p_self, godot_string *r_dest) {
+	memnew_placement(r_dest, String(p_self->operator String()));
 }
 
 godot_vector2 godotsharp_variant_as_vector2(const Variant *p_self) {
@@ -814,25 +811,16 @@ godot_color godotsharp_variant_as_color(const Variant *p_self) {
 	return raw_dest;
 }
 
-godot_string_name godotsharp_variant_as_string_name(const Variant *p_self) {
-	godot_string_name raw_dest;
-	StringName *dest = (StringName *)&raw_dest;
-	memnew_placement(dest, StringName(p_self->operator StringName()));
-	return raw_dest;
+void godotsharp_variant_as_string_name(const Variant *p_self, godot_string_name *r_dest) {
+	memnew_placement(r_dest, StringName(p_self->operator StringName()));
 }
 
-godot_node_path godotsharp_variant_as_node_path(const Variant *p_self) {
-	godot_node_path raw_dest;
-	NodePath *dest = (NodePath *)&raw_dest;
-	memnew_placement(dest, NodePath(p_self->operator NodePath()));
-	return raw_dest;
+void godotsharp_variant_as_node_path(const Variant *p_self, godot_node_path *r_dest) {
+	memnew_placement(r_dest, NodePath(p_self->operator NodePath()));
 }
 
-godot_rid godotsharp_variant_as_rid(const Variant *p_self) {
-	godot_rid raw_dest;
-	RID *dest = (RID *)&raw_dest;
-	memnew_placement(dest, RID(p_self->operator ::RID()));
-	return raw_dest;
+void godotsharp_variant_as_rid(const Variant *p_self, godot_rid *r_dest) {
+	memnew_placement(r_dest, RID(p_self->operator ::RID()));
 }
 
 godot_callable godotsharp_variant_as_callable(const Variant *p_self) {

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -428,6 +428,33 @@ using godot_plugins_initialize_fn = bool (*)(void *, bool, gdmono::PluginCallbac
 using godot_plugins_initialize_fn = bool (*)(void *, GDMonoCache::ManagedCallbacks *, const void **, int32_t);
 #endif
 
+#if defined(GD_MONO_LIBGODOT_ENABLED)
+// Export macros for DLL visibility
+#if (defined(_MSC_VER) || defined(__MINGW32__))
+#define MONO_LIBGODOT_API __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define MONO_LIBGODOT_API __attribute__((visibility("default")))
+#else
+#define MONO_LIBGODOT_API
+#endif
+
+using try_load_from_executable_callback_fn = godot_plugins_initialize_fn (*)();
+try_load_from_executable_callback_fn try_load_from_executable_fn = nullptr;
+
+extern "C" MONO_LIBGODOT_API void set_load_from_executable_fn(try_load_from_executable_callback_fn callback) {
+	try_load_from_executable_fn = callback;
+}
+
+#undef MONO_LIBGODOT_API
+
+godot_plugins_initialize_fn try_load_from_executable() {
+	if (try_load_from_executable_fn == nullptr) {
+		return nullptr;
+	}
+	return try_load_from_executable_fn();
+}
+#endif
+
 #ifdef TOOLS_ENABLED
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
@@ -636,6 +663,41 @@ static bool _on_core_api_assembly_loaded() {
 	return true;
 }
 
+bool load_godot_plugins_initialize(godot_plugins_initialize_fn &r_godot_plugins_initialize, void *&r_hostfxr_dll_handle, void *&r_coreclr_dll_handle, bool &r_runtime_initialized) {
+#if defined(GD_MONO_LIBGODOT_ENABLED)
+	r_godot_plugins_initialize = try_load_from_executable();
+
+	if (r_godot_plugins_initialize != nullptr) {
+		r_runtime_initialized = true;
+		return true;
+	}
+#endif
+
+	if (load_hostfxr(r_hostfxr_dll_handle)) {
+		r_godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(r_runtime_initialized);
+		ERR_FAIL_NULL_V(r_godot_plugins_initialize, false);
+		return true;
+	}
+
+#if !defined(TOOLS_ENABLED)
+	if (load_coreclr(r_coreclr_dll_handle)) {
+		r_godot_plugins_initialize = initialize_coreclr_and_godot_plugins(r_runtime_initialized);
+		ERR_FAIL_NULL_V(r_godot_plugins_initialize, false);
+		return true;
+	}
+
+	void *dll_handle = nullptr;
+	r_godot_plugins_initialize = try_load_native_aot_library(dll_handle);
+
+	if (r_godot_plugins_initialize != nullptr) {
+		r_runtime_initialized = true;
+		return true;
+	}
+#endif
+
+	return false;
+}
+
 void GDMono::initialize() {
 	print_verbose(".NET: Initializing module...");
 
@@ -643,7 +705,7 @@ void GDMono::initialize() {
 
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
-#if !defined(APPLE_EMBEDDED_ENABLED)
+#if !(defined(APPLE_EMBEDDED_ENABLED) || defined(GD_MONO_LIBGODOT_ENABLED))
 	// Check that the .NET assemblies directory exists before trying to use it.
 	if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
 		OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
@@ -651,30 +713,12 @@ void GDMono::initialize() {
 	}
 #endif
 
-	if (load_hostfxr(hostfxr_dll_handle)) {
-		godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(runtime_initialized);
-		ERR_FAIL_NULL(godot_plugins_initialize);
-	} else {
-#if !defined(TOOLS_ENABLED)
-		if (load_coreclr(coreclr_dll_handle)) {
-			godot_plugins_initialize = initialize_coreclr_and_godot_plugins(runtime_initialized);
-		} else {
-			void *dll_handle = nullptr;
-			godot_plugins_initialize = try_load_native_aot_library(dll_handle);
-			if (godot_plugins_initialize != nullptr) {
-				runtime_initialized = true;
-			}
-		}
-
-		if (godot_plugins_initialize == nullptr) {
-			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
-		}
-#else
-
+	if (!load_godot_plugins_initialize(godot_plugins_initialize, hostfxr_dll_handle, coreclr_dll_handle, runtime_initialized)) {
+#ifdef TOOLS_ENABLED
 		// Show a message box to the user to make the problem explicit (and explain a potential crash).
 		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
-		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 #endif
+		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 	}
 
 	int32_t interop_funcs_size = 0;

--- a/modules/mono/web/callMain_stub.js
+++ b/modules/mono/web/callMain_stub.js
@@ -1,0 +1,6 @@
+// When we are passing "callMain" to <EmccExportedRuntimeMethod /> it checks if "callMain" exists,
+// but doesn't generate "callMain" itself. I guess emscripten is hard wired to detect
+// main and only generates "callMain" if it detects it. Or it is some C# customization.
+const callMain = function (_args) { // eslint-disable-line no-unused-vars
+	throw new Error('"callMain" is not implemented.');
+};

--- a/modules/mono/web/mono_bridge.js
+++ b/modules/mono/web/mono_bridge.js
@@ -1,0 +1,93 @@
+/**************************************************************************/
+/*  mono_bridge.js                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// Custom Godot replacement. As long as it accepts what original accepted
+// and returns emscripten module, it can serve as a substitute.
+const Godot = async (moduleConfig) => { // eslint-disable-line no-unused-vars
+	// Needed for working [JSImport]/[JSExport] and multithreading
+	// It actually kind of worked with only single thread, but
+	// [JSImport]/[JSExport] still didn't work.
+	delete moduleConfig['instantiateWasm'];
+
+	// Depends on "dotnet.native.wasm" being in place of "godot.wasm".
+	const loadPath = moduleConfig['locateFile']('dotnet.native.wasm');
+	// Get preloaded wasm.
+	let preloadedWasm = moduleConfig['getPreloadedWasm']();
+
+	// dynamic module import.
+	const dotnetjs = await import('./_framework/dotnet.js');
+	const dotnet = dotnetjs.dotnet;
+
+	dotnet
+		// Pass emscripten config.
+		.withModuleConfig(moduleConfig)
+		.withConfig({
+			// We passed -sPTHREAD_POOL_SIZE=0 as C# depend on it, but C# provides its own
+			// setting to configure the initial thread pool size that we can use instead.
+			pthreadPoolInitialSize: moduleConfig['emscriptenPoolSize'] || 8,
+			// Enables sync calls from and to [JSImport]/[JSExport]
+			// when multithreading is enabled.
+			jsThreadBlockingMode: 'ThrowWhenBlockingWait',
+		})
+		.withResourceLoader((_type, name, _defaultUri, _integrity, _behavior) => {
+			if (name === 'dotnet.native.wasm') {
+				if (preloadedWasm) {
+					// Resource loader allows us to pass a promise with response
+					// so we pass preloaded wasm here as a promise.
+					const promise = Promise.resolve(preloadedWasm);
+					preloadedWasm = null;
+					return promise;
+				}
+				// Now that we don't have wasm, if it needs it for something
+				// pass the path to it.
+				return loadPath;
+			}
+			// Use the default path.
+			return null;
+		});
+
+	await dotnet.download();
+	const { setModuleImports, getAssemblyExports, getConfig, runMain, Module } = await dotnet.create();
+
+	const dotnetConfig = getConfig();
+
+	if (moduleConfig['godotSharpImports']) {
+		const moduleImports = moduleConfig['godotSharpImports'];
+		for (const moduleName of Object.keys(moduleImports)) {
+			setModuleImports(moduleName, moduleImports[moduleName]);
+		}
+	}
+	Module['getGodotSharpExports'] = getAssemblyExports.bind(null, dotnetConfig.mainAssemblyName);
+
+	// As "callMain" is missing, we can create custom replacement,
+	// as this is what Godot calls to start wasm.
+	Module.callMain = (args) => runMain(dotnetConfig.mainAssemblyName, args);
+	return Module;
+};

--- a/modules/mono/web/setjmp_stub.js
+++ b/modules/mono/web/setjmp_stub.js
@@ -1,0 +1,12 @@
+// Missing functions for godot when building C# wasm. I still don't know why they are missing.
+const SetJmpStub = {
+	__wasm_setjmp_sig: 'vpip',
+	__wasm_setjmp: function (_env, _label, _func_invocation_id) { },
+
+	__wasm_setjmp_test_sig: 'ipp',
+	__wasm_setjmp_test: function (_env, _func_invocation_id) {
+		return 0;
+	},
+};
+
+addToLibrary(SetJmpStub);

--- a/modules/webxr/config.py
+++ b/modules/webxr/config.py
@@ -3,6 +3,11 @@ def can_build(env, platform):
         # WebXR is incompatible with proxy_to_pthread.
         return False
 
+    if platform == "web" and env["module_mono_enabled"]:
+        # NOTE: Remove when C# emscripten updates from 3.1.56.
+        # Single-threaded build should support it.
+        return False
+
     return env["opengl3"] and not env["disable_xr"]
 
 

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -5,6 +5,8 @@ Import("env")
 
 import platform_linuxbsd_builders
 
+from platform_methods import combine_libs_ar, filter_file_libs
+
 common_linuxbsd = [
     "crash_handler_linuxbsd.cpp",
     "os_linuxbsd.cpp",
@@ -41,9 +43,14 @@ if env["dbus"]:
         common_linuxbsd.append("dbus-so_wrap.c")
 
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", common_linuxbsd)
+    linux_lib = env.add_library("#bin/godot_static", common_linuxbsd)
+    prog = env.CommandNoCache(
+        f"#bin/libgodot{env['LIBSUFFIX']}", filter_file_libs([linux_lib] + env["LIBS"]), env.Run(combine_libs_ar)
+    )
+    env.add_configuration_file("#bin/libgodot")
 elif env["library_type"] == "shared_library":
     prog = env.add_shared_library("#bin/godot", common_linuxbsd)
+    env.add_configuration_file("#bin/libgodot")
 else:
     prog = env.add_program("#bin/godot", common_linuxbsd)
 

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -43,6 +43,10 @@
 #undef CRASH_HANDLER_ENABLED
 #endif
 
+#ifdef DISABLE_CRASH_HANDLER
+#undef CRASH_HANDLER_ENABLED
+#endif
+
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -203,6 +203,9 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
 
+    if env["library_type"] == "static_library":
+        env["OBJCOPY"] = "llvm-objcopy" if env["use_llvm"] else "objcopy"
+
     if env["library_type"] == "shared_library":
         env.Append(CCFLAGS=["-fPIC"])
 
@@ -225,7 +228,11 @@ def configure(env: "SConsEnvironment"):
             env.Append(CCFLAGS=["-flto"])
             env.Append(LINKFLAGS=["-flto"])
 
-        if not env["use_llvm"]:
+    if env["lto"] != "none" or env["library_type"] == "static_library":
+        if env["use_llvm"]:
+            env["RANLIB"] = "llvm-ranlib"
+            env["AR"] = "llvm-ar"
+        else:
             env["RANLIB"] = "gcc-ranlib"
             env["AR"] = "gcc-ar"
 

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -46,6 +46,10 @@
 #define CRASH_HANDLER_ENABLED 1
 #endif
 
+#if defined(DISABLE_CRASH_HANDLER)
+#undef CRASH_HANDLER_ENABLED
+#endif
+
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -2,6 +2,7 @@
 from misc.utility.scons_hints import *
 
 from methods import print_error
+from platform_methods import combine_libs_ar, filter_file_libs
 
 Import("env")
 
@@ -26,9 +27,13 @@ web_files = [
     "display_server_web.cpp",
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",
-    "web_main.cpp",
     "os_web.cpp",
 ]
+
+if env["library_type"] == "executable":
+    web_files += ["web_main.cpp"]
+else:
+    web_files += ["libgodot_web.cpp"]
 
 if env["target"] == "editor":
     env.add_source_files(web_files, "editor/*.cpp")
@@ -69,14 +74,54 @@ for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 sys_env["ENV"]["EMCC_CLOSURE_ARGS"] = sys_env["ENV"]["EMCC_CLOSURE_ARGS"].strip()
 
-if len(env["EXPORTED_FUNCTIONS"]):
-    sys_env.Append(LINKFLAGS=["-sEXPORTED_FUNCTIONS=" + repr(sorted(list(set(env["EXPORTED_FUNCTIONS"]))))])
-if len(env["EXPORTED_RUNTIME_METHODS"]):
-    sys_env.Append(LINKFLAGS=["-sEXPORTED_RUNTIME_METHODS=" + repr(sorted(list(set(env["EXPORTED_RUNTIME_METHODS"]))))])
-
-build = []
 build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
-if env["dlink_enabled"]:
+main_js = None
+main_wasm = None
+side_wasm = None
+libgodot = None
+
+if env["library_type"] != "executable":
+    libgodot = {}
+    conf_env = env.Clone()
+    # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
+    conf_env.Append(LIBS=["idbfs.js"])
+    if env["library_type"] == "shared_library":
+        conf_env["CCFLAGS"].remove("-sSIDE_MODULE=2")
+        conf_env["LINKFLAGS"].remove("-sSIDE_MODULE=2")
+        conf_env["CCFLAGS"].remove("-fvisibility=hidden")
+        conf_env["LINKFLAGS"].remove("-fvisibility=hidden")
+    libgodot["config"] = conf_env.add_configuration_file(
+        "#bin/libgodot",
+        {
+            "EMCC_EXPORTED_FUNCTIONS": ";".join(env["EXPORTED_FUNCTIONS"]),
+            "EMCC_EXPORTED_RUNTIME_METHODS": ";".join(env["EXPORTED_RUNTIME_METHODS"]),
+        },
+    )[0]
+    if env["CUSTOM_GODOT_JS"] is not None:
+        main_js = env["CUSTOM_GODOT_JS"]
+    else:
+        main_js = env.Textfile(build_targets[0], [""])[0]
+    libgodot["JS_LIBS"] = sys_env["JS_LIBS"]
+    libgodot["JS_PRE"] = sys_env["JS_PRE"]
+    libgodot["JS_POST"] = sys_env["JS_POST"]
+    libgodot["JS_EXTERNS"] = sys_env["JS_EXTERNS"]
+
+if len(env["EXPORTED_FUNCTIONS"]):
+    sys_env.Append(LINKFLAGS=[env.Literal("-sEXPORTED_FUNCTIONS=" + ",".join(env["EXPORTED_FUNCTIONS"]))])
+if len(env["EXPORTED_RUNTIME_METHODS"]):
+    sys_env.Append(LINKFLAGS=[env.Literal("-sEXPORTED_RUNTIME_METHODS=" + ",".join(env["EXPORTED_RUNTIME_METHODS"]))])
+
+if env["library_type"] == "static_library":
+    web_lib = sys_env.add_library("#bin/libgodot_static", web_files)
+    libgodot["libgodot"] = sys_env.CommandNoCache(
+        "#bin/libgodot${LIBSUFFIX}", filter_file_libs([web_lib] + sys_env["LIBS"]), sys_env.Run(combine_libs_ar)
+    )[0]
+elif env["library_type"] == "shared_library":
+    if len(env["EXPORTED_FUNCTIONS_SHARED"]):
+        env.Append(LINKFLAGS=[env.Literal("-sEXPORTED_FUNCTIONS=" + ",".join(env["EXPORTED_FUNCTIONS_SHARED"]))])
+    # The side library, containing all Godot code.
+    side_wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)[0]
+elif env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
@@ -84,28 +129,27 @@ if env["dlink_enabled"]:
     # Configure it as a main module (dynamic linking support).
     sys_env["CCFLAGS"].remove("-sSIDE_MODULE=2")
     sys_env["LINKFLAGS"].remove("-sSIDE_MODULE=2")
-    sys_env.Append(CCFLAGS=["-s", "MAIN_MODULE=1"])
-    sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
-    sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
-    sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
     sys_env["CCFLAGS"].remove("-fvisibility=hidden")
     sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
+    sys_env.Append(CCFLAGS=["-sMAIN_MODULE=1"])
+    sys_env.Append(LINKFLAGS=["-sMAIN_MODULE=1"])
+    sys_env.Append(LINKFLAGS=["-sEXPORT_ALL=1"])
+    sys_env.Append(LINKFLAGS=["-sWARN_ON_UNDEFINED_SYMBOLS=0"])
 
     # The main emscripten runtime, with exported standard libraries.
-    sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
+    main_js, main_wasm = sys_env.add_program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
-    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
-    build = sys + [wasm[0]]
+    side_wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)[0]
 else:
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
-    build = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
+    main_js, main_wasm = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
 
-sys_env.Depends(build[0], sys_env["JS_LIBS"])
-sys_env.Depends(build[0], sys_env["JS_PRE"])
-sys_env.Depends(build[0], sys_env["JS_POST"])
-sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
+sys_env.Depends(main_js, sys_env["JS_LIBS"])
+sys_env.Depends(main_js, sys_env["JS_PRE"])
+sys_env.Depends(main_js, sys_env["JS_POST"])
+sys_env.Depends(main_js, sys_env["JS_EXTERNS"])
 
 engine = [
     "js/engine/features.js",
@@ -118,7 +162,7 @@ js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, ex
 env.Depends(js_engine, externs)
 
 wrap_list = [
-    build[0],
+    main_js,
     js_engine,
 ]
 js_wrapped = env.NoCache(
@@ -126,6 +170,7 @@ js_wrapped = env.NoCache(
 )
 
 # 0 - unwrapped js file (use wrapped one instead)
-# 1 - wasm file
-# 2 - wasm side (when dlink is enabled).
-env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)
+# 1 - wasm file (when libgodot is disabled).
+# 2 - wasm side (when dlink is enabled or shared libgodot is used).
+# 3 - libgodot bundle.
+env.CreateTemplateZip(js_wrapped, main_wasm, side_wasm, libgodot)

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -91,6 +91,7 @@ def get_flags():
         # run-time performance.
         # Note that this overrides the "auto" behavior for target/dev_build.
         "optimize": "size",
+        "supported": ["library", "mono"],
     }
 
 
@@ -114,13 +115,23 @@ def configure(env: "SConsEnvironment"):
     cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
 
     # Minimum emscripten requirements.
-    if cc_semver < (4, 0, 0):
+    if env["module_mono_enabled"] and cc_semver < (3, 1, 56):
+        print_error("The minimum Emscripten version to build Godot with C# is 3.1.56, detected: %s.%s.%s" % cc_semver)
+        sys.exit(255)
+    elif not env["module_mono_enabled"] and cc_semver < (4, 0, 0):
         print_error("The minimum Emscripten version to build Godot is 4.0.0, detected: %s.%s.%s" % cc_semver)
         sys.exit(255)
 
+    if cc_semver < (4, 0, 0):
+        print_warning(
+            "The Emscripten version for C# is %s.%s.%s while minimum supported version to build "
+            "Godot is 4.0.0, export is experimental." % cc_semver
+        )
+
     env.Append(LIBEMITTER=[library_emitter])
 
-    env["EXPORTED_FUNCTIONS"] = ["_main"]
+    env["EXPORTED_FUNCTIONS"] = []
+    env["EXPORTED_FUNCTIONS_SHARED"] = []
     env["EXPORTED_RUNTIME_METHODS"] = []
 
     # Validate arch.
@@ -236,6 +247,8 @@ def configure(env: "SConsEnvironment"):
     # Add method for creating the final zip file
     env.AddMethod(create_template_zip, "CreateTemplateZip")
 
+    env["CUSTOM_GODOT_JS"] = None
+
     # Use TempFileMunge since some AR invocations are too long for cmd.exe.
     # Use POSIX-style paths, required with TempFileMunge.
     env["ARCOM_POSIX"] = env["ARCOM"].replace("$TARGET", "$TARGET.posix").replace("$SOURCES", "$SOURCES.posix")
@@ -295,13 +308,31 @@ def configure(env: "SConsEnvironment"):
         if env["proxy_to_pthread"]:
             print_warning("GDExtension support requires proxy_to_pthread=no, disabling proxy to pthread.")
             env["proxy_to_pthread"] = False
+        if env["library_type"] == "static_library":
+            print_warning(
+                "GDExtension support compiles Godot code as a side library, switching to library_type=shared_library for ease of access."
+            )
+            env["library_type"] = "shared_library"
 
         env.Append(CPPDEFINES=["WEB_DLINK_ENABLED"])
+        env.extra_suffix = ".dlink" + env.extra_suffix
+
+    if env["dlink_enabled"] or env["library_type"] == "shared_library":
         env.Append(CCFLAGS=["-sSIDE_MODULE=2"])
         env.Append(LINKFLAGS=["-sSIDE_MODULE=2"])
         env.Append(CCFLAGS=["-fvisibility=hidden"])
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
-        env.extra_suffix = ".dlink" + env.extra_suffix
+
+    if env["library_type"] == "executable":
+        env["EXPORTED_FUNCTIONS"] += ["_main"]
+
+    if env["library_type"] == "shared_library":
+        env.Append(LINKFLAGS=["-sEXPORT_KEEPALIVE=1"])
+        env["EXPORTED_FUNCTIONS_SHARED"] += [
+            "_libgodot_create_godot_instance",
+            "_libgodot_destroy_godot_instance",
+            "_libgodot_web_iteration",
+        ]
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])
     env.Append(CCFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -30,23 +30,24 @@ def create_engine_file(env, target, source, externs, threads_enabled):
     return env.Substfile(target=target, source=[env.File(s) for s in source], SUBST_DICT=subst_dict)
 
 
-def create_template_zip(env, js, wasm, side):
+def create_template_zip(env, js, wasm, side, libgodot):
     binary_name = "godot.editor" if env.editor_build else "godot"
     zip_dir = env.Dir(env.GetTemplateZipPath())
     in_files = [
         js,
-        wasm,
         "#platform/web/js/libs/audio.worklet.js",
         "#platform/web/js/libs/audio.position.worklet.js",
     ]
     out_files = [
         zip_dir.File(binary_name + ".js"),
-        zip_dir.File(binary_name + ".wasm"),
         zip_dir.File(binary_name + ".audio.worklet.js"),
         zip_dir.File(binary_name + ".audio.position.worklet.js"),
     ]
-    # Dynamic linking (extensions) specific.
-    if env["dlink_enabled"]:
+    if wasm is not None:
+        in_files.append(wasm)  # Wasm (contains the actual Godot code).
+        out_files.append(zip_dir.File(binary_name + ".wasm"))
+    # Dynamic linking specific.
+    if side is not None:
         in_files.append(side)  # Side wasm (contains the actual Godot code).
         out_files.append(zip_dir.File(binary_name + ".side.wasm"))
 
@@ -107,6 +108,26 @@ def create_template_zip(env, js, wasm, side):
         out_files.append(zip_dir.File(binary_name + ".service.worker.js"))
         in_files.append("#misc/dist/html/offline-export.html")
         out_files.append(zip_dir.File("godot.offline.html"))
+
+    if libgodot is not None:
+        libgodot_dir = zip_dir.Dir("libgodot")
+
+        def add_libgodot_folder(dir_name, files):
+            files_dir = libgodot_dir.Dir(dir_name)
+            for file in files:
+                in_files.append(file)
+                out_files.append(files_dir.File(file.name))
+
+        if "libgodot" in libgodot:
+            in_files.append(libgodot["libgodot"])
+            out_files.append(libgodot_dir.File("libgodot.a"))
+        in_files.append(libgodot["config"])
+        out_files.append(libgodot_dir.File("config.json"))
+
+        add_libgodot_folder("js_library", libgodot["JS_LIBS"])
+        add_libgodot_folder("pre_js", libgodot["JS_PRE"])
+        add_libgodot_folder("post_js", libgodot["JS_POST"])
+        add_libgodot_folder("externs", libgodot["JS_EXTERNS"])
 
     zip_files = env.NoCache(env.InstallAs(out_files, in_files))
     env.NoCache(

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -34,6 +34,8 @@
 #include "core/os/os.h"
 #include "editor/file_system/editor_paths.h"
 
+#include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
+
 void EditorHTTPServer::_server_thread_poll(void *data) {
 	EditorHTTPServer *web_server = static_cast<EditorHTTPServer *>(data);
 	while (!web_server->server_quit.is_set()) {
@@ -88,7 +90,7 @@ void EditorHTTPServer::_send_response() {
 	const int query_index = req[1].find_char('?');
 	const String path = (query_index == -1) ? req[1] : req[1].substr(0, query_index);
 
-	const String req_file = path.get_file();
+	const String req_file = path.begins_with("/") ? path.substr(1) : path;
 	const String req_ext = path.get_extension();
 	const String cache_path = EditorPaths::get_singleton()->get_temp_dir().path_join("web");
 	const String filepath = cache_path.path_join(req_file);
@@ -250,6 +252,17 @@ EditorHTTPServer::EditorHTTPServer() {
 	mimes["png"] = "image/png";
 	mimes["svg"] = "image/svg";
 	mimes["wasm"] = "application/wasm";
+#ifdef MODULE_MONO_ENABLED
+	// https://github.com/dotnet/runtime/blob/main/src/mono/wasm/features.md#mime-types
+	mimes["mjs"] = "application/javascript";
+	mimes["bin"] = "application/octet-stream";
+	mimes["dat"] = "application/octet-stream";
+	mimes["map"] = "application/json";
+	mimes["symbols"] = "text/plain";
+	mimes["pdb"] = "application/octet-stream";
+	mimes["dll"] = "application/octet-stream";
+	mimes["webcil"] = "application/octet-stream";
+#endif
 	server.instantiate();
 	stop();
 }

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -90,7 +90,12 @@ Error EditorExportPlatformWeb::_extract_template(const String &p_template, const
 		unzCloseCurrentFile(pkg);
 
 		//write
-		String dst = p_dir.path_join(file.replace("godot", p_name));
+		String dst = p_dir.path_join(file.contains("libgodot") ? file : file.replace("godot", p_name));
+		String dst_dir = dst.get_base_dir();
+		if (!DirAccess::exists(dst_dir)) {
+			DirAccess::make_dir_recursive_absolute(dst_dir);
+		}
+
 		Ref<FileAccess> f = FileAccess::open(dst, FileAccess::WRITE);
 		if (f.is_null()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Could not write file: \"%s\"."), dst));
@@ -422,17 +427,19 @@ Ref<Texture2D> EditorExportPlatformWeb::get_logo() const {
 }
 
 bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
-#ifdef MODULE_MONO_ENABLED
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
-	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	return false;
-#else
-
 	String err;
 	bool valid = false;
 	bool extensions = (bool)p_preset->get("variant/extensions_support");
 	bool thread_support = (bool)p_preset->get("variant/thread_support");
+
+#ifdef MODULE_MONO_ENABLED
+	// Web export is still a work in progress, keep a message as a warning.
+	err += TTR("Exporting to Web when using C#/.NET is experimental.") + "\n";
+	if (extensions) {
+		r_error += TTR("Exporting C#/.NET with GDExtensions is currently not supported.") + "\n";
+		return false;
+	}
+#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 	bool dvalid = exists_export_template(_get_template_name(extensions, thread_support, true), &err);
@@ -459,7 +466,6 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
-#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
@@ -488,8 +494,6 @@ List<String> EditorExportPlatformWeb::get_binary_extensions(const Ref<EditorExpo
 }
 
 Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
-	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
-
 	const String custom_debug = p_preset->get("custom_template/debug");
 	const String custom_release = p_preset->get("custom_template/release");
 	const String custom_html = p_preset->get("html/custom_html_shell");
@@ -519,10 +523,25 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 		return ERR_FILE_NOT_FOUND;
 	}
 
+	// Extract templates.
+	Error error = _extract_template(template_path, base_dir, base_name, pwa);
+	if (error) {
+		// Message is supplied by the subroutine method.
+		return error;
+	}
+
+	// TODO: Should we add a step between _export_begin and _export_end, something like _export_modify, and put _export_begin back to the beginning?
+	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
+
+	// Check if any export plugin failed.
+	if (get_worst_message_type() == EXPORT_MESSAGE_ERROR) {
+		return ERR_SCRIPT_FAILED;
+	}
+
 	// Export pck and shared objects
 	Vector<SharedObject> shared_objects;
 	String pck_path = base_path + ".pck";
-	Error error = save_pack(p_preset, p_debug, pck_path, &shared_objects);
+	error = save_pack(p_preset, p_debug, pck_path, &shared_objects);
 	if (error != OK) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not write file: \"%s\"."), pck_path));
 		return error;
@@ -538,13 +557,6 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 				return error;
 			}
 		}
-	}
-
-	// Extract templates.
-	error = _extract_template(template_path, base_dir, base_name, pwa);
-	if (error) {
-		// Message is supplied by the subroutine method.
-		return error;
 	}
 
 	// Parse generated file sizes (pck and wasm, to help show a meaningful loading bar).
@@ -611,6 +623,14 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 			// Message is supplied by the subroutine method.
 			return err;
 		}
+	}
+
+	// Remove libgodot related files if they exist.
+	String libgodot_dir = base_dir.path_join("libgodot");
+	if (DirAccess::exists(libgodot_dir)) {
+		Ref<DirAccess> libgodot_dir_da = DirAccess::open(libgodot_dir);
+		libgodot_dir_da->erase_contents_recursive();
+		DirAccess::remove_absolute(libgodot_dir);
 	}
 
 	return OK;
@@ -860,18 +880,10 @@ Error EditorExportPlatformWeb::_export_project(const Ref<EditorExportPreset> &p_
 	Error err = export_project(p_preset, true, basepath + ".html", p_debug_flags);
 	if (err != OK) {
 		// Export generates several files, clean them up on failure.
-		DirAccess::remove_file_or_error(basepath + ".html");
-		DirAccess::remove_file_or_error(basepath + ".offline.html");
-		DirAccess::remove_file_or_error(basepath + ".js");
-		DirAccess::remove_file_or_error(basepath + ".audio.worklet.js");
-		DirAccess::remove_file_or_error(basepath + ".audio.position.worklet.js");
-		DirAccess::remove_file_or_error(basepath + ".service.worker.js");
-		DirAccess::remove_file_or_error(basepath + ".pck");
-		DirAccess::remove_file_or_error(basepath + ".png");
-		DirAccess::remove_file_or_error(basepath + ".side.wasm");
-		DirAccess::remove_file_or_error(basepath + ".wasm");
-		DirAccess::remove_file_or_error(basepath + ".icon.png");
-		DirAccess::remove_file_or_error(basepath + ".apple-touch-icon.png");
+		if (DirAccess::exists(dest)) {
+			Ref<DirAccess> dest_da = DirAccess::open(dest);
+			dest_da->erase_contents_recursive();
+		}
 	}
 	return err;
 }

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -144,6 +144,14 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 */
 		godotPoolSize: 4,
 		/**
+		 * Pass imports to dotnet.setModuleImports(key, value).
+		 *
+		 * @memberof EngineConfig
+		 * @type {?Object}
+		 * @default
+		 */
+		dotnetModuleImports: null,
+		/**
 		 * A callback function for handling Godot's ``OS.execute`` calls.
 		 *
 		 * This is for example used in the Web Editor template to switch between project manager and editor, and for running the game.
@@ -255,6 +263,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.onPrintError = parse('onPrintError', this.onPrintError);
 		this.onPrint = parse('onPrint', this.onPrint);
 		this.onProgress = parse('onProgress', this.onProgress);
+		this.dotnetModuleImports = parse('dotnetModuleImports', this.dotnetModuleImports);
 
 		// Godot config
 		this.canvas = parse('canvas', this.canvas);
@@ -282,6 +291,9 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 	 * @param {Response} response
 	 */
 	Config.prototype.getModuleConfig = function (loadPath, response) {
+		// Extract directory path if it exists.
+		const dirPath = loadPath.split('/').slice(0, -1).join('/');
+
 		let r = response;
 		const gdext = this.gdextensionLibs;
 		return {
@@ -306,23 +318,35 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 				return {};
 			},
 			'locateFile': function (path) {
-				if (!path.startsWith('godot.')) {
-					return path;
-				} else if (path.endsWith('.audio.worklet.js')) {
-					return `${loadPath}.audio.worklet.js`;
-				} else if (path.endsWith('.audio.position.worklet.js')) {
-					return `${loadPath}.audio.position.worklet.js`;
-				} else if (path.endsWith('.js')) {
-					return `${loadPath}.js`;
-				} else if (path in gdext) {
-					return path;
-				} else if (path.endsWith('.side.wasm')) {
-					return `${loadPath}.side.wasm`;
-				} else if (path.endsWith('.wasm')) {
-					return `${loadPath}.wasm`;
+				if (path.startsWith('godot.')) {
+					if (path.endsWith('.audio.worklet.js')) {
+						return `${loadPath}.audio.worklet.js`;
+					} else if (path.endsWith('.audio.position.worklet.js')) {
+						return `${loadPath}.audio.position.worklet.js`;
+					} else if (path.endsWith('.js')) {
+						return `${loadPath}.js`;
+					} else if (path in gdext) {
+						return path;
+					} else if (path.endsWith('.side.wasm')) {
+						return `${loadPath}.side.wasm`;
+					} else if (path.endsWith('.wasm')) {
+						return `${loadPath}.wasm`;
+					}
+				}
+				if (path.startsWith('dotnet.')) {
+					if (path === 'dotnet.native.wasm') {
+						return `${loadPath}.wasm`;
+					}
+					return `${dirPath}/_framework/${path}`;
 				}
 				return path;
 			},
+			'getPreloadedWasm': function () {
+				const tempResponse = r;
+				r = null;
+				return tempResponse;
+			},
+			'godotSharpImports': this.dotnetModuleImports,
 		};
 	};
 

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -172,10 +172,13 @@ const Engine = (function () {
 							me.rtenv['copyToFS'](file.path, file.buffer);
 						}
 						preloader.preloadedFiles.length = 0; // Clear memory
-						me.rtenv['callMain'](me.config.args);
-						initPromise = null;
-						me.installServiceWorker();
-						resolve();
+
+						// Adds optional support for custom async 'callMain'.
+						Promise.resolve(me.rtenv['callMain'](me.config.args)).then(function () {
+							initPromise = null;
+							me.installServiceWorker();
+							resolve();
+						});
 					});
 				});
 			},
@@ -249,6 +252,18 @@ const Engine = (function () {
 				}
 				return Promise.resolve();
 			},
+
+			/**
+			 * Get [JsExport] methods.
+			 *
+			 * @returns {Promise} The exports promise.
+			 */
+			getDotnetExports: function () {
+				if (this.rtenv && this.rtenv['getGodotSharpExports']) {
+					return this.rtenv['getGodotSharpExports']();
+				}
+				return Promise.resolve();
+			},
 		};
 
 		Engine.prototype = proto;
@@ -260,6 +275,7 @@ const Engine = (function () {
 		Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
 		Engine.prototype['requestQuit'] = Engine.prototype.requestQuit;
 		Engine.prototype['installServiceWorker'] = Engine.prototype.installServiceWorker;
+		Engine.prototype['getDotnetExports'] = Engine.prototype.getDotnetExports;
 		// Also expose static methods as instance methods
 		Engine.prototype['load'] = Engine.load;
 		Engine.prototype['unload'] = Engine.unload;

--- a/platform/web/libgodot_web.cpp
+++ b/platform/web/libgodot_web.cpp
@@ -1,0 +1,145 @@
+/**************************************************************************/
+/*  libgodot_web.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "display_server_web.h"
+#include "godot_js.h"
+#include "os_web.h"
+
+#include "core/profiling/profiling.h"
+
+#ifndef PROXY_TO_PTHREAD_ENABLED
+#include "core/config/engine.h"
+#endif
+#include "core/extension/godot_instance.h"
+#include "core/extension/libgodot.h"
+#include "core/io/resource_loader.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+#include "core/variant/variant.h"
+#include "main/main.h"
+
+#include <cstdlib>
+
+static OS_Web *os = nullptr;
+
+static GodotInstance *instance = nullptr;
+#ifndef PROXY_TO_PTHREAD_ENABLED
+uint64_t target_ticks = 0;
+#endif
+
+static void print_web_header() {
+	// Emscripten.
+	char *emscripten_version_char = godot_js_emscripten_get_version();
+	String emscripten_version = vformat("Emscripten %s", emscripten_version_char);
+	// `free()` is used here because it's not memory that was allocated by Godot.
+	free(emscripten_version_char);
+
+	// Build features.
+	String thread_support = OS::get_singleton()->has_feature("threads")
+			? "multi-threaded"
+			: "single-threaded";
+	String extensions_support = OS::get_singleton()->has_feature("web_extensions")
+			? "GDExtension support"
+			: "no GDExtension support";
+
+	Vector<String> build_configuration = { emscripten_version, thread_support, extensions_support };
+	print_line(vformat("Build configuration: %s.", String(", ").join(build_configuration)));
+}
+
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+
+	godot_init_profiler();
+
+	os = new OS_Web();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	instance = memnew(GodotInstance);
+	if (!instance->initialize(p_init_func)) {
+		memdelete(instance);
+		// Note: When Godot Engine supports reinitialization, clear the instance pointer here.
+		//instance = nullptr;
+		return nullptr;
+	}
+
+	print_web_header();
+
+	// Ease up compatibility.
+	ResourceLoader::set_abort_on_missing_resources(false);
+
+	return static_cast<GDExtensionObjectPtr>(instance);
+}
+
+void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	GodotInstance *godot_instance = static_cast<GodotInstance *>(p_godot_instance);
+	if (instance == godot_instance) {
+		godot_instance->stop();
+		memdelete(godot_instance);
+		instance = nullptr;
+		Main::cleanup();
+		delete os;
+		os = nullptr;
+		godot_cleanup_profiler();
+	}
+}
+
+// Needs to be exported. Should GodotInstance have a way to register custom iteration?
+extern "C" LIBGODOT_API GDExtensionBool libgodot_web_iteration() {
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	uint64_t current_ticks = os->get_ticks_usec();
+#endif
+
+	bool force_draw = DisplayServerWeb::get_singleton()->check_size_force_redraw();
+	if (force_draw) {
+		Main::force_redraw();
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	} else if (current_ticks < target_ticks) {
+		return false; // Skip frame.
+#endif
+	}
+
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	int max_fps = Engine::get_singleton()->get_max_fps();
+	if (max_fps > 0) {
+		if (current_ticks - target_ticks > 1000000) {
+			// When the window loses focus, we stop getting updates and accumulate delay.
+			// For this reason, if the difference is too big, we reset target ticks to the current ticks.
+			target_ticks = current_ticks;
+		}
+		target_ticks += (uint64_t)(1000000 / max_fps);
+	}
+#endif
+
+	return os->main_loop_iterate();
+}

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -35,11 +35,14 @@
 // Crash handler exception only enabled with MSVC
 #if defined(DEBUG_ENABLED)
 #define CRASH_HANDLER_EXCEPTION 1
-
-#ifdef _MSC_VER
-extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);
 #endif
 
+#if defined(DISABLE_CRASH_HANDLER)
+#undef CRASH_HANDLER_EXCEPTION
+#endif
+
+#if defined(CRASH_HANDLER_EXCEPTION) && defined(_MSC_VER)
+extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);
 #endif
 
 class CrashHandler {

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -161,6 +161,49 @@ def detect_mvk(env, osname):
     return ""
 
 
+def filter_file_libs(libs):
+    from SCons.Node.FS import File
+    from SCons.Script import Flatten
+
+    sources = []
+
+    for lib in Flatten(libs):
+        if isinstance(lib, File):
+            sources.append(lib)
+    return sources
+
+
+def combine_libs_ar(target, source, env):
+    import tempfile
+
+    from SCons.Script import Flatten
+
+    lib_path = target[0].srcnode().abspath
+    paths = [lib.srcnode().abspath for lib in Flatten(source)]
+    paths = [path for path in paths if path.endswith(".a") or path.endswith(".lib")]
+    for lib in Flatten(env["LIBS"]):
+        if isinstance(lib, str) and (lib.endswith(".a") or lib.endswith(".lib")):
+            paths.append(lib)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".mri", delete_on_close=False) as fp:
+        fp.write(f"create {lib_path}\n")
+        for path in paths:
+            fp.write(f"addlib {path}\n")
+        fp.write("save\n")
+        fp.write("end")
+        fp.close()
+
+        env.Execute(f"$AR -M <{fp.name}")
+
+    # Doesn't work on web https://github.com/llvm/llvm-project/issues/50623 ,
+    # but looks like web doesn't need it? Maybe it is because it's still mono on web
+    if env["platform"] != "web" and env["module_mono_enabled"]:
+        # Fix duplicate vtables for Object
+        env.Execute(f'$OBJCOPY --redefine-sym _ZTV6Object=_ZTV6_godot_Object "{lib_path}"')
+
+    env.Execute(f'$RANLIB "{lib_path}"')
+
+
 def combine_libs_apple_embedded(target, source, env):
     lib_path = target[0].srcnode().abspath
     if "osxcross" in env:


### PR DESCRIPTION
This PR serves as an alternative to https://github.com/godotengine/godot/pull/106125.

# Overview

Uses static LibGodot to link Godot as a library for web export.

A huge portion of this PR was adding LibGodot support to web platform and figuring out a way to pass a static library to the final step. In comparison the changes to the way mono itself works are minor.

LibGodot setup itself doesn't use the module mono and instead uses a simple interface written natively in C#. To initialize the module mono it now exports a function when LibGodot is enabled that can be called to set the initialization function for the module, this indirection allows us to call it early from the C# side and be sure that the module mono will safely check it later, and if it is set it will call it when the module begin initializing. Doing it this way preserves the normal order `GDMono::initialize` is initialized. The initialization function itself passes normal initialization from `InitializeFromGameProject`.

## Works:
- JS import and export with `[JSExport]`/`[JSImport]`.
- Single-threaded and multi-threaded builds.
- .NET 9 and .NET 10, currently only tested on demo.
- Normal build and Web AOT compilation enabled with `RunAOTCompilation`.
- It's basically a normal `browser-wasm` publish with a statically linked Godot to it, so everything that works on `browser-wasm` should work here, this was briefly tested with `System.Security.Cryptography` and `System.Net.Http.HttpClient`.

## Downsides:

### Major downsides:
- It will force the support for Emscripten 3.1.56 until C# Emscripten is updated (https://github.com/dotnet/runtime/issues/113786).
- Can't export with GDExtensions supported, C# WASM can't be build with `-sMAIN_MODULE` flag.
- Currently it is not a problem, but CoreCLR also uses `Object` without namespace, so it causes duplicate symbols for `Object` vtable. If C# WASM will move to CoreCLR https://github.com/dotnet/runtime/issues/121511 after updating Emscripten to be new enough to use `--allow-multiple-definition` https://github.com/llvm/llvm-project/pull/97699 this won't be a problem.

### Small downsides:
- Slow to export, as it needs to link the whole Godot as a static library.
- Can't use Godot as an `lto` library.
- Always needs to use `wasm-tools` workload.
- C# emscripten cache is frozen, so some combination of flags can require the usage of `WasmCachePath`, on Windows this path needs to be on the same drive as the drive C# is installed on.
- C# multi-threading runs main C# thread as a worker thread https://github.com/dotnet/runtime/issues/101421, https://github.com/dotnet/runtime/issues/126438.
- C# multi-threading is incompatible with `webxr` for the same reason `proxy_to_pthread` is also incompatible.
- C# multi-threading JS interop doesn't allow sync `C#->JS->C#` or `JS->C#->JS`, with `jsThreadBlockingMode: 'ThrowWhenBlockingWait'` it allows sync `C#->JS` and `JS->C#`, but that's all. More info https://github.com/dotnet/runtime/issues/101421#issuecomment-2072439395 and this seems also correct https://dev.to/lostbeard/blazor-wasms-deputy-thread-model-will-break-javascript-interop-heres-why-that-matters-1n9n.

## Hacks:
- Calls web's `_export_begin` after extracting templates. It's needed for passing the path to the extracted static library in `ExportPlugin.cs._ExportBegin`. I think it is possible to add a separate step after extracting templates, but before `_export_file` begins, but I'm not sure.
- Some functions needed stubs because they were missing.

Closes: https://github.com/godotengine/godot/issues/70796.
Demo repo: https://github.com/NoctemCat/DotnetWebExportDemo.

Thanks to @GabCoolDude for help writing it, testing export on Windows, and testing it overall.