### PR TITLE
Allow empty Inherits field in Create Script dialog

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -220,7 +220,7 @@ void ScriptCreateDialog::set_inheritance_base_type(const String &p_base) {
 
 bool ScriptCreateDialog::_validate_parent(const String &p_string) {
 	if (p_string.length() == 0) {
-		return false;
+		return true;
 	}
 
 	if (can_inherit_from_file && p_string.is_quoted()) {
@@ -371,7 +371,7 @@ void ScriptCreateDialog::_create_new() {
 	const ScriptLanguage::ScriptTemplate sinfo = _get_current_template();
 
 	String parent_class = parent_name->get_text();
-	if (!parent_name->get_text().is_quoted() && !ClassDB::class_exists(parent_class) && !ScriptServer::is_global_class(parent_class)) {
+	if (!parent_class.is_empty() && !parent_name->get_text().is_quoted() && !ClassDB::class_exists(parent_class) && !ScriptServer::is_global_class(parent_class)) {
 		// If base is a custom type, replace with script path instead.
 		const EditorData::CustomType *type = EditorNode::get_editor_data().get_custom_type_by_name(parent_class);
 		ERR_FAIL_NULL(type);

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -220,7 +220,8 @@ void ScriptCreateDialog::set_inheritance_base_type(const String &p_base) {
 
 bool ScriptCreateDialog::_validate_parent(const String &p_string) {
 	if (p_string.length() == 0) {
-		return true;
+		ScriptLanguage *lang = ScriptServer::get_language(language_menu->get_selected());
+		return lang && lang->get_name() == "GDScript";
 	}
 
 	if (can_inherit_from_file && p_string.is_quoted()) {
@@ -633,6 +634,10 @@ void ScriptCreateDialog::_update_dialog() {
 
 	if (!is_parent_name_valid && is_new_script_created) {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
+	}
+
+	if (is_parent_name_valid && is_new_script_created && parent_name->get_text().is_empty()) {
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("GDScript only: Script will implicitly extend RefCounted."), EditorValidationPanel::MSG_INFO, false);
 	}
 
 	if (validation_panel->is_valid() && !is_new_script_created) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -110,8 +110,12 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 									 .replace(" -> Object", "");
 	}
 
-	processed_template = processed_template.replace("_BASE_", p_base_class_name)
-								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_unicode_identifier())
+	if (p_base_class_name.is_empty()) {
+		processed_template = processed_template.replace("extends _BASE_\n", "");
+	} else {
+		processed_template = processed_template.replace("_BASE_", p_base_class_name);
+	}
+	processed_template = processed_template.replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_unicode_identifier())
 								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_unicode_identifier())
 								 .replace("_TS_", _get_indentation());
 	scr->set_source_code(processed_template);


### PR DESCRIPTION
Fixes #118763

Newly created scripts now have the ability to inherit nothing.