### PR TITLE
Fix `ERROR: Camera is not inside scene` when closing/reloading the editor with a `Skeleton3D` node selected

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -975,6 +975,9 @@ void Skeleton3DEditor::_update_properties() {
 	if (pose_editor) {
 		pose_editor->_update_properties();
 	}
+	if (!skeleton || !skeleton->is_inside_tree()) {
+		return;
+	}
 	Node3DEditor::get_singleton()->update_transform_gizmo();
 }
 
@@ -1265,6 +1268,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			update_joint_tree();
 		} break;
 		case NOTIFICATION_PREDELETE: {
+			_disconnect_from_tree();
 			if (skeleton) {
 				select_bone(-1); // Requires that the joint_tree has not been deleted.
 				_disconnect_from_skeleton();
@@ -1280,16 +1284,19 @@ void Skeleton3DEditor::_notification(int p_what) {
 }
 
 void Skeleton3DEditor::_node_removed(Node *p_node) {
-	if (skeleton && p_node == skeleton) {
-		_disconnect_from_skeleton();
-		if (pose_editor) {
-			pose_editor->set_skeleton(nullptr);
-			pose_editor->set_visible(false);
-		}
-		edit_mode = false;
-		skeleton = nullptr;
-		skeleton_options->hide();
+	if (!skeleton || p_node != skeleton) {
+		return;
 	}
+
+	_disconnect_from_tree();
+	_disconnect_from_skeleton();
+	if (pose_editor) {
+		pose_editor->set_skeleton(nullptr);
+		pose_editor->set_visible(false);
+	}
+	edit_mode = false;
+	skeleton = nullptr;
+	skeleton_options->hide();
 
 	_update_properties();
 }
@@ -1310,6 +1317,21 @@ void Skeleton3DEditor::_disconnect_from_skeleton() {
 	}
 	if (skeleton->is_connected(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_update_properties))) {
 		skeleton->disconnect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_update_properties));
+	}
+}
+
+void Skeleton3DEditor::_disconnect_from_tree() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	SceneTree *tree = get_tree();
+	if (!tree) {
+		return;
+	}
+
+	if (tree->is_connected("node_removed", callable_mp(this, &Skeleton3DEditor::_node_removed))) {
+		tree->disconnect("node_removed", callable_mp(this, &Skeleton3DEditor::_node_removed));
 	}
 }
 

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -220,6 +220,7 @@ class Skeleton3DEditor : public VBoxContainer {
 
 	void _subgizmo_selection_change();
 	void _disconnect_from_skeleton();
+	void _disconnect_from_tree();
 
 	int selected_bone = -1;
 


### PR DESCRIPTION
The regression was introduced by previous fix for a crash in the editor in https://github.com/godotengine/godot/pull/113631

This preserves the nature of the original fix, and also stops receiving events the moment that it is no longer needed (addressing the ONE_SHOT difference).

This fixes https://github.com/godotengine/godot/issues/118663

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
