### PR TITLE
Simplify array property parsing

### DIFF
--- a/core/object/property_info.cpp
+++ b/core/object/property_info.cpp
@@ -86,7 +86,7 @@ String PropertyInfo::serialize_hint_type() {
 	return serialize_hint_type(type, hint, hint_string);
 }
 
-bool PropertyInfo::try_parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string) {
+bool PropertyInfo::try_parse_hint_type_string(const String &p_string, Variant::Type &r_type, PropertyHint &r_hint, String &r_hint_string) {
 	int subtype_separator = p_string.find_char(':');
 	if (subtype_separator < 0) {
 		return false;
@@ -94,11 +94,11 @@ bool PropertyInfo::try_parse_hint_type_string(const String &p_string, Variant::T
 	String subtype_string = p_string.substr(0, subtype_separator);
 	int slash_pos = subtype_string.find_char('/');
 	if (slash_pos >= 0) {
-		out_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
+		r_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
 		subtype_string = subtype_string.substr(0, slash_pos);
 	}
-	out_hint_string = p_string.substr(subtype_separator + 1);
-	out_type = Variant::Type(subtype_string.to_int());
+	r_hint_string = p_string.substr(subtype_separator + 1);
+	r_type = Variant::Type(subtype_string.to_int());
 	return true;
 }
 

--- a/core/object/property_info.cpp
+++ b/core/object/property_info.cpp
@@ -74,6 +74,34 @@ PropertyInfo PropertyInfo::from_dict(const Dictionary &p_dict) {
 	return pi;
 }
 
+String PropertyInfo::serialize_hint_type(Variant::Type p_type, PropertyHint p_hint, const String &p_hint_string) {
+	String str = itos(p_type);
+	if (p_hint) {
+		str += "/" + itos(p_hint);
+	}
+	return str + ":" + p_hint_string;
+}
+
+String PropertyInfo::serialize_hint_type() {
+	return serialize_hint_type(type, hint, hint_string);
+}
+
+bool PropertyInfo::try_parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string) {
+	int subtype_separator = p_string.find_char(':');
+	if (subtype_separator < 0) {
+		return false;
+	}
+	String subtype_string = p_string.substr(0, subtype_separator);
+	int slash_pos = subtype_string.find_char('/');
+	if (slash_pos >= 0) {
+		out_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
+		subtype_string = subtype_string.substr(0, slash_pos);
+	}
+	out_hint_string = p_string.substr(subtype_separator + 1);
+	out_type = Variant::Type(subtype_string.to_int());
+	return true;
+}
+
 TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list) {
 	TypedArray<Dictionary> va;
 	for (const List<PropertyInfo>::Element *E = p_list->front(); E; E = E->next()) {

--- a/core/object/property_info.h
+++ b/core/object/property_info.h
@@ -140,6 +140,9 @@ struct PropertyInfo {
 	operator Dictionary() const;
 
 	static PropertyInfo from_dict(const Dictionary &p_dict);
+	static String serialize_hint_type(Variant::Type p_type, PropertyHint p_hint, const String &p_hint_string = "");
+	String serialize_hint_type();
+	static bool try_parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string);
 
 	PropertyInfo() {}
 

--- a/core/object/property_info.h
+++ b/core/object/property_info.h
@@ -142,7 +142,7 @@ struct PropertyInfo {
 	static PropertyInfo from_dict(const Dictionary &p_dict);
 	static String serialize_hint_type(Variant::Type p_type, PropertyHint p_hint, const String &p_hint_string = "");
 	String serialize_hint_type();
-	static bool try_parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string);
+	static bool try_parse_hint_type_string(const String &p_string, Variant::Type &r_type, PropertyHint &r_hint, String &r_hint_string);
 
 	PropertyInfo() {}
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4275,59 +4275,19 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			}
 		} break;
-		case Variant::ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_BYTE_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_BYTE_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_INT32_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_INT32_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_INT64_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_INT64_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_FLOAT32_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_FLOAT32_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_FLOAT64_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_FLOAT64_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_STRING_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_STRING_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_VECTOR2_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_VECTOR2_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_VECTOR3_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_VECTOR3_ARRAY, p_hint_text);
-			return editor;
-		} break;
-		case Variant::PACKED_COLOR_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_COLOR_ARRAY, p_hint_text);
-			return editor;
-		} break;
+		case Variant::ARRAY:
+		case Variant::PACKED_BYTE_ARRAY:
+		case Variant::PACKED_INT32_ARRAY:
+		case Variant::PACKED_INT64_ARRAY:
+		case Variant::PACKED_FLOAT32_ARRAY:
+		case Variant::PACKED_FLOAT64_ARRAY:
+		case Variant::PACKED_STRING_ARRAY:
+		case Variant::PACKED_VECTOR2_ARRAY:
+		case Variant::PACKED_VECTOR3_ARRAY:
+		case Variant::PACKED_COLOR_ARRAY:
 		case Variant::PACKED_VECTOR4_ARRAY: {
 			EditorPropertyArray *editor = memnew(EditorPropertyArray);
-			editor->setup(Variant::PACKED_VECTOR4_ARRAY, p_hint_text);
+			editor->setup(p_type, p_hint_text);
 			return editor;
 		} break;
 		default: {

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -49,6 +49,21 @@
 #include "scene/gui/margin_container.h"
 #include "scene/main/scene_tree.h"
 
+// Helper functions shared between Array & Dictionary editor properties
+
+void parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string) {
+	if (!PropertyInfo::try_parse_hint_type_string(p_string, out_type, out_hint, out_hint_string)) {
+		out_type = Variant::get_type_by_name(p_string);
+		if (out_type == Variant::VARIANT_MAX) {
+			out_type = Variant::OBJECT;
+			out_hint = PROPERTY_HINT_RESOURCE_TYPE;
+			out_hint_string = p_string;
+		}
+	}
+}
+
+///////////////////
+
 bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 
@@ -365,7 +380,6 @@ void EditorPropertyArray::set_preview_value(bool p_preview_value) {
 
 void EditorPropertyArray::update_property() {
 	Variant array = get_edited_property_value();
-
 	String array_type_name = Variant::get_type_name(array_type);
 	String array_sub_type_name;
 	if (array_type == Variant::ARRAY && subtype != Variant::NIL) {
@@ -477,6 +491,7 @@ void EditorPropertyArray::update_property() {
 			SET_DRAG_FORWARDING_CD(button_add_item, EditorPropertyArray);
 			button_add_item->set_disabled(is_read_only());
 			button_add_item->set_accessibility_name(TTRC("Add"));
+			button_add_item->set_visible(page_index == max_page);
 			vbox->add_child(button_add_item);
 
 			paginator = memnew(EditorPaginator);
@@ -490,7 +505,6 @@ void EditorPropertyArray::update_property() {
 
 		size_slider->set_value(size);
 		property_vbox->set_visible(size > 0);
-		button_add_item->set_visible(page_index == max_page);
 		paginator->update(page_index, max_page);
 		paginator->set_visible(max_page > 0);
 
@@ -886,28 +900,7 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 
 	// The format of p_hint_string is:
 	// subType/subTypeHint:nextSubtype ... etc.
-	if (!p_hint_string.is_empty()) {
-		int hint_subtype_separator = p_hint_string.find_char(':');
-		if (hint_subtype_separator >= 0) {
-			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
-			int slash_pos = subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
-				subtype_string = subtype_string.substr(0, slash_pos);
-			}
-
-			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1);
-			subtype = Variant::Type(subtype_string.to_int());
-		} else {
-			subtype = Variant::get_type_by_name(p_hint_string);
-
-			if (subtype == Variant::VARIANT_MAX) {
-				subtype = Variant::OBJECT;
-				subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				subtype_hint_string = p_hint_string;
-			}
-		}
-	}
+	parse_hint_type_string(p_hint_string, subtype, subtype_hint, subtype_hint_string);
 }
 
 void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_event) {
@@ -1189,27 +1182,7 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 	PackedStringArray types = p_hint_string.split(";", true, 1);
 	if (types.size() > 0 && !types[0].is_empty()) {
 		String key = types[0];
-		int hint_key_subtype_separator = key.find_char(':');
-		if (hint_key_subtype_separator >= 0) {
-			String key_subtype_string = key.substr(0, hint_key_subtype_separator);
-			int slash_pos = key_subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				key_subtype_hint = PropertyHint(key_subtype_string.substr(slash_pos + 1).to_int());
-				key_subtype_string = key_subtype_string.substr(0, slash_pos);
-			}
-
-			key_subtype_hint_string = key.substr(hint_key_subtype_separator + 1);
-			key_subtype = Variant::Type(key_subtype_string.to_int());
-		} else {
-			key_subtype = Variant::get_type_by_name(key);
-
-			if (key_subtype == Variant::VARIANT_MAX) {
-				key_subtype = Variant::OBJECT;
-				key_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				key_subtype_hint_string = key;
-			}
-		}
-
+		parse_hint_type_string(key, key_subtype, key_subtype_hint, key_subtype_hint_string);
 		Variant new_key = object->get_new_item_key();
 		VariantInternal::initialize(&new_key, key_subtype);
 		object->set_new_item_key(new_key);
@@ -1217,27 +1190,7 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 
 	if (types.size() > 1 && !types[1].is_empty()) {
 		String value = types[1];
-		int hint_value_subtype_separator = value.find_char(':');
-		if (hint_value_subtype_separator >= 0) {
-			String value_subtype_string = value.substr(0, hint_value_subtype_separator);
-			int slash_pos = value_subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				value_subtype_hint = PropertyHint(value_subtype_string.substr(slash_pos + 1).to_int());
-				value_subtype_string = value_subtype_string.substr(0, slash_pos);
-			}
-
-			value_subtype_hint_string = value.substr(hint_value_subtype_separator + 1);
-			value_subtype = Variant::Type(value_subtype_string.to_int());
-		} else {
-			value_subtype = Variant::get_type_by_name(value);
-
-			if (value_subtype == Variant::VARIANT_MAX) {
-				value_subtype = Variant::OBJECT;
-				value_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				value_subtype_hint_string = value;
-			}
-		}
-
+		parse_hint_type_string(value, value_subtype, value_subtype_hint, value_subtype_hint_string);
 		Variant new_value = object->get_new_item_value();
 		VariantInternal::initialize(&new_value, value_subtype);
 		object->set_new_item_value(new_value);

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -51,13 +51,13 @@
 
 // Helper functions shared between Array & Dictionary editor properties
 
-void parse_hint_type_string(const String &p_string, Variant::Type &out_type, PropertyHint &out_hint, String &out_hint_string) {
-	if (!PropertyInfo::try_parse_hint_type_string(p_string, out_type, out_hint, out_hint_string)) {
-		out_type = Variant::get_type_by_name(p_string);
-		if (out_type == Variant::VARIANT_MAX) {
-			out_type = Variant::OBJECT;
-			out_hint = PROPERTY_HINT_RESOURCE_TYPE;
-			out_hint_string = p_string;
+void parse_hint_type_string(const String &p_string, Variant::Type &r_type, PropertyHint &r_hint, String &r_hint_string) {
+	if (!PropertyInfo::try_parse_hint_type_string(p_string, r_type, r_hint, r_hint_string)) {
+		r_type = Variant::get_type_by_name(p_string);
+		if (r_type == Variant::VARIANT_MAX) {
+			r_type = Variant::OBJECT;
+			r_hint = PROPERTY_HINT_RESOURCE_TYPE;
+			r_hint_string = p_string;
 		}
 	}
 }

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -51,7 +51,7 @@
 
 // Helper functions shared between Array & Dictionary editor properties
 
-void parse_hint_type_string(const String &p_string, Variant::Type &r_type, PropertyHint &r_hint, String &r_hint_string) {
+static void _parse_hint_type_string(const String &p_string, Variant::Type &r_type, PropertyHint &r_hint, String &r_hint_string) {
 	if (!PropertyInfo::try_parse_hint_type_string(p_string, r_type, r_hint, r_hint_string)) {
 		r_type = Variant::get_type_by_name(p_string);
 		if (r_type == Variant::VARIANT_MAX) {
@@ -900,7 +900,7 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 
 	// The format of p_hint_string is:
 	// subType/subTypeHint:nextSubtype ... etc.
-	parse_hint_type_string(p_hint_string, subtype, subtype_hint, subtype_hint_string);
+	_parse_hint_type_string(p_hint_string, subtype, subtype_hint, subtype_hint_string);
 }
 
 void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_event) {
@@ -1182,7 +1182,7 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 	PackedStringArray types = p_hint_string.split(";", true, 1);
 	if (types.size() > 0 && !types[0].is_empty()) {
 		String key = types[0];
-		parse_hint_type_string(key, key_subtype, key_subtype_hint, key_subtype_hint_string);
+		_parse_hint_type_string(key, key_subtype, key_subtype_hint, key_subtype_hint_string);
 		Variant new_key = object->get_new_item_key();
 		VariantInternal::initialize(&new_key, key_subtype);
 		object->set_new_item_key(new_key);
@@ -1190,7 +1190,7 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 
 	if (types.size() > 1 && !types[1].is_empty()) {
 		String value = types[1];
-		parse_hint_type_string(value, value_subtype, value_subtype_hint, value_subtype_hint_string);
+		_parse_hint_type_string(value, value_subtype, value_subtype_hint, value_subtype_hint_string);
 		Variant new_value = object->get_new_item_value();
 		VariantInternal::initialize(&new_value, value_subtype);
 		object->set_new_item_value(new_value);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4782,7 +4782,6 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 	}
 
 	bool use_default_variable_type_check = true;
-
 	if (p_annotation->name == SNAME("@export_range")) {
 		if (export_type.builtin_type == Variant::INT) {
 			variable->export_info.type = Variant::INT;
@@ -4877,11 +4876,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 		}
 
 		if (is_dict) {
-			String key_prefix = itos(variable->export_info.type);
-			if (variable->export_info.hint) {
-				key_prefix += "/" + itos(variable->export_info.hint);
-			}
-			key_prefix += ":" + variable->export_info.hint_string;
+			String key_prefix = variable->export_info.serialize_hint_type();
 
 			// Now parse value.
 			export_type = export_type.get_container_element_type(0);
@@ -4947,11 +4942,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 				return false;
 			}
 
-			String value_prefix = itos(variable->export_info.type);
-			if (variable->export_info.hint) {
-				value_prefix += "/" + itos(variable->export_info.hint);
-			}
-			value_prefix += ":" + variable->export_info.hint_string;
+			String value_prefix = variable->export_info.serialize_hint_type();
 
 			variable->export_info.type = Variant::DICTIONARY;
 			variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
@@ -4990,13 +4981,9 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 	}
 
 	if (is_array) {
-		String hint_prefix = itos(variable->export_info.type);
-		if (variable->export_info.hint) {
-			hint_prefix += "/" + itos(variable->export_info.hint);
-		}
+		variable->export_info.hint_string = variable->export_info.serialize_hint_type();
 		variable->export_info.type = original_export_type_builtin;
 		variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
-		variable->export_info.hint_string = hint_prefix + ":" + variable->export_info.hint_string;
 		variable->export_info.usage = PROPERTY_USAGE_DEFAULT;
 		variable->export_info.class_name = StringName();
 	}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -545,7 +545,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_music", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_movies", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_user_selected", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::ARRAY, "codesign/entitlements/app_sandbox/helper_executables", PROPERTY_HINT_ARRAY_TYPE, PropertyInfo::serialize_hint_type(Variant::STRING,PROPERTY_HINT_GLOBAL_FILE)), Array()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::ARRAY, "codesign/entitlements/app_sandbox/helper_executables", PROPERTY_HINT_ARRAY_TYPE, PropertyInfo::serialize_hint_type(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE)), Array()));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements/additional", PROPERTY_HINT_MULTILINE_TEXT, "monospace,no_wrap"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "codesign/custom_options"), PackedStringArray()));
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -545,7 +545,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_music", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_movies", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/entitlements/app_sandbox/files_user_selected", PROPERTY_HINT_ENUM, "No,Read-only,Read-write"), 0));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::ARRAY, "codesign/entitlements/app_sandbox/helper_executables", PROPERTY_HINT_ARRAY_TYPE, itos(Variant::STRING) + "/" + itos(PROPERTY_HINT_GLOBAL_FILE) + ":"), Array()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::ARRAY, "codesign/entitlements/app_sandbox/helper_executables", PROPERTY_HINT_ARRAY_TYPE, PropertyInfo::serialize_hint_type(Variant::STRING,PROPERTY_HINT_GLOBAL_FILE)), Array()));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/entitlements/additional", PROPERTY_HINT_MULTILINE_TEXT, "monospace,no_wrap"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "codesign/custom_options"), PackedStringArray()));
 


### PR DESCRIPTION
I'm working on a [separate change](https://github.com/TastiestLemon/godot/pull/1) that adds a new `PropertyHint` to the `EditorPropertyArray`.
In doing so, I found a lot of duplicated logic that wasn't too easy to follow. Since my other change is a bit niche and may not be merged, I figured it'd be best to move the refactoring to its own file, as I do think these changes just make the code more elegant to look through, and make it easier for other people to add new `PropertyHint`s to the array (or dictionary) in the future.

There was also a slight fix to `button_add_item->set_visible(page_index == max_page);`, where this line was occasionally being used in a case where `button_add_item` wasn't initialized, leading to dereferencing a nullptr.
I could move this to another branch if preferred, it was just a small thing I added while touching everything else that still felt somewhat relevant to these changes. (plus my other change that adds a new `PropertyHint` modifies `button_add_item`, so I'm figuring I either fix it in this branch or my other one)

Other than moving `button_add_item`, this branch has no behavioral changes.
(or I hope so at least, please let me know if there's something I missed 😅)