### PR TITLE
[macOS] Fix horizontal scrolling with Shift.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1924,6 +1924,12 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, macOS, Windows, and Linux (X11/Wayland).
 			</description>
 		</method>
+		<method name="shift_swaps_scroll_axis" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if holding [kbd]Shift[/kbd] swaps scrolling wheel axis.
+			</description>
+		</method>
 		<method name="show_emoji_and_symbol_picker" qualifiers="const">
 			<return type="void" />
 			<description>

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -134,6 +134,8 @@ public:
 	virtual void mouse_set_mode_override_enabled(bool p_override_enabled) override;
 	virtual bool mouse_is_mode_override_enabled() const override;
 
+	virtual bool shift_swaps_scroll_axis() const override { return true; }
+
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;
 	virtual Ref<Image> clipboard_get_image() const override;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -36,6 +36,7 @@
 #include "core/os/os.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
+#include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 
 void ItemList::_shape_text(int p_idx) {
@@ -867,9 +868,10 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) { // Copied from ScrollContainer.
 		if (mb->is_pressed()) {
 			bool v_scroll_hidden = !scroll_bar_v->is_visible();
+			bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				// By default, the vertical orientation takes precedence. This is an exception.
-				if (mb->is_shift_pressed() || v_scroll_hidden) {
+				if (swap_axis || v_scroll_hidden) {
 					scroll_bar_h->scroll(-scroll_bar_h->get_page() / 8 * mb->get_factor());
 					scroll_value_modified = true;
 				} else {
@@ -878,7 +880,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN) {
-				if (mb->is_shift_pressed() || v_scroll_hidden) {
+				if (swap_axis || v_scroll_hidden) {
 					scroll_bar_h->scroll(scroll_bar_h->get_page() / 8 * mb->get_factor());
 					scroll_value_modified = true;
 				} else {
@@ -890,7 +892,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			bool h_scroll_hidden = !scroll_bar_h->is_visible();
 			if (mb->get_button_index() == MouseButton::WHEEL_LEFT) {
 				// By default, the horizontal orientation takes precedence. This is an exception.
-				if (mb->is_shift_pressed() || h_scroll_hidden) {
+				if (swap_axis || h_scroll_hidden) {
 					scroll_bar_v->scroll(-scroll_bar_v->get_page() / 8 * mb->get_factor());
 					scroll_value_modified = true;
 				} else {
@@ -899,7 +901,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_RIGHT) {
-				if (mb->is_shift_pressed() || h_scroll_hidden) {
+				if (swap_axis || h_scroll_hidden) {
 					scroll_bar_v->scroll(scroll_bar_v->get_page() / 8 * mb->get_factor());
 					scroll_value_modified = true;
 				} else {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -176,7 +176,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (mb.is_valid()) {
 		if (mb->is_pressed()) {
 			bool scroll_value_modified = false;
-			bool swap_axes = scroll_horizontal_by_default != mb->is_shift_pressed();
+			bool swap_axes = (!DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed()) == scroll_horizontal_by_default;
 
 			bool v_scroll_hidden = !v_scroll->is_visible() && vertical_scroll_mode != SCROLL_MODE_SHOW_NEVER;
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2267,7 +2267,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (mb->is_pressed()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP && !mb->is_command_or_control_pressed()) {
-				if (mb->is_shift_pressed()) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (swap_axis) {
 					h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
 					queue_accessibility_update();
 				} else if (mb->is_alt_pressed()) {
@@ -2279,7 +2280,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN && !mb->is_command_or_control_pressed()) {
-				if (mb->is_shift_pressed()) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (swap_axis) {
 					h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
 					queue_accessibility_update();
 				} else if (mb->is_alt_pressed()) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4284,25 +4284,29 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 			} break;
 			case MouseButton::WHEEL_UP: {
-				if (_scroll(mb->is_shift_pressed(), -mb->get_factor() / 8)) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (_scroll(swap_axis, -mb->get_factor() / 8)) {
 					accept_event();
 				}
 
 			} break;
 			case MouseButton::WHEEL_DOWN: {
-				if (_scroll(mb->is_shift_pressed(), mb->get_factor() / 8)) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (_scroll(swap_axis, mb->get_factor() / 8)) {
 					accept_event();
 				}
 
 			} break;
 			case MouseButton::WHEEL_LEFT: {
-				if (_scroll(!mb->is_shift_pressed(), -mb->get_factor() / 8)) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (_scroll(!swap_axis, -mb->get_factor() / 8)) {
 					accept_event();
 				}
 
 			} break;
 			case MouseButton::WHEEL_RIGHT: {
-				if (_scroll(!mb->is_shift_pressed(), mb->get_factor() / 8)) {
+				bool swap_axis = !DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed();
+				if (_scroll(!swap_axis, mb->get_factor() / 8)) {
 					accept_event();
 				}
 

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -34,6 +34,7 @@
 #include "core/input/shortcut.h"
 #include "core/os/keyboard.h"
 #include "scene/main/viewport.h"
+#include "servers/display/display_server.h"
 
 bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) {
 	Ref<InputEventMouseButton> mb = p_event;
@@ -58,7 +59,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 						panning = Vector2(panning.x + panning.y, 0);
 					} else if (pan_axis == PAN_AXIS_VERTICAL) {
 						panning = Vector2(0, panning.x + panning.y);
-					} else if (mb->is_shift_pressed()) {
+					} else if (!DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed()) {
 						panning = Vector2(panning.y, panning.x);
 					}
 					pan_callback.call(-panning * scroll_speed, p_event);
@@ -71,7 +72,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 						panning = Vector2(panning.x + panning.y, 0);
 					} else if (pan_axis == PAN_AXIS_VERTICAL) {
 						panning = Vector2(0, panning.x + panning.y);
-					} else if (mb->is_shift_pressed()) {
+					} else if (!DisplayServer::get_singleton()->shift_swaps_scroll_axis() && mb->is_shift_pressed()) {
 						panning = Vector2(panning.y, panning.x);
 					}
 					pan_callback.call(-panning * scroll_speed, p_event);

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1454,6 +1454,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("mouse_get_position"), &DisplayServer::mouse_get_position);
 	ClassDB::bind_method(D_METHOD("mouse_get_button_state"), &DisplayServer::mouse_get_button_state);
 
+	ClassDB::bind_method(D_METHOD("shift_swaps_scroll_axis"), &DisplayServer::shift_swaps_scroll_axis);
+
 	ClassDB::bind_method(D_METHOD("clipboard_set", "clipboard"), &DisplayServer::clipboard_set);
 	ClassDB::bind_method(D_METHOD("clipboard_get"), &DisplayServer::clipboard_get);
 	ClassDB::bind_method(D_METHOD("clipboard_get_image"), &DisplayServer::clipboard_get_image);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -256,6 +256,8 @@ public:
 	virtual void mouse_set_mode_override_enabled(bool p_override_enabled);
 	virtual bool mouse_is_mode_override_enabled() const;
 
+	virtual bool shift_swaps_scroll_axis() const { return false; }
+
 	virtual void warp_mouse(const Point2i &p_position);
 	virtual Point2i mouse_get_position() const;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118981

macOS already converts vertical scrolling events to horizontal when Shift is hold, so Godot was swapping axis back.