### PR TITLE
Make error about keyless animation tracks a verbose warning instead

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -732,7 +732,10 @@ bool AnimationMixer::_update_caches() {
 					case Animation::TYPE_VALUE: {
 						// If a value track without a key is cached first, the initial value cannot be determined.
 						// It is a corner case, but which may cause problems with blending.
-						ERR_CONTINUE_MSG(anim->track_get_key_count(i) == 0, mixer_name + ": '" + String(E) + "', Value Track:  '" + String(path) + "' must have at least one key to cache for blending.");
+						if (anim->track_get_key_count(i) == 0) {
+							WARN_VERBOSE(mixer_name + ": '" + String(E) + "', Value Track:  '" + String(path) + "' must have at least one key to cache for blending.");
+							continue;
+						}
 
 						TrackCacheValue *track_value = memnew(TrackCacheValue);
 


### PR DESCRIPTION
It's very easy to trigger this error by doing seamlessly innocuous things like just creating keys, or saving tracks without keys. And while it's technically correct, it gives an unpolished look to the editor.

This PR turns that into a warning that only appears when verbose mode is enabled.