### PR TITLE
Always emit post-enter translation notification

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -186,9 +186,7 @@ void Node::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_POST_ENTER_TREE: {
-			if (data.auto_translate_mode != AUTO_TRANSLATE_MODE_DISABLED) {
-				notification(NOTIFICATION_TRANSLATION_CHANGED);
-			}
+			notification(NOTIFICATION_TRANSLATION_CHANGED);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
* Fixes #118998

#118536 introduced a deferred minimum-size update, which has caused some very specific things to break because they used to not have such an update. This latest find is that tooltips, specifically those on buttons with shortcuts, appear wider than expected. 

Tracing this, the issue was due to the `label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);` call in `BaseButton::make_custom_tooltip()`. Turns out, setting translation mode to disabled causes the `NOTIFICATION_TRANSLATION_CHANGED` emitted by `Node` in `NOTIFICATION_POST_ENTER_TREE` to not be emitted.

For some reason that I, frankly, don't fully understand, the `queue_redraw` call from `Label`'s reaction to `NOTIFICATION_TRANSLATION_CHANGED` is necessary for it to be the correct size once it has entered the scene tree. 
I assume this is due to code paths being blocked when not in the scene tree (as hinted by the minimum-size deferred update now happening after entering the tree, rather than before, as changed by #118536). 

The reason I updated `Node`'s behavior instead of `Label` is that this issue may not be limited to `Label` (`Button`, etc., which have similar text behaviors). This change should pose no risk, as all those nodes are already set up to handle the signal at that time if their translation isn't disabled (which is actually the case in most scenarios). 

cc @YeldhamDev 