### PR TITLE
Mono: Generate dispatch entries for C# methods with default parameters

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
@@ -12,6 +12,10 @@ partial class Methods
         /// Cached name for the 'MethodWithOverload' method.
         /// </summary>
         public new static readonly global::Godot.StringName @MethodWithOverload = "MethodWithOverload";
+        /// <summary>
+        /// Cached name for the 'MethodWithDefaultValues' method.
+        /// </summary>
+        public new static readonly global::Godot.StringName @MethodWithDefaultValues = "MethodWithDefaultValues";
     }
     /// <summary>
     /// Get the method information for all the methods declared in this class.
@@ -21,10 +25,11 @@ partial class Methods
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotMethodList()
     {
-        var methods = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(3);
+        var methods = new global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>(4);
         methods.Add(new(name: MethodName.@MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: null, defaultArguments: null));
         methods.Add(new(name: MethodName.@MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         methods.Add(new(name: MethodName.@MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "b", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
+        methods.Add(new(name: MethodName.@MethodWithDefaultValues, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "b", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         return methods;
     }
 #pragma warning restore CS0109
@@ -47,6 +52,16 @@ partial class Methods
             ret = default;
             return true;
         }
+        if (method == MethodName.@MethodWithDefaultValues && args.Count == 1) {
+            @MethodWithDefaultValues(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.@MethodWithDefaultValues && args.Count == 2) {
+            @MethodWithDefaultValues(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+            ret = default;
+            return true;
+        }
         return base.InvokeGodotClassMethod(method, args, out ret);
     }
     /// <inheritdoc/>
@@ -54,6 +69,9 @@ partial class Methods
     protected override bool HasGodotClassMethod(in godot_string_name method)
     {
         if (method == MethodName.@MethodWithOverload) {
+           return true;
+        }
+        if (method == MethodName.@MethodWithDefaultValues) {
            return true;
         }
         return base.HasGodotClassMethod(method);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Methods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/Methods.cs
@@ -23,4 +23,8 @@ public partial class Methods : GodotObject
     private void GenericMethod<T>(T t)
     {
     }
+
+    private void MethodWithDefaultValues(int a, int b = 1)
+    {
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -425,50 +425,63 @@ namespace Godot.SourceGenerators
         )
         {
             string methodName = method.Method.Name;
+            int totalParams = method.ParamTypes.Length;
 
-            source.Append("        if (method == MethodName.@");
-            source.Append(methodName);
-            source.Append(" && args.Count == ");
-            source.Append(method.ParamTypes.Length);
-            source.Append(") {\n");
-
-            if (method.RetType != null)
-                source.Append("            var callRet = ");
-            else
-                source.Append("            ");
-
-            source.Append("@");
-            source.Append(methodName);
-            source.Append("(");
-
-            for (int i = 0; i < method.ParamTypes.Length; i++)
+            int minArgs = totalParams;
+            for (int i = totalParams - 1; i >= 0; i--)
             {
-                if (i != 0)
-                    source.Append(", ");
-
-                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
-                    method.ParamTypeSymbols[i], method.ParamTypes[i]);
+                if (method.Method.Parameters[i].HasExplicitDefaultValue)
+                    minArgs = i;
+                else
+                    break;
             }
 
-            source.Append(");\n");
-
-            if (method.RetType != null)
+            for (int argCount = minArgs; argCount <= totalParams; argCount++)
             {
-                source.Append("            ret = ");
+                source.Append("        if (method == MethodName.@");
+                source.Append(methodName);
+                source.Append(" && args.Count == ");
+                source.Append(argCount);
+                source.Append(") {\n");
 
-                source.AppendManagedToNativeVariantExpr("callRet",
-                    method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
-                source.Append(";\n");
+                if (method.RetType != null)
+                    source.Append("            var callRet = ");
+                else
+                    source.Append("            ");
 
-                source.Append("            return true;\n");
+                source.Append("@");
+                source.Append(methodName);
+                source.Append("(");
+
+                for (int i = 0; i < argCount; i++)
+                {
+                    if (i != 0)
+                        source.Append(", ");
+
+                    source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
+                        method.ParamTypeSymbols[i], method.ParamTypes[i]);
+                }
+
+                source.Append(");\n");
+
+                if (method.RetType != null)
+                {
+                    source.Append("            ret = ");
+
+                    source.AppendManagedToNativeVariantExpr("callRet",
+                        method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
+                    source.Append(";\n");
+
+                    source.Append("            return true;\n");
+                }
+                else
+                {
+                    source.Append("            ret = default;\n");
+                    source.Append("            return true;\n");
+                }
+
+                source.Append("        }\n");
             }
-            else
-            {
-                source.Append("            ret = default;\n");
-                source.Append("            return true;\n");
-            }
-
-            source.Append("        }\n");
         }
     }
 }


### PR DESCRIPTION
Fixes #59025 

When calling a C# method with default parameters from GDScript, the call fails with `Invalid call. Nonexistent function` because the generated `InvokeGodotClassMethod` dispatch only matches the exact total param count.

For example, a method like `Log(string msg, string offsetChar = " ")` only generated a dispatch entry for `args.Count == 2`, so calling `Log(msg)` from GDScript with one argument wouldn't match.

This PR generates dispatch entries for each valid argument count, so callers can omit arguments that have default values. For methods with no default params, behavior is unchanged. 