### PR TITLE
Improve EditorPropertyClassName

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2941,6 +2941,7 @@
 			[/csharp]
 			[/codeblocks]
 			[b]Note:[/b] The trailing colon is required for properly detecting built-in types.
+			[b]Note:[/b] When picking a script type from the inspector, the property will store the script's path instead of class name.
 		</constant>
 		<constant name="PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE" value="24" enum="PropertyHint" deprecated="This hint is not used by the engine.">
 		</constant>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -578,7 +578,9 @@ void EditorInterface::popup_create_dialog(const Callable &p_callback, const Stri
 	create_dialog->set_type_blocklist(blocklist);
 
 	String safe_base_type = p_base_type;
-	if (p_base_type.is_empty() || (!ClassDB::class_exists(p_base_type) && !ScriptServer::is_global_class(p_base_type))) {
+	if (safe_base_type.is_empty()) {
+		safe_base_type = "Object";
+	} else if (!ClassDB::class_exists(p_base_type) && !ScriptServer::is_global_class(p_base_type)) {
 		ERR_PRINT(vformat("Invalid base type '%s'. The base type has fallen back to 'Object'.", p_base_type));
 		safe_base_type = "Object";
 	}

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -876,17 +876,20 @@ void EditorPropertyClassName::_set_read_only(bool p_read_only) {
 	property->set_disabled(p_read_only);
 }
 
-void EditorPropertyClassName::setup(const String &p_base_type, const String &p_selected_type) {
+void EditorPropertyClassName::setup(const String &p_base_type) {
 	base_type = p_base_type;
-	dialog->set_base_type(base_type);
-	selected_type = p_selected_type;
-	property->set_text(selected_type);
+	dialog->set_base_type(base_type.is_empty() ? "Object" : base_type);
 }
 
 void EditorPropertyClassName::update_property() {
-	String s = get_edited_property_value();
-	property->set_text(s);
-	selected_type = s;
+	selected_type = get_edited_property_value();
+	if (selected_type.is_empty()) {
+		property->set_text(TTR("<None>"));
+		property->set_tooltip_text(String());
+	} else {
+		property->set_text(selected_type);
+		property->set_tooltip_text(selected_type);
+	}
 }
 
 void EditorPropertyClassName::_property_selected() {
@@ -901,12 +904,13 @@ void EditorPropertyClassName::_dialog_created() {
 
 EditorPropertyClassName::EditorPropertyClassName() {
 	property = memnew(Button);
-	property->set_clip_text(true);
 	property->set_theme_type_variation(SNAME("EditorInspectorButton"));
+	property->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	property->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	add_child(property);
 	add_focusable(property);
-	property->set_text(selected_type);
 	property->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyClassName::_property_selected));
+
 	dialog = memnew(CreateDialog);
 	dialog->set_base_type(base_type);
 	dialog->connect("create", callable_mp(this, &EditorPropertyClassName::_dialog_created));
@@ -4059,7 +4063,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_TYPE_STRING) {
 				EditorPropertyClassName *editor = memnew(EditorPropertyClassName);
-				editor->setup(p_hint_text, p_hint_text);
+				editor->setup(p_hint_text);
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_LOCALE_ID) {
 				EditorPropertyLocale *editor = memnew(EditorPropertyLocale);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -258,7 +258,7 @@ protected:
 	virtual void _set_read_only(bool p_read_only) override;
 
 public:
-	void setup(const String &p_base_type, const String &p_selected_type);
+	void setup(const String &p_base_type);
 	virtual void update_property() override;
 	EditorPropertyClassName();
 };


### PR DESCRIPTION
Improvements to the editor for PROPERTY_HINT_TYPE_STRING.

- Mention the new behavior of script classes (fixes #115831 )
- Display `<None>` when no type is selected, instead of empty button.
- Repeat the button text in tooltip, in case it's too long.
- Replace text clipping with ellipsis.
- Fix crash when hint string of PROPERTY_HINT_TYPE_STRING is empty.
- Fix type name getting auto-translated.
- Remove redundant `p_selected_type` parameter when setting up the property editor (`update_property()` overwrites the text anyway).