### PR TITLE
Editor: Add and Delete Tags from Project List

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1384,6 +1384,9 @@
 		<member name="project_manager/directory_naming_convention" type="int" setter="" getter="">
 			Directory naming convention for the project manager. Options are "No Convention" (project name is directory name), "kebab-case" (default), "snake_case", "camelCase", "PascalCase", or "Title Case".
 		</member>
+		<member name="project_manager/show_warning_on_tag_deletion" type="bool" setter="" getter="">
+			If [code]true[/code], shows a warning popup when deleting a tag from the Project List directly. Does not show when using the Manage Tags dialog.
+		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.
 		</member>

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -102,10 +102,17 @@ void ProjectListItemControl::_notification(int p_what) {
 
 			if (project_is_missing) {
 				explore_button->set_button_icon(get_editor_theme_icon(SNAME("FileBroken")));
+				add_tag_button->hide();
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 			} else {
 				explore_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
+				add_tag_button->show();
 #endif
+			}
+			if (tag_container) {
+				add_tag_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+				add_tag_button->set_custom_maximum_size(Vector2(24, 24) * EDSCALE);
+				add_tag_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			}
 			if (touch_menu_button) {
 				touch_menu_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
@@ -242,6 +249,10 @@ void ProjectListItemControl::_explore_button_pressed() {
 	emit_signal(SNAME("explore_pressed"));
 }
 
+void ProjectListItemControl::_add_tag_button_pressed() {
+	emit_signal(SNAME("add_tag_pressed"));
+}
+
 void ProjectListItemControl::_request_menu() {
 	emit_signal(SNAME("request_menu"), Vector2(touch_menu_button->get_position()));
 }
@@ -260,9 +271,10 @@ void ProjectListItemControl::set_project_path(const String &p_path) {
 
 void ProjectListItemControl::set_tags(const PackedStringArray &p_tags, ProjectList *p_parent_list) {
 	for (const String &tag : p_tags) {
-		ProjectTag *tag_control = memnew(ProjectTag(tag));
+		ProjectTag *tag_control = memnew(ProjectTag(tag, false, false));
 		tag_container->add_child(tag_control);
 		tag_control->connect_button_to(callable_mp(p_parent_list, &ProjectList::add_search_tag).bind(tag));
+		tag_control->connect_aux_button_to(callable_mp(p_parent_list, &ProjectList::_remove_project_tag).bind(tag));
 	}
 }
 
@@ -432,14 +444,14 @@ void ProjectListItemControl::set_project_title_autowrap() {
 	title_fullsize_cache = project_title->get_size().x;
 	window_size_cache = get_window()->get_size().x;
 
-	int tag_size = 0;
+	int tag_size = add_tag_button->get_size().x;
 	int tag_maxsize = 0;
 	for (Node *child : tag_container->iterate_children()) {
 		ProjectTag *tag = Object::cast_to<ProjectTag>(child);
-		tag_size += tag->get_size().x;
+		tag_size += tag->get_size().x + tag->get_aux_button_size().x;
 
 		if (tag_maxsize == 0) {
-			tag_maxsize = tag->get_custom_maximum_size().x;
+			tag_maxsize = tag->get_custom_maximum_size().x + add_tag_button->get_size().x;
 		}
 	}
 	tag_size_cache = MIN(tag_size, tag_maxsize);
@@ -475,7 +487,7 @@ void ProjectListItemControl::resize_project_title() {
 		return;
 	}
 	ProjectTag tag = ProjectTag("dummy");
-	int tag_maxsize = tag.get_custom_maximum_size().x;
+	int tag_maxsize = tag.get_custom_maximum_size().x + add_tag_button->get_size().x;
 	int title_maxsize = title_size_cache - tag_size_cache;
 	int title_minsize = title_size_cache - tag_maxsize;
 
@@ -494,9 +506,20 @@ void ProjectListItemControl::resize_project_title() {
 	}
 }
 
+ProjectTag *ProjectListItemControl::get_tag_control(const String &p_tag) {
+	for (Node *child : tag_container->iterate_children()) {
+		ProjectTag *tag_control = Object::cast_to<ProjectTag>(child);
+		if (tag_control && tag_control->get_tag() == p_tag) {
+			return tag_control;
+		}
+	}
+	return nullptr;
+}
+
 void ProjectListItemControl::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("favorite_pressed"));
 	ADD_SIGNAL(MethodInfo("explore_pressed"));
+	ADD_SIGNAL(MethodInfo("add_tag_pressed"));
 	ADD_SIGNAL(MethodInfo("request_menu"));
 }
 
@@ -550,7 +573,16 @@ ProjectListItemControl::ProjectListItemControl() {
 		tag_container = memnew(HFlowContainer);
 		tag_container->set_alignment(FlowContainer::ALIGNMENT_END);
 		tag_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		tag_container->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 		title_hb->add_child(tag_container);
+
+		add_tag_button = memnew(Button);
+		add_tag_button->set_v_size_flags(SIZE_SHRINK_CENTER);
+		add_tag_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+		add_tag_button->set_mouse_filter(MOUSE_FILTER_PASS);
+		add_tag_button->set_tooltip_text(TTRC("Add tag"));
+		title_hb->add_child(add_tag_button);
+		add_tag_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_add_tag_button_pressed));
 	}
 
 	// Bottom half, containing the path and view folder button.
@@ -1207,6 +1239,10 @@ void ProjectList::_create_project_item_control(int p_index) {
 	Item &item = _projects.write[p_index];
 	ERR_FAIL_COND(item.control != nullptr); // Already created
 
+	project_title_index_count = item.project_title_index == -1 ? project_title_index_count + 1 : project_title_index_count;
+	item.project_title_index = item.project_title_index == -1 ? project_title_index_count : item.project_title_index;
+	title_size_cache[project_title_index_count] = item.project_title_index == project_title_index_count ? 0 : title_size_cache[project_title_index_count];
+
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
 	hb->add_theme_constant_override("separation", 10 * EDSCALE);
 
@@ -1221,23 +1257,17 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->set_is_favorite(item.favorite);
 	hb->set_is_missing(item.missing);
 	hb->set_is_grayed(item.grayed);
+	hb->set_project_title_index(item.project_title_index);
 
 	hb->connect(SceneStringName(gui_input), callable_mp(this, &ProjectList::_list_item_input).bind(hb));
 	hb->connect("favorite_pressed", callable_mp(this, &ProjectList::_on_favorite_pressed).bind(hb));
-
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 	hb->connect("explore_pressed", callable_mp(this, &ProjectList::_on_explore_pressed).bind(item.path));
 #endif
+	hb->connect("add_tag_pressed", callable_mp(this, &ProjectList::_on_add_tag_pressed));
 	hb->connect("request_menu", callable_mp(this, &ProjectList::_open_menu).bind(hb));
-
-	if (item.project_title_index == -1) {
-		project_title_index_count++;
-		title_size_cache[project_title_index_count] = 0;
-		item.project_title_index = project_title_index_count;
-		hb->set_project_title_index(project_title_index_count);
-	} else {
-		hb->set_project_title_index(item.project_title_index);
-	}
+	hb->connect(SceneStringName(mouse_entered), callable_mp(this, &ProjectList::_update_tag_aux_button_visibility).bind(hb, true));
+	hb->connect(SceneStringName(mouse_exited), callable_mp(this, &ProjectList::_update_tag_aux_button_visibility).bind(hb, false));
 
 	project_list_vbox->add_child(hb);
 	item.control = hb;
@@ -1366,6 +1396,25 @@ void ProjectList::_on_favorite_pressed(Node *p_hb) {
 
 void ProjectList::_on_explore_pressed(const String &p_path) {
 	OS::get_singleton()->shell_show_in_file_manager(p_path, true);
+}
+
+void ProjectList::_on_add_tag_pressed() {
+	ProjectManager::get_singleton()->manage_project_tags();
+}
+
+void ProjectList::_update_tag_aux_button_visibility(ProjectListItemControl *p_control, bool p_show) {
+	int idx = get_index(p_control);
+	Item &item = _projects.write[idx];
+	for (const String &tag : item.tags) {
+		ProjectTag *tag_control = item.control->get_tag_control(tag);
+		if (tag_control) {
+			tag_control->update_aux_button_visibility(p_show);
+		}
+	}
+}
+
+void ProjectList::_remove_project_tag(const String &p_tag) {
+	ProjectManager::get_singleton()->show_remove_tag_warning_dialog(p_tag);
 }
 
 void ProjectList::_open_menu(const Vector2 &p_at, Control *p_hb) {

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -42,6 +42,7 @@ class PopupMenu;
 class ProjectList;
 class TextureButton;
 class TextureRect;
+class ProjectTag;
 
 class ProjectListItemControl : public HBoxContainer {
 	GDCLASS(ProjectListItemControl, HBoxContainer)
@@ -49,6 +50,7 @@ class ProjectListItemControl : public HBoxContainer {
 	VBoxContainer *main_vbox = nullptr;
 	TextureButton *favorite_button = nullptr;
 	Button *explore_button = nullptr;
+	Button *add_tag_button = nullptr;
 
 	TextureRect *project_icon = nullptr;
 	Label *project_title = nullptr;
@@ -84,6 +86,8 @@ class ProjectListItemControl : public HBoxContainer {
 	void _update_favorite_button_focus_color();
 	void _favorite_button_pressed();
 	void _explore_button_pressed();
+	void _add_tag_button_pressed();
+
 	void _request_menu();
 
 	ProjectList *get_list() const;
@@ -124,6 +128,8 @@ public:
 	void set_project_title_autowrap();
 
 	void resize_project_title();
+
+	ProjectTag *get_tag_control(const String &p_tag);
 
 	ProjectListItemControl();
 };
@@ -277,7 +283,10 @@ private:
 	void _list_item_input(const Ref<InputEvent> &p_ev, Control *p_hb);
 	void _on_favorite_pressed(Node *p_hb);
 	void _on_explore_pressed(const String &p_path);
+	void _on_add_tag_pressed();
+	void _update_tag_aux_button_visibility(ProjectListItemControl *p_control, bool p_show);
 
+	void _remove_project_tag(const String &p_tag);
 	void _open_menu(const Vector2 &p_at, Control *p_hb);
 	void _menu_option(int p_option);
 	void _update_menu_icons();
@@ -316,7 +325,6 @@ public:
 	void update_project_list();
 	void sort_projects();
 	int get_project_count() const;
-
 	void find_projects(const String &p_path);
 	void find_projects_multiple(const PackedStringArray &p_paths);
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -50,7 +50,6 @@
 #include "editor/inspector/editor_inspector.h"
 #include "editor/project_manager/engine_update_label.h"
 #include "editor/project_manager/project_dialog.h"
-#include "editor/project_manager/project_list.h"
 #include "editor/project_manager/project_tag.h"
 #include "editor/project_manager/quick_settings_dialog.h"
 #include "editor/settings/editor_settings.h"
@@ -300,6 +299,11 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			open_btn_container->add_theme_constant_override("separation", 0);
 			open_options_popup->set_item_icon(0, get_editor_theme_icon("Notification"));
 			open_options_popup->set_item_icon(1, get_editor_theme_icon("NodeWarning"));
+
+			//prettify create tag button
+			create_tag_btn->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+			create_tag_btn->set_custom_maximum_size(Vector2(24, 24) * EDSCALE);
+			create_tag_btn->set_v_size_flags(SIZE_SHRINK_CENTER);
 		}
 
 		// Dialogs.
@@ -440,7 +444,7 @@ void ProjectManager::_project_list_menu_option(int p_option) {
 			break;
 
 		case ProjectList::MENU_MANAGE_TAGS:
-			_manage_project_tags();
+			manage_project_tags();
 			break;
 
 		case ProjectList::MENU_DUPLICATE:
@@ -453,9 +457,10 @@ void ProjectManager::_project_list_menu_option(int p_option) {
 	}
 }
 
-void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size) {
+void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size, bool p_autowrap) {
 	error_dialog->set_text(p_message);
-	error_dialog->popup_centered(p_min_size);
+	error_dialog->set_autowrap(p_autowrap);
+	error_dialog->popup_centered(p_min_size * EDSCALE);
 }
 
 void ProjectManager::_dim_window() {
@@ -1014,7 +1019,7 @@ LineEdit *ProjectManager::get_search_box() {
 
 // Project tag management.
 
-void ProjectManager::_manage_project_tags() {
+void ProjectManager::manage_project_tags() {
 	for (int i = 0; i < project_tags->get_child_count(); i++) {
 		project_tags->get_child(i)->queue_free();
 	}
@@ -1022,9 +1027,10 @@ void ProjectManager::_manage_project_tags() {
 	const ProjectList::Item item = project_list->get_selected_projects()[0];
 	current_project_tags = item.tags;
 	for (const String &tag : current_project_tags) {
-		ProjectTag *tag_control = memnew(ProjectTag(tag, true));
+		ProjectTag *tag_control = memnew(ProjectTag(tag));
 		project_tags->add_child(tag_control);
 		tag_control->connect_button_to(callable_mp(this, &ProjectManager::_delete_project_tag).bind(tag));
+		tag_control->connect_aux_button_to(callable_mp(this, &ProjectManager::_delete_project_tag).bind(tag));
 	}
 
 	tag_edit_error->hide();
@@ -1037,9 +1043,35 @@ void ProjectManager::_add_project_tag(const String &p_tag) {
 	}
 	current_project_tags.append(p_tag);
 
-	ProjectTag *tag_control = memnew(ProjectTag(p_tag, true));
+	ProjectTag *tag_control = memnew(ProjectTag(p_tag));
 	project_tags->add_child(tag_control);
 	tag_control->connect_button_to(callable_mp(this, &ProjectManager::_delete_project_tag).bind(p_tag));
+	tag_control->connect_aux_button_to(callable_mp(this, &ProjectManager::_delete_project_tag).bind(p_tag));
+}
+
+void ProjectManager::_remove_project_tag() {
+	if (del_tag_warning_cb->is_pressed()) {
+		EditorSettings::get_singleton()->set_setting("project_manager/show_warning_on_tag_deletion", false);
+		del_tag_warning_cb->set_pressed(false);
+	}
+
+	const ProjectList::Item item = project_list->get_selected_projects()[0];
+	const String project_godot = item.path.path_join("project.godot");
+
+	// So tags aren't removed from an invalid project.
+	if (!FileAccess::exists(project_godot)) {
+		_show_error(vformat(TTR("Couldn't load project at\n%s.\nIt may be missing."), project_godot));
+		error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &ProjectManager::_on_projects_updated), CONNECT_ONE_SHOT);
+		return;
+	}
+
+	current_project_tags = item.tags;
+	current_project_tags.erase(tag_to_del);
+	ProjectTag *tag_control = item.control->get_tag_control(tag_to_del);
+	if (tag_control) {
+		memdelete(tag_control);
+		_apply_project_tags();
+	}
 }
 
 void ProjectManager::_delete_project_tag(const String &p_tag) {
@@ -1054,34 +1086,26 @@ void ProjectManager::_delete_project_tag(const String &p_tag) {
 }
 
 void ProjectManager::_apply_project_tags() {
-	PackedStringArray tags;
-	for (int i = 0; i < project_tags->get_child_count(); i++) {
-		ProjectTag *tag_control = Object::cast_to<ProjectTag>(project_tags->get_child(i));
-		if (tag_control) {
-			tags.append(tag_control->get_tag());
-		}
-	}
-
 	const String project_godot = project_list->get_selected_projects()[0].path.path_join("project.godot");
 	ProjectSettings *cfg = memnew(ProjectSettings(project_godot));
+
 	if (!cfg->is_project_loaded()) {
 		memdelete(cfg);
-		tag_edit_error->set_text(vformat(TTR("Couldn't load project at '%s'. It may be missing or corrupted."), project_godot));
-		tag_edit_error->show();
-		callable_mp((Window *)tag_manage_dialog, &Window::show).call_deferred(); // Make sure the dialog does not disappear.
+		_show_error(vformat(TTR("Couldn't load project at\n%s.\nIt may be missing or corrupted."), project_godot), Vector2(500, 0), true);
+		error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &ProjectManager::_on_projects_updated), CONNECT_ONE_SHOT);
 		return;
-	} else {
-		tags.sort();
-		cfg->set("application/config/tags", tags);
-		Error err = cfg->save_custom(project_godot);
-		memdelete(cfg);
+	}
+	PackedStringArray tags = current_project_tags;
 
-		if (err != OK) {
-			tag_edit_error->set_text(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err));
-			tag_edit_error->show();
-			callable_mp((Window *)tag_manage_dialog, &Window::show).call_deferred();
-			return;
-		}
+	tags.sort();
+	cfg->set("application/config/tags", tags);
+	Error err = cfg->save_custom(project_godot);
+	memdelete(cfg);
+
+	if (err != OK) {
+		_show_error(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err), Vector2(500, 0), true);
+		error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &ProjectManager::_on_projects_updated), CONNECT_ONE_SHOT);
+		return;
 	}
 
 	_on_projects_updated();
@@ -1140,11 +1164,23 @@ void ProjectManager::_create_new_tag() {
 void ProjectManager::add_new_tag(const String &p_tag) {
 	if (!tag_set.has(p_tag)) {
 		tag_set.insert(p_tag);
-		ProjectTag *tag_control = memnew(ProjectTag(p_tag));
+		ProjectTag *tag_control = memnew(ProjectTag(p_tag, true));
 		all_tags->add_child(tag_control);
 		all_tags->move_child(tag_control, -2);
 		tag_control->connect_button_to(callable_mp(this, &ProjectManager::_add_project_tag).bind(p_tag));
+		tag_control->connect_aux_button_to(callable_mp(this, &ProjectManager::_add_project_tag).bind(p_tag));
 	}
+}
+
+void ProjectManager::show_remove_tag_warning_dialog(const String &p_tag) {
+	tag_to_del = p_tag;
+	bool bypass = Input::get_singleton()->is_physical_key_pressed(Key::SHIFT);
+	if (bypass || !EDITOR_GET("project_manager/show_warning_on_tag_deletion")) {
+		_remove_project_tag();
+		return;
+	}
+
+	del_tag_warning_dialog->popup_centered(Vector2(300, 0) * EDSCALE);
 }
 
 // Project converter/migration tool.
@@ -1890,7 +1926,7 @@ ProjectManager::ProjectManager() {
 		add_child(tag_manage_dialog);
 		tag_manage_dialog->set_title(TTRC("Manage Project Tags"));
 		tag_manage_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_apply_project_tags));
-		manage_tags_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_manage_project_tags));
+		manage_tags_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::manage_project_tags));
 
 		VBoxContainer *tag_vb = memnew(VBoxContainer);
 		tag_manage_dialog->add_child(tag_vb);
@@ -1955,6 +1991,24 @@ ProjectManager::ProjectManager() {
 		create_tag_btn->set_accessibility_name(TTRC("Create Tag"));
 		all_tags->add_child(create_tag_btn);
 		create_tag_btn->connect(SceneStringName(pressed), callable_mp((Window *)create_tag_dialog, &Window::popup_centered).bind(Vector2i(500, 0) * EDSCALE));
+
+		del_tag_warning_dialog = memnew(ConfirmationDialog);
+		add_child(del_tag_warning_dialog);
+		del_tag_warning_dialog->set_title(TTRC("Delete Tag"));
+		del_tag_warning_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ProjectManager::_remove_project_tag));
+
+		VBoxContainer *vb = memnew(VBoxContainer);
+		del_tag_warning_dialog->add_child(vb);
+
+		label = memnew(Label);
+		vb->add_child(label);
+		label->set_text(vformat(TTR("Are you sure you want to remove this tag?\nHold Shift when deleting to skip this dialog.")));
+		label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+
+		del_tag_warning_cb = memnew(CheckBox);
+		vb->add_child(del_tag_warning_cb);
+		del_tag_warning_cb->set_text("Don't Show Again");
+		del_tag_warning_cb->set_h_size_flags(SIZE_SHRINK_CENTER);
 
 		_set_new_tag_name("");
 	}

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "editor/project_manager/project_list.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/scroll_container.h"
 
@@ -45,7 +46,6 @@ class OptionButton;
 class PanelContainer;
 class PopupMenu;
 class ProjectDialog;
-class ProjectList;
 class QuickSettingsDialog;
 class RichTextLabel;
 class TabContainer;
@@ -122,7 +122,7 @@ class ProjectManager : public Control {
 
 	AcceptDialog *error_dialog = nullptr;
 
-	void _show_error(const String &p_message, const Size2 &p_min_size = Size2());
+	void _show_error(const String &p_message, const Size2 &p_min_size = Size2(), bool p_autowrap = false);
 	void _dim_window();
 
 	// Quick settings.
@@ -220,6 +220,7 @@ class ProjectManager : public Control {
 	// Project tag management.
 
 	HashSet<String> tag_set;
+	String tag_to_del;
 	PackedStringArray current_project_tags;
 	PackedStringArray forbidden_tag_characters{ "/", "\\", "-" };
 
@@ -233,8 +234,11 @@ class ProjectManager : public Control {
 	LineEdit *new_tag_name = nullptr;
 	Label *tag_error = nullptr;
 
-	void _manage_project_tags();
+	ConfirmationDialog *del_tag_warning_dialog = nullptr;
+	CheckBox *del_tag_warning_cb = nullptr;
+
 	void _add_project_tag(const String &p_tag);
+	void _remove_project_tag();
 	void _delete_project_tag(const String &p_tag);
 	void _apply_project_tags();
 	void _set_new_tag_name(const String p_name);
@@ -285,6 +289,8 @@ public:
 	// Project tag management.
 
 	void add_new_tag(const String &p_tag);
+	void manage_project_tags();
+	void show_remove_tag_warning_dialog(const String &p_tag);
 
 	// Theme.
 	Ref<Theme> get_theme() const { return theme; }

--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -35,8 +35,12 @@
 #include "scene/gui/color_rect.h"
 
 void ProjectTag::_notification(int p_what) {
-	if (display_close && p_what == NOTIFICATION_THEME_CHANGED) {
-		button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
+	// Needed to get the correct icons in ProjectList and Manage Project Tags dialog on Project Manager Startup.
+	if (is_add_button && p_what == NOTIFICATION_THEME_CHANGED) {
+		aux_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+	}
+	if (!is_add_button && is_aux_button_visible && p_what == NOTIFICATION_THEME_CHANGED) {
+		aux_button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
 	}
 	// HACK: Can't be set in constructor because `get_size()` would return empty.
 	// This logic should be migrated once `Button` utilizes internal labels.
@@ -46,20 +50,39 @@ void ProjectTag::_notification(int p_what) {
 	}
 }
 
+void ProjectTag::update_aux_button_visibility(bool p_show) {
+	if (p_show) {
+		aux_button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
+	} else {
+		Ref<Texture2D> icon;
+		aux_button->set_button_icon(icon);
+	}
+}
+
 void ProjectTag::connect_button_to(const Callable &p_callable) {
 	button->connect(SceneStringName(pressed), p_callable, CONNECT_DEFERRED);
+}
+
+void ProjectTag::connect_aux_button_to(const Callable &p_callable) {
+	aux_button->connect(SceneStringName(pressed), p_callable, CONNECT_DEFERRED);
+}
+
+Size2 ProjectTag::get_aux_button_size() const {
+	return aux_button->get_custom_maximum_size();
 }
 
 const String ProjectTag::get_tag() const {
 	return tag_string;
 }
 
-ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
+ProjectTag::ProjectTag(const String &p_text, bool p_aux_is_add_button, bool p_aux_button_visible) {
 	add_theme_constant_override(SNAME("separation"), 0);
 	set_v_size_flags(SIZE_SHRINK_CENTER);
-	set_custom_maximum_size(Vector2(336 * EDSCALE, -1));
+	set_custom_maximum_size(Vector2(356, 24) * EDSCALE);
+
 	tag_string = p_text;
-	display_close = p_display_close;
+	is_add_button = p_aux_is_add_button;
+	is_aux_button_visible = p_aux_button_visible;
 
 	Color tag_color = Color(1, 0, 0);
 	tag_color.set_ok_hsl_s(0.8);
@@ -74,12 +97,24 @@ ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
 
 	button = memnew(Button);
 	add_child(button);
+	;
 	button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	button->set_text(p_text.capitalize());
 	button->set_tooltip_text(p_text.capitalize());
 	button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button->set_accessibility_name(vformat(TTR("Project Tag: %s"), p_text));
-	button->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	button->set_theme_type_variation(SNAME("ProjectTagButton"));
+	button->set_custom_maximum_size(Vector2(332, 24) * EDSCALE);
 	button->set_mouse_filter(MOUSE_FILTER_PASS);
+
+	aux_button = memnew(Button);
+	add_child(aux_button);
+	aux_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	aux_button->set_focus_mode(FOCUS_ACCESSIBILITY);
+	aux_button->set_accessibility_name(vformat(TTR("Remove Tag: %s"), p_text));
+	aux_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	aux_button->set_theme_type_variation(SNAME("ProjectTagAuxButton"));
+	aux_button->set_custom_minimum_size(Vector2(20, 24) * EDSCALE);
+	aux_button->set_custom_maximum_size(Vector2(20, 24) * EDSCALE);
+	aux_button->set_mouse_filter(MOUSE_FILTER_PASS);
 }

--- a/editor/project_manager/project_tag.h
+++ b/editor/project_manager/project_tag.h
@@ -38,16 +38,21 @@ class ProjectTag : public HBoxContainer {
 	GDCLASS(ProjectTag, HBoxContainer);
 
 	String tag_string;
-	bool display_close = false;
+	bool is_add_button = false;
+	bool is_aux_button_visible = false;
 
 	Button *button = nullptr;
+	Button *aux_button = nullptr;
 
 protected:
 	void _notification(int p_what);
 
 public:
+	void update_aux_button_visibility(bool p_show);
 	void connect_button_to(const Callable &p_callable);
+	void connect_aux_button_to(const Callable &p_callable);
+	Size2 get_aux_button_size() const;
 	const String get_tag() const;
 
-	ProjectTag(const String &p_text, bool p_display_close = false);
+	ProjectTag(const String &p_text, bool p_aux_is_add_button = false, bool p_aux_button_visible = true);
 };

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1188,6 +1188,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No Convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "project_manager/show_warning_on_tag_deletion", true, "")
 
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1591,25 +1591,39 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
 			tag->set_bg_color(p_config.dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_hover->duplicate();
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_pressed->duplicate();
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
+
+			p_theme->set_type_variation("ProjectTagAuxButton", "Button");
+
+			Ref<StyleBoxFlat> tag_aux = p_config.button_style->duplicate();
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagAuxButton", tag_aux);
+
+			tag_aux = p_config.button_style_hover->duplicate();
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagAuxButton", tag_aux);
+
+			tag_aux = p_config.button_style_pressed->duplicate();
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagAuxButton", tag_aux);
 		}
 	}
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1629,27 +1629,44 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 			Ref<StyleBoxFlat> tag = p_config.button_style->duplicate();
 			tag->set_border_width_all(0);
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_hover->duplicate();
 			tag->set_border_width_all(0);
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagButton", tag);
 
 			tag = p_config.button_style_pressed->duplicate();
 			tag->set_border_width_all(0);
-			tag->set_corner_radius(CORNER_TOP_LEFT, 0);
-			tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
-			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			tag->set_corner_radius_all(0);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
+
+			p_theme->set_type_variation("ProjectTagAuxButton", "Button");
+
+			Ref<StyleBoxFlat> tag_aux = p_config.button_style->duplicate();
+			tag_aux->set_border_width_all(0);
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectTagAuxButton", tag_aux);
+
+			tag_aux = p_config.button_style_hover->duplicate();
+			tag_aux->set_border_width_all(0);
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectTagAuxButton", tag_aux);
+
+			tag_aux = p_config.button_style_pressed->duplicate();
+			tag_aux->set_border_width_all(0);
+			tag_aux->set_corner_radius(CORNER_TOP_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			tag_aux->set_corner_radius(CORNER_TOP_RIGHT, 4);
+			tag_aux->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagAuxButton", tag_aux);
 		}
 	}
 


### PR DESCRIPTION
Closes [#14728](https://github.com/godotengine/godot-proposals/issues/14728)

Phase one of three phases to improve the Project Tag System for better organisation. See discussion [#14703](https://github.com/godotengine/godot-proposals/discussions/14703)

Add two buttons to every project in the Project Manager to make it easier to add and remove tags.

Add tag buttons that will create visibility for those that may not know it exists yet (however unlikely)
<img width="67" height="40" alt="add_tag_twins" src="https://github.com/user-attachments/assets/0a742c9b-6a52-46fb-889d-4468be971cc0" />

Remove button attached to every tag so users can forgo having to open the Manage Project Tags dialog
<img width="51" height="22" alt="new_fangled_tag" src="https://github.com/user-attachments/assets/99d47de7-f194-4e5b-8adf-9f668002e77d" />

In Practice
<img width="722" height="52" alt="full_look" src="https://github.com/user-attachments/assets/392225fb-4b0c-4afe-90cd-f51f26e5ab34" />
<img width="721" height="54" alt="project_lonely" src="https://github.com/user-attachments/assets/15968f22-d5bb-4784-a959-93af51360afb" />
