### PR TITLE
Fix `ubo:X` numbers for multiview UBOs in Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -482,7 +482,7 @@ struct MultiviewData {
 	highp vec4 eye_offset[MAX_VIEWS];
 };
 
-layout(std140) uniform MultiviewDataBlock { // ubo:8
+layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
 }
 multiview_data_block;
@@ -1227,7 +1227,7 @@ struct MultiviewData {
 	highp vec4 eye_offset[MAX_VIEWS];
 };
 
-layout(std140) uniform MultiviewDataBlock { // ubo:8
+layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
 }
 multiview_data_block;

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -119,7 +119,7 @@ layout(std140) uniform MaterialUniforms{ //ubo:3
 #endif
 
 #ifdef USE_MULTIVIEW
-layout(std140) uniform MultiviewData { // ubo:11
+layout(std140) uniform MultiviewData { // ubo:12
 	highp mat4 projection_matrix_view[MAX_VIEWS];
 	highp mat4 inv_projection_matrix_view[MAX_VIEWS];
 	highp vec4 eye_offset[MAX_VIEWS];


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119018
Fixes https://github.com/godotengine/godot/issues/118961