### PR TITLE
Set a default text for Control nodes (and Label3D) when created in the editor

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -64,10 +64,12 @@
 #include "editor/shader/shader_create_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/node_2d.h"
+#include "scene/3d/label_3d.h"
 #include "scene/animation/animation_tree.h"
 #include "scene/audio/audio_stream_player.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/color_picker.h"
 #include "scene/gui/panel_container.h"
 #include "scene/main/scene_tree.h"
 #include "scene/property_utils.h"
@@ -3080,20 +3082,48 @@ void SceneTreeDock::_post_do_create(Node *p_child) {
 	editor_selection->add_node(p_child);
 	_push_item(p_child);
 
-	// Make editor more comfortable, so some controls don't appear super shrunk.
 	Control *control = Object::cast_to<Control>(p_child);
 	if (control) {
+		// Set default text to give immediate visual feedback when creating controls in the editor.
+		// Use `get_class_name()` so that `class_name` is respected for custom controls.
+		// Do not set text on ColorPickerButton, as doing so increases its minimum width
+		// (even if the text can't be seen).
+		if (!Object::cast_to<ColorPickerButton>(control)) {
+			control->set("text", control->get_class_name());
+			// For FoldableContainer, GraphFrame, and GraphNode.
+			control->set("title", control->get_class_name());
+		}
+
+		// Increase the size of small controls, so that they are easily visible in their default state
+		// and can have their handles easily dragged.
 		Size2 ms = control->get_minimum_size();
-		if (ms.width < 4) {
+		if (ms.width < 10) {
 			ms.width = 40;
 		}
-		if (ms.height < 4) {
+		if (ms.height < 10) {
 			ms.height = 40;
 		}
 		if (control->is_layout_rtl()) {
 			control->set_position(control->get_position() - Vector2(ms.x, 0));
 		}
 		control->set_size(ms);
+
+		// Set a reasonable minimum size for controls that do not resize according to their text.
+		// The minimum size is set to allow the default text to show without wrapping
+		// (or in ColorPicker's case, allow the color to be seen).
+		constexpr int DEFAULT_LINE_HEIGHT = 31;
+		if (Object::cast_to<RichTextLabel>(control)) {
+			control->set_custom_minimum_size(Vector2(120, DEFAULT_LINE_HEIGHT));
+		} else if (Object::cast_to<TextEdit>(control)) {
+			control->set_custom_minimum_size(Vector2(80, DEFAULT_LINE_HEIGHT));
+		} else if (Object::cast_to<ColorPickerButton>(control)) {
+			control->set_custom_minimum_size(Vector2(40, DEFAULT_LINE_HEIGHT));
+		}
+	}
+
+	Label3D *label_3d = Object::cast_to<Label3D>(p_child);
+	if (label_3d) {
+		label_3d->set_text(label_3d->get_class_name());
 	}
 
 	emit_signal(SNAME("node_created"), p_child);


### PR DESCRIPTION
This allows for immediate visual feedback when adding Control nodes in the editor. A minimum size is also set for controls that don't resize according to their text, so that the text can be displayed without wrapping, even when placed in a Container.

For compatibility, this does not affect nodes created through code (in a `@tool` script or otherwise).

- This closes https://github.com/godotengine/godot-proposals/issues/14750.

## Preview

*Top: nodes added in `master` in an HBoxContainer. (The first node is a ColorPickerButton.)*
*Bottom: nodes added in this PR in an HBoxContainer.*

<img width="741" height="111" alt="image" src="https://github.com/user-attachments/assets/ce8dc790-7233-43dd-b74b-ade0edab6035" />

## TODO

- [ ] Consider moving the naming logic to affect any Node, not just Control and Label3D, so that nodes like Window and FileDialog can have titles set automatically.
- [ ] Add a virtual method in Control to get a default minimum size to apply in the editor, so that we don't have to hardcode exceptions here. This would also be more friendly to plugins.
- [ ] Read the theme font and scale the minimum sizes accordingly using TextServer methods.
  - If this is not feasible because the node isn't created yet, use the default theme scale from the Project Settings to multiply the values.