### PR TITLE
Fix albedo color space in ResourceImporterOBJ's MTL code

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -68,7 +68,7 @@ static Error _parse_material_library(const String &p_path, HashMap<String, Ref<S
 			c.r = v[1].to_float();
 			c.g = v[2].to_float();
 			c.b = v[3].to_float();
-			current->set_albedo(c);
+			current->set_albedo(c.linear_to_srgb());
 		} else if (l.begins_with("Ks ")) {
 			// Specular color.
 			ERR_FAIL_COND_V(current.is_null(), ERR_FILE_CORRUPT);


### PR DESCRIPTION
I tried exporting from Blender an object with an albedo color as an OBJ (something I don't usually do since I usually use glTF and usually use non-colored meshes). The OBJ looks correct in macOS Preview, and looks correct when importing back into Blender, but looks wrong in Godot, it was way too dark.

I tried changing the ResourceImporterOBJ's MTL code to call `linear_to_srgb` on the color and now it looks correct. This PR is submitting that one-line fix, making Godot match Blender and macOS Preview.