### PR TITLE
Fix `NavigationServer3D.map_get_closest_point_normal` returning unnormalized value

### DIFF
--- a/modules/navigation_3d/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_queries_3d.cpp
@@ -1010,7 +1010,7 @@ ClosestPointQueryResult NavMeshQueries3D::map_iteration_get_closest_point_info(c
 				if (distance_squared < closest_point_distance_squared) {
 					closest_point_distance_squared = distance_squared;
 					result.point = p_point - plane_normalized * distance;
-					result.normal = plane_normal;
+					result.normal = plane_normalized;
 					result.owner = polygon.owner->get_self();
 
 					if (Math::is_zero_approx(distance)) {
@@ -1022,7 +1022,7 @@ ClosestPointQueryResult NavMeshQueries3D::map_iteration_get_closest_point_info(c
 				if (distance < closest_point_distance_squared) {
 					closest_point_distance_squared = distance;
 					result.point = closest_on_polygon;
-					result.normal = plane_normal;
+					result.normal = plane_normal.normalized();
 					result.owner = polygon.owner->get_self();
 				}
 			}


### PR DESCRIPTION
Fixes #118768

map_get_closest_point_normal() was returning the raw cross product of 
two triangle edges as the normal vector, which has magnitude equal to 
2 × triangle_area instead of 1.0.

Fixed by using plane_normalized (already computed for the inside branch) 
and calling plane_normal.normalized() for the outside branch.