### PR TITLE
Fix duplicate MultiplayerSynchronizer property insertion freeze

### DIFF
--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -325,8 +325,8 @@ void PropertySelector::_confirmed() {
 	if (!ti) {
 		return;
 	}
-	emit_signal(SNAME("selected"), ti->get_metadata(0));
 	hide();
+	emit_signal(SNAME("selected"), ti->get_metadata(0));
 }
 
 void PropertySelector::_item_selected() {


### PR DESCRIPTION
Fix a UI freeze when re-adding an already synchronized property from the MultiplayerSynchronizer replication picker.

The property selector now hides before emitting its selection signal, preventing the duplicate-warning flow from reentering the modal state and leaving the editor unresponsive.

Fixes #102459