### PR TITLE
[Web] Fix Bus.addAt(-1) scrambling bus array on Sample playback

### DIFF
--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -881,12 +881,18 @@ class Bus {
 
 	/**
 	 * Adds a new bus at the specified index.
-	 * @param {number} index Index to add a new bus.
+	 * @param {number} index Index to add a new bus, or -1 to append.
 	 * @returns {void}
 	 */
 	static addAt(index) {
 		const newBus = GodotAudio.Bus.create();
-		if (index !== newBus.getId()) {
+		// `index === -1` is the "append" sentinel from C++ AudioServer::add_bus when
+		// p_at_pos >= buses.size(); Bus.create() already pushed to the end, so any
+		// move would be incorrect. Without this guard, Bus.move(N, -1) does
+		// splice(toIndex - 1, 0, item) i.e. splice(-2, 0, item) which inserts at
+		// length-2 instead of the end, scrambling the JS bus array relative to C++
+		// and eventually disconnecting Master from ctx.destination on Sample playback.
+		if (index !== -1 && index !== newBus.getId()) {
 			GodotAudio.Bus.move(newBus.getId(), index);
 		}
 	}


### PR DESCRIPTION
Fixes #119026.

When `AudioServer::add_bus(p_at_pos)` is called with `p_at_pos >= buses.size()`, the value is normalized to `-1` ("append") and forwarded to JS via `add_sample_bus(p_at_pos)`. JS `Bus.addAt(-1)` correctly creates the bus at the end via `Bus.create()`, but then enters the `if (index !== newBus.getId())` branch (since `-1 !== N`) and calls `Bus.move(newBus.getId(), -1)`. `Bus.move`'s body does `splice(toIndex - 1, 0, item)` -> `splice(-2, 0, item)`, inserting at `length - 2` instead of at end. The JS bus array desyncs from C++; subsequent `set_bus_send(busIdx, sendIdx)` calls land on the wrong buses; Master's `_send` ends up reassigned away from `null`; `Bus.connect()`'s unconditional `getOutputNode().disconnect()` severs Master from `ctx.destination`.

Result: every web export with `default_playback_type.web=Sample` (the default since 4.3 via #91382) and >=2 buses is silent on Sample playback. `register_sample` produces real PCM (verified by reading the `AudioBuffer` post-`copyToChannel` — amplitude ~1.0), the `SampleNode` lifecycle runs cleanly to `_source.start()`, but the bus chain leading to `ctx.destination` is broken.

**Fix:** skip `Bus.move` when `index === -1`. The bus is already at the correct position from `Bus.create`'s push.

**Testing:** I verified by patching the bundled `library_godot_audio.js` post-export on a Godot 4.6.2 single-threaded HTML5 build with 5 buses (Master + Music + Ambient + SFX + Vocab). Pre-fix: Master `_send=3`, audio silent at master peak `-inf`. Post-fix: Master `_send=null` (direct to destination), audio plays correctly. No regression on single-bus or stream-mode scenarios.

Single-file, single-line behavioral change (plus a comment block explaining why the guard exists, so the next contributor doesn't remove it).
