### PR TITLE
Better clarify `assert` behavior

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="condition" type="bool" />
 			<param index="1" name="message" type="String" default="&quot;&quot;" />
 			<description>
-				Asserts that the [param condition] is [code]true[/code]. If the [param condition] is [code]false[/code], an error is generated. When running from the editor, the running project will also be paused until you resume it. This can be used as a stronger form of [method @GlobalScope.push_error] for reporting errors to project developers or add-on users.
+				Asserts that the [param condition] is [code]true[/code]. If the [param condition] is [code]false[/code], an error is generated and the current method returns a default value. When running from the editor, failed asserts also cause a debugger break. This can be used as a stronger form of [method @GlobalScope.push_error] for reporting errors to project developers or add-on users.
 				An optional [param message] can be shown in addition to the generic "Assertion failed" message. You can use this to provide additional details about why the assertion failed.
 				[b]Warning:[/b] For performance reasons, the code inside [method assert] is only executed in debug builds or when running the project from the editor. Don't include code that has side effects in an [method assert] call. Otherwise, the project will behave differently when exported in release mode.
 				[codeblock]


### PR DESCRIPTION
- Assert causes the currently executing method to return. It's rather important to mention.
- Assert failed at runtime causes _debugger break_ (breakpoint), which is not the same as "pause".