### PR TITLE
Fix `RETURN_TO_HOLD` and `hold_previous` in `AudioStreamInteractive` not working if last played clip holds previous

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -788,13 +788,13 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 		}
 	}
 
+	if (transition.hold_previous) {
+		return_memory = playback_current;
+	}
+
 	if (return_memory != -1 && stream->clips[p_to_clip_index].auto_advance == AudioStreamInteractive::AUTO_ADVANCE_RETURN_TO_HOLD) {
 		auto_advance_to = return_memory;
 		return_memory = -1;
-	}
-
-	if (transition.hold_previous) {
-		return_memory = playback_current;
 	}
 
 	if (transition.use_filler_clip && transition.filler_clip >= 0 && transition.filler_clip < (int)stream->clip_count && states[transition.filler_clip].playback.is_valid() && playback_current != transition.filler_clip && p_to_clip_index != transition.filler_clip) {
@@ -845,7 +845,9 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 			to_state.fade_speed = fade_speed;
 		}
 
-		to_state.auto_advance = auto_advance_to;
+		if (to_state.auto_advance != auto_advance_to) {
+			to_state.auto_advance = auto_advance_to;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes: https://github.com/godotengine/godot/issues/119043

Checking if `return_memory` is set so we have a clip to return to should happen AFTER `return_memory` is set, not before.

Tested, works on my end, code seems to make sense to me.

Still, not sure if this was a problem because I didn't set things up properly... but I think I did. Read the Issue for more information.

**EDIT:** I think I figured out what is going on. What doesn't work is the return to hold functionality when there are only two clips to transition back and forth. The second clip can't return to the first using this functionality. Or I guess in more general terms, return to hold doesn't work if the last clip played is the one holding previous.
This PR makes that possible.

**Audio meeting update:** we are unsure if the issue is a bug, or undocumented intented behavior. We should try to get thoughts from people who actually make use of this Resource. Until then, I'm working on a docs PR that should include the current behavior as a note. We'll see the best way to approach that in docs.