### PR TITLE
Fix disabling of `CoreBind` classes, and improve the error message on problems

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -5,13 +5,36 @@ from io import TextIOWrapper
 
 import methods
 
+# Classes whose C++ type lives in `CoreBind::`.
+COREBIND_CLASSES = {
+    "ClassDB",
+    "Engine",
+    "EngineDebugger",
+    "Geometry2D",
+    "Geometry3D",
+    "Logger",
+    "Marshalls",
+    "Mutex",
+    "OS",
+    "ResourceLoader",
+    "ResourceSaver",
+    "Semaphore",
+    "Thread",
+}
+
 
 # Generate disabled classes
 def disabled_class_builder(target, source, env):
     with methods.generated_wrapper(str(target[0])) as file:
         for c in source[0].read():
             if cs := c.strip():
-                file.write(f"class {cs}; template <> struct is_class_enabled<{cs}> : std::false_type {{}};\n")
+                if cs in COREBIND_CLASSES:
+                    file.write(
+                        f"namespace CoreBind {{ class {cs}; }} "
+                        f"template <> struct is_class_enabled<CoreBind::{cs}> : std::false_type {{}};\n"
+                    )
+                else:
+                    file.write(f"class {cs}; template <> struct is_class_enabled<{cs}> : std::false_type {{}};\n")
 
 
 # Generate version info

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -52,6 +52,11 @@ struct is_class_enabled<T, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 };
 
 template <typename T>
+struct is_class_enabled<T, std::enable_if_t<!std::is_base_of_v<Object, T>>> {
+	static_assert(std::is_base_of_v<Object, T>, "T needs to be a subclass of Object. Note that there are CoreBind versions of some symbols, in which case use GD_IS_CLASS_ENABLED(CoreBind::<T>) instead of GD_IS_CLASS_ENABLED(<T>).");
+};
+
+template <typename T>
 inline constexpr bool is_class_enabled_v = is_class_enabled<T>::value;
 
 #define GD_IS_CLASS_ENABLED(m_class) is_class_enabled_v<m_class>


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/issues/117414
- Related to https://github.com/godotengine/godot/pull/117477

Currently, when trying to disable core classes, our generators / bindings simply fail without much help.
The problem is that the generators & macros assume that the classes are in the global namespace, but some are actually in `CoreBind`. This can result in e.g. `CoreBind::Geometry3D` being misinterpreted as `::Geometry3D`, which is a namespace.

The handling of this issue changed with https://github.com/godotengine/godot/pull/108121, though I'm not sure to what capacity exactly (i don't work with disabled classes, i just see the reports 😅).
https://github.com/godotengine/godot/pull/115452 made this issue more visible sometimes, as builds failed when `Geometry3D` was disabled.

Since https://github.com/godotengine/godot/pull/117477, auto-disabling only disables `Resource` and `Node` subtypes. This is somewhat at odds with this one (no `CoreBind` class is currently a `Resource` or `Node` subclass). We could either further solidify this limitation downstream (erroring out when trying to disable anything else), or we could consider reverting https://github.com/godotengine/godot/pull/117477 with this fix in place.