### PR TITLE
Fix area light texture color conversion

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3495,7 +3495,7 @@ void TextureStorage::update_area_light_atlas() {
 			Texture *src_tex = get_texture(E.key);
 			Rect2 uv_rect = t->uv_rect;
 
-			copy_effects->copy_to_atlas_fb(src_tex->rd_texture, mm0.fb, uv_rect, draw_list);
+			copy_effects->copy_to_atlas_fb(src_tex->rd_texture_srgb, mm0.fb, uv_rect, draw_list);
 		}
 		RD::get_singleton()->draw_list_end();
 


### PR DESCRIPTION
This PR fixes the color conversion specifically for mip 0 of the area light textures.

From what I understand, the texture passed to the `area_texture` property is in sRGB. When it is copied to the atlas, the conversion to linear space is not performed, which causes the texture to look washed out when rendered.

|Washed out ❌|Correct ✅|
|--------|--------|
|<img width="1152" height="648" alt="before" src="https://github.com/user-attachments/assets/17e9474f-3388-4353-95b0-27ad5e4ea60f" />|<img width="1152" height="648" alt="after" src="https://github.com/user-attachments/assets/aefe47cc-88c2-4db6-81b4-d192268e052d" />|

|Atlas Mip 0 (sRGB)|Atlas Mip 0 (Linear)|
|--------|--------|
|<img width="256" height="256" alt="atlas_before" src="https://github.com/user-attachments/assets/295f5985-f356-43e8-be7a-4c04cdd98e82" />|<img width="256" height="256" alt="atlas_after" src="https://github.com/user-attachments/assets/f7bf504b-3b97-45b9-9fbb-76161c39a947" />|

This does not happen with the mipmaps because the conversion to linear is handled during the Gaussian filter application. This results in an inconsistency when transitioning from mip 0 to mip 1.

|Mip transition|Atlas Mip 1 (Linear)|
|--------|--------|
|<img width="256" height="150" alt="before2" src="https://github.com/user-attachments/assets/d84e344b-70ae-4920-90e0-d60896047b2d" />|<img width="128" height="128" alt="mip" src="https://github.com/user-attachments/assets/1730a2db-eb5a-4350-959b-9a1e61f2fbb8" />|

The solution I implemented was using `rd_texture_srgb` instead of `rd_texture`. While it might not be the ideal approach, it is simple and practical.