### PR TITLE
Fix a couple more `ubo:X` numbers for XR in Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -238,7 +238,7 @@ layout(std140) uniform SceneDataBlock { // ubo:2
 scene_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
-layout(std140) uniform PrevSceneDataBlock { // ubo:12
+layout(std140) uniform PrevSceneDataBlock { // ubo:13
 	SceneData data;
 }
 prev_scene_data_block;
@@ -488,7 +488,7 @@ layout(std140) uniform MultiviewDataBlock { // ubo:9
 multiview_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
-layout(std140) uniform PrevMultiviewDataBlock { // ubo:13
+layout(std140) uniform PrevMultiviewDataBlock { // ubo:14
 	MultiviewData data;
 }
 prev_multiview_data_block;


### PR DESCRIPTION
This fixes a couple more `ubo:X` numbers that weren't incremented in https://github.com/godotengine/godot/pull/108219

I should have included these in https://github.com/godotengine/godot/pull/119019 but I didn't catch them yesterday, because they are only used with space warp or frame synthesis, and I didn't use either of those features in my test project. Sorry about that!

In any case, this PR fixes space warp and frame synthesis in the Compatibility renderer for me!