### PR TITLE
OpenXR: Allow flipping Y direction of motion vectors for frame synthesis

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3583,6 +3583,10 @@
 			If [code]true[/code] the frame synthesis extension will be activated if supported by the platform.
 			[b]Note:[/b] This feature should not be enabled in conjunction with Application Space Warp, if supported this replaces ASW.
 		</member>
+		<member name="xr/openxr/extensions/frame_synthesis/flip_y" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] the Y value of the motion vectors submitted to the frame synthesis extension will be flipped.
+			[b]Note:[/b] Since this is only needed on some platforms, it should usually be set using a feature tag, for example, to target Android XR: [code]xr/openxr/extensions/frame_synthesis/flip_y.androidxr[/code]
+		</member>
 		<member name="xr/openxr/extensions/hand_interaction_profile" type="bool" setter="" getter="" default="false">
 			If [code]true[/code] the hand interaction profile extension will be activated if supported by the platform.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2884,6 +2884,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/debug_utils", PROPERTY_HINT_ENUM, "Disabled,Error,Warning,Info,Verbose"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/debug_message_types", PROPERTY_HINT_FLAGS, "General,Validation,Performance,Conformance"), "15");
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/frame_synthesis", false);
+	GLOBAL_DEF_BASIC("xr/openxr/extensions/frame_synthesis/flip_y", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/hand_tracking", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/hand_tracking_unobstructed_data_source", false); // XR_HAND_TRACKING_DATA_SOURCE_UNOBSTRUCTED_EXT
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/hand_tracking_controller_data_source", false); // XR_HAND_TRACKING_DATA_SOURCE_CONTROLLER_EXT

--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
@@ -220,6 +220,12 @@ void OpenXRFrameSynthesisExtension::on_main_swapchains_created() {
 	// Set up our frame synthesis info.
 	render_state.frame_synthesis_info.resize(view_count);
 
+	// Y direction is undefined so we allow users to flip it for conflicting implementations.
+	float y_scale = 1.0;
+	if (GLOBAL_GET("xr/openxr/extensions/frame_synthesis/flip_y")) {
+		y_scale = -1.0;
+	}
+
 	uint32_t index = 0;
 	for (XrFrameSynthesisInfoEXT &frame_synthesis_info : render_state.frame_synthesis_info) {
 		frame_synthesis_info.type = XR_TYPE_FRAME_SYNTHESIS_INFO_EXT;
@@ -234,8 +240,7 @@ void OpenXRFrameSynthesisExtension::on_main_swapchains_created() {
 		frame_synthesis_info.motionVectorSubImage.imageRect.extent.width = width;
 		frame_synthesis_info.motionVectorSubImage.imageRect.extent.height = height;
 
-		// Q: this should be 1.0, -1.0, 1.0. We output OpenGL NDC, frame synthesis expects Vulkan NDC, but might be a problem on runtime I'm testing.
-		frame_synthesis_info.motionVectorScale = { 1.0, 1.0, 1.0, 0.0 };
+		frame_synthesis_info.motionVectorScale = { 1.0, y_scale, 1.0, 0.0 };
 		frame_synthesis_info.motionVectorOffset = { 0.0, 0.0, 0.0, 0.0 };
 		frame_synthesis_info.appSpaceDeltaPose = { { 0.0, 0.0, 0.0, 1.0 }, { 0.0, 0.0, 0.0 } };
 


### PR DESCRIPTION
The Y direction that `XR_EXT_frame_synthesis` expects for the submitted motion vectors is undefined, and not all OpenXR runtimes have the same expectation.

Meta and Pico expect the Y direction to match `XR_FB_space_warp`, however, Android XR, expects the reverse when using Vulkan.

This PR adds a setting to flip the Y direction for OpenXR runtimes (like, Android XR) that expect the reverse Y direction.

**UPDATED (2026-07-08):** Originally, I had interpretted the spec to be saying that the Y direction of Vulkan-style NDC should be used, and so we should default to that (which is the reverse of what our implementation has been doing up until now). However, I now think the spec isn't clear enough and this is essentially undefined. So, rather than changing our default, let's keep it how it was (which is also compatible with more OpenXR runtimes and devices) and have the setting flip the Y direction. This no longer breaks compat.

## Original description

My understanding of the OpenXR spec is that we should be submitting motion vectors for frame synthesis using Vulkan NDC:

> The motion vector must derived from normalized device coordinate (NDC) space, which in this context uses Vulkan-style conventions: the NDC range is defined as [-1, -1, 0] to [1, 1, 1], different from OpenGL’s NDC range. However, the motion vector itself is not constrained to this range; its values depend on the pixel’s movement and may extend beyond the boundaries of the NDC space. For example, given that a pixel’s NDC in the previous frame is PrevNDC, and CurrNDC in current frame, and that there is no scale or offset, then the motion vector value is "(CurrNDC - PrevNDC)xyz".

See https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#_submit_motion_vector_images_and_depth_images

However, we are currently submitting them using OpenGL NDC (which differs in the range of the Z component, as well as the Y direction).

This works on Pico (which our implementation was built against), but not on Android XR when using Vulkan.

**This PR switches to using Vulkan NDC _always_ with an option to flip the Y for platforms that may implement this incorrectly.**

At the very least, this would be a compatibility breakage on Pico, where developers would need to start using the "Flip Y" option, but I personally think that's acceptable assuming my interpretation of the spec is correct: we should default to the spec conforming behavior and the option should be used for the exception.

However, I'm not 100% sure that using Vulkan NDC _always_ is the right option, because this actually doesn't work on Android XR when using OpenGL (where it appears to expect the OpenGL NDC).

The default that would work on the most platforms out-of-the-box would actually be to use OpenGL NDC on OpenGL, and Vulkan NDC on Vulkan, and have the "Flip Y" option reverse that. Then the only platform that would need the option is Pico when using Vulkan.

But that goes against the principle I gave above about conforming to the spec by default. So, this will require some discussion around the interpretation of the spec and which default makes the most sense.