### PR TITLE
Fix GDScript hot reload member defaults

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1996,6 +1996,42 @@ const Variant GDScriptInstance::get_rpc_config() const {
 	return script->get_rpc_config();
 }
 
+#ifdef DEBUG_ENABLED
+// Mirrors GDScriptFunction::_get_default_variant_for_data_type() for newly
+// introduced members during hot reload.
+static Variant _get_default_variant_for_reload(const GDScriptDataType &p_data_type) {
+	if (p_data_type.kind != GDScriptDataType::BUILTIN) {
+		return Variant();
+	}
+
+	if (p_data_type.builtin_type == Variant::ARRAY) {
+		Array array;
+		if (p_data_type.has_container_element_type(0)) {
+			const GDScriptDataType &element_type = p_data_type.get_container_element_type(0);
+			array.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
+		}
+		return array;
+	}
+
+	if (p_data_type.builtin_type == Variant::DICTIONARY) {
+		Dictionary dictionary;
+		if (p_data_type.has_container_element_types()) {
+			const GDScriptDataType &key_type = p_data_type.get_container_element_type_or_variant(0);
+			const GDScriptDataType &value_type = p_data_type.get_container_element_type_or_variant(1);
+			dictionary.set_typed(key_type.builtin_type, key_type.native_type, key_type.script_type, value_type.builtin_type, value_type.native_type, value_type.script_type);
+		}
+		return dictionary;
+	}
+
+	Callable::CallError err;
+	Variant default_value;
+	Variant::construct(p_data_type.builtin_type, default_value, nullptr, 0, err);
+	ERR_FAIL_COND_V(err.error != Callable::CallError::CALL_OK, Variant());
+	return default_value;
+}
+
+#endif
+
 void GDScriptInstance::reload_members() {
 #ifdef DEBUG_ENABLED
 
@@ -2007,6 +2043,28 @@ void GDScriptInstance::reload_members() {
 		if (member_indices_cache.has(E.key)) {
 			Variant value = members[member_indices_cache[E.key]];
 			new_members.write[E.value.index] = value;
+		} else {
+#ifdef TOOLS_ENABLED
+			Variant default_value;
+			bool has_default_value = false;
+			for (GDScript *script_ptr = script.ptr(); script_ptr; script_ptr = script_ptr->base.ptr()) {
+				if (!script_ptr->members.has(E.key)) {
+					continue;
+				}
+				if (HashMap<StringName, Variant>::ConstIterator member_default_value = script_ptr->member_default_values.find(E.key)) {
+					default_value = member_default_value->value;
+					has_default_value = true;
+				}
+				break;
+			}
+
+			if (has_default_value) {
+				new_members.write[E.value.index] = default_value;
+			} else
+#endif
+			{
+				new_members.write[E.value.index] = _get_default_variant_for_reload(E.value.data_type);
+			}
 		}
 	}
 

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -91,6 +91,98 @@ func _init():
 	CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
 }
 
+#ifdef DEBUG_ENABLED
+TEST_CASE("[Modules][GDScript] Hot reload initializes newly added member defaults") {
+	GDScriptLanguage::get_singleton()->init();
+	Ref<GDScript> gdscript = memnew(GDScript);
+	gdscript->set_source_code(R"(
+extends RefCounted
+
+func describe() -> String:
+	return "v1"
+)");
+
+	ERR_PRINT_OFF;
+	Error error = gdscript->reload();
+	ERR_PRINT_ON;
+	REQUIRE_MESSAGE(error == OK, "The v1 script should parse successfully.");
+
+	Callable::CallError call_error;
+	Variant instance_a = gdscript->_new(nullptr, 0, call_error);
+	REQUIRE(call_error.error == Callable::CallError::CALL_OK);
+	Ref<RefCounted> ref_a = instance_a;
+	REQUIRE(ref_a.is_valid());
+
+	call_error = Callable::CallError();
+	Variant instance_b = gdscript->_new(nullptr, 0, call_error);
+	REQUIRE(call_error.error == Callable::CallError::CALL_OK);
+	Ref<RefCounted> ref_b = instance_b;
+	REQUIRE(ref_b.is_valid());
+
+	gdscript->set_source_code(R"(
+extends RefCounted
+
+var injected_dict: Dictionary = {}
+var injected_array: Array = []
+
+func describe() -> String:
+	return "dict=%d array=%d" % [injected_dict.keys().size(), injected_array.size()]
+)");
+
+	ERR_PRINT_OFF;
+	error = gdscript->reload(true);
+	ERR_PRINT_ON;
+	REQUIRE_MESSAGE(error == OK, "The v2 script should hot-reload successfully.");
+
+	Object *object_a = ref_a.ptr();
+	List<PropertyInfo> property_list;
+	object_a->get_property_list(&property_list);
+
+	bool has_injected_dict = false;
+	bool has_injected_array = false;
+	for (const PropertyInfo &property : property_list) {
+		if (property.name == StringName("injected_dict")) {
+			has_injected_dict = true;
+		} else if (property.name == StringName("injected_array")) {
+			has_injected_array = true;
+		}
+	}
+	CHECK(has_injected_dict);
+	CHECK(has_injected_array);
+
+	bool valid = false;
+	Variant dict_value = object_a->get(StringName("injected_dict"), &valid);
+	CHECK(valid);
+	REQUIRE(dict_value.get_type() == Variant::DICTIONARY);
+	Dictionary dict_value_as_dictionary = dict_value;
+	CHECK_EQ(dict_value_as_dictionary.size(), 0);
+
+	valid = false;
+	Variant array_value = object_a->get(StringName("injected_array"), &valid);
+	CHECK(valid);
+	REQUIRE(array_value.get_type() == Variant::ARRAY);
+	Array array_value_as_array = array_value;
+	CHECK_EQ(array_value_as_array.size(), 0);
+
+	call_error = Callable::CallError();
+	Variant result = object_a->callp(StringName("describe"), nullptr, 0, call_error);
+	REQUIRE(call_error.error == Callable::CallError::CALL_OK);
+	String result_string = result;
+	CHECK_EQ(result_string, "dict=0 array=0");
+
+	Dictionary dict_a = object_a->get(StringName("injected_dict"));
+	dict_a[String("key")] = 1;
+	Array array_a = object_a->get(StringName("injected_array"));
+	array_a.push_back(1);
+
+	Object *object_b = ref_b.ptr();
+	Dictionary dict_b = object_b->get(StringName("injected_dict"));
+	Array array_b = object_b->get(StringName("injected_array"));
+	CHECK_EQ(dict_b.size(), 0);
+	CHECK_EQ(array_b.size(), 0);
+}
+#endif // DEBUG_ENABLED
+
 TEST_CASE("[Modules][GDScript] Loading keeps ResourceCache and GDScriptCache in sync") {
 	const String path = TestUtils::get_temp_path("gdscript_load_test.gd");
 

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -141,9 +141,9 @@ func describe() -> String:
 	bool has_injected_dict = false;
 	bool has_injected_array = false;
 	for (const PropertyInfo &property : property_list) {
-		if (property.name == StringName("injected_dict")) {
+		if (property.name == "injected_dict") {
 			has_injected_dict = true;
-		} else if (property.name == StringName("injected_array")) {
+		} else if (property.name == "injected_array") {
 			has_injected_array = true;
 		}
 	}
@@ -151,33 +151,33 @@ func describe() -> String:
 	CHECK(has_injected_array);
 
 	bool valid = false;
-	Variant dict_value = object_a->get(StringName("injected_dict"), &valid);
+	Variant dict_value = object_a->get("injected_dict", &valid);
 	CHECK(valid);
 	REQUIRE(dict_value.get_type() == Variant::DICTIONARY);
 	Dictionary dict_value_as_dictionary = dict_value;
 	CHECK_EQ(dict_value_as_dictionary.size(), 0);
 
 	valid = false;
-	Variant array_value = object_a->get(StringName("injected_array"), &valid);
+	Variant array_value = object_a->get("injected_array", &valid);
 	CHECK(valid);
 	REQUIRE(array_value.get_type() == Variant::ARRAY);
 	Array array_value_as_array = array_value;
 	CHECK_EQ(array_value_as_array.size(), 0);
 
 	call_error = Callable::CallError();
-	Variant result = object_a->callp(StringName("describe"), nullptr, 0, call_error);
+	Variant result = object_a->callp("describe", nullptr, 0, call_error);
 	REQUIRE(call_error.error == Callable::CallError::CALL_OK);
 	String result_string = result;
 	CHECK_EQ(result_string, "dict=0 array=0");
 
-	Dictionary dict_a = object_a->get(StringName("injected_dict"));
+	Dictionary dict_a = object_a->get("injected_dict");
 	dict_a[String("key")] = 1;
-	Array array_a = object_a->get(StringName("injected_array"));
+	Array array_a = object_a->get("injected_array");
 	array_a.push_back(1);
 
 	Object *object_b = ref_b.ptr();
-	Dictionary dict_b = object_b->get(StringName("injected_dict"));
-	Array array_b = object_b->get(StringName("injected_array"));
+	Dictionary dict_b = object_b->get("injected_dict");
+	Array array_b = object_b->get("injected_array");
 	CHECK_EQ(dict_b.size(), 0);
 	CHECK_EQ(array_b.size(), 0);
 }


### PR DESCRIPTION
Fixes #119057.

Fix GDScript hot-reload migration for newly added member defaults.

Before this PR, `GDScriptInstance::reload_members()` remapped existing member values into the new member layout, but newly added members were left as default-constructed `Variant::NIL`. This could leave a migrated live instance exposing a new property while `instance.get()` returned Nil.

Example shape:

```gdscript
# v1
extends RefCounted
```

Hot-reload to:

```gdscript
extends RefCounted

var injected_dict: Dictionary = {}
var injected_array: Array = []

func describe() -> String:
    return "dict=%d array=%d" % [injected_dict.keys().size(), injected_array.size()]
```

Existing live instances should have empty `Dictionary` / `Array` values after reload. Before the fix, `injected_dict` could be Nil and `.keys()` could crash.

This PR initializes newly introduced members during hot-reload live-instance migration from compiled member defaults when available, and otherwise falls back to typed built-in defaults. Compiled defaults are assigned directly, matching normal construction semantics for constant references.

Fresh instances already worked because normal construction runs `@implicit_new()`. This fix is limited to live-instance member migration during hot reload; it does not rerun arbitrary initializer expressions or `@onready` initialization, because doing so would rerun user code and could clobber migrated values. Initializer contents that only exist in `@implicit_new()` bytecode are therefore out of scope for this narrow migration fix.

Regression coverage adds a GDScript test for:

- v1 script with no field
- live instances created from v1
- hot reload to v2 with `Dictionary = {}` and `Array = []`
- migrated instances exposing non-Nil empty containers
- calling `injected_dict.keys()` without crashing
- migrated instances not sharing their newly constructed empty containers

Related to #97834 and #98221, but this fixes a separate newly added member default migration case.

Tested locally:

```bash
scons platform=macos target=editor dev_build=yes tests=yes vulkan=no angle=no accesskit=no -j8
bin/godot.macos.editor.dev.arm64 --headless --test --test-case="[Modules][GDScript] Hot reload initializes newly added member defaults"
bin/godot.macos.editor.dev.arm64 --headless --test --test-case="*[GDScript]*"
bin/godot.macos.editor.dev.arm64 --headless --test --test-suite="[Modules][GDScript]"
git diff --check
```

**AI Disclosure**: this PR was implemented with assistance from AI-powered tools. I, a human, was in the loop to guide the tools, review their process, craft explanations and ensure overall quality as best I could. I view them and try to use them as a way to make myself a more productive and valuable contributor. And I'm always open to feedback. 🙂