### PR TITLE
Animation: Only erase properties for a specific node

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -782,7 +782,7 @@ void AnimationTree::_animation_node_renamed(const ObjectID &p_oid, const String 
 
 void AnimationTree::_animation_node_removed(const ObjectID &p_oid, const StringName &p_node) {
 	for (const StringName &parent_path : instance_paths[p_oid]) {
-		String base_path = String(parent_path) + String(p_node);
+		String base_path = String(parent_path) + String(p_node) + "/";
 
 		for (const PropertyInfo &E : properties) {
 			if (E.name.begins_with(base_path)) {


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/119029

The current method would match too broadly. E.g. if you have a "running" and a "run" node, then delete "run", it would clear the parameters for both.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
