### PR TITLE
Fix `validate_node` not running after triangles are modified.

### DIFF
--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -293,6 +293,7 @@ void AnimationNodeBlendSpace2D::add_triangle(int p_x, int p_y, int p_z, int p_at
 	} else {
 		triangles.insert(p_at_index, t);
 	}
+	_node_updated(get_instance_id());
 }
 
 int AnimationNodeBlendSpace2D::get_triangle_point(int p_triangle, int p_point) {
@@ -307,6 +308,7 @@ void AnimationNodeBlendSpace2D::remove_triangle(int p_triangle) {
 	ERR_FAIL_INDEX(p_triangle, triangles.size());
 
 	triangles.remove_at(p_triangle);
+	_node_updated(get_instance_id());
 }
 
 int AnimationNodeBlendSpace2D::get_triangle_count() const {
@@ -458,6 +460,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 	triangles.clear();
 	if (blend_points_used < 3) {
 		emit_signal(SNAME("triangles_updated"));
+		_node_updated(get_instance_id());
 		return;
 	}
 
@@ -473,6 +476,7 @@ void AnimationNodeBlendSpace2D::_update_triangles() {
 		add_triangle(tr[i].points[0], tr[i].points[1], tr[i].points[2]);
 	}
 	emit_signal(SNAME("triangles_updated"));
+	_node_updated(get_instance_id());
 }
 
 Vector2 AnimationNodeBlendSpace2D::get_closest_point(const Vector2 &p_point) {


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/119029
Regression from https://github.com/godotengine/godot/pull/117277

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
