### PR TITLE
Validate name in `add_blend_point` and forbid duplicates

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -166,6 +166,8 @@ void AnimationNodeBlendSpace1D::add_blend_point(const Ref<AnimationRootNode> &p_
 #else
 	ERR_FAIL_COND(p_name == StringName());
 #endif
+	ERR_FAIL_COND(p_name.is_empty() || String(p_name).contains_char('.') || String(p_name).contains_char('/'));
+	ERR_FAIL_COND_MSG(find_blend_point_by_name(p_name) != -1, "Blend point name must be unique.");
 	if (p_at_index == -1 || p_at_index == blend_points_used) {
 		p_at_index = blend_points_used;
 	} else {
@@ -220,6 +222,8 @@ void AnimationNodeBlendSpace1D::set_blend_point_name(int p_point, const StringNa
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 	String new_name = p_name;
 	ERR_FAIL_COND(new_name.is_empty() || new_name.contains_char('.') || new_name.contains_char('/'));
+	int existing_index = find_blend_point_by_name(p_name);
+	ERR_FAIL_COND_MSG(existing_index != -1 && existing_index != p_point, "Blend point name must be unique.");
 
 	String old_name = blend_points[p_point].name;
 	if (new_name != old_name) {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -78,6 +78,8 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 	ERR_FAIL_COND(p_name == StringName());
 #endif
 
+	ERR_FAIL_COND(p_name.is_empty() || String(p_name).contains_char('.') || String(p_name).contains_char('/'));
+	ERR_FAIL_COND_MSG(find_blend_point_by_name(p_name) != -1, "Blend point name must be unique.");
 	if (p_at_index == -1 || p_at_index == blend_points_used) {
 		p_at_index = blend_points_used;
 	} else {
@@ -139,6 +141,8 @@ void AnimationNodeBlendSpace2D::set_blend_point_name(int p_point, const StringNa
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 	String new_name = p_name;
 	ERR_FAIL_COND(new_name.is_empty() || new_name.contains_char('.') || new_name.contains_char('/'));
+	int existing_index = find_blend_point_by_name(p_name);
+	ERR_FAIL_COND_MSG(existing_index != -1 && existing_index != p_point, "Blend point name must be unique.");
 
 	String old_name = blend_points[p_point].name;
 	if (new_name != old_name) {


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/119029

Name validation is already done in `set_blend_point_name` so it should be done in `add_blend_point` as well.

Also having duplicate names will cause issues, so I've added a check for that as well.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
