### PR TITLE
Regenerate auto triangles when a blend point is removed

### DIFF
--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -195,6 +195,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 
 	emit_signal(SNAME("animation_node_removed"), get_instance_id(), itos(p_point));
 	_tree_changed();
+	_queue_auto_triangles();
 }
 
 int AnimationNodeBlendSpace2D::get_blend_point_count() const {


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/119029

When `auto_triangles` is enabled, removing a blend point should regenerate the triangulation. Currently, it does not, leaving the blend space in a broken state.

This can be mitigated by toggling the "Generate blend triangles automatically" button off and on again, but that is tedious and should not be required.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
