### PR TITLE
Blend space editor: Use correct name in events, and clean all states

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -247,6 +247,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
+	String removed_name = blend_points[p_point].name;
 	_remove_node(blend_points[p_point].node);
 
 	for (int i = p_point; i < blend_points_used - 1; i++) {
@@ -255,10 +256,10 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 
 	blend_points_used--;
 
-	blend_points[blend_points_used].name = StringName();
+	blend_points[blend_points_used].reset();
 	lengths_dirty = true;
 
-	emit_signal(SNAME("animation_node_removed"), get_instance_id(), itos(p_point));
+	emit_signal(SNAME("animation_node_removed"), get_instance_id(), removed_name);
 	_tree_changed();
 }
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -58,6 +58,12 @@ protected:
 		StringName name;
 		Ref<AnimationRootNode> node;
 		float position = 0.0;
+
+		void reset() {
+			name = StringName();
+			node = Ref<AnimationRootNode>();
+			position = 0.0;
+		}
 	};
 
 	BlendPoint blend_points[MAX_BLEND_POINTS];

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -166,6 +166,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
+	String removed_name = blend_points[p_point].name;
 	_remove_node(blend_points[p_point].node);
 
 	for (int i = 0; i < triangles.size(); i++) {
@@ -190,10 +191,10 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	}
 	blend_points_used--;
 
-	blend_points[blend_points_used].name = StringName();
+	blend_points[blend_points_used].reset();
 	lengths_dirty = true;
 
-	emit_signal(SNAME("animation_node_removed"), get_instance_id(), itos(p_point));
+	emit_signal(SNAME("animation_node_removed"), get_instance_id(), removed_name);
 	_tree_changed();
 }
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -58,6 +58,12 @@ protected:
 		StringName name;
 		Ref<AnimationRootNode> node;
 		Vector2 position;
+
+		void reset() {
+			name = StringName();
+			node = Ref<AnimationRootNode>();
+			position = Vector2();
+		}
 	};
 
 	BlendPoint blend_points[MAX_BLEND_POINTS];


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/119029
Resolves https://github.com/godotengine/godot/issues/118982

https://github.com/godotengine/godot/pull/110369 changed the names from `itos(index)`, to custom names however the `animation_node_removed` signal was not updated to reflect that change.

Also, it's safer to clear all the state when removing, rather than just the name.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
