### PR TITLE
Fix `ScrollContainer` and `Tree` autoscrolling when dragging tabs to them

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -525,7 +525,11 @@ void ScrollContainer::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			if (scroll_on_drag_hover && is_visible_in_tree()) {
-				set_process_internal(true);
+				const Dictionary drag_data = get_viewport()->gui_get_drag_data();
+				// Enable scrolling, unless dragging a tab.
+				if (drag_data.get("type", "").operator String() != "tab") {
+					set_process_internal(true);
+				}
 			}
 		} break;
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5129,8 +5129,12 @@ void Tree::_notification(int p_what) {
 		case NOTIFICATION_DRAG_BEGIN: {
 			single_select_defer = nullptr;
 			if (theme_cache.scroll_speed > 0) {
-				scrolling = true;
-				set_process_internal(true);
+				const Dictionary drag_data = get_viewport()->gui_get_drag_data();
+				// Enable scrolling, unless dragging a tab.
+				if (drag_data.get("type", "").operator String() != "tab") {
+					scrolling = true;
+					set_process_internal(true);
+				}
 			}
 		} break;
 


### PR DESCRIPTION
Fixes #93755.
Supersedes #111113.

Solution taken from [this comment](https://github.com/godotengine/godot/pull/111113#issuecomment-3694249305).
