### PR TITLE
Fix Variant return type displaying as void in completion hint tooltip

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -801,7 +801,9 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 	if (p_just_args) {
 		arghint = "(";
 	} else {
-		if (p_function->get_datatype().builtin_type == Variant::NIL) {
+		if (p_function->get_datatype().is_variant()) {
+			arghint = "Variant " + p_function->identifier->name + "(";
+		} else if (p_function->get_datatype().builtin_type == Variant::NIL) {
 			arghint = "void " + p_function->identifier->name + "(";
 		} else {
 			arghint = p_function->get_datatype().to_string() + " " + p_function->identifier->name + "(";


### PR DESCRIPTION
Fixes #119041

Methods with a Variant return type were displaying as void in the 
completion hint tooltip. Both void and Variant have builtin_type == 
Variant::NIL, so the check was falling into the void branch for both.

Fixed by checking is_variant() first, which correctly distinguishes 
Variant return types from void. This matches how parameters already 
handle the same distinction.