### PR TITLE
Replace `VSeparator` with `HSeparator` in Misc tab

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2490,7 +2490,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 			info_left->add_child(lehb);
 		}
 
-		misc->add_child(memnew(VSeparator));
+		misc->add_child(memnew(HSeparator));
 
 		HBoxContainer *buttons = memnew(HBoxContainer);
 


### PR DESCRIPTION
Absolutely massive PR incoming... Fixes 👇

<img width="1700" height="318" alt="image" src="https://github.com/user-attachments/assets/2bed0346-8884-435f-8c33-252e747c2ee4" />

--

Replaces the `VSeparator` in this tab with an `HSeparator`, so this small line doesn't appear. ~Could also be HSeparator instead?~