### PR TITLE
Improve custom iterator performance

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -212,7 +212,7 @@
 			<return type="bool" />
 			<param index="0" name="iter" type="Array" />
 			<description>
-				Initializes the iterator. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. Returns [code]true[/code] so long as the iterator has not reached the end.
+				Initializes the iterator. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. This array should not be resized. Returns [code]true[/code] so long as the iterator has not reached the end.
 				[codeblock]
 				class MyRange:
 					var _from
@@ -247,7 +247,7 @@
 			<return type="bool" />
 			<param index="0" name="iter" type="Array" />
 			<description>
-				Moves the iterator to the next iteration. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. Returns [code]true[/code] so long as the iterator has not reached the end.
+				Moves the iterator to the next iteration. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. This array should not be resized. Returns [code]true[/code] so long as the iterator has not reached the end.
 			</description>
 		</method>
 		<method name="_notification" qualifiers="virtual">

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3348,7 +3348,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE(OPCODE_ITERATE_BEGIN_OBJECT) {
 				CHECK_SPACE(4);
 
-				GET_VARIANT_PTR(counter, 0);
+				GET_VARIANT_PTR(state, 0);
 				GET_VARIANT_PTR(container, 1);
 
 #ifdef DEBUG_ENABLED
@@ -3365,20 +3365,16 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Object *obj = *VariantInternal::get_object(container);
 #endif
 
-				*counter = Variant();
-				Array ref = { *counter };
-				Variant vref;
-				VariantInternal::initialize(&vref, Variant::ARRAY);
-				*VariantInternal::get_array(&vref) = ref;
-
-				const Variant *args[] = { &vref };
+				Array ref = { Variant() };
+				VariantInternal::initialize(state, Variant::ARRAY);
+				*VariantInternal::get_array(state) = ref;
 
 				Callable::CallError ce;
-				Variant has_next = obj->callp(CoreStringName(_iter_init), args, 1, ce);
+				Variant has_next = obj->callp(CoreStringName(_iter_init), const_cast<const Variant **>(&state), 1, ce);
 
 #ifdef DEBUG_ENABLED
 				if (ref.size() != 1 || ce.error != Callable::CallError::CALL_OK) {
-					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type %s.)", *container);
+					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
 					OPCODE_BREAK;
 				}
 #endif
@@ -3387,13 +3383,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
 					ip = jumpto;
 				} else {
-					*counter = ref[0];
+					Variant *state_ptr = &(ref[0]);
 
 					GET_VARIANT_PTR(iterator, 2);
-					*iterator = obj->callp(CoreStringName(_iter_get), (const Variant **)&counter, 1, ce);
+					*iterator = obj->callp(CoreStringName(_iter_get), const_cast<const Variant **>(&state_ptr), 1, ce);
 #ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
-						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type %s.)", *container);
+						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
 						OPCODE_BREAK;
 					}
 #endif
@@ -3715,7 +3711,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			OPCODE(OPCODE_ITERATE_OBJECT) {
 				CHECK_SPACE(4);
 
-				GET_VARIANT_PTR(counter, 0);
+				GET_VARIANT_PTR(state, 0);
 				GET_VARIANT_PTR(container, 1);
 
 #ifdef DEBUG_ENABLED
@@ -3732,19 +3728,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Object *obj = *VariantInternal::get_object(container);
 #endif
 
-				Array ref = { *counter };
-				Variant vref;
-				VariantInternal::initialize(&vref, Variant::ARRAY);
-				*VariantInternal::get_array(&vref) = ref;
-
-				const Variant *args[] = { &vref };
-
 				Callable::CallError ce;
-				Variant has_next = obj->callp(CoreStringName(_iter_next), args, 1, ce);
+				Variant has_next = obj->callp(CoreStringName(_iter_next), const_cast<const Variant **>(&state), 1, ce);
 
 #ifdef DEBUG_ENABLED
-				if (ref.size() != 1 || ce.error != Callable::CallError::CALL_OK) {
-					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type %s.)", *container);
+				if (VariantInternal::get_array(state)->size() != 1 || ce.error != Callable::CallError::CALL_OK) {
+					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
 					OPCODE_BREAK;
 				}
 #endif
@@ -3753,13 +3742,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
 					ip = jumpto;
 				} else {
-					*counter = ref[0];
+					// For _iter_get(): get a pointer to the single element in the array.
+					Variant *state_ptr = &((*VariantInternal::get_array(state))[0]);
 
 					GET_VARIANT_PTR(iterator, 2);
-					*iterator = obj->callp(CoreStringName(_iter_get), (const Variant **)&counter, 1, ce);
+					*iterator = obj->callp(CoreStringName(_iter_get), const_cast<const Variant **>(&state_ptr), 1, ce);
 #ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
-						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type %s.)", *container);
+						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type "%s".)", GDScript::debug_get_script_name(obj->get_script_instance()->get_script()));
 						OPCODE_BREAK;
 					}
 #endif

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.gd
@@ -1,0 +1,94 @@
+func iterate(v: Variant):
+	for i in v:
+		print(i)
+
+class BadInit:
+	# Whether to push or pop during init
+	var push
+
+	func _init(new_push):
+		push = new_push
+
+	func _iter_init(iter: Array):
+		if push:
+			iter.push_back("hi")
+		else:
+			iter.pop_back()
+		return true
+
+	func _iter_next(iter: Array):
+		iter.pop_back()
+		return !iter.is_empty()
+
+	func _iter_get(iter):
+		return iter
+
+func subtest_init_array_large():
+	print("SUBTEST_INIT_ARRAY_LARGE")
+	for i in BadInit.new(true):
+		print(i)
+
+func subtest_init_array_empty():
+	print("SUBTEST_INIT_ARRAY_EMPTY")
+	for i in BadInit.new(false):
+		print(i)
+
+func subtest_variant_init_array_large():
+	print("SUBTEST_VARIANT_INIT_ARRAY_LARGE")
+	iterate(BadInit.new(true))
+
+func subtest_variant_init_array_empty():
+	print("SUBTEST_VARIANT_INIT_ARRAY_EMPTY")
+	iterate(BadInit.new(false))
+
+class BadNext:
+	var push: bool
+
+	func _init(new_push):
+		push = new_push
+
+	func _iter_init(iter: Array):
+		iter[0] = 1
+		return true
+
+	func _iter_next(iter: Array):
+		if push:
+			iter.push_back(2)
+		else:
+			iter.pop_back()
+		return true
+
+	func _iter_get(iter):
+		return iter
+
+func subtest_next_array_large():
+	print("SUBTEST_NEXT_ARRAY_LARGE")
+	for i in BadNext.new(true):
+		print(i)
+
+func subtest_next_array_empty():
+	print("SUBTEST_NEXT_ARRAY_EMPTY")
+	for i in BadNext.new(false):
+		print(i)
+
+func subtest_variant_next_array_large():
+	print("SUBTEST_VARIANT_NEXT_ARRAY_LARGE")
+	iterate(BadNext.new(true))
+
+func subtest_variant_next_array_empty():
+	print("SUBTEST_VARIANT_NEXT_ARRAY_EMPTY")
+	iterate(BadNext.new(false))
+
+
+func test():
+	# Typed
+	subtest_init_array_large()
+	subtest_init_array_empty()
+	subtest_next_array_large()
+	subtest_next_array_empty()
+
+	# Untyped
+	subtest_variant_init_array_large()
+	subtest_variant_init_array_empty()
+	subtest_variant_next_array_large()
+	subtest_variant_next_array_empty()

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
@@ -1,0 +1,21 @@
+GDTEST_RUNTIME_ERROR
+SUBTEST_INIT_ARRAY_LARGE
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:28 on subtest_init_array_large(): There was an error calling "_iter_next" on iterator object of type "BadInit".
+SUBTEST_INIT_ARRAY_EMPTY
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:33 on subtest_init_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadInit".
+SUBTEST_NEXT_ARRAY_LARGE
+1
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:67 on subtest_next_array_large(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+SUBTEST_NEXT_ARRAY_EMPTY
+1
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:72 on subtest_next_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+SUBTEST_VARIANT_INIT_ARRAY_LARGE
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
+SUBTEST_VARIANT_INIT_ARRAY_EMPTY
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
+SUBTEST_VARIANT_NEXT_ARRAY_LARGE
+1
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
+SUBTEST_VARIANT_NEXT_ARRAY_EMPTY
+1
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).

--- a/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_object.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_object.gd
@@ -1,0 +1,102 @@
+# Tests custom iterator correctness both typed and untyped.
+
+class ExponentialIterator:
+	var base: int
+	var end: int
+
+	func _init(new_base: int, new_end: int):
+		self.base = new_base
+		self.end = new_end
+
+	func _iter_init(iter: Array):
+		iter[0] = 1
+		return iter[0] < end
+
+	func _iter_next(iter: Array):
+		iter[0] *= base
+		return iter[0] < end
+
+	func _iter_get(iter: Variant):
+		return iter
+
+
+@warning_ignore_start("unsafe_method_access")
+class StringIterator:
+	var s: String
+
+	func _init(value: String):
+		self.s = value
+
+	func _iter_init(iter: Array):
+		iter[0] = s
+		return !iter[0].is_empty()
+
+	func _iter_next(iter: Array):
+		iter[0] = iter[0].substr(1)
+		return !iter[0].is_empty()
+
+	func _iter_get(iter: Variant):
+		return iter.left(1)
+
+
+func iterate_variant(v: Variant, break_condition: Callable = Callable()):
+	for i in v:
+		if break_condition.is_valid() and break_condition.call(i):
+			break
+		print(i)
+
+
+func iterate_variant_nested(a: Variant, b: Variant, break_condition: Callable = Callable()):
+	for i in a:
+		for j in b:
+			if break_condition.is_valid() and break_condition.call(i, j):
+				break
+			print(i, j)
+
+
+func test():
+	print("Test typed exp 2,16")
+	for i in ExponentialIterator.new(2, 17):
+		print(i)
+
+	print("Test variant exp 2,16")
+	iterate_variant(ExponentialIterator.new(2, 17))
+
+	print("Test typed exp -3,-27")
+	for i in ExponentialIterator.new(-3, 30):
+		print(i)
+
+	print("Test typed exp -3,-27")
+	iterate_variant(ExponentialIterator.new(-3, 30))
+
+	print("Test typed nested same str iterator")
+	var si := StringIterator.new("abc")
+	for i in si:
+		for j in si:
+			print(i, j)
+
+	print("Test nested variant same str iterator")
+	iterate_variant_nested(si, si)
+
+	print("Test break from typed str")
+	for i in StringIterator.new("world"):
+		if i in "hello":
+			break
+		print(i)
+
+	print("Test break from variant str")
+	iterate_variant(StringIterator.new("world"), func(i): return i in "hello")
+
+	print("Test break from nested diff typed")
+	for i: String in StringIterator.new("a2z"):
+		for j in ExponentialIterator.new(2, 100):
+			if j > ord(i):
+				break
+			print(i, j)
+
+	print("Test break from nested diff variant")
+	iterate_variant_nested(
+		StringIterator.new("a2z"),
+		ExponentialIterator.new(2, 100),
+		func(i: String, j): return j > ord(i)
+	)

--- a/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_object.out
+++ b/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_object.out
@@ -1,0 +1,89 @@
+GDTEST_OK
+Test typed exp 2,16
+1
+2
+4
+8
+16
+Test variant exp 2,16
+1
+2
+4
+8
+16
+Test typed exp -3,-27
+1
+-3
+9
+-27
+Test typed exp -3,-27
+1
+-3
+9
+-27
+Test typed nested same str iterator
+aa
+ab
+ac
+ba
+bb
+bc
+ca
+cb
+cc
+Test nested variant same str iterator
+aa
+ab
+ac
+ba
+bb
+bc
+ca
+cb
+cc
+Test break from typed str
+w
+Test break from variant str
+w
+Test break from nested diff typed
+a1
+a2
+a4
+a8
+a16
+a32
+a64
+21
+22
+24
+28
+216
+232
+z1
+z2
+z4
+z8
+z16
+z32
+z64
+Test break from nested diff variant
+a1
+a2
+a4
+a8
+a16
+a32
+a64
+21
+22
+24
+28
+216
+232
+z1
+z2
+z4
+z8
+z16
+z32
+z64


### PR DESCRIPTION
# Overview

By removing an `Array` allocation on every iteration for custom objects, we see a **30-44%** reduction of overhead time.

Fixes #42053.

# Background

Custom iterators are implemented by overriding the `_iter_init`, `_iter_next` and `_iter_get` methods. To allow updating the iterator state, the first two methods have an array parameter as a pseudo-pointer. However internally only the state—the singular element in the array—is persisted. The array passed to `_iter_init` and `_iter_next` is actually created each time the methods are called. These allocations make up a significant part of the iteration overhead.

There are two code-paths in the GDScript VM where custom iterators are used. One is in the GDScript VM with the specialized opcodes `OPCODE_ITERATE_BEGIN_OBJECT/OPCODE_ITERATE_OBJECT`. The other is in the generic iterator opcodes `OPCODE_ITERATE_BEGIN/OPCODE_ITERATE` which is dispatched to the `Variant::iter_*` methods.

The two code-paths are similar and both have the repeated array creation issue.

# Solution

Instead of storing only the singular element, we now store the entire array. This way we only need to allocate once. All three of the `_iter_*` methods will have to be used differently in both code-paths to accommodate this change.

There is a slight change in semantics due to the new implementation. 
- If debug is not enabled, the user is able to append items to the array and have them persist. Previously they would be discarded.
- Similarly, the parameter passed to `_iter_get` and `_iter_next` within a loop is the same Array instance whereas before it was always a newly created one.

# Reviewer notes

- I recommend viewing the diff in split layout as opposed to unified. 

- ~~`variant_setget.cpp`~~
  - ~~Each operation is separated well in this file: `iter_init`, `iter_next` and `iter_get`~~

- `gdscript_vm.cpp`
    1. `OPCODE_ITERATE_BEGIN_OBJECT`: calls `_iter_init` and `_iter_get`
    2. `OPCODE_ITERATE_OBJECT`: calls `_iter_next` and `_iter_get`

- Tests:
  - `for_loop_iterator_object` tests custom iterator correctness. This covers the success case for both code-paths.
  - `for_loop_iterator_array_size` tests iter operations changing array size.

# Discussion

1. Should we require that the Array has size = 1 at all times?
   - The current behaviour is that we check this when `DEBUG_ENABLED`. Without debug, no error occurs but a new array with only the first element will be passed into the next iteration. With the current state of the PR, this latter behaviour is changed, with the entire array persisting.
   - Options:
     1. Leave as is, only check size when `DEBUG_ENABLED`, new behaviour on release.
     2. Enforce size = 1 during runtime
     3. Allow size >= 1, check before `_iter_get` call
     4. Allow any size, no runtime checks
2. If we allow the Array to have sizes >= 1 then what do we call `_iter_get` with? First or last element?

# Performance

I tested a local benchmark project using release export templates.

Project for batch testing: [custom-iterator-benchmark.zip](https://github.com/user-attachments/files/27226823/custom-iterator-benchmark.zip).

**Note:** Output is delimited with tabs for easy spreadsheet calculations. Also, the batching of test runs seems to have made scenario A and B slower.

<details>
<summary><code>CustomIterable</code> class implementation</summary>

```
class CustomIterable:
	var n: int

	func _init(n: int) -> void:
		self.n = n

	func _iter_init(iter: Array) -> bool:
		iter[0] = 0
		return iter[0] < n

	func _iter_next(iter: Array) -> bool:
		iter[0] += 1
		return iter[0] < n

	func _iter_get(iter: Variant) -> Variant:
		return iter
```
</details>

<details>
<summary><b>See the four testing scenarios A, B, C, D</b></summary>

### A (int w/ int opcode)

Regular range for loop

```
for i in N:
    pass
```

### B (int w/ generic opcode)

```
func iterate(iterator: Variant):
    for i in iterator:
        pass
```

```
iterate(N)
```

### C (object w/ object opcode)

Object typed with custom iterator

```
for i in CustomIterable.new(N):
    pass
```

### D (object w/ generic opcode)

```
iterate(CustomIterable.new(N))
```

</details>

## Results

<details>
<summary>Expand for detailed test summaries</summary>

Scenarios A and B are unaffected but are shown for comparison. Each test is repeated `T` times with `N` iterations and then averaged.

All tests are run on Windows 11 x86_64. Old 320e81846979bd716341e0669231954543c4afbd new e53d192733c70520addff25829b743358ca4c264.

### `T` = 20, `N` = 10,000,000, MSVC
| Scenario | Old (s) | New (s) | Diff |
| --- | --- | --- | --- |
| A | 0.1282 | 0.1305 | - |
| B | 0.1279 | 0.1290 | - |
| C | 2.173 | 1.282 | -41% |
| D | 1.961 | 1.282 | -35% |

### `T` = 10, `N` = 100,000,000, MSVC

| Scenario | Old (s) | New (s) | Diff |
| --- | --- | --- | --- |
| A | 1.2714 | 1.3122 | - |
| B | 1.2725 | 1.2931 | - |
| C | 21.928 | 12.874 | -41% |
| D | 19.783 | 12.931 | -35% |

### `T` = 20, `N` = 10,000,000, MinGW

| Scenario | Old (s) | New (s) | Diff |
| --- | --- | --- | --- |
| A | 0.0997 | 0.1005 | - |
| B | 0.0997 | 0.1005 | - |
| C | 2.0533 | 1.2376 | -40% |
| D | 1.7763 | 1.2619 | -29% |

### `T` = 10, `N` = 100,000,000, MinGW

| Scenario | Old (s) | New (s) | Diff |
| --- | --- | --- | --- |
| A | 1.0092 | 0.9990 | - |
| B | 1.0076 | 0.9985 | - |
| C | 20.722 | 12.422 | -40% |
| D | 17.834 | 12.321 | -31% |

</details>

A similar improvement is seen across both MSVC and MinGW builds. Scenario C (`OPCODE_ITERATE_OBJECT_BEGIN`/`OPCODE_ITERATE_OBJECT`) runs ~**40%** faster, while scenario D (`OPCODE_ITERATE_BEGIN`/`OPCODE_ITERATE`) runs ~**30%** faster. 

Interestingly, scenario D was slightly faster than scenario C but now it is equal or marginally slower. This new outcome is not surprising since we expect the specialized opcode to be at least as performant.

### Additional Testing

If we opt to use the object state instead of the array in the iterator, the base benchmark becomes even faster. The performance improvement in this case is 44%.

<details>
<summary>Modified class and results</summary>

```
class CustomIterableClassState:
	var n: int
	var i: int
	
	func _init(n: int) -> void:
		self.n = n
	
	func _iter_init(_iter: Array) -> bool:
		i = 0
		return i < n
	
	func _iter_next(_iter: Array) -> bool:
		i += 1
		return i < n
	
	func _iter_get(_iter: Variant) -> Variant:
		return i
```

All run on MinGW. Scenario C with the above class instead. Averaged over `N` runs.

| N | T | Old (s) | New (s) | Diff |
| --- | --- | --- | --- | --- |
| 20 | 1e7 | 1.828 | 1.019 | -44% |
| 10 | 1e8 | 18.286 | 10.197 | -44% |

</details>


### Profiling

I used Tracy to profile a single iteration of the typed opcode with `N`=1,000,000 on MSVC. Only the `_iter_*` methods show up because the engine opcodes are not annotated. Zooming into the zones, we can see that the gaps before an `_iter_next` call is greatly minimized in the change. 

<img width="621" height="62" alt="image" src="https://github.com/user-attachments/assets/0c2d4ed1-d29a-4b61-a62f-e020b4997822" />

-----

The cumulative `_iter_*` method call times remain within a margin of error. 

<img width="683" height="156" alt="image" src="https://github.com/user-attachments/assets/db71b44a-8ddf-4c51-a0da-2d0f0cdf4376" />


