### PR TITLE
Support read-only `operator[]` for `StringName`

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3467,6 +3467,8 @@ bool Variant::is_read_only() const {
 			return reinterpret_cast<const Array *>(_data._mem)->is_read_only();
 		case DICTIONARY:
 			return reinterpret_cast<const Dictionary *>(_data._mem)->is_read_only();
+		case STRING_NAME:
+			return true;
 		default:
 			return false;
 	}

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -844,6 +844,45 @@ struct VariantIndexedSetGet_String {
 	static uint64_t get_indexed_size(const Variant *base) { return VariantInternal::get_string(base)->length(); }
 };
 
+struct VariantIndexedSetGet_StringName {
+	static void get(const Variant *base, int64_t index, Variant *value, bool *oob) {
+		int64_t length = VariantInternalAccessor<StringName>::get(base).length();
+		if (index < 0) {
+			index += length;
+		}
+		if (index < 0 || index >= length) {
+			*oob = true;
+			return;
+		}
+		*value = String::chr((VariantInternalAccessor<StringName>::get(base))[index]);
+		*oob = false;
+	}
+	static void ptr_get(const void *base, int64_t index, void *member) {
+		/* avoid ptrconvert for performance*/
+		const StringName &v = *reinterpret_cast<const StringName *>(base);
+		if (index < 0) {
+			index += v.length();
+		}
+		OOB_TEST(index, v.length());
+		PtrToArg<String>::encode(String::chr(v[index]), member);
+	}
+	static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {
+		// StringName points to const data, so any set operation is invalid.
+		*valid = false;
+		*oob = true;
+	}
+	static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {
+		// StringName points to const data, so any set operation is invalid.
+		*oob = true;
+	}
+	static void ptr_set(void *base, int64_t index, const void *member) {
+		// StringName points to const data, so any set operation is invalid.
+	}
+	static Variant::Type get_index_type() { return Variant::STRING; }
+	static uint32_t get_index_usage() { return PROPERTY_USAGE_DEFAULT; }
+	static uint64_t get_indexed_size(const Variant *base) { return VariantInternal::get_string_name(base)->length(); }
+};
+
 INDEXED_SETGET_STRUCT_BUILTIN_NUMERIC(Vector2, double, real_t, 2)
 INDEXED_SETGET_STRUCT_BUILTIN_NUMERIC(Vector2i, int64_t, int32_t, 2)
 INDEXED_SETGET_STRUCT_BUILTIN_NUMERIC(Vector3, double, real_t, 3)
@@ -911,6 +950,7 @@ void register_indexed_setters_getters() {
 #define REGISTER_INDEXED_MEMBER(m_base_type) register_indexed_member<VariantIndexedSetGet_##m_base_type>(GetTypeInfo<m_base_type>::VARIANT_TYPE)
 
 	REGISTER_INDEXED_MEMBER(String);
+	REGISTER_INDEXED_MEMBER(StringName);
 	REGISTER_INDEXED_MEMBER(Vector2);
 	REGISTER_INDEXED_MEMBER(Vector2i);
 	REGISTER_INDEXED_MEMBER(Vector3);

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -1212,5 +1212,12 @@
 				Returns [code]true[/code] if the left [StringName]'s pointer comes after [param right] or if they are the same. Note that this will not match their [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url].
 			</description>
 		</operator>
+		<operator name="operator []">
+			<return type="String" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns a new [String] that only contains the character at [param index]. Indices start from [code]0[/code]. If [param index] is greater or equal to [code]0[/code], the character is fetched starting from the beginning of the string. If [param index] is a negative value, it is fetched starting from the end. Accessing a string out-of-bounds will cause a run-time error, pausing the project execution if run from the editor.
+			</description>
+		</operator>
 	</operators>
 </class>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4938,6 +4938,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 							case Variant::PACKED_VECTOR4_ARRAY:
 							case Variant::ARRAY:
 							case Variant::STRING:
+							case Variant::STRING_NAME:
 								error = index_type.builtin_type != Variant::INT && index_type.builtin_type != Variant::FLOAT;
 								break;
 							// Expect String only.
@@ -4976,7 +4977,6 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 							case Variant::NIL:
 							case Variant::NODE_PATH:
 							case Variant::SIGNAL:
-							case Variant::STRING_NAME:
 								break;
 							// Support depends on if the dictionary has a typed key, otherwise anything is valid.
 							case Variant::DICTIONARY:
@@ -5044,7 +5044,6 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 					case Variant::NIL:
 					case Variant::NODE_PATH:
 					case Variant::SIGNAL:
-					case Variant::STRING_NAME:
 						result_type.kind = GDScriptParser::DataType::VARIANT;
 						push_error(vformat(R"(Cannot use subscript operator on a base of type "%s".)", base_type.to_string()), p_subscript->base);
 						break;
@@ -5069,7 +5068,9 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 					// Return String.
 					case Variant::PACKED_STRING_ARRAY:
 					case Variant::STRING:
+					case Variant::STRING_NAME:
 						result_type.builtin_type = Variant::STRING;
+						result_type.is_read_only = base_type.builtin_type == Variant::STRING_NAME;
 						break;
 					// Return Vector2.
 					case Variant::PACKED_VECTOR2_ARRAY:

--- a/modules/gdscript/tests/scripts/parser/features/string_indexing.gd
+++ b/modules/gdscript/tests/scripts/parser/features/string_indexing.gd
@@ -1,0 +1,10 @@
+func test():
+	var s := String("abcd")
+	print(s[3])
+	print(s[0] + s[1] + s[2] + s[3])
+	print(s[3] == s[-1])
+
+	var sn := StringName(&"abcd")
+	print(sn[3])
+	print(sn[0] + sn[1] + sn[2] + sn[3])
+	print(sn[3] == sn[-1])

--- a/modules/gdscript/tests/scripts/parser/features/string_indexing.out
+++ b/modules/gdscript/tests/scripts/parser/features/string_indexing.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+d
+abcd
+true
+d
+abcd
+true

--- a/modules/gdscript/tests/scripts/runtime/errors/string_name_bad_index.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/string_name_bad_index.gd
@@ -1,0 +1,6 @@
+func test():
+	var s := String("abcd")
+	s[1] = "z" # OK: can assign to String index, as it is mutable
+
+	var sn := StringName(&"abcd")
+	sn[1] = "z" # Error: cannot modify a read-only type

--- a/modules/gdscript/tests/scripts/runtime/errors/string_name_bad_index.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/string_name_bad_index.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 6: Cannot assign a new value to a read-only property.

--- a/tests/core/string/test_string_name.cpp
+++ b/tests/core/string/test_string_name.cpp
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  test_string_name.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_string_name)
+
+#include "core/string/string_name.h"
+#include "core/string/ustring.h"
+#include "core/variant/variant.h"
+
+namespace TestStringName {
+
+TEST_CASE("[StringName] Variant indexed get") {
+	Variant s = StringName("abcd");
+	bool valid = false;
+	bool oob = true;
+
+	String r = s.get_indexed(1, valid, oob);
+
+	CHECK(valid);
+	CHECK_FALSE(oob);
+	CHECK_EQ(r, String("b"));
+}
+
+TEST_CASE("[StringName] Variant validated indexed get") {
+	Variant s = StringName("abcd");
+
+	Variant::ValidatedIndexedGetter getter = Variant::get_member_validated_indexed_getter(Variant::STRING_NAME);
+
+	Variant r;
+	bool oob = true;
+	getter(&s, 1, &r, &oob);
+
+	CHECK_FALSE(oob);
+	CHECK_EQ(r, String("b"));
+}
+
+TEST_CASE("[StringName] Variant ptr indexed get") {
+	StringName s("abcd");
+
+	Variant::PTRIndexedGetter getter = Variant::get_member_ptr_indexed_getter(Variant::STRING_NAME);
+
+	String r;
+	getter(&s, 1, &r);
+
+	CHECK_EQ(r, String("b"));
+}
+
+TEST_CASE("[StringName] Variant indexed set") {
+	Variant s = StringName("abcd");
+	bool valid = false;
+	bool oob = false;
+
+	s.set_indexed(1, String("z"), valid, oob);
+
+	CHECK_FALSE(valid);
+	CHECK(oob);
+	CHECK_EQ(StringName(s), StringName("abcd"));
+}
+
+TEST_CASE("[StringName] Variant validated indexed set") {
+	Variant s = StringName("abcd");
+
+	Variant::ValidatedIndexedSetter setter = Variant::get_member_validated_indexed_setter(Variant::STRING_NAME);
+
+	Variant v = String("z");
+	bool oob = false;
+	setter(&s, 1, &v, &oob);
+
+	CHECK(oob);
+	CHECK_EQ(StringName(s), StringName("abcd"));
+}
+
+TEST_CASE("[StringName] Variant ptr indexed set") {
+	StringName s("abcd");
+
+	Variant::PTRIndexedSetter setter = Variant::get_member_ptr_indexed_setter(Variant::STRING_NAME);
+
+	String v("z");
+	setter(&s, 1, &v);
+
+	CHECK_EQ(StringName(s), StringName("abcd"));
+}
+
+} // namespace TestStringName


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14756

`StringName` was lacking an `operator[]` like `String` does, to access specific chars directly on the underlying text. This is especially annoying when dealing with internal engine variables of this type (e.g. Node `name`'s)

This introduces the operator internally, with the remark that any set operation on `StringName`s will fail (both at runtime and at GDScript parsing), as these are effectively const/read-only types.
