### PR TITLE
Fix gltf import naming_version mixup

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -420,7 +420,7 @@ void EditorSceneFormatImporterBlend::handle_compatibility_options(HashMap<String
 	if (!p_import_params.has("gltf/texture_map_mode")) {
 		// If an existing import file is missing the glTF
 		// texture map mode, we need to use "Do Not Remap".
-		p_import_params["gltf/naming_version"] = (int64_t)GLTFDocument::TEXTURE_MAP_MODE_DO_NOT_REMAP;
+		p_import_params["gltf/texture_map_mode"] = (int64_t)GLTFDocument::TEXTURE_MAP_MODE_DO_NOT_REMAP;
 	}
 }
 

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -100,7 +100,7 @@ void EditorSceneFormatImporterGLTF::handle_compatibility_options(HashMap<StringN
 	if (!p_import_params.has("gltf/texture_map_mode")) {
 		// If an existing import file is missing the glTF
 		// texture map mode, we need to use "Do Not Remap".
-		p_import_params["gltf/naming_version"] = (int64_t)GLTFDocument::TEXTURE_MAP_MODE_DO_NOT_REMAP;
+		p_import_params["gltf/texture_map_mode"] = (int64_t)GLTFDocument::TEXTURE_MAP_MODE_DO_NOT_REMAP;
 	}
 }
 


### PR DESCRIPTION
The PR https://github.com/godotengine/godot/pull/96748 introduced the gltf .import parameter "texture_map_mode", but in the compatibility handling overwrote "naming_version" instead. This leads to slightly different names in the imported nodes and (in our case) changed properties on those nodes in editable children getting lost.

This issue describes the problem very well: https://github.com/godotengine/godot/issues/118761

Fixes https://github.com/godotengine/godot/issues/118761 


