### PR TITLE
Editor: Fix Tag Overrun Behavior

### DIFF
--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -38,6 +38,12 @@ void ProjectTag::_notification(int p_what) {
 	if (display_close && p_what == NOTIFICATION_THEME_CHANGED) {
 		button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
 	}
+	// HACK: Can't be set in constructor because `get_size()` would return empty.
+	// This logic should be migrated once `Button` utilizes internal labels.
+	if (p_what == NOTIFICATION_READY) {
+		button->set_custom_minimum_size(get_size());
+		button->set_text_overrun_behavior(TextServer::OverrunBehavior::OVERRUN_TRIM_ELLIPSIS);
+	}
 }
 
 void ProjectTag::connect_button_to(const Callable &p_callable) {


### PR DESCRIPTION

Supplemental Fix to #118876. In that PR I was unable to set the overrun behaviour as recommended by @KoBewi in this [comment](https://github.com/godotengine/godot/pull/118876#discussion_r3129478182). This fix gets the overrun to behave properly by utilising the `set_custom_minimum_size` by plugging in the size it currently is, this is done when NOTIFICATION_READY is emitted.

<img width="980" height="102" alt="proper_overrun" src="https://github.com/user-attachments/assets/3c6be827-42ad-4ac5-98c9-d7f5bbba5859" />
