### PR TITLE
Fix negative time scale regression in BlendSpace1D and BlendSpace2D

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -447,7 +447,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_
 	deltas.resize_initialized(blend_points_used);
 	if (sync_mode == SYNC_MODE_NONE) {
 		for (int i = 0; i < blend_points_used; i++) {
-			deltas[i] = -1; // Not process.
+			deltas[i] = NAN; // Not process.
 		}
 	}
 
@@ -576,12 +576,12 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_
 		pi.seeked = true;
 		pi.weight = 1.0;
 		mind = blend_node(p_process_state, p_instance, instance_new_closest, pi, FILTER_IGNORE, true, p_test_only);
-		deltas[new_closest] = -1; // No more blend new_closest point.
+		deltas[new_closest] = NAN; // No more blend new_closest point.
 	}
 
 	// Normal case, blend all points.
 	for (int i = 0; i < blend_points_used; i++) {
-		if (std::signbit(deltas[i])) {
+		if (Math::is_nan(deltas[i])) {
 			continue;
 		}
 		pi = p_playback_info;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -589,7 +589,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_
 	deltas.resize_initialized(blend_points_used);
 	if (sync_mode == SYNC_MODE_NONE) {
 		for (int i = 0; i < blend_points_used; i++) {
-			deltas[i] = -1; // Not process.
+			deltas[i] = NAN; // Not process.
 		}
 	}
 
@@ -736,12 +736,12 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_
 		pi.seeked = true;
 		pi.weight = 1.0;
 		mind = blend_node(p_process_state, p_instance, instance_new_closest, pi, FILTER_IGNORE, true, p_test_only);
-		deltas[new_closest] = -1; // No more blend new_closest point.
+		deltas[new_closest] = NAN; // No more blend new_closest point.
 	}
 
 	// Normal case, blend all points.
 	for (int i = 0; i < blend_points_used; i++) {
-		if (std::signbit(deltas[i])) {
+		if (Math::is_nan(deltas[i])) {
 			continue;
 		}
 		pi = p_playback_info;


### PR DESCRIPTION
Replace -1 sentinel value in deltas array with NAN to distinguish between "skip this blend point" and a legitimate negative delta from a negative time scale node. std::signbit was incorrectly skipping blend points with negative deltas, causing animation playback failure and an out-of-bounds error when using negative time scale for reverse animation.

Fixes #119060