### PR TITLE
Add Shift+Enter and Shift+KpEnter as default shortcuts for newline

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -581,6 +581,8 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::ENTER));
 	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::ENTER));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::KP_ENTER));
 	default_builtin_cache.insert("ui_text_newline", inputs);
 
 	inputs = List<Ref<InputEvent>>();


### PR DESCRIPTION
These conflict with `ui_text_completion_replace` (accept autocompletion), but the latter seems to take precedence if an autocomplete popup is open, so this still works as expected.

Fixes #119085