### PR TITLE
SCons: Drop VS2017 support, use C17 universally

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -777,35 +777,20 @@ elif methods.using_clang(env):
                 env["debug_paths_relative"] = False
 
 elif env.msvc:
-    # Ensure latest minor builds of Visual Studio 2017/2019.
-    # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
-    if env.get("winrt"):
-        if cc_version_major < 16 or (cc_version_major == 16 and cc_version_minor < 11):
-            print_error(
-                "Detected Visual Studio 2019 version older than 16.11, which does not fully support "
-                "C++20. Use a newer VS2019 version, or VS2022, or disable WinRT support by passing "
-                '"winrt=no" to the SCons command line.'
-            )
-            Exit(255)
-    else:
-        if cc_version_major == 16 and cc_version_minor < 11:
-            print_error(
-                "Detected Visual Studio 2019 version older than 16.11, which has bugs "
-                "when compiling Godot. Use a newer VS2019 version, or VS2022."
-            )
-            Exit(255)
-        if cc_version_major == 15 and cc_version_minor < 9:
-            print_error(
-                "Detected Visual Studio 2017 version older than 15.9, which has bugs "
-                "when compiling Godot. Use a newer VS2017 version, or VS2019/VS2022."
-            )
-            Exit(255)
-        if cc_version_major < 15:
-            print_error(
-                "Detected Visual Studio 2015 or earlier, which is unsupported in Godot. "
-                "Supported versions are Visual Studio 2017 and later."
-            )
-            Exit(255)
+    if cc_version_major == 16 and cc_version_minor < 11:
+        # Ensure latest minor build of Visual Studio 2019.
+        # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
+        print_error(
+            "Detected Visual Studio 2019 version older than 16.11, which has bugs "
+            "when compiling Godot. Use a newer VS2019 version, or VS2022+."
+        )
+        Exit(255)
+    elif cc_version_major < 16:
+        print_error(
+            "Detected Visual Studio 2017 or earlier, which is unsupported in Godot. "
+            "Supported versions are Visual Studio 2019 and later."
+        )
+        Exit(255)
 
 # Set x86 CPU instruction sets to use by the compiler's autovectorization.
 if env["arch"] == "x86_64":
@@ -931,12 +916,9 @@ if not env.msvc:
     env.Prepend(CXXFLAGS=["-std=gnu++17"])
 else:
     # MSVC started offering C standard support with Visual Studio 2019 16.8, which covers all
-    # of our supported VS2019 & VS2022 versions; VS2017 will only pass the C++ standard.
+    # of our supported Visual Studio versions.
+    env.Prepend(CFLAGS=["/std:c17"])
     env.Prepend(CXXFLAGS=["/std:c++17"])
-    if cc_version_major < 16:
-        print_warning("Visual Studio 2017 cannot specify a C-Standard.")
-    else:
-        env.Prepend(CFLAGS=["/std:c17"])
     # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -100,12 +100,7 @@ def find_msbuild_tools_path_reg():
                 raise ValueError("Value of `installationPath` entry is empty")
 
             # Since VS2019, the directory is simply named "Current"
-            msbuild_dir = os.path.join(val, "MSBuild", "Current", "Bin")
-            if os.path.isdir(msbuild_dir):
-                return msbuild_dir
-
-            # Directory name "15.0" is used in VS 2017
-            return os.path.join(val, "MSBuild", "15.0", "Bin")
+            return os.path.join(val, "MSBuild", "Current", "Bin")
 
         raise ValueError("Cannot find `installationPath` entry")
     except ValueError as e:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -95,7 +95,7 @@ def detect_build_env_arch():
         "arm64": "arm64",
         "aarch64": "arm64",
     }
-    if os.getenv("VCINSTALLDIR") or os.getenv("VCTOOLSINSTALLDIR"):
+    if os.getenv("VCTOOLSINSTALLDIR"):
         if os.getenv("Platform"):
             msvc_arch = os.getenv("Platform").lower()
             if msvc_arch in msvc_target_aliases.keys():
@@ -106,32 +106,11 @@ def detect_build_env_arch():
             if msvc_arch in msvc_target_aliases.keys():
                 return msvc_target_aliases[msvc_arch]
 
-        # Pre VS 2017 checks.
-        if os.getenv("VCINSTALLDIR"):
-            PATH = os.getenv("PATH").upper()
-            VCINSTALLDIR = os.getenv("VCINSTALLDIR").upper()
-            path_arch = {
-                "BIN\\x86_ARM;": "arm32",
-                "BIN\\amd64_ARM;": "arm32",
-                "BIN\\x86_ARM64;": "arm64",
-                "BIN\\amd64_ARM64;": "arm64",
-                "BIN\\x86_amd64;": "a86_64",
-                "BIN\\amd64;": "x86_64",
-                "BIN\\amd64_x86;": "x86_32",
-                "BIN;": "x86_32",
-            }
-            for path, arch in path_arch.items():
-                final_path = VCINSTALLDIR + path
-                if final_path in PATH:
-                    return arch
-
-        # VS 2017 and newer.
-        if os.getenv("VCTOOLSINSTALLDIR"):
-            host_path_index = os.getenv("PATH").upper().find(os.getenv("VCTOOLSINSTALLDIR").upper() + "BIN\\HOST")
-            if host_path_index > -1:
-                first_path_arch = os.getenv("PATH")[host_path_index:].split(";")[0].rsplit("\\", 1)[-1].lower()
-                if first_path_arch in msvc_target_aliases.keys():
-                    return msvc_target_aliases[first_path_arch]
+        host_path_index = os.getenv("PATH").upper().find(os.getenv("VCTOOLSINSTALLDIR").upper() + "BIN\\HOST")
+        if host_path_index > -1:
+            first_path_arch = os.getenv("PATH")[host_path_index:].split(";")[0].rsplit("\\", 1)[-1].lower()
+            if first_path_arch in msvc_target_aliases.keys():
+                return msvc_target_aliases[first_path_arch]
 
     msys_target_aliases = {
         "mingw32": "x86_32",


### PR DESCRIPTION
VS2017 is nearly a decade old at this point, and now feels like the appropriate time to send it off. Its existence causes a small but noteworthy blindspot in our build logic: it's entirely incapable of specifying a C Standard. While we currently have a simple warning in place to account for this, it's far from ideal & puts into question any C code generated by it. We don't currently test for VS2017 so these concerns are somewhat hypothetical, but the existance of this special case makes further adjustments to C/C++ Standard assignment/detection (ex: #118260) much more tedious to a point that I'd prefer to exclude it altogether.