### PR TITLE
Fix issue with constant editor redraw if any Joint3D derived node exists in scene

### DIFF
--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -334,7 +334,7 @@ void Joint3DGizmoPlugin::incremental_update_gizmos() {
 		}
 
 		last_drawn = *E;
-		
+
 		if (!perform_redraw) {
 			return;
 		}

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -295,14 +295,51 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 void Joint3DGizmoPlugin::incremental_update_gizmos() {
 	if (!current_gizmos.is_empty()) {
 		HashSet<EditorNode3DGizmo *>::Iterator E = current_gizmos.find(last_drawn);
+		bool perform_redraw = false;
 		if (E) {
 			++E;
 		}
 		if (!E) {
 			E = current_gizmos.begin();
 		}
-		redraw(*E);
+
+		HashMap<EditorNode3DGizmo *, JointStateHistory>::Iterator it = gizmo_histories.find(*E);
+
+		if (it) {
+			Joint3D *joint = Object::cast_to<Joint3D>((*E)->get_node_3d());
+
+			Node3D *node_body_a = nullptr;
+			if (!joint->get_node_a().is_empty()) {
+				node_body_a = Object::cast_to<Node3D>(joint->get_node(joint->get_node_a()));
+				Vector3 pos = node_body_a->get_global_position();
+				Vector3 &prev_pos = it->value.node_a_last_global_pos;
+
+				if (!pos.is_equal_approx(prev_pos)) {
+					prev_pos = pos;
+					perform_redraw = true;
+				}
+			}
+
+			Node3D *node_body_b = nullptr;
+			if (!joint->get_node_b().is_empty()) {
+				node_body_b = Object::cast_to<Node3D>(joint->get_node(joint->get_node_b()));
+				Vector3 pos = node_body_b->get_global_position();
+				Vector3 &prev_pos = it->value.node_b_last_global_pos;
+
+				if (!pos.is_equal_approx(prev_pos)) {
+					prev_pos = pos;
+					perform_redraw = true;
+				}
+			}
+		}
+
 		last_drawn = *E;
+		
+		if (!perform_redraw) {
+			return;
+		}
+
+		redraw(*E);
 	}
 }
 
@@ -458,6 +495,16 @@ void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(body_a_points, body_a_material);
 		p_gizmo->add_lines(body_b_points, body_b_material);
 	}
+}
+
+void Joint3DGizmoPlugin::register_gizmo(EditorNode3DGizmo *p_gizmo) {
+	EditorNode3DGizmoPlugin::register_gizmo(p_gizmo);
+	gizmo_histories.insert(p_gizmo, {});
+}
+
+void Joint3DGizmoPlugin::unregister_gizmo(EditorNode3DGizmo *p_gizmo) {
+	EditorNode3DGizmoPlugin::unregister_gizmo(p_gizmo);
+	gizmo_histories.erase(p_gizmo);
 }
 
 void Joint3DGizmoPlugin::CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points) {

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -42,13 +42,12 @@ class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 	void incremental_update_gizmos();
 
-	struct JointStateHistory
-	{
+	struct JointStateHistory {
 		Vector3 node_a_last_global_pos;
 		Vector3 node_b_last_global_pos;
 	};
 
-	HashMap<EditorNode3DGizmo*, JointStateHistory> gizmo_histories;
+	HashMap<EditorNode3DGizmo *, JointStateHistory> gizmo_histories;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -42,11 +42,22 @@ class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 	void incremental_update_gizmos();
 
+	struct JointStateHistory
+	{
+		Vector3 node_a_last_global_pos;
+		Vector3 node_b_last_global_pos;
+	};
+
+	HashMap<EditorNode3DGizmo*, JointStateHistory> gizmo_histories;
+
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
+
+	virtual void register_gizmo(EditorNode3DGizmo *p_gizmo) override;
+	virtual void unregister_gizmo(EditorNode3DGizmo *p_gizmo) override;
 
 	static void CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points);
 	static void CreateHingeJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_limit_lower, real_t p_limit_upper, bool p_use_limit, Vector<Vector3> &r_common_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -1067,7 +1067,7 @@ Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_spatial) {
 	ref->set_node_3d(p_spatial);
 	ref->set_hidden(current_state == HIDDEN);
 
-	current_gizmos.insert(ref.ptr());
+	register_gizmo(ref.ptr());
 	return ref;
 }
 
@@ -1218,6 +1218,10 @@ void EditorNode3DGizmoPlugin::set_state(int p_state) {
 
 int EditorNode3DGizmoPlugin::get_state() const {
 	return current_state;
+}
+
+void EditorNode3DGizmoPlugin::register_gizmo(EditorNode3DGizmo *p_gizmo) {
+	current_gizmos.insert(p_gizmo);
 }
 
 void EditorNode3DGizmoPlugin::unregister_gizmo(EditorNode3DGizmo *p_gizmo) {

--- a/editor/scene/3d/node_3d_editor_gizmos.h
+++ b/editor/scene/3d/node_3d_editor_gizmos.h
@@ -222,7 +222,8 @@ public:
 	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_spatial);
 	void set_state(int p_state);
 	int get_state() const;
-	void unregister_gizmo(EditorNode3DGizmo *p_gizmo);
+	virtual void register_gizmo(EditorNode3DGizmo *p_gizmo);
+	virtual void unregister_gizmo(EditorNode3DGizmo *p_gizmo);
 
 	EditorNode3DGizmoPlugin();
 	virtual ~EditorNode3DGizmoPlugin();

--- a/scene/3d/physics/joints/joint_3d.cpp
+++ b/scene/3d/physics/joints/joint_3d.cpp
@@ -135,6 +135,7 @@ void Joint3D::set_node_a(const NodePath &p_node_a) {
 
 	a = p_node_a;
 	_update_joint();
+	update_gizmos();
 }
 
 NodePath Joint3D::get_node_a() const {
@@ -152,6 +153,7 @@ void Joint3D::set_node_b(const NodePath &p_node_b) {
 
 	b = p_node_b;
 	_update_joint();
+	update_gizmos();
 }
 
 NodePath Joint3D::get_node_b() const {
@@ -183,6 +185,10 @@ void Joint3D::_notification(int p_what) {
 				_disconnect_signals();
 			}
 			_update_joint(true);
+		} break;
+
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			update_gizmos();
 		} break;
 	}
 }


### PR DESCRIPTION
Instead of lazily just redrawing every now and then, instead we check for a couple of specific conditions:

1. The joint node has moved (notification TRANSFORM_CHANGED)
2. Node A or B has been changed in the joint.
3. Node A or B has been moved since last update. This is currently done via polling and keeping track of the last known positional state, which isn't optimal, but better than letting the editor constantly redraw.

To keep track of each gizmos individual a/b nodes previous positions, I added a `register_gizmo` method to `EditorNode3DGizmo` (already had a deregister method) and made them virtual so that we can hook in and react to when gizmos are added/removed.

In the end, this avoids redrawing unnecessarily. We noticed this as the spinner kept spinning constantly, and we also realized that we had better performance when running our game if the viewport wasn't opened in the editor (e.g. script tab was opened instead), which is probably the most important reason for this fix.

It still has a timer set to 120hz, that updates a single gizmo per "tick", effectively amortizing the cost of polling for changes. It's not pretty, but I couldn't find a better way to listen to "external" node transform changes.

Test project:
[joint-3d-redraw-fix.zip](https://github.com/user-attachments/files/27216650/joint-3d-redraw-fix.zip)
