### PR TITLE
Fix item focused signal description

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -278,7 +278,7 @@
 		<signal name="item_focused">
 			<param index="0" name="index" type="int" />
 			<description>
-				Emitted when the user navigates to an item using the [member ProjectSettings.input/ui_up] or [member ProjectSettings.input/ui_down] input actions. The index of the item selected is passed as argument.
+				Emitted when the user navigates to an item using the [member ProjectSettings.input/ui_up] or [member ProjectSettings.input/ui_down] input actions. The index of the item focused is passed as argument.
 			</description>
 		</signal>
 		<signal name="item_selected">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
`item_focused` signal in OptionButton says the argument is for "selected" item, but it's for "focused" item