### PR TITLE
Add cleanup of `EditorInspector` clipboard contents

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -338,6 +338,7 @@ void unregister_editor_types() {
 	TextureLayeredEditor::finish_shaders();
 	TexturePreview::finish_shaders();
 
+	EditorInspector::set_property_clipboard(EditorInspector::PropertyClipboard::Type::EMPTY, Variant());
 	EditorNode::cleanup();
 	EditorInterface::free();
 


### PR DESCRIPTION
Fixes #119107.

The `EditorInspector` clipboard contents (which is `static`) weren't being cleared in `Main::cleanup`, leading to resources being cleaned up at program exit instead, which can lead to all kinds of crashes and general [SIOF](https://en.cppreference.com/cpp/language/siof) problems.

This fixes that by setting the clipboard to be an empty `Variant` as part of `unregister_editor_types()`.