### PR TITLE
Allow building Web platform with C#/.NET module enabled

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -11,11 +11,6 @@ def module_supports_tools_on(platform):
 
 
 def configure(env, env_mono):
-    # is_android = env["platform"] == "android"
-    # is_web = env["platform"] == "web"
-    # is_ios = env["platform"] == "ios"
-    # is_ios_sim = is_ios and env["arch"] in ["x86_32", "x86_64"]
-
     if env.editor_build:
         if not module_supports_tools_on(env["platform"]):
             raise RuntimeError("This module does not currently support building for this platform for editor builds.")

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -79,6 +79,7 @@ def get_flags():
     return {
         "arch": "wasm32",
         "target": "template_debug",
+        "supported": ["mono"],
         "builtin_pcre2_with_jit": False,
         "vulkan": False,
         # Embree is heavy and requires too much memory (GH-70621).

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -424,7 +424,7 @@ Ref<Texture2D> EditorExportPlatformWeb::get_logo() const {
 bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
 #ifdef MODULE_MONO_ENABLED
 	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
+	r_error += TTR("Exporting to Web with C#/.NET is not yet implemented in Godot 4. Runtime support is in development.") + "\n";
 	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
 	return false;
 #else


### PR DESCRIPTION
## Summary

Declares the Web platform as supporting the `mono` module so that
`scons platform=web module_mono_enabled=yes` no longer aborts in
`modules/mono/config.py` before any C++ compiles.

This is a **build-system unblock only**. C#/.NET exports to Web are
still gated at the editor level — the runtime hosting, exporter
changes, and template variants required for functional C# web exports
are not part of this PR. The export-time error message is updated to
reflect that support is in development rather than directing users
back to Godot 3.

This is intended as a small, low-risk first step that unblocks
parallel work on the runtime side without committing to any specific
runtime-hosting design.

Refs #70796

## Changes

- `platform/web/detect.py`: add `"supported": ["mono"]` to `get_flags()`
  (mirrors the pattern used by Android, iOS, macOS, Windows, Linux).
- `modules/mono/build_scripts/mono_configure.py`: remove four
  commented-out platform-detection lines that have been dead since the
  .NET rewrite.
- `platform/web/export/export_plugin.cpp`: replace the "Use Godot 3"
  message with copy that signals work-in-progress.

## What this enables

- `scons platform=web target=template_{debug,release} module_mono_enabled=yes`
  succeeds.
- Non-C# Web exports are unaffected (the .NET runtime is never
  initialized in non-editor builds without the `dotnet` feature).
- Editor builds for Web remain rejected as before
  (`module_supports_tools_on(env["platform"])` still returns false).
