### PR TITLE
Fix broken loop on stream import if `loop_offset` is greater than `beat_count`

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -51,7 +51,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : mp3_stream->loop;
 
-	bool beat_loop = use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
+	beat_loop = use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
 	if (beat_loop) {
 		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
 	}
@@ -135,7 +135,10 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= mp3_stream->get_length()) {
+	double real_length = beat_loop ? 60.0 / mp3_stream->get_bpm() * mp3_stream->beat_count : mp3_stream->get_length();
+
+	if (p_time >= real_length || p_time < 0) {
+		WARN_PRINT_ED("Seeking out of bounds. Setting position to 0.");
 		p_time = 0;
 	}
 

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -51,6 +51,7 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 	uint32_t frames_mixed = 0;
 	bool active = false;
 	int loops = 0;
+	bool beat_loop = false;
 
 	friend class AudioStreamMP3;
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -48,7 +48,8 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : vorbis_stream->loop;
 
-	if (use_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0) {
+	beat_loop = use_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0;
+	if (beat_loop) {
 		beat_length_frames = vorbis_stream->get_beat_count() * vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
 	}
 
@@ -284,7 +285,10 @@ void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= vorbis_stream->get_length()) {
+	double real_length = beat_loop ? 60.0 / vorbis_stream->get_bpm() * vorbis_stream->beat_count : vorbis_stream->get_length();
+
+	if (p_time >= real_length || p_time < 0) {
+		WARN_PRINT_ED("Seeking out of bounds. Setting position to 0.");
 		p_time = 0;
 	}
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -47,6 +47,7 @@ class AudioStreamPlaybackOggVorbis : public AudioStreamPlaybackResampled {
 	bool looping_override = false;
 	bool looping = false;
 	int loops = 0;
+	bool beat_loop = false;
 
 	enum {
 		FADE_SIZE = 256


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes: https://github.com/godotengine/godot/issues/117817
Fixes: https://github.com/godotengine/godot/issues/98192 (if merged with https://github.com/godotengine/godot/pull/119084)
Fixes: https://github.com/godotengine/godot/issues/89390
Possibly supersedes: https://github.com/godotengine/godot/pull/117856
Supersedes: https://github.com/godotengine/godot/pull/96384 (encountered randomly after submitting this PR)

Audio freezes if `loop_offset` is greater than `beat_count`. Playback is basically seeking past the length of the track.

In this PR, within the `seek()` functions, the stream length to be used is checked. We use either the full length, or length dictated by `beat_count` if beat-synced loop is active.

Why this different approach?
According to [this comment](https://github.com/godotengine/godot/issues/117817#issuecomment-4132396124), https://github.com/godotengine/godot/pull/117856 fixes the problem. However, I don't believe it to be the best approach, since an argument that should've been modified in `seek()` is still valid, and the problem is dealt with in the mixing step. I'd have simply reviewed for a change, if this alternative approach wasn't completely different.
To be fair, I don't fully understand the other pull request (audio mixing isn't something I'm super familiar with yet), neither have tried it myself, so that one could probably be the right approach. But I also imagine there's the possibility of both being merged, since neither get in the way of the other.

Tested on my end by setting different values in the advanced importer, different sounds, running the project and also calling `play()` and `seek()` with different values. Tried with both `AudioStreamMP3` and `AudioStreamOggVorbis` on an `AudioStreamPlayer`.

Extra stuff I did since I was in the same function and was quite similar: set position to 0 if position argument passed to `play()` and `seek()` is negative, which breaks audio playback.

**Audio meeting update:** we thought handling invalid values as an error instead of setting to 0 might be better. I'll make another PR with that approach, and add here.
Edit: here's the new PR: https://github.com/godotengine/godot/pull/119446