### PR TITLE
Clarify when `is_queued_for_deletion` returns true and added mention to `SceneTree.queue_delete`.

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -794,7 +794,8 @@
 		<method name="is_queued_for_deletion" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [method Node.queue_free] method was called for the object.
+				Returns [code]true[/code] if the methods [method Node.queue_free] or [method SceneTree.queue_delete] was called for the object.
+				[b]Note:[/b] This method does not return [code]true[/code] on children of the node that [method Node.queue_free] has been called on, even though they will be freed together with the parent.
 			</description>
 		</method>
 		<method name="notification">


### PR DESCRIPTION
Basically, the story is, I was trying to use  `is_queued_for_deletion` in the children of a node that I called `queue_free` on, and it was returning false, unless I called it directly on said child.

And [in rocket](https://chat.godotengine.org/channel/core?msg=KfmJQBozHXRBv4k8E) chat I learned that `SceneTree.queue_delete` is a thing, and `is_queued_for_deletion` can be used for that function too.

So, I am changing the docs so the behavior is more explicit, and added a  mention to `SceneTree.queue_delete`