### PR TITLE
Fix typo in C# string interpolation in `TYPE_STRING` doc

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2903,7 +2903,7 @@
 			[csharp]
 			// Array of elemType.
 			hintString = $"{elemType:D}:";
-			hintString = $"{elemType:}/{elemHint:D}:{elemHintString}";
+			hintString = $"{elemType:D}/{elemHint:D}:{elemHintString}";
 			// Two-dimensional array of elemType (array of arrays of elemType).
 			hintString = $"{Variant.Type.Array:D}:{elemType:D}:";
 			hintString = $"{Variant.Type.Array:D}:{elemType:D}/{elemHint:D}:{elemHintString}";


### PR DESCRIPTION
Noticed this minor typo in the docs when writing custom property hints for arrays in C#. One of the interpolated values is missing the format specifier after the colon. Likely a basic typo, as every other `elemType` is correctly formatted.

<img width="1161" height="264" alt="image" src="https://github.com/user-attachments/assets/61b39962-abe5-4d00-9873-964f0dbd1b1e" />

(Context for those unfamiliar with C#, a colon after an interped value specifies a format, and `D` represents decimals or int values. See https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings)

----------

But just to be sure, here's what it looks like if we use the current line without the fix:

<img width="560" height="120" alt="image" src="https://github.com/user-attachments/assets/02dcd081-e7e6-471a-b83c-a7808e4c6fd0" />


After:

<img width="559" height="111" alt="image" src="https://github.com/user-attachments/assets/d5a73f30-8916-4d22-b3cd-8402f0294cbd" />

