### PR TITLE
Enable vertical layout in Output dock

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -489,7 +489,7 @@ EditorLog::EditorLog() {
 	set_icon_name("Output");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_output_bottom_panel", TTRC("Toggle Output Dock"), KeyModifierMask::ALT | Key::O));
 	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
-	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_ALL);
 	set_process_shortcut_input(true);
 	set_shortcut_context(this);
 


### PR DESCRIPTION
Follow-up to #113024

Enables vertical layout for Output and Audio docks.

- Output did not require any changes thanks to flow container
<img width="379" height="968" alt="image" src="https://github.com/user-attachments/assets/d7a76dbe-e1b4-4eb5-97cb-0b0a13e3d58a" />
- Audio switches to alternative button layout in vertical mode
<img width="319" height="964" alt="image" src="https://github.com/user-attachments/assets/9ba0f061-59bb-4880-be1a-450e5021f233" />
Button alignment up to discussion
<img width="457" height="202" alt="image" src="https://github.com/user-attachments/assets/4119b607-e807-4ba6-b0a2-6d5482ed4af0" />
