### PR TITLE
Only focus the shader editor when directly opened

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1267,11 +1267,14 @@ void EditorNode::_remove_plugin_from_enabled(const String &p_name) {
 	ps->set("editor_plugins/enabled", enabled_plugins);
 }
 
-void EditorNode::_plugin_over_edit(EditorPlugin *p_plugin, Object *p_object) {
+void EditorNode::_plugin_over_edit(EditorPlugin *p_plugin, Object *p_object, bool p_set_current) {
 	if (p_object) {
 		editor_plugins_over->add_plugin(p_plugin);
 		p_plugin->edit(p_object);
 		p_plugin->make_visible(true);
+		if (p_set_current) {
+			p_plugin->set_current();
+		}
 	} else {
 		editor_plugins_over->remove_plugin(p_plugin);
 		p_plugin->edit(nullptr);
@@ -2906,7 +2909,7 @@ bool EditorNode::_is_class_editor_disabled_by_feature_profile(const StringName &
 	return false;
 }
 
-void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
+void EditorNode::edit_item(Object *p_object, Object *p_editing_owner, bool p_set_current) {
 	ERR_FAIL_NULL(p_editing_owner);
 
 	// Editing for this type of object may be disabled by user's feature profile.
@@ -2954,6 +2957,9 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 			// Plugin was already active, just change the object and ensure it's visible.
 			plugin->make_visible(true);
 			plugin->edit(p_object);
+			if (p_set_current) {
+				plugin->set_current();
+			}
 			continue;
 		}
 
@@ -2961,6 +2967,9 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 			// Plugin is already active, but as self-owning, so it needs a separate check.
 			plugin->make_visible(true);
 			plugin->edit(p_object);
+			if (p_set_current) {
+				plugin->set_current();
+			}
 			continue;
 		}
 
@@ -3000,7 +3009,7 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 	}
 
 	for (EditorPlugin *plugin : to_over_edit) {
-		_plugin_over_edit(plugin, p_object);
+		_plugin_over_edit(plugin, p_object, p_set_current);
 	}
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -561,7 +561,7 @@ private:
 	void _palette_quick_open_dialog();
 
 	void _remove_plugin_from_enabled(const String &p_name);
-	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object);
+	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object, bool p_set_current = true);
 	void _plugin_over_self_own(EditorPlugin *p_plugin);
 
 	void _fs_changed();
@@ -839,7 +839,7 @@ public:
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void push_item_no_inspector(Object *p_object);
 	void edit_previous_item();
-	void edit_item(Object *p_object, Object *p_editing_owner);
+	void edit_item(Object *p_object, Object *p_editing_owner, bool p_set_current = true);
 	void push_node_item(Node *p_node);
 	void hide_unused_editors(const Object *p_editing_owner = nullptr);
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3410,6 +3410,7 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 	if (!p_inspect && use_sub_inspector) {
 		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
+		user_opened_editor = unfold;
 		update_property();
 	} else if (!is_checkable() || is_checked()) {
 		emit_signal(SNAME("resource_selected"), get_edited_property(), p_resource);
@@ -3524,7 +3525,7 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 void EditorPropertyResource::_open_editor_pressed() {
 	Ref<Resource> res = get_edited_property_value();
 	if (res.is_valid()) {
-		EditorNode::get_singleton()->edit_item(res.ptr(), this);
+		EditorNode::get_singleton()->edit_item(res.ptr(), this, user_opened_editor);
 	}
 }
 
@@ -3728,6 +3729,8 @@ void EditorPropertyResource::update_property() {
 	resource_picker->set_edited_resource_no_check(res);
 	const Ref<Resource> &real_res = get_edited_property_value();
 	resource_picker->set_force_allow_unique(real_res.is_null() && res.is_valid());
+
+	user_opened_editor = false;
 }
 
 void EditorPropertyResource::collapse_all_folding() {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -748,6 +748,7 @@ class EditorPropertyResource : public EditorProperty {
 	EditorInspector *sub_inspector = nullptr;
 	bool opened_editor = false;
 	bool use_filter = false;
+	bool user_opened_editor = false;
 
 	void _resource_selected(const Ref<Resource> &p_resource, bool p_inspect);
 	void _resource_changed(const Ref<Resource> &p_resource);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -199,6 +199,7 @@ public:
 	virtual void set_plugin_version(const String &p_version);
 	virtual bool has_main_screen() const;
 	virtual void make_visible(bool p_visible);
+	virtual void set_current() {}
 	virtual void selected_notify() {} //notify that it was raised by the user, not the editor
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -150,7 +150,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 			if (edited_shaders[i].shader_inc.ptr() == shader_include) {
 				shader_tabs->set_current_tab(i);
 				shader_list->select(i);
-				_switch_to_editor(edited_shaders[i].shader_editor, true);
+				_switch_to_editor(edited_shaders[i].shader_editor);
 				return;
 			}
 		}
@@ -170,7 +170,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 			if (edited_shaders[i].shader.ptr() == shader) {
 				shader_tabs->set_current_tab(i);
 				shader_list->select(i);
-				_switch_to_editor(edited_shaders[i].shader_editor, true);
+				_switch_to_editor(edited_shaders[i].shader_editor);
 				return;
 			}
 		}
@@ -203,7 +203,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 	shader_tabs->set_current_tab(shader_tabs->get_tab_count() - 1);
 	edited_shaders.push_back(es);
 	_update_shader_list();
-	_switch_to_editor(es.shader_editor, !restoring_layout);
+	_switch_to_editor(es.shader_editor);
 }
 
 bool ShaderEditorPlugin::handles(Object *p_object) const {
@@ -212,7 +212,15 @@ bool ShaderEditorPlugin::handles(Object *p_object) const {
 
 void ShaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		shader_dock->make_visible();
+		shader_dock->open();
+	}
+}
+
+void ShaderEditorPlugin::set_current() {
+	shader_dock->make_visible();
+	TextShaderEditor *text_shader_editor = Object::cast_to<TextShaderEditor>(shader_tabs->get_current_tab_control());
+	if (text_shader_editor) {
+		text_shader_editor->get_code_editor()->get_text_editor()->grab_focus();
 	}
 }
 
@@ -226,8 +234,6 @@ ShaderEditor *ShaderEditorPlugin::get_shader_editor(const Ref<Shader> &p_for_sha
 }
 
 void ShaderEditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
-	restoring_layout = true;
-
 	if (!bool(EDITOR_GET("editors/shader_editor/behavior/files/restore_shaders_on_load"))) {
 		return;
 	}
@@ -263,8 +269,6 @@ void ShaderEditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 	_shader_selected(selected_shader_idx, false);
 
 	_set_text_shader_zoom_factor(p_layout->get_value("ShaderEditor", "text_shader_zoom_factor", 1.0f));
-
-	restoring_layout = false;
 }
 
 void ShaderEditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
@@ -773,7 +777,7 @@ void ShaderEditorPlugin::_update_shader_editor_zoom_factor(CodeTextEditor *p_sha
 	}
 }
 
-void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor, bool p_focus) {
+void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor) {
 	ERR_FAIL_NULL(p_editor);
 	if (file_menu->get_parent() != nullptr) {
 		file_menu->get_parent()->remove_child(file_menu);
@@ -782,13 +786,6 @@ void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor, bool p_focus)
 	shader_tabs->show();
 	p_editor->use_menu_bar(file_menu);
 	file_menu->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-
-	if (p_focus) {
-		TextShaderEditor *text_shader_editor = Object::cast_to<TextShaderEditor>(p_editor);
-		if (text_shader_editor) {
-			text_shader_editor->get_code_editor()->get_text_editor()->grab_focus();
-		}
-	}
 }
 
 void ShaderEditorPlugin::_file_removed(const String &p_removed_file) {

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -94,7 +94,6 @@ class ShaderEditorPlugin : public EditorPlugin {
 	ShaderCreateDialog *shader_create_dialog = nullptr;
 
 	float text_shader_zoom_factor = 1.0f;
-	bool restoring_layout = false;
 
 	Ref<Resource> _get_current_shader();
 	void _update_shader_list();
@@ -122,7 +121,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	void _set_text_shader_zoom_factor(float p_zoom_factor);
 	void _update_shader_editor_zoom_factor(CodeTextEditor *p_shader_editor) const;
 
-	void _switch_to_editor(ShaderEditor *p_editor, bool p_focus = false);
+	void _switch_to_editor(ShaderEditor *p_editor);
 
 protected:
 	void _notification(int p_what);
@@ -134,6 +133,7 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+	virtual void set_current() override;
 
 	ShaderEditor *get_shader_editor(const Ref<Shader> &p_for_shader);
 


### PR DESCRIPTION
- Supersedes https://github.com/godotengine/godot/pull/102248
- Fixes https://github.com/godotengine/godot/issues/100152 (it opens if it was closed but doesn't switch to anymore)
- Fixes https://github.com/godotengine/godot/issues/99772
- Fixes https://github.com/godotengine/godot/issues/117758

When opening the inspector and a shader resource is unfolded, now it only edits it and makes sure the dock isn't closed. Only when the user directly unfolds the resource section does the Shader Editor dock get switched to and focused.

The new unexposed `EditorPlugin::set_current` is only for ShaderEditor for now, I don't think other docks really have this issue, but it basically does what `make_visible` true did. I didn't want to change `make_visible` itself for compatibility.

