### PR TITLE
Rename 'name' in XRController3D signal parameters.

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -54,26 +54,26 @@
 	</methods>
 	<signals>
 		<signal name="button_pressed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<description>
 				Emitted when a button on this controller is pressed.
 			</description>
 		</signal>
 		<signal name="button_released">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<description>
 				Emitted when a button on this controller is released.
 			</description>
 		</signal>
 		<signal name="input_float_changed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<param index="1" name="value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this controller changes value.
 			</description>
 		</signal>
 		<signal name="input_vector2_changed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<param index="1" name="value" type="Vector2" />
 			<description>
 				Emitted when a thumbstick or thumbpad on this controller is moved.

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -534,10 +534,10 @@ void XRController3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_tracker_hand"), &XRController3D::get_tracker_hand);
 
-	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value")));
+	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "action_name")));
+	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "action_name")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "action_name"), PropertyInfo(Variant::FLOAT, "value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "action_name"), PropertyInfo(Variant::VECTOR2, "value")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
 }
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/119148

When connecting these signals to the script, there was a SHADOWED_VARIABLE_BASE_CLASS warning for these signals:

```button_pressed(name: String)```
```button_released(name: String)```
```input_float_changed(name: String, value: float)```
```input_vector2_changed(name: String, value: Vector2)```

This pull request simply changes the parameter name in the signals from ```name``` to ```action_name``` to avoid the warning when connecting these signals to a script.