### PR TITLE
Docs: Clarify CharacterBody motion mode wording

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -205,10 +205,10 @@
 	</members>
 	<constants>
 		<constant name="MOTION_MODE_GROUNDED" value="0" enum="MotionMode">
-			Apply when notions of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for sided games like platformers.
+			Apply when concepts of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for sided games like platformers.
 		</constant>
 		<constant name="MOTION_MODE_FLOATING" value="1" enum="MotionMode">
-			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for top-down games.
+			Apply when there is no concept of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for top-down games.
 		</constant>
 		<constant name="PLATFORM_ON_LEAVE_ADD_VELOCITY" value="0" enum="PlatformOnLeave">
 			Add the last platform velocity to the [member velocity] when you leave a moving platform.

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -196,10 +196,10 @@
 	</members>
 	<constants>
 		<constant name="MOTION_MODE_GROUNDED" value="0" enum="MotionMode">
-			Apply when notions of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for grounded games like platformers.
+			Apply when concepts of walls, ceiling and floor are relevant. In this mode the body motion will react to slopes (acceleration/slowdown). This mode is suitable for grounded games like platformers.
 		</constant>
 		<constant name="MOTION_MODE_FLOATING" value="1" enum="MotionMode">
-			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for games without ground like space games.
+			Apply when there is no concept of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for games without ground like space games.
 		</constant>
 		<constant name="PLATFORM_ON_LEAVE_ADD_VELOCITY" value="0" enum="PlatformOnLeave">
 			Add the last platform velocity to the [member velocity] when you leave a moving platform.


### PR DESCRIPTION
## Summary
- Clarifies CharacterBody2D and CharacterBody3D `MotionMode` documentation by replacing "notion(s)" with "concept(s)".
- Matches the wording suggested in godotengine/godot-docs#10738 to avoid confusion with motion terminology.

## Testing
- Parsed both edited XML files with Python `xml.etree.ElementTree`.
- Ran `git diff --check`.

Fixes godotengine/godot-docs#10738
