### PR TITLE
Add the possibility to edit keys from dictionaries

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -209,6 +209,10 @@ bool Dictionary::set(const Variant &p_key, const Variant &p_value) {
 	return true;
 }
 
+bool Dictionary::replace_key(const Variant &p_key, const Variant &p_new_key) {
+	return _p->variant_map.replace_key(p_key, p_new_key);
+}
+
 int Dictionary::size() const {
 	return _p->variant_map.size();
 }

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -69,6 +69,7 @@ public:
 	Variant get(const Variant &p_key, const Variant &p_default) const;
 	Variant get_or_add(const Variant &p_key, const Variant &p_default);
 	bool set(const Variant &p_key, const Variant &p_value);
+	bool replace_key(const Variant &p_key, const Variant &p_new_key);
 
 	int size() const;
 	bool is_empty() const;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -54,7 +54,6 @@
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
-#include "editor/themes/editor_scale.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
@@ -231,6 +230,7 @@ Size2 EditorProperty::get_minimum_size() const {
 	}
 
 	Size2 ms = Size2(0, theme_cache.inspector_property_height);
+	bool no_children = true;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i));
 		if (!c) {
@@ -248,8 +248,11 @@ Size2 EditorProperty::get_minimum_size() const {
 
 		Size2 minsize = c->get_combined_minimum_size();
 		ms = ms.max(minsize);
+		no_children = false;
 	}
-
+	if (no_children && !draw_label) {
+		ms.height = 0;
+	}
 	if (!label.is_empty()) {
 		ms.width += theme_cache.font_offset + theme_cache.horizontal_separation;
 	}
@@ -285,8 +288,12 @@ Size2 EditorProperty::get_minimum_size() const {
 	ms.height = MAX(ms.height, rs.y);
 
 	if (bottom_editor != nullptr && bottom_editor->is_visible()) {
-		ms.height += label.is_empty() ? 0 : _get_v_separation();
+		ms.height += (no_children && !draw_label) ? 0 : _get_v_separation();
 		Size2 bems = bottom_editor->get_combined_minimum_size();
+		if (has_borders_enabled()) {
+			bems += 4 * EDSCALE * Vector2(1, 1);
+		}
+
 		ms.height += bems.height;
 		ms.width = MAX(ms.width, bems.width);
 	}
@@ -382,7 +389,9 @@ void EditorProperty::_notification(int p_what) {
 					}
 					height = MAX(height, minsize.height);
 				}
-
+				if (no_children && !draw_label) {
+					height = 0;
+				}
 				if (no_children) {
 					text_size = size.width;
 					rect = Rect2(size.width - 1, 0, 1, height);
@@ -391,7 +400,7 @@ void EditorProperty::_notification(int p_what) {
 					rect = Rect2(1, 0, size.width - 1, height);
 				} else {
 					text_size = MAX(0, size.width - (child_room + separation));
-					if (is_layout_rtl()) {
+					if (is_layout_rtl() != draw_label_inverted) {
 						rect = Rect2(1, 0, child_room, height);
 					} else {
 						rect = Rect2(size.width - child_room, 0, child_room, height);
@@ -399,15 +408,28 @@ void EditorProperty::_notification(int p_what) {
 				}
 
 				if (rect.size.x > 1) {
-					rect.size.x -= right_container->get_combined_minimum_size().x;
+					Control *container = draw_label_inverted ? left_container : right_container;
+					rect.size.x -= container->get_combined_minimum_size().x;
 					if (is_layout_rtl()) {
-						rect.position.x += right_container->get_combined_minimum_size().x;
+						rect.position.x += container->get_combined_minimum_size().x;
 					}
 				}
 
 				if (bottom_editor) {
-					int v_offset = label.is_empty() ? 0 : _get_v_separation();
-					bottom_rect = Rect2(0, rect.size.height + v_offset, size.width, bottom_editor->get_combined_minimum_size().height);
+					int v_offset = (no_children && !draw_label) ? 0 : _get_v_separation();
+					if (draw_label_inverted) {
+						bottom_rect = Rect2(0, 0, size.width, bottom_editor->get_combined_minimum_size().height);
+						rect.position.y = bottom_editor->get_combined_minimum_size().height + v_offset;
+					} else {
+						bottom_rect = Rect2(0, rect.size.height + v_offset, size.width, bottom_editor->get_combined_minimum_size().height);
+					}
+					if (sub_inspector_color_level >= 0) {
+						bottom_rect.position += 2 * EDSCALE * Vector2(1, 1);
+						bottom_rect.size.x -= 4 * EDSCALE;
+						if (draw_label_inverted) {
+							rect.position.y += 4 * EDSCALE;
+						}
+					}
 				}
 
 				if (keying) {
@@ -492,19 +514,28 @@ void EditorProperty::_notification(int p_what) {
 
 			Size2 rs = right_container->get_combined_minimum_size();
 			rs.y = MAX(rs.y, rect.size.y);
-			if (is_layout_rtl()) {
-				fit_child_in_rect(right_container, Rect2(0, 0, rs.width, rs.y));
-			} else {
-				fit_child_in_rect(right_container, Rect2(size.width - rs.width, 0, rs.width, rs.y));
-			}
 
 			Size2 ls = left_container->get_combined_minimum_size();
-			real_t right_size = rect.size.x + rs.x;
 			ls.y = MAX(ls.y, rect.size.y);
-			if (is_layout_rtl()) {
-				fit_child_in_rect(left_container, Rect2(right_size, 0, size.x - right_size, ls.y));
+
+			if (draw_label_inverted) {
+				real_t left_size = rect.size.x + ls.x;
+				if (is_layout_rtl()) {
+					fit_child_in_rect(left_container, Rect2(size.width - ls.width, rect.position.y, ls.width, ls.y));
+					fit_child_in_rect(right_container, Rect2(0, rect.position.y, size.x - left_size, rs.y));
+				} else {
+					fit_child_in_rect(left_container, Rect2(0, rect.position.y, ls.width, ls.y));
+					fit_child_in_rect(right_container, Rect2(left_size, rect.position.y, size.x - left_size, rs.y));
+				}
 			} else {
-				fit_child_in_rect(left_container, Rect2(0, 0, size.x - right_size, ls.y));
+				real_t right_size = rect.size.x + rs.x;
+				if (is_layout_rtl()) {
+					fit_child_in_rect(right_container, Rect2(0, rect.position.y, rs.width, rs.y));
+					fit_child_in_rect(left_container, Rect2(right_size, rect.position.y, size.x - right_size, ls.y));
+				} else {
+					fit_child_in_rect(right_container, Rect2(size.width - rs.width, rect.position.y, rs.width, rs.y));
+					fit_child_in_rect(left_container, Rect2(0, rect.position.y, size.x - right_size, ls.y));
+				}
 			}
 
 			queue_redraw(); // Need to redraw the text.
@@ -517,35 +548,41 @@ void EditorProperty::_notification(int p_what) {
 
 			Size2 size = get_size();
 			if (bottom_editor) {
-				size.height = bottom_editor->get_offset(SIDE_TOP) - _get_v_separation();
+				size.height = right_child_rect.size.height;
 			} else if (label_reference) {
 				size.height = label_reference->get_size().height;
 			}
 			size.height = MAX(size.height, left_container->get_size().height);
 
-			// Only draw the label if it's not empty.
-			if (label.is_empty()) {
-				size.height = 0;
-			} else if (sub_inspector_color_level >= 0 && theme_cache.sub_inspector_background[sub_inspector_color_level].is_valid()) {
-				draw_style_box(theme_cache.sub_inspector_background[sub_inspector_color_level], Rect2(Vector2(), size));
+			if (sub_inspector_color_level >= 0 && theme_cache.sub_inspector_property_background[sub_inspector_color_level].is_valid()) {
+				draw_style_box(theme_cache.sub_inspector_property_background[sub_inspector_color_level], Rect2(0, 0, size.x, size.y + _get_v_separation() + bottom_child_rect.size.y + 4 * EDSCALE));
+				if (draw_label_inverted) {
+					draw_style_box(theme_cache.sub_inspector_background_inverted[sub_inspector_color_level], bottom_child_rect);
+				} else {
+					draw_style_box(theme_cache.sub_inspector_background[sub_inspector_color_level], bottom_child_rect);
+				}
 			} else {
-				draw_style_box(selected ? theme_cache.background_selected : theme_cache.background, Rect2(Vector2(), size));
+				Rect2 rect = Rect2(0, 0, size.x, size.y);
+				draw_style_box(selected ? theme_cache.background_selected : theme_cache.background, rect);
+
+				if (bottom_child_rect != Rect2() && draw_background) {
+					draw_style_box(theme_cache.child_background, bottom_child_rect);
+				}
 			}
 
 			if (draw_top_bg && right_child_rect != Rect2() && draw_background) {
 				draw_style_box(theme_cache.child_background, right_child_rect);
 			}
-			if (bottom_child_rect != Rect2() && draw_background) {
-				draw_style_box(theme_cache.child_background, bottom_child_rect);
-			}
 
 			Color color;
 			if (draw_warning || draw_prop_warning) {
 				color = is_read_only() ? theme_cache.readonly_warning_color : theme_cache.warning_color;
+			} else if (sub_inspector_color_level >= 0) {
+				color = theme_cache.sub_inspector_property_color;
 			} else if (is_read_only()) {
-				color = (sub_inspector_color_level >= 0) ? theme_cache.sub_inspector_property_color : theme_cache.readonly_property_color;
+				color = theme_cache.readonly_property_color;
 			} else {
-				color = (sub_inspector_color_level >= 0) ? theme_cache.sub_inspector_property_color : theme_cache.property_color;
+				color = theme_cache.property_color;
 			}
 			if (label.contains_char('.')) {
 				// FIXME: Move this to the project settings editor, as this is only used
@@ -611,8 +648,8 @@ void EditorProperty::_notification(int p_what) {
 				revert_rect = Rect2(ofs + text_limit, 0, rectw, size.height);
 
 				Point2 rtl_pos;
-				if (rtl) {
-					rtl_pos = Point2(size.width - revert_rect.position.x - rectw, revert_rect.position.y);
+				if (rtl != draw_label_inverted) {
+					rtl_pos = Point2(size.width - revert_rect.position.x - (reload_icon->get_width() + padding + (1 * EDSCALE)), revert_rect.position.y);
 				}
 
 				Color color2(1, 1, 1);
@@ -621,7 +658,7 @@ void EditorProperty::_notification(int p_what) {
 					color2.g *= 1.2;
 					color2.b *= 1.2;
 
-					if (rtl) {
+					if (rtl != draw_label_inverted) {
 						draw_style_box(theme_cache.hover, Rect2(rtl_pos, revert_rect.size));
 					} else {
 						draw_style_box(theme_cache.hover, revert_rect);
@@ -629,7 +666,7 @@ void EditorProperty::_notification(int p_what) {
 				}
 
 				Point2 icon_ofs = (Point2(padding, size.height - reload_icon->get_height()) / 2).round();
-				if (rtl) {
+				if (rtl != draw_label_inverted) {
 					draw_texture(reload_icon, rtl_pos + icon_ofs, color2);
 				} else {
 					draw_texture(reload_icon, revert_rect.position + icon_ofs, color2);
@@ -655,10 +692,11 @@ void EditorProperty::_notification(int p_what) {
 			}
 
 			int v_ofs = (size.height - font->get_height(font_size)) / 2;
-			if (rtl) {
-				draw_string(font, Point2(size.width - ofs - text_limit, v_ofs + font->get_ascent(font_size)), label, HORIZONTAL_ALIGNMENT_RIGHT, text_limit, font_size, color);
+			HorizontalAlignment alignment = rtl ? HORIZONTAL_ALIGNMENT_RIGHT : HORIZONTAL_ALIGNMENT_LEFT;
+			if (rtl != draw_label_inverted) {
+				draw_string(font, Point2(size.width - ofs - text_limit, v_ofs + font->get_ascent(font_size)), label, alignment, text_limit, font_size, color);
 			} else {
-				draw_string(font, Point2(ofs, v_ofs + font->get_ascent(font_size)), label, HORIZONTAL_ALIGNMENT_LEFT, text_limit, font_size, color);
+				draw_string(font, Point2(ofs, v_ofs + font->get_ascent(font_size)), label, alignment, text_limit, font_size, color);
 			}
 
 			ofs = size.width;
@@ -747,7 +785,7 @@ void EditorProperty::_notification(int p_what) {
 			}
 			set_shortcut_context(inspector);
 
-			if (has_borders) {
+			if (has_borders_enabled()) {
 				get_parent()->connect(SceneStringName(theme_changed), callable_mp(this, &EditorProperty::_update_property_bg));
 				_update_property_bg();
 			}
@@ -776,7 +814,7 @@ void EditorProperty::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (has_borders) {
+			if (has_borders_enabled()) {
 				get_parent()->disconnect(SceneStringName(theme_changed), callable_mp(this, &EditorProperty::_update_property_bg));
 			}
 		} break;
@@ -902,6 +940,11 @@ void EditorProperty::_update_property_bg() {
 	if (!is_inside_tree()) {
 		return;
 	}
+	if (!has_borders_enabled()) {
+		sub_inspector_color_level = -1;
+		queue_redraw();
+		return;
+	}
 
 	if (bottom_editor) {
 		ColorationMode nested_color_mode = (ColorationMode)(int)EDITOR_GET("interface/inspector/nested_color_mode");
@@ -922,10 +965,7 @@ void EditorProperty::_update_property_bg() {
 			}
 		}
 		add_theme_style_override(SNAME("DictionaryAddItem"), get_theme_stylebox("DictionaryAddItem" + itos(sub_inspector_color_level), EditorStringName(EditorStyles)));
-		if (delimitate_all_container_and_resources || is_colored(nested_color_mode)) {
-			bottom_editor->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("sub_inspector_bg" + itos(sub_inspector_color_level), EditorStringName(EditorStyles)));
-		} else {
-			bottom_editor->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles)));
+		if (!(delimitate_all_container_and_resources || is_colored(nested_color_mode))) {
 			sub_inspector_color_level = -1;
 		}
 	} else {
@@ -993,9 +1033,18 @@ void EditorProperty::set_draw_label(bool p_draw_label) {
 	queue_redraw();
 	queue_sort();
 }
+void EditorProperty::set_draw_label_inverted(bool p_draw_label_inverted) {
+	draw_label_inverted = p_draw_label_inverted;
+	queue_redraw();
+	queue_sort();
+}
 
 bool EditorProperty::is_draw_label() const {
 	return draw_label;
+}
+
+bool EditorProperty::is_draw_label_inverted() const {
+	return draw_label_inverted;
 }
 
 void EditorProperty::set_draw_background(bool p_draw_background) {
@@ -1005,6 +1054,29 @@ void EditorProperty::set_draw_background(bool p_draw_background) {
 
 bool EditorProperty::is_draw_background() const {
 	return draw_background;
+}
+
+void EditorProperty::set_force_borders(bool p_force_borders) {
+	if (has_borders) {
+		return; // If borders are already enabled, no need to force them.
+	}
+	if (force_borders == p_force_borders) {
+		return;
+	}
+	force_borders = p_force_borders;
+	if (is_inside_tree()) {
+		if (has_borders_enabled()) {
+			get_parent()->connect(SceneStringName(theme_changed), callable_mp(this, &EditorProperty::_update_property_bg));
+		} else {
+			get_parent()->disconnect(SceneStringName(theme_changed), callable_mp(this, &EditorProperty::_update_property_bg));
+		}
+		_update_property_bg();
+	}
+	queue_redraw();
+}
+
+bool EditorProperty::has_borders_enabled() const {
+	return has_borders || force_borders;
 }
 
 void EditorProperty::set_checkable(bool p_checkable) {
@@ -1321,7 +1393,7 @@ HBoxContainer *EditorProperty::get_inline_container(InlineControlSide p_side) {
 
 void EditorProperty::set_bottom_editor(Control *p_control) {
 	bottom_editor = p_control;
-	if (has_borders) {
+	if (has_borders_enabled()) {
 		_update_property_bg();
 	}
 }
@@ -4001,7 +4073,9 @@ void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_ca
 	if (p_control == parent_inspector) {
 		// Only initialize for the inspector, as stand-alone properties won't need it.
 		for (int i = 0; i <= 16; i++) {
-			p_cache.sub_inspector_background[i] = p_control->get_theme_stylebox("sub_inspector_property_bg" + itos(i), EditorStringName(EditorStyles));
+			p_cache.sub_inspector_property_background[i] = p_control->get_theme_stylebox("sub_inspector_property_bg" + itos(i), EditorStringName(EditorStyles));
+			p_cache.sub_inspector_background[i] = p_control->get_theme_stylebox("sub_inspector_bg" + itos(i), EditorStringName(EditorStyles));
+			p_cache.sub_inspector_background_inverted[i] = p_control->get_theme_stylebox("sub_inspector_bg_inverted" + itos(i), EditorStringName(EditorStyles));
 		}
 	}
 }

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -80,7 +80,9 @@ protected:
 		Ref<StyleBox> background_selected;
 		Ref<StyleBox> child_background;
 		Ref<StyleBox> hover;
+		Ref<StyleBox> sub_inspector_property_background[17];
 		Ref<StyleBox> sub_inspector_background[17];
+		Ref<StyleBox> sub_inspector_background_inverted[17];
 
 		Ref<Texture2D> key_icon;
 		Ref<Texture2D> key_next_icon;
@@ -154,6 +156,7 @@ private:
 	int property_usage;
 
 	bool draw_label = true;
+	bool draw_label_inverted = false;
 	bool draw_background = true;
 	bool read_only = false;
 	bool checkable = false;
@@ -217,6 +220,7 @@ private:
 
 protected:
 	bool has_borders = false;
+	bool force_borders = false;
 	bool can_override = false;
 	bool bottom_editor_seperation = false;
 
@@ -250,10 +254,17 @@ public:
 	bool is_read_only() const;
 
 	void set_draw_label(bool p_draw_label);
+	void set_draw_label_inverted(bool p_draw_label_inverted);
 	bool is_draw_label() const;
+	bool is_draw_label_inverted() const;
 
 	void set_draw_background(bool p_draw_background);
 	bool is_draw_background() const;
+
+	void set_force_borders(bool p_force_borders);
+	bool get_force_borders() const { return force_borders; }
+
+	bool has_borders_enabled() const;
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -117,9 +117,13 @@ bool EditorPropertyDictionaryObject::_set(const StringName &p_name, const Varian
 
 	if (name.begins_with("indices")) {
 		dict = dict.duplicate();
-		int index = name.get_slicec('/', 1).to_int();
-		Variant key = dict.get_key_at_index(index);
-		dict[key] = p_value;
+		int index = name.get_slicec('_', 1).to_int();
+		if (index == editing_key_index) {
+			set_edited_key(p_value);
+		} else {
+			Variant key = dict.get_key_at_index(index);
+			dict[key] = p_value;
+		}
 		return true;
 	}
 
@@ -137,39 +141,45 @@ bool EditorPropertyDictionaryObject::_get(const StringName &p_name, Variant &r_r
 }
 
 bool EditorPropertyDictionaryObject::get_by_property_name(const String &p_name, Variant &r_ret) const {
-	String name = p_name;
-
-	if (name == "new_item_key") {
+	if (p_name == "new_item_key") {
 		r_ret = new_item_key;
 		return true;
 	}
 
-	if (name == "new_item_value") {
+	if (p_name == "new_item_value") {
 		r_ret = new_item_value;
 		return true;
 	}
 
-	if (name == "new_item_key_name") {
+	if (p_name == "new_item_key_name") {
 		r_ret = TTR("New Key:");
 		return true;
 	}
 
-	if (name == "new_item_value_name") {
+	if (p_name == "new_item_value_name") {
 		r_ret = TTR("New Value:");
 		return true;
 	}
 
-	if (name.begins_with("indices")) {
-		int index = name.get_slicec('/', 1).to_int();
-		Variant key = dict.get_key_at_index(index);
-		r_ret = dict[key];
+	if (p_name.begins_with("indices")) {
+		int index = p_name.get_slicec('_', 1).to_int();
+		if (index == editing_key_index) {
+			r_ret = edited_key;
+		} else {
+			Variant key = dict.get_key_at_index(index);
+			r_ret = dict[key];
+		}
 		return true;
 	}
 
-	if (name.begins_with("keys")) {
-		int index = name.get_slicec('/', 1).to_int();
+	if (p_name.begins_with("keys")) {
+		int index = p_name.get_slicec('_', 1).to_int();
 		Variant key = dict.get_key_at_index(index);
-		r_ret = key;
+		if (index == editing_key_index) {
+			r_ret = dict[key];
+		} else {
+			r_ret = key;
+		}
 		return true;
 	}
 
@@ -207,7 +217,7 @@ String EditorPropertyDictionaryObject::get_property_name_for_index(int p_index) 
 		case NEW_VALUE_INDEX:
 			return "new_item_value";
 		default:
-			return "indices/" + itos(p_index);
+			return "indices_" + itos(p_index);
 	}
 }
 
@@ -218,7 +228,7 @@ String EditorPropertyDictionaryObject::get_key_name_for_index(int p_index) {
 		case NEW_VALUE_INDEX:
 			return "new_item_value_name";
 		default:
-			return "keys/" + itos(p_index);
+			return "keys_" + itos(p_index);
 	}
 }
 
@@ -234,6 +244,46 @@ String EditorPropertyDictionaryObject::get_label_for_index(int p_index) {
 			return dict.get_key_at_index(p_index).get_construct_string();
 			break;
 	}
+}
+void EditorPropertyDictionaryObject::set_edited_key(const Variant &p_edited_key) {
+	edited_key = p_edited_key;
+	if (!dict.has(edited_key)) {
+		Variant old_key = dict.get_key_at_index(editing_key_index);
+		dict.replace_key(old_key, edited_key);
+	}
+}
+
+Variant EditorPropertyDictionaryObject::get_edited_key() {
+	return edited_key;
+}
+
+bool EditorPropertyDictionaryObject::has_unsaved_edited_key() {
+	return editing_key_index > -1 && edited_key != dict.get_key_at_index(editing_key_index);
+}
+
+void EditorPropertyDictionaryObject::edit_key_at_index(int p_index) {
+	if (p_index == editing_key_index) {
+		editing_key_index = NEW_KEY_INDEX - 1;
+		edited_key = Variant();
+	} else {
+		editing_key_index = p_index;
+		edited_key = dict.get_key_at_index(p_index);
+	}
+}
+
+int EditorPropertyDictionaryObject::get_editing_key_index() {
+	return editing_key_index;
+}
+
+String EditorPropertyDictionaryObject::_get_property_warning(const StringName &p_property) {
+	if (p_property == get_property_name_for_index(editing_key_index) && has_unsaved_edited_key()) {
+		return "The currently edited key has conflict with an already existing key!";
+	}
+	return "";
+}
+
+void EditorPropertyDictionaryObject::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &EditorPropertyDictionaryObject::_get_property_warning);
 }
 
 ///////////////////// ARRAY ///////////////////////////
@@ -461,16 +511,13 @@ void EditorPropertyArray::update_property() {
 		updating = true;
 
 		if (!container) {
-			container = memnew(PanelContainer);
+			container = memnew(VBoxContainer);
+			container->set_theme_type_variation(SNAME("EditorPropertyContainer"));
 			add_child(container);
 			set_bottom_editor(container);
 
-			VBoxContainer *vbox = memnew(VBoxContainer);
-			vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
-			container->add_child(vbox);
-
 			HBoxContainer *hbox = memnew(HBoxContainer);
-			vbox->add_child(hbox);
+			container->add_child(hbox);
 
 			Label *size_label = memnew(Label(TTR("Size:")));
 			size_label->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -489,7 +536,7 @@ void EditorPropertyArray::update_property() {
 			property_vbox = memnew(VBoxContainer);
 			property_vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
-			vbox->add_child(property_vbox);
+			container->add_child(property_vbox);
 
 			button_add_item = memnew(EditorInspectorActionButton(TTRC("Add Element"), SNAME("Add")));
 			button_add_item->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_add_element));
@@ -497,11 +544,11 @@ void EditorPropertyArray::update_property() {
 			SET_DRAG_FORWARDING_CD(button_add_item, EditorPropertyArray);
 			button_add_item->set_disabled(is_read_only());
 			button_add_item->set_accessibility_name(TTRC("Add"));
-			vbox->add_child(button_add_item);
+			container->add_child(button_add_item);
 
 			paginator = memnew(EditorPaginator);
 			paginator->connect("page_changed", callable_mp(this, &EditorPropertyArray::_page_changed));
-			vbox->add_child(paginator);
+			container->add_child(paginator);
 
 			for (int i = 0; i < page_length; i++) {
 				_create_new_property_slot();
@@ -1059,12 +1106,19 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 		update_property();
 	}
 }
+void EditorPropertyDictionary::edit_key_at_slot_index(int p_slot_index) {
+	int index = slots[p_slot_index].index;
+	object->edit_key_at_index(index);
+	update_property();
+}
 
 void EditorPropertyDictionary::_change_type(Object *p_button, int p_slot_index) {
 	Button *button = Object::cast_to<Button>(p_button);
 	int index = slots[p_slot_index].index;
 	Rect2 rect = button->get_screen_rect();
 	change_type->set_item_disabled(change_type->get_item_index(Variant::VARIANT_MAX), index < 0);
+	change_type->set_item_disabled(change_type->get_item_index(MENU_EDIT_KEY), index < 0);
+	change_type->set_item_text(change_type->get_item_index(MENU_EDIT_KEY), index == object->get_editing_key_index() ? "Edit Value" : "Edit Key");
 	change_type->reset_size();
 	change_type->set_position(rect.get_end() - Vector2(change_type->get_contents_minimum_size().x, 0));
 	change_type->popup();
@@ -1100,23 +1154,16 @@ void EditorPropertyDictionary::_add_key_value() {
 void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 	HBoxContainer *hbox = memnew(HBoxContainer);
 
-	EditorProperty *prop_key = nullptr;
-	if (p_idx != EditorPropertyDictionaryObject::NEW_KEY_INDEX && p_idx != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
-		prop_key = memnew(EditorPropertyNil);
-	}
-
 	EditorProperty *prop = memnew(EditorPropertyNil);
 	prop->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbox->add_child(prop);
-	if (prop_key) {
-		prop->add_inline_control(prop_key, INLINE_CONTROL_LEFT);
-	}
 
 	bool use_key = p_idx == EditorPropertyDictionaryObject::NEW_KEY_INDEX;
 	bool is_untyped_dict = (use_key ? key_subtype : value_subtype) == Variant::NIL;
 
 	Button *edit_btn = nullptr;
 	Button *remove_btn = nullptr;
+	Button *edit_key_btn = nullptr;
 	if (is_untyped_dict) {
 		edit_btn = memnew(Button);
 		edit_btn->set_accessibility_name(TTRC("Edit"));
@@ -1133,6 +1180,14 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 		remove_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
 		remove_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_remove_pressed).bind(slots.size()));
 		prop->add_inline_control(remove_btn, INLINE_CONTROL_RIGHT);
+
+		edit_key_btn = memnew(Button);
+		edit_key_btn->set_accessibility_name(TTRC("Edit Key"));
+		edit_key_btn->set_button_icon(EditorIconManager::get_icon(SNAME("Edit")));
+		edit_key_btn->set_disabled(is_read_only());
+		edit_key_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
+		edit_key_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::edit_key_at_slot_index).bind(slots.size()));
+		prop->add_inline_control(edit_key_btn, INLINE_CONTROL_RIGHT);
 	}
 
 	if (add_panel) {
@@ -1143,11 +1198,11 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 
 	Slot slot;
 	slot.prop = prop;
-	slot.prop_key = prop_key;
 	slot.object = object;
 	slot.container = hbox;
 	slot.edit_button = edit_btn;
 	slot.remove_button = remove_btn;
+	slot.edit_key_button = edit_key_btn;
 	int index = p_idx + (p_idx >= 0 ? page_index * page_length : 0);
 	slot.set_index(index);
 	slots.push_back(slot);
@@ -1172,20 +1227,27 @@ void EditorPropertyDictionary::_change_type_menu(int p_index) {
 			break;
 
 		default:
-			Dictionary dict = object->get_dict().duplicate();
-			Variant key = dict.get_key_at_index(changing_type_index);
-			if (p_index < Variant::VARIANT_MAX) {
-				VariantInternal::initialize(&value, Variant::Type(p_index));
-				dict[key] = value;
-			} else {
-				dict.erase(key);
-				object->set_dict(dict);
-				for (Slot &slot : slots) {
-					slot.update_prop_or_index();
-				}
-			}
+			Dictionary dict;
+			Variant key;
+			switch (p_index) {
+				case MENU_EDIT_KEY:
+					object->edit_key_at_index(changing_type_index);
+					update_property();
+					break;
 
-			emit_changed(get_edited_property(), dict);
+				case Variant::VARIANT_MAX:
+					dict = object->get_dict().duplicate();
+					key = dict.get_key_at_index(changing_type_index);
+					dict.erase(key);
+					emit_changed(get_edited_property(), dict);
+					break;
+
+				default:
+					VariantInternal::initialize(&value, Variant::Type(p_index));
+					object->set("indices_" + itos(changing_type_index), value);
+					emit_changed(get_edited_property(), object->get_dict());
+					break;
+			}
 	}
 }
 
@@ -1331,22 +1393,19 @@ void EditorPropertyDictionary::update_property() {
 		updating = true;
 
 		if (!container) {
-			container = memnew(PanelContainer);
+			container = memnew(VBoxContainer);
+			container->set_theme_type_variation(SNAME("EditorPropertyContainer"));
 			add_child(container);
 			set_bottom_editor(container);
-
-			VBoxContainer *vbox = memnew(VBoxContainer);
-			vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
-			container->add_child(vbox);
 
 			property_vbox = memnew(VBoxContainer);
 			property_vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
-			vbox->add_child(property_vbox);
+			container->add_child(property_vbox);
 
 			paginator = memnew(EditorPaginator);
 			paginator->connect("page_changed", callable_mp(this, &EditorPropertyDictionary::_page_changed));
-			vbox->add_child(paginator);
+			container->add_child(paginator);
 
 			for (int i = 0; i < page_length; i++) {
 				_create_new_property_slot(slots.size());
@@ -1389,8 +1448,10 @@ void EditorPropertyDictionary::update_property() {
 				continue;
 			}
 
+			slot.set_editing_key(slot.index == object->get_editing_key_index());
+
 			// Check if the editor property key needs to be updated.
-			if (slot.prop_key) {
+			if (slot.index >= 0) {
 				Variant key;
 				object->get_by_property_name(slot.key_name, key);
 				Variant::Type key_type = key.get_type();
@@ -1426,21 +1487,22 @@ void EditorPropertyDictionary::update_property() {
 						dict_prop->set_preview_value(true);
 					}
 					slot.set_key_prop(new_prop);
-					if (slot.prop) {
-						slot.prop->add_inline_control(new_prop, INLINE_CONTROL_LEFT);
-					}
 				}
 			}
 
 			Variant value;
 			object->get_by_property_name(slot.prop_name, value);
 
-			Variant::Type value_type;
+			Variant::Type value_type = value.get_type();
 
-			if (dict.is_typed_value() && value_subtype != Variant::NIL && slot.prop_key) {
-				value_type = value_subtype;
-			} else {
-				value_type = value.get_type();
+			if (dict.is_typed_value()) {
+				if (slot.editing_key || slot.index == EditorPropertyDictionaryObject::NEW_KEY_INDEX) {
+					if (key_subtype != Variant::NIL) {
+						value_type = key_subtype;
+					}
+				} else if (value_subtype != Variant::NIL) {
+					value_type = value_subtype;
+				}
 			}
 
 			// Check if the editor property needs to be updated.
@@ -1454,7 +1516,7 @@ void EditorPropertyDictionary::update_property() {
 					editor->setup("Object");
 					new_prop = editor;
 				} else {
-					bool use_key = slot.index == EditorPropertyDictionaryObject::NEW_KEY_INDEX;
+					bool use_key = slot.index == EditorPropertyDictionaryObject::NEW_KEY_INDEX || slot.index == object->get_editing_key_index();
 					new_prop = EditorInspector::instantiate_property_editor(this, value_type, "", use_key ? key_subtype_hint : value_subtype_hint,
 							use_key ? key_subtype_hint_string : value_subtype_hint_string, PROPERTY_USAGE_NONE);
 				}
@@ -1471,16 +1533,6 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_label_overlayed(true);
 				}
 				new_prop->set_read_only(is_read_only());
-				if (slot.remove_button) {
-					new_prop->add_inline_control(slot.remove_button, INLINE_CONTROL_RIGHT);
-				}
-				if (slot.edit_button) {
-					new_prop->add_inline_control(slot.edit_button, INLINE_CONTROL_RIGHT);
-				}
-				if (slot.prop_key) {
-					new_prop->add_inline_control(slot.prop_key, INLINE_CONTROL_LEFT);
-				}
-
 				slot.set_prop(new_prop);
 
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
@@ -1497,6 +1549,7 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			slot.prop->update_property();
+			slot.prop->update_editor_property_status();
 			if (slot.prop_key) {
 				slot.prop_key->update_property();
 			}
@@ -1589,6 +1642,8 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	button_add_item = nullptr;
 	paginator = nullptr;
 	change_type = memnew(EditorVariantTypePopupMenu(true));
+	change_type->add_icon_item(EditorIconManager::get_icon(SNAME("Edit")), TTR("Edit Key"), MENU_EDIT_KEY);
+	change_type->set_item_index(change_type->get_item_index(MENU_EDIT_KEY), 0);
 	add_child(change_type);
 	change_type->connect(SceneStringName(id_pressed), callable_mp(this, &EditorPropertyDictionary::_change_type_menu));
 	changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -62,6 +62,8 @@ class EditorPropertyDictionaryObject : public RefCounted {
 	Variant new_item_key;
 	Variant new_item_value;
 	Dictionary dict;
+	Variant edited_key;
+	int editing_key_index = NEW_KEY_INDEX - 1;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -84,9 +86,23 @@ public:
 	void set_new_item_value(const Variant &p_new_item);
 	Variant get_new_item_value();
 
+	void set_edited_key(const Variant &p_edited_key);
+	Variant get_edited_key();
+
+	bool has_unsaved_edited_key();
+
+	void edit_key_at_index(int p_index);
+	int get_editing_key_index();
+
 	String get_label_for_index(int p_index);
 	String get_property_name_for_index(int p_index);
 	String get_key_name_for_index(int p_index);
+
+	void set_layout_direction_on_child(Node *node, bool p_editing_key = true);
+
+	bool has_unsaved_edited_key() const;
+	String _get_property_warning(const StringName &p_property);
+	static void _bind_methods();
 };
 
 class EditorPropertyArray : public EditorProperty {
@@ -118,7 +134,7 @@ class EditorPropertyArray : public EditorProperty {
 	int page_index = 0;
 	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
 	Button *edit = nullptr;
-	PanelContainer *container = nullptr;
+	VBoxContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 	EditorSpinSlider *size_slider = nullptr;
 	Button *button_add_item = nullptr;
@@ -192,9 +208,19 @@ class EditorPropertyDictionary : public EditorProperty {
 		EditorProperty *prop = nullptr;
 		EditorProperty *prop_key = nullptr;
 		Button *edit_button = nullptr;
+		Button *edit_key_button = nullptr;
 		Button *remove_button = nullptr;
 		String prop_name;
 		String key_name;
+		bool editing_key = false;
+
+		void set_editing_key(bool p_editing_key) {
+			if (editing_key == p_editing_key) {
+				return;
+			}
+			editing_key = p_editing_key;
+			update_prop_or_index();
+		}
 
 		void set_index(int p_idx) {
 			index = p_idx;
@@ -212,11 +238,10 @@ class EditorPropertyDictionary : public EditorProperty {
 
 		void set_key_prop(EditorProperty *p_prop) {
 			if (prop_key) {
-				prop_key->add_sibling(p_prop);
 				prop_key->queue_free();
-				prop_key = p_prop;
-				update_prop_or_index();
 			}
+			prop_key = p_prop;
+			update_prop_or_index();
 		}
 
 		void update_prop_or_index() {
@@ -226,8 +251,25 @@ class EditorPropertyDictionary : public EditorProperty {
 			} else {
 				prop->set_label(object->get_label_for_index(index));
 			}
+			prop->set_force_borders(editing_key);
+			if (prop_key) {
+				prop->add_inline_control(prop_key, editing_key ? INLINE_CONTROL_RIGHT : INLINE_CONTROL_LEFT);
+				prop->set_draw_label_inverted(editing_key);
+			}
+
+			if (edit_key_button) {
+				prop->add_inline_control(edit_key_button, INLINE_CONTROL_RIGHT);
+			}
+			if (remove_button) {
+				prop->add_inline_control(remove_button, INLINE_CONTROL_RIGHT);
+			}
+			if (edit_button) {
+				prop->add_inline_control(edit_button, INLINE_CONTROL_RIGHT);
+			}
 		}
 	};
+
+	static constexpr int MENU_EDIT_KEY = Variant::VARIANT_MAX + 1;
 
 	EditorVariantTypePopupMenu *change_type = nullptr;
 	bool updating = false;
@@ -238,7 +280,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	int page_index = 0;
 	int changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
 	Button *edit = nullptr;
-	PanelContainer *container = nullptr;
+	VBoxContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 	PanelContainer *add_panel = nullptr;
 	Button *button_add_item = nullptr;
@@ -249,6 +291,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	void _page_changed(int p_page);
 	void _edit_pressed();
 	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
+	void edit_key_at_slot_index(int p_slot_index);
 	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _change_type(Object *p_button, int p_slot_index);
 	void _change_type_menu(int p_index);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2466,19 +2466,21 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Sub-inspector background.
 			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
 			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
-			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
-			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+			sub_inspector_bg->set_border_width_all(0);
+
+			Ref<StyleBoxFlat> sub_inspector_bg_inverted = sub_inspector_bg->duplicate();
+
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
+			sub_inspector_bg_inverted->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+			sub_inspector_bg_inverted->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 			p_theme->set_stylebox("sub_inspector_bg" + itos(i + 1), EditorStringName(EditorStyles), sub_inspector_bg);
+			p_theme->set_stylebox("sub_inspector_bg_inverted" + itos(i + 1), EditorStringName(EditorStyles), sub_inspector_bg_inverted);
 
 			// EditorProperty background while it has a sub-inspector open.
 			Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(si_base_color * Color(0.7, 0.7, 0.7, 0.8), 0, 0, 0, 0, p_config.corner_radius);
 			bg_color->set_anti_aliased(false);
-			bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-			bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
 
@@ -2495,26 +2497,24 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("sub_inspector_color_category_bg" + itos(i + 1), EditorStringName(EditorStyles), category_bg_sub_color);
 
 			// Dictionary editor add item.
-			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
 
 			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
 			Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
-			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
 			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
 		}
 		Color si_base_color = p_config.accent_color;
 
 		// Sub-inspector background.
-		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
-		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
-		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
-		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
-		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+		Ref<StyleBoxFlat> sub_inspector_bg = style_property_child_bg->duplicate();
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
+		Ref<StyleBoxFlat> sub_inspector_bg_inverted = style_property_child_bg->duplicate();
+		sub_inspector_bg_inverted->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		sub_inspector_bg_inverted->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+
 		p_theme->set_stylebox("sub_inspector_bg0", EditorStringName(EditorStyles), sub_inspector_bg);
+		p_theme->set_stylebox("sub_inspector_bg_inverted0", EditorStringName(EditorStyles), sub_inspector_bg_inverted);
 
 		// Sub-inspector background no border.
 
@@ -2526,8 +2526,6 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// EditorProperty background while it has a sub-inspector open.
 		Ref<StyleBoxFlat> bg_color = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1.lerp(si_base_color, 0.15), 0, 0, 0, 0, p_config.corner_radius);
 		bg_color->set_anti_aliased(false);
-		bg_color->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 		p_theme->set_stylebox("sub_inspector_property_bg0", EditorStringName(EditorStyles), bg_color);
 


### PR DESCRIPTION
Supersedes #90258 

This started as a salvage of this previous PR as I was reminded of it but in the end I went way farther and improve quite a bit how it looks.
I've made it so that when editing the key the editor property is reversed which means label is on the right, main editor is on the left and bottom editor is on top.

As in some cases having some bottom editor on top made it somewhat unreadable I added a border through th esame system of border as for object,array and dict.

I would really like to have feedback from a usability standpoint if it makes sense, if anyone would have ideas to improve or find anything that doesn't work well with my solution.

For now this is marked as draft as I haven't made the change to the classic theme and will wait for usability feedback before applying the changes.

Here are a few screenshots of how it looks like in modern theme :
<img width="349" height="316" alt="Capture d’écran 2026-05-02 à 03 09 27" src="https://github.com/user-attachments/assets/f5f7bab0-8d8b-4c14-a853-4b6e6230e494" />
<img width="342" height="680" alt="Capture d’écran 2026-05-02 à 03 08 39" src="https://github.com/user-attachments/assets/c39e7b9d-7344-4028-b0b1-6e31545cabe0" />

<img width="189" height="186" alt="Capture d’écran 2026-05-02 à 03 10 11" src="https://github.com/user-attachments/assets/940af213-cf15-4502-b420-dbea7f846744" />
<img width="191" height="144" alt="Capture d’écran 2026-05-02 à 03 10 01" src="https://github.com/user-attachments/assets/a3fad96f-91d5-4c67-aa2f-1b7e5ebbcc75" />

<img width="592" height="117" alt="Capture d’écran 2026-05-02 à 03 17 18" src="https://github.com/user-attachments/assets/cdd740e4-2184-4476-9e8f-0089a2b8fa55" />
