### PR TITLE
Add better error message when trying to decompress ZSTD with `decompress_dynamic`

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -291,7 +291,7 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int64_t p_max_d
 #endif
 	} else {
 		// This function only supports GZip and Deflate.
-		ERR_FAIL_COND_V(p_mode != MODE_DEFLATE && p_mode != MODE_GZIP, Z_ERRNO);
+		ERR_FAIL_COND_V_MSG(p_mode != MODE_DEFLATE && p_mode != MODE_GZIP, Z_ERRNO, "Dynamic decompression is only supported with gzip, DEFLATE, and Brotli compression methods.");
 
 		int ret;
 		z_stream strm;


### PR DESCRIPTION
Right now, if you try to decompress ZSTD using `decompress_dynamic`, Godot will throw an error ```Condition "p_mode != MODE_DEFLATE && p_mode != MODE_GZIP" is true. Returning: (-1)```.

It's long, intimidating, and not obvious for developer what did they do wrong.

With this commit, trying to call `decompress_dynamic` with ZSTD compression will throw a more useful error `Dynamic decompression is only supported with gzip, DEFLATE, and Brotli compression methods.`

---

While documentation does mention that only gzip, DEFLATE, and Brotli are supported, it's possible that developer might not notice that, reuse existing code, or use code provided by an LLM.