### PR TITLE
Fix `TileSet` editor terrain preview icons in paint mode

### DIFF
--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1891,7 +1891,6 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 		terrain_property_editor->hide();
 	} else {
 		options.clear();
-		Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2(16, 16) * EDSCALE);
 		options.push_back(String(TTR("No terrain")) + String(":-1"));
 		for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
 			String name = tile_set->get_terrain_name(terrain_set, i);
@@ -1904,11 +1903,16 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 		terrain_property_editor->setup(options);
 		terrain_property_editor->update_property();
 
+		const Size2i terrain_icon_size = Size2(16, 16) * EDSCALE;
 		// Kind of a hack to set icons.
 		// We could provide a way to modify that in the EditorProperty.
 		OptionButton *option_button = terrain_property_editor->get_option_button();
 		for (int terrain = 0; terrain < tile_set->get_terrains_count(terrain_set); terrain++) {
-			option_button->set_item_icon(terrain + 1, icons[terrain_set][terrain]);
+			Ref<Image> img = Image::create_empty(1, 1, false, Image::FORMAT_RGBA8);
+			img->set_pixel(0, 0, tile_set->get_terrain_color(terrain_set, terrain));
+			Ref<ImageTexture> icon = ImageTexture::create_from_image(img);
+			icon->set_size_override(terrain_icon_size);
+			option_button->set_item_icon(terrain + 1, icon);
 		}
 		terrain_property_editor->show();
 	}


### PR DESCRIPTION
Fixes #119155.

Makes the terrain icons in the TileSet editor paint mode show the terrains' assigned colors instead of "most fitting tiles" (which is also used in TileMap -> Terrains tab (see https://github.com/godotengine/godot/issues/119155#issuecomment-4363900868)).


Before<br>v4.6.2.stable.official [71f334935]|After<br>(this PR)
-|-
<img width="566" height="281" alt="Godot_v4 6 2-stable_win64_yg86cnUXMp" src="https://github.com/user-attachments/assets/3cfcc493-00e2-4b5c-babb-087cb02ade9b" />|<img width="566" height="281" alt="lZfHN1wNfe" src="https://github.com/user-attachments/assets/fcd314de-a4fd-4656-a701-4922e9339ff6" />

---

Note the modulation of the icon when the OptionButton is selected, this might need changing/fixing too. Anyway, it's the same before/after, for potential another PR.

https://github.com/user-attachments/assets/0b579670-9f08-47a7-9ca4-c75f4ff72c86


