### PR TITLE
Fix pragma includes

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1024,12 +1024,12 @@ public:
 	}
 
 	template <typename U = T, std::enable_if_t<std::is_base_of_v<RefCounted, U>, int> = 0>
-	_FORCE_INLINE_ element_type *ptr() const {
+	_FORCE_INLINE_ T *ptr() const {
 		return *_value;
 	}
 
 	template <typename U = T, std::enable_if_t<!std::is_base_of_v<RefCounted, U>, int> = 0>
-	_FORCE_INLINE_ element_type *ptr() const {
+	_FORCE_INLINE_ T *ptr() const {
 		return _value;
 	}
 
@@ -1042,11 +1042,11 @@ public:
 		return Ref<T_Other>(_value);
 	}
 
-	_FORCE_INLINE_ element_type *operator*() const {
+	_FORCE_INLINE_ T *operator*() const {
 		return ptr();
 	}
 
-	_FORCE_INLINE_ element_type *operator->() const {
+	_FORCE_INLINE_ T *operator->() const {
 		return ptr();
 	}
 };

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/image.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/string/translation_server.h"
 #include "editor/editor_string_names.h"
 #include "editor/run/editor_run_bar.h"

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/image.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/string/translation_server.h"
 #include "editor/editor_string_names.h"
 #include "editor/run/editor_run_bar.h"

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -31,7 +31,6 @@
 #include "editor_dock_manager.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/docks/dock_tab_container.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/editor_node.h"

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/settings/editor_settings.h"
 #include "scene/main/timer.h"
 

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -34,7 +34,6 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -31,7 +31,6 @@
 #include "editor_dir_dialog.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/docks/filesystem_dock.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/directory_create_dialog.h"

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -31,7 +31,6 @@
 #include "window_wrapper.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/progress_dialog.h"

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -36,7 +36,6 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
-#include "core/variant/typed_dictionary.h" // IWYU pragma: keep. For EditorDebuggerRemoteObjects.
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc/doc_tools.h"

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -34,7 +34,6 @@
 #include "core/io/dir_access.h"
 #include "core/io/resource_saver.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/object/script_language.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"

--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/json.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_string_names.h"

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -34,7 +34,6 @@
 #include "core/io/dir_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_node.h"

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -34,7 +34,6 @@
 #include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/version.h"

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -31,7 +31,6 @@
 #include "quick_settings_dialog.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/doc/editor_help.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/editor_properties.h"

--- a/editor/project_upgrade/project_upgrade_tool.cpp
+++ b/editor/project_upgrade/project_upgrade_tool.cpp
@@ -35,7 +35,6 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/scene/editor_scene_tabs.h"

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -33,7 +33,6 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_node.h"

--- a/editor/run/editor_run_native.cpp
+++ b/editor/run/editor_run_native.cpp
@@ -31,7 +31,6 @@
 #include "editor_run_native.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_node.h"
 #include "editor/export/editor_export.h"
 #include "editor/export/editor_export_platform.h"

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "editor/editor_string_names.h"
 #include "scene/main/timer.h"

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/process_id.h"
 #include "core/string/translation_server.h"
 #include "editor/debugger/editor_debugger_node.h"

--- a/editor/scene/2d/tiles/tile_atlas_view.cpp
+++ b/editor/scene/2d/tiles/tile_atlas_view.cpp
@@ -31,7 +31,6 @@
 #include "tile_atlas_view.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/tile_map_layer.h"

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"

--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -31,7 +31,6 @@
 #include "control_editor_plugin.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/canvas_item_editor_plugin.h"

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/texture/color_channel_selector.cpp
+++ b/editor/scene/texture/color_channel_selector.cpp
@@ -31,7 +31,6 @@
 #include "color_channel_selector.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -31,7 +31,6 @@
 #include "action_map_editor.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_event_search_bar.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/settings/editor_event_search_bar.cpp
+++ b/editor/settings/editor_event_search_bar.cpp
@@ -31,7 +31,6 @@
 #include "editor_event_search_bar.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/settings/event_listener_line_edit.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"

--- a/editor/settings/editor_layouts_dialog.cpp
+++ b/editor/settings/editor_layouts_dialog.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/item_list.h"

--- a/editor/settings/event_listener_line_edit.cpp
+++ b/editor/settings/event_listener_line_edit.cpp
@@ -32,7 +32,6 @@
 
 #include "core/input/input_map.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
 #include "scene/gui/dialogs.h"
 #include "servers/display/accessibility_server.h"

--- a/editor/translations/editor_locale_dialog.cpp
+++ b/editor/translations/editor_locale_dialog.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/string/translation_server.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/themes/editor_scale.h"

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/editor_string_names.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/settings/editor_settings.h"

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "replication_editor.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"

--- a/modules/objectdb_profiler/snapshot_collector.cpp
+++ b/modules/objectdb_profiler/snapshot_collector.cpp
@@ -37,7 +37,7 @@
 #include "core/version.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h" // IWYU pragma: keep. Used via `get_root()`.
+#include "scene/main/window.h" // IWYU pragma: keep. FIXME: Couldn't figure out how to make RequiredResult<T> equality checks be analyzed properly by include-cleaner.
 
 void SnapshotCollector::initialize() {
 	pending_snapshots.clear();

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -31,7 +31,6 @@
 #include "openxr_select_action_dialog.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -34,7 +34,6 @@
 #include "../openxr_api.h"
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/themes/editor_scale.h"
 
 void OpenXRSelectInteractionProfileDialog::_bind_methods() {

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -49,7 +49,7 @@
 #include "scene/debugger/scene_debugger_object.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h" // SceneTree:get_root()
+#include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -35,7 +35,6 @@
 #include "core/config/engine.h"
 #include "core/input/input.h"
 #include "core/input/shortcut.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h" // IWYU pragma: keep. Needed to get the mouse position from the root window.
 

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -36,7 +36,7 @@
 #include "core/input/input.h"
 #include "core/input/shortcut.h"
 #include "scene/main/scene_tree.h"
-#include "scene/main/window.h" // IWYU pragma: keep. Needed to get the mouse position from the root window.
+#include "scene/main/window.h"
 
 using namespace View3DControllerConsts;
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "scene/gui/panel.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"


### PR DESCRIPTION
This PR accomplishes two things:
* Remove the now unnecessary `#include "core/object/class_db.h" // IWYU pragma: keep. ADD_SIGNAL macro.` includes. These are unnecessary since #117474 removed the `ClassDB` dependency for that macro. 
  * There's also one other include which I could remove which isn't `class_db.h`, I'm grouping it in this "one thing". 
* Removes the `using element_type = T` from `RequiredParam`/`RequiredResult` templates. `clangd-tidy`'s include cleaner just doesn't like that. So it's gone, and now it won't trigger unused include warnings, with one narrow exception ([see comment](https://github.com/godotengine/godot/pull/119174#issuecomment-4364378370)). 

<details>
<summary> Outdated Part 2 </summary>

* Adds `// IWYU pragma: keep. Used via get_root()` to all of the `window.h` includes, which now need it after #118590. These missing pragmas have been causing a bunch of PR to fail `clangd-tidy` checks for something completely unrelated to their work. 

Some details on 2:
It appears that `clang`'s `include-cleaner` (which `clangd-tidy` uses) has some issues with templates. In these cases, `RequiredResult<T>`. The pragma is only needed if the following conditions are met:
1. The result of the method which returns `RequiredResult<T>` is never stored as `T` or `T *`
2. The methods called on the result are not `T` methods but methods from `T`'s ancestor classes. 
4. Those ancestor classes are included (directly or transitively)

In all cases, it's due to `SceneTree::get_singleton()->get_root()` which returns `RequiredResult<Window>`, and then (in most) being directly used for `add_child()` (which is a `Node` method, and `Node` is pretty much universally included) in the form `SceneTree::get_singleton()->get_root()->add_child()`. 
</details>