### PR TITLE
Don't allow empty strings when splitting `base_directory_path` string

### DIFF
--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -136,7 +136,7 @@ void EditorDirDialog::_notification(int p_what) {
 				}
 
 				tree->deselect_all();
-				const PackedStringArray parts = base_directory_path.trim_prefix("res://").split("/");
+				const PackedStringArray parts = base_directory_path.trim_prefix("res://").split("/", false);
 				if (parts.is_empty()) {
 					break;
 				}


### PR DESCRIPTION
Fixes #118732

See [my commentary](https://github.com/godotengine/godot/issues/118732#issuecomment-4364024479) for the explanation about the bug.