### PR TITLE
Prioritize 'step' in Range property order

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -406,9 +406,9 @@ void Range::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("value_changed", PropertyInfo(Variant::FLOAT, "value")));
 	ADD_SIGNAL(MethodInfo("changed"));
 
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step"), "set_step", "get_step");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_value"), "set_min", "get_min");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_value"), "set_max", "get_max");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step"), "set_step", "get_step");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "page"), "set_page", "get_page");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "value"), "set_value", "get_value");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ratio", PROPERTY_HINT_RANGE, "0,1,0.01", PROPERTY_USAGE_NONE), "set_as_ratio", "get_as_ratio");


### PR DESCRIPTION
In Range the 'min_value' property uses the 'step' property in it's calculation for snapping 'value'. Setting 'step' after 'min_value' causes unexpected behavior. This PR aims to make the editor work with this order in mind.

For example this fixes issue #119137 where the users tries to assign a fractional negative "min_value" and leave "value" at zero. Since the Range assumes that the "step" is 1 while assigning "min_value", it will snap "value" to the nearest integer offset from 'min_value'. In the case of this issue min_value is -0.2, it maps 'value' from 0 to -0.2, even though the user also sets 'step' to 0 .0001 which would include 0 as a valid snapping target, but 'value' has already been snapped to -0.2, before step is assigned.

This stale snapping occurs when launching or saving the project.. reordering step ahead of min_value fixes both of these.

This seems to be the same issue described in #89252