### PR TITLE
Fix wrong `beat_count` set in stream import when it's greater than previous `beat_max`

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -471,6 +471,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 			int beats = config_file->get_value("params", "beat_count", 0);
 			bpm_edit->set_value(bpm > 0 ? bpm : 120);
 			bpm_enabled->set_pressed(bpm > 0);
+			beats_edit->set_max(99999); // Temporarily disable `max` in case current `beat_count` > previously set `beat_max`. It will be set to the appropriate value in `_settings_changed()` right afterwards.
 			beats_edit->set_value(beats);
 			beats_enabled->set_pressed(beats > 0);
 			loop->set_pressed(config_file->get_value("params", "loop", false));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes: https://github.com/godotengine/godot/issues/95697

When streams are loaded in the advanced importer, the max value (`beat_max`) set for `beat_count` is the length of the loaded stream, in beats. This step happens after the `value` is set.
If a new stream is loaded, and its `beat_count` is larger than the `beat_max` set for the previous stream, `beat_count` is capped to `beat_max`. The value is only updated properly if you reopen that stream, since the correct `beat_max` will be set.

This could be solved in a number of different approaches, but I went with the simplest one:
During the creation of the importer, the max value for `beat_count` is set to `99999`. So I simply set the max to that value again, before setting the actual value of `beat_count`. Setting it to the right value is redundant, since it's set afterwards anyway.