### PR TITLE
Free LTC RIDs

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4750,6 +4750,13 @@ void sky() {
 }
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {
+	if (ltc.lut1_texture.is_valid()) {
+		RS::get_singleton()->free_rid(ltc.lut1_texture);
+	}
+	if (ltc.lut2_texture.is_valid()) {
+		RS::get_singleton()->free_rid(ltc.lut2_texture);
+	}
+
 	GLES3::Utilities::get_singleton()->buffer_free_data(scene_state.directional_light_buffer);
 	GLES3::Utilities::get_singleton()->buffer_free_data(scene_state.omni_light_buffer);
 	GLES3::Utilities::get_singleton()->buffer_free_data(scene_state.spot_light_buffer);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Opening and closing an empty project with the compatibility renderer as of 16bb065ac31b79c0ed24b3b944d3b5275123e854 will yield the following:

```
ERROR: 2 RID allocations of type 'N5GLES37TextureE' were leaked at exit.
ERROR: Texture with GL ID of 438: leaked 87376 bytes.
   at: ~Utilities (drivers/gles3/storage/utilities.cpp:82)
ERROR: Texture with GL ID of 439: leaked 87376 bytes.
   at: ~Utilities (drivers/gles3/storage/utilities.cpp:82)
```

Turns out the error above is due to the LTC textures added in #108219 that were not freed.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119190*