### PR TITLE
Fix TileSet tile inspector fold state

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -500,6 +500,24 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 	}
 }
 
+bool TileSetAtlasSourceEditor::AtlasTileProxyObject::is_editing(TileSetAtlasSource *p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles) const {
+	if (tile_set_atlas_source.ptr() != p_tile_set_atlas_source || tiles.size() != p_tiles.size()) {
+		return false;
+	}
+
+	const RBSet<TileSelection>::Element *edited_tile = tiles.front();
+	const RBSet<TileSelection>::Element *tile = p_tiles.front();
+	while (edited_tile && tile) {
+		if (edited_tile->get().tile != tile->get().tile || edited_tile->get().alternative != tile->get().alternative) {
+			return false;
+		}
+		edited_tile = edited_tile->next();
+		tile = tile->next();
+	}
+
+	return edited_tile == nullptr && tile == nullptr;
+}
+
 void TileSetAtlasSourceEditor::AtlasTileProxyObject::edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles) {
 	ERR_FAIL_COND(p_tile_set_atlas_source.is_null());
 	ERR_FAIL_COND(p_tiles.is_empty());
@@ -609,10 +627,20 @@ void TileSetAtlasSourceEditor::_update_tile_inspector() {
 	// Update visibility.
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
 		if (!selection.is_empty()) {
-			tile_proxy_object.instantiate(this);
-			tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_proxy_object_changed));
-			tile_proxy_object->edit(tile_set_atlas_source, selection);
-			tile_inspector->edit(tile_proxy_object.ptr());
+			Ref<AtlasTileProxyObject> proxy;
+			Object *edited = tile_inspector->get_edited_object();
+			if (edited) {
+				proxy = Ref<AtlasTileProxyObject>(edited);
+			}
+
+			if (proxy.is_valid() && proxy->is_editing(tile_set_atlas_source, selection)) {
+				proxy->edit(tile_set_atlas_source, selection);
+			} else {
+				tile_proxy_object.instantiate(this);
+				tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_proxy_object_changed));
+				tile_proxy_object->edit(tile_set_atlas_source, selection);
+				tile_inspector->edit(tile_proxy_object.ptr());
+			}
 		}
 		tile_inspector->set_visible(!selection.is_empty());
 		tile_inspector_no_tile_selected_label->set_visible(selection.is_empty());

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -101,6 +101,7 @@ public:
 	public:
 		Ref<TileSetAtlasSource> get_edited_tile_set_atlas_source() const { return tile_set_atlas_source; }
 		RBSet<TileSelection> get_edited_tiles() const { return RBSet<TileSelection>(tiles); }
+		bool is_editing(TileSetAtlasSource *p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles) const;
 
 		// Update the proxied object.
 		void edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles = RBSet<TileSelection>());


### PR DESCRIPTION
Fixes #119192

Updates the TileSet atlas source editor's tile inspector refresh logic so it reuses the existing `AtlasTileProxyObject` when the inspector is already editing the same atlas source and tile selection.
When reusing the proxy, it is still refreshed with `edit()`, so the inspector data stays up to date without replacing the edited object.

## Testing
Tested with the reproduction project from #119192 on macOS 26.4.1, arm64.

- Reproduced the issue on the parent commit before this fix.
- Changing `Columns` no longer automatically collapses the `Animation` section.
- After switching from `Select` to `Paint` and back to `Select`, the tile inspector still works correctly.
- Ran `python3 misc/scripts/file_format.py editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp editor/scene/2d/tiles/tile_set_atlas_source_editor.h`
- Ran `git diff --check origin/master..HEAD`
- Built editor with `python3 -m SCons platform=macos target=editor dev_build=yes metal=yes vulkan=no angle=no accesskit=no -j8`


https://github.com/user-attachments/assets/4e7c134e-6f1d-4d12-8f80-9ab2c34d53ae

AI assistance was used for debugging this issue.
