### PR TITLE
Add macOS support for display cutouts

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -857,16 +857,22 @@
 		</method>
 		<method name="get_display_cutouts" qualifiers="const">
 			<return type="Rect2[]" />
+			<param index="0" name="screen" type="int" />
 			<description>
 				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
-				[b]Note:[/b] Currently only implemented on Android. Other platforms will return an empty array even if they do have display cutouts or notches.
+				[b]Note:[/b] The returned rectangles are relative to the physical screen and not the virtual desktop.
+				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
+				[b]Note:[/b] Currently only implemented on Android and macOS. Other platforms will return an empty array even if they do have display cutouts or notches.
 			</description>
 		</method>
 		<method name="get_display_safe_area" qualifiers="const">
 			<return type="Rect2i" />
+			<param index="0" name="screen" type="int" />
 			<description>
 				Returns the unobscured area of the display where interactive controls should be rendered. See also [method get_display_cutouts].
-				[b]Note:[/b] Currently only implemented on Android and iOS. On other platforms, [code]screen_get_usable_rect(SCREEN_OF_MAIN_WINDOW)[/code] will be returned as a fallback. See also [method screen_get_usable_rect].
+				[b]Note:[/b] The returned rectangle is relative to the physical screen and not the virtual desktop.
+				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
+				[b]Note:[/b] Currently only implemented on Android, iOS, and macOS. On other platforms, [code]screen_get_usable_rect(SCREEN_OF_MAIN_WINDOW)[/code] will be returned as a fallback. See also [method screen_get_usable_rect].
 			</description>
 		</method>
 		<method name="get_keyboard_focus_screen" qualifiers="const">

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -164,7 +164,7 @@ public:
 	virtual bool is_dark_mode() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Rect2i get_display_safe_area() const override;
+	virtual Rect2i get_display_safe_area(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual int get_screen_count() const override;
 	virtual int get_primary_screen() const override;

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -479,7 +479,11 @@ void DisplayServerAppleEmbedded::emit_system_theme_changed() {
 	}
 }
 
-Rect2i DisplayServerAppleEmbedded::get_display_safe_area() const {
+Rect2i DisplayServerAppleEmbedded::get_display_safe_area(int p_screen) const {
+	p_screen = _get_screen_index(p_screen);
+	int screen_count = get_screen_count();
+	ERR_FAIL_INDEX_V(p_screen, screen_count, Rect2i());
+
 	UIEdgeInsets insets = UIEdgeInsetsZero;
 	UIView *view = GDTAppDelegateService.viewController.godotView;
 	if ([view respondsToSelector:@selector(safeAreaInsets)]) {

--- a/misc/extension_api_validation/4.7-stable/GH-119196.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-119196.txt
@@ -1,0 +1,8 @@
+GH-119196
+--------------
+
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/DisplayServer/methods/get_display_cutouts': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/DisplayServer/methods/get_display_safe_area': arguments
+
+Added optional screen parameter to get_display_cutouts and get_display_safe_area for macOS implementation.
+Compatibility methods registered.

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -254,13 +254,21 @@ Color DisplayServerAndroid::get_base_color() const {
 	return godot_java->get_base_color();
 }
 
-TypedArray<Rect2> DisplayServerAndroid::get_display_cutouts() const {
+TypedArray<Rect2> DisplayServerAndroid::get_display_cutouts(int p_screen) const {
+	p_screen = _get_screen_index(p_screen);
+	int screen_count = get_screen_count();
+	ERR_FAIL_INDEX_V(p_screen, screen_count, TypedArray<Rect2>());
+
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, Array());
 	return godot_io_java->get_display_cutouts();
 }
 
-Rect2i DisplayServerAndroid::get_display_safe_area() const {
+Rect2i DisplayServerAndroid::get_display_safe_area(int p_screen) const {
+	p_screen = _get_screen_index(p_screen);
+	int screen_count = get_screen_count();
+	ERR_FAIL_INDEX_V(p_screen, screen_count, Rect2i());
+
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, Rect2i());
 	return godot_io_java->get_display_safe_area();

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -139,8 +139,8 @@ public:
 	virtual Color get_accent_color() const override;
 	virtual Color get_base_color() const override;
 
-	virtual TypedArray<Rect2> get_display_cutouts() const override;
-	virtual Rect2i get_display_safe_area() const override;
+	virtual TypedArray<Rect2> get_display_cutouts(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i get_display_safe_area(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override;
 	virtual bool screen_is_kept_on() const override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -300,6 +300,9 @@ public:
 	virtual Point2i mouse_get_position() const override;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
 
+	virtual TypedArray<Rect2> get_display_cutouts(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i get_display_safe_area(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+
 	virtual int get_screen_count() const override;
 	virtual int get_keyboard_focus_screen() const override;
 	virtual Point2i screen_get_position(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1534,6 +1534,84 @@ Rect2i DisplayServerMacOS::screen_get_usable_rect(int p_screen) const {
 	return Rect2i();
 }
 
+TypedArray<Rect2> DisplayServerMacOS::get_display_cutouts(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+	int screen_count = get_screen_count();
+	TypedArray<Rect2> ret = TypedArray<Rect2>();
+
+	ERR_FAIL_INDEX_V(p_screen, screen_count, ret);
+
+	NSArray *screenArray = [NSScreen screens];
+	if ((NSUInteger)p_screen < [screenArray count]) {
+		const float scale = screen_get_max_scale();
+		NSRect nsrect = [[screenArray objectAtIndex:p_screen] frame];
+		NSEdgeInsets safeAreaInsets = [[screenArray objectAtIndex:p_screen] safeAreaInsets];
+
+		float inset_left = safeAreaInsets.left * scale;
+		float inset_top = safeAreaInsets.top * scale;
+		float inset_right = safeAreaInsets.right * scale;
+		float inset_bottom = safeAreaInsets.bottom * scale;
+
+		float screen_width = nsrect.size.width * scale;
+		float screen_height = nsrect.size.height * scale;
+
+		if (inset_left > 0) {
+			Rect2 rect = Rect2(0.0, 0.0, inset_left, screen_height);
+			ret.push_back(rect);
+		}
+
+		if (inset_top > 0) {
+			Rect2 rect = Rect2(0.0, 0.0, screen_width, inset_top);
+			ret.push_back(rect);
+		}
+
+		if (inset_bottom > 0) {
+			Rect2 rect = Rect2(0.0, screen_height - inset_bottom, screen_width, inset_bottom);
+			ret.push_back(rect);
+		}
+
+		if (inset_right > 0) {
+			Rect2 rect = Rect2(screen_width - inset_right, 0.0, inset_right, screen_width);
+			ret.push_back(rect);
+		}
+	}
+
+	return ret;
+}
+
+Rect2i DisplayServerMacOS::get_display_safe_area(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+	int screen_count = get_screen_count();
+	ERR_FAIL_INDEX_V(p_screen, screen_count, Rect2i());
+
+	NSArray *screenArray = [NSScreen screens];
+	if ((NSUInteger)p_screen < [screenArray count]) {
+		const float scale = screen_get_max_scale();
+		NSRect nsrect = [[screenArray objectAtIndex:p_screen] frame];
+		NSEdgeInsets safeAreaInsets = [[screenArray objectAtIndex:p_screen] safeAreaInsets];
+
+		int inset_left = safeAreaInsets.left * scale;
+		int inset_top = safeAreaInsets.top * scale;
+		int inset_right = safeAreaInsets.right * scale;
+		int inset_bottom = safeAreaInsets.bottom * scale;
+
+		int screen_width = nsrect.size.width * scale;
+		int screen_height = nsrect.size.height * scale;
+
+		return Rect2i(
+				inset_left,
+				inset_top,
+				screen_width - (inset_left + inset_right),
+				screen_height - (inset_top + inset_bottom));
+	}
+
+	return Rect2i();
+}
+
 Color DisplayServerMacOS::screen_get_pixel(const Point2i &p_position) const {
 	HashSet<CGWindowID> exclude_windows;
 	for (HashMap<DisplayServerEnums::WindowID, WindowData>::ConstIterator E = windows.begin(); E; ++E) {

--- a/servers/display/display_server.compat.inc
+++ b/servers/display/display_server.compat.inc
@@ -46,10 +46,20 @@ RID DisplayServer::_accessibility_create_sub_text_edit_elements_bind_compat_1134
 	return accessibility_create_sub_text_edit_elements(p_parent_rid, p_shaped_text, p_min_height, p_insert_pos, false);
 }
 
+TypedArray<Rect2> DisplayServer::_get_display_cutouts_bind_compat_119196() const {
+	return get_display_cutouts(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW);
+}
+
+Rect2i DisplayServer::_get_display_safe_area_bind_compat_119196() const {
+	return get_display_safe_area(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW);
+}
+
 void DisplayServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback"), &DisplayServer::_file_dialog_show_bind_compat_98194);
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback"), &DisplayServer::_file_dialog_with_options_show_bind_compat_98194);
 	ClassDB::bind_compatibility_method(D_METHOD("accessibility_create_sub_text_edit_elements", "parent_rid", "shaped_text", "min_height", "insert_pos"), &DisplayServer::_accessibility_create_sub_text_edit_elements_bind_compat_113459, DEFVAL(-1));
+	ClassDB::bind_compatibility_method(D_METHOD("get_display_cutouts"), &DisplayServer::_get_display_cutouts_bind_compat_119196);
+	ClassDB::bind_compatibility_method(D_METHOD("get_display_safe_area"), &DisplayServer::_get_display_safe_area_bind_compat_119196);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1462,8 +1462,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clipboard_set_primary", "clipboard_primary"), &DisplayServer::clipboard_set_primary);
 	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);
 
-	ClassDB::bind_method(D_METHOD("get_display_cutouts"), &DisplayServer::get_display_cutouts);
-	ClassDB::bind_method(D_METHOD("get_display_safe_area"), &DisplayServer::get_display_safe_area);
+	ClassDB::bind_method(D_METHOD("get_display_cutouts", "screen"), &DisplayServer::get_display_cutouts);
+	ClassDB::bind_method(D_METHOD("get_display_safe_area", "screen"), &DisplayServer::get_display_safe_area);
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("get_primary_screen"), &DisplayServer::get_primary_screen);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -306,8 +306,8 @@ public:
 
 	const float SCREEN_REFRESH_RATE_FALLBACK = -1.0; // Returned by screen_get_refresh_rate if the method fails.
 
-	virtual TypedArray<Rect2> get_display_cutouts() const { return TypedArray<Rect2>(); }
-	virtual Rect2i get_display_safe_area() const { return screen_get_usable_rect(); }
+	virtual TypedArray<Rect2> get_display_cutouts(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const { return TypedArray<Rect2>(); }
+	virtual Rect2i get_display_safe_area(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const { return screen_get_usable_rect(p_screen); }
 
 	int _get_screen_index(int p_screen) const {
 		switch (p_screen) {
@@ -509,6 +509,8 @@ public:
 #ifndef DISABLE_DEPRECATED
 	Error _file_dialog_show_bind_compat_98194(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback);
 	Error _file_dialog_with_options_show_bind_compat_98194(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback);
+	TypedArray<Rect2> _get_display_cutouts_bind_compat_119196() const;
+	Rect2i _get_display_safe_area_bind_compat_119196() const;
 #endif
 
 	virtual void show_emoji_and_symbol_picker() const;


### PR DESCRIPTION
macOS supports display cutouts like iOS and Android. Particularly newer MacBooks have a notch on the top edge of the screen, and the screen area left and right of the notch cannot be occupied by applications. 

The implementation of `DisplayServer::get_display_safe_area` differs from `DisplayServer::screen_get_usable_rect` in that the former only subtracts physical insets from the screen rectangle, while the latter returns the area of the screen that is not covered by the system UI elements (status bar and dock).

Using `DisplayServer::get_display_safe_area` is now the simplest way to get the correct size or aspect ratio of a full-screen window on macOS.


Before, with the fallback to `screen_get_usable_rect`:
<img width="1800" height="1169" alt="Screenshot 2026-05-03 at 16 28 01" src="https://github.com/user-attachments/assets/6cd80637-af80-4397-a882-34b051db9464" />

After, with inset based implementation:
<img width="1800" height="1169" alt="Screenshot 2026-05-03 at 16 27 13" src="https://github.com/user-attachments/assets/a7e5b021-bc57-42fe-a7c1-7f6e39904861" />

(The example uses a system dock that is positioned on the left side of the screen. This results in the usable rect width being reduced.)