### PR TITLE
GUI: Fix non-editable LineEdit selection reset on focus loss

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1686,6 +1686,8 @@ void LineEdit::_notification(int p_what) {
 			if (editing) {
 				unedit();
 				emit_signal(SNAME("editing_toggled"), false);
+			} else if (deselect_on_focus_loss_enabled && !selection.drag_attempt) {
+				deselect();
 			}
 		} break;
 


### PR DESCRIPTION
Fixes #118576

When a LineEdit is non-editable and loses focus, its text selection was not being reset unlike a normal editable LineEdit. This ensures the selection is deselected consistently when focus exits.

Tested locally.