### PR TITLE
Improve circular references handling

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -831,12 +831,12 @@ void ResourceLoader::notify_load_error(const String &p_err) {
 	}
 }
 
-void ResourceLoader::notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type) {
+void ResourceLoader::notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type, int p_line) {
 	if (dep_err_notify) {
 		if (Thread::get_caller_id() == Thread::get_main_id()) {
-			dep_err_notify(p_path, p_dependency, p_type);
+			dep_err_notify(p_path, p_dependency, p_type, p_line);
 		} else {
-			MessageQueue::get_main_singleton()->push_callable(callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type));
+			MessageQueue::get_main_singleton()->push_callable(callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type, p_line));
 		}
 	}
 }

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -95,7 +95,7 @@ public:
 };
 
 typedef void (*ResourceLoadErrorNotify)(const String &p_text);
-typedef void (*DependencyErrorNotify)(const String &p_loading, const String &p_which, const String &p_type);
+typedef void (*DependencyErrorNotify)(const String &p_loading, const String &p_which, const String &p_type, int p_line);
 
 typedef Error (*ResourceLoaderImport)(const String &p_path);
 typedef void (*ResourceLoadedCallback)(Ref<Resource> p_resource, const String &p_path);
@@ -281,7 +281,7 @@ public:
 	}
 
 	// Loaders can safely use this regardless which thread they are running on.
-	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type);
+	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type, int p_line = -1);
 
 	static void set_dependency_error_notify_func(DependencyErrorNotify p_err_notify) {
 		dep_err_notify = p_err_notify;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -501,12 +501,16 @@ private:
 
 	String _get_system_info() const;
 
-	static void _dependency_error_report(const String &p_path, const String &p_dep, const String &p_type) {
+	static void _dependency_error_report(const String &p_path, const String &p_dep, const String &p_type, int p_line) {
 		DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 		if (!singleton->dependency_errors.has(p_path)) {
 			singleton->dependency_errors[p_path] = HashSet<String>();
 		}
-		singleton->dependency_errors[p_path].insert(p_dep + "::" + p_type);
+		String entry = p_dep + "::" + p_type;
+		if (p_line > 0) {
+			entry += "::" + itos(p_line);
+		}
+		singleton->dependency_errors[p_path].insert(entry);
 	}
 
 	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -48,6 +48,7 @@
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/popup_menu.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/tree.h"
 
 static void _setup_search_file_dialog(EditorFileDialog *p_dialog, const String &p_file, const String &p_type) {

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -941,23 +941,20 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 	// A cycle exists when a "missing" resource is also an owner of another missing resource
 	// that points back to it (A references B, B references A).
 	bool has_cycles = false;
+	HashSet<String> cycle_types;
 	for (const KeyValue<String, HashSet<String>> &E : missing_to_owners) {
 		const String &missing_path = E.key.get_slice("::", 0);
+		const String &missing_type = E.key.get_slice("::", 1);
 		if (p_report.has(missing_path)) {
 			for (const String &owner_path : E.value) {
 				for (const String &owner_missing : p_report[missing_path]) {
 					if (owner_missing.get_slice("::", 0) == owner_path) {
 						has_cycles = true;
+						cycle_types.insert(missing_type);
 						break;
 					}
 				}
-				if (has_cycles) {
-					break;
-				}
 			}
-		}
-		if (has_cycles) {
-			break;
 		}
 	}
 
@@ -1006,6 +1003,8 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 			owner_ti->add_button(1, files->get_editor_theme_icon(SNAME("Edit")), BUTTON_ID_OPEN_DEPS_EDITOR, false, TTRC("Fix Dependencies"));
 		}
 	}
+
+	_update_hint_label(has_cycles, cycle_types);
 
 	set_ok_button_text(TTRC("Open Anyway"));
 	popup_centered();
@@ -1123,12 +1122,42 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	vb->add_child(mc);
 	files->set_accessibility_name(files_label->get_text());
 
+	hint_label = memnew(RichTextLabel);
+	hint_label->set_use_bbcode(true);
+	hint_label->set_fit_content(true);
+	hint_label->set_scroll_active(false);
+	hint_label->hide();
+	vb->add_child(hint_label);
+
 	set_min_size(Size2(500, 320) * EDSCALE);
 	set_cancel_button_text(TTRC("Close"));
 
 	Label *text = memnew(Label(TTRC("Which action should be taken?")));
 	text->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	vb->add_child(text);
+}
+
+void DependencyErrorDialog::_update_hint_label(bool p_has_cycles, const HashSet<String> &p_cycle_types) {
+	if (p_has_cycles) {
+		String hint_text = TTR("[b]Cyclic reference detected[/b]\n\n"
+				"[b]To fix the affected scene(s):[/b]\n"
+				"1. Create a new empty scene (e.g., [code]placeholder.tscn[/code])\n"
+				"2. Click the edit icon next to a listed file to open the dependency editor\n"
+				"3. Replace one of the cyclic references with the placeholder scene\n"
+				"4. Open the scene and fix the underlying issue\n\n");
+
+		if (p_cycle_types.has("PackedScene")) {
+			hint_text += TTR("[b]To prevent this in future:[/b]\n"
+					"Scenes cannot reference each other as [code]@export var scene: PackedScene[/code].\n"
+					"Use [code]@export_file(\"*.tscn\") var scene_path: String[/code] instead,\n"
+					"then load dynamically: [code]var scene = load(scene_path)[/code]");
+		}
+
+		hint_label->set_text(hint_text);
+		hint_label->show();
+	} else {
+		hint_label->hide();
+	}
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -937,6 +937,37 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 		}
 	}
 
+	// Detect if this is a cyclic reference situation.
+	// A cycle exists when a "missing" resource is also an owner of another missing resource
+	// that points back to it (A references B, B references A).
+	bool has_cycles = false;
+	for (const KeyValue<String, HashSet<String>> &E : missing_to_owners) {
+		const String &missing_path = E.key.get_slice("::", 0);
+		if (p_report.has(missing_path)) {
+			for (const String &owner_path : E.value) {
+				for (const String &owner_missing : p_report[missing_path]) {
+					if (owner_missing.get_slice("::", 0) == owner_path) {
+						has_cycles = true;
+						break;
+					}
+				}
+				if (has_cycles) {
+					break;
+				}
+			}
+		}
+		if (has_cycles) {
+			break;
+		}
+	}
+
+	// Update label based on whether cycles were detected.
+	if (has_cycles) {
+		files_label->set_text(TTR("Load failed due to cyclic references:"));
+	} else {
+		files_label->set_text(TTR("Load failed due to missing dependencies:"));
+	}
+
 	files->clear();
 	TreeItem *root = files->create_item(nullptr);
 	Ref<Texture2D> folder_icon = get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
@@ -945,19 +976,31 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 		const String &missing_path = E.key.get_slice("::", 0);
 		const String &missing_type = E.key.get_slice("::", 1);
 
+		// Check if this specific item is part of a cycle.
+		bool is_cyclic = has_cycles && p_report.has(missing_path);
+
 		TreeItem *missing_ti = root->create_child();
 		missing_ti->set_text(0, missing_path);
 		missing_ti->set_metadata(0, E.key);
 		missing_ti->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		missing_ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(missing_type));
-		missing_ti->set_icon(1, get_editor_theme_icon(icon_name_fail));
+		if (is_cyclic) {
+			missing_ti->set_icon(1, get_editor_theme_icon(SNAME("StatusWarning")));
+		} else {
+			missing_ti->set_icon(1, get_editor_theme_icon(icon_name_fail));
+		}
 		missing_ti->add_button(1, folder_icon, BUTTON_ID_SEARCH, false, TTRC("Search"));
 		missing_ti->set_collapsed(true);
 
 		for (const String &owner_path : E.value) {
 			TreeItem *owner_ti = missing_ti->create_child();
-			// TRANSLATORS: The placeholder is a file path.
-			owner_ti->set_text(0, vformat(TTR("Referenced by %s"), owner_path));
+			if (is_cyclic) {
+				// TRANSLATORS: The placeholder is a file path.
+				owner_ti->set_text(0, vformat(TTR("Cyclic reference with %s"), owner_path));
+			} else {
+				// TRANSLATORS: The placeholder is a file path.
+				owner_ti->set_text(0, vformat(TTR("Referenced by %s"), owner_path));
+			}
 			owner_ti->set_metadata(0, owner_path);
 			owner_ti->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 			owner_ti->add_button(1, files->get_editor_theme_icon(SNAME("Edit")), BUTTON_ID_OPEN_DEPS_EDITOR, false, TTRC("Fix Dependencies"));
@@ -1061,6 +1104,11 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	VBoxContainer *vb = memnew(VBoxContainer);
 	add_child(vb);
 
+	files_label = memnew(Label);
+	files_label->set_theme_type_variation("HeaderSmall");
+	files_label->set_text(TTRC("Load failed due to missing dependencies:"));
+	vb->add_child(files_label);
+
 	files = memnew(Tree);
 	files->set_hide_root(true);
 	files->set_select_mode(Tree::SELECT_ROW);
@@ -1068,7 +1116,12 @@ DependencyErrorDialog::DependencyErrorDialog() {
 	files->set_column_expand(1, false);
 	files->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	files->connect("button_clicked", callable_mp(this, &DependencyErrorDialog::_on_files_button_clicked));
-	vb->add_margin_child(TTRC("Load failed due to missing dependencies:"), files, true);
+
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->add_child(files, true);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->add_child(mc);
+	files->set_accessibility_name(files_label->get_text());
 
 	set_min_size(Size2(500, 320) * EDSCALE);
 	set_cancel_button_text(TTRC("Close"));

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -1007,9 +1007,11 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 			if (is_cyclic) {
 				// TRANSLATORS: The placeholder is a file path.
 				owner_ti->set_text(0, vformat(TTR("Cyclic reference with %s"), owner_path));
+				owner_ti->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 			} else {
 				// TRANSLATORS: The placeholder is a file path.
 				owner_ti->set_text(0, vformat(TTR("Referenced by %s"), owner_path));
+				owner_ti->clear_custom_color(0);
 			}
 			owner_ti->set_metadata(0, owner_path);
 			owner_ti->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
@@ -1156,13 +1158,15 @@ void DependencyErrorDialog::_check_for_resolved() {
 				item_is_cyclic = true;
 			}
 
-			// Keep owner row wording in sync with the current cyclic edge status.
+			// Keep owner row wording and tint in sync with the current edge.
 			if (edge_cyclic) {
 				// TRANSLATORS: The placeholder is a file path.
 				owner_ti->set_text(0, vformat(TTR("Cyclic reference with %s"), owner_path));
+				owner_ti->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 			} else {
 				// TRANSLATORS: The placeholder is a file path.
 				owner_ti->set_text(0, vformat(TTR("Referenced by %s"), owner_path));
+				owner_ti->clear_custom_color(0);
 			}
 		}
 

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -928,6 +928,13 @@ enum {
 void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String, HashSet<String>> &p_report) {
 	for_file = p_for_file;
 
+	// Reset state that persists between shows: a prior session's `errors_fixed`
+	// would otherwise cause `ok_pressed` to ask the loader not to ignore broken
+	// deps, looping the dialog. `replacing_item` points into the tree that we
+	// rebuild below.
+	errors_fixed = false;
+	replacing_item = nullptr;
+
 	// TRANSLATORS: The placeholder is a filename.
 	set_title(vformat(TTR("Error loading: %s"), p_for_file.get_file()));
 
@@ -1050,6 +1057,13 @@ void DependencyErrorDialog::_on_files_button_clicked(TreeItem *p_item, int p_col
 }
 
 void DependencyErrorDialog::_on_replacement_file_selected(const String &p_path) {
+	// `replacing_item` is set when the user clicks the Search button on a row;
+	// it is also nulled in `show()`. The signal flow guarantees this is non-null
+	// here in normal usage, but enforce it explicitly so a stray invocation
+	// (or a future refactor that opens the file dialog by another path) cannot
+	// dereference a stale or null pointer.
+	ERR_FAIL_NULL(replacing_item);
+
 	const String &missing_path = String(replacing_item->get_metadata(0)).get_slice("::", 0);
 
 	for (TreeItem *owner_ti = replacing_item->get_first_child(); owner_ti; owner_ti = owner_ti->get_next()) {
@@ -1066,11 +1080,36 @@ void DependencyErrorDialog::_check_for_resolved() {
 	}
 
 	errors_fixed = true;
+	// Forward deps for each owner_path; populates errors_fixed as a side effect.
 	HashMap<String, LocalVector<String>> owner_deps;
+	// Reverse deps for each missing_path (used purely for cycle detection, so
+	// kept separate from owner_deps to avoid letting unrelated missing-deps of
+	// the missing file count against errors_fixed).
+	HashMap<String, LocalVector<String>> missing_back_deps;
+
+	// `any_cyclic` drives the cycle-styled heading and hint panel.
+	// `any_unresolved` tracks whether any tree row still shows fail/warning
+	// (i.e. is unfixed in the dialog). It is intentionally separate from
+	// `errors_fixed`, which is a wider on-disk truth — a forward-dep scan can
+	// discover unrelated missing deps that aren't in the tree, and we don't
+	// want those to drive the heading text away from the user's actual view.
+	bool any_cyclic = false;
+	bool any_unresolved = false;
+	HashSet<String> cycle_types;
+
+	// TODO: cycle detection here only catches direct A↔B 2-cycles, matching
+	// `show()`'s shallow scan. Longer cycles (A→B→C→A) won't be classified as
+	// cyclic — they fall through to the plain "missing dependency" branch.
+	// Deeper detection would require walking the dep graph transitively.
 
 	TreeItem *root = files->get_root();
 	for (TreeItem *missing_ti = root->get_first_child(); missing_ti; missing_ti = missing_ti->get_next()) {
+		const String &missing_meta = missing_ti->get_metadata(0);
+		const String &missing_path = missing_meta.get_slice("::", 0);
+		const String &missing_type = missing_meta.get_slice("::", 1);
+
 		bool all_owners_fixed = true;
+		bool item_is_cyclic = false;
 
 		for (TreeItem *owner_ti = missing_ti->get_first_child(); owner_ti; owner_ti = owner_ti->get_next()) {
 			const String &owner_path = owner_ti->get_metadata(0);
@@ -1087,18 +1126,70 @@ void DependencyErrorDialog::_check_for_resolved() {
 					stored_paths.push_back(_get_stored_dep_path(dep));
 				}
 			}
-			const LocalVector<String> &stored_paths = owner_deps[owner_path];
-			const String &missing_path = String(missing_ti->get_metadata(0)).get_slice("::", 0);
+			const LocalVector<String> &owner_stored_paths = owner_deps[owner_path];
 
-			if (stored_paths.has(missing_path)) {
+			const bool owner_still_refs = owner_stored_paths.has(missing_path);
+			if (owner_still_refs) {
 				all_owners_fixed = false;
-				break;
+			}
+
+			// Per-edge cycle check: this edge is cyclic iff owner still
+			// references missing_path AND missing_path's on-disk deps still
+			// reference owner_path (i.e. the round trip survives). Skip the
+			// reverse lookup if missing_path isn't on disk — `get_dependencies`
+			// would silently return empty (a no-op today, but the guard makes
+			// the intent explicit and avoids any future error spam if that
+			// changes).
+			bool edge_cyclic = false;
+			if (owner_still_refs && FileAccess::exists(missing_path)) {
+				if (!missing_back_deps.has(missing_path)) {
+					List<String> back_deps;
+					ResourceLoader::get_dependencies(missing_path, &back_deps);
+					LocalVector<String> &mstored = missing_back_deps[missing_path];
+					for (const String &dep : back_deps) {
+						mstored.push_back(_get_stored_dep_path(dep));
+					}
+				}
+				edge_cyclic = missing_back_deps[missing_path].has(owner_path);
+			}
+			if (edge_cyclic) {
+				item_is_cyclic = true;
+			}
+
+			// Keep owner row wording in sync with the current cyclic edge status.
+			if (edge_cyclic) {
+				// TRANSLATORS: The placeholder is a file path.
+				owner_ti->set_text(0, vformat(TTR("Cyclic reference with %s"), owner_path));
+			} else {
+				// TRANSLATORS: The placeholder is a file path.
+				owner_ti->set_text(0, vformat(TTR("Referenced by %s"), owner_path));
 			}
 		}
 
-		missing_ti->set_icon(1, get_editor_theme_icon(all_owners_fixed ? icon_name_check : icon_name_fail));
+		if (all_owners_fixed) {
+			missing_ti->set_icon(1, get_editor_theme_icon(icon_name_check));
+		} else if (item_is_cyclic) {
+			missing_ti->set_icon(1, get_editor_theme_icon(SNAME("StatusWarning")));
+			any_cyclic = true;
+			any_unresolved = true;
+			cycle_types.insert(missing_type);
+		} else {
+			missing_ti->set_icon(1, get_editor_theme_icon(icon_name_fail));
+			any_unresolved = true;
+		}
 	}
 
+	// Heading reflects what the user sees in the tree, not the wider on-disk
+	// state tracked by `errors_fixed`. If the tree is all-resolved we leave
+	// the previous text alone — the dialog is about to be dismissed and the
+	// "load failed" wording is harmless in that brief moment.
+	if (any_cyclic) {
+		files_label->set_text(TTR("Load failed due to cyclic references:"));
+	} else if (any_unresolved) {
+		files_label->set_text(TTR("Load failed due to missing dependencies:"));
+	}
+
+	_update_hint_label(any_cyclic, cycle_types);
 	set_ok_button_text(errors_fixed ? TTRC("Open") : TTRC("Open Anyway"));
 }
 

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -1146,17 +1146,17 @@ DependencyErrorDialog::DependencyErrorDialog() {
 void DependencyErrorDialog::_update_hint_label(bool p_has_cycles, const HashSet<String> &p_cycle_types) {
 	if (p_has_cycles) {
 		String hint_text = TTR("[b]Cyclic reference detected[/b]\n\n"
-				"[b]To fix the affected scene(s):[/b]\n"
-				"1. Create a new empty scene (e.g., [code]placeholder.tscn[/code])\n"
-				"2. Click the edit icon next to a listed file to open the dependency editor\n"
-				"3. Replace one of the cyclic references with the placeholder scene\n"
-				"4. Open the scene and fix the underlying issue\n\n");
+							   "[b]To fix the affected scene(s):[/b]\n"
+							   "1. Create a new empty scene (e.g., [code]placeholder.tscn[/code])\n"
+							   "2. Click the edit icon next to a listed file to open the dependency editor\n"
+							   "3. Replace one of the cyclic references with the placeholder scene\n"
+							   "4. Open the scene and fix the underlying issue\n\n");
 
 		if (p_cycle_types.has("PackedScene")) {
 			hint_text += TTR("[b]To prevent this in future:[/b]\n"
-					"Scenes cannot reference each other as [code]@export var scene: PackedScene[/code].\n"
-					"Use [code]@export_file(\"*.tscn\") var scene_path: String[/code] instead,\n"
-					"then load dynamically: [code]var scene = load(scene_path)[/code]");
+							 "Scenes cannot reference each other as [code]@export var scene: PackedScene[/code].\n"
+							 "Use [code]@export_file(\"*.tscn\") var scene_path: String[/code] instead,\n"
+							 "then load dynamically: [code]var scene = load(scene_path)[/code]");
 		}
 
 		hint_label->set_text(hint_text);

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -972,12 +972,17 @@ void DependencyErrorDialog::show(const String &p_for_file, const HashMap<String,
 	for (const KeyValue<String, HashSet<String>> &E : missing_to_owners) {
 		const String &missing_path = E.key.get_slice("::", 0);
 		const String &missing_type = E.key.get_slice("::", 1);
+		const String &missing_line = E.key.get_slice("::", 2); // May be empty.
 
 		// Check if this specific item is part of a cycle.
 		bool is_cyclic = has_cycles && p_report.has(missing_path);
 
 		TreeItem *missing_ti = root->create_child();
-		missing_ti->set_text(0, missing_path);
+		if (!missing_line.is_empty()) {
+			missing_ti->set_text(0, vformat("%s (line %s)", missing_path, missing_line));
+		} else {
+			missing_ti->set_text(0, missing_path);
+		}
 		missing_ti->set_metadata(0, E.key);
 		missing_ti->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		missing_ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(missing_type));

--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -36,6 +36,7 @@ class EditorFileDialog;
 class EditorFileSystemDirectory;
 class ItemList;
 class PopupMenu;
+class RichTextLabel;
 class Tree;
 class TreeItem;
 class VBoxContainer;

--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -178,6 +178,7 @@ class DependencyErrorDialog : public ConfirmationDialog {
 	bool errors_fixed = false;
 
 	Tree *files = nullptr;
+	Label *files_label = nullptr;
 
 	EditorFileDialog *replacement_file_dialog = nullptr;
 	DependencyEditor *deps_editor = nullptr;

--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -179,6 +179,7 @@ class DependencyErrorDialog : public ConfirmationDialog {
 
 	Tree *files = nullptr;
 	Label *files_label = nullptr;
+	RichTextLabel *hint_label = nullptr;
 
 	EditorFileDialog *replacement_file_dialog = nullptr;
 	DependencyEditor *deps_editor = nullptr;
@@ -188,6 +189,7 @@ class DependencyErrorDialog : public ConfirmationDialog {
 	void _on_files_button_clicked(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);
 	void _on_replacement_file_selected(const String &p_path);
 	void _check_for_resolved();
+	void _update_hint_label(bool p_has_cycles, const HashSet<String> &p_cycle_types);
 
 public:
 	void show(const String &p_for_file, const HashMap<String, HashSet<String>> &p_report);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -158,7 +158,7 @@ Error ResourceLoaderText::_parse_ext_resource(VariantParser::Stream *p_stream, R
 						_printerr();
 						err = error;
 					} else {
-						ResourceLoader::notify_dependency_error(local_path, path, type);
+						ResourceLoader::notify_dependency_error(local_path, path, type, line);
 					}
 				}
 			} else {
@@ -532,7 +532,7 @@ Error ResourceLoaderText::load() {
 				_printerr();
 				return error;
 			} else {
-				ResourceLoader::notify_dependency_error(local_path, path, type);
+				ResourceLoader::notify_dependency_error(local_path, path, type, lines);
 			}
 		}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -150,7 +150,11 @@ Error ResourceLoaderText::_parse_ext_resource(VariantParser::Stream *p_stream, R
 				if (!ResourceLoader::is_cleaning_tasks()) {
 					if (ResourceLoader::get_abort_on_missing_resources()) {
 						error = ERR_FILE_MISSING_DEPENDENCIES;
-						error_text = "[ext_resource] referenced non-existent resource at: " + path;
+						if (err == ERR_BUSY) {
+							error_text = "[ext_resource] cyclic reference while loading: " + path;
+						} else {
+							error_text = "[ext_resource] referenced non-existent resource at: " + path;
+						}
 						_printerr();
 						err = error;
 					} else {
@@ -289,6 +293,9 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				if (error) {
 					if (error == ERR_FILE_MISSING_DEPENDENCIES) {
 						// Resource loading error, just skip it.
+					} else if (error == ERR_BUSY) {
+						ERR_PRINT(vformat("Cyclic resource reference detected. [Resource file %s:%d]", res_path, lines));
+						return Ref<PackedScene>();
 					} else if (error != ERR_FILE_EOF) {
 						ERR_PRINT(vformat("Parse Error: %s. [Resource file %s:%d]", error_names[error], res_path, lines));
 						return Ref<PackedScene>();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -151,7 +151,9 @@ Error ResourceLoaderText::_parse_ext_resource(VariantParser::Stream *p_stream, R
 					if (ResourceLoader::get_abort_on_missing_resources()) {
 						error = ERR_FILE_MISSING_DEPENDENCIES;
 						if (err == ERR_BUSY) {
-							error_text = "[ext_resource] cyclic reference while loading: " + path;
+							// At runtime, this also surfaces as later "null instance" errors
+							// in script code that uses the property — make the link explicit.
+							error_text = "[ext_resource] cyclic reference while loading: " + path + "; the reference will be null at runtime";
 						} else {
 							error_text = "[ext_resource] referenced non-existent resource at: " + path;
 						}
@@ -294,7 +296,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					if (error == ERR_FILE_MISSING_DEPENDENCIES) {
 						// Resource loading error, just skip it.
 					} else if (error == ERR_BUSY) {
-						ERR_PRINT(vformat("Cyclic resource reference detected. [Resource file %s:%d]", res_path, lines));
+						ERR_PRINT(vformat("Cyclic resource reference detected, scene will fail to load. [Resource file %s:%d]", res_path, lines));
 						return Ref<PackedScene>();
 					} else if (error != ERR_FILE_EOF) {
 						ERR_PRINT(vformat("Parse Error: %s. [Resource file %s:%d]", error_names[error], res_path, lines));


### PR DESCRIPTION
# Improve handling of circular references in scene loading

While the PackedScene loading crash when circular references from https://github.com/godotengine/godot/issues/24146 is fixed, the user experience when circular references exist in a project remains confusing and difficult.

When two scenes reference each other via `@export var scene: PackedScene` (e.g., Scene A → Scene B → Scene A), Godot previously showed confusing error messages like "non-existent resource" or cryptic "Busy" errors. It displays a dialog that complains that the scenes could not be found, with a list of sub-resources referenced by each scene, but no explanation for why these scenes (which do in fact exist) could not be found, or that the underlying issue was really a loading error caused by a circular reference.

This PR improves the user experience by:

- Clearly identifying cyclic references in both console output and the editor dialog
- Providing actionable guidance on how to fix affected scenes
- Showing line numbers to help locate problematic references
- Suggesting prevention strategies for PackedScene cycles

I was prompted to raise this after spending some time manually repairing a project for someone I was helping with Godot as they were completely stuck after creating a scene where one portal in a level scene could take the player back to a prior level (with level links specified using `@export var to_load : PackedScene`. That's not the right way to implement that pattern, but the author didn't know that, it's a pattern shown in various (3rd party) guides, and Godot broke pretty badly when they did it.

## Test

With the same test case as attached to https://github.com/godotengine/godot/issues/24146#issuecomment-4367331978 when I open it in a patched build I now see:

<img width="500" height="503" alt="image" src="https://github.com/user-attachments/assets/873f5805-2f1c-44e2-9b2f-706ec70b279b" />


and logs are

```
➜  godot-engine git:(improve-circular-references-handling) ✗ Vulkan 1.4.312 - Forward+ - Using Device #1: NVIDIA - NVIDIA RTX PRO 2000 Blackwell Generation Laptop GPU

ERROR: Cyclic resource reference detected. [Resource file res://circular2.tscn:8]
   at: _parse_node_tag (scene/resources/resource_format_text.cpp:297)
ERROR: Failed loading resource: res://circular2.tscn.
   at: _load (core/io/resource_loader.cpp:317)
ERROR: Cyclic resource reference detected. [Resource file res://circular1.tscn:8]
   at: _parse_node_tag (scene/resources/resource_format_text.cpp:297)
ERROR: Failed loading resource: res://circular1.tscn.
   at: _load (core/io/resource_loader.cpp:317)
```

## Changes

(LLM-assisted)

**Console error messages:**
- Changed "referenced non-existent resource" to "cyclic reference while loading" when `ERR_BUSY` is detected
- Changed generic "Busy" parse error to "Cyclic resource reference detected"

**Dependency error dialog:**
- Dialog now shows "Load failed due to cyclic references:" instead of "missing dependencies" when cycles are detected
- Uses warning icon instead of failure icon for cyclic items
- Shows "Cyclic reference with \<path\>" instead of "Referenced by \<path\>"
- Displays line numbers from the .tscn file (e.g., "res://scene2.tscn (line 3)")

**Recovery hints:**
- Added a hint panel with step-by-step instructions to fix cyclic references using a placeholder scene
- For PackedScene cycles specifically, suggests using `@export_file("*.tscn")` with dynamic loading

## Notes

This PR does not prevent cyclic references from being created. Save-time detection would require dependency analysis of external resources, which I thought was going to be too intrusive and possibly risky. 

Instead, it focuses on helping users understand and recover from the situation when it occurs.

Since #97912, `@export_file` paths auto-update when files are moved, making the suggested workaround (`@export_file("*.tscn")` with dynamic loading) more practical.