### PR TITLE
Clarify `Node.is_node_ready()` documentation

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -664,8 +664,7 @@
 		<method name="is_node_ready" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the node is ready, i.e. it's inside scene tree and all its children are initialized.
-				[method request_ready] resets it back to [code]false[/code].
+				Returns [code]true[/code] if the node has been marked ready, i.e. it has received [constant NOTIFICATION_READY] at least once and its [method _ready] callback has been called. This does not require the node to currently be inside the [SceneTree]; once marked ready, the node stays ready even after it is removed from the tree, until [method request_ready] resets it back to [code]false[/code] (so that [method _ready] is called again the next time the node enters the tree).
 			</description>
 		</method>
 		<method name="is_part_of_edited_scene" qualifiers="const">


### PR DESCRIPTION
## Description

The `Node.is_node_ready()` doc said the method returns `true` when the node is inside the scene tree and its children are initialized. That is not what the implementation does. `is_node_ready()` simply returns the internal `ready_first` flag, which is set when the node receives `NOTIFICATION_READY` for the first time and only gets reset by `request_ready()`. A node that entered the tree once and was later removed still reports as ready.

This PR rewrites the description so it matches the actual behavior:

- the node is considered ready once it has received `NOTIFICATION_READY` at least once and its `_ready` callback has run,
- being currently inside the `SceneTree` is not required,
- `request_ready()` resets the flag so `_ready` runs again the next time the node enters the tree.

Wording is based on what was confirmed in the issue thread.

Fixes #117780.

## AI Assistance Disclosure

AI tooling was used to help draft and word this PR (description and commit message). The behavioral claim is grounded in the source links shared by @kleonc on issue #117780, which were verified before submitting.