### PR TITLE
Fix bugs with editing enter key shortcuts

### DIFF
--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -47,9 +47,10 @@ void InputEventConfigurationDialog::_set_event(const Ref<InputEvent> &p_event, c
 		// If there is already a binding set, let enter or escape confirm/cancel the popup.
 		if (event.is_valid()) {
 			Ref<InputEventKey> current_key = p_event;
+			Ref<InputEventWithModifiers> modifiers = p_event;
 			// Without this is_visible() check, the gui would not open if the already bound
 			// keybind was escape.
-			if (current_key.is_valid() && is_visible()) {
+			if (current_key.is_valid() && is_visible() && event_listener->has_focus() && !modifiers->get_modifiers_mask()) {
 				if (current_key->get_physical_keycode() == Key::ENTER) {
 					_ok_pressed();
 					return;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119087

Now the "listening for input" box requires focus for the "enter" shortcut to work, and requires that no modifiers are being held for it to work.

(Trying to rebind an existing keybind to enter still requires selecting enter from the list, or adding a new shortcut)