### PR TITLE
Document that `@rpc` takes precedence over `Node.rpc_config()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -898,6 +898,7 @@
 				- [code]call_local[/code]: if [code]true[/code], the method will also be called locally;
 				- [code]channel[/code]: an [int] representing the channel to send the RPC on.
 				[b]Note:[/b] In GDScript, this method corresponds to the [annotation @GDScript.@rpc] annotation, with various parameters passed ([code]@rpc(any)[/code], [code]@rpc(authority)[/code]...). See also the [url=$DOCS_URL/tutorials/networking/high_level_multiplayer.html]high-level multiplayer[/url] tutorial.
+				[b]Note:[/b] If the same [param method] is configured both with [annotation @GDScript.@rpc] in a script and with this method, the script-level configuration takes precedence; the configuration set here is only used for methods that do not have an [annotation @GDScript.@rpc] annotation. Use [method Script.get_rpc_config] to inspect the script-level configuration and [method get_node_rpc_config] for the configuration set via this method.
 			</description>
 		</method>
 		<method name="rpc_id" qualifiers="vararg">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -898,7 +898,7 @@
 				- [code]call_local[/code]: if [code]true[/code], the method will also be called locally;
 				- [code]channel[/code]: an [int] representing the channel to send the RPC on.
 				[b]Note:[/b] In GDScript, this method corresponds to the [annotation @GDScript.@rpc] annotation, with various parameters passed ([code]@rpc(any)[/code], [code]@rpc(authority)[/code]...). See also the [url=$DOCS_URL/tutorials/networking/high_level_multiplayer.html]high-level multiplayer[/url] tutorial.
-				[b]Note:[/b] If the same [param method] is configured both with [annotation @GDScript.@rpc] in a script and with this method, the script-level configuration takes precedence; the configuration set here is only used for methods that do not have an [annotation @GDScript.@rpc] annotation. Use [method Script.get_rpc_config] to inspect the script-level configuration and [method get_node_rpc_config] for the configuration set via this method.
+				[b]Note:[/b] If the same [param method] is configured both with [annotation @GDScript.@rpc] in a script and with this method, the script-level configuration takes priority; the configuration set here is only used for methods that do not have an [annotation @GDScript.@rpc] annotation. Use [method Script.get_rpc_config] to inspect the script-level configuration and [method get_node_rpc_config] for the configuration set via this method.
 			</description>
 		</method>
 		<method name="rpc_id" qualifiers="vararg">


### PR DESCRIPTION
The `Node.rpc_config()` documentation describes the method as if it always sets the RPC configuration for the given method, but that is not what actually happens at runtime. When the same method has both a script-level `@rpc` annotation and a `Node.rpc_config()` call, the script-level configuration wins. This is enforced in `modules/multiplayer/scene_rpc_interface.cpp` (around lines 105 to 117), which consults the script-defined config first and only falls back to the node-level config when no annotation exists.

This PR adds a second `[b]Note:[/b]` to the existing `rpc_config` description spelling out that precedence rule. It also points readers at `Script.get_rpc_config` and `get_node_rpc_config` so they can inspect each layer independently when debugging mismatches between expected and actual RPC behavior.

No code is changed, this is a doc-only correction in `doc/classes/Node.xml`.

Fixes #118021.