### PR TITLE
Use MD5 for checking modified project.godot

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -972,7 +972,10 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 			// If we're loading a project.godot from source code, we can operate some
 			// ProjectSettings conversions if need be.
 			_convert_to_last_version(config_version);
+#ifdef TOOLS_ENABLED
 			last_save_time = FileAccess::get_modified_time(get_resource_path().path_join("project.godot"));
+			last_save_md5 = FileAccess::get_md5(get_resource_path().path_join("project.godot"));
+#endif
 			return OK;
 		}
 		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Error parsing '%s' at line %d: %s File might be corrupted.", p_path, lines, error_text));
@@ -1068,9 +1071,12 @@ void ProjectSettings::clear(const String &p_name) {
 
 Error ProjectSettings::save() {
 	Error error = save_custom(get_resource_path().path_join("project.godot"));
+#ifdef TOOLS_ENABLED
 	if (error == OK) {
 		last_save_time = FileAccess::get_modified_time(get_resource_path().path_join("project.godot"));
+		last_save_md5 = FileAccess::get_md5(get_resource_path().path_join("project.godot"));
 	}
+#endif
 	return error;
 }
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -96,7 +96,10 @@ protected:
 
 	int last_order = NO_BUILTIN_ORDER_BASE;
 	int last_builtin_order = 0;
+#ifdef TOOLS_ENABLED
 	uint64_t last_save_time = 0;
+	String last_save_md5;
+#endif
 
 	RBMap<StringName, VariantContainer> props; // NOTE: Key order is used e.g. in the save_custom method.
 	String resource_path;
@@ -203,7 +206,10 @@ public:
 	Error save();
 	void set_custom_property_info(const PropertyInfo &p_info);
 	const HashMap<StringName, PropertyInfo> &get_custom_property_info() const;
+#ifdef TOOLS_ENABLED
 	uint64_t get_last_saved_time() { return last_save_time; }
+	String get_last_saved_md5() { return last_save_md5; }
+#endif
 
 	List<String> get_input_presets() const { return List<String>(input_presets); }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1572,7 +1572,7 @@ void EditorNode::_scan_external_changes() {
 	}
 
 	String project_settings_path = ProjectSettings::get_singleton()->get_resource_path().path_join("project.godot");
-	if (FileAccess::get_modified_time(project_settings_path) > ProjectSettings::get_singleton()->get_last_saved_time()) {
+	if (FileAccess::get_modified_time(project_settings_path) > ProjectSettings::get_singleton()->get_last_saved_time() && FileAccess::get_md5(project_settings_path) != ProjectSettings::get_singleton()->get_last_saved_md5()) {
 		TreeItem *ti = disk_changed_list->create_item(r);
 		ti->set_text(0, "project.godot");
 		need_reload = true;


### PR DESCRIPTION
Fixes #119219

Simply opening the project will modify `project.godot`, so the prompt is a pain every time you open multiple instances of a project for whatever reason. The prompt may also be triggered by git or whatever (so I guess we could do the same for scenes maybe).

Also wraps modified time and MD5 of project settings in TOOLS_ENABLED, because they are used only in the editor.