### PR TITLE
SCons: Remove implicit `PATH` assignment, require `import_env_vars`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -111,12 +111,7 @@ for x in sorted(glob.glob("platform/*")):
 # We let SCons build its default ENV as it includes OS-specific things which we don't
 # want to have to pull in manually. However we enforce no "tools", which we register
 # further down after parsing our platform-specific configuration.
-# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
 env = Environment(tools=[])
-env.PrependENVPath("PATH", os.getenv("PATH"))
-env.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
-if "TERM" in os.environ:  # Used for colored output.
-    env["ENV"]["TERM"] = os.environ["TERM"]
 
 env.disabled_modules = set()
 env.module_version_string = ""
@@ -374,9 +369,12 @@ methods.prepare_cache(env)
 
 # Copy custom environment variables if set.
 if env["import_env_vars"]:
-    for env_var in str(env["import_env_vars"]).split(","):
-        if env_var in os.environ:
-            env["ENV"][env_var] = os.environ[env_var]
+    for key in str(env["import_env_vars"]).split(","):
+        if value := os.getenv(key):
+            if "PATH" in key:
+                env.PrependENVPath(key, value)
+            else:
+                env["ENV"][key] = value
 
 # Platform selection: validate input, and add options.
 


### PR DESCRIPTION
We've largely removed the `PATH` environment dependencies in our buildsystem, but there's still the main prependment that always occurs right after setup. After some testing, this seems to be a largely deprecated step, as our CI builds perfectly fine without them. Instead, if we want to have something appended to the SCons environment, it should be in the form of the explicit `import_env_vars` argument

As such, all of the automatic assignment has been removed, with prior functionality being achievable via `import_env_vars` and passing the relevant keys. In addition, should any of these keys contain `PATH`, the import process will be handled via `PrependENVPath` instead