### PR TITLE
Fix error spam when changing VirtualJoystick's Joystick Size or Tip Size

### DIFF
--- a/scene/gui/virtual_joystick.cpp
+++ b/scene/gui/virtual_joystick.cpp
@@ -178,10 +178,15 @@ void VirtualJoystick::_reset() {
 	joystick_pos = get_size() * initial_offset_ratio;
 	tip_pos = joystick_pos;
 
-	Input *input = Input::get_singleton();
-	for (const StringName &action : { action_left, action_right, action_down, action_up }) {
-		if (input->is_action_pressed(action)) {
-			input->action_release(action);
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		// Only release actions when not currently in the editor.
+		// Custom input actions are not defined while in the editor,
+		// so this would lead to error spam due to unknown input actions.
+		Input *input = Input::get_singleton();
+		for (const StringName &action : { action_left, action_right, action_down, action_up }) {
+			if (input->is_action_pressed(action)) {
+				input->action_release(action);
+			}
 		}
 	}
 


### PR DESCRIPTION
This skips the input release process while in the editor, since VirtualJoystick should normally do nothing while in the editor (it is currently not used for 3D navigation on Android).

Errors are still printed if the project is run.

- This closes https://github.com/godotengine/godot/issues/116321.
