### PR TITLE
CI: Add dependency groups to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
+[dependency-groups]
+build = ["scons>=4", "ninja", "prek"]
+dev = [
+	{ include-group = "build" },
+	"clang-format",
+	"clang-tidy",
+	"clangd-tidy",
+	"clangd",
+	"mypy",
+	"ruff",
+]
+
 [tool.mypy]
 disallow_any_generics = true
 explicit_package_bases = true


### PR DESCRIPTION
- See https://github.com/godotengine/godot/pull/119150#pullrequestreview-4216092336

Part of making the process of installing `prek`, and by extension our current toolset, more streamlined. Now a user would merely have to pass `pip install --group build` to the command line in the repo to seamlessly install SCons, ninja, and prek. This takes advantage of [dependency groups](https://packaging.python.org/en/latest/specifications/dependency-groups/), which is a functionality available from any pip bundled with python 3.9 and later. This can extend to `pip install --group dev`, which would also install the various tools used for validating our hooks directly

When documentation is updated to account for installing `prek`, we can point to this simplified installation method which would only require python to be installed (and pip, but that's practically stapled on as-is)