### PR TITLE
Add SPIR-V reflection information API

### DIFF
--- a/doc/classes/RDShaderReflection.xml
+++ b/doc/classes/RDShaderReflection.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDShaderReflection" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		SPIR-V shader reflection data for [RenderingDevice].
+	</brief_description>
+	<description>
+		Contains reflection data returned by [method RenderingDevice.shader_reflect_spirv]. This data describes the resources and constants declared by SPIR-V bytecode.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="compute_local_size" type="Vector3i" setter="" getter="get_compute_local_size" default="Vector3i(0, 0, 0)">
+			The local workgroup size declared by a compute shader.
+		</member>
+		<member name="fragment_output_mask" type="int" setter="" getter="get_fragment_output_mask" default="0">
+			Bitmask of fragment output locations used by the shader.
+		</member>
+		<member name="has_dynamic_buffers" type="bool" setter="" getter="get_has_dynamic_buffers" default="false">
+			Whether the shader uses dynamic buffers.
+		</member>
+		<member name="has_multiview" type="bool" setter="" getter="get_has_multiview" default="false">
+			Whether the shader uses multiview.
+		</member>
+		<member name="pipeline_type" type="int" setter="" getter="get_pipeline_type" default="0">
+			The pipeline type used by the shader: [code]0[/code] for rasterization, [code]1[/code] for compute, or [code]2[/code] for ray tracing.
+		</member>
+		<member name="push_constant_members" type="RDShaderReflectionMember[]" setter="" getter="get_push_constant_members" default="[]">
+			Members of the push constant block.
+		</member>
+		<member name="push_constant_name" type="String" setter="" getter="get_push_constant_name" default="&quot;&quot;">
+			Name of the push constant block, if present in the SPIR-V bytecode.
+		</member>
+		<member name="push_constant_size" type="int" setter="" getter="get_push_constant_size" default="0">
+			Size in bytes of the push constant block.
+		</member>
+		<member name="push_constant_stages" type="int" setter="" getter="get_push_constant_stages" default="0">
+			Bitmask of shader stages that use push constants. Use the [code]RenderingDevice.SHADER_STAGE_*_BIT[/code] constants to test the returned value.
+		</member>
+		<member name="specialization_constants" type="RDShaderReflectionSpecializationConstant[]" setter="" getter="get_specialization_constants" default="[]">
+			Specialization constants declared by the shader.
+		</member>
+		<member name="stages" type="int" setter="" getter="get_stages" default="0">
+			Bitmask of shader stages present in the SPIR-V bytecode. Use the [code]RenderingDevice.SHADER_STAGE_*_BIT[/code] constants to test the returned value.
+		</member>
+		<member name="uniforms" type="RDShaderReflectionUniform[]" setter="" getter="get_uniforms" default="[]">
+			Uniform resources declared by the shader.
+		</member>
+		<member name="vertex_input_mask" type="int" setter="" getter="get_vertex_input_mask" default="0">
+			Bitmask of vertex input locations used by the shader.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RDShaderReflectionMember.xml
+++ b/doc/classes/RDShaderReflectionMember.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDShaderReflectionMember" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Shader reflection member reflected from SPIR-V bytecode.
+	</brief_description>
+	<description>
+		Describes a member of a shader block reflected with [method RenderingDevice.shader_reflect_spirv]. Nested structure members are exposed recursively through [member members].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="array_dimensions" type="PackedInt32Array" setter="" getter="get_array_dimensions" default="PackedInt32Array()">
+			Array dimensions for this member.
+		</member>
+		<member name="matrix_column_count" type="int" setter="" getter="get_matrix_column_count" default="0">
+			Number of matrix columns, or [code]0[/code] if this member is not a matrix.
+		</member>
+		<member name="matrix_row_count" type="int" setter="" getter="get_matrix_row_count" default="0">
+			Number of matrix rows, or [code]0[/code] if this member is not a matrix.
+		</member>
+		<member name="matrix_stride" type="int" setter="" getter="get_matrix_stride" default="0">
+			Matrix stride in bytes.
+		</member>
+		<member name="members" type="RDShaderReflectionMember[]" setter="" getter="get_members" default="[]">
+			Nested structure members.
+		</member>
+		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The reflected member name, if present in the SPIR-V bytecode.
+		</member>
+		<member name="numeric_signedness" type="int" setter="" getter="get_numeric_signedness" default="0">
+			Numeric signedness for scalar, vector, and matrix members.
+		</member>
+		<member name="numeric_width" type="int" setter="" getter="get_numeric_width" default="0">
+			Numeric width in bits for scalar, vector, and matrix members.
+		</member>
+		<member name="offset" type="int" setter="" getter="get_offset" default="0">
+			Offset in bytes relative to the containing block or structure.
+		</member>
+		<member name="padded_size" type="int" setter="" getter="get_padded_size" default="0">
+			Padded size in bytes.
+		</member>
+		<member name="size" type="int" setter="" getter="get_size" default="0">
+			Size in bytes.
+		</member>
+		<member name="type_op" type="int" setter="" getter="get_type_op" default="0">
+			The SPIR-V type operation value for this member.
+		</member>
+		<member name="vector_component_count" type="int" setter="" getter="get_vector_component_count" default="0">
+			Number of vector components, or [code]0[/code] if this member is not a vector.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RDShaderReflectionSpecializationConstant.xml
+++ b/doc/classes/RDShaderReflectionSpecializationConstant.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDShaderReflectionSpecializationConstant" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Specialization constant reflected from SPIR-V bytecode.
+	</brief_description>
+	<description>
+		Describes a specialization constant declared by SPIR-V bytecode reflected with [method RenderingDevice.shader_reflect_spirv].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="constant_id" type="int" setter="" getter="get_constant_id" default="0">
+			The specialization constant ID declared by the shader.
+		</member>
+		<member name="default_value" type="Variant" setter="" getter="get_default_value">
+			The default value declared by the shader.
+		</member>
+		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The reflected constant name, if present in the SPIR-V bytecode.
+		</member>
+		<member name="stages" type="int" setter="" getter="get_stages" default="0">
+			Bitmask of shader stages that use this specialization constant. Use the [code]RenderingDevice.SHADER_STAGE_*_BIT[/code] constants to test the returned value.
+		</member>
+		<member name="value_type" type="int" setter="" getter="get_value_type" default="0">
+			The [enum RenderingDevice.PipelineSpecializationConstantType] value type.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RDShaderReflectionUniform.xml
+++ b/doc/classes/RDShaderReflectionUniform.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDShaderReflectionUniform" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Uniform resource reflected from SPIR-V bytecode.
+	</brief_description>
+	<description>
+		Describes a uniform resource declared by SPIR-V bytecode reflected with [method RenderingDevice.shader_reflect_spirv].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="binding" type="int" setter="" getter="get_binding" default="0">
+			The binding number declared by the shader.
+		</member>
+		<member name="descriptor_set" type="int" setter="" getter="get_descriptor_set" default="0">
+			The descriptor set number declared by the shader.
+		</member>
+		<member name="length" type="int" setter="" getter="get_length" default="0">
+			Array length, or buffer size in bytes for buffer resources.
+		</member>
+		<member name="members" type="RDShaderReflectionMember[]" setter="" getter="get_members" default="[]">
+			Members of this uniform or storage buffer block. Empty for resources that do not declare a block layout.
+		</member>
+		<member name="name" type="String" setter="" getter="get_name" default="&quot;&quot;">
+			The reflected resource name, if present in the SPIR-V bytecode.
+		</member>
+		<member name="resource_type" type="int" setter="" getter="get_resource_type" default="13">
+			The [enum RenderingDevice.UniformType] resource type.
+		</member>
+		<member name="stages" type="int" setter="" getter="get_stages" default="0">
+			Bitmask of shader stages that use this uniform. Use the [code]RenderingDevice.SHADER_STAGE_*_BIT[/code] constants to test the returned value.
+		</member>
+		<member name="writable" type="bool" setter="" getter="get_writable" default="false">
+			Whether the resource is writable by the shader.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1056,6 +1056,14 @@
 				Returns the internal vertex input mask. Internally, the vertex input mask is an unsigned integer consisting of the locations (specified in GLSL via. [code]layout(location = ...)[/code]) of the input variables (specified in GLSL by the [code]in[/code] keyword).
 			</description>
 		</method>
+		<method name="shader_reflect_spirv">
+			<return type="RDShaderReflection" />
+			<param index="0" name="spirv_data" type="RDShaderSPIRV" />
+			<param index="1" name="name" type="String" default="&quot;&quot;" />
+			<description>
+				Returns reflection information for SPIR-V intermediate code without creating a shader RID. This can be used to inspect uniforms, specialization constants, and push constant layout before creating pipelines.
+			</description>
+		</method>
 		<method name="storage_buffer_create">
 			<return type="RID" />
 			<param index="0" name="size_bytes" type="int" />

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -244,6 +244,10 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDShaderSource);
 	GDREGISTER_CLASS(RDShaderSPIRV);
 	GDREGISTER_CLASS(RDShaderFile);
+	GDREGISTER_CLASS(RDShaderReflection);
+	GDREGISTER_CLASS(RDShaderReflectionUniform);
+	GDREGISTER_CLASS(RDShaderReflectionSpecializationConstant);
+	GDREGISTER_CLASS(RDShaderReflectionMember);
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
 	GDREGISTER_CLASS(RDAccelerationStructureGeometry);
 	GDREGISTER_CLASS(RDAccelerationStructureInstance);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -9060,6 +9060,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_compile_spirv_from_source", "shader_source", "allow_cache"), &RenderingDevice::_shader_compile_spirv_from_source, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("shader_compile_binary_from_spirv", "spirv_data", "name"), &RenderingDevice::_shader_compile_binary_from_spirv, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("shader_create_from_spirv", "spirv_data", "name"), &RenderingDevice::_shader_create_from_spirv, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("shader_reflect_spirv", "spirv_data", "name"), &RenderingDevice::_shader_reflect_spirv, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("shader_create_from_bytecode", "binary_data", "placeholder_rid"), &RenderingDevice::shader_create_from_bytecode, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("shader_create_placeholder"), &RenderingDevice::shader_create_placeholder);
 
@@ -10025,6 +10026,131 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 		stage_data.push_back(sd);
 	}
 	return shader_create_from_spirv(stage_data);
+}
+
+static Ref<RDShaderReflectionMember> _make_reflection_member(const RenderingDeviceCommons::ShaderMember &p_member) {
+	Ref<RDShaderReflectionMember> member;
+	member.instantiate();
+	member->set_name(p_member.name);
+	member->set_offset(p_member.offset);
+	member->set_size(p_member.size);
+	member->set_padded_size(p_member.padded_size);
+	member->set_type_op(p_member.type);
+	member->set_numeric_width(p_member.numeric_width);
+	member->set_numeric_signedness(p_member.numeric_signedness);
+	member->set_vector_component_count(p_member.vector_component_count);
+	member->set_matrix_column_count(p_member.matrix_column_count);
+	member->set_matrix_row_count(p_member.matrix_row_count);
+	member->set_matrix_stride(p_member.matrix_stride);
+	member->set_array_dimensions(p_member.array_dimensions);
+
+	TypedArray<RDShaderReflectionMember> members;
+	for (int i = 0; i < p_member.members.size(); i++) {
+		members.push_back(_make_reflection_member(p_member.members[i]));
+	}
+	member->set_members(members);
+
+	return member;
+}
+
+Ref<RDShaderReflection> RenderingDevice::_shader_reflect_spirv(const Ref<RDShaderSPIRV> &p_spirv, const String &p_shader_name) {
+	ERR_FAIL_COND_V(p_spirv.is_null(), Ref<RDShaderReflection>());
+
+	Vector<ShaderStageSPIRVData> stage_data;
+	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
+		ShaderStage stage = ShaderStage(i);
+		ShaderStageSPIRVData sd;
+		sd.shader_stage = stage;
+		String error = p_spirv->get_stage_compile_error(stage);
+		ERR_FAIL_COND_V_MSG(!error.is_empty(), Ref<RDShaderReflection>(), "Can't reflect an errored bytecode. Check errors in source bytecode.");
+		sd.spirv = p_spirv->get_stage_bytecode(stage);
+		if (sd.spirv.is_empty()) {
+			continue;
+		}
+		stage_data.push_back(sd);
+	}
+
+	ERR_FAIL_COND_V(stage_data.is_empty(), Ref<RDShaderReflection>());
+
+	const RenderingShaderContainerFormat &container_format = driver->get_shader_container_format();
+	Ref<RenderingShaderContainer> shader_container = container_format.create_container();
+	ERR_FAIL_COND_V(shader_container.is_null(), Ref<RDShaderReflection>());
+
+	ShaderReflection shader_reflection = shader_container->get_reflection_from_spirv(p_shader_name, stage_data);
+	ERR_FAIL_COND_V_MSG(shader_reflection.stages_vector.is_empty(), Ref<RDShaderReflection>(), "Failed to reflect SPIR-V shader.");
+
+	Ref<RDShaderReflection> reflection;
+	reflection.instantiate();
+	reflection->set_vertex_input_mask(shader_reflection.vertex_input_mask);
+	reflection->set_fragment_output_mask(shader_reflection.fragment_output_mask);
+	reflection->set_pipeline_type(shader_reflection.pipeline_type);
+	reflection->set_has_multiview(shader_reflection.has_multiview);
+	reflection->set_has_dynamic_buffers(shader_reflection.has_dynamic_buffers);
+	reflection->set_compute_local_size(Vector3i(shader_reflection.compute_local_size[0], shader_reflection.compute_local_size[1], shader_reflection.compute_local_size[2]));
+	reflection->set_push_constant_name(shader_reflection.push_constant_name);
+	reflection->set_push_constant_size(shader_reflection.push_constant_size);
+	reflection->set_push_constant_stages(uint32_t(shader_reflection.push_constant_stages));
+
+	TypedArray<RDShaderReflectionMember> push_constant_members;
+	for (int i = 0; i < shader_reflection.push_constant_members.size(); i++) {
+		push_constant_members.push_back(_make_reflection_member(shader_reflection.push_constant_members[i]));
+	}
+	reflection->set_push_constant_members(push_constant_members);
+
+	reflection->set_stages(uint32_t(shader_reflection.stages_bits));
+
+	TypedArray<RDShaderReflectionUniform> uniforms;
+	for (int set_index = 0; set_index < shader_reflection.uniform_sets.size(); set_index++) {
+		const Vector<ShaderUniform> &uniform_set = shader_reflection.uniform_sets[set_index];
+		for (int uniform_index = 0; uniform_index < uniform_set.size(); uniform_index++) {
+			const ShaderUniform &shader_uniform = uniform_set[uniform_index];
+			Ref<RDShaderReflectionUniform> uniform;
+			uniform.instantiate();
+			uniform->set_descriptor_set(set_index);
+			uniform->set_binding(shader_uniform.binding);
+			uniform->set_resource_type(shader_uniform.type);
+			uniform->set_stages(uint32_t(shader_uniform.stages));
+			uniform->set_length(shader_uniform.length);
+			uniform->set_writable(shader_uniform.writable);
+			uniform->set_name(shader_uniform.name);
+
+			TypedArray<RDShaderReflectionMember> uniform_members;
+			for (int i = 0; i < shader_uniform.members.size(); i++) {
+				uniform_members.push_back(_make_reflection_member(shader_uniform.members[i]));
+			}
+			uniform->set_members(uniform_members);
+			uniforms.push_back(uniform);
+		}
+	}
+	reflection->set_uniforms(uniforms);
+
+	TypedArray<RDShaderReflectionSpecializationConstant> specialization_constants;
+	for (int i = 0; i < shader_reflection.specialization_constants.size(); i++) {
+		const ShaderSpecializationConstant &shader_specialization_constant = shader_reflection.specialization_constants[i];
+		Ref<RDShaderReflectionSpecializationConstant> specialization_constant;
+		specialization_constant.instantiate();
+		specialization_constant->set_name(shader_specialization_constant.name);
+		specialization_constant->set_constant_id(shader_specialization_constant.constant_id);
+		specialization_constant->set_value_type(shader_specialization_constant.type);
+		specialization_constant->set_stages(uint32_t(shader_specialization_constant.stages));
+
+		switch (shader_specialization_constant.type) {
+			case PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL:
+				specialization_constant->set_default_value(shader_specialization_constant.bool_value);
+				break;
+			case PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT:
+				specialization_constant->set_default_value(shader_specialization_constant.int_value);
+				break;
+			case PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT:
+				specialization_constant->set_default_value(shader_specialization_constant.float_value);
+				break;
+		}
+
+		specialization_constants.push_back(specialization_constant);
+	}
+	reflection->set_specialization_constants(specialization_constants);
+
+	return reflection;
 }
 
 RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -50,6 +50,7 @@ class RDTextureView;
 class RDAttachmentFormat;
 class RDSamplerState;
 class RDVertexAttribute;
+class RDShaderReflection;
 class RDShaderSource;
 class RDShaderSPIRV;
 class RDUniform;
@@ -1999,6 +2000,7 @@ private:
 	Ref<RDShaderSPIRV> _shader_compile_spirv_from_source(const Ref<RDShaderSource> &p_source, bool p_allow_cache = true);
 	Vector<uint8_t> _shader_compile_binary_from_spirv(const Ref<RDShaderSPIRV> &p_bytecode, const String &p_shader_name = "");
 	RID _shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv, const String &p_shader_name = "");
+	Ref<RDShaderReflection> _shader_reflect_spirv(const Ref<RDShaderSPIRV> &p_spirv, const String &p_shader_name = "");
 
 	RID _uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
 

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -470,6 +470,284 @@ protected:
 	}
 };
 
+class RDShaderReflectionMember : public RefCounted {
+	GDCLASS(RDShaderReflectionMember, RefCounted)
+
+	String name;
+	uint32_t offset = 0;
+	uint32_t size = 0;
+	uint32_t padded_size = 0;
+	uint32_t type_op = 0;
+	uint32_t numeric_width = 0;
+	uint32_t numeric_signedness = 0;
+	uint32_t vector_component_count = 0;
+	uint32_t matrix_column_count = 0;
+	uint32_t matrix_row_count = 0;
+	uint32_t matrix_stride = 0;
+	PackedInt32Array array_dimensions;
+	TypedArray<RDShaderReflectionMember> members;
+
+public:
+	void set_name(const String &p_name) { name = p_name; }
+	String get_name() const { return name; }
+
+	void set_offset(uint32_t p_offset) { offset = p_offset; }
+	uint32_t get_offset() const { return offset; }
+
+	void set_size(uint32_t p_size) { size = p_size; }
+	uint32_t get_size() const { return size; }
+
+	void set_padded_size(uint32_t p_padded_size) { padded_size = p_padded_size; }
+	uint32_t get_padded_size() const { return padded_size; }
+
+	void set_type_op(uint32_t p_type_op) { type_op = p_type_op; }
+	uint32_t get_type_op() const { return type_op; }
+
+	void set_numeric_width(uint32_t p_numeric_width) { numeric_width = p_numeric_width; }
+	uint32_t get_numeric_width() const { return numeric_width; }
+
+	void set_numeric_signedness(uint32_t p_numeric_signedness) { numeric_signedness = p_numeric_signedness; }
+	uint32_t get_numeric_signedness() const { return numeric_signedness; }
+
+	void set_vector_component_count(uint32_t p_vector_component_count) { vector_component_count = p_vector_component_count; }
+	uint32_t get_vector_component_count() const { return vector_component_count; }
+
+	void set_matrix_column_count(uint32_t p_matrix_column_count) { matrix_column_count = p_matrix_column_count; }
+	uint32_t get_matrix_column_count() const { return matrix_column_count; }
+
+	void set_matrix_row_count(uint32_t p_matrix_row_count) { matrix_row_count = p_matrix_row_count; }
+	uint32_t get_matrix_row_count() const { return matrix_row_count; }
+
+	void set_matrix_stride(uint32_t p_matrix_stride) { matrix_stride = p_matrix_stride; }
+	uint32_t get_matrix_stride() const { return matrix_stride; }
+
+	void set_array_dimensions(const PackedInt32Array &p_array_dimensions) { array_dimensions = p_array_dimensions; }
+	PackedInt32Array get_array_dimensions() const { return array_dimensions; }
+
+	void set_members(const TypedArray<RDShaderReflectionMember> &p_members) { members = p_members; }
+	TypedArray<RDShaderReflectionMember> get_members() const { return members; }
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("get_name"), &RDShaderReflectionMember::get_name);
+		ClassDB::bind_method(D_METHOD("get_offset"), &RDShaderReflectionMember::get_offset);
+		ClassDB::bind_method(D_METHOD("get_size"), &RDShaderReflectionMember::get_size);
+		ClassDB::bind_method(D_METHOD("get_padded_size"), &RDShaderReflectionMember::get_padded_size);
+		ClassDB::bind_method(D_METHOD("get_type_op"), &RDShaderReflectionMember::get_type_op);
+		ClassDB::bind_method(D_METHOD("get_numeric_width"), &RDShaderReflectionMember::get_numeric_width);
+		ClassDB::bind_method(D_METHOD("get_numeric_signedness"), &RDShaderReflectionMember::get_numeric_signedness);
+		ClassDB::bind_method(D_METHOD("get_vector_component_count"), &RDShaderReflectionMember::get_vector_component_count);
+		ClassDB::bind_method(D_METHOD("get_matrix_column_count"), &RDShaderReflectionMember::get_matrix_column_count);
+		ClassDB::bind_method(D_METHOD("get_matrix_row_count"), &RDShaderReflectionMember::get_matrix_row_count);
+		ClassDB::bind_method(D_METHOD("get_matrix_stride"), &RDShaderReflectionMember::get_matrix_stride);
+		ClassDB::bind_method(D_METHOD("get_array_dimensions"), &RDShaderReflectionMember::get_array_dimensions);
+		ClassDB::bind_method(D_METHOD("get_members"), &RDShaderReflectionMember::get_members);
+
+		ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_name");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_offset");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_size");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "padded_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_padded_size");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "type_op", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_type_op");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "numeric_width", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_numeric_width");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "numeric_signedness", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_numeric_signedness");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "vector_component_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_vector_component_count");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "matrix_column_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_matrix_column_count");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "matrix_row_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_matrix_row_count");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "matrix_stride", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_matrix_stride");
+		ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "array_dimensions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_array_dimensions");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "members", PROPERTY_HINT_ARRAY_TYPE, "RDShaderReflectionMember", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_members");
+	}
+};
+
+class RDShaderReflectionUniform : public RefCounted {
+	GDCLASS(RDShaderReflectionUniform, RefCounted)
+
+	String name;
+	uint32_t descriptor_set = 0;
+	uint32_t binding = 0;
+	uint32_t resource_type = RD::UNIFORM_TYPE_MAX;
+	uint32_t stages = 0;
+	uint32_t length = 0;
+	bool writable = false;
+	TypedArray<RDShaderReflectionMember> members;
+
+public:
+	void set_name(const String &p_name) { name = p_name; }
+	String get_name() const { return name; }
+
+	void set_descriptor_set(uint32_t p_descriptor_set) { descriptor_set = p_descriptor_set; }
+	uint32_t get_descriptor_set() const { return descriptor_set; }
+
+	void set_binding(uint32_t p_binding) { binding = p_binding; }
+	uint32_t get_binding() const { return binding; }
+
+	void set_resource_type(uint32_t p_resource_type) { resource_type = p_resource_type; }
+	uint32_t get_resource_type() const { return resource_type; }
+
+	void set_stages(uint32_t p_stages) { stages = p_stages; }
+	uint32_t get_stages() const { return stages; }
+
+	void set_length(uint32_t p_length) { length = p_length; }
+	uint32_t get_length() const { return length; }
+
+	void set_writable(bool p_writable) { writable = p_writable; }
+	bool get_writable() const { return writable; }
+
+	void set_members(const TypedArray<RDShaderReflectionMember> &p_members) { members = p_members; }
+	TypedArray<RDShaderReflectionMember> get_members() const { return members; }
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("get_name"), &RDShaderReflectionUniform::get_name);
+		ClassDB::bind_method(D_METHOD("get_descriptor_set"), &RDShaderReflectionUniform::get_descriptor_set);
+		ClassDB::bind_method(D_METHOD("get_binding"), &RDShaderReflectionUniform::get_binding);
+		ClassDB::bind_method(D_METHOD("get_resource_type"), &RDShaderReflectionUniform::get_resource_type);
+		ClassDB::bind_method(D_METHOD("get_stages"), &RDShaderReflectionUniform::get_stages);
+		ClassDB::bind_method(D_METHOD("get_length"), &RDShaderReflectionUniform::get_length);
+		ClassDB::bind_method(D_METHOD("get_writable"), &RDShaderReflectionUniform::get_writable);
+		ClassDB::bind_method(D_METHOD("get_members"), &RDShaderReflectionUniform::get_members);
+
+		ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_name");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "descriptor_set", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_descriptor_set");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "binding", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_binding");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "resource_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_resource_type");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "stages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_stages");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "length", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_length");
+		ADD_PROPERTY(PropertyInfo(Variant::BOOL, "writable", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_writable");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "members", PROPERTY_HINT_ARRAY_TYPE, "RDShaderReflectionMember", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_members");
+	}
+};
+
+class RDShaderReflectionSpecializationConstant : public RefCounted {
+	GDCLASS(RDShaderReflectionSpecializationConstant, RefCounted)
+
+	String name;
+	uint32_t constant_id = 0;
+	uint32_t value_type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
+	Variant default_value = false;
+	uint32_t stages = 0;
+
+public:
+	void set_name(const String &p_name) { name = p_name; }
+	String get_name() const { return name; }
+
+	void set_constant_id(uint32_t p_constant_id) { constant_id = p_constant_id; }
+	uint32_t get_constant_id() const { return constant_id; }
+
+	void set_value_type(uint32_t p_value_type) { value_type = p_value_type; }
+	uint32_t get_value_type() const { return value_type; }
+
+	void set_default_value(const Variant &p_default_value) { default_value = p_default_value; }
+	Variant get_default_value() const { return default_value; }
+
+	void set_stages(uint32_t p_stages) { stages = p_stages; }
+	uint32_t get_stages() const { return stages; }
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("get_name"), &RDShaderReflectionSpecializationConstant::get_name);
+		ClassDB::bind_method(D_METHOD("get_constant_id"), &RDShaderReflectionSpecializationConstant::get_constant_id);
+		ClassDB::bind_method(D_METHOD("get_value_type"), &RDShaderReflectionSpecializationConstant::get_value_type);
+		ClassDB::bind_method(D_METHOD("get_default_value"), &RDShaderReflectionSpecializationConstant::get_default_value);
+		ClassDB::bind_method(D_METHOD("get_stages"), &RDShaderReflectionSpecializationConstant::get_stages);
+
+		ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_name");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "constant_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_constant_id");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "value_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_value_type");
+		ADD_PROPERTY(PropertyInfo(Variant::NIL, "default_value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT | PROPERTY_USAGE_READ_ONLY), "", "get_default_value");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "stages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_stages");
+	}
+};
+
+class RDShaderReflection : public RefCounted {
+	GDCLASS(RDShaderReflection, RefCounted)
+
+	uint64_t vertex_input_mask = 0;
+	uint32_t fragment_output_mask = 0;
+	uint32_t pipeline_type = RD::PIPELINE_TYPE_RASTERIZATION;
+	bool has_multiview = false;
+	bool has_dynamic_buffers = false;
+	Vector3i compute_local_size;
+	String push_constant_name;
+	uint32_t push_constant_size = 0;
+	uint32_t push_constant_stages = 0;
+	uint32_t stages = 0;
+	TypedArray<RDShaderReflectionUniform> uniforms;
+	TypedArray<RDShaderReflectionSpecializationConstant> specialization_constants;
+	TypedArray<RDShaderReflectionMember> push_constant_members;
+
+public:
+	void set_vertex_input_mask(uint64_t p_vertex_input_mask) { vertex_input_mask = p_vertex_input_mask; }
+	uint64_t get_vertex_input_mask() const { return vertex_input_mask; }
+
+	void set_fragment_output_mask(uint32_t p_fragment_output_mask) { fragment_output_mask = p_fragment_output_mask; }
+	uint32_t get_fragment_output_mask() const { return fragment_output_mask; }
+
+	void set_pipeline_type(uint32_t p_pipeline_type) { pipeline_type = p_pipeline_type; }
+	uint32_t get_pipeline_type() const { return pipeline_type; }
+
+	void set_has_multiview(bool p_has_multiview) { has_multiview = p_has_multiview; }
+	bool get_has_multiview() const { return has_multiview; }
+
+	void set_has_dynamic_buffers(bool p_has_dynamic_buffers) { has_dynamic_buffers = p_has_dynamic_buffers; }
+	bool get_has_dynamic_buffers() const { return has_dynamic_buffers; }
+
+	void set_compute_local_size(const Vector3i &p_compute_local_size) { compute_local_size = p_compute_local_size; }
+	Vector3i get_compute_local_size() const { return compute_local_size; }
+
+	void set_push_constant_name(const String &p_push_constant_name) { push_constant_name = p_push_constant_name; }
+	String get_push_constant_name() const { return push_constant_name; }
+
+	void set_push_constant_size(uint32_t p_push_constant_size) { push_constant_size = p_push_constant_size; }
+	uint32_t get_push_constant_size() const { return push_constant_size; }
+
+	void set_push_constant_stages(uint32_t p_push_constant_stages) { push_constant_stages = p_push_constant_stages; }
+	uint32_t get_push_constant_stages() const { return push_constant_stages; }
+
+	void set_stages(uint32_t p_stages) { stages = p_stages; }
+	uint32_t get_stages() const { return stages; }
+
+	void set_uniforms(const TypedArray<RDShaderReflectionUniform> &p_uniforms) { uniforms = p_uniforms; }
+	TypedArray<RDShaderReflectionUniform> get_uniforms() const { return uniforms; }
+
+	void set_specialization_constants(const TypedArray<RDShaderReflectionSpecializationConstant> &p_specialization_constants) { specialization_constants = p_specialization_constants; }
+	TypedArray<RDShaderReflectionSpecializationConstant> get_specialization_constants() const { return specialization_constants; }
+
+	void set_push_constant_members(const TypedArray<RDShaderReflectionMember> &p_push_constant_members) { push_constant_members = p_push_constant_members; }
+	TypedArray<RDShaderReflectionMember> get_push_constant_members() const { return push_constant_members; }
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("get_vertex_input_mask"), &RDShaderReflection::get_vertex_input_mask);
+		ClassDB::bind_method(D_METHOD("get_fragment_output_mask"), &RDShaderReflection::get_fragment_output_mask);
+		ClassDB::bind_method(D_METHOD("get_pipeline_type"), &RDShaderReflection::get_pipeline_type);
+		ClassDB::bind_method(D_METHOD("get_has_multiview"), &RDShaderReflection::get_has_multiview);
+		ClassDB::bind_method(D_METHOD("get_has_dynamic_buffers"), &RDShaderReflection::get_has_dynamic_buffers);
+		ClassDB::bind_method(D_METHOD("get_compute_local_size"), &RDShaderReflection::get_compute_local_size);
+		ClassDB::bind_method(D_METHOD("get_push_constant_name"), &RDShaderReflection::get_push_constant_name);
+		ClassDB::bind_method(D_METHOD("get_push_constant_size"), &RDShaderReflection::get_push_constant_size);
+		ClassDB::bind_method(D_METHOD("get_push_constant_stages"), &RDShaderReflection::get_push_constant_stages);
+		ClassDB::bind_method(D_METHOD("get_stages"), &RDShaderReflection::get_stages);
+		ClassDB::bind_method(D_METHOD("get_uniforms"), &RDShaderReflection::get_uniforms);
+		ClassDB::bind_method(D_METHOD("get_specialization_constants"), &RDShaderReflection::get_specialization_constants);
+		ClassDB::bind_method(D_METHOD("get_push_constant_members"), &RDShaderReflection::get_push_constant_members);
+
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "vertex_input_mask", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_vertex_input_mask");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "fragment_output_mask", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_fragment_output_mask");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "pipeline_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_pipeline_type");
+		ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_multiview", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_has_multiview");
+		ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_dynamic_buffers", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_has_dynamic_buffers");
+		ADD_PROPERTY(PropertyInfo(Variant::VECTOR3I, "compute_local_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_compute_local_size");
+		ADD_PROPERTY(PropertyInfo(Variant::STRING, "push_constant_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_push_constant_name");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "push_constant_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_push_constant_size");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "push_constant_stages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_push_constant_stages");
+		ADD_PROPERTY(PropertyInfo(Variant::INT, "stages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_stages");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "uniforms", PROPERTY_HINT_ARRAY_TYPE, "RDShaderReflectionUniform", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_uniforms");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "specialization_constants", PROPERTY_HINT_ARRAY_TYPE, "RDShaderReflectionSpecializationConstant", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_specialization_constants");
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "push_constant_members", PROPERTY_HINT_ARRAY_TYPE, "RDShaderReflectionMember", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "", "get_push_constant_members");
+	}
+};
+
 class RDUniform : public RefCounted {
 	GDCLASS(RDUniform, RefCounted)
 	friend class RenderingDevice;

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -1103,12 +1103,30 @@ public:
 
 	static const char *SHADER_STAGE_NAMES[SHADER_STAGE_MAX];
 
+	struct ShaderMember {
+		String name;
+		uint32_t offset = 0;
+		uint32_t size = 0;
+		uint32_t padded_size = 0;
+		uint32_t type = 0;
+		uint32_t numeric_width = 0;
+		uint32_t numeric_signedness = 0;
+		uint32_t vector_component_count = 0;
+		uint32_t matrix_column_count = 0;
+		uint32_t matrix_row_count = 0;
+		uint32_t matrix_stride = 0;
+		PackedInt32Array array_dimensions;
+		Vector<ShaderMember> members;
+	};
+
 	struct ShaderUniform {
+		String name;
 		UniformType type = UniformType::UNIFORM_TYPE_MAX;
 		bool writable = false;
 		uint32_t binding = 0;
 		BitField<ShaderStage> stages = {};
 		uint32_t length = 0; // Size of arrays (in total elements), or ubos (in bytes * total elements).
+		Vector<ShaderMember> members;
 
 		bool operator!=(const ShaderUniform &p_other) const {
 			return binding != p_other.binding || type != p_other.type || writable != p_other.writable || stages != p_other.stages || length != p_other.length;
@@ -1135,6 +1153,7 @@ public:
 	};
 
 	struct ShaderSpecializationConstant : public PipelineSpecializationConstant {
+		String name;
 		BitField<ShaderStage> stages = {};
 
 		bool operator<(const ShaderSpecializationConstant &p_other) const { return constant_id < p_other.constant_id; }
@@ -1147,7 +1166,9 @@ public:
 		bool has_multiview = false;
 		bool has_dynamic_buffers = false;
 		uint32_t compute_local_size[3] = {};
+		String push_constant_name;
 		uint32_t push_constant_size = 0;
+		Vector<ShaderMember> push_constant_members;
 
 		Vector<Vector<ShaderUniform>> uniform_sets;
 		Vector<ShaderSpecializationConstant> specialization_constants;

--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -232,7 +232,90 @@ static RenderingDeviceCommons::DataFormat spv_image_format_to_data_format(const 
 	return RDC::DATA_FORMAT_MAX;
 }
 
-Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv, ReflectShader &r_shader) {
+static String spv_reflect_name_or_unnamed(const char *p_name) {
+	return p_name != nullptr ? String::utf8(p_name) : String("<unnamed>");
+}
+
+static RenderingDeviceCommons::ShaderMember spv_block_variable_to_shader_member(const SpvReflectBlockVariable &p_variable) {
+	RenderingDeviceCommons::ShaderMember member;
+	member.name = p_variable.name != nullptr ? String::utf8(p_variable.name) : String();
+	member.offset = p_variable.offset;
+	member.size = p_variable.size;
+	member.padded_size = p_variable.padded_size;
+	if (p_variable.type_description != nullptr) {
+		member.type = uint32_t(p_variable.type_description->op);
+	}
+	member.numeric_width = p_variable.numeric.scalar.width;
+	member.numeric_signedness = p_variable.numeric.scalar.signedness;
+	member.vector_component_count = p_variable.numeric.vector.component_count;
+	member.matrix_column_count = p_variable.numeric.matrix.column_count;
+	member.matrix_row_count = p_variable.numeric.matrix.row_count;
+	member.matrix_stride = p_variable.numeric.matrix.stride;
+	member.array_dimensions.resize(p_variable.array.dims_count);
+	for (uint32_t i = 0; i < p_variable.array.dims_count; i++) {
+		member.array_dimensions.write[i] = p_variable.array.dims[i];
+	}
+	member.members.resize(p_variable.member_count);
+	for (uint32_t i = 0; i < p_variable.member_count; i++) {
+		member.members.write[i] = spv_block_variable_to_shader_member(p_variable.members[i]);
+	}
+	return member;
+}
+
+RenderingDeviceCommons::ShaderReflection RenderingShaderContainer::make_shader_reflection(const ReflectShader &p_reflection) const {
+	RenderingDeviceCommons::ShaderReflection shader_refl;
+	shader_refl.push_constant_name = p_reflection.push_constant_name;
+	shader_refl.push_constant_size = p_reflection.push_constant_size;
+	shader_refl.push_constant_members = p_reflection.push_constant_members;
+	shader_refl.push_constant_stages = p_reflection.push_constant_stages;
+	shader_refl.vertex_input_mask = p_reflection.vertex_input_mask;
+	shader_refl.fragment_output_mask = p_reflection.fragment_output_mask;
+	shader_refl.pipeline_type = p_reflection.pipeline_type;
+	shader_refl.has_multiview = p_reflection.has_multiview;
+	shader_refl.has_dynamic_buffers = p_reflection.has_dynamic_buffers;
+	shader_refl.compute_local_size[0] = p_reflection.compute_local_size[0];
+	shader_refl.compute_local_size[1] = p_reflection.compute_local_size[1];
+	shader_refl.compute_local_size[2] = p_reflection.compute_local_size[2];
+	shader_refl.uniform_sets.resize(p_reflection.uniform_sets.size());
+
+	for (uint32_t i = 0; i < p_reflection.uniform_sets.size(); i++) {
+		Vector<RenderingDeviceCommons::ShaderUniform> &uniform_set = shader_refl.uniform_sets.ptrw()[i];
+		uniform_set.resize(p_reflection.uniform_sets[i].size());
+		for (uint32_t j = 0; j < p_reflection.uniform_sets[i].size(); j++) {
+			const ReflectUniform &reflected_uniform = p_reflection.uniform_sets[i][j];
+			RenderingDeviceCommons::ShaderUniform &uniform = uniform_set.ptrw()[j];
+			uniform.name = reflected_uniform.name;
+			uniform.type = reflected_uniform.type;
+			uniform.writable = reflected_uniform.writable;
+			uniform.length = reflected_uniform.length;
+			uniform.binding = reflected_uniform.binding;
+			uniform.stages = reflected_uniform.stages;
+			uniform.members = reflected_uniform.members;
+		}
+	}
+
+	shader_refl.specialization_constants.resize(p_reflection.specialization_constants.size());
+	for (uint32_t i = 0; i < p_reflection.specialization_constants.size(); i++) {
+		const ReflectSpecializationConstant &reflected_spec = p_reflection.specialization_constants[i];
+		RenderingDeviceCommons::ShaderSpecializationConstant &spec = shader_refl.specialization_constants.ptrw()[i];
+		spec.name = reflected_spec.name;
+		spec.type = reflected_spec.type;
+		spec.constant_id = reflected_spec.constant_id;
+		spec.int_value = reflected_spec.int_value;
+		spec.stages = reflected_spec.stages;
+	}
+
+	for (uint32_t i = 0; i < RenderingDeviceCommons::SHADER_STAGE_MAX; i++) {
+		if (p_reflection.stages_bits.has_flag(RenderingDeviceCommons::ShaderStage(1U << i))) {
+			shader_refl.stages_vector.push_back(RenderingDeviceCommons::ShaderStage(i));
+			shader_refl.stages_bits.set_flag(RenderingDeviceCommons::ShaderStage(1U << i));
+		}
+	}
+
+	return shader_refl;
+}
+
+Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv, ReflectShader &r_shader, bool p_full_reflection) {
 	ReflectShader &reflection = r_shader;
 
 	shader_name = p_shader_name.utf8();
@@ -339,6 +422,9 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 					const SpvReflectDescriptorBinding &binding = *bindings[j];
 
 					ReflectUniform uniform;
+					if (p_full_reflection) {
+						uniform.name = binding.name != nullptr ? String::utf8(binding.name) : String();
+					}
 					uniform.set_spv_reflect(stage, &binding);
 
 					bool need_array_dimensions = false;
@@ -424,6 +510,12 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						}
 					} else if (need_block_size) {
 						uniform.length = binding.block.size;
+						if (p_full_reflection) {
+							uniform.members.resize(binding.block.member_count);
+							for (uint32_t k = 0; k < binding.block.member_count; k++) {
+								uniform.members.write[k] = spv_block_variable_to_shader_member(binding.block.members[k]);
+							}
+						}
 					} else {
 						uniform.length = 0;
 					}
@@ -446,7 +538,7 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 					uint32_t set = binding.set;
 
 					ERR_FAIL_COND_V_MSG(set >= RDC::MAX_UNIFORM_SETS, FAILED,
-							"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + binding.name + "' uses a set (" + itos(set) + ") index larger than what is supported (" + itos(RDC::MAX_UNIFORM_SETS) + ").");
+							"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + spv_reflect_name_or_unnamed(binding.name) + "' uses a set (" + itos(set) + ") index larger than what is supported (" + itos(RDC::MAX_UNIFORM_SETS) + ").");
 
 					if (set < (uint32_t)reflection.uniform_sets.size()) {
 						// Check if this already exists.
@@ -455,15 +547,15 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 							if (reflection.uniform_sets[set][k].binding == uniform.binding) {
 								// Already exists, verify that it's the same type.
 								ERR_FAIL_COND_V_MSG(reflection.uniform_sets[set][k].type != uniform.type, FAILED,
-										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + binding.name + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different uniform type.");
+										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + spv_reflect_name_or_unnamed(binding.name) + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different uniform type.");
 
 								// Also, verify that it's the same size.
 								ERR_FAIL_COND_V_MSG(reflection.uniform_sets[set][k].length != uniform.length, FAILED,
-										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + binding.name + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different uniform size.");
+										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + spv_reflect_name_or_unnamed(binding.name) + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different uniform size.");
 
 								// Also, verify that it has the same writability.
 								ERR_FAIL_COND_V_MSG(reflection.uniform_sets[set][k].writable != uniform.writable, FAILED,
-										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + binding.name + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different writability.");
+										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + spv_reflect_name_or_unnamed(binding.name) + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different writability.");
 
 								// Just append stage mask and return.
 								reflection.uniform_sets[set][k].stages.set_flag(uniform_stage_flags);
@@ -507,6 +599,9 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						int32_t existing = -1;
 						ReflectSpecializationConstant sconst;
 						SpvReflectSpecializationConstant *spc = spec_constants[j];
+						if (p_full_reflection) {
+							sconst.name = spc->name != nullptr ? String::utf8(spc->name) : String();
+						}
 						sconst.set_spv_reflect(stage, spc);
 
 						if (spc->default_value_size != 4) {
@@ -636,6 +731,13 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						"Reflection of SPIR-V shader stage '" + String(RDC::SHADER_STAGE_NAMES[p_spirv[i].shader_stage]) + "': Push constant block must be the same across shader stages.");
 
 				reflection.push_constant_size = pconstants[0]->size;
+				if (p_full_reflection && reflection.push_constant_members.is_empty()) {
+					reflection.push_constant_name = pconstants[0]->name != nullptr ? String::utf8(pconstants[0]->name) : String();
+					reflection.push_constant_members.resize(pconstants[0]->member_count);
+					for (uint32_t j = 0; j < pconstants[0]->member_count; j++) {
+						reflection.push_constant_members.write[j] = spv_block_variable_to_shader_member(pconstants[0]->members[j]);
+					}
+				}
 				reflection.push_constant_stages.set_flag(uniform_stage_flags);
 
 				//print_line("Stage: " + String(RDC::SHADER_STAGE_NAMES[stage]) + " push constant of size=" + itos(push_constant.push_constant_size));
@@ -711,6 +813,18 @@ bool RenderingShaderContainer::set_code_from_spirv(const String &p_shader_name, 
 	ReflectShader shader;
 	ERR_FAIL_COND_V(reflect_spirv(p_shader_name, p_spirv, shader) != OK, false);
 	return _set_code_from_spirv(shader);
+}
+
+bool RenderingShaderContainer::set_reflection_from_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv) {
+	ReflectShader shader;
+	ERR_FAIL_COND_V(reflect_spirv(p_shader_name, p_spirv, shader) != OK, false);
+	return true;
+}
+
+RenderingDeviceCommons::ShaderReflection RenderingShaderContainer::get_reflection_from_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv) {
+	ReflectShader shader;
+	ERR_FAIL_COND_V(reflect_spirv(p_shader_name, p_spirv, shader, true) != OK, RDC::ShaderReflection());
+	return make_shader_reflection(shader);
 }
 
 RenderingDeviceCommons::ShaderReflection RenderingShaderContainer::get_shader_reflection() const {

--- a/servers/rendering/rendering_shader_container.h
+++ b/servers/rendering/rendering_shader_container.h
@@ -167,12 +167,14 @@ protected:
 	};
 
 	struct ReflectUniform : ReflectSymbol<SpvReflectDescriptorBinding> {
+		String name;
 		RDC::UniformType type = RDC::UniformType::UNIFORM_TYPE_MAX;
 		uint32_t binding = 0;
 
 		ReflectImageTraits image;
 
 		uint32_t length = 0; // Size of arrays (in total elements), or ubos (in bytes * total elements).
+		Vector<RDC::ShaderMember> members;
 		bool writable = false;
 
 		bool operator<(const ReflectUniform &p_other) const {
@@ -196,6 +198,7 @@ protected:
 	};
 
 	struct ReflectSpecializationConstant : ReflectSymbol<SpvReflectSpecializationConstant> {
+		String name;
 		RDC::PipelineSpecializationConstantType type = {};
 		uint32_t constant_id = 0xffffffff;
 		union {
@@ -229,7 +232,9 @@ protected:
 		uint64_t vertex_input_mask = 0;
 		uint32_t fragment_output_mask = 0;
 		uint32_t compute_local_size[3] = {};
+		String push_constant_name;
 		uint32_t push_constant_size = 0;
+		Vector<RDC::ShaderMember> push_constant_members;
 		bool has_multiview = false;
 		bool has_dynamic_buffers = false;
 		RDC::PipelineType pipeline_type = RDC::PIPELINE_TYPE_RASTERIZATION;
@@ -277,7 +282,8 @@ protected:
 	virtual bool _set_code_from_spirv(const ReflectShader &p_shader) = 0;
 
 	void set_from_shader_reflection(const ReflectShader &p_reflection);
-	Error reflect_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv, ReflectShader &r_shader);
+	RDC::ShaderReflection make_shader_reflection(const ReflectShader &p_reflection) const;
+	Error reflect_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv, ReflectShader &r_shader, bool p_full_reflection = false);
 
 public:
 	enum CompressionFlags {
@@ -295,6 +301,8 @@ public:
 	Vector<Shader> shaders;
 
 	bool set_code_from_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv);
+	bool set_reflection_from_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv);
+	RDC::ShaderReflection get_reflection_from_spirv(const String &p_shader_name, Span<RDC::ShaderStageSPIRVData> p_spirv);
 	RDC::ShaderReflection get_shader_reflection() const;
 	bool from_bytes(const PackedByteArray &p_bytes);
 	PackedByteArray to_bytes() const;


### PR DESCRIPTION
Adds a structured `RenderingDevice.shader_reflect_spirv()` API to inspect SPIR-V bytecode before creating a shader
and exposes most of the reflection data. This helps users bind resources for custom SPIR-V shaders without having to run a separate reflection tool.

Reflection data is returned through read-only `RDShaderReflection*` objects.
(I'm not sure whethre introducing these classes is too heavy for this usage, so if  exposing as a simple dictionary is preferred, I would change to that way)


The full name/member reflection path is only used when `shader_reflect_spirv()` is called, so normal `shader_create_from_spirv()` usage does not pay the extra reflection cost. 

SPIR-V without debug/name information is supported for basic binding data; names are returned empty when stripped.

The API adds the following read-only reflection objects:
`RDShaderReflection`
`RDShaderReflectionUniform`,
`RDShaderReflectionSpecializationConstant`
`RDShaderReflectionMember`.


Typical usage:
```gdscript
var reflection := RenderingServer.get_rendering_device().shader_reflect_spirv(spirv)
print("local size: ", reflection.compute_local_size)
print("push constant size: ", reflection.push_constant_size)
for member in reflection.push_constant_members:
	print("push member: ", member.name, " offset=", member.offset, " size=", member.size)
for uniform in reflection.uniforms:
	print("uniform: set=", uniform.descriptor_set, " binding=", uniform.binding, " type=", uniform.resource_type)
	for member in uniform.members:
		print("  block member: ", member.name, " offset=", member.offset, " size=", member.size)
for spec_constant in reflection.specialization_constants:
	print("specialization: id=", spec_constant.constant_id, " default=", spec_constant.default_value)
```


This has some overlap with #106581, but targets a bit different use case: reflecting `RDShaderSPIRV` bytecode before shader creation rather than querying an already-created shader RID.

Related proposals:
- godotengine/godot-proposals#10740