### PR TITLE
Improve error messages when trying to save invalid resources in the editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1745,9 +1745,9 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 
 	if (err != OK) {
 		if (ResourceLoader::is_imported(p_resource->get_path())) {
-			show_accept(TTR("Imported resources can't be saved."), TTR("OK"));
+			show_accept(vformat(TTR("Cannot save resource at path \"%s\", as it is imported.\nImported resources can't be saved. Instead, modify the source file or change options in the Import dock."), path), TTR("OK"));
 		} else {
-			show_accept(TTR("Error saving resource!"), TTR("OK"));
+			show_accept(vformat(TTR("Error saving resource at path \"%s\": %s."), path, error_names[err]), TTR("OK"));
 		}
 
 		saving_resources_in_path.erase(p_resource);


### PR DESCRIPTION
To test this:

- Create a script.
- Rename the script's extension to `.scn` in the FileSystem dock.
- Try to save the resource in the inspector using the save icon at the top.

## Preview

<img width="618" height="136" alt="image" src="https://github.com/user-attachments/assets/a5339636-f469-44e0-868b-cd3706f4d564" />

- This closes https://github.com/godotengine/godot/issues/109780.