### PR TITLE
Implement LSP method `workspace/symbol`

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -619,6 +619,121 @@ Array GDScriptLanguageProtocol::lsp_completion(const Dictionary &p_params) {
 	return arr;
 }
 
+LSP::Range get_enum_value_range(const GDScriptParser::EnumNode::Value &p_enum_value) {
+	LSP::Range r;
+	r.start.line = p_enum_value.line - 1;
+	r.start.character = p_enum_value.start_column;
+	r.end.line = p_enum_value.line - 1;
+	r.end.character = p_enum_value.end_column;
+	return r;
+}
+
+LSP::Range get_node_range(const GDScriptParser::Node *p_node) {
+	LSP::Range r;
+	r.start.line = p_node->start_line - 1;
+	r.start.character = p_node->start_column;
+	r.end.line = p_node->end_line - 1;
+	r.end.character = p_node->end_column;
+	return r;
+}
+
+void collect_workspace_symbols(Array &p_arr, const GDScriptParser::ClassNode *p_tree, const String &p_uri, const String &p_query) {
+	if (!p_tree) {
+		return;
+	}
+
+	LSP::WorkspaceSymbol ws;
+	if (p_tree->outer) {
+		ws.containerName = p_tree->outer->identifier->name;
+		ws.name = p_tree->identifier->name;
+	} else {
+		ws.name = p_tree->get_global_name();
+	}
+	ws.kind = LSP::SymbolKind::Class;
+	ws.location.uri = p_uri;
+	ws.location.range = get_node_range(p_tree);
+	if (p_query.is_empty() || ws.name.matchn(p_query)) {
+		p_arr.append(ws.to_json());
+	}
+
+	for (const GDScriptParser::ClassNode::Member &member : p_tree->members) {
+		LSP::WorkspaceSymbol member_ws;
+		member_ws.location.uri = p_uri;
+		member_ws.location.range = get_node_range(member.get_source_node());
+		member_ws.name = member.get_name();
+		member_ws.containerName = ws.name;
+		switch (member.type) {
+			case GDScriptParser::ClassNode::Member::CLASS:
+				collect_workspace_symbols(p_arr, member.m_class, p_uri, p_query);
+				break;
+			case GDScriptParser::ClassNode::Member::CONSTANT:
+				member_ws.kind = LSP::SymbolKind::Constant;
+				break;
+			case GDScriptParser::ClassNode::Member::FUNCTION:
+				member_ws.kind = LSP::SymbolKind::Function;
+				break;
+			case GDScriptParser::ClassNode::Member::SIGNAL:
+				member_ws.kind = LSP::SymbolKind::Event;
+				break;
+			case GDScriptParser::ClassNode::Member::VARIABLE:
+				member_ws.kind = LSP::SymbolKind::Variable;
+				break;
+			case GDScriptParser::ClassNode::Member::ENUM:
+				member_ws.kind = LSP::SymbolKind::Enum;
+				for (const GDScriptParser::EnumNode::Value &value : member.m_enum->values) {
+					LSP::WorkspaceSymbol enum_value_ws;
+					enum_value_ws.name = value.identifier->name;
+					enum_value_ws.kind = LSP::SymbolKind::EnumMember;
+					enum_value_ws.location.uri = p_uri;
+					enum_value_ws.location.range = get_enum_value_range(value);
+					enum_value_ws.containerName = member_ws.name;
+					if (p_query.is_empty() || enum_value_ws.name.matchn(p_query)) {
+						p_arr.push_back(enum_value_ws.to_json());
+					}
+				}
+				break;
+			case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+				member_ws.kind = LSP::SymbolKind::EnumMember;
+				break;
+			default:
+				continue;
+		}
+		if (p_query.is_empty() || member_ws.name.matchn(p_query)) {
+			p_arr.push_back(member_ws.to_json());
+		}
+	}
+}
+
+Array GDScriptLanguageProtocol::lsp_symbol(const Dictionary &p_params) {
+	Array arr;
+	LSP_CLIENT_V(arr);
+	String query = p_params["query"];
+	List<String> all_scripts;
+	workspace->list_script_files("res://", all_scripts);
+
+	for (const String &path : all_scripts) {
+		String uri = workspace->get_file_uri(path);
+		if (client->parse_results.has(path)) {
+			const ExtendGDScriptParser *cached_parser = client->parse_results.get(path);
+			collect_workspace_symbols(arr, cached_parser->get_tree(), uri, query);
+		} else {
+			String content;
+			const LSP::TextDocumentItem *document = client->managed_files.getptr(path);
+			if (document == nullptr) {
+				Error err;
+				content = FileAccess::get_file_as_string(path, &err);
+				ERR_FAIL_COND_V(err != OK, arr);
+			} else {
+				content = document->text;
+			}
+			GDScriptParser parser;
+			parser.parse(content, path, false);
+			collect_workspace_symbols(arr, parser.get_tree(), workspace->get_file_uri(path), query);
+		}
+	}
+	return arr;
+}
+
 void GDScriptLanguageProtocol::resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list) {
 	LSP_CLIENT;
 
@@ -699,6 +814,8 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	SET_DOCUMENT_METHOD(nativeSymbol); // Custom method.
 
 	SET_COMPLETION_METHOD(resolve);
+
+	SET_WORKSPACE_METHOD(symbol);
 
 	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
 	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -153,6 +153,9 @@ public:
 	// Completion
 	Array lsp_completion(const Dictionary &p_params);
 
+	// Workspace
+	Array lsp_symbol(const Dictionary &p_params);
+
 	/**
 	 * Returns a list of symbols that might be related to the document position.
 	 *

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -783,6 +783,10 @@ Error GDScriptWorkspace::resolve_signature(const LSP::TextDocumentPositionParams
 	return ERR_METHOD_NOT_FOUND;
 }
 
+Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
+	return GDScriptLanguageProtocol::get_singleton()->lsp_symbol(p_params);
+}
+
 GDScriptWorkspace::GDScriptWorkspace() {}
 
 GDScriptWorkspace::~GDScriptWorkspace() {}

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -67,8 +67,6 @@ protected:
 
 	void reload_all_workspace_scripts();
 
-	void list_script_files(const String &p_root_dir, List<String> &r_files);
-
 	void apply_new_signal(Object *obj, String function, PackedStringArray args);
 
 public:
@@ -96,6 +94,9 @@ public:
 	bool can_rename(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::DocumentSymbol &r_symbol, LSP::Range &r_range);
 	Vector<LSP::Location> find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path);
 	Vector<LSP::Location> find_all_usages(const LSP::DocumentSymbol &p_symbol);
+	void list_script_files(const String &p_root_dir, List<String> &r_files);
+
+	Array symbol(const Dictionary &p_params);
 
 	GDScriptWorkspace();
 	~GDScriptWorkspace();

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1702,6 +1702,41 @@ struct Workspace {
 	}
 };
 
+struct WorkspaceSymbol {
+	/**
+	 * name of this symbol.
+	 */
+	String name;
+
+	/**
+	 * The kind of this symbol
+	 */
+	int kind;
+
+	/**
+	 * The symbol containing this symbol
+	 */
+	String containerName;
+
+	/**
+	 * The location of this symbol
+	 */
+	Location location;
+
+	Dictionary to_json() const {
+		Dictionary dict;
+
+		dict["name"] = name;
+		dict["kind"] = kind;
+		if (!containerName.is_empty()) {
+			dict["containerName"] = containerName;
+		}
+		dict["location"] = location.to_json();
+
+		return dict;
+	}
+};
+
 struct ServerCapabilities {
 	/**
 	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
@@ -1761,7 +1796,7 @@ struct ServerCapabilities {
 	/**
 	 * The server provides workspace symbol support.
 	 */
-	bool workspaceSymbolProvider = false;
+	bool workspaceSymbolProvider = true;
 
 	/**
 	 * The server supports workspace folder.


### PR DESCRIPTION
This PR implements the [`workspace/symbol`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol
) method in LSP. Related to [#14786](https://github.com/godotengine/godot-proposals/issues/14786)

This would prove useful to other code editing environments for GDScript, or if the default script editor wants to add a feature for viewing the workspace symbols

In the below examples I'm using the neovim LSP client with my plugin [Vimdow](https://github.com/migmoog/vimdow) that automatically attached neovim to Godot's LSP.

## Before 

https://github.com/user-attachments/assets/e657917a-04c0-4d2f-9a18-abfa07bc106a

## After

https://github.com/user-attachments/assets/d08c7f08-c434-4e1d-8611-a5db43e0d98c