### PR TITLE
Fix incorrect grid floor position before input in the `GridMap` editor

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -60,14 +60,6 @@
 #include "scene/main/window.h"
 #include "servers/rendering/rendering_server.h"
 
-void GridMapEditor::_configure() {
-	if (!node) {
-		return;
-	}
-
-	update_grid();
-}
-
 void GridMapEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_PREV_LEVEL: {
@@ -1253,8 +1245,7 @@ void GridMapEditor::update_grid() {
 
 	grid_ofs[edit_axis] = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
 
-	// If there's a valid tile cursor, offset the grid, otherwise move it back to the node.
-	edit_grid_xform.origin = cursor_instance.is_valid() ? grid_ofs : Vector3();
+	edit_grid_xform.origin = grid_ofs;
 	edit_grid_xform.basis = Basis();
 
 	for (int i = 0; i < 3; i++) {
@@ -1487,7 +1478,6 @@ void GridMapEditor::_floor_mouse_exited() {
 }
 
 void GridMapEditor::_bind_methods() {
-	ClassDB::bind_method("_configure", &GridMapEditor::_configure);
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
 
 	ADD_SIGNAL(MethodInfo("overlay_update_requested"));

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -221,7 +221,6 @@ class GridMapEditor : public EditorDock {
 
 	void update_grid(); // Change which and where the grid is displayed.
 	void _draw_grids(const Vector3 &cell_size);
-	void _configure();
 	void _menu_option(int);
 	void update_palette();
 	void _update_resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_idx);


### PR DESCRIPTION
Before moving the mouse around the viewport while the `GridMap` editor is enabled, the grid's floor will be at level 0, instead of the saved level in the node's metadata.

This PR fixes that by partially undoing #78265. In my tests, the bug the original PR fixed was not present.

I also removed an unused method.