### PR TITLE
Add mandatory AI disclosure to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,3 +4,11 @@ Please target the `master` branch. We will take care of backporting relevant fix
 Before submitting, please read our checklist for new contributors:
 https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
 -->
+
+### Was AI used to create any part of this PR including its description?
+
+<!--
+The Godot project requires AI-assisted contributions to be disclosed. You can find out more about this policy in the docs: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#ai-assisted-contributions
+
+WARNING. If you do not add an answer to this in your PR description, it will be closed. NO EXCEPTIONS.
+-->


### PR DESCRIPTION
This was partially taken from PR #118624 and then modified.

Current enforcement of our AI policy (which you can read [here](https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#ai-assisted-contributions)) has been tricky due to a number of factors. One of those factors being that while we do have the policy in place, there's nothing  at the point of PR creation that explicitly informs users they need to disclose AI usage. We have a link to our checklist but I wouldn't consider that explicit. This makes differentiating between good faith users who aren't aware of the policy, and bad faith users/AI agents willfully ignoring the policy difficult.

By adding a disclosure requirement with zero tolerance for ignoring the question, this makes the policy more visible, and makes deciding what to do when the AI policy is ignored easier. Obviously there's no 100% accurate way to figure out if something is AI or not, but if we come across something with clear and convincing evidence it's AI, that also says in the disclosure that they didn't use AI at all, it's now easier to decide if the account should be blocked or not, as we don't have to worry if that would be too harsh or not.