### PR TITLE
Fix update blend point name

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -67,6 +67,12 @@ void AnimationNodeBlendSpace1D::_tree_changed() {
 }
 
 void AnimationNodeBlendSpace1D::_animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) {
+	for (int at_index = 0; at_index < blend_points_used; at_index++) {
+		if (blend_points[at_index].name == p_old_name) {
+			blend_points[at_index].name = p_new_name;
+			break;
+		}
+	}
 	AnimationRootNode::_animation_node_renamed(p_oid, p_old_name, p_new_name);
 }
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -39,12 +39,16 @@ void AnimationNodeAnimation::set_animation(const StringName &p_name) {
 	if (animation == p_name) {
 		return;
 	}
+	StringName p_old_name = animation;
 	animation = p_name;
 	animation_version++;
 	if (unlikely(animation_version == 0)) {
 		animation_version = 1;
 	}
 	_node_updated(get_instance_id());
+	if (p_old_name != p_name) {
+		_animation_node_renamed(get_instance_id(), p_old_name, p_name);
+	}
 }
 
 StringName AnimationNodeAnimation::get_animation() const {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/119164

## Issue Description

When we update `animation` from `Inspector`, the `AnimationNodeAnimation` didn't trigger `_animation_node_renamed` signal, and `AnimationNodeBlendSpace1D` didn't handle `_animation_node_renamed` signal, too.

## Solution

We can consider whether the `animation` of `AnimationNodeAnimation` changed, and trigger `_animation_node_renamed` signal.

Then we need update `name` of `blend_point` in `_animation_node_renamed()`.

The name of blend_point can be updated successful.

[blend-point-name.webm](https://github.com/user-attachments/assets/0e5d520e-d8e3-462d-b925-feae2ef2b78c)


## Etc

But, I cannot find how to trigger `redraw` for `AnimationNodeBlendSpace1DEditor`. So the label of `blend_point` cannot update immediately. We should switch tab to see the final result of label.

Is there any advice for `redraw`?