### PR TITLE
Fit windows to the parent when rect is changed from editor, add property to make fitting optional.

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -678,6 +678,10 @@
 			[b]Note:[/b] This property is implemented only on macOS.
 			[b]Note:[/b] This property only works with native windows.
 		</member>
+		<member name="fit_to_parent" type="bool" setter="set_fit_to_parent" getter="get_fit_to_parent" default="true">
+			If [code]true[/code], embedded window size and position are fitted to the parent window.
+			[b]Note:[/b] This property has no effect on native windows.
+		</member>
 		<member name="force_native" type="bool" setter="set_force_native" getter="get_force_native" default="false">
 			If [code]true[/code], native window will be used regardless of parent viewport and project settings.
 		</member>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1191,11 +1191,13 @@ bool Viewport::_set_size(const Size2i &p_size, const int p_view_count, const Siz
 	Rect2i limit = get_visible_rect();
 	for (int i = 0; i < gui.sub_windows.size(); ++i) {
 		Window *sw = gui.sub_windows[i].window;
-		Rect2i rect = Rect2i(sw->position, sw->size);
-		Rect2i new_rect = sw->fit_rect_in_parent(rect, limit);
-		if (new_rect != rect) {
-			sw->set_position(new_rect.position);
-			sw->set_size(new_rect.size);
+		if (sw->get_fit_to_parent()) {
+			Rect2i rect = Rect2i(sw->position, sw->size);
+			Rect2i new_rect = sw->fit_rect_in_parent(rect, limit);
+			if (new_rect != rect) {
+				sw->set_position(new_rect.position);
+				sw->set_size(new_rect.size);
+			}
 		}
 	}
 	return true;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -376,6 +376,15 @@ void Window::set_position(const Point2i &p_position) {
 	ERR_MAIN_THREAD_GUARD;
 
 	position = p_position;
+	if (fit_to_parent && is_in_edited_scene_root()) {
+		Rect2i rect = Rect2i(position, size);
+		Rect2i new_rect = fit_rect_in_parent(rect, get_parent_rect());
+		if (rect != new_rect) {
+			position = new_rect.position;
+			size = new_rect.size;
+			_update_window_size();
+		}
+	}
 
 	if (embedder) {
 		embedder->_sub_window_update(this);
@@ -420,6 +429,18 @@ void Window::set_size(const Size2i &p_size) {
 #endif
 
 	size = p_size;
+	if (fit_to_parent && is_in_edited_scene_root()) {
+		Rect2i rect = Rect2i(position, size);
+		Rect2i new_rect = fit_rect_in_parent(rect, get_parent_rect());
+		if (rect != new_rect) {
+			position = new_rect.position;
+			size = new_rect.size;
+			if (embedder) {
+				embedder->_sub_window_update(this);
+			}
+		}
+	}
+
 	_update_window_size();
 	_settings_changed();
 }
@@ -432,6 +453,30 @@ Size2i Window::get_size() const {
 void Window::reset_size() {
 	ERR_MAIN_THREAD_GUARD;
 	set_size(Size2i());
+}
+
+void Window::set_fit_to_parent(bool p_enabled) {
+	if (fit_to_parent == p_enabled) {
+		return;
+	}
+	fit_to_parent = p_enabled;
+
+	if (fit_to_parent && is_in_edited_scene_root()) {
+		Rect2i rect = Rect2i(position, size);
+		Rect2i new_rect = fit_rect_in_parent(rect, get_parent_rect());
+		if (rect != new_rect) {
+			position = new_rect.position;
+			size = new_rect.size;
+			_update_window_size();
+			if (embedder) {
+				embedder->_sub_window_update(this);
+			}
+		}
+	}
+}
+
+bool Window::get_fit_to_parent() const {
+	return fit_to_parent;
 }
 
 Point2i Window::get_position_with_decorations() const {
@@ -1634,6 +1679,14 @@ void Window::_notification(int p_what) {
 			if (is_in_edited_scene_root()) {
 				if (!ProjectSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &Window::_settings_changed))) {
 					ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Window::_settings_changed));
+				}
+				if (fit_to_parent) {
+					Rect2i rect = Rect2i(position, size);
+					Rect2i new_rect = fit_rect_in_parent(rect, get_parent_rect());
+					if (rect != new_rect) {
+						position = new_rect.position;
+						size = new_rect.size;
+					}
 				}
 			} else if (get_parent() && get_tree()->get_root()->is_embedding_subwindows()) {
 				// Is not the main window and main window is embedding.
@@ -3370,6 +3423,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_size"), &Window::get_size);
 	ClassDB::bind_method(D_METHOD("reset_size"), &Window::reset_size);
 
+	ClassDB::bind_method(D_METHOD("set_fit_to_parent", "enabled"), &Window::set_fit_to_parent);
+	ClassDB::bind_method(D_METHOD("get_fit_to_parent"), &Window::get_fit_to_parent);
+
 	ClassDB::bind_method(D_METHOD("get_position_with_decorations"), &Window::get_position_with_decorations);
 	ClassDB::bind_method(D_METHOD("get_size_with_decorations"), &Window::get_size_with_decorations);
 
@@ -3553,6 +3609,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_screen", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), "set_current_screen", "get_current_screen");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2I, "nonclient_area", PROPERTY_HINT_NONE, ""), "set_nonclient_area", "get_nonclient_area");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fit_to_parent"), "set_fit_to_parent", "get_fit_to_parent");
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "mouse_passthrough_polygon"), "set_mouse_passthrough_polygon", "get_mouse_passthrough_polygon");
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -132,6 +132,7 @@ private:
 	bool focused = false;
 	WindowInitialPosition initial_position = WINDOW_INITIAL_POSITION_ABSOLUTE;
 	bool force_native = false;
+	bool fit_to_parent = true;
 
 	mutable bool hdr_output_requested = false;
 
@@ -327,6 +328,9 @@ public:
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;
 	void reset_size();
+
+	void set_fit_to_parent(bool p_enabled);
+	bool get_fit_to_parent() const;
 
 	Point2i get_position_with_decorations() const;
 	Size2i get_size_with_decorations() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119180

- Applies fitting behavior when `position` or `size` are changed in the editor.
- Adds `fit_to_parent` property to disable fitting behavior completely.

Note: there's internal `clamp_to_embedder` property, which seems to server slightly different purpose, it's only fitting window when it pops up or dragged in certain conditions. But all embedded windows are fitted to parent each time parent is resized.