### PR TITLE
Fix color picker permission box being visible on non-MacOS platforms

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2333,6 +2333,7 @@ ColorPicker::ColorPicker() {
 	perm_link->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_req_permission));
 	perm_hb->add_child(perm_link);
 	real_vbox->add_child(perm_hb);
+	perm_hb->set_visible(false);
 }
 
 void ColorPicker::_req_permission() {


### PR DESCRIPTION
Fixes a bug where the color picker permission box would be shown on non-MacOS platforms, introduced in #118799 (thanks @LiveTrower).