### PR TITLE
Deprecate GDExtension's `object_cast_to` and `classdb_get_class_tag`, in favour of `is_class` casts.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1400,6 +1400,7 @@ static GDExtensionBool gdextension_object_get_class_name(GDExtensionConstObjectP
 	return true;
 }
 
+#ifndef DISABLE_DEPRECATED
 static GDExtensionObjectPtr gdextension_object_cast_to(GDExtensionConstObjectPtr p_object, void *p_class_tag) {
 	if (!p_object) {
 		return nullptr;
@@ -1408,6 +1409,7 @@ static GDExtensionObjectPtr gdextension_object_cast_to(GDExtensionConstObjectPtr
 
 	return o->is_class_ptr(p_class_tag) ? (GDExtensionObjectPtr)o : (GDExtensionObjectPtr) nullptr;
 }
+#endif
 
 static GDObjectInstanceID gdextension_object_get_instance_id(GDExtensionConstObjectPtr p_object) {
 	const Object *o = (const Object *)p_object;
@@ -1669,11 +1671,13 @@ static GDExtensionObjectPtr gdextension_classdb_construct_object3(GDExtensionCon
 	return (GDExtensionObjectPtr)ClassDB::instantiate_without_postinitialization_with_refcount(classname);
 }
 
+#ifndef DISABLE_DEPRECATED
 static void *gdextension_classdb_get_class_tag(GDExtensionConstStringNamePtr p_classname) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(classname);
 	return class_info ? class_info->class_ptr : nullptr;
 }
+#endif
 
 static void gdextension_editor_add_plugin(GDExtensionConstStringNamePtr p_classname) {
 #ifdef TOOLS_ENABLED
@@ -1844,7 +1848,9 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(object_free_instance_binding);
 	REGISTER_INTERFACE_FUNC(object_set_instance);
 	REGISTER_INTERFACE_FUNC(object_get_class_name);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(object_cast_to);
+#endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(object_get_instance_from_id);
 	REGISTER_INTERFACE_FUNC(object_get_instance_id);
 	REGISTER_INTERFACE_FUNC(object_has_script_method);
@@ -1871,7 +1877,9 @@ void gdextension_setup_interface() {
 #endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(classdb_construct_object3);
 	REGISTER_INTERFACE_FUNC(classdb_get_method_bind);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(classdb_get_class_tag);
+#endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(editor_add_plugin);
 	REGISTER_INTERFACE_FUNC(editor_remove_plugin);
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars);

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -7950,7 +7950,11 @@
             "description": [
                 "Casts an Object to a different type."
             ],
-            "since": "4.1"
+            "since": "4.1",
+            "deprecated": {
+                "since": "4.7",
+                "message": "Use the `is_class` method on `Object` to check if an object can be cast instead. If true, the previous pointer can be reinterpreted as a pointer to the target type."
+            }
         },
         {
             "name": "object_get_instance_from_id",
@@ -8560,7 +8564,11 @@
             "description": [
                 "Gets a pointer uniquely identifying the given built-in class in the ClassDB."
             ],
-            "since": "4.1"
+            "since": "4.1",
+            "deprecated": {
+                "since": "4.7",
+                "message": "No longer needed. Use the `is_class` method on `Object` instead."
+            }
         },
         {
             "name": "classdb_register_extension_class",


### PR DESCRIPTION
- Follow-up to #118582 
- Follow-up to https://github.com/godotengine/godot/pull/105793
- Started via https://github.com/godotengine/godot-cpp/pull/1974

Changes the recommended way to cast to `object && object->is_class(T::get_class_name_static()) ? object : nullptr`, which is simpler and more predictable than the previous class-tag based approach.

We can do this now because `is_class` became perfectly performant — in fact, it can be _faster_ than class-tag casting by #118582 and https://github.com/godotengine/godot/pull/105793
