### PR TITLE
Autocompletion: Do not suggest outer classes' members for attribute access

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1205,9 +1205,9 @@ static void _find_identifiers_in_suite(const GDScriptParser::SuiteNode *p_suite,
 	}
 }
 
-static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base, bool p_only_functions, bool p_types_only, bool p_add_braces, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth);
+static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base, bool p_only_functions, bool p_types_only, bool p_add_braces, bool p_check_outer, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth);
 
-static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class, bool p_only_functions, bool p_types_only, bool p_static, bool p_parent_only, bool p_add_braces, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth) {
+static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class, bool p_only_functions, bool p_types_only, bool p_static, bool p_parent_only, bool p_add_braces, bool p_check_outer, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth) {
 	ERR_FAIL_COND(p_recursion_depth > COMPLETION_RECURSION_LIMIT);
 
 	if (!p_parent_only) {
@@ -1284,7 +1284,7 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 				}
 				r_result.insert(option.display, option);
 			}
-			if (p_types_only) {
+			if (p_types_only || !p_check_outer) {
 				break; // Otherwise, it will fill the results with types from the outer class (which is undesired for that case).
 			}
 
@@ -1299,10 +1299,10 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 	base_type.type = p_class->base_type;
 	base_type.type.is_meta_type = p_static;
 
-	_find_identifiers_in_base(base_type, p_only_functions, p_types_only, p_add_braces, r_result, p_recursion_depth + 1);
+	_find_identifiers_in_base(base_type, p_only_functions, p_types_only, p_add_braces, p_check_outer, r_result, p_recursion_depth + 1);
 }
 
-static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base, bool p_only_functions, bool p_types_only, bool p_add_braces, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth) {
+static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base, bool p_only_functions, bool p_types_only, bool p_add_braces, bool p_check_outer, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result, int p_recursion_depth) {
 	ERR_FAIL_COND(p_recursion_depth > COMPLETION_RECURSION_LIMIT);
 
 	GDScriptParser::DataType base_type = p_base.type;
@@ -1319,7 +1319,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 	while (!base_type.has_no_type()) {
 		switch (base_type.kind) {
 			case GDScriptParser::DataType::CLASS: {
-				_find_identifiers_in_class(base_type.class_type, p_only_functions, p_types_only, base_type.is_meta_type, false, p_add_braces, r_result, p_recursion_depth);
+				_find_identifiers_in_class(base_type.class_type, p_only_functions, p_types_only, base_type.is_meta_type, false, p_add_braces, p_check_outer, r_result, p_recursion_depth);
 				// This already finds all parent identifiers, so we are done.
 				base_type = GDScriptParser::DataType();
 			} break;
@@ -1590,7 +1590,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	}
 
 	if (p_context.current_class) {
-		_find_identifiers_in_class(p_context.current_class, p_only_functions, false, (!p_context.current_function || p_context.current_function->is_static), false, p_add_braces, r_result, p_recursion_depth);
+		_find_identifiers_in_class(p_context.current_class, p_only_functions, false, (!p_context.current_function || p_context.current_function->is_static), false, p_add_braces, true, r_result, p_recursion_depth);
 	}
 
 	List<StringName> functions;
@@ -3591,7 +3591,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					break;
 				}
 
-				_find_identifiers_in_base(base, is_function, false, !_guess_expecting_callable(completion_context), options, 0);
+				_find_identifiers_in_base(base, is_function, false, !_guess_expecting_callable(completion_context), false, options, 0);
 			}
 		} break;
 		case GDScriptParser::COMPLETION_SUBSCRIPT: {
@@ -3622,7 +3622,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					// Quote the options if they are not accessed as attribute.
 
 					HashMap<String, ScriptLanguage::CodeCompletionOption> opt;
-					_find_identifiers_in_base(base, false, false, false, opt, 0);
+					_find_identifiers_in_base(base, false, false, false, true, opt, 0);
 					for (const KeyValue<String, CodeCompletionOption> &E : opt) {
 						ScriptLanguage::CodeCompletionOption option = _calculate_string_insertion(existing_index, E.value.insert_text);
 						option.kind = E.value.kind;
@@ -3630,7 +3630,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						options.insert(option.display, option);
 					}
 				} else {
-					_find_identifiers_in_base(base, false, false, !_guess_expecting_callable(completion_context), options, 0);
+					_find_identifiers_in_base(base, false, false, !_guess_expecting_callable(completion_context), true, options, 0);
 				}
 			}
 		} break;
@@ -3655,7 +3655,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 				}
 				if (found) {
-					_find_identifiers_in_base(base, false, true, true, options, 0);
+					_find_identifiers_in_base(base, false, true, true, true, options, 0);
 				}
 			}
 
@@ -3848,7 +3848,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			if (!completion_context.current_class) {
 				break;
 			}
-			_find_identifiers_in_class(completion_context.current_class, true, false, false, true, !_guess_expecting_callable(completion_context), options, 0);
+			_find_identifiers_in_class(completion_context.current_class, true, false, false, true, !_guess_expecting_callable(completion_context), true, options, 0);
 		} break;
 	}
 

--- a/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_instance.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_instance.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "D"},
+    {"display": "v"},
+    {"display": "f()"},
+    {"display": "g()"},
+]
+exclude=[
+    {"display": "B"},
+    {"display": "C"},
+    {"display": "InnerClass1"},
+    {"display": "InnerClass2"},
+    {"display": "E"},
+    {"display": "h()"},
+    {"display": "i()"},
+    {"display": "X"},
+    {"display": "Y"},
+    {"display": "Z"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_instance.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_instance.gd
@@ -1,0 +1,27 @@
+enum B {X, Y, Z}
+const C = 1
+
+class InnerClass1:
+    const D = 1
+    var v: int
+
+    static func f():
+        pass
+
+    func g():
+        pass
+
+
+class InnerClass2:
+    const E = 1
+
+    static func h():
+        pass
+
+    func i():
+        pass
+
+
+func a():
+    var instance := InnerClass1.new()
+    instance.➡

--- a/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_static.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_static.cfg
@@ -1,0 +1,19 @@
+[output]
+include=[
+    {"display": "D"},
+    {"display": "f()"},
+]
+exclude=[
+    {"display": "v"},
+    {"display": "B"},
+    {"display": "C"},
+    {"display": "InnerClass1"},
+    {"display": "g()"},
+    {"display": "InnerClass2"},
+    {"display": "E"},
+    {"display": "h()"},
+    {"display": "i()"},
+    {"display": "X"},
+    {"display": "Y"},
+    {"display": "Z"},
+]

--- a/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_static.gd
+++ b/modules/gdscript/tests/scripts/completion/types/hints/inner_class_attribute_static.gd
@@ -1,0 +1,26 @@
+enum B {X, Y, Z}
+const C = 1
+
+class InnerClass1:
+    const D = 1
+    var v: int
+
+    static func f():
+        pass
+
+    func g():
+        pass
+
+
+class InnerClass2:
+    const E = 1
+
+    static func h():
+        pass
+
+    func i():
+        pass
+
+
+func a():
+    InnerClass1.➡


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes #117548 fixes #110313.

## Problem

Autocompletion suggests items from outer classes even when the type is an attribute. However, constant members of an outer class are only accessible inside an inner class body and not as an attribute.

## Solution

Do not visit outer classes when completion type is `COMPLETION_ATTRIBUTE`.

The fix adds a new parameter that when true, visits outer classes. All existing call sites have it set to true, except for the attribute/attribute method completion one that this PR addresses. 

I am open to ideas on better ways to implement this. Adding another boolean flag is not ideal but I don't see a simpler way to implement it without refactoring the existing system.