### PR TITLE
Fix crash when baking shaders for D3D12 from Vulkan.

### DIFF
--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -1013,6 +1013,10 @@ RenderingDeviceCommons::ShaderSpirvVersion RenderingShaderContainerFormatD3D12::
 	return SHADER_SPIRV_VERSION_1_5;
 }
 
-RenderingShaderContainerFormatD3D12::RenderingShaderContainerFormatD3D12() {}
+RenderingShaderContainerFormatD3D12::RenderingShaderContainerFormatD3D12() {
+	glsl_type_singleton_init_or_ref();
+}
 
-RenderingShaderContainerFormatD3D12::~RenderingShaderContainerFormatD3D12() {}
+RenderingShaderContainerFormatD3D12::~RenderingShaderContainerFormatD3D12() {
+	glsl_type_singleton_decref();
+}


### PR DESCRIPTION
Fixes #119198.

But that issue shows another weird problem where exporting for Linux is baking D3D12 shaders. I managed to replicate this by setting the non-platform specific driver value to D3D12, and that also seems to be the case for OP.