### PR TITLE
Remove unused loop counter from `EditorPropertySizeFlags::setup()`

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -373,7 +373,7 @@ void EditorPropertySizeFlags::setup(const Vector<String> &p_options, bool p_vert
 	}
 
 	HashMap<int, String> flags;
-	for (int i = 0, j = 0; i < p_options.size(); i++, j++) {
+	for (int i = 0; i < p_options.size(); i++) {
 		Vector<String> text_split = p_options[i].split(":");
 		int64_t current_val = text_split[1].to_int();
 		flags[current_val] = text_split[0];


### PR DESCRIPTION
`EditorPropertySizeFlags::setup()` has a `for` loop that declares `i` and `j`. 

However, `j` isn't used anywhere, and the new GCC 16 began emitting a warning (althought this is not the only one). This is an issue if the engine is usually built with `werror=yes` there.