### PR TITLE
Editor: Fix symbol lookup (CTRL + click) ignoring outer classes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4297,6 +4297,17 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	return ERR_CANT_RESOLVE;
 }
 
+static Error _lookup_symbol_from_outer_classes(const GDScriptParser::DataType &p_base, const String &p_symbol, GDScriptLanguage::LookupResult &r_result) {
+	GDScriptParser::DataType outer_class = p_base;
+	while (outer_class.class_type->outer != nullptr) {
+		outer_class = outer_class.class_type->outer->datatype;
+		if (_lookup_symbol_from_base(outer_class, p_symbol, r_result) == OK) {
+			return OK;
+		}
+	}
+	return ERR_CANT_RESOLVE;
+}
+
 ::Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) {
 	// Before parsing, try the usual stuff.
 	if (GDScriptAnalyzer::class_exists(p_symbol)) {
@@ -4560,6 +4571,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					return OK;
 				}
 			}
+
+			if (_lookup_symbol_from_outer_classes(base_type, p_symbol, r_result) == OK) {
+				return OK;
+			}
 		} break;
 		case GDScriptParser::COMPLETION_ATTRIBUTE_METHOD:
 		case GDScriptParser::COMPLETION_ATTRIBUTE: {
@@ -4627,6 +4642,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			GDScriptParser::DataType base_type = context.current_class->get_datatype();
 
 			if (_lookup_symbol_from_base(base_type, p_symbol, r_result) == OK) {
+				return OK;
+			}
+
+			if (_lookup_symbol_from_outer_classes(base_type, p_symbol, r_result) == OK) {
 				return OK;
 			}
 		} break;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes #117948.

For the following completion types, checks all the outer classes if nothing is found after the existing checks.

<details>
<summary>Completion types affected</summary>

```
# Part 1
COMPLETION_SUPER_METHOD
COMPLETION_METHOD
COMPLETION_ASSIGN
COMPLETION_CALL_ARGUMENTS
COMPLETION_DECLARATION
COMPLETION_INHERIT_TYPE
COMPLETION_IDENTIFIER
COMPLETION_PROPERTY_METHOD
COMPLETION_SUBSCRIPT
# Part 2
COMPLETION_PROPERTY_DECLARATION_OR_TYPE
COMPLETION_TYPE_NAME_OR_VOID
COMPLETION_TYPE_NAME
```
</details>
