### PR TITLE
Add option to close docks with middle mouse button

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -165,6 +165,13 @@ void DockTabContainer::_tab_rmb_clicked(int p_tab_idx) {
 	dock_context_popup->popup();
 }
 
+void DockTabContainer::_tab_close_pressed(int p_tab_idx) {
+	EditorDock *hovered_dock = get_dock(p_tab_idx);
+	if (hovered_dock) {
+		hovered_dock->close();
+	}
+}
+
 void DockTabContainer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
 		connect("pre_popup_pressed", callable_mp(this, &DockTabContainer::_pre_popup));
@@ -262,6 +269,7 @@ DockTabContainer::DockTabContainer(EditorDock::DockSlot p_slot) {
 
 	get_tab_bar()->set_switch_on_release(true);
 	get_tab_bar()->connect("tab_rmb_clicked", callable_mp(this, &DockTabContainer::_tab_rmb_clicked));
+	get_tab_bar()->connect("tab_close_pressed", callable_mp(this, &DockTabContainer::_tab_close_pressed));
 }
 
 SideDockTabContainer::SideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect) :

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -75,6 +75,7 @@ class DockTabContainer : public TabContainer {
 
 	void _pre_popup();
 	void _tab_rmb_clicked(int p_tab_idx);
+	void _tab_close_pressed(int p_tab_idx);
 
 protected:
 	DockContextPopup *dock_context_popup = nullptr;


### PR DESCRIPTION
Fixes [godotengine/godot-proposals/issues/14731](https://github.com/godotengine/godot-proposals/issues/14731)

Added middle mouse click to close any dock.

<img width="1848" height="890" alt="close_docks_with_middle_mouse" src="https://github.com/user-attachments/assets/f57058a7-2d79-45b2-9028-cd55e38ffe62" />

