### PR TITLE
Fix incorrect feature overrides when exporting for Linux.

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -282,7 +282,6 @@ void EditorExportPlatformPC::set_logo(const Ref<Texture2D> &p_logo) {
 
 void EditorExportPlatformPC::get_platform_features(List<String> *r_features) const {
 	r_features->push_back("pc"); // Identify PC platforms as such.
-	r_features->push_back(get_os_name().to_lower()); // OS name is a feature.
 }
 
 void EditorExportPlatformPC::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -227,6 +227,12 @@ bool EditorExportPlatformLinuxBSD::is_executable(const String &p_path) const {
 	return is_elf(p_path) || is_shebang(p_path);
 }
 
+void EditorExportPlatformLinuxBSD::get_platform_features(List<String> *r_features) const {
+	EditorExportPlatformPC::get_platform_features(r_features);
+	r_features->push_back("linux");
+	r_features->push_back("linuxbsd");
+}
+
 bool EditorExportPlatformLinuxBSD::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
 	String err;
 	bool valid = EditorExportPlatformPC::has_valid_export_configuration(p_preset, err, r_missing_templates, p_debug);

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -79,6 +79,8 @@ public:
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 	virtual bool is_executable(const String &p_path) const override;
 
+	virtual void get_platform_features(List<String> *r_features) const override;
+
 	virtual Ref<Texture2D> get_run_icon() const override;
 	virtual bool poll_export() override;
 	virtual Ref<Texture2D> get_option_icon(int p_index) const override;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -919,6 +919,11 @@ Error EditorExportPlatformWindows::fixup_embedded_pck(const String &p_path, int6
 	return OK;
 }
 
+void EditorExportPlatformWindows::get_platform_features(List<String> *r_features) const {
+	EditorExportPlatformPC::get_platform_features(r_features);
+	r_features->push_back("windows");
+}
+
 Ref<Texture2D> EditorExportPlatformWindows::get_run_icon() const {
 	return run_icon;
 }

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -86,6 +86,8 @@ public:
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 
+	virtual void get_platform_features(List<String> *r_features) const override;
+
 	virtual Ref<Texture2D> get_run_icon() const override;
 	virtual bool poll_export() override;
 	virtual Ref<Texture2D> get_option_icon(int p_index) const override;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/119259

Exporter was using readable OS name (which is "Linux"), instead of feature flag ("linuxbsd") and using wrong renderer for shader baking.