### PR TITLE
Fix clip children on transparent background/viewport draws black

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2876,7 +2876,7 @@ uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_n
 
 void fragment() {
 	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = c;
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2876,7 +2876,8 @@ uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_n
 
 void fragment() {
 	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR = c;
+	COLOR.rgb = c.rgb;
+	COLOR.a = COLOR.a * c.a;
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2109,7 +2109,7 @@ uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_n
 
 void fragment() {
 	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = c;
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2109,7 +2109,8 @@ uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_n
 
 void fragment() {
 	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
-	COLOR = c;
+	COLOR.rgb = c.rgb;
+	COLOR.a = COLOR.a * c.a;
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();


### PR DESCRIPTION
…arent window and web.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

As the issue describe in #70158, the nodes which are used with clip children setting to "clip-only", they look fine in editor but renders as a black box in transparent window and in web. This issue exists in 4.6 also. Previously, the default shader used in Clip-Only setting ignored the alpha, which made it black. 

* *Bugsquad edit, fixes: #70158*