### PR TITLE
Create folders recursively on export to avoid errors

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2072,6 +2072,20 @@ void EditorExportPlatform::zip_folder_recursive(zipFile &p_zip, const String &p_
 	da->list_dir_end();
 }
 
+Error EditorExportPlatform::ensure_folder(Ref<DirAccess> &p_da, const String &p_folder) {
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (da.is_valid() && !DirAccess::exists(p_folder)) {
+		if (FileAccess::exists(p_folder)) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("A file with the same name as the export destination directory \"%s\" already exists. Remove it or select another destination."), p_folder));
+			return ERR_CANT_CREATE;
+		}
+		da->make_dir_recursive(p_folder);
+		print_line(vformat("Creating folder for export: %s", p_folder));
+	}
+
+	return OK;
+}
+
 Dictionary EditorExportPlatform::_save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, bool p_embed) {
 	Vector<SharedObject> so_files;
 	int64_t embedded_start = 0;

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -195,6 +195,8 @@ protected:
 
 	virtual void zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name);
 
+	Error ensure_folder(Ref<DirAccess> &da, const String &p_path);
+
 	Error _ssh_run_on_remote(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, Array r_output = Array(), int p_port_fwd = -1) const {
 		String pipe;
 		Error err = ssh_run_on_remote(p_host, p_port, p_ssh_args, p_cmd_args, &pipe, p_port_fwd);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1655,14 +1655,17 @@ Error EditorExportPlatformAppleEmbedded::export_project(const Ref<EditorExportPr
 Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_oneclick) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	const String dest_dir = p_path.get_base_dir() + "/";
+	// Allow exporting to `res://` and `user://` for convenience, but ensure the export folder exists beforehand.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	const String base_dir = ProjectSettings::get_singleton()->globalize_path(p_path.get_base_dir());
+	Error err = ensure_folder(da, base_dir);
+	if (err != OK) {
+		return err;
+	}
+
+	const String dest_dir = base_dir + "/";
 	const String binary_name = p_path.get_file().get_basename();
 	const String binary_dir = dest_dir + binary_name;
-
-	if (!DirAccess::exists(dest_dir)) {
-		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Target folder does not exist or is inaccessible: \"%s\""), dest_dir));
-		return ERR_FILE_BAD_PATH;
-	}
 
 	bool export_project_only = p_preset->get("application/export_project_only");
 	if (p_oneclick) {
@@ -1682,17 +1685,16 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 	}
 
 	if (src_pkg_name.is_empty()) {
-		String err;
-		src_pkg_name = find_export_template(get_platform_name() + ".zip", &err);
+		String error_string;
+		src_pkg_name = find_export_template(get_platform_name() + ".zip", &error_string);
 		if (src_pkg_name.is_empty()) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found."));
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found.") + "\n" + error_string);
 			return ERR_FILE_NOT_FOUND;
 		}
 	}
 
 	{
 		bool delete_old = p_preset->get("application/delete_old_export_files_unconditionally");
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		if (da.is_valid()) {
 			String current_dir = da->get_current_dir();
 
@@ -1760,7 +1762,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 			da->change_dir(current_dir);
 
 			if (!da->dir_exists(binary_dir)) {
-				Error err = da->make_dir(binary_dir);
+				err = da->make_dir(binary_dir);
 				if (err != OK) {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Failed to create the directory: \"%s\""), binary_dir));
 					return err;
@@ -1774,7 +1776,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 	}
 	String pack_path = binary_dir + ".pck";
 	Vector<SharedObject> libraries;
-	Error err = save_pack(p_preset, p_debug, pack_path, &libraries);
+	err = save_pack(p_preset, p_debug, pack_path, &libraries);
 	if (err) {
 		// Message is supplied by the subroutine method.
 		return err;

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -153,9 +153,12 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 }
 
 Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
-	if (!DirAccess::exists(p_path.get_base_dir())) {
-		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Template"), TTR("The given export path doesn't exist."));
-		return ERR_FILE_BAD_PATH;
+	// Allow exporting to `res://` and `user://` for convenience, but ensure the export folder exists beforehand.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	const String base_dir = ProjectSettings::get_singleton()->globalize_path(p_path.get_base_dir());
+	Error err = ensure_folder(da, base_dir);
+	if (err != OK) {
+		return err;
 	}
 
 	String custom_debug = p_preset->get("custom_template/debug");
@@ -185,9 +188,7 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 	int con_wrapper_mode = p_preset->get("debug/export_console_wrapper");
 	bool copy_wrapper = (con_wrapper_mode == 1 && p_debug) || (con_wrapper_mode == 2);
 
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	da->make_dir_recursive(p_path.get_base_dir());
-	Error err = da->copy(template_path, p_path, get_chmod_flags());
+	err = da->copy(template_path, p_path, get_chmod_flags());
 	if (err == OK && copy_wrapper) {
 		for (int i = 0; wrapper_extensions[i]; ++i) {
 			const String wrapper_path = template_path.get_basename() + wrapper_extensions[i];

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3703,14 +3703,15 @@ static String _copy_keystore_to_temp(const String &p_keystore_path, const String
 Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	const String base_dir = p_path.get_base_dir();
-	if (!DirAccess::exists(base_dir)) {
-		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Target folder does not exist or is inaccessible: \"%s\""), base_dir));
-		return ERR_FILE_BAD_PATH;
+	// Allow exporting to `res://` and `user://` for convenience, but ensure the export folder exists beforehand.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	const String base_dir = ProjectSettings::get_singleton()->globalize_path(p_path.get_base_dir());
+	Error err = ensure_folder(da, base_dir);
+	if (err != OK) {
+		return err;
 	}
 
 	String src_apk;
-	Error err;
 
 	EditorProgress ep("export", TTR("Exporting for Android"), 105, true);
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1626,11 +1626,12 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	const String base_dir = p_path.get_base_dir();
-
-	if (!DirAccess::exists(base_dir)) {
-		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Target folder does not exist or is inaccessible: \"%s\""), base_dir));
-		return ERR_FILE_BAD_PATH;
+	// Allow exporting to `res://` and `user://` for convenience, but ensure the export folder exists beforehand.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	const String base_dir = ProjectSettings::get_singleton()->globalize_path(p_path.get_base_dir());
+	Error err = ensure_folder(da, base_dir);
+	if (err != OK) {
+		return err;
 	}
 
 	EditorProgress ep("export", TTR("Exporting for macOS"), 3, true);
@@ -1643,10 +1644,10 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 	}
 
 	if (src_pkg_name.is_empty()) {
-		String err;
-		src_pkg_name = find_export_template("macos.zip", &err);
+		String error_string;
+		src_pkg_name = find_export_template("macos.zip", &error_string);
 		if (src_pkg_name.is_empty()) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found.") + "\n" + err);
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found.") + "\n" + error_string);
 			return ERR_FILE_NOT_FOUND;
 		}
 	}
@@ -1710,7 +1711,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	print_verbose("Exporting to " + tmp_app_path_name);
 
-	Error err = OK;
+	err = OK;
 
 	Ref<DirAccess> tmp_app_dir = DirAccess::create_for_path(tmp_base_path_name);
 	if (tmp_app_dir.is_null()) {
@@ -2294,7 +2295,6 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if ((err == OK) && helpers.size() > 0) {
-			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			for (int i = 0; i < helpers.size(); i++) {
 				String hlp_path = helpers[i];
 				err = da->copy(hlp_path, tmp_app_path_name + "/Contents/Helpers/" + hlp_path.get_file());
@@ -2311,7 +2311,6 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (err == OK) {
-			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			for (int i = 0; i < shared_objects.size(); i++) {
 				String src_path = ProjectSettings::get_singleton()->globalize_path(shared_objects[i].path);
 				if (shared_objects[i].target.is_empty()) {
@@ -2341,7 +2340,6 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			if (dist_type == 2) {
 				String pprof = p_preset->get_or_env("codesign/provisioning_profile", ENV_MAC_CODESIGN_PROFILE).operator String();
 				if (!pprof.is_empty()) {
-					Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 					err = da->copy(pprof, tmp_app_path_name + "/Contents/embedded.provisionprofile");
 				}
 			}

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -490,20 +490,22 @@ List<String> EditorExportPlatformWeb::get_binary_extensions(const Ref<EditorExpo
 Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
+	// Allow exporting to `res://` and `user://` for convenience, but ensure the export folder exists beforehand.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	const String base_dir = ProjectSettings::get_singleton()->globalize_path(p_path.get_base_dir());
+	Error err = ensure_folder(da, base_dir);
+	if (err != OK) {
+		return err;
+	}
+
 	const String custom_debug = p_preset->get("custom_template/debug");
 	const String custom_release = p_preset->get("custom_template/release");
 	const String custom_html = p_preset->get("html/custom_html_shell");
 	const bool export_icon = p_preset->get("html/export_icon");
 	const bool pwa = p_preset->get("progressive_web_app/enabled");
 
-	const String base_dir = p_path.get_base_dir();
 	const String base_path = p_path.get_basename();
 	const String base_name = p_path.get_file().get_basename();
-
-	if (!DirAccess::exists(base_dir)) {
-		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Target folder does not exist or is inaccessible: \"%s\""), base_dir));
-		return ERR_FILE_BAD_PATH;
-	}
 
 	// Find the correct template
 	String template_path = p_debug ? custom_debug : custom_release;
@@ -529,7 +531,6 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	}
 
 	{
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		for (int i = 0; i < shared_objects.size(); i++) {
 			String dst = base_dir.path_join(shared_objects[i].path.get_file());
 			error = da->copy(shared_objects[i].path, dst);
@@ -572,7 +573,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 
 	// Generate HTML file with replaced strings.
 	_fix_html(html, p_preset, base_name, p_debug, p_flags, shared_objects, file_sizes);
-	Error err = _write_or_error(html.ptr(), html.size(), p_path);
+	err = _write_or_error(html.ptr(), html.size(), p_path);
 	if (err != OK) {
 		// Message is supplied by the subroutine method.
 		return err;


### PR DESCRIPTION
This makes for a more seamless CLI export experience, particularly when setting up CI.

This prints a message when one or more folders has to be created, so that you can be notified of possible typos in the export path.

I've tested this on Linux with `res://`/`user://` paths, relative and absolute paths; it works correctly in all cases.

- This closes https://github.com/godotengine/godot-proposals/issues/14621.
