### PR TITLE
Warn about `--gpu-index` CLI argument being unsupported in Compatibility

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -194,6 +194,9 @@ typedef void(GLAPIENTRY *DebugMessageCallbackARB)(DEBUGPROCARB callback, const v
 
 void RasterizerGLES3::initialize() {
 	Engine::get_singleton()->print_header(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
+	if (Engine::get_singleton()->get_gpu_index() >= 0) {
+		WARN_PRINT("The Compatibility renderer does not support overriding the GPU with the --gpu-index command line argument. Falling back to the default GPU for OpenGL applications.");
+	}
 }
 
 void RasterizerGLES3::finalize() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -617,7 +617,7 @@ void Main::print_help(const char *p_binary) {
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
 	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");
-	print_help_option("--gpu-index <device_index>", "Use a specific GPU (run with --verbose to get a list of available devices).\n");
+	print_help_option("--gpu-index <device_index>", "Use a specific GPU (only available on the Forward+/Mobile renderers; run with --verbose to get a list of available devices).\n");
 	print_help_option("--text-driver <driver>", "Text driver (used for font rendering, bidirectional support and shaping).\n");
 	print_help_option("--tablet-driver <driver>", "Pen tablet input driver.\n");
 	print_help_option("--headless", "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -8302,7 +8302,13 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	print_verbose("Devices:");
 	int32_t device_index = Engine::get_singleton()->get_gpu_index();
 	const uint32_t device_count = context->device_get_count();
-	const bool detect_device = (device_index < 0) || (device_index >= int32_t(device_count));
+	const bool device_index_out_of_range = (device_index >= int32_t(device_count));
+	const bool detect_device = (device_index < 0) || device_index_out_of_range;
+
+	if (device_index_out_of_range) {
+		WARN_PRINT(vformat("The specified GPU index %d is out of range on this system (0-%d). Falling back to automatic device selection.", device_index, device_count - 1));
+	}
+
 	uint32_t device_type_score = 0;
 	for (uint32_t i = 0; i < device_count; i++) {
 		RenderingContextDriver::Device device_option = context->device_get(i);


### PR DESCRIPTION
- Print a warning when `--gpu-index` is out of range in RenderingDevice-based renderers, since it falls back to automatic GPU selection.

The GPU selection logic is only available in RenderingDevice-based renderers.

- See https://github.com/godotengine/godot/issues/87763.

## Preview

### `--gpu-index` used in Compatibility

```
Godot Engine v4.7.beta.custom_build.b65872ab0 (2026-05-06 17:15:35 UTC) - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 580.142 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce RTX 5090
WARNING: The Compatibility renderer does not support overriding the GPU with the --gpu-index command line argument. Falling back to the default GPU for OpenGL applications.
     at: initialize (./drivers/gles3/rasterizer_gles3.cpp:198)
```

### `--gpu-index` out of range

```
Godot Engine v4.7.beta.custom_build.314bbd21a (2026-05-06 15:53:37 UTC) - https://godotengine.org
WARNING: The specified GPU index 2 is out of range on this system (0-1). Falling back to automatic device selection.
     at: initialize (./servers/rendering/rendering_device.cpp:8309)
Vulkan 1.4.312 - Forward+ - Using Device #0: NVIDIA - NVIDIA GeForce RTX 5090
```