### PR TITLE
Rename 'name' in AnimationPlayer signal parameter to 'anim_name'

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -343,7 +343,7 @@
 			</description>
 		</signal>
 		<signal name="current_animation_changed">
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="anim_name" type="StringName" />
 			<description>
 				Emitted when [member current_animation] changes.
 			</description>

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1067,7 +1067,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
 
-	ADD_SIGNAL(MethodInfo("current_animation_changed", PropertyInfo(Variant::STRING_NAME, "name")));
+	ADD_SIGNAL(MethodInfo("current_animation_changed", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
 }
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/119266

When connecting the ```current_animation_changed(name: StringName)``` signal to a script, there was a SHADOWED_VARIABLE_BASE_CLASS warning.

This pull request changes the signal parameter name from ```name``` to ```anim_name``` to avoid the warning when we connect this signal to a script.