### PR TITLE
Bump min. Scons version to 4.4.0.

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           # Sync with Ensure*Version in SConstruct.
           python-version: 3.9
-          scons-version: 4.0
+          scons-version: 4.4
 
       - name: Force remove preinstalled .NET SDKs
         if: matrix.build-mono

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
-EnsureSConsVersion(4, 0)
+EnsureSConsVersion(4, 4)
 EnsurePythonVersion(3, 9)
 
 # System
@@ -1196,10 +1196,6 @@ if env["compiledb"]:
         env["COMPILATIONDB_COMSTR"] = "$GENCOMSTR"
 
 if env["ninja"]:
-    if env.scons_version < (4, 2, 0):
-        print_error(f"The `ninja=yes` option requires SCons 4.2 or later, but your version is {scons_raw_version}.")
-        Exit(255)
-
     SetOption("experimental", "ninja")
     env["NINJA_FILE_NAME"] = env["ninja_file"]
     env["NINJA_DISABLE_AUTO_RUN"] = not env["ninja_auto_run"]

--- a/methods.py
+++ b/methods.py
@@ -526,12 +526,7 @@ def find_visual_c_batch_file(env):
     from SCons.Tool.MSCommon.vc import find_batch_file, find_vc_pdir, get_default_version, get_host_target
 
     msvc_version = get_default_version(env)
-
-    # Syntax changed in SCons 4.4.0.
-    if env.scons_version >= (4, 4, 0):
-        (host_platform, target_platform, _) = get_host_target(env, msvc_version)
-    else:
-        (host_platform, target_platform, _) = get_host_target(env)
+    host_platform, target_platform, _ = get_host_target(env, msvc_version)
 
     if env.scons_version < (4, 6, 0):
         return find_batch_file(env, msvc_version, host_platform, target_platform)[0]


### PR DESCRIPTION
Required for Windows SDK detection introduced by https://github.com/godotengine/godot/pull/119278.

> Added MSVC_SDK_VERSION construction variable which allows building with a specific Microsoft SDK version. This variable is used with the msvc batch file determined via autodetection. Refer to the documentation for additional requirements and validation details.
>
> _from https://scons.org/scons-440-is-available.html_

For the reference Ubuntu 24.04 LTS use 4.5.1, and a fresh version should be installable with `pip` on older versions.