### PR TITLE
Reconnect to pulseaudio after connection is lost

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -46,6 +46,10 @@
 #endif
 #endif
 
+// How long to wait before reconnecting when we lose our connection
+// to PulseAudio
+const int64_t PA_RECONNECT_MSEC = 1000;
+
 void AudioDriverPulseAudio::pa_state_cb(pa_context *c, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
@@ -404,6 +408,8 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	unsigned int write_ofs = 0;
 	size_t avail_bytes = 0;
 	uint64_t default_device_msec = OS::get_singleton()->get_ticks_msec();
+	uint64_t reconnect_next_msec = 0;
+	bool input_was_active = false;
 
 	while (!ad->exit_thread.is_set()) {
 		size_t read_bytes = 0;
@@ -454,7 +460,60 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			ret = pa_mainloop_iterate(ad->pa_ml, 0, nullptr);
 		} while (ret > 0);
 
-		if (avail_bytes > 0 && pa_stream_get_state(ad->pa_str) == PA_STREAM_READY) {
+		// Reconnect if context has died (e.g. pulseaudio was killed and restarted).
+		if (ad->pa_ready < 0) {
+			uint64_t msec = OS::get_singleton()->get_ticks_msec();
+			if (msec >= reconnect_next_msec) {
+				reconnect_next_msec = msec + PA_RECONNECT_MSEC;
+				print_verbose("PulseAudio: context dead, attempting reconnect...");
+
+				if (ad->pa_rec_str != nullptr) {
+					input_was_active = true;
+				}
+				ad->finish_output_device();
+				ad->finish_input_device();
+				if (ad->pa_ctx) {
+					pa_context_disconnect(ad->pa_ctx);
+					pa_context_unref(ad->pa_ctx);
+					ad->pa_ctx = nullptr;
+				}
+
+				if (ad->connect_context() != OK) {
+					// We'll try again in PA_RECONNECT_MSEC
+					ad->pa_ready = -1;
+				}
+			}
+		}
+
+		// Once the context becomes ready after a reconnect, reinit audio devices.
+		if (ad->pa_ready == 1 && ad->pa_str == nullptr) {
+			Error err = ad->init_output_device();
+			if (err != OK) {
+				ERR_PRINT("PulseAudio: failed to reinit output device after reconnect");
+				ad->pa_ready = -1;
+			} else {
+				if (input_was_active) {
+					err = ad->init_input_device();
+					if (err != OK) {
+						/* This is a pretty unfortunate case: we successfully reconnected
+						   to pulseaudio, but our input device is gone.  Maybe the user unplugged
+						   their microphone. We keep input_was_active to true for now, which will
+						   let the microphone reconnect if pulseaudio restarts again.
+						   Longer-term, we should subscribe to updates from pulseaudio so that
+						   we can notice when devices change.
+						*/
+						ERR_PRINT("PulseAudio: failed to reinit input device after reconnect");
+					} else {
+						input_was_active = false;
+					}
+				}
+				avail_bytes = 0;
+				write_ofs = 0;
+				print_verbose("PulseAudio: successfully reconnected");
+			}
+		}
+
+		if (avail_bytes > 0 && ad->pa_str != nullptr && pa_stream_get_state(ad->pa_str) == PA_STREAM_READY) {
 			size_t bytes = pa_stream_writable_size(ad->pa_str);
 			if (bytes > 0) {
 				size_t bytes_to_write = MIN(bytes, avail_bytes);
@@ -494,7 +553,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 		}
 
 		// If we're using the default output device, check that the current output device is still the default
-		if (ad->output_device_name == "Default") {
+		if (ad->output_device_name == "Default" && ad->pa_ctx != nullptr && ad->pa_ready == 1) {
 			uint64_t msec = OS::get_singleton()->get_ticks_msec();
 			if (msec > (default_device_msec + 1000)) {
 				String old_default_device = ad->default_output_device;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -281,6 +281,9 @@ Error AudioDriverPulseAudio::init_output_device() {
 }
 
 Error AudioDriverPulseAudio::connect_context() {
+	// PA_OK is not an error, so we expect that after pa_context_connect returns -1,
+	// we won't see it from pa_context_errno
+	static int last_reported_errno = PA_OK;
 	pa_ctx = pa_context_new(pa_mainloop_get_api(pa_ml), pa_context_name.utf8().ptr());
 	ERR_FAIL_NULL_V(pa_ctx, ERR_CANT_OPEN);
 
@@ -289,7 +292,13 @@ Error AudioDriverPulseAudio::connect_context() {
 
 	int ret = pa_context_connect(pa_ctx, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
 	if (ret < 0) {
-		ERR_PRINT("PulseAudio: pa_context_connect error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
+		int pa_errno = pa_context_errno(pa_ctx);
+		// Only report connection errors once per type
+		if (pa_errno != last_reported_errno) {
+			ERR_PRINT("PulseAudio: pa_context_connect error: " +
+					String(pa_strerror(pa_errno)));
+			last_reported_errno = pa_errno;
+		}
 		if (pa_ctx) {
 			pa_context_unref(pa_ctx);
 			pa_ctx = nullptr;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -276,6 +276,26 @@ Error AudioDriverPulseAudio::init_output_device() {
 	return OK;
 }
 
+Error AudioDriverPulseAudio::connect_context() {
+	pa_ctx = pa_context_new(pa_mainloop_get_api(pa_ml), pa_context_name.utf8().ptr());
+	ERR_FAIL_NULL_V(pa_ctx, ERR_CANT_OPEN);
+
+	pa_ready = 0;
+	pa_context_set_state_callback(pa_ctx, pa_state_cb, (void *)this);
+
+	int ret = pa_context_connect(pa_ctx, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
+	if (ret < 0) {
+		ERR_PRINT("PulseAudio: pa_context_connect error: " + String(pa_strerror(pa_context_errno(pa_ctx))));
+		if (pa_ctx) {
+			pa_context_unref(pa_ctx);
+			pa_ctx = nullptr;
+		}
+		return ERR_CANT_OPEN;
+	}
+
+	return OK;
+}
+
 Error AudioDriverPulseAudio::init() {
 #ifdef SOWRAP_ENABLED
 #ifdef DEBUG_ENABLED
@@ -311,29 +331,16 @@ Error AudioDriverPulseAudio::init() {
 	pa_ml = pa_mainloop_new();
 	ERR_FAIL_NULL_V(pa_ml, ERR_CANT_OPEN);
 
-	String context_name;
 	if (Engine::get_singleton()->is_editor_hint()) {
-		context_name = GODOT_VERSION_NAME " Editor";
+		pa_context_name = GODOT_VERSION_NAME " Editor";
 	} else {
-		context_name = GLOBAL_GET("application/config/name");
-		if (context_name.is_empty()) {
-			context_name = GODOT_VERSION_NAME " Project";
+		pa_context_name = GLOBAL_GET("application/config/name");
+		if (pa_context_name.is_empty()) {
+			pa_context_name = GODOT_VERSION_NAME " Project";
 		}
 	}
 
-	pa_ctx = pa_context_new(pa_mainloop_get_api(pa_ml), context_name.utf8().ptr());
-	ERR_FAIL_NULL_V(pa_ctx, ERR_CANT_OPEN);
-
-	pa_ready = 0;
-	pa_context_set_state_callback(pa_ctx, pa_state_cb, (void *)this);
-
-	int ret = pa_context_connect(pa_ctx, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
-	if (ret < 0) {
-		if (pa_ctx) {
-			pa_context_unref(pa_ctx);
-			pa_ctx = nullptr;
-		}
-
+	if (connect_context() != OK) {
 		if (pa_ml) {
 			pa_mainloop_free(pa_ml);
 			pa_ml = nullptr;
@@ -343,7 +350,7 @@ Error AudioDriverPulseAudio::init() {
 	}
 
 	while (pa_ready == 0) {
-		ret = pa_mainloop_iterate(pa_ml, 1, nullptr);
+		int ret = pa_mainloop_iterate(pa_ml, 1, nullptr);
 		if (ret < 0) {
 			ERR_PRINT("pa_mainloop_iterate error");
 		}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -393,6 +393,10 @@ Error AudioDriverPulseAudio::init() {
 float AudioDriverPulseAudio::get_latency() {
 	lock();
 
+	if (pa_str == nullptr) {
+		return 0;
+	}
+
 	pa_usec_t pa_lat = 0;
 	if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
 		int negative = 0;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -54,6 +54,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	pa_channel_map pa_map = {};
 	pa_channel_map pa_rec_map = {};
 
+	String pa_context_name;
+
 	String output_device_name = "Default";
 	String new_output_device = "Default";
 	String default_output_device;
@@ -85,6 +87,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	static void pa_server_info_cb(pa_context *c, const pa_server_info *i, void *userdata);
 	static void pa_sinklist_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
 	static void pa_sourcelist_cb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
+
+	Error connect_context();
 
 	Error init_output_device();
 	void finish_output_device();


### PR DESCRIPTION
After we lose our connection to pulseaudio, retry connecting every one second.  We track whether we had any input devices connected, and if we did, we try to set them up again. We unconditionally set up output devices.
    
There's at least one bug that remains: the case where we successfully reconnect to pulseaudio, but our input device is gone.  Maybe the user unplugged their microphone. We would like to set up input again if they plug it back in, but that's out-of-scope.  So  instead, we just hope that pulseaudio dies again; if it does, we'll try again to get our input back.

I have manually tested with the attached test project:
[pa-test-project.zip](https://github.com/user-attachments/files/27457939/pa-test-project.zip)

Test plan: 
1. Before this patch: run the test program (from the editor). 
2. Click the button and listen to the sound. 
3. Disconnect pulseaudio -- for me, that's `systemctl --user restart pipewire-pulse.service`. 
4. Notice the spam
5. Click the button and notice that there is no sound.
6. After the patch, repeat these steps, except that there's no spam and there is sound!

LLM disclosure: Claude diagnosed the problem and wrote some ugly code to fix it. I cleaned up the code to handle a bunch of edge cases, and to match the surrounding code as best as I could.  I wrote all of this text (including the comment in the code about reconnecting audio). I confirm that I understand the code, and that it's as good as I can make it, with the following caveat: I'm adding about 50 lines to a 200-line function.  I chose to do it this way because rewriting the function would make more work for the maintainers to review, but if that's what you prefer, then I will happily do it.

- *Bugsquad edit:* This PR fixes #54584