### PR TITLE
Rendering: Zero uninitialized InstanceData fields 

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -848,6 +848,10 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		} else {
 			RendererRD::MaterialStorage::store_transform_transposed_3x4(Transform3D(), instance_data.transform);
 			RendererRD::MaterialStorage::store_transform_transposed_3x4(Transform3D(), instance_data.prev_transform);
+#ifdef REAL_T_IS_DOUBLE
+			memset(instance_data.model_precision, 0, sizeof(instance_data.model_precision));
+			memset(instance_data.prev_model_precision, 0, sizeof(instance_data.prev_model_precision));
+#endif
 		}
 
 		instance_data.flags = inst->flags_cache;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2120,6 +2120,10 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 		} else {
 			RendererRD::MaterialStorage::store_transform_transposed_3x4(Transform3D(), instance_data.transform);
 			RendererRD::MaterialStorage::store_transform_transposed_3x4(Transform3D(), instance_data.prev_transform);
+#ifdef REAL_T_IS_DOUBLE
+			memset(instance_data.model_precision, 0, sizeof(instance_data.model_precision));
+			memset(instance_data.prev_model_precision, 0, sizeof(instance_data.prev_model_precision));
+#endif
 		}
 
 		instance_data.flags = inst->flags_cache;


### PR DESCRIPTION
Root cause was unitinitialised stack variable.

I was able to reproduce by enabling this build-flag:

```
-ftrivial-auto-var-init=pattern
```

which initialises stack allocated variables with hostile values.

Closes #118918

<details>
<summary>🤖 AI disclosure</summary>

I used AI to:

- ✅ identify the issue, which it did correctly as an uninitialised stack variable
- ✅ determine how to effectively reproduce the issue (using `-ftrivial-auto-var-init=pattern`)
- ✅ identify the solution (which was obvious without AI, given it was uninitialised data)


For reference, the prompt was:

> Read this issue (and comments) https://github.com/godotengine/godot/issues/118918 as a comment has the bisected PR (https://github.com/godotengine/godot/pull/111183) that caused it and identify a root cause. I wonder how double-precision could be the issue?

</details>