### PR TITLE
Add copy/paste icons to `EditorResourcePicker`

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -400,12 +400,12 @@ void EditorResourcePicker::_update_menu_items() {
 		edit_menu->add_separator();
 
 		if (edited_resource.is_valid()) {
-			edit_menu->add_item(TTRC("Copy"), OBJ_MENU_COPY);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionCopy")), TTRC("Copy"), OBJ_MENU_COPY);
 		}
 
 		if (paste_valid) {
-			edit_menu->add_item(TTRC("Paste"), OBJ_MENU_PASTE);
-			edit_menu->add_item(TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste"), OBJ_MENU_PASTE);
+			edit_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste as Unique"), OBJ_MENU_PASTE_AS_UNIQUE);
 		}
 	}
 


### PR DESCRIPTION
Forgive the lack of issue report, and maybe even for framing this as a bug in the first place, but this seemed like a glaring omission with a quick and easy fix.

Before:

<img width="237" height="526" alt="Before" src="https://github.com/user-attachments/assets/61ee94a5-ad98-43d2-b6db-d0370e1ab3eb" />

After:

<img width="243" height="527" alt="After" src="https://github.com/user-attachments/assets/8ba95970-e2ba-4fad-89af-f5cd7804690d" />
