### PR TITLE
Rename various signal parameters called 'name'

### DIFF
--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -62,29 +62,29 @@
 	</methods>
 	<signals>
 		<signal name="animation_added">
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="anim_name" type="StringName" />
 			<description>
-				Emitted when an [Animation] is added, under the key [param name].
+				Emitted when an [Animation] is added, under the key [param anim_name].
 			</description>
 		</signal>
 		<signal name="animation_changed">
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="anim_name" type="StringName" />
 			<description>
-				Emitted when there's a change in one of the animations, e.g. tracks are added, moved or have changed paths. [param name] is the key of the animation that was changed.
+				Emitted when there's a change in one of the animations, e.g. tracks are added, moved or have changed paths. [param anim_name] is the key of the animation that was changed.
 				See also [signal Resource.changed], which this acts as a relay for.
 			</description>
 		</signal>
 		<signal name="animation_removed">
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="anim_name" type="StringName" />
 			<description>
-				Emitted when an [Animation] stored with the key [param name] is removed.
+				Emitted when an [Animation] stored with the key [param anim_name] is removed.
 			</description>
 		</signal>
 		<signal name="animation_renamed">
-			<param index="0" name="name" type="StringName" />
-			<param index="1" name="to_name" type="StringName" />
+			<param index="0" name="old_name" type="StringName" />
+			<param index="1" name="new_name" type="StringName" />
 			<description>
-				Emitted when the key for an [Animation] is changed, from [param name] to [param to_name].
+				Emitted when the key for an [Animation] is changed, from [param old_name] to [param new_name].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -212,7 +212,7 @@
 	<signals>
 		<signal name="animation_node_removed">
 			<param index="0" name="object_id" type="int" />
-			<param index="1" name="name" type="String" />
+			<param index="1" name="node_name" type="String" />
 			<description>
 				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation nodes removes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -343,7 +343,7 @@
 			</description>
 		</signal>
 		<signal name="current_animation_changed">
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="anim_name" type="StringName" />
 			<description>
 				Emitted when [member current_animation] changes.
 			</description>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -70,26 +70,26 @@
 	</members>
 	<signals>
 		<signal name="button_pressed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<description>
 				Emitted when a button on this tracker is pressed. Note that many XR runtimes allow other inputs to be mapped to buttons.
 			</description>
 		</signal>
 		<signal name="button_released">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<description>
 				Emitted when a button on this tracker is released.
 			</description>
 		</signal>
 		<signal name="input_float_changed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<param index="1" name="value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this tracker changes value.
 			</description>
 		</signal>
 		<signal name="input_vector2_changed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="action_name" type="String" />
 			<param index="1" name="vector" type="Vector2" />
 			<description>
 				Emitted when a thumbstick or thumbpad on this tracker moves.

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1067,7 +1067,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
 
-	ADD_SIGNAL(MethodInfo("current_animation_changed", PropertyInfo(Variant::STRING_NAME, "name")));
+	ADD_SIGNAL(MethodInfo("current_animation_changed", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
 }
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -576,7 +576,7 @@ void AnimationNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_changed"));
 	ADD_SIGNAL(MethodInfo("node_updated", PropertyInfo(Variant::INT, "object_id")));
 	ADD_SIGNAL(MethodInfo("animation_node_renamed", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
-	ADD_SIGNAL(MethodInfo("animation_node_removed", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo("animation_node_removed", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "node_name")));
 
 	BIND_ENUM_CONSTANT(FILTER_IGNORE);
 	BIND_ENUM_CONSTANT(FILTER_PASS);

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -172,10 +172,10 @@ void AnimationLibrary::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 
-	ADD_SIGNAL(MethodInfo("animation_added", PropertyInfo(Variant::STRING_NAME, "name")));
-	ADD_SIGNAL(MethodInfo("animation_removed", PropertyInfo(Variant::STRING_NAME, "name")));
-	ADD_SIGNAL(MethodInfo("animation_renamed", PropertyInfo(Variant::STRING_NAME, "name"), PropertyInfo(Variant::STRING_NAME, "to_name")));
-	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "name")));
+	ADD_SIGNAL(MethodInfo("animation_added", PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo("animation_removed", PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo("animation_renamed", PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
+	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 }
 AnimationLibrary::AnimationLibrary() {
 }

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -56,10 +56,10 @@ void XRPositionalTracker::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_input", "name"), &XRPositionalTracker::get_input);
 	ClassDB::bind_method(D_METHOD("set_input", "name", "value"), &XRPositionalTracker::set_input);
-	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
+	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "action_name")));
+	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "action_name")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "action_name"), PropertyInfo(Variant::FLOAT, "value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "action_name"), PropertyInfo(Variant::VECTOR2, "vector")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/godotengine/godot/pull/119292#issuecomment-4391153030

This PR renames various signal parameters containing 'name' on various signals. This is to avoid issues similarly mentioned in https://github.com/godotengine/godot/issues/119266 where users that connect signals to their scripts using the given signal parameter names would receive the SHADOWED_VARIABLE_BASE_CLASS warning.

Below is a list of name changes:

In `AnimationLibrary`:
- `animation_added(name: StringName)` -> `animation_added(anim_name: StringName)`
- `animation_changed(name: StringName)` -> `animation_changed(anim_name: StringName)`
- `animation_removed(name: StringName)` -> `animation_removed(anim_name: StringName)`
- `animation_renamed(name: StringName, to_name: StringName)` -> `animation_renamed(old_name: StringName, new_name: StringName)`

In `AnimationNode`:
- `animation_node_removed(name: String)` -> `animation_node_removed(node_name: String)`

In  `AnimationPlayer`:
- `current_animation_changed(name: StringName)` -> `current_animation_changed(anim_name: StringName)`

In `XRPositionalTracker`:
- `button_pressed(name: String)` -> `button_pressed(action_name: String)`
- `button_released(name: String)` -> `button_released(action_name: String)`
- `input_float_changed(name: String, value: float)` -> `input_float_changed(action_name: String, value: float)`
- `input_vector2_changed(name: String, vector: Vector2)` -> `input_vector2_changed(action_name: String, vector: Vector2)`

_Bugsquad edited:_
- Follow up #119158
- Fixes #119266
- Supersedes/Closes #119292