### PR TITLE
Add `[ExportName]` support for C# exported properties to customize Inspector labels

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -186,6 +186,12 @@ public:
 	virtual void update_exports() {} //editor tool
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+#ifdef TOOLS_ENABLED
+	virtual String get_property_display_name(const StringName &p_property) const {
+		(void)p_property;
+		return String();
+	}
+#endif
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -188,7 +188,6 @@ public:
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
 #ifdef TOOLS_ENABLED
 	virtual String get_property_display_name(const StringName &p_property) const {
-		(void)p_property;
 		return String();
 	}
 #endif

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -35,6 +35,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
@@ -4501,7 +4502,16 @@ void EditorInspector::update_tree() {
 		if ((p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) && name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED) {
 			name_style = EditorPropertyNameProcessor::STYLE_CAPITALIZED;
 		}
-		const String property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override, name_style, p.name, doc_name) + feature_tag;
+		String display_name;
+		Ref<Script> script = object->get_script();
+		if (script.is_valid()) {
+			display_name = script->get_property_display_name(p.name);
+		}
+		String property_label_string = display_name;
+		if (property_label_string.is_empty()) {
+			property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override, name_style, p.name, doc_name);
+		}
+		property_label_string += feature_tag;
 
 		// Remove the property from the path.
 		int idx = path.rfind_char('/');

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2088,6 +2088,7 @@ void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript 
 
 		StringName name = *reinterpret_cast<const StringName *>(&prop.name);
 		String hint_string = *reinterpret_cast<const String *>(&prop.hint_string);
+		String display_name = *reinterpret_cast<const String *>(&prop.display_name);
 
 		PropertyInfo pinfo(prop.type, name, prop.hint, hint_string, prop.usage);
 
@@ -2096,6 +2097,9 @@ void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript 
 		if (prop.exported) {
 #ifdef TOOLS_ENABLED
 			p_script->exported_members_cache.push_back(pinfo);
+			if (!display_name.is_empty()) {
+				p_script->exported_members_display_names_cache[name] = display_name;
+			}
 #endif
 
 #if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
@@ -2147,6 +2151,7 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 
 #ifdef TOOLS_ENABLED
 		exported_members_cache.clear();
+		exported_members_display_names_cache.clear();
 		exported_members_defval_cache.clear();
 #endif
 
@@ -2749,6 +2754,25 @@ void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 	}
 #endif
 }
+
+#ifdef TOOLS_ENABLED
+String CSharpScript::get_property_display_name(const StringName &p_property) const {
+	const CSharpScript *top = this;
+	while (top != nullptr) {
+		const String *display_name = top->exported_members_display_names_cache.getptr(p_property);
+		if (display_name != nullptr) {
+			return *display_name;
+		}
+		if (top->member_info.has(p_property)) {
+			return String();
+		}
+
+		top = top->base_script.ptr();
+	}
+
+	return String();
+}
+#endif
 
 int CSharpScript::get_member_line(const StringName &p_member) const {
 	// TODO omnisharp

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -189,6 +189,7 @@ private:
 
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
+	HashMap<StringName, String> exported_members_display_names_cache;
 	HashMap<StringName, Variant> exported_members_defval_cache; // member_default_values_cache
 	HashSet<PlaceHolderScriptInstance *> placeholders;
 	bool source_changed_cache = false;
@@ -258,6 +259,9 @@ public:
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 	void get_script_property_list(List<PropertyInfo> *r_list) const override;
+#ifdef TOOLS_ENABLED
+	String get_property_display_name(const StringName &p_property) const override;
+#endif
 	void update_exports() override;
 
 	void get_members(HashSet<StringName> *p_members) override;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -25,6 +25,10 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @NotGenerateReturnsProperty = "NotGenerateReturnsProperty";
         /// <summary>
+        /// Cached name for the 'ExportNameProperty' property.
+        /// </summary>
+        public new static readonly global::Godot.StringName @ExportNameProperty = "ExportNameProperty";
+        /// <summary>
         /// Cached name for the 'FullPropertyString' property.
         /// </summary>
         public new static readonly global::Godot.StringName @FullPropertyString = "FullPropertyString";
@@ -339,6 +343,10 @@ partial class ExportedProperties
         }
         if (name == PropertyName.@NotGenerateReturnsProperty) {
             this.@NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            return true;
+        }
+        if (name == PropertyName.@ExportNameProperty) {
+            this.@ExportNameProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
             return true;
         }
         if (name == PropertyName.@FullPropertyString) {
@@ -659,6 +667,10 @@ partial class ExportedProperties
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateReturnsProperty);
             return true;
         }
+        if (name == PropertyName.@ExportNameProperty) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ExportNameProperty);
+            return true;
+        }
         if (name == PropertyName.@FullPropertyString) {
             value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString);
             return true;
@@ -972,6 +984,7 @@ partial class ExportedProperties
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@NotGenerateComplexReturnProperty, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)2, name: PropertyName.@_notGeneratePropertyInt, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@NotGenerateReturnsProperty, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
+        properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@ExportNameProperty, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true, displayName: "Custom Display Label"));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_fullPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@FullPropertyString, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4102, exported: true));
         properties.Add(new(type: (global::Godot.Variant.Type)4, name: PropertyName.@_fullPropertyStringComplex, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4096, exported: false));

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptPropertyDefVal.generated.cs
@@ -11,7 +11,7 @@ partial class ExportedProperties
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal new static global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant> GetGodotPropertyDefaultValues()
     {
-        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(71);
+        var values = new global::System.Collections.Generic.Dictionary<global::Godot.StringName, global::Godot.Variant>(72);
         string __NotGenerateComplexLamdaProperty_default_value = default;
         values.Add(PropertyName.@NotGenerateComplexLamdaProperty, global::Godot.Variant.From<string>(__NotGenerateComplexLamdaProperty_default_value));
         string __NotGenerateLamdaNoFieldProperty_default_value = default;
@@ -20,6 +20,8 @@ partial class ExportedProperties
         values.Add(PropertyName.@NotGenerateComplexReturnProperty, global::Godot.Variant.From<string>(__NotGenerateComplexReturnProperty_default_value));
         string __NotGenerateReturnsProperty_default_value = default;
         values.Add(PropertyName.@NotGenerateReturnsProperty, global::Godot.Variant.From<string>(__NotGenerateReturnsProperty_default_value));
+        string __ExportNameProperty_default_value = "ExportNameProperty";
+        values.Add(PropertyName.@ExportNameProperty, global::Godot.Variant.From<string>(__ExportNameProperty_default_value));
         string __FullPropertyString_default_value = "FullPropertyString";
         values.Add(PropertyName.@FullPropertyString, global::Godot.Variant.From<string>(__FullPropertyString_default_value));
         string __FullPropertyString_Complex_default_value = new string("FullPropertyString_Complex")   + global::System.Convert.ToInt32("1");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportedProperties.cs
@@ -54,6 +54,10 @@ public partial class ExportedProperties(string primaryCtorParameter) : GodotObje
         }
     }
 
+    [Export]
+    [ExportName("Custom Display Label")]
+    public String ExportNameProperty { get; set; } = "ExportNameProperty";
+
     // Full Property
     private String _fullPropertyString = "FullPropertyString";
     [Export]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -278,6 +278,9 @@ namespace Godot.SourceGenerators
         public static bool IsGodotExportAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportAttr;
 
+        public static bool IsGodotExportNameAttribute(this INamedTypeSymbol symbol)
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportNameAttr;
+
         public static bool IsGodotSignalAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SignalAttr;
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -9,6 +9,7 @@ namespace Godot.SourceGenerators
         public const string ExportAttr = "Godot.ExportAttribute";
         public const string ExportCategoryAttr = "Godot.ExportCategoryAttribute";
         public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
+        public const string ExportNameAttr = "Godot.ExportNameAttribute";
         public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";
         public const string ExportToolButtonAttr = "Godot.ExportToolButtonAttribute";
         public const string SignalAttr = "Godot.SignalAttribute";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
@@ -3,11 +3,11 @@ namespace Godot.SourceGenerators
     internal readonly struct PropertyInfo
     {
         public PropertyInfo(VariantType type, string name, PropertyHint hint,
-            string? hintString, PropertyUsageFlags usage, bool exported)
-            : this(type, name, hint, hintString, usage, className: null, exported) { }
+            string? hintString, PropertyUsageFlags usage, bool exported, string? displayName = null)
+            : this(type, name, hint, hintString, usage, className: null, exported, displayName) { }
 
         public PropertyInfo(VariantType type, string name, PropertyHint hint,
-            string? hintString, PropertyUsageFlags usage, string? className, bool exported)
+            string? hintString, PropertyUsageFlags usage, string? className, bool exported, string? displayName = null)
         {
             Type = type;
             Name = name;
@@ -16,6 +16,7 @@ namespace Godot.SourceGenerators
             Usage = usage;
             ClassName = className;
             Exported = exported;
+            DisplayName = displayName;
         }
 
         public VariantType Type { get; }
@@ -25,5 +26,6 @@ namespace Godot.SourceGenerators
         public PropertyUsageFlags Usage { get; }
         public string? ClassName { get; }
         public bool Exported { get; }
+        public string? DisplayName { get; }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -390,7 +390,12 @@ namespace Godot.SourceGenerators
                 .Append((int)propertyInfo.Usage)
                 .Append(", exported: ")
                 .Append(propertyInfo.Exported ? "true" : "false")
-                .Append("));\n");
+                .Append(propertyInfo.DisplayName != null ? ", displayName: " : "");
+            if (propertyInfo.DisplayName != null)
+            {
+                source.Append(SymbolDisplay.FormatLiteral(propertyInfo.DisplayName, quote: true));
+            }
+            source.Append("));\n");
         }
 
         private static IEnumerable<PropertyInfo> DetermineGroupingPropertyInfo(ISymbol memberSymbol)
@@ -432,6 +437,13 @@ namespace Godot.SourceGenerators
 
             var exportToolButtonAttr = memberSymbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.IsGodotExportToolButtonAttribute() ?? false);
+
+            var exportNameAttr = memberSymbol.GetAttributes()
+                .FirstOrDefault(a => a.AttributeClass?.IsGodotExportNameAttribute() ?? false);
+
+            string? displayName = exportNameAttr?.ConstructorArguments.Length > 0 ?
+                exportNameAttr.ConstructorArguments[0].Value?.ToString() :
+                null;
 
             if (exportAttr != null && exportToolButtonAttr != null)
             {
@@ -583,7 +595,7 @@ namespace Godot.SourceGenerators
                 }
 
                 return new PropertyInfo(memberVariantType, memberName, PropertyHint.ToolButton,
-                    hintString: hintString, PropertyUsageFlags.Editor, exported: true);
+                    hintString: hintString, PropertyUsageFlags.Editor, exported: true, displayName: displayName);
             }
 
             if (exportAttr == null)
@@ -624,7 +636,7 @@ namespace Godot.SourceGenerators
                 propUsage |= PropertyUsageFlags.NilIsVariant;
 
             return new PropertyInfo(memberVariantType, memberName,
-                hint, hintString, propUsage, exported: true);
+                hint, hintString, propUsage, exported: true, displayName: displayName);
         }
 
         private static bool TryGetMemberExportHint(

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportNameAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportNameAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Overrides the display name used by the editor inspector for the annotated exported member.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportNameAttribute : Attribute
+    {
+        /// <summary>
+        /// The display name to show in the editor inspector.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Overrides the display name used by the editor inspector for the annotated exported member.
+        /// </summary>
+        /// <param name="name">The display name to show in the editor inspector.</param>
+        public ExportNameAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
@@ -11,13 +11,22 @@ public readonly struct PropertyInfo
     public PropertyUsageFlags Usage { get; init; }
     public StringName? ClassName { get; init; }
     public bool Exported { get; init; }
+    public string DisplayName { get; init; }
 
     public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
         PropertyUsageFlags usage, bool exported)
-        : this(type, name, hint, hintString, usage, className: null, exported) { }
+        : this(type, name, hint, hintString, usage, exported, displayName: "") { }
+
+    public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
+        PropertyUsageFlags usage, bool exported, string displayName = "")
+        : this(type, name, hint, hintString, usage, className: null, exported, displayName) { }
 
     public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
         PropertyUsageFlags usage, StringName? className, bool exported)
+        : this(type, name, hint, hintString, usage, className, exported, displayName: "") { }
+
+    public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
+        PropertyUsageFlags usage, StringName? className, bool exported, string displayName = "")
     {
         Type = type;
         Name = name;
@@ -26,5 +35,6 @@ public readonly struct PropertyInfo
         Usage = usage;
         ClassName = className;
         Exported = exported;
+        DisplayName = displayName;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -982,6 +982,7 @@ namespace Godot.Bridge
             // Careful with padding...
             public godot_string_name Name; // Not owned
             public godot_string HintString;
+            public godot_string DisplayName;
             public int Type;
             public int Hint;
             public int Usage;
@@ -990,6 +991,7 @@ namespace Godot.Bridge
             public void Dispose()
             {
                 HintString.Dispose();
+                DisplayName.Dispose();
             }
         }
 #pragma warning restore IDE1006
@@ -1062,6 +1064,7 @@ namespace Godot.Bridge
                             Name = (godot_string_name)property.Name.NativeValue, // Not owned
                             Hint = (int)property.Hint,
                             HintString = Marshaling.ConvertStringToNative(property.HintString),
+                            DisplayName = Marshaling.ConvertStringToNative(property.DisplayName ?? ""),
                             Usage = (int)property.Usage,
                             Exported = property.Exported.ToGodotBool()
                         };

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
     <Compile Include="Core\Attributes\ExportCategoryAttribute.cs" />
     <Compile Include="Core\Attributes\ExportGroupAttribute.cs" />
+    <Compile Include="Core\Attributes\ExportNameAttribute.cs" />
     <Compile Include="Core\Attributes\ExportSubgroupAttribute.cs" />
     <Compile Include="Core\Attributes\GlobalClassAttribute.cs" />
     <Compile Include="Core\Attributes\GodotClassNameAttribute.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -56,6 +56,7 @@ namespace GDMonoCache {
 struct godotsharp_property_info {
 	godot_string_name name; // Not owned
 	godot_string hint_string;
+	godot_string display_name;
 	Variant::Type type;
 	PropertyHint hint;
 	PropertyUsageFlags usage;


### PR DESCRIPTION
## Summary

Add support for `[ExportName]` on C# exported members so the Inspector can display a custom label without changing the underlying property name.

## Changes

- add `Godot.ExportNameAttribute` in GodotSharp
- update the source generator to emit an optional display name for exported properties
- pass the display name through the C# bridge/native interop layer
- store display names in `CSharpScript` editor metadata
- make the Inspector prefer the custom display name when available
- add source generator test coverage

## Notes

This only affects the Inspector display label. 
Property keys, get/set behavior, and serialization names are unchanged.

## Example

```csharp
[Export]
[ExportName("Short Name")]
public string LongPropertyNameInTheCsharpScript { get; set; }
```

## Related

- Closes godotengine/godot-proposals#3510