### PR TITLE
[Accessibility] Fix positions of nested popups sent to the screen reader.

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -763,6 +763,8 @@ public:
 	void set_accessibility_flow_to_nodes(const TypedArray<NodePath> &p_node_path);
 	TypedArray<NodePath> get_accessibility_flow_to_nodes() const;
 
+	virtual Transform2D get_accessibility_transform() const override { return get_transform(); }
+
 	// Rendering.
 
 	void set_default_cursor_shape(CursorShape p_shape);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3725,6 +3725,14 @@ RID Node::get_focused_accessibility_element() const {
 	}
 }
 
+Transform2D Node::get_accessibility_transform() const {
+	if (is_inside_tree() && data.parent) {
+		return data.parent->get_accessibility_transform();
+	} else {
+		return Transform2D();
+	}
+}
+
 void Node::queue_accessibility_update() {
 	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		data.tree->_accessibility_notify_change(this);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -725,6 +725,7 @@ public:
 	virtual RID get_accessibility_element() const;
 	virtual RID get_focused_accessibility_element() const;
 	virtual bool accessibility_override_tree_hierarchy() const { return false; }
+	virtual Transform2D get_accessibility_transform() const;
 
 	virtual PackedStringArray get_accessibility_configuration_warnings() const;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1547,6 +1547,25 @@ PackedStringArray Window::get_accessibility_configuration_warnings() const {
 	return warnings;
 }
 
+Transform2D Window::get_accessibility_transform() const {
+	if (is_inside_tree() && get_parent()) {
+		Transform2D parent_tr = get_parent()->get_accessibility_transform();
+		Transform2D window_tr;
+		if (window_id == DisplayServerEnums::INVALID_WINDOW_ID) {
+			window_tr.set_origin(position);
+		} else {
+			Window *np = get_non_popup_window();
+			if (np) {
+				window_tr.set_origin(get_position() - np->get_position());
+			}
+		}
+		window_tr.set_scale(Vector2(1.f, 1.f) * get_content_scale_factor());
+		return parent_tr.affine_inverse() * window_tr;
+	} else {
+		return Transform2D();
+	}
+}
+
 void Window::_notification(int p_what) {
 	ERR_MAIN_THREAD_GUARD;
 	switch (p_what) {
@@ -1573,19 +1592,8 @@ void Window::_notification(int p_what) {
 			AccessibilityServer::get_singleton()->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !visible);
 
 			if (get_embedder() || is_popup()) {
-				Control *parent_ctrl = Object::cast_to<Control>(get_parent());
-				Transform2D parent_tr = parent_ctrl ? parent_ctrl->get_global_transform() : Transform2D();
-				Transform2D tr;
-				if (window_id == DisplayServerEnums::INVALID_WINDOW_ID) {
-					tr.set_origin(position);
-				} else {
-					Window *np = get_non_popup_window();
-					if (np) {
-						tr.set_origin(get_position() - np->get_position());
-					}
-				}
-				AccessibilityServer::get_singleton()->update_set_transform(ae, parent_tr.affine_inverse() * tr);
-				AccessibilityServer::get_singleton()->update_set_bounds(ae, Rect2(Point2(), size));
+				AccessibilityServer::get_singleton()->update_set_transform(ae, get_accessibility_transform());
+				AccessibilityServer::get_singleton()->update_set_bounds(ae, Rect2(Point2(), Vector2(size) / get_content_scale_factor()));
 
 				if (accessibility_title_element.is_null()) {
 					accessibility_title_element = AccessibilityServer::get_singleton()->create_sub_element(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_TITLE_BAR);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -457,6 +457,8 @@ public:
 
 	void accessibility_announcement(const String &p_announcement);
 
+	virtual Transform2D get_accessibility_transform() const override;
+
 	// Internationalization.
 
 	void set_layout_direction(LayoutDirection p_direction);


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/119311

- Fixes nested popup positions.
- Fixes popup content scale.

| Before | After |
|--|--|
| <img width="486" height="334" alt="Screenshot 2026-05-08 at 08 38 18" src="https://github.com/user-attachments/assets/6dd09a5c-b1e2-41bf-8a58-69f0ac264799" /> | <img width="486" height="334" alt="Screenshot 2026-05-08 at 08 38 46" src="https://github.com/user-attachments/assets/aa20b9f7-adfd-42c5-a419-da08d7e3c030" /> |

Tested with #119311 MRP on macOS, and on Windows with NVDA and Narrator.

Note for testing: it is only fixing transform for a screen reader, there are no visual changes. Menu item positions are fixed by https://github.com/godotengine/godot/pull/119312.