### PR TITLE
Fix incorrect `get_drop_section_at_position` results in Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6630,7 +6630,8 @@ TreeItem *Tree::_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_
 						}
 					} else if (pos.y < r_height / 4) {
 						// Near top edge.
-						if (current_item_depth > 0) { // Not root, since root cannot have siblings.
+						bool item_can_have_siblings = (p_item != root) && (current_item_depth > 0 || hide_root); // Disqualify root.
+						if (item_can_have_siblings) {
 							r_section = parent_allows_drop ? -1 : COLUMN_NOT_FOUND; // Sibling above.
 						} else {
 							r_section = item_allows_drop ? 0 : COLUMN_NOT_FOUND; // On root, or as last child of root.
@@ -6898,7 +6899,7 @@ int Tree::get_column_at_position(const Point2 &p_pos) const {
 }
 
 int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
-	if (!root || !Rect2(Vector2(), get_size()).has_point(p_pos)) {
+	if (!root || !Rect2(Vector2(), get_size()).has_point(p_pos) || !drop_mode_flags) {
 		return COLUMN_NOT_FOUND;
 	}
 


### PR DESCRIPTION
Addresses inconsistencies noted in #119023, but if its larger concern is considered a regression...

> The larger issue, however, is that after these changes, it is now impossible to get the correct drop section in situations where dropping an item there would not be allowed. There are a number of different situations where you would want to be able to access the theoretical drop section regardless of whether it would be valid, such as changing the text of a warning tooltip or writing custom logic to determine if the specific item being dropped is valid in that section.
>
> It is unclear if this is an intended change, but if it is, it is a compatibility-breaking change, which https://github.com/godotengine/godot/pull/112993 is not labeled as (assuming that PR introduced the issue).

...restoring `get_drop_section_at_position` to always return all sections and not just those it considers valid will involve a refactor of changes made by #112993.