### PR TITLE
Split `PopupMenu.search_bar_enabled_on_item_count` into two properties

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -140,12 +140,6 @@
 				Returns [code]true[/code] if the item at index [param idx] is marked as a separator.
 			</description>
 		</method>
-		<method name="is_search_bar_enabled" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the search bar is enabled.
-			</description>
-		</method>
 		<method name="remove_item">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
@@ -239,9 +233,6 @@
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">
 			If [code]true[/code], the currently selected item can be selected again.
 		</member>
-		<member name="enable_search_bar_on_item_count" type="int" setter="set_search_bar_enabled_on_item_count" getter="get_search_bar_enabled_on_item_count" default="0">
-			Enables the [PopupMenu] search bar if the item count is greater than [code]0[/code].
-		</member>
 		<member name="fit_to_longest_item" type="bool" setter="set_fit_to_longest_item" getter="is_fit_to_longest_item" default="true">
 			If [code]true[/code], minimum size will be determined by the longest item's text, instead of the currently selected one's.
 			[b]Note:[/b] For performance reasons, the minimum size doesn't update immediately when adding, removing or modifying items.
@@ -269,12 +260,18 @@
 			The text of the item at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
 		</member>
+		<member name="search_bar_enabled" type="bool" setter="set_search_bar_enabled" getter="is_search_bar_enabled" default="false">
+			If [code]true[/code], shows a search bar at the top of the [PopupMenu] for filtering items. See [member search_bar_min_item_count] for dynamically controlling its visibility based on the number of items.
+		</member>
 		<member name="search_bar_fuzzy_search_enabled" type="bool" setter="set_search_bar_fuzzy_search_enabled" getter="is_search_bar_fuzzy_search_enabled" default="true">
 			If [code]true[/code], enables fuzzy searching in the [PopupMenu] search bar. This allows the search results to include items that almost match the search query, as well items that match the individual characters of the search query, but not in sequence.
 			Use [member search_bar_fuzzy_search_max_misses] to set the maximum number of mismatches allowed in the search results.
 		</member>
 		<member name="search_bar_fuzzy_search_max_misses" type="int" setter="set_search_bar_fuzzy_search_max_misses" getter="get_search_bar_fuzzy_search_max_misses" default="2">
 			Sets the maximum number of mismatches allowed in each search result when fuzzy searching is enabled for the [PopupMenu] search bar. Any item with more mismatches will be hidden from the search results.
+		</member>
+		<member name="search_bar_min_item_count" type="int" setter="set_search_bar_min_item_count" getter="get_search_bar_min_item_count" default="0">
+			Sets the minimum number of items required for the [PopupMenu] search bar to be visible. [member search_bar_enabled] must be [code]true[/code] for this to have any effect.
 		</member>
 		<member name="selected" type="int" setter="_select_int" getter="get_selected" default="-1">
 			The index of the currently selected item, or [code]-1[/code] if no item is selected.

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -408,12 +408,6 @@
 				Returns [code]true[/code] if the system native menu is supported and currently used by this [PopupMenu].
 			</description>
 		</method>
-		<method name="is_search_bar_enabled" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if search bar is currently enabled.
-			</description>
-		</method>
 		<method name="is_system_menu" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -705,8 +699,8 @@
 			If [code]true[/code], [MenuBar] will use native menu when supported.
 			[b]Note:[/b] If [PopupMenu] is linked to [StatusIndicator], [MenuBar], or another [PopupMenu] item it can use native menu regardless of this property, use [method is_native_menu] to check it.
 		</member>
-		<member name="search_bar_enabled_on_item_count" type="int" setter="set_search_bar_enabled_on_item_count" getter="get_search_bar_enabled_on_item_count" default="0">
-			Enables the [PopupMenu] search bar if the item count is greater than [code]0[/code].
+		<member name="search_bar_enabled" type="bool" setter="set_search_bar_enabled" getter="is_search_bar_enabled" default="false">
+			If [code]true[/code], shows a search bar at the top of the [PopupMenu] for filtering items. See [member search_bar_min_item_count] for dynamically controlling its visibility based on the number of items.
 			[b]Note:[/b] When enabled, [member allow_search] is ignored.
 		</member>
 		<member name="search_bar_fuzzy_search_enabled" type="bool" setter="set_search_bar_fuzzy_search_enabled" getter="is_search_bar_fuzzy_search_enabled" default="true">
@@ -715,6 +709,9 @@
 		</member>
 		<member name="search_bar_fuzzy_search_max_misses" type="int" setter="set_search_bar_fuzzy_search_max_misses" getter="get_search_bar_fuzzy_search_max_misses" default="2">
 			Sets the maximum number of mismatches allowed in each search result when fuzzy searching is enabled for the [PopupMenu] search bar. Any item with more mismatches will be hidden from the search results.
+		</member>
+		<member name="search_bar_min_item_count" type="int" setter="set_search_bar_min_item_count" getter="get_search_bar_min_item_count" default="0">
+			Sets the minimum number of items required for the search bar to be visible. [member search_bar_enabled] must be [code]true[/code] for this to have any effect.
 		</member>
 		<member name="shrink_height" type="bool" setter="set_shrink_height" getter="get_shrink_height" default="true">
 			If [code]true[/code], shrinks [PopupMenu] to minimum height when it's shown.

--- a/editor/gui/editor_variant_type_selectors.cpp
+++ b/editor/gui/editor_variant_type_selectors.cpp
@@ -176,5 +176,6 @@ void EditorVariantTypePopupMenu::_popup_base(const Rect2i &p_bounds) {
 
 EditorVariantTypePopupMenu::EditorVariantTypePopupMenu(bool p_remove_item) {
 	remove_item = p_remove_item;
-	set_search_bar_enabled_on_item_count(10);
+	set_search_bar_enabled(true);
+	set_search_bar_min_item_count(10);
 }

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -586,7 +586,8 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 	option_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	option_button->set_clip_text(true);
 	option_button->set_flat(true);
-	option_button->set_search_bar_enabled_on_item_count(10);
+	option_button->set_search_bar_enabled(true);
+	option_button->set_search_bar_min_item_count(10);
 	option_button->set_theme_type_variation(SNAME("EditorInspectorButton"));
 	option_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	default_layout->add_child(option_button);
@@ -999,7 +1000,8 @@ EditorPropertyEnum::EditorPropertyEnum() {
 	options->set_flat(true);
 	options->set_theme_type_variation(SNAME("EditorInspectorButton"));
 	options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	options->set_search_bar_enabled_on_item_count(10);
+	options->set_search_bar_enabled(true);
+	options->set_search_bar_min_item_count(10);
 	add_child(options);
 	add_focusable(options);
 	options->connect(SceneStringName(item_selected), callable_mp(this, &EditorPropertyEnum::_option_selected));

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1240,7 +1240,8 @@ void EditorResourcePicker::_ensure_resource_menu() {
 		return;
 	}
 	edit_menu = memnew(PopupMenu);
-	edit_menu->set_search_bar_enabled_on_item_count(10);
+	edit_menu->set_search_bar_enabled(true);
+	edit_menu->set_search_bar_min_item_count(10);
 	edit_menu->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	add_child(edit_menu);
 	edit_menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorResourcePicker::_edit_menu_cbk));

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -499,7 +499,8 @@ EditorSceneTabs::EditorSceneTabs() {
 	scene_list->set_accessibility_name(TTRC("Show Opened Scenes List"));
 	scene_list->set_shortcut(ED_SHORTCUT("editor/show_opened_scenes_list", TTRC("Show Opened Scenes List"), KeyModifierMask::ALT | Key::T));
 	scene_list->get_popup()->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	scene_list->get_popup()->set_search_bar_enabled_on_item_count(10);
+	scene_list->get_popup()->set_search_bar_enabled(true);
+	scene_list->get_popup()->set_search_bar_min_item_count(10);
 	scene_list->get_popup()->connect("about_to_popup", callable_mp(this, &EditorSceneTabs::_update_scene_list));
 	scene_list->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
 	tabbar_container->add_child(scene_list);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -390,17 +390,20 @@ bool OptionButton::get_allow_reselect() const {
 	return allow_reselect;
 }
 
+void OptionButton::set_search_bar_enabled(bool p_enabled) {
+	popup->set_search_bar_enabled(p_enabled);
+}
+
 bool OptionButton::is_search_bar_enabled() const {
 	return popup->is_search_bar_enabled();
 }
 
-void OptionButton::set_search_bar_enabled_on_item_count(int p_count) {
-	popup->set_search_bar_enabled_on_item_count(p_count);
-	notify_property_list_changed();
+void OptionButton::set_search_bar_min_item_count(int p_count) {
+	popup->set_search_bar_min_item_count(p_count);
 }
 
-int OptionButton::get_search_bar_enabled_on_item_count() const {
-	return popup->get_search_bar_enabled_on_item_count();
+int OptionButton::get_search_bar_min_item_count() const {
+	return popup->get_search_bar_min_item_count();
 }
 
 void OptionButton::set_search_bar_fuzzy_search_enabled(bool p_enabled) {
@@ -587,12 +590,6 @@ void OptionButton::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "text" || p_property.name == "icon") {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-
-	if (popup->get_search_bar_enabled_on_item_count() == 0) {
-		if (p_property.name == "search_bar_fuzzy_search_enabled" || p_property.name == "search_bar_fuzzy_search_max_misses") {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
 }
 
 void OptionButton::_bind_methods() {
@@ -605,7 +602,9 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_metadata", "idx", "metadata"), &OptionButton::set_item_metadata);
 	ClassDB::bind_method(D_METHOD("set_item_tooltip", "idx", "tooltip"), &OptionButton::set_item_tooltip);
 	ClassDB::bind_method(D_METHOD("set_item_auto_translate_mode", "idx", "mode"), &OptionButton::set_item_auto_translate_mode);
-	ClassDB::bind_method(D_METHOD("set_search_bar_enabled_on_item_count", "counts"), &OptionButton::set_search_bar_enabled_on_item_count);
+	ClassDB::bind_method(D_METHOD("set_search_bar_enabled", "enabled"), &OptionButton::set_search_bar_enabled);
+	ClassDB::bind_method(D_METHOD("set_search_bar_min_item_count", "count"), &OptionButton::set_search_bar_min_item_count);
+	ClassDB::bind_method(D_METHOD("get_search_bar_min_item_count"), &OptionButton::get_search_bar_min_item_count);
 	ClassDB::bind_method(D_METHOD("set_search_bar_fuzzy_search_enabled", "enabled"), &OptionButton::set_search_bar_fuzzy_search_enabled);
 	ClassDB::bind_method(D_METHOD("is_search_bar_fuzzy_search_enabled"), &OptionButton::is_search_bar_fuzzy_search_enabled);
 	ClassDB::bind_method(D_METHOD("set_search_bar_fuzzy_search_max_misses", "max_misses"), &OptionButton::set_search_bar_fuzzy_search_max_misses);
@@ -620,7 +619,6 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_item_disabled", "idx"), &OptionButton::is_item_disabled);
 	ClassDB::bind_method(D_METHOD("is_item_separator", "idx"), &OptionButton::is_item_separator);
 	ClassDB::bind_method(D_METHOD("is_search_bar_enabled"), &OptionButton::is_search_bar_enabled);
-	ClassDB::bind_method(D_METHOD("get_search_bar_enabled_on_item_count"), &OptionButton::get_search_bar_enabled_on_item_count);
 	ClassDB::bind_method(D_METHOD("add_separator", "text"), &OptionButton::add_separator, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("clear"), &OptionButton::clear);
 	ClassDB::bind_method(D_METHOD("select", "idx"), &OptionButton::select);
@@ -646,9 +644,13 @@ void OptionButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fit_to_longest_item"), "set_fit_to_longest_item", "is_fit_to_longest_item");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "enable_search_bar_on_item_count", PROPERTY_HINT_RANGE, "0,20,1,or_greater"), "set_search_bar_enabled_on_item_count", "get_search_bar_enabled_on_item_count");
+
+	ADD_GROUP("Search Bar", "search_bar_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "search_bar_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_search_bar_enabled", "is_search_bar_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "search_bar_min_item_count", PROPERTY_HINT_RANGE, "0,20,1,or_greater"), "set_search_bar_min_item_count", "get_search_bar_min_item_count");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "search_bar_fuzzy_search_enabled"), "set_search_bar_fuzzy_search_enabled", "is_search_bar_fuzzy_search_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "search_bar_fuzzy_search_max_misses", PROPERTY_HINT_RANGE, "0,2,1,or_greater"), "set_search_bar_fuzzy_search_max_misses", "get_search_bar_fuzzy_search_max_misses");
+
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");
 
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -107,7 +107,6 @@ public:
 	void set_item_disabled(int p_idx, bool p_disabled);
 	void set_item_tooltip(int p_idx, const String &p_tooltip);
 	void set_item_auto_translate_mode(int p_idx, AutoTranslateMode p_mode);
-	void set_search_bar_enabled_on_item_count(int p_count);
 
 	String get_item_text(int p_idx) const;
 	Ref<Texture2D> get_item_icon(int p_idx) const;
@@ -118,8 +117,12 @@ public:
 	bool is_item_separator(int p_idx) const;
 	String get_item_tooltip(int p_idx) const;
 	AutoTranslateMode get_item_auto_translate_mode(int p_idx) const;
+
+	void set_search_bar_enabled(bool p_enabled);
 	bool is_search_bar_enabled() const;
-	int get_search_bar_enabled_on_item_count() const;
+
+	void set_search_bar_min_item_count(int p_count);
+	int get_search_bar_min_item_count() const;
 
 	void set_search_bar_fuzzy_search_enabled(bool p_enabled);
 	bool is_search_bar_fuzzy_search_enabled() const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -285,7 +285,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		}
 	}
 
-	if (is_search_bar_enabled()) {
+	if (search_bar->is_visible()) {
 		Size2 sb_min_size = search_bar->get_minimum_size();
 		minsize.width += MAX(body_max_w, sb_min_size.width);
 		minsize.height += sb_min_size.height + theme_cache.search_bar_separation;
@@ -1079,6 +1079,12 @@ void PopupMenu::_draw_items() {
 	}
 }
 
+void PopupMenu::_update_search_bar_visibility() {
+	if (search_bar) {
+		search_bar->set_visible(search_bar_enabled && items.size() >= search_bar_min_item_count);
+	}
+}
+
 void PopupMenu::_search_bar_input(const Ref<InputEvent> &p_event) {
 	// Redirect navigational key events to the tree.
 	Ref<InputEventKey> key = p_event;
@@ -1231,6 +1237,7 @@ void PopupMenu::_shape_item(int p_idx) const {
 }
 
 void PopupMenu::_menu_changed() {
+	_update_search_bar_visibility();
 	emit_signal(SNAME("menu_changed"));
 }
 
@@ -3237,17 +3244,23 @@ String PopupMenu::get_tooltip(const Point2 &p_pos) const {
 	return items[over].tooltip;
 }
 
+void PopupMenu::set_search_bar_enabled(bool p_enabled) {
+	search_bar_enabled = p_enabled;
+	_update_search_bar_visibility();
+}
+
 bool PopupMenu::is_search_bar_enabled() const {
-	return search_bar_enabled_on_item_count > 0 && items.size() >= search_bar_enabled_on_item_count;
+	return search_bar_enabled;
 }
 
-void PopupMenu::set_search_bar_enabled_on_item_count(int p_count) {
-	search_bar_enabled_on_item_count = p_count;
-	notify_property_list_changed();
+void PopupMenu::set_search_bar_min_item_count(int p_count) {
+	ERR_FAIL_COND(p_count < 0);
+	search_bar_min_item_count = p_count;
+	_update_search_bar_visibility();
 }
 
-int PopupMenu::get_search_bar_enabled_on_item_count() const {
-	return search_bar_enabled_on_item_count;
+int PopupMenu::get_search_bar_min_item_count() const {
+	return search_bar_min_item_count;
 }
 
 void PopupMenu::set_search_bar_fuzzy_search_enabled(bool p_enabled) {
@@ -3338,14 +3351,6 @@ bool PopupMenu::_set(const StringName &p_name, const Variant &p_value) {
 	}
 #endif
 	return false;
-}
-
-void PopupMenu::_validate_property(PropertyInfo &p_property) const {
-	if (search_bar_enabled_on_item_count == 0) {
-		if (p_property.name == "search_bar_fuzzy_search_enabled" || p_property.name == "search_bar_fuzzy_search_max_misses") {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
 }
 
 void PopupMenu::_bind_methods() {
@@ -3459,9 +3464,10 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_system_menu", "system_menu_id"), &PopupMenu::set_system_menu);
 	ClassDB::bind_method(D_METHOD("get_system_menu"), &PopupMenu::get_system_menu);
 
+	ClassDB::bind_method(D_METHOD("set_search_bar_enabled", "enabled"), &PopupMenu::set_search_bar_enabled);
 	ClassDB::bind_method(D_METHOD("is_search_bar_enabled"), &PopupMenu::is_search_bar_enabled);
-	ClassDB::bind_method(D_METHOD("set_search_bar_enabled_on_item_count", "count"), &PopupMenu::set_search_bar_enabled_on_item_count);
-	ClassDB::bind_method(D_METHOD("get_search_bar_enabled_on_item_count"), &PopupMenu::get_search_bar_enabled_on_item_count);
+	ClassDB::bind_method(D_METHOD("set_search_bar_min_item_count", "count"), &PopupMenu::set_search_bar_min_item_count);
+	ClassDB::bind_method(D_METHOD("get_search_bar_min_item_count"), &PopupMenu::get_search_bar_min_item_count);
 	ClassDB::bind_method(D_METHOD("set_search_bar_fuzzy_search_enabled", "enabled"), &PopupMenu::set_search_bar_fuzzy_search_enabled);
 	ClassDB::bind_method(D_METHOD("is_search_bar_fuzzy_search_enabled"), &PopupMenu::is_search_bar_fuzzy_search_enabled);
 	ClassDB::bind_method(D_METHOD("set_search_bar_fuzzy_search_max_misses", "max_misses"), &PopupMenu::set_search_bar_fuzzy_search_max_misses);
@@ -3483,7 +3489,9 @@ void PopupMenu::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shrink_height"), "set_shrink_height", "get_shrink_height");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shrink_width"), "set_shrink_width", "get_shrink_width");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "search_bar_enabled_on_item_count", PROPERTY_HINT_RANGE, "0,20,1,or_greater"), "set_search_bar_enabled_on_item_count", "get_search_bar_enabled_on_item_count");
+	ADD_GROUP("Search Bar", "search_bar_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "search_bar_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_search_bar_enabled", "is_search_bar_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "search_bar_min_item_count", PROPERTY_HINT_RANGE, "0,20,1,or_greater"), "set_search_bar_min_item_count", "get_search_bar_min_item_count");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "search_bar_fuzzy_search_enabled"), "set_search_bar_fuzzy_search_enabled", "is_search_bar_fuzzy_search_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "search_bar_fuzzy_search_max_misses", PROPERTY_HINT_RANGE, "0,2,1,or_greater"), "set_search_bar_fuzzy_search_max_misses", "get_search_bar_fuzzy_search_max_misses");
 
@@ -3691,7 +3699,6 @@ void PopupMenu::set_visible(bool p_visible) {
 	if (p_visible) {
 		PopupMenu *parent_popup = Object::cast_to<PopupMenu>(get_parent());
 		if (!parent_popup) {
-			search_bar->set_visible(is_search_bar_enabled());
 			if (search_bar->is_visible()) {
 				search_bar->edit(true);
 			}
@@ -3729,7 +3736,7 @@ PopupMenu::PopupMenu() {
 	panel->add_child(vbox_container, false, INTERNAL_MODE_FRONT);
 
 	search_bar = memnew(LineEdit);
-	search_bar->set_visible(is_search_bar_enabled());
+	search_bar->set_visible(false);
 	search_bar->set_clear_button_enabled(true);
 	search_bar->set_placeholder(ETR("Search"));
 	search_bar->set_keep_editing_on_text_submit(true);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -179,7 +179,8 @@ class PopupMenu : public Popup {
 	uint64_t search_time_msec = 0;
 	String search_string = "";
 
-	int search_bar_enabled_on_item_count = 0;
+	bool search_bar_enabled = false;
+	int search_bar_min_item_count = 0;
 	bool search_bar_fuzzy_search_enabled = true;
 	int search_bar_fuzzy_search_max_misses = 2;
 	PanelContainer *panel = nullptr;
@@ -241,6 +242,7 @@ class PopupMenu : public Popup {
 	} theme_cache;
 
 	void _draw_items();
+	void _update_search_bar_visibility();
 	void _search_bar_input(const Ref<InputEvent> &p_event);
 	void _search_bar_text_changed(const String &p_new_text);
 	void _filter_items(const String &p_query);
@@ -273,7 +275,6 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }
 	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
-	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 	virtual String _get_accessibility_name() const override;
@@ -390,10 +391,11 @@ public:
 	void set_prefer_native_menu(bool p_enabled);
 	bool is_prefer_native_menu() const;
 
+	void set_search_bar_enabled(bool p_enabled);
 	bool is_search_bar_enabled() const;
 
-	void set_search_bar_enabled_on_item_count(int p_count);
-	int get_search_bar_enabled_on_item_count() const;
+	void set_search_bar_min_item_count(int p_count);
+	int get_search_bar_min_item_count() const;
 
 	void set_search_bar_fuzzy_search_enabled(bool p_enabled);
 	bool is_search_bar_fuzzy_search_enabled() const;


### PR DESCRIPTION
Applies the change to `PopupMenu` talked about [here](https://github.com/godotengine/godot/pull/119117#pullrequestreview-4247585569), where ~~the `enable_search_bar_on_item_count` property on `PopupMenu` (and `OptionButton` as a result) is replaced with a simple `search_bar_enabled` toggle instead, meaning users of it (e.g. `EditorResourcePicker`) just have to enable it based on count themselves instead~~ the `search_bar_enabled_on_item_count` property on `PopupMenu` is split into `search_bar_enabled` and `search_bar_min_item_count`.

I also threw in `ADD_GROUP("Search Bar", "search_bar_")`, since there's a handful of search properties already, and it's possible we'll be adding even more in the future, if/when `FuzzySearch` is exposed.

This also technically fixes what I would consider to be a bug, where setting `enable_search_bar_on_item_count` to `0` after the popup had been opened (with the search bar visible) wouldn't hide the search bar, so I'll label this as such.

---
_Disclaimer: AI tooling was used to author parts of this change, at my direction. Any code not physically typed out by myself has been carefully reviewed to the best of my ability._