### PR TITLE
Make `Button` use an internal `Label`

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -113,16 +113,20 @@ void EditorLog::_update_theme() {
 
 	Button *button = type_filter_map[MSG_TYPE_STD]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Popup")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_text(wide_text);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size().x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_ERROR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_text(wide_text);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size().x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_WARNING]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusWarning")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_text(wide_text);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size().x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_EDITOR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_text(wide_text);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size().x * EDSCALE, 0));
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -849,9 +849,12 @@ void GameView::_update_speed_state_size() {
 		return;
 	}
 	float min_size = 0;
+	String prev_text = speed_state_button->get_text();
 	for (const String lbl : time_scale_label) {
-		min_size = MAX(speed_state_button->get_minimum_size_for_text_and_icon(vformat(U"%s×", lbl), Ref<Texture2D>()).x, min_size);
+		speed_state_button->set_text(vformat(U"%s×", lbl));
+		min_size = MAX(speed_state_button->get_minimum_size().x, min_size);
 	}
+	speed_state_button->set_text(prev_text);
 	speed_state_button->set_custom_minimum_size(Vector2(min_size, 0));
 }
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -33,16 +33,79 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/label.h"
+#include "scene/resources/style_box.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
-Size2 Button::get_minimum_size() const {
+Size2 Button::_get_minimum_size(bool p_desired) const {
 	Ref<Texture2D> _icon = icon;
 	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
 		_icon = theme_cache.icon;
 	}
 
-	return get_minimum_size_for_text_and_icon("", _icon);
+	Size2 text_min_size = text.is_empty() ? Size2() : (p_desired ? text_label->get_desired_size() : text_label->get_minimum_size());
+	Size2 icon_min_size = (!expand_icon && _icon.is_valid()) ? _fit_icon_size(_icon->get_size()) : Size2();
+
+	Size2 minsize;
+
+	switch (horizontal_icon_alignment) {
+		case HORIZONTAL_ALIGNMENT_CENTER: {
+			minsize.width = MAX(text_min_size.width, icon_min_size.width);
+		} break;
+		case HORIZONTAL_ALIGNMENT_LEFT:
+		case HORIZONTAL_ALIGNMENT_RIGHT: {
+			minsize.width = text_min_size.width + icon_min_size.width + theme_cache.h_separation;
+		} break;
+		default: {
+			// Button doesn't support horizontal fill alignment for icon, so do nothing here.
+		} break;
+	}
+
+	switch (vertical_icon_alignment) {
+		case VERTICAL_ALIGNMENT_CENTER: {
+			minsize.height = MAX(text_min_size.height, icon_min_size.height);
+		} break;
+		case VERTICAL_ALIGNMENT_TOP:
+		case VERTICAL_ALIGNMENT_BOTTOM: {
+			minsize.height = text_min_size.height + icon_min_size.height;
+		} break;
+		default: {
+			// Button doesn't support vertical fill alignment for icon, so do nothing here.
+		} break;
+	}
+
+	return (theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size()) + minsize;
+}
+
+Size2 Button::get_minimum_size() const {
+	return _get_minimum_size();
+}
+
+Size2 Button::get_desired_size() const {
+	return _get_minimum_size(true);
+}
+
+void Button::_maximum_size_changed() {
+	Size2 ms = get_combined_maximum_size();
+	ms -= theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size();
+
+	Ref<Texture2D> _icon = icon;
+	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
+		_icon = theme_cache.icon;
+	}
+	Size2 icon_min_size = (!expand_icon && _icon.is_valid()) ? _fit_icon_size(_icon->get_size()) : Size2();
+
+	if (horizontal_icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
+		ms.width -= icon_min_size.width;
+		ms.width -= icon_min_size.width > 0 ? theme_cache.h_separation : 0;
+	}
+	if (vertical_icon_alignment != VERTICAL_ALIGNMENT_CENTER) {
+		ms.height -= icon_min_size.height;
+	}
+
+	text_label->set_parent_maximum_size_cache(ms);
+	update_desired_size();
 }
 
 void Button::_set_internal_margin(Side p_side, float p_value) {
@@ -94,6 +157,15 @@ void Button::_update_theme_item_cache() {
 		_update_style_margins(theme_cache.disabled);
 	}
 	theme_cache.max_style_size = theme_cache.max_style_size.max(Vector2(theme_cache.style_margin_left + theme_cache.style_margin_right, theme_cache.style_margin_top + theme_cache.style_margin_bottom));
+
+	// Propagate font theme items to the internal Label.
+	if (text_label) {
+		text_label->add_theme_font_override(SceneStringName(font), theme_cache.font);
+		text_label->add_theme_font_size_override(SceneStringName(font_size), theme_cache.font_size);
+		text_label->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
+		text_label->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);
+		text_label->add_theme_constant_override(SNAME("line_spacing"), theme_cache.line_spacing);
+	}
 }
 
 Size2 Button::_get_largest_stylebox_size() const {
@@ -155,11 +227,12 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 
 String Button::_get_accessibility_name() const {
 	const String &ac_name = Control::_get_accessibility_name();
-	if (!xl_text.is_empty() && ac_name.is_empty()) {
-		return xl_text;
-	} else if (!xl_text.is_empty() && !ac_name.is_empty() && ac_name != xl_text) {
-		return ac_name + ": " + xl_text;
-	} else if (xl_text.is_empty() && ac_name.is_empty() && !get_tooltip_text().is_empty()) {
+	const String &label_text = text_label->get_text();
+	if (!label_text.is_empty() && ac_name.is_empty()) {
+		return label_text;
+	} else if (!label_text.is_empty() && !ac_name.is_empty() && ac_name != label_text) {
+		return ac_name + ": " + label_text;
+	} else if (label_text.is_empty() && ac_name.is_empty() && !get_tooltip_text().is_empty()) {
 		return get_tooltip_text(); // Fall back to tooltip.
 	} else {
 		return ac_name;
@@ -183,9 +256,9 @@ void Button::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			xl_text = _get_translated_text(text);
-			_shape();
+			text_label->set_text(_get_translated_text(text));
 
+			update_desired_size();
 			update_minimum_size();
 			update_configuration_warnings();
 			queue_accessibility_update();
@@ -193,29 +266,16 @@ void Button::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			_shape();
-
+			update_desired_size();
 			update_minimum_size();
 			queue_redraw();
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
-				_shape();
-
-				update_minimum_size();
-				queue_redraw();
-			}
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			// Reshape and update size min. if text is invalidated by an external source (e.g., oversampling).
-			if (text_buf.is_valid() && !TS->shaped_text_is_ready(text_buf->get_rid())) {
-				_shape();
-
-				update_minimum_size();
-			}
-
 			const RID ci = get_canvas_item();
 			const Size2 size = get_size();
 
@@ -234,7 +294,10 @@ void Button::_notification(int p_what) {
 				_icon = theme_cache.icon;
 			}
 
-			if (xl_text.is_empty() && _icon.is_null()) {
+			const String &label_text = text_label->get_text();
+
+			if (label_text.is_empty() && _icon.is_null()) {
+				text_label->set_visible(false);
 				break;
 			}
 
@@ -245,7 +308,7 @@ void Button::_notification(int p_what) {
 
 			Size2 drawable_size_remained = size;
 
-			{ // The size after the stelybox is stripped.
+			{ // The size after the stylebox is stripped.
 				drawable_size_remained.width -= style_margin_left + style_margin_right;
 				drawable_size_remained.height -= style_margin_top + style_margin_bottom;
 			}
@@ -268,18 +331,12 @@ void Button::_notification(int p_what) {
 			}
 
 			HorizontalAlignment icon_align_rtl_checked = horizontal_icon_alignment;
-			HorizontalAlignment align_rtl_checked = alignment;
-			// Swap icon and text alignment sides if right-to-left layout is set.
+			// Swap icon alignment sides if right-to-left layout is set.
 			if (is_layout_rtl()) {
 				if (horizontal_icon_alignment == HORIZONTAL_ALIGNMENT_RIGHT) {
 					icon_align_rtl_checked = HORIZONTAL_ALIGNMENT_LEFT;
 				} else if (horizontal_icon_alignment == HORIZONTAL_ALIGNMENT_LEFT) {
 					icon_align_rtl_checked = HORIZONTAL_ALIGNMENT_RIGHT;
-				}
-				if (alignment == HORIZONTAL_ALIGNMENT_RIGHT) {
-					align_rtl_checked = HORIZONTAL_ALIGNMENT_LEFT;
-				} else if (alignment == HORIZONTAL_ALIGNMENT_LEFT) {
-					align_rtl_checked = HORIZONTAL_ALIGNMENT_RIGHT;
 				}
 			}
 
@@ -337,7 +394,7 @@ void Button::_notification(int p_what) {
 				} break;
 			}
 
-			const bool is_clipped = clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF;
+			const bool is_clipped = text_label->is_clipping_text() || text_label->get_text_overrun_behavior() != TextServer::OVERRUN_NO_TRIMMING || text_label->get_autowrap_mode() != TextServer::AUTOWRAP_OFF;
 			const Size2 custom_element_size = drawable_size_remained;
 
 			// Draw the icon.
@@ -348,16 +405,16 @@ void Button::_notification(int p_what) {
 					icon_size = _icon->get_size();
 
 					if (expand_icon) {
-						const Size2 text_buf_size = text_buf->get_size();
+						const Size2 text_min_size = text_label->get_minimum_size();
 						Size2 _size = custom_element_size;
-						if (!is_clipped && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER && text_buf_size.width > 0.0f) {
+						if (!is_clipped && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER && text_min_size.width > 1.0f) {
 							// If there is not enough space for icon and h_separation, h_separation will occupy the space first,
 							// so the icon's width may be negative. Keep it negative to make it easier to calculate the space
 							// reserved for text later.
-							_size.width -= text_buf_size.width + h_separation;
+							_size.width -= text_min_size.width + h_separation;
 						}
-						if (vertical_icon_alignment != VERTICAL_ALIGNMENT_CENTER) {
-							_size.height -= text_buf_size.height;
+						if (vertical_icon_alignment != VERTICAL_ALIGNMENT_CENTER && !label_text.is_empty()) {
+							_size.height -= text_min_size.height;
 						}
 
 						float icon_width = icon_size.width * _size.height / icon_size.height;
@@ -416,7 +473,7 @@ void Button::_notification(int p_what) {
 					draw_texture_rect(_icon, icon_region, false, icon_modulate_color);
 				}
 
-				if (!xl_text.is_empty()) {
+				if (!label_text.is_empty()) {
 					// Update the size after the icon is stripped. Stripping only when the icon alignments are not center.
 					if (icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
 						// Subtract the space's width occupied by icon and h_separation together.
@@ -429,46 +486,36 @@ void Button::_notification(int p_what) {
 				}
 			}
 
-			// Draw the text.
-			if (!xl_text.is_empty()) {
-				text_buf->set_alignment(align_rtl_checked);
+			// Position the internal Label for text rendering.
+			if (!label_text.is_empty()) {
+				text_label->set_visible(true);
 
-				float text_buf_width = Math::ceil(MAX(1.0f, drawable_size_remained.width)); // The space's width filled by the text_buf.
-				if (autowrap_mode != TextServer::AUTOWRAP_OFF && !Math::is_equal_approx(text_buf_width, text_buf->get_width())) {
-					update_minimum_size();
+				Point2 label_pos;
+				label_pos.x = style_margin_left + left_internal_margin_with_h_separation;
+				label_pos.y = style_margin_top;
+
+				if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT && _icon.is_valid()) {
+					label_pos.x += custom_element_size.width - drawable_size_remained.width;
 				}
-				text_buf->set_width(text_buf_width);
-
-				Point2 text_ofs;
-
-				switch (align_rtl_checked) {
-					case HORIZONTAL_ALIGNMENT_CENTER: {
-						text_ofs.x = (drawable_size_remained.width - text_buf_width) / 2.0f;
-					}
-						[[fallthrough]];
-					case HORIZONTAL_ALIGNMENT_FILL:
-					case HORIZONTAL_ALIGNMENT_LEFT:
-					case HORIZONTAL_ALIGNMENT_RIGHT: {
-						text_ofs.x += style_margin_left;
-						text_ofs.x += left_internal_margin_with_h_separation;
-						if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
-							// Offset by the space's width that occupied by icon and h_separation together.
-							text_ofs.x += custom_element_size.width - drawable_size_remained.width;
-						}
-					} break;
+				if (vertical_icon_alignment == VERTICAL_ALIGNMENT_TOP && _icon.is_valid()) {
+					label_pos.y += custom_element_size.height - drawable_size_remained.height;
 				}
 
-				text_ofs.y = (drawable_size_remained.height - text_buf->get_size().height) / 2.0f + style_margin_top;
-				if (vertical_icon_alignment == VERTICAL_ALIGNMENT_TOP) {
-					text_ofs.y += custom_element_size.height - drawable_size_remained.height; // Offset by the icon's height.
+				Size2 label_size;
+				label_size.width = MAX(1.0f, drawable_size_remained.width);
+				label_size.height = MAX(1.0f, drawable_size_remained.height);
+
+				if (text_label->get_position() != label_pos) {
+					text_label->set_position(label_pos);
+				}
+				if (text_label->get_size() != label_size) {
+					text_label->set_size(label_size);
 				}
 
-				Color font_outline_color = theme_cache.font_outline_color;
-				int outline_size = theme_cache.outline_size;
-				if (outline_size > 0 && font_outline_color.a > 0.0f) {
-					text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
-				}
-				text_buf->draw(ci, text_ofs, font_color);
+				// Update font color based on current draw state.
+				text_label->add_theme_color_override(SceneStringName(font_color), font_color);
+			} else {
+				text_label->set_visible(false);
 			}
 		} break;
 	}
@@ -486,129 +533,40 @@ Size2 Button::_fit_icon_size(const Size2 &p_size) const {
 	return icon_size;
 }
 
-Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const {
-	// Do not include `_internal_margin`, it's already added in the `get_minimum_size` overrides.
-
-	Ref<TextParagraph> paragraph;
-	if (p_text.is_empty()) {
-		paragraph = text_buf;
-	} else {
-		paragraph.instantiate();
-		_shape(paragraph, p_text);
-	}
-
-	Size2 minsize = paragraph->get_size();
-	if (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF) {
-		minsize.width = 0;
-	}
-
-	if (!expand_icon && p_icon.is_valid()) {
-		Size2 icon_size = _fit_icon_size(p_icon->get_size());
-		if (vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {
-			minsize.height = MAX(minsize.height, icon_size.height);
-		} else {
-			minsize.height += icon_size.height;
-		}
-
-		if (horizontal_icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
-			minsize.width += icon_size.width;
-			if (!xl_text.is_empty() || !p_text.is_empty()) {
-				minsize.width += MAX(0, theme_cache.h_separation);
-			}
-		} else {
-			minsize.width = MAX(minsize.width, icon_size.width);
-		}
-	}
-
-	if (!xl_text.is_empty() || !p_text.is_empty()) {
-		Ref<Font> font = theme_cache.font;
-		float font_height = font->get_height(theme_cache.font_size);
-		if (vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {
-			minsize.height = MAX(font_height, minsize.height);
-		} else {
-			minsize.height += font_height;
-		}
-	}
-
-	return (theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size()) + minsize;
-}
-
-void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) const {
-	if (p_paragraph.is_null()) {
-		p_paragraph = text_buf;
-	}
-
-	if (p_text.is_empty()) {
-		p_text = xl_text;
-	}
-
-	p_paragraph->clear();
-
-	Ref<Font> font = theme_cache.font;
-	int font_size = theme_cache.font_size;
-	if (font.is_null() || font_size == 0) {
-		// Can't shape without a valid font and a non-zero size.
-		return;
-	}
-
-	BitField<TextServer::LineBreakFlag> autowrap_flags = TextServer::BREAK_MANDATORY;
-	switch (autowrap_mode) {
-		case TextServer::AUTOWRAP_WORD_SMART:
-			autowrap_flags = TextServer::BREAK_WORD_BOUND | TextServer::BREAK_ADAPTIVE | TextServer::BREAK_MANDATORY;
-			break;
-		case TextServer::AUTOWRAP_WORD:
-			autowrap_flags = TextServer::BREAK_WORD_BOUND | TextServer::BREAK_MANDATORY;
-			break;
-		case TextServer::AUTOWRAP_ARBITRARY:
-			autowrap_flags = TextServer::BREAK_GRAPHEME_BOUND | TextServer::BREAK_MANDATORY;
-			break;
-		case TextServer::AUTOWRAP_OFF:
-			break;
-	}
-	autowrap_flags = autowrap_flags | autowrap_flags_trim;
-	p_paragraph->set_break_flags(autowrap_flags);
-	p_paragraph->set_line_spacing(theme_cache.line_spacing);
-
-	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
-		p_paragraph->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
-	} else {
-		p_paragraph->set_direction((TextServer::Direction)text_direction);
-	}
-	const String &lang = language.is_empty() ? _get_locale() : language;
-	p_paragraph->add_string(p_text, font, font_size, lang);
-	p_paragraph->set_text_overrun_behavior(overrun_behavior);
+Label *Button::_get_text_label() const {
+	return text_label;
 }
 
 void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
-	if (overrun_behavior != p_behavior) {
-		bool need_update_cache = overrun_behavior == TextServer::OVERRUN_NO_TRIMMING || p_behavior == TextServer::OVERRUN_NO_TRIMMING;
-		overrun_behavior = p_behavior;
-		_shape();
+	if (text_label->get_text_overrun_behavior() != p_behavior) {
+		bool need_update_cache = text_label->get_text_overrun_behavior() == TextServer::OVERRUN_NO_TRIMMING || p_behavior == TextServer::OVERRUN_NO_TRIMMING;
+		text_label->set_text_overrun_behavior(p_behavior);
 
 		if (need_update_cache) {
 			_queue_update_size_cache();
 		}
 		queue_redraw();
+		update_desired_size();
 		update_minimum_size();
 	}
 }
 
 TextServer::OverrunBehavior Button::get_text_overrun_behavior() const {
-	return overrun_behavior;
+	return text_label->get_text_overrun_behavior();
 }
 
 void Button::set_text(const String &p_text) {
 	const String translated_text = _get_translated_text(p_text);
-	if (text == p_text && xl_text == translated_text) {
+	if (text == p_text && text_label->get_text() == translated_text) {
 		return;
 	}
 	text = p_text;
-	xl_text = translated_text;
-	_shape();
+	text_label->set_text(translated_text);
 
 	update_configuration_warnings();
 	queue_accessibility_update();
 	queue_redraw();
+	update_desired_size();
 	update_minimum_size();
 }
 
@@ -617,56 +575,54 @@ String Button::get_text() const {
 }
 
 void Button::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
-	if (autowrap_mode != p_mode) {
-		autowrap_mode = p_mode;
-		_shape();
+	if (text_label->get_autowrap_mode() != p_mode) {
+		text_label->set_autowrap_mode(p_mode);
 		queue_redraw();
+		update_desired_size();
 		update_minimum_size();
 	}
 }
 
 TextServer::AutowrapMode Button::get_autowrap_mode() const {
-	return autowrap_mode;
+	return text_label->get_autowrap_mode();
 }
 
 void Button::set_autowrap_trim_flags(BitField<TextServer::LineBreakFlag> p_flags) {
-	if (autowrap_flags_trim != (p_flags & TextServer::BREAK_TRIM_MASK)) {
-		autowrap_flags_trim = p_flags & TextServer::BREAK_TRIM_MASK;
-		_shape();
+	if (text_label->get_autowrap_trim_flags() != (p_flags & TextServer::BREAK_TRIM_MASK)) {
+		text_label->set_autowrap_trim_flags(p_flags);
 		queue_redraw();
+		update_desired_size();
 		update_minimum_size();
 	}
 }
 
 BitField<TextServer::LineBreakFlag> Button::get_autowrap_trim_flags() const {
-	return autowrap_flags_trim;
+	return text_label->get_autowrap_trim_flags();
 }
 
 void Button::set_text_direction(Control::TextDirection p_text_direction) {
 	ERR_FAIL_COND((int)p_text_direction < -1 || (int)p_text_direction > 3);
-	if (text_direction != p_text_direction) {
-		text_direction = p_text_direction;
-		_shape();
+	if (text_label->get_text_direction() != p_text_direction) {
+		text_label->set_text_direction(p_text_direction);
 		queue_accessibility_update();
 		queue_redraw();
 	}
 }
 
 Control::TextDirection Button::get_text_direction() const {
-	return text_direction;
+	return text_label->get_text_direction();
 }
 
 void Button::set_language(const String &p_language) {
-	if (language != p_language) {
-		language = p_language;
-		_shape();
+	if (text_label->get_language() != p_language) {
+		text_label->set_language(p_language);
 		queue_accessibility_update();
 		queue_redraw();
 	}
 }
 
 String Button::get_language() const {
-	return language;
+	return text_label->get_language();
 }
 
 void Button::set_button_icon(const Ref<Texture2D> &p_icon) {
@@ -685,11 +641,13 @@ void Button::set_button_icon(const Ref<Texture2D> &p_icon) {
 	}
 
 	queue_redraw();
+	update_desired_size();
 	update_minimum_size();
 }
 
 void Button::_texture_changed() {
 	queue_redraw();
+	update_desired_size();
 	update_minimum_size();
 }
 
@@ -710,6 +668,7 @@ void Button::set_expand_icon(bool p_enabled) {
 		expand_icon = p_enabled;
 		_queue_update_size_cache();
 		queue_redraw();
+		update_desired_size();
 		update_minimum_size();
 	}
 }
@@ -730,29 +689,30 @@ bool Button::is_flat() const {
 }
 
 void Button::set_clip_text(bool p_enabled) {
-	if (clip_text != p_enabled) {
-		clip_text = p_enabled;
+	if (text_label->is_clipping_text() != p_enabled) {
+		text_label->set_clip_text(p_enabled);
 
 		_queue_update_size_cache();
 		queue_redraw();
+		update_desired_size();
 		update_minimum_size();
 	}
 }
 
 bool Button::get_clip_text() const {
-	return clip_text;
+	return text_label->is_clipping_text();
 }
 
 void Button::set_text_alignment(HorizontalAlignment p_alignment) {
-	if (alignment != p_alignment) {
-		alignment = p_alignment;
+	if (text_label->get_horizontal_alignment() != p_alignment) {
+		text_label->set_horizontal_alignment(p_alignment);
 		queue_accessibility_update();
 		queue_redraw();
 	}
 }
 
 HorizontalAlignment Button::get_text_alignment() const {
-	return alignment;
+	return text_label->get_horizontal_alignment();
 }
 
 void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
@@ -761,6 +721,7 @@ void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
 	}
 
 	horizontal_icon_alignment = p_alignment;
+	update_desired_size();
 	update_minimum_size();
 	queue_redraw();
 }
@@ -775,6 +736,7 @@ void Button::set_vertical_icon_alignment(VerticalAlignment p_alignment) {
 	if (need_update_cache) {
 		_queue_update_size_cache();
 	}
+	update_desired_size();
 	update_minimum_size();
 	queue_redraw();
 }
@@ -876,10 +838,18 @@ void Button::_bind_methods() {
 }
 
 Button::Button(const String &p_text) {
-	text_buf.instantiate();
-	text_buf->set_break_flags(TextServer::BREAK_MANDATORY | autowrap_flags_trim);
+	connect(SceneStringName(maximum_size_changed), callable_mp(this, &Button::_maximum_size_changed));
+
 	set_mouse_filter(MOUSE_FILTER_STOP);
 
+	text_label = memnew(Label);
+	text_label->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	text_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	text_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	text_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	text_label->add_theme_style_override(CoreStringName(normal), memnew(StyleBoxEmpty));
+	add_child(text_label, false, INTERNAL_MODE_FRONT);
+	set_autowrap_trim_flags(TextServer::BREAK_MANDATORY | TextServer::BREAK_TRIM_END_EDGE_SPACES);
 	set_text(p_text);
 }
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -31,7 +31,8 @@
 #pragma once
 
 #include "scene/gui/base_button.h"
-#include "scene/resources/text_paragraph.h"
+
+class Label;
 
 class Button : public BaseButton {
 	GDCLASS(Button, BaseButton);
@@ -39,19 +40,10 @@ class Button : public BaseButton {
 private:
 	bool flat = false;
 	String text;
-	String xl_text;
-	Ref<TextParagraph> text_buf;
-
-	String language;
-	TextDirection text_direction = TEXT_DIRECTION_AUTO;
-	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
-	BitField<TextServer::LineBreakFlag> autowrap_flags_trim = TextServer::BREAK_TRIM_END_EDGE_SPACES;
-	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
+	Label *text_label = nullptr;
 
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
-	bool clip_text = false;
-	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
 	float _internal_margin[4] = {};
@@ -103,9 +95,12 @@ private:
 		int line_spacing = 0;
 	} theme_cache;
 
-	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "") const;
 	void _texture_changed();
 	void _update_style_margins(const Ref<StyleBox> &p_stylebox);
+
+	void _maximum_size_changed();
+
+	Size2 _get_minimum_size(bool p_desired = false) const;
 
 protected:
 	virtual void _update_theme_item_cache() override;
@@ -117,6 +112,7 @@ protected:
 	Size2 _fit_icon_size(const Size2 &p_size) const;
 	Ref<StyleBox> _get_current_stylebox() const;
 	Size2 _get_largest_stylebox_size() const;
+	Label *_get_text_label() const;
 	void _notification(int p_what);
 	static void _bind_methods();
 
@@ -124,8 +120,7 @@ protected:
 
 public:
 	virtual Size2 get_minimum_size() const override;
-
-	Size2 get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const;
+	virtual Size2 get_desired_size() const override;
 
 	void set_text(const String &p_text);
 	String get_text() const;

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/gui/label.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
@@ -479,9 +480,16 @@ void OptionButton::_refresh_size_cache() {
 
 	if (fit_to_longest_item) {
 		_cached_size = theme_cache.normal->get_minimum_size();
+		Label *label = _get_text_label();
+		String prev_text = label->get_text();
+		Ref<Texture2D> prev_icon = get_button_icon();
 		for (int i = 0; i < get_item_count(); i++) {
-			_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(popup->get_item_xl_text(i), get_item_icon(i)));
+			label->set_text(popup->get_item_xl_text(i));
+			set_button_icon(get_item_icon(i));
+			_cached_size = _cached_size.max(Button::get_minimum_size());
 		}
+		label->set_text(prev_text);
+		set_button_icon(prev_icon);
 	}
 	update_minimum_size();
 }


### PR DESCRIPTION
Unintended bugfixing:
* Supersedes #115857
* Fixes #115774


This PR makes `Button` use an internal `Label` node, removing all text-related handling code from `Button`. This means that `Button`'s text handling is now as robust as `Label`'s (since it uses it). 
Thanks to that, `Button`s with overrun modes now use the "desired size" paradigm introduced by #118651, thus making them work with the `custom_maximum_size` introduced in #116640, in the same way that `Label`s do. 

In the future, this also means that porting over `Label` features into `Button`, such as autowrapping text or the to-be-merged #116791 feature, will be a lot simpler.

Known limitation: 
This behaves poorly inside of `Container` nodes. As such, this does not fix the hack introduced in #119088 (unfortunately). 
* Related: #119346 

This is an issue with how `Container` nodes react (or rather, don't react) to desired sizes. Fixing this limitation is thus out of scope for this PR (and I am working on it). 