### PR TITLE
Add support for more items to the context menu of multi-selected instances.

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1352,30 +1352,15 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			if (selection.size() != 1) {
-				break;
-			}
+			List<Node *> selection = editor_selection->get_full_selected_node_list();
+			ItemCheckState editable_state = _is_editable_children(selection);
+			bool editable = editable_state == STATE_CHECKED;
 
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
-				if (node) {
-					bool is_external = node->is_instance();
-					bool is_top_level = node->get_owner() == nullptr;
-					if (!is_external || is_top_level) {
-						break;
-					}
-
-					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
-
-					if (editable) {
-						editable_instance_remove_dialog->set_text(TTRC("Disabling \"Editable Children\" will cause all properties of this subscene's descendant nodes to be reverted to their default."));
-						editable_instance_remove_dialog->popup_centered();
-						break;
-					}
-					_toggle_editable_children(node);
-				}
+			if (editable) {
+				editable_instance_remove_dialog->set_text(TTR("Disabling \"Editable Children\" will cause all properties of this subscene's descendant nodes to be reverted to their default."));
+				editable_instance_remove_dialog->popup_centered();
+			} else {
+				_toggle_editable_children(selection);
 			}
 		} break;
 		case TOOL_SCENE_USE_PLACEHOLDER: {
@@ -1387,35 +1372,27 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
-				if (node) {
-					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
-					bool placeholder = node->get_scene_instance_load_placeholder();
+			List<Node *> selection = editor_selection->get_full_selected_node_list();
+			ItemCheckState editable_state = _is_editable_children(selection);
+			ItemCheckState placeholder_state = _is_placeholder(selection);
+			bool editable = editable_state != STATE_UNCHECKED;
+			bool placeholder = placeholder_state == STATE_CHECKED;
+			// Fire confirmation dialog when children are editable.
+			if (editable && !placeholder) {
+				placeholder_editable_instance_remove_dialog->set_text(TTR("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
+				placeholder_editable_instance_remove_dialog->popup_centered();
+			} else {
+				placeholder = !placeholder;
+				for (Node *node : selection) {
+					if (node) {
+						if (placeholder) {
+							EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
+						}
 
-					// Fire confirmation dialog when children are editable.
-					if (editable && !placeholder) {
-						placeholder_editable_instance_remove_dialog->set_text(TTRC("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
-						placeholder_editable_instance_remove_dialog->popup_centered();
-						break;
+						node->set_scene_instance_load_placeholder(placeholder);
 					}
-
-					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-
-					placeholder = !placeholder;
-
-					undo_redo->create_action(TTR("Toggle Load as Placeholder"));
-					undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", !placeholder);
-					undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", placeholder);
-
-					if (placeholder) {
-						EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
-					}
-
-					undo_redo->commit_action();
 				}
+				scene_tree->update_tree();
 			}
 		} break;
 		case TOOL_SCENE_MAKE_LOCAL: {
@@ -1427,30 +1404,28 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
+			const List<Node *> selection = editor_selection->get_full_selected_node_list();
+			Node *root = EditorNode::get_singleton()->get_edited_scene();
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Make Local"));
+			for (Node *node : selection) {
 				if (node) {
-					Node *root = EditorNode::get_singleton()->get_edited_scene();
-					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 					if (!root) {
-						break;
+						continue;
 					}
 
-					ERR_FAIL_COND(!node->is_instance());
-					undo_redo->create_action(TTR("Make Local"));
+					ERR_CONTINUE(!node->is_instance());
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
 					_node_replace_owner(node, node, root);
 					_node_strip_signal_inheritance(node);
 					SignalsDock::get_singleton()->set_object(node); // Refresh.
 					GroupsDock::get_singleton()->set_selection(Vector<Node *>{ node }); // Refresh.
-					undo_redo->add_do_method(scene_tree, "update_tree");
-					undo_redo->add_undo_method(scene_tree, "update_tree");
-					undo_redo->commit_action();
 				}
 			}
+			undo_redo->add_do_method(scene_tree, "update_tree");
+			undo_redo->add_undo_method(scene_tree, "update_tree");
+			undo_redo->commit_action();
 		} break;
 		case TOOL_SCENE_OPEN: {
 			const List<Node *> selection = editor_selection->get_top_selected_node_list();
@@ -1529,7 +1504,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				return;
 			}
 
-			bool enabling = !first_selected->is_unique_name_in_owner();
+			ItemCheckState unique_name_state = _is_unique_name(full_selection);
+			bool enabling = unique_name_state != STATE_CHECKED;
 
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
@@ -2746,30 +2722,24 @@ void SceneTreeDock::_shader_creation_closed() {
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {
-	const List<Node *> selection = editor_selection->get_top_selected_node_list();
-	const List<Node *>::Element *e = selection.front();
-
-	if (e) {
-		_toggle_editable_children(e->get());
-	}
+	List<Node *> selection = editor_selection->get_full_selected_node_list();
+	_toggle_editable_children(selection);
 }
 
 void SceneTreeDock::_toggle_placeholder_from_selection() {
-	const List<Node *> selection = editor_selection->get_top_selected_node_list();
-	const List<Node *>::Element *e = selection.front();
+	List<Node *> selection = editor_selection->get_full_selected_node_list();
+	ItemCheckState placeholder_state = _is_placeholder(selection);
+	bool placeholder = placeholder_state != STATE_CHECKED;
+	if (placeholder) {
+		_toggle_editable_children(selection, STATE_CHECKED);
+	}
 
-	if (e) {
-		Node *node = e->get();
+	for (Node *node : selection) {
 		if (node) {
-			_toggle_editable_children(node);
-
-			bool placeholder = node->get_scene_instance_load_placeholder();
-			placeholder = !placeholder;
-
 			node->set_scene_instance_load_placeholder(placeholder);
-			scene_tree->update_tree();
 		}
 	}
+	scene_tree->update_tree();
 }
 
 void SceneTreeDock::_reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner) {
@@ -2826,67 +2796,139 @@ void SceneTreeDock::_reparent_nodes_to_paths_with_transform_and_name(Node *p_roo
 	}
 }
 
-void SceneTreeDock::_toggle_editable_children(Node *p_node) {
-	if (!p_node) {
-		return;
-	}
-
+void SceneTreeDock::_toggle_editable_children(List<Node *> &p_nodes, ItemCheckState p_current_state) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 	undo_redo->create_action(TTR("Toggle Editable Children"));
 
-	bool editable = !EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(p_node);
+	bool is_indeterminate = p_current_state == STATE_INDETERMINATE;
+	ItemCheckState editable_state = is_indeterminate ? _is_editable_children(p_nodes) : p_current_state;
+	bool editable = editable_state != STATE_CHECKED;
 
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", p_node, !editable);
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", p_node, editable);
+	for (Node *node : p_nodes) {
+		if (node) {
+			undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", node, !editable);
+			undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", node, editable);
 
-	if (editable) {
-		bool original_scene_instance_load_placeholder = p_node->get_scene_instance_load_placeholder();
+			if (editable) {
+				bool original_scene_instance_load_placeholder = node->get_scene_instance_load_placeholder();
 
-		undo_redo->add_undo_method(p_node, "set_scene_instance_load_placeholder", original_scene_instance_load_placeholder);
-		undo_redo->add_do_method(p_node, "set_scene_instance_load_placeholder", false);
-	} else {
-		List<Node *> owned;
-		p_node->get_owned_by(edited_scene, &owned);
+				undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", original_scene_instance_load_placeholder);
+				undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", false);
+			} else {
+				List<Node *> owned;
+				node->get_owned_by(edited_scene, &owned);
 
-		// Get the original paths, transforms, and names for undo.
-		Array owned_nodes_array;
-		Array paths_array;
-		Array transform_array;
-		Array name_array;
+				// Get the original paths, transforms, and names for undo.
+				Array owned_nodes_array;
+				Array paths_array;
+				Array transform_array;
+				Array name_array;
 
-		for (Node *owned_node : owned) {
-			if (owned_node != p_node && owned_node != edited_scene && owned_node->get_owner() == edited_scene && owned_node->get_parent()->get_owner() != edited_scene) {
-				owned_nodes_array.push_back(owned_node);
-				paths_array.push_back(p_node->get_path_to(owned_node->get_parent()));
-				name_array.push_back(owned_node->get_name());
-				Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
-				if (node_3d) {
-					transform_array.push_back(node_3d->get_transform());
-				} else {
-					Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
-					if (node_2d) {
-						transform_array.push_back(node_2d->get_transform());
-					} else {
-						transform_array.push_back(Variant());
+				for (Node *owned_node : owned) {
+					if (owned_node != node && owned_node != edited_scene && owned_node->get_owner() == edited_scene && owned_node->get_parent()->get_owner() != edited_scene) {
+						owned_nodes_array.push_back(owned_node);
+						paths_array.push_back(node->get_path_to(owned_node->get_parent()));
+						name_array.push_back(owned_node->get_name());
+						Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
+						if (node_3d) {
+							transform_array.push_back(node_3d->get_transform());
+						} else {
+							Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
+							if (node_2d) {
+								transform_array.push_back(node_2d->get_transform());
+							} else {
+								transform_array.push_back(Variant());
+							}
+						}
 					}
 				}
-			}
-		}
 
-		if (!owned_nodes_array.is_empty()) {
-			undo_redo->add_undo_method(this, "_reparent_nodes_to_paths_with_transform_and_name", p_node, owned_nodes_array, paths_array, transform_array, name_array, edited_scene);
-			undo_redo->add_do_method(this, "_reparent_nodes_to_root", p_node, owned_nodes_array, edited_scene);
+				if (!owned_nodes_array.is_empty()) {
+					undo_redo->add_undo_method(this, "_reparent_nodes_to_paths_with_transform_and_name", node, owned_nodes_array, paths_array, transform_array, name_array, edited_scene);
+					undo_redo->add_do_method(this, "_reparent_nodes_to_root", node, owned_nodes_array, edited_scene);
+				}
+			}
+
+			undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", node);
+			undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", node);
+		}
+	}
+	undo_redo->add_undo_method(scene_tree, "update_tree");
+	undo_redo->add_do_method(scene_tree, "update_tree");
+	undo_redo->commit_action();
+}
+
+bool SceneTreeDock::_is_external(Node *p_node) const {
+	return p_node->is_instance();
+}
+
+bool SceneTreeDock::_is_top_level(Node *p_node) const {
+	return !p_node->get_owner();
+}
+
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_editable_children(List<Node *> &p_nodes) {
+	int editable_count = 0;
+
+	// Filter valid nodes first.
+	List<Node *> valid_nodes;
+	for (Node *node : p_nodes) {
+		if (node) {
+			bool is_external = _is_external(node);
+			bool is_top_level = _is_top_level(node);
+			if (is_external && !is_top_level) {
+				valid_nodes.push_back(node);
+			}
 		}
 	}
 
-	undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
-	undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
+	p_nodes = valid_nodes;
 
-	undo_redo->add_undo_method(scene_tree, "update_tree");
-	undo_redo->add_do_method(scene_tree, "update_tree");
+	for (const Node *node : valid_nodes) {
+		if (EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node)) {
+			editable_count++;
+		}
+	}
+	return (editable_count == 0) ? STATE_UNCHECKED : (editable_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
+}
 
-	undo_redo->commit_action();
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_placeholder(List<Node *> &p_nodes) {
+	int placeholder_count = 0;
+
+	// Filter valid nodes first.
+	List<Node *> valid_nodes;
+	for (Node *node : p_nodes) {
+		if (node) {
+			bool is_external = _is_external(node);
+			bool is_top_level = _is_top_level(node);
+			if (is_external && !is_top_level) {
+				valid_nodes.push_back(node);
+			}
+		}
+	}
+
+	p_nodes = valid_nodes;
+
+	for (const Node *node : valid_nodes) {
+		if (node->get_scene_instance_load_placeholder()) {
+			placeholder_count++;
+		}
+	}
+	return (placeholder_count == 0) ? STATE_UNCHECKED : (placeholder_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
+}
+
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_unique_name(List<Node *> &p_nodes) {
+	int unique_name_count = 0;
+
+	for (Node *node : p_nodes) {
+		if (node) {
+			if (node->is_unique_name_in_owner()) {
+				unique_name_count++;
+			}
+		}
+	}
+
+	return (unique_name_count == 0) ? STATE_UNCHECKED : (unique_name_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
 }
 
 void SceneTreeDock::_delete_confirm(bool p_cut) {
@@ -4079,42 +4121,60 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 	bool is_tool_scene_open_available = false;
 	bool is_tool_scene_open_inherited_available = false;
+	bool is_top_level = false;
+	bool is_external = false;
 	if (selection.size() == 1) {
 		if (profile_allow_editing) {
 			BEGIN_SECTION()
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
 		}
-
-		// Group "make_local" etc. with "save_branch_as_scene", if it is available.
-		bool is_external = selection.front()->get()->is_instance();
+		is_external = _is_external(selection.front()->get());
+		is_top_level = _is_top_level(selection.front()->get());
 		if (is_external) {
 			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
-			bool is_top_level = selection.front()->get()->get_owner() == nullptr;
 			if (is_inherited && is_top_level) {
 				if (profile_allow_editing) {
 					BEGIN_SECTION()
-					menu->add_item(TTRC("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
+					menu->add_item(TTR("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
+					END_SECTION()
 				}
 				is_tool_scene_open_inherited_available = true;
-			} else if (!is_top_level) {
-				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
-				bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
-				if (profile_allow_editing) {
-					BEGIN_SECTION()
-					menu->add_item(TTRC("Make Local"), TOOL_SCENE_MAKE_LOCAL);
-
-					menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
-					menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
-
-					menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Editable Children")), editable);
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Load as Placeholder")), placeholder);
-				}
-				is_tool_scene_open_available = true;
 			}
 		}
-		END_SECTION()
+	}
+
+	TypedArray<Node> selected_nodes = editor_selection->get_selected_nodes();
+	is_top_level = selected_nodes.all(callable_mp(this, &SceneTreeDock::_is_top_level));
+	is_external = selected_nodes.all(callable_mp(this, &SceneTreeDock::_is_external));
+
+	if (is_external) {
+		if (!is_top_level) {
+			List<Node *> full_selection_list = editor_selection->get_full_selected_node_list();
+			ItemCheckState editable_state = _is_editable_children(full_selection_list);
+			ItemCheckState placeholder_state = _is_placeholder(full_selection_list);
+			if (profile_allow_editing) {
+				BEGIN_SECTION()
+				menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+
+				menu->add_check_item(TTR("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
+				menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
+				if (editable_state != STATE_INDETERMINATE) {
+					menu->set_item_checked(-1, bool(editable_state));
+				} else {
+					menu->set_item_indeterminate(-1, true);
+				}
+
+				menu->add_check_item(TTR("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
+				if (placeholder_state != STATE_INDETERMINATE) {
+					menu->set_item_checked(-1, bool(placeholder_state));
+				} else {
+					menu->set_item_indeterminate(-1, true);
+				}
+
+				END_SECTION()
+			}
+			is_tool_scene_open_available = true;
+		}
 	}
 
 	if (selection.size() == 1) {
@@ -4139,10 +4199,14 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			if (menu->get_item_index(TOOL_COPY_NODE_PATH) == -1) {
 				BEGIN_SECTION()
 			}
-			Node *node = full_selection.front()->get();
+			ItemCheckState unique_name_state = _is_unique_name(full_selection);
 			menu->add_icon_check_item(get_editor_theme_icon(SNAME("SceneUniqueName")), TTRC("Access as Unique Name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
-			menu->set_item_shortcut(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), ED_GET_SHORTCUT("scene_tree/toggle_unique_name"));
-			menu->set_item_checked(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), node->is_unique_name_in_owner());
+			menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_unique_name"));
+			if (unique_name_state != STATE_INDETERMINATE) {
+				menu->set_item_checked(-1, bool(unique_name_state));
+			} else {
+				menu->set_item_indeterminate(-1, true);
+			}
 		}
 		END_SECTION()
 	}

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1371,30 +1371,15 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			if (selection.size() != 1) {
-				break;
-			}
+			List<Node *> selection = editor_selection->get_full_selected_node_list();
+			ItemCheckState editable_state = _is_editable_children(selection);
+			bool editable = editable_state == STATE_CHECKED;
 
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
-				if (node) {
-					bool is_external = node->is_instance();
-					bool is_top_level = node->get_owner() == nullptr;
-					if (!is_external || is_top_level) {
-						break;
-					}
-
-					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
-
-					if (editable) {
-						editable_instance_remove_dialog->set_text(TTRC("Disabling \"Editable Children\" will cause all properties of this subscene's descendant nodes to be reverted to their default."));
-						editable_instance_remove_dialog->popup_centered();
-						break;
-					}
-					_toggle_editable_children(node);
-				}
+			if (editable) {
+				editable_instance_remove_dialog->set_text(TTR("Disabling \"Editable Children\" will cause all properties of this subscene's descendant nodes to be reverted to their default."));
+				editable_instance_remove_dialog->popup_centered();
+			} else {
+				_toggle_editable_children(selection);
 			}
 		} break;
 		case TOOL_SCENE_USE_PLACEHOLDER: {
@@ -1402,39 +1387,31 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
+			List<Node *> selection = editor_selection->get_full_selected_node_list();
 			if (!_validate_no_foreign_selected(selection)) {
 				break;
 			}
 
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
-				if (node) {
-					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
-					bool placeholder = node->get_scene_instance_load_placeholder();
+			ItemCheckState editable_state = _is_editable_children(selection);
+			ItemCheckState placeholder_state = _is_placeholder(selection);
+			bool editable = editable_state != STATE_UNCHECKED;
+			bool placeholder = placeholder_state == STATE_CHECKED;
+			// Fire confirmation dialog when children are editable.
+			if (editable && !placeholder) {
+				placeholder_editable_instance_remove_dialog->set_text(TTR("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
+				placeholder_editable_instance_remove_dialog->popup_centered();
+			} else {
+				placeholder = !placeholder;
+				for (Node *node : selection) {
+					if (node) {
+						if (placeholder) {
+							EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
+						}
 
-					// Fire confirmation dialog when children are editable.
-					if (editable && !placeholder) {
-						placeholder_editable_instance_remove_dialog->set_text(TTRC("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
-						placeholder_editable_instance_remove_dialog->popup_centered();
-						break;
+						node->set_scene_instance_load_placeholder(placeholder);
 					}
-
-					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-
-					placeholder = !placeholder;
-
-					undo_redo->create_action(TTR("Toggle Load as Placeholder"));
-					undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", !placeholder);
-					undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", placeholder);
-
-					if (placeholder) {
-						EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
-					}
-
-					undo_redo->commit_action();
 				}
+				scene_tree->update_tree();
 			}
 		} break;
 		case TOOL_SCENE_MAKE_LOCAL: {
@@ -1442,34 +1419,32 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
+			const List<Node *> selection = editor_selection->get_full_selected_node_list();
 			if (!_validate_no_foreign_selected(selection)) {
 				break;
 			}
 
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
+			Node *root = EditorNode::get_singleton()->get_edited_scene();
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Make Local"));
+			for (Node *node : selection) {
 				if (node) {
-					Node *root = EditorNode::get_singleton()->get_edited_scene();
-					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 					if (!root) {
-						break;
+						continue;
 					}
 
-					ERR_FAIL_COND(!node->is_instance());
-					undo_redo->create_action(TTR("Make Local"));
+					ERR_CONTINUE(!node->is_instance());
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
 					_node_replace_owner(node, node, root);
 					_node_strip_signal_inheritance(node);
 					SignalsDock::get_singleton()->set_object(node); // Refresh.
 					GroupsDock::get_singleton()->set_selection(Vector<Node *>{ node }); // Refresh.
-					undo_redo->add_do_method(scene_tree, "update_tree");
-					undo_redo->add_undo_method(scene_tree, "update_tree");
-					undo_redo->commit_action();
 				}
 			}
+			undo_redo->add_do_method(scene_tree, "update_tree");
+			undo_redo->add_undo_method(scene_tree, "update_tree");
+			undo_redo->commit_action();
 		} break;
 		case TOOL_SCENE_OPEN: {
 			const List<Node *> selection = editor_selection->get_top_selected_node_list();
@@ -1548,7 +1523,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				return;
 			}
 
-			bool enabling = !first_selected->is_unique_name_in_owner();
+			ItemCheckState unique_name_state = _is_unique_name(full_selection);
+			bool enabling = unique_name_state != STATE_CHECKED;
 
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
@@ -2787,30 +2763,24 @@ void SceneTreeDock::_shader_creation_closed() {
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {
-	const List<Node *> selection = editor_selection->get_top_selected_node_list();
-	const List<Node *>::Element *e = selection.front();
-
-	if (e) {
-		_toggle_editable_children(e->get());
-	}
+	List<Node *> selection = editor_selection->get_full_selected_node_list();
+	_toggle_editable_children(selection);
 }
 
 void SceneTreeDock::_toggle_placeholder_from_selection() {
-	const List<Node *> selection = editor_selection->get_top_selected_node_list();
-	const List<Node *>::Element *e = selection.front();
+	List<Node *> selection = editor_selection->get_full_selected_node_list();
+	ItemCheckState placeholder_state = _is_placeholder(selection);
+	bool placeholder = placeholder_state != STATE_CHECKED;
+	if (placeholder) {
+		_toggle_editable_children(selection, STATE_CHECKED);
+	}
 
-	if (e) {
-		Node *node = e->get();
+	for (Node *node : selection) {
 		if (node) {
-			_toggle_editable_children(node);
-
-			bool placeholder = node->get_scene_instance_load_placeholder();
-			placeholder = !placeholder;
-
 			node->set_scene_instance_load_placeholder(placeholder);
-			scene_tree->update_tree();
 		}
 	}
+	scene_tree->update_tree();
 }
 
 void SceneTreeDock::_reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner) {
@@ -2867,67 +2837,139 @@ void SceneTreeDock::_reparent_nodes_to_paths_with_transform_and_name(Node *p_roo
 	}
 }
 
-void SceneTreeDock::_toggle_editable_children(Node *p_node) {
-	if (!p_node) {
-		return;
-	}
-
+void SceneTreeDock::_toggle_editable_children(List<Node *> &p_nodes, ItemCheckState p_current_state) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 	undo_redo->create_action(TTR("Toggle Editable Children"));
 
-	bool editable = !EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(p_node);
+	bool is_indeterminate = p_current_state == STATE_INDETERMINATE;
+	ItemCheckState editable_state = is_indeterminate ? _is_editable_children(p_nodes) : p_current_state;
+	bool editable = editable_state != STATE_CHECKED;
 
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", p_node, !editable);
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", p_node, editable);
+	for (Node *node : p_nodes) {
+		if (node) {
+			undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", node, !editable);
+			undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", node, editable);
 
-	if (editable) {
-		bool original_scene_instance_load_placeholder = p_node->get_scene_instance_load_placeholder();
+			if (editable) {
+				bool original_scene_instance_load_placeholder = node->get_scene_instance_load_placeholder();
 
-		undo_redo->add_undo_method(p_node, "set_scene_instance_load_placeholder", original_scene_instance_load_placeholder);
-		undo_redo->add_do_method(p_node, "set_scene_instance_load_placeholder", false);
-	} else {
-		List<Node *> owned;
-		p_node->get_owned_by(edited_scene, &owned);
+				undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", original_scene_instance_load_placeholder);
+				undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", false);
+			} else {
+				List<Node *> owned;
+				node->get_owned_by(edited_scene, &owned);
 
-		// Get the original paths, transforms, and names for undo.
-		Array owned_nodes_array;
-		Array paths_array;
-		Array transform_array;
-		Array name_array;
+				// Get the original paths, transforms, and names for undo.
+				Array owned_nodes_array;
+				Array paths_array;
+				Array transform_array;
+				Array name_array;
 
-		for (Node *owned_node : owned) {
-			if (owned_node != p_node && owned_node != edited_scene && owned_node->get_owner() == edited_scene && owned_node->get_parent()->get_owner() != edited_scene) {
-				owned_nodes_array.push_back(owned_node);
-				paths_array.push_back(p_node->get_path_to(owned_node->get_parent()));
-				name_array.push_back(owned_node->get_name());
-				Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
-				if (node_3d) {
-					transform_array.push_back(node_3d->get_transform());
-				} else {
-					Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
-					if (node_2d) {
-						transform_array.push_back(node_2d->get_transform());
-					} else {
-						transform_array.push_back(Variant());
+				for (Node *owned_node : owned) {
+					if (owned_node != node && owned_node != edited_scene && owned_node->get_owner() == edited_scene && owned_node->get_parent()->get_owner() != edited_scene) {
+						owned_nodes_array.push_back(owned_node);
+						paths_array.push_back(node->get_path_to(owned_node->get_parent()));
+						name_array.push_back(owned_node->get_name());
+						Node3D *node_3d = Object::cast_to<Node3D>(owned_node);
+						if (node_3d) {
+							transform_array.push_back(node_3d->get_transform());
+						} else {
+							Node2D *node_2d = Object::cast_to<Node2D>(owned_node);
+							if (node_2d) {
+								transform_array.push_back(node_2d->get_transform());
+							} else {
+								transform_array.push_back(Variant());
+							}
+						}
 					}
 				}
-			}
-		}
 
-		if (!owned_nodes_array.is_empty()) {
-			undo_redo->add_undo_method(this, "_reparent_nodes_to_paths_with_transform_and_name", p_node, owned_nodes_array, paths_array, transform_array, name_array, edited_scene);
-			undo_redo->add_do_method(this, "_reparent_nodes_to_root", p_node, owned_nodes_array, edited_scene);
+				if (!owned_nodes_array.is_empty()) {
+					undo_redo->add_undo_method(this, "_reparent_nodes_to_paths_with_transform_and_name", node, owned_nodes_array, paths_array, transform_array, name_array, edited_scene);
+					undo_redo->add_do_method(this, "_reparent_nodes_to_root", node, owned_nodes_array, edited_scene);
+				}
+			}
+
+			undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", node);
+			undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", node);
+		}
+	}
+	undo_redo->add_undo_method(scene_tree, "update_tree");
+	undo_redo->add_do_method(scene_tree, "update_tree");
+	undo_redo->commit_action();
+}
+
+bool SceneTreeDock::_is_external(Node *p_node) const {
+	return p_node->is_instance();
+}
+
+bool SceneTreeDock::_is_top_level(Node *p_node) const {
+	return !p_node->get_owner();
+}
+
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_editable_children(List<Node *> &p_nodes) {
+	int editable_count = 0;
+
+	// Filter valid nodes first.
+	List<Node *> valid_nodes;
+	for (Node *node : p_nodes) {
+		if (node) {
+			bool is_external = _is_external(node);
+			bool is_top_level = _is_top_level(node);
+			if (is_external && !is_top_level) {
+				valid_nodes.push_back(node);
+			}
 		}
 	}
 
-	undo_redo->add_undo_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
-	undo_redo->add_do_method(Node3DEditor::get_singleton(), "update_all_gizmos", p_node);
+	p_nodes = valid_nodes;
 
-	undo_redo->add_undo_method(scene_tree, "update_tree");
-	undo_redo->add_do_method(scene_tree, "update_tree");
+	for (const Node *node : valid_nodes) {
+		if (EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node)) {
+			editable_count++;
+		}
+	}
+	return (editable_count == 0) ? STATE_UNCHECKED : (editable_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
+}
 
-	undo_redo->commit_action();
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_placeholder(List<Node *> &p_nodes) {
+	int placeholder_count = 0;
+
+	// Filter valid nodes first.
+	List<Node *> valid_nodes;
+	for (Node *node : p_nodes) {
+		if (node) {
+			bool is_external = _is_external(node);
+			bool is_top_level = _is_top_level(node);
+			if (is_external && !is_top_level) {
+				valid_nodes.push_back(node);
+			}
+		}
+	}
+
+	p_nodes = valid_nodes;
+
+	for (const Node *node : valid_nodes) {
+		if (node->get_scene_instance_load_placeholder()) {
+			placeholder_count++;
+		}
+	}
+	return (placeholder_count == 0) ? STATE_UNCHECKED : (placeholder_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
+}
+
+SceneTreeDock::ItemCheckState SceneTreeDock::_is_unique_name(List<Node *> &p_nodes) {
+	int unique_name_count = 0;
+
+	for (Node *node : p_nodes) {
+		if (node) {
+			if (node->is_unique_name_in_owner()) {
+				unique_name_count++;
+			}
+		}
+	}
+
+	return (unique_name_count == 0) ? STATE_UNCHECKED : (unique_name_count == p_nodes.size() ? STATE_CHECKED : STATE_INDETERMINATE);
 }
 
 void SceneTreeDock::_delete_confirm(bool p_cut) {
@@ -4140,42 +4182,61 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 	bool is_tool_scene_open_available = false;
 	bool is_tool_scene_open_inherited_available = false;
+	bool is_top_level = false;
+	bool is_external = false;
 	if (selection.size() == 1) {
 		if (profile_allow_editing) {
 			BEGIN_SECTION()
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
 		}
-
-		// Group "make_local" etc. with "save_branch_as_scene", if it is available.
-		bool is_external = selection.front()->get()->is_instance();
-		bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
-		bool is_top_level = selection.front()->get()->get_owner() == nullptr;
-		if (is_inherited && is_top_level) {
-			if (profile_allow_editing) {
-				BEGIN_SECTION()
-				menu->add_item(TTRC("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
+		is_external = _is_external(selection.front()->get());
+		is_top_level = _is_top_level(selection.front()->get());
+		if (is_external) {
+			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
+			if (is_inherited && is_top_level) {
+				if (profile_allow_editing) {
+					BEGIN_SECTION()
+					menu->add_item(TTR("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
+					END_SECTION()
+				}
+				is_tool_scene_open_inherited_available = true;
 			}
 			is_tool_scene_open_inherited_available = true;
 		}
+	}
 
-		if (is_external && !is_top_level) {
-			bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
-			bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
+	TypedArray<Node> selected_nodes = editor_selection->get_selected_nodes();
+	is_top_level = selected_nodes.all(callable_mp(this, &SceneTreeDock::_is_top_level));
+	is_external = selected_nodes.all(callable_mp(this, &SceneTreeDock::_is_external));
+
+	if (is_external) {
+		if (!is_top_level) {
+			List<Node *> full_selection_list = editor_selection->get_full_selected_node_list();
+			ItemCheckState editable_state = _is_editable_children(full_selection_list);
+			ItemCheckState placeholder_state = _is_placeholder(full_selection_list);
 			if (profile_allow_editing) {
 				BEGIN_SECTION()
-				menu->add_item(TTRC("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+				menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
 
-				menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
+				menu->add_check_item(TTR("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 				menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
-				menu->set_item_checked(-1, editable);
+				if (editable_state != STATE_INDETERMINATE) {
+					menu->set_item_checked(-1, bool(editable_state));
+				} else {
+					menu->set_item_indeterminate(-1, true);
+				}
 
-				menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-				menu->set_item_checked(-1, placeholder);
+				menu->add_check_item(TTR("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
+				if (placeholder_state != STATE_INDETERMINATE) {
+					menu->set_item_checked(-1, bool(placeholder_state));
+				} else {
+					menu->set_item_indeterminate(-1, true);
+				}
+
+				END_SECTION()
 			}
 			is_tool_scene_open_available = true;
 		}
-
-		END_SECTION()
 	}
 
 	if (selection.size() == 1) {
@@ -4200,10 +4261,14 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			if (menu->get_item_index(TOOL_COPY_NODE_PATH) == -1) {
 				BEGIN_SECTION()
 			}
-			Node *node = full_selection.front()->get();
+			ItemCheckState unique_name_state = _is_unique_name(full_selection);
 			menu->add_icon_check_item(get_editor_theme_icon(SNAME("SceneUniqueName")), TTRC("Access as Unique Name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
-			menu->set_item_shortcut(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), ED_GET_SHORTCUT("scene_tree/toggle_unique_name"));
-			menu->set_item_checked(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), node->is_unique_name_in_owner());
+			menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_unique_name"));
+			if (unique_name_state != STATE_INDETERMINATE) {
+				menu->set_item_checked(-1, bool(unique_name_state));
+			} else {
+				menu->set_item_indeterminate(-1, true);
+			}
 		}
 		END_SECTION()
 	}

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -205,6 +205,12 @@ class SceneTreeDock : public EditorDock {
 		MODE_UNDO
 	};
 
+	enum ItemCheckState {
+		STATE_INDETERMINATE = -1,
+		STATE_UNCHECKED = 0,
+		STATE_CHECKED = 1,
+	};
+
 	void _node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode = MODE_BIDI);
 	void _node_strip_signal_inheritance(Node *p_node);
 	void _load_request(const String &p_path);
@@ -229,7 +235,14 @@ class SceneTreeDock : public EditorDock {
 
 	void _reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner);
 	void _reparent_nodes_to_paths_with_transform_and_name(Node *p_root, const Array &p_nodes, const Array &p_paths, const Array &p_transforms, const Array &p_names, Node *p_owner);
-	void _toggle_editable_children(Node *p_node);
+	void _toggle_editable_children(List<Node *> &p_nodes, ItemCheckState p_current_state = STATE_INDETERMINATE);
+
+	bool _is_external(Node *p_node) const;
+	bool _is_top_level(Node *p_node) const;
+
+	ItemCheckState _is_editable_children(List<Node *> &p_nodes);
+	ItemCheckState _is_placeholder(List<Node *> &p_nodes);
+	ItemCheckState _is_unique_name(List<Node *> &p_nodes);
 
 	void _toggle_placeholder_from_selection();
 

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -208,6 +208,12 @@ class SceneTreeDock : public EditorDock {
 		MODE_UNDO
 	};
 
+	enum ItemCheckState {
+		STATE_INDETERMINATE = -1,
+		STATE_UNCHECKED = 0,
+		STATE_CHECKED = 1,
+	};
+
 	void _node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode = MODE_BIDI);
 	void _node_strip_signal_inheritance(Node *p_node);
 	void _load_request(const String &p_path);
@@ -232,7 +238,14 @@ class SceneTreeDock : public EditorDock {
 
 	void _reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner);
 	void _reparent_nodes_to_paths_with_transform_and_name(Node *p_root, const Array &p_nodes, const Array &p_paths, const Array &p_transforms, const Array &p_names, Node *p_owner);
-	void _toggle_editable_children(Node *p_node);
+	void _toggle_editable_children(List<Node *> &p_nodes, ItemCheckState p_current_state = STATE_INDETERMINATE);
+
+	bool _is_external(Node *p_node) const;
+	bool _is_top_level(Node *p_node) const;
+
+	ItemCheckState _is_editable_children(List<Node *> &p_nodes);
+	ItemCheckState _is_placeholder(List<Node *> &p_nodes);
+	ItemCheckState _is_unique_name(List<Node *> &p_nodes);
 
 	void _toggle_placeholder_from_selection();
 


### PR DESCRIPTION
Require https://github.com/godotengine/godot/pull/119669
This PR continues to improve the SceneTree by allowing more multi-selection actions.
Supported actions:
- `Make Local`
- `Editable Children`
- `Load as Placeholder`

Indeterminate state for:
- `Access as Unique Name`

Closes https://github.com/godotengine/godot-proposals/issues/14611

The `Add Child` and `Instantiate Scene` actions were previously implemented in:
* https://github.com/godotengine/godot/pull/113562