### PR TITLE
GDScript: Register `GDScriptFunctionState` with `ClassDB`

### DIFF
--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -137,6 +137,7 @@ static void _editor_init() {
 void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		GDREGISTER_CLASS(GDScript);
+		GDREGISTER_INTERNAL_CLASS(GDScriptFunctionState);
 
 		script_language_gd = memnew(GDScriptLanguage);
 		ScriptServer::register_language(script_language_gd);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119014

Some recent GDType change requires signals to be registered on the main thread. Since we never registered `GDScriptFunctionState` it was initialized when the first instance was created. This could very well be on a secondary thread which is not valid anymore.

We now register the class to ensure it is initialized properly on the main thread.
