### PR TITLE
Fix: 1-tick lag when CharacterBody stands on a moving kinematic platform (2D + 3D)

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -315,8 +315,7 @@ void GodotBody2D::set_state(PhysicsServer2D::BodyState p_state, const Variant &p
 					// current-tick data rather than last-step data.
 					if (last_step > 0.0) {
 						real_t inv_step = 1.0 / last_step;
-						pending_linear_velocity = (new_transform.get_origin() - get_transform().get_origin()) * inv_step
-								+ constant_linear_velocity;
+						pending_linear_velocity = (new_transform.get_origin() - get_transform().get_origin()) * inv_step + constant_linear_velocity;
 						real_t rot = new_transform.get_rotation() - get_transform().get_rotation();
 						pending_angular_velocity = constant_angular_velocity + std::remainder(rot, 2.0 * Math::PI) * inv_step;
 					}

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -309,6 +309,18 @@ void GodotBody2D::set_state(PhysicsServer2D::BodyState p_state, const Variant &p
 					_set_transform(p_variant);
 					_set_inv_transform(get_transform().affine_inverse());
 					first_time_kinematic = false;
+				} else {
+					// Cache the velocity implied by this transform change so that
+					// body_get_direct_state() in the same _physics_process tick returns
+					// current-tick data rather than last-step data.
+					if (last_step > 0.0) {
+						real_t inv_step = 1.0 / last_step;
+						pending_linear_velocity = (new_transform.get_origin() - get_transform().get_origin()) * inv_step
+								+ constant_linear_velocity;
+						real_t rot = new_transform.get_rotation() - get_transform().get_rotation();
+						pending_angular_velocity = constant_angular_velocity + std::remainder(rot, 2.0 * Math::PI) * inv_step;
+					}
+					pending_transform_valid = true;
 				}
 			} else if (mode == PhysicsServer2D::BODY_MODE_STATIC) {
 				_set_transform(p_variant);
@@ -558,6 +570,8 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 	bool do_motion = false;
 
 	if (mode == PhysicsServer2D::BODY_MODE_KINEMATIC) {
+		// Store step for pending velocity computation in set_state(BODY_STATE_TRANSFORM).
+		last_step = p_step;
 		//compute motion, angular and etc. velocities from prev transform
 		motion = new_transform.get_origin() - get_transform().get_origin();
 		linear_velocity = constant_linear_velocity + motion / p_step;

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -105,6 +105,19 @@ class GodotBody2D : public GodotCollisionObject2D {
 	virtual void _shapes_changed() override;
 	Transform2D new_transform;
 
+	// Pending state: set when a kinematic body writes new_transform during _physics_process.
+	// Consumed by body_get_direct_state() in the same tick so other bodies read current-tick data.
+	// Reset at the END of GodotStep2D::step(), never inside integrate_forces().
+	real_t last_step = 1.0 / 60.0;
+	bool pending_transform_valid = false;
+	Vector2 pending_linear_velocity;
+	real_t pending_angular_velocity = 0.0;
+
+	_FORCE_INLINE_ bool has_pending_transform() const { return pending_transform_valid; }
+	_FORCE_INLINE_ const Transform2D &get_pending_transform() const { return new_transform; }
+	_FORCE_INLINE_ Vector2 get_pending_linear_velocity() const { return pending_linear_velocity; }
+	_FORCE_INLINE_ real_t get_pending_angular_velocity() const { return pending_angular_velocity; }
+
 	List<Pair<GodotConstraint2D *, int>> constraint_list;
 
 	struct AreaCMP {
@@ -156,6 +169,8 @@ class GodotBody2D : public GodotCollisionObject2D {
 	friend class GodotPhysicsDirectBodyState2D; // i give up, too many functions to expose
 
 public:
+	_FORCE_INLINE_ void clear_pending_transform() { pending_transform_valid = false; }
+
 	void set_state_sync_callback(const Callable &p_callable);
 	void set_force_integration_callback(const Callable &p_callable, const Variant &p_udata = Variant());
 

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
@@ -67,6 +67,9 @@ void GodotPhysicsDirectBodyState2D::set_linear_velocity(const Vector2 &p_velocit
 }
 
 Vector2 GodotPhysicsDirectBodyState2D::get_linear_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_linear_velocity();
+	}
 	return body->get_linear_velocity();
 }
 
@@ -76,6 +79,9 @@ void GodotPhysicsDirectBodyState2D::set_angular_velocity(real_t p_velocity) {
 }
 
 real_t GodotPhysicsDirectBodyState2D::get_angular_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_angular_velocity();
+	}
 	return body->get_angular_velocity();
 }
 
@@ -84,10 +90,18 @@ void GodotPhysicsDirectBodyState2D::set_transform(const Transform2D &p_transform
 }
 
 Transform2D GodotPhysicsDirectBodyState2D::get_transform() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_transform();
+	}
 	return body->get_transform();
 }
 
 Vector2 GodotPhysicsDirectBodyState2D::get_velocity_at_local_position(const Vector2 &p_position) const {
+	if (body->has_pending_transform()) {
+		// v = v_linear + ω × r  (2D cross: ω is scalar, r is Vector2)
+		real_t ω = body->get_pending_angular_velocity();
+		return body->get_pending_linear_velocity() + Vector2(-ω * p_position.y, ω * p_position.x);
+	}
 	return body->get_velocity_in_local_point(p_position);
 }
 

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
@@ -98,9 +98,9 @@ Transform2D GodotPhysicsDirectBodyState2D::get_transform() const {
 
 Vector2 GodotPhysicsDirectBodyState2D::get_velocity_at_local_position(const Vector2 &p_position) const {
 	if (body->has_pending_transform()) {
-		// v = v_linear + ω × r  (2D cross: ω is scalar, r is Vector2)
-		real_t ω = body->get_pending_angular_velocity();
-		return body->get_pending_linear_velocity() + Vector2(-ω * p_position.y, ω * p_position.x);
+		// v = v_linear + ang_vel x r  (2D cross: ang_vel is scalar, r is Vector2)
+		real_t ang_vel = body->get_pending_angular_velocity();
+		return body->get_pending_linear_velocity() + Vector2(-ang_vel * p_position.y, ang_vel * p_position.x);
 	}
 	return body->get_velocity_in_local_point(p_position);
 }

--- a/modules/godot_physics_2d/godot_step_2d.cpp
+++ b/modules/godot_physics_2d/godot_step_2d.cpp
@@ -294,6 +294,18 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 
 	all_constraints.clear();
 
+	/* CLEAR PENDING TRANSFORM FLAGS */
+	// Reset pending_transform_valid for all kinematic bodies at the END of step().
+	// The flag is set during _physics_process (which runs AFTER step finishes),
+	// so it must be cleared here — not at the beginning of the next step.
+	{
+		const SelfList<GodotBody2D> *b = body_list->first();
+		while (b) {
+			b->self()->clear_pending_transform();
+			b = b->next();
+		}
+	}
+
 	p_space->unlock();
 	_step++;
 }

--- a/modules/godot_physics_2d/godot_step_2d.cpp
+++ b/modules/godot_physics_2d/godot_step_2d.cpp
@@ -299,10 +299,10 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 	// The flag is set during _physics_process (which runs AFTER step finishes),
 	// so it must be cleared here — not at the beginning of the next step.
 	{
-		const SelfList<GodotBody2D> *b = body_list->first();
-		while (b) {
-			b->self()->clear_pending_transform();
-			b = b->next();
+		const SelfList<GodotBody2D> *kb = body_list->first();
+		while (kb) {
+			kb->self()->clear_pending_transform();
+			kb = kb->next();
 		}
 	}
 

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -360,6 +360,23 @@ void GodotBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant &p
 					_set_transform(p_variant);
 					_set_inv_transform(get_transform().affine_inverse());
 					first_time_kinematic = false;
+				} else {
+					// Cache the velocity implied by this transform change so that
+					// body_get_direct_state() in the same _physics_process tick returns
+					// current-tick data rather than last-step data.
+					if (last_step > 0.0) {
+						real_t inv_step = 1.0 / last_step;
+						pending_linear_velocity = (new_transform.origin - get_transform().origin) * inv_step
+								+ constant_linear_velocity;
+						Basis rot = new_transform.basis.orthonormalized()
+								* get_transform().basis.orthonormalized().transposed();
+						Vector3 axis;
+						real_t angle;
+						rot.get_axis_angle(axis, angle);
+						axis.normalize();
+						pending_angular_velocity = constant_angular_velocity + axis * (angle * inv_step);
+					}
+					pending_transform_valid = true;
 				}
 
 			} else if (mode == PhysicsServer3D::BODY_MODE_STATIC) {
@@ -613,6 +630,8 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 	bool do_motion = false;
 
 	if (mode == PhysicsServer3D::BODY_MODE_KINEMATIC) {
+		// Store step for pending velocity computation in set_state(BODY_STATE_TRANSFORM).
+		last_step = p_step;
 		//compute motion, angular and etc. velocities from prev transform
 		motion = new_transform.origin - get_transform().origin;
 		do_motion = true;

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -366,10 +366,8 @@ void GodotBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant &p
 					// current-tick data rather than last-step data.
 					if (last_step > 0.0) {
 						real_t inv_step = 1.0 / last_step;
-						pending_linear_velocity = (new_transform.origin - get_transform().origin) * inv_step
-								+ constant_linear_velocity;
-						Basis rot = new_transform.basis.orthonormalized()
-								* get_transform().basis.orthonormalized().transposed();
+						pending_linear_velocity = (new_transform.origin - get_transform().origin) * inv_step + constant_linear_velocity;
+						Basis rot = new_transform.basis.orthonormalized() * get_transform().basis.orthonormalized().transposed();
 						Vector3 axis;
 						real_t angle;
 						rot.get_axis_angle(axis, angle);

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -111,6 +111,20 @@ class GodotBody3D : public GodotCollisionObject3D {
 	virtual void _shapes_changed() override;
 	Transform3D new_transform;
 
+	// Pending state: set when a kinematic body writes new_transform during _physics_process.
+	// Consumed by body_get_direct_state() in the same tick so other bodies read current-tick data.
+	// Reset at the END of GodotStep3D::step(), never inside integrate_forces() — because
+	// body_test_motion() also calls integrate_forces() and must not clear the flag mid-frame.
+	real_t last_step = 1.0 / 60.0;
+	bool pending_transform_valid = false;
+	Vector3 pending_linear_velocity;
+	Vector3 pending_angular_velocity;
+
+	_FORCE_INLINE_ bool has_pending_transform() const { return pending_transform_valid; }
+	_FORCE_INLINE_ const Transform3D &get_pending_transform() const { return new_transform; }
+	_FORCE_INLINE_ Vector3 get_pending_linear_velocity() const { return pending_linear_velocity; }
+	_FORCE_INLINE_ Vector3 get_pending_angular_velocity() const { return pending_angular_velocity; }
+
 	HashMap<GodotConstraint3D *, int> constraint_map;
 
 	Vector<AreaCMP> areas;
@@ -150,6 +164,8 @@ class GodotBody3D : public GodotCollisionObject3D {
 	friend class GodotPhysicsDirectBodyState3D; // i give up, too many functions to expose
 
 public:
+	_FORCE_INLINE_ void clear_pending_transform() { pending_transform_valid = false; }
+
 	void set_state_sync_callback(const Callable &p_callable);
 	void set_force_integration_callback(const Callable &p_callable, const Variant &p_udata = Variant());
 

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
@@ -106,8 +106,7 @@ Transform3D GodotPhysicsDirectBodyState3D::get_transform() const {
 
 Vector3 GodotPhysicsDirectBodyState3D::get_velocity_at_local_position(const Vector3 &p_position) const {
 	if (body->has_pending_transform()) {
-		return body->get_pending_linear_velocity()
-				+ body->get_pending_angular_velocity().cross(p_position - body->get_center_of_mass());
+		return body->get_pending_linear_velocity() + body->get_pending_angular_velocity().cross(p_position - body->get_center_of_mass());
 	}
 	return body->get_velocity_in_local_point(p_position);
 }

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
@@ -75,6 +75,9 @@ void GodotPhysicsDirectBodyState3D::set_linear_velocity(const Vector3 &p_velocit
 }
 
 Vector3 GodotPhysicsDirectBodyState3D::get_linear_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_linear_velocity();
+	}
 	return body->get_linear_velocity();
 }
 
@@ -84,6 +87,9 @@ void GodotPhysicsDirectBodyState3D::set_angular_velocity(const Vector3 &p_veloci
 }
 
 Vector3 GodotPhysicsDirectBodyState3D::get_angular_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_angular_velocity();
+	}
 	return body->get_angular_velocity();
 }
 
@@ -92,10 +98,17 @@ void GodotPhysicsDirectBodyState3D::set_transform(const Transform3D &p_transform
 }
 
 Transform3D GodotPhysicsDirectBodyState3D::get_transform() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_transform();
+	}
 	return body->get_transform();
 }
 
 Vector3 GodotPhysicsDirectBodyState3D::get_velocity_at_local_position(const Vector3 &p_position) const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_linear_velocity()
+				+ body->get_pending_angular_velocity().cross(p_position - body->get_center_of_mass());
+	}
 	return body->get_velocity_in_local_point(p_position);
 }
 

--- a/modules/godot_physics_3d/godot_step_3d.cpp
+++ b/modules/godot_physics_3d/godot_step_3d.cpp
@@ -409,10 +409,10 @@ void GodotStep3D::step(GodotSpace3D *p_space, real_t p_delta) {
 	// The flag is set during _physics_process (which runs AFTER step finishes),
 	// so it must be cleared here — at the end of the previous step — not at the beginning.
 	{
-		const SelfList<GodotBody3D> *b = body_list->first();
-		while (b) {
-			b->self()->clear_pending_transform();
-			b = b->next();
+		const SelfList<GodotBody3D> *kb = body_list->first();
+		while (kb) {
+			kb->self()->clear_pending_transform();
+			kb = kb->next();
 		}
 	}
 

--- a/modules/godot_physics_3d/godot_step_3d.cpp
+++ b/modules/godot_physics_3d/godot_step_3d.cpp
@@ -404,6 +404,18 @@ void GodotStep3D::step(GodotSpace3D *p_space, real_t p_delta) {
 
 	all_constraints.clear();
 
+	/* CLEAR PENDING TRANSFORM FLAGS */
+	// Reset pending_transform_valid for all kinematic bodies at the END of step().
+	// The flag is set during _physics_process (which runs AFTER step finishes),
+	// so it must be cleared here — at the end of the previous step — not at the beginning.
+	{
+		const SelfList<GodotBody3D> *b = body_list->first();
+		while (b) {
+			b->self()->clear_pending_transform();
+			b = b->next();
+		}
+	}
+
 	p_space->unlock();
 	_step++;
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -526,6 +526,20 @@ void JoltBody3D::set_transform(Transform3D p_transform) {
 		jolt_settings->mPosition = to_jolt_r(p_transform.origin);
 		jolt_settings->mRotation = to_jolt(p_transform.basis);
 	} else if (is_kinematic()) {
+		// Cache the velocity implied by this transform change so that
+		// body_get_direct_state() in the same _physics_process tick returns
+		// current-tick data rather than last-step data.
+		if (last_step > 0.0f) {
+			const real_t inv_step = 1.0f / last_step;
+			pending_linear_velocity = (p_transform.origin - kinematic_transform.origin) * inv_step + linear_surface_velocity;
+			Basis rot = p_transform.basis.orthonormalized() * kinematic_transform.basis.orthonormalized().transposed();
+			Vector3 axis;
+			real_t angle;
+			rot.get_axis_angle(axis, angle);
+			axis.normalize();
+			pending_angular_velocity = angular_surface_velocity + axis * (angle * inv_step);
+			pending_transform_valid = true;
+		}
 		kinematic_transform = p_transform;
 	} else {
 		space->get_body_iface().SetPositionAndRotation(jolt_body->GetID(), to_jolt_r(p_transform.origin), to_jolt(p_transform.basis), JPH::EActivation::DontActivate);
@@ -1111,6 +1125,11 @@ void JoltBody3D::pre_step(float p_step) {
 			_integrate_forces(p_step);
 		} break;
 		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
+			// Clear the pending flag from the previous _physics_process tick and store
+			// the step duration for pending velocity computation in set_transform().
+			clear_pending_transform();
+			last_step = p_step;
+
 			if (has_point_gravity) {
 				_update_environmental_properties();
 			}

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -69,6 +69,14 @@ private:
 
 	Transform3D kinematic_transform;
 
+	// Pending state: set when a kinematic body calls set_transform() during _physics_process.
+	// Consumed by body_get_direct_state() in the same tick so other bodies read current-tick data.
+	// Cleared at the START of the next pre_step() — before _move_kinematic runs for the new frame.
+	float last_step = 0.0f;
+	bool pending_transform_valid = false;
+	Vector3 pending_linear_velocity;
+	Vector3 pending_angular_velocity;
+
 	Vector3 inertia;
 	Vector3 center_of_mass_custom;
 	Vector3 constant_force;
@@ -151,6 +159,12 @@ private:
 	void _sleep_allowed_changed();
 
 public:
+	_FORCE_INLINE_ void clear_pending_transform() { pending_transform_valid = false; }
+	_FORCE_INLINE_ bool has_pending_transform() const { return pending_transform_valid; }
+	_FORCE_INLINE_ Transform3D get_pending_transform() const { return kinematic_transform.scaled_local(scale); }
+	_FORCE_INLINE_ Vector3 get_pending_linear_velocity() const { return pending_linear_velocity; }
+	_FORCE_INLINE_ Vector3 get_pending_angular_velocity() const { return pending_angular_velocity; }
+
 	JoltBody3D();
 	virtual ~JoltBody3D() override;
 

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
@@ -75,6 +75,9 @@ Basis JoltPhysicsDirectBodyState3D::get_inverse_inertia_tensor() const {
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::get_linear_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_linear_velocity();
+	}
 	return body->get_linear_velocity();
 }
 
@@ -83,6 +86,9 @@ void JoltPhysicsDirectBodyState3D::set_linear_velocity(const Vector3 &p_velocity
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::get_angular_velocity() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_angular_velocity();
+	}
 	return body->get_angular_velocity();
 }
 
@@ -95,10 +101,17 @@ void JoltPhysicsDirectBodyState3D::set_transform(const Transform3D &p_transform)
 }
 
 Transform3D JoltPhysicsDirectBodyState3D::get_transform() const {
+	if (body->has_pending_transform()) {
+		return body->get_pending_transform();
+	}
 	return body->get_transform_scaled();
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::get_velocity_at_local_position(const Vector3 &p_local_position) const {
+	if (body->has_pending_transform()) {
+		// v = v_linear + ang_vel x r,  r = local_pos - COM_relative (COM relative to body origin)
+		return body->get_pending_linear_velocity() + body->get_pending_angular_velocity().cross(p_local_position - body->get_center_of_mass_relative());
+	}
 	return body->get_velocity_at_position(body->get_position() + p_local_position);
 }
 

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -507,7 +507,7 @@ const Vector2 &CharacterBody2D::get_platform_velocity() const {
 
 Node *CharacterBody2D::get_physics_process_dependency() const {
 	if (platform_object_id.is_valid()) {
-		return Object::cast_to<Node>(ObjectDB::get_instance(platform_object_id));
+		return ObjectDB::get_instance<Node>(platform_object_id);
 	}
 	return nullptr;
 }

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -505,6 +505,13 @@ const Vector2 &CharacterBody2D::get_platform_velocity() const {
 	return platform_velocity;
 }
 
+Node *CharacterBody2D::get_physics_process_dependency() const {
+	if (platform_object_id.is_valid()) {
+		return Object::cast_to<Node>(ObjectDB::get_instance(platform_object_id));
+	}
+	return nullptr;
+}
+
 int CharacterBody2D::get_slide_collision_count() const {
 	return motion_results.size();
 }

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -67,6 +67,8 @@ public:
 	real_t get_floor_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
 	const Vector2 &get_platform_velocity() const;
 
+	virtual Node *get_physics_process_dependency() const override;
+
 	int get_slide_collision_count() const;
 	PhysicsServer2D::MotionResult get_slide_collision(int p_bounce) const;
 

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -117,6 +117,15 @@ bool PhysicsBody2D::move_and_collide(const PhysicsServer2D::MotionParameters &p_
 	if (!p_test_only) {
 		Transform2D gt = p_parameters.from;
 		gt.columns[2] += r_result.travel;
+		// Immediately push the new transform to the physics server so that
+		// body_get_direct_state() in the same _physics_process tick returns
+		// current-tick velocity (pending_transform cache). Without this, the
+		// transform update is deferred via xform_change_list and fires after
+		// all _physics_process callbacks, making the pending cache useless.
+		// Gated by the "physics/common/platform_velocity_correction_beta" project setting.
+		if (SceneTree::is_platform_velocity_correction_enabled()) {
+			PhysicsServer2D::get_singleton()->body_set_state(get_rid(), PhysicsServer2D::BODY_STATE_TRANSFORM, gt);
+		}
 		set_global_transform(gt);
 	}
 

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -713,6 +713,16 @@ Vector3 CharacterBody3D::get_linear_velocity() const {
 	return get_real_velocity();
 }
 
+Node *CharacterBody3D::get_physics_process_dependency() const {
+	// Return the floor platform node so SceneTree can guarantee it processes
+	// before this CharacterBody3D within the same physics_process_priority group.
+	// platform_object_id is set in _set_platform_data() when we land on a floor.
+	if (platform_object_id.is_valid()) {
+		return Object::cast_to<Node>(ObjectDB::get_instance(platform_object_id));
+	}
+	return nullptr;
+}
+
 int CharacterBody3D::get_slide_collision_count() const {
 	return motion_results.size();
 }

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -718,7 +718,7 @@ Node *CharacterBody3D::get_physics_process_dependency() const {
 	// before this CharacterBody3D within the same physics_process_priority group.
 	// platform_object_id is set in _set_platform_data() when we land on a floor.
 	if (platform_object_id.is_valid()) {
-		return Object::cast_to<Node>(ObjectDB::get_instance(platform_object_id));
+		return ObjectDB::get_instance<Node>(platform_object_id);
 	}
 	return nullptr;
 }

--- a/scene/3d/physics/character_body_3d.h
+++ b/scene/3d/physics/character_body_3d.h
@@ -69,6 +69,11 @@ public:
 
 	virtual Vector3 get_linear_velocity() const override;
 
+	// Returns the floor platform node this body is currently standing on, so
+	// SceneTree can ensure the platform's _physics_process runs first within
+	// the same priority group (adaptive ordering — no manual priority needed).
+	virtual Node *get_physics_process_dependency() const override;
+
 	int get_slide_collision_count() const;
 	PhysicsServer3D::MotionResult get_slide_collision(int p_bounce) const;
 

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -159,6 +159,15 @@ bool PhysicsBody3D::move_and_collide(const PhysicsServer3D::MotionParameters &p_
 	if (!p_test_only) {
 		Transform3D gt = p_parameters.from;
 		gt.origin += r_result.travel;
+		// Immediately push the new transform to the physics server so that
+		// body_get_direct_state() in the same _physics_process tick returns
+		// current-tick velocity (pending_transform cache). Without this, the
+		// transform update is deferred via xform_change_list and fires after
+		// all _physics_process callbacks, making the pending cache useless.
+		// Gated by the "physics/common/platform_velocity_correction_beta" project setting.
+		if (SceneTree::is_platform_velocity_correction_enabled()) {
+			PhysicsServer3D::get_singleton()->body_set_state(get_rid(), PhysicsServer3D::BODY_STATE_TRANSFORM, gt);
+		}
 		set_global_transform(gt);
 	}
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -242,6 +242,14 @@ private:
 		int process_priority = 0;
 		int physics_process_priority = 0;
 
+		// Adaptive physics dependency tracking.
+		// physics_process_last_frame: set to Engine::get_physics_frames() after the node's
+		//   _physics_process runs, so other nodes can test whether it has already run this tick.
+		// physics_defer_last_frame: set when the node is deferred (swapped) once; prevents
+		//   infinite deferral loops if the dependency can never be satisfied this frame.
+		uint64_t physics_process_last_frame = 0;
+		uint64_t physics_defer_last_frame = 0;
+
 		// Keep bitpacked values together to get better packing.
 		ProcessMode process_mode : 3;
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
@@ -675,6 +683,13 @@ public:
 
 	void set_physics_process_priority(int p_priority);
 	int get_physics_process_priority() const;
+
+	// Override in subclasses to declare a physics-process ordering dependency.
+	// If this returns a non-null node, SceneTree will ensure the returned node's
+	// _physics_process runs before this node's _physics_process within the same
+	// physics_process_priority group, even if the tree order would produce the
+	// opposite sequence.  Returns nullptr (no dependency) by default.
+	virtual Node *get_physics_process_dependency() const { return nullptr; }
 
 	void set_process_input(bool p_enable);
 	bool is_processing_input() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -147,6 +147,7 @@ void SceneTree::ClientPhysicsInterpolation::physics_process() {
 
 bool SceneTree::_physics_interpolation_enabled = false;
 bool SceneTree::_physics_interpolation_enabled_in_project = false;
+bool SceneTree::_platform_velocity_correction_enabled = true;
 
 void SceneTree::tree_changed() {
 	emit_signal(tree_changed_name);
@@ -588,6 +589,16 @@ void SceneTree::initialize() {
 	ERR_FAIL_NULL(root);
 	MainLoop::initialize();
 	root->_set_tree(this);
+
+	// Register and cache the platform velocity correction project setting.
+	// Shown in Project Settings under Physics > Common.
+	GLOBAL_DEF("physics/common/platform_velocity_correction_beta", true);
+	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(
+			Variant::BOOL,
+			"physics/common/platform_velocity_correction_beta",
+			PROPERTY_HINT_NONE, "",
+			PROPERTY_USAGE_DEFAULT));
+	_platform_velocity_correction_enabled = GLOBAL_GET("physics/common/platform_velocity_correction_beta");
 }
 
 void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
@@ -1202,6 +1213,8 @@ void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
 	uint32_t node_count = nodes_copy.size();
 	Node **nodes_ptr = (Node **)nodes_copy.ptr(); // Force cast, pointer will not change.
 
+	const uint64_t current_physics_frame = p_physics ? Engine::get_singleton()->get_physics_frames() : 0;
+
 	for (uint32_t i = 0; i < node_count; i++) {
 		Node *n = nodes_ptr[i];
 		if (nodes_removed_on_group_call.has(n)) {
@@ -1215,12 +1228,56 @@ void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
 		}
 
 		if (p_physics) {
+			// Adaptive dependency ordering:
+			// If this node declares a physics-process dependency (e.g. CharacterBody3D on its
+			// floor platform) AND that node has not yet been processed this frame AND it lives
+			// later in the list with the same priority, promote it by swapping it to position i
+			// and deferring this node.  This handles chains of any depth (A on B on C …).
+			//
+			// Cycle protection: if dep itself was deferred this frame AND dep's own dependency
+			// points back to n (mutual A↔B cycle), we break it by processing n immediately.
+			// This is the only case where deferral is skipped.
+			//
+			// Gated by the "physics/common/platform_velocity_correction_beta" project setting.
+			if (_platform_velocity_correction_enabled) {
+				Node *dep = n->get_physics_process_dependency();
+				if (dep && dep->get_physics_process_priority() == n->get_physics_process_priority() &&
+						dep->data.physics_process_last_frame != current_physics_frame) {
+					// Detect mutual cycle: dep was already deferred this frame AND dep's own
+					// dependency is n — would cause infinite swapping between the two.
+					const bool circular = (dep->data.physics_defer_last_frame == current_physics_frame &&
+							dep->get_physics_process_dependency() == n);
+					if (!circular) {
+						// Search for dep in the remaining (not-yet-processed) portion of the list.
+						bool found = false;
+						for (uint32_t j = i + 1; j < node_count; j++) {
+							if (nodes_ptr[j] == dep) {
+								// Promote dep to current position; defer n.
+								SWAP(nodes_ptr[i], nodes_ptr[j]);
+								n->data.physics_defer_last_frame = current_physics_frame;
+								i--; // reprocess position i (now holds dep)
+								found = true;
+								break;
+							}
+						}
+						if (found) {
+							continue;
+						}
+						// dep not found ahead of us (different group / already processed) —
+						// fall through and process n normally.
+					}
+				}
+			}
+
 			if (n->is_physics_processing_internal()) {
 				n->notification(Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 			}
 			if (n->is_physics_processing()) {
 				n->notification(Node::NOTIFICATION_PHYSICS_PROCESS);
 			}
+			// Mark this node as having completed its physics process for this frame
+			// so dependencies declared by other nodes can detect it was already run.
+			n->data.physics_process_last_frame = current_physics_frame;
 		} else {
 			if (n->is_processing_internal()) {
 				n->notification(Node::NOTIFICATION_INTERNAL_PROCESS);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -151,6 +151,10 @@ private:
 	// Static so we can get directly instead of via SceneTree pointer.
 	static bool _physics_interpolation_enabled;
 
+	// Project setting: physics/common/platform_velocity_correction_beta (default true).
+	// When true, kinematic platform 1-tick lag fix and adaptive process ordering are active.
+	static bool _platform_velocity_correction_enabled;
+
 	// Note that physics interpolation is hard coded to OFF in the editor,
 	// therefore we have a second bool to enable e.g. configuration warnings
 	// to only take effect when the project is using physics interpolation.
@@ -462,6 +466,7 @@ public:
 	// Different name to disambiguate fast static versions from the user bound versions.
 	static bool is_fti_enabled() { return _physics_interpolation_enabled; }
 	static bool is_fti_enabled_in_project() { return _physics_interpolation_enabled_in_project; }
+	static bool is_platform_velocity_correction_enabled() { return _platform_velocity_correction_enabled; }
 
 #ifndef _3D_DISABLED
 	void client_physics_interpolation_add_node_3d(SelfList<Node3D> *p_elem);


### PR DESCRIPTION
## Summary of changes

New boolean property `platform_velocity_correction_beta` on `CharacterBody3D`/`CharacterBody2D`. When enabled, eliminates the one-physics-tick lag when a `CharacterBody3D` rides another `CharacterBody3D`.

### ⚠️ **Disclaimer:** This documentation was partially build by AI(claude). Also AI was involved into searching the codebase for the right place to put the fix. And help with initial understanding of a codebase around SceneTree and godot_physics_*. Some code comments was added by AI. But i Do have understanding of the code that i wrote and did test it with many scenarios


## Motivation

Bug report:
Fixes: https://github.com/godotengine/godot/issues/101253

A `CharacterBody3D` standing on a `AnimatableBody3D` or `CharacterBody3D` that moving by `move_and_collide()` or `move_and_slide()`  always reads the platform's velocity from the **previous** tick, because `move_and_collide()` defers the physics body transform update via `xform_change_list`, which flushes only after all `_physics_process` callbacks complete. The lag scales visibly with speed.

## Technical overview

Three changes, applied identically to both 2D and 3D:

**1. Immediate physics body push** (`physics_body_3d.cpp`, `physics_body_2d.cpp`)
Before `set_global_transform()`, call `body_set_state(BODY_STATE_TRANSFORM)` directly on the physics server — bypassing `xform_change_list` so the new transform is available within the same tick.

**2. Pending velocity cache** (`modules/godot_physics_3d/`, `modules/godot_physics_2d/`)
When `body_set_state` fires for a kinematic body mid-step, compute and cache `pending_linear_velocity` / `pending_angular_velocity`. `GodotPhysicsDirectBodyState` getters return cached values while the flag is set. Flag clears at end of `GodotStep::step()`.

**3. Adaptive process ordering** (`scene_tree.cpp`, `node.h`, `CharacterBody3D/2D`)
`CharacterBody3D/2D` override `get_physics_process_dependency()` to return their floor node. `SceneTree::_process_group()` auto-swaps nodes with equal `physics_process_priority` so the platform always runs before the rider — no manual priority config needed, works for stacking chains of any depth.

## Testing

Tested on Windows 10, engine fork based on 4.6.2.

**Before fix** (stock 4.5/4.6):

https://github.com/user-attachments/assets/16ccee21-c594-40f0-90a5-a3f881690cda

**After fix:**

https://github.com/user-attachments/assets/621bbf20-ec62-4f2c-8b26-ea4f448e33d3

Tested scenarios: `AnimatableBody3D` + `move_and_collide()`, `CharacterBody3D` + `move_and_slide()`, multi-level stacking, arbitrary scene tree order. different and same `physics_process_priority`

## Discussion

**Risks & caveats:**
- The auto-sort only works within a single process group (same `process_thread_group` + same priority). Cross-group cases still require manual `physics_process_priority`.
- If the rider has a *lower* `physics_process_priority` than the platform, auto-sort is intentionally skipped to respect explicit priority settings.
- `sync_to_physics = true` on `AnimatableBody` conflicts with `move_and_collide()` and should not be combined with this fix.
- Needs broader testing — stacking chains may interact with ceiling collisions in edge cases.
- This is my first engine contribution; I am not a professional C++ developer.

## Additional work & disclosure

I would appreciate feedback on the correctness of the `GodotStep` flag-clearing placement and the `SceneTree` swap logic.

Parts of this PR involved AI assistance (Claude): searching the codebase for the right integration points, understanding `SceneTree`/`godot_physics_*` internals, and some code comments. All logic was created, reviewed and tested by me personally.