### PR TITLE
Add warning messages for sync_to_physics on AnimatableBody nodes.

### DIFF
--- a/scene/2d/physics/animatable_body_2d.cpp
+++ b/scene/2d/physics/animatable_body_2d.cpp
@@ -101,7 +101,7 @@ void AnimatableBody2D::_notification(int p_what) {
 			set_notify_local_transform(true);
 
 #ifdef DEBUG_ENABLED
-			if (unlikely (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
+			if (unlikely(sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
 				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
 			}
 #endif

--- a/scene/2d/physics/animatable_body_2d.cpp
+++ b/scene/2d/physics/animatable_body_2d.cpp
@@ -99,6 +99,10 @@ void AnimatableBody2D::_notification(int p_what) {
 			set_notify_local_transform(false);
 			set_global_transform(last_valid_transform);
 			set_notify_local_transform(true);
+
+			if (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame()) {
+				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
+			}
 		} break;
 	}
 }

--- a/scene/2d/physics/animatable_body_2d.cpp
+++ b/scene/2d/physics/animatable_body_2d.cpp
@@ -100,9 +100,11 @@ void AnimatableBody2D::_notification(int p_what) {
 			set_global_transform(last_valid_transform);
 			set_notify_local_transform(true);
 
-			if (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame()) {
+#ifdef DEBUG_ENABLED
+			if (unlikely (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
 				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
 			}
+#endif
 		} break;
 	}
 }

--- a/scene/3d/physics/animatable_body_3d.cpp
+++ b/scene/3d/physics/animatable_body_3d.cpp
@@ -117,7 +117,7 @@ void AnimatableBody3D::_notification(int p_what) {
 			_on_transform_changed();
 
 #ifdef DEBUG_ENABLED
-			if (unlikely (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
+			if (unlikely(sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
 				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
 			}
 #endif

--- a/scene/3d/physics/animatable_body_3d.cpp
+++ b/scene/3d/physics/animatable_body_3d.cpp
@@ -116,9 +116,11 @@ void AnimatableBody3D::_notification(int p_what) {
 			set_notify_local_transform(true);
 			_on_transform_changed();
 
-			if (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame()) {
+#ifdef DEBUG_ENABLED
+			if (unlikely (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame())) {
 				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
 			}
+#endif
 		} break;
 	}
 }

--- a/scene/3d/physics/animatable_body_3d.cpp
+++ b/scene/3d/physics/animatable_body_3d.cpp
@@ -115,6 +115,10 @@ void AnimatableBody3D::_notification(int p_what) {
 			set_global_transform(last_valid_transform);
 			set_notify_local_transform(true);
 			_on_transform_changed();
+
+			if (sync_to_physics && !Engine::get_singleton()->is_in_physics_frame()) {
+				WARN_PRINT("Transform update outside of physics frame is ignored, as sync_to_physics is set to true.");
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Add warning messages when updating transform of AnimatableBody nodes (2D and 3D variations) outside of the physics frame when sync_to_physics is set to true. If this happens, the update is ignored, but the user is now informed, whereas before there would be no warning or error.

This is intended to resolve https://github.com/godotengine/godot-proposals/issues/14805.

Tweaks can be made to make the warning message more concise or clear, if needed.

This video demonstrates the enhancement, and shows my main testing methodology as it relates to my own project.

https://github.com/user-attachments/assets/158e1da6-1cdc-478c-a430-46639739d7b2



