### PR TITLE
Remove physics process update from NavigationRegions

### DIFF
--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -164,7 +164,7 @@ void NavigationRegion2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			set_physics_process_internal(true);
+			_region_update_transform();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -178,11 +178,6 @@ void NavigationRegion2D::_notification(int p_what) {
 #ifdef DEBUG_ENABLED
 			_set_debug_visible(false);
 #endif // DEBUG_ENABLED
-		} break;
-
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			set_physics_process_internal(false);
-			_region_update_transform();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -424,9 +419,7 @@ void NavigationRegion2D::_region_enter_navigation_map() {
 		NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
 	}
 
-	current_global_transform = get_global_transform();
-	NavigationServer2D::get_singleton()->region_set_transform(region, current_global_transform);
-
+	NavigationServer2D::get_singleton()->region_set_transform(region, get_global_transform());
 	NavigationServer2D::get_singleton()->region_set_enabled(region, enabled);
 
 	queue_redraw();
@@ -441,11 +434,7 @@ void NavigationRegion2D::_region_update_transform() {
 		return;
 	}
 
-	Transform2D new_global_transform = get_global_transform();
-	if (current_global_transform != new_global_transform) {
-		current_global_transform = new_global_transform;
-		NavigationServer2D::get_singleton()->region_set_transform(region, current_global_transform);
-	}
+	NavigationServer2D::get_singleton()->region_set_transform(region, get_global_transform());
 
 	queue_redraw();
 }

--- a/scene/2d/navigation/navigation_region_2d.h
+++ b/scene/2d/navigation/navigation_region_2d.h
@@ -46,8 +46,6 @@ class NavigationRegion2D : public Node2D {
 	real_t travel_cost = 1.0;
 	Ref<NavigationPolygon> navigation_polygon;
 
-	Transform2D current_global_transform;
-
 	void _navigation_polygon_changed();
 
 	Rect2 bounds;

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -173,11 +173,6 @@ void NavigationRegion3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			set_physics_process_internal(true);
-		} break;
-
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			set_physics_process_internal(false);
 			_region_update_transform();
 		} break;
 
@@ -386,9 +381,7 @@ void NavigationRegion3D::_region_enter_navigation_map() {
 		NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
 	}
 
-	current_global_transform = get_global_transform();
-	NavigationServer3D::get_singleton()->region_set_transform(region, current_global_transform);
-
+	NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform());
 	NavigationServer3D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
@@ -415,16 +408,12 @@ void NavigationRegion3D::_region_update_transform() {
 		return;
 	}
 
-	Transform3D new_global_transform = get_global_transform();
-	if (current_global_transform != new_global_transform) {
-		current_global_transform = new_global_transform;
-		NavigationServer3D::get_singleton()->region_set_transform(region, current_global_transform);
+	NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform());
 #ifdef DEBUG_ENABLED
-		if (debug_instance.is_valid()) {
-			RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
-		}
-#endif // DEBUG_ENABLED
+	if (debug_instance.is_valid()) {
+		RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
 	}
+#endif // DEBUG_ENABLED
 }
 
 NavigationRegion3D::NavigationRegion3D() {
@@ -618,7 +607,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 	RS::get_singleton()->instance_set_base(debug_instance, debug_mesh->get_rid());
 	if (is_inside_tree()) {
 		RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
+		RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
 		RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
 	}
 	if (!is_enabled()) {

--- a/scene/3d/navigation/navigation_region_3d.h
+++ b/scene/3d/navigation/navigation_region_3d.h
@@ -46,8 +46,6 @@ class NavigationRegion3D : public Node3D {
 	real_t travel_cost = 1.0;
 	Ref<NavigationMesh> navigation_mesh;
 
-	Transform3D current_global_transform;
-
 	void _navigation_mesh_changed();
 
 	AABB bounds;


### PR DESCRIPTION
Removes the dependency on the physics process callback inside NavigationRegions to update their transforms and changes it back to just default transform notifications.

This was a performance saving measure of old and to not miss the major single sync point that happened on the physics step. This is no longer needed due to the changes to the server internals e.g. async updates and internal iteration queues.

- the server by now blocks nearly all redundant updates that do not change the value by default.
- the server, when already building an iteration update, does queue the next change automatically, instead of doing x-amount of wasteful updates back to back.
- the physics process does not run every frame so transform changes may get stuck in the iteration queue far longer than necessary.

In general for the navigation system we need to do more changes to move away from anything physics process that is not step related.

The users often do not see this physics caused delay because the debug visuals update on the node immediately. Meanwhile the users often can feel the delay on the server queries having outdated data for long and do not understand what and why this is all happening because it happens more obscure behind node and server internals.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
