### PR TITLE
Core: Add `Variant`-typed constants to `GDType`

### DIFF
--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -64,6 +64,7 @@ void GDType::initialize() {
 		super_type->init_state = InitState::FINALIZED;
 
 		constant_map = super_type->constant_map;
+		variant_constant_map = super_type->variant_constant_map;
 		enum_map = super_type->enum_map;
 		signal_map = super_type->signal_map;
 	}
@@ -75,6 +76,7 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
 	ERR_FAIL_COND_MSG(self_constant_map.has(p_name), vformat("Class '%s' already has constant '%s'.", String(name), String(p_name)));
+	ERR_FAIL_COND_MSG(self_variant_constant_map.has(p_name), vformat("Class '%s' already has constant '%s' as a variant constant.", String(name), String(p_name)));
 
 	constant_map[p_name] = p_constant;
 	self_constant_map[p_name] = p_constant;
@@ -100,6 +102,21 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 			enum_map[enum_name] = enum_info;
 		}
 	}
+}
+
+void GDType::bind_variant_constant(const StringName &p_name, const Variant &p_constant) {
+	ERR_FAIL_COND(!Thread::is_main_thread());
+	ERR_FAIL_COND(init_state != InitState::MUTABLE);
+	ERR_FAIL_COND_MSG(self_constant_map.has(p_name), vformat("Class '%s' already has constant '%s' as an integer constant.", String(name), String(p_name)));
+	ERR_FAIL_COND_MSG(self_variant_constant_map.has(p_name), vformat("Class '%s' already has constant '%s'.", String(name), String(p_name)));
+
+	Variant::Type type = p_constant.get_type();
+	String type_name = Variant::get_type_name(type);
+	ERR_FAIL_COND_MSG(type == Variant::OBJECT || type == Variant::DICTIONARY || type_name.contains("ARRAY"),
+			vformat("Class '%s': constant '%s' has unsupported type '%s' (Object, Dictionary, and array types are not allowed).", String(name), String(p_name), type_name));
+
+	variant_constant_map[p_name] = p_constant;
+	self_variant_constant_map[p_name] = p_constant;
 }
 
 const GDType::EnumInfo *GDType::get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance) const {

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -35,6 +35,8 @@
 #include "core/templates/a_hash_map.h"
 #include "core/templates/vector.h"
 
+class Variant;
+
 class GDType {
 public:
 	enum class InitState {
@@ -61,6 +63,9 @@ protected:
 	AHashMap<StringName, int64_t> constant_map;
 	AHashMap<StringName, int64_t> self_constant_map;
 
+	AHashMap<StringName, Variant> variant_constant_map;
+	AHashMap<StringName, Variant> self_variant_constant_map;
+
 	AHashMap<StringName, const EnumInfo *> enum_map;
 	AHashMap<StringName, const EnumInfo *> self_enum_map;
 
@@ -83,7 +88,9 @@ public:
 	const Vector<StringName> &get_name_hierarchy() const { return name_hierarchy; }
 
 	void bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
+	void bind_variant_constant(const StringName &p_name, const Variant &p_constant);
 	const AHashMap<StringName, int64_t> &get_integer_constant_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_constant_map : constant_map; }
+	const AHashMap<StringName, Variant> &get_variant_constant_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_variant_constant_map : variant_constant_map; }
 	const AHashMap<StringName, const EnumInfo *> &get_enum_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_enum_map : enum_map; }
 	const EnumInfo *get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance = false) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1210,29 +1210,15 @@ struct _VariantCall {
 		signal->emit(p_args, p_argcount);
 	}
 
-	// Storage for constants added via add_variant_constant(). Once GDType supports storing these directly, this can be removed and the variants constants can be stored in the GDType instead. Integer constants and enums are already handled that way.
-	static HashMap<StringName, Variant> *variant_constants;
-
 	static void add_constant(int p_type, const StringName &p_constant_name, int64_t p_constant_value) {
-#ifdef DEBUG_ENABLED
-		ERR_FAIL_COND(variant_constants[p_type].has(p_constant_name));
-#endif // DEBUG_ENABLED
 		const_cast<GDType &>(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type))).bind_integer_constant(StringName(), p_constant_name, p_constant_value);
 	}
 
 	static void add_variant_constant(int p_type, const StringName &p_constant_name, const Variant &p_constant_value) {
-#ifdef DEBUG_ENABLED
-		ERR_FAIL_COND(variant_constants[p_type].has(p_constant_name));
-		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).get_enum_map(true).has(p_constant_name));
-		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).get_integer_constant_map(true).has(p_constant_name));
-#endif // DEBUG_ENABLED
-		variant_constants[p_type][p_constant_name] = p_constant_value;
+		const_cast<GDType &>(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type))).bind_variant_constant(p_constant_name, p_constant_value);
 	}
 
 	static void add_enum_constant(int p_type, const StringName &p_enum_type_name, const StringName &p_enumeration_name, int p_enum_value) {
-#ifdef DEBUG_ENABLED
-		ERR_FAIL_COND(variant_constants[p_type].has(p_enumeration_name));
-#endif // DEBUG_ENABLED
 		const_cast<GDType &>(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type))).bind_integer_constant(p_enum_type_name, p_enumeration_name, p_enum_value);
 	}
 
@@ -1248,8 +1234,6 @@ struct _VariantCall {
 	}
 #endif
 };
-
-HashMap<StringName, Variant> *_VariantCall::variant_constants = nullptr;
 
 struct VariantBuiltInMethodInfo {
 	void (*call)(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
@@ -1662,7 +1646,7 @@ void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_c
 		}
 	}
 
-	for (const KeyValue<StringName, Variant> &E : _VariantCall::variant_constants[p_type]) {
+	for (const KeyValue<StringName, Variant> &E : _get_gdtype_for_type(p_type).get_variant_constant_map(false)) {
 		p_constants->push_back(E.key);
 	}
 }
@@ -1680,7 +1664,7 @@ bool Variant::has_constant(Variant::Type p_type, const StringName &p_value) {
 	const bool is_non_enum_integer_constant =
 			_get_gdtype_for_type(p_type).get_integer_constant_map(false).has(p_value) &&
 			_get_gdtype_for_type(p_type).get_integer_constant_enum(p_value, false) == nullptr;
-	return is_non_enum_integer_constant || _VariantCall::variant_constants[p_type].has(p_value);
+	return is_non_enum_integer_constant || _get_gdtype_for_type(p_type).get_variant_constant_map(false).has(p_value);
 }
 
 Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_value, bool *r_valid) {
@@ -1698,12 +1682,12 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 		return *int_value;
 	}
 
-	HashMap<StringName, Variant>::Iterator F = _VariantCall::variant_constants[p_type].find(p_value);
-	if (F) {
+	const Variant *variant_value = _get_gdtype_for_type(p_type).get_variant_constant_map(false).getptr(p_value);
+	if (variant_value) {
 		if (r_valid) {
 			*r_valid = true;
 		}
-		return F->value;
+		return *variant_value;
 	}
 
 	return -1;
@@ -1955,7 +1939,6 @@ StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringN
 	register_builtin_compat_method<Method_##m_type##_##m_name>(sarray(m_arg_name), Vector<Variant>());
 
 static void _register_variant_builtin_methods_string() {
-	_VariantCall::variant_constants = memnew_arr_template<HashMap<StringName, Variant>>(Variant::VARIANT_MAX);
 	builtin_method_info = memnew_arr(BuiltinMethodMap, Variant::VARIANT_MAX);
 	builtin_method_names = memnew_arr(List<StringName>, Variant::VARIANT_MAX);
 #ifndef DISABLE_DEPRECATED
@@ -3169,5 +3152,4 @@ void Variant::_unregister_variant_methods() {
 #ifndef DISABLE_DEPRECATED
 	memdelete_arr(builtin_compat_method_info);
 #endif
-	memdelete_arr(_VariantCall::variant_constants);
 }


### PR DESCRIPTION
* Follow up to #117451 
* Work towards https://github.com/godotengine/godot-proposals/issues/13216

The previous PR added support for `GDType` to `Variant` in order to migrate enum and integer constants from `Variant`'s internal maps to the new unified `GDType`. 
This PR follows that up by adding support for `Variant`-typed constants to `GDType`, and migrating from `Variant`'s internal maps to this new system. 

Two decisions were made:
1. Just like in #117451, variant and integer constants are mutually exclusive. See [justification comment](https://github.com/godotengine/godot/pull/117451#discussion_r2937459046).
2. These constants cannot be `Variant::OBJECT`, `Variant::DICTIONARY`, or any flavor of `Variant::ARRAY`. This was discussed during the core meetings, and this is the outcome that was agreed upon, as those types cannot be truly constant. 
2.1. This is not an issue for the migration, as those types never had any constants. 