### PR TITLE
Do not overwrite read-only files on Linux

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -139,6 +139,14 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 		}
 		save_path = is_link ? link : path;
 
+		// Fail if file exists and is not writable. Renaming a file to a target file
+		// in POSIX only cares about folder permissions, not file permissions, and is
+		// thus confusing to users if we overwrite it regardless.
+		if (access(save_path.utf8().get_data(), F_OK) == 0 && access(save_path.utf8().get_data(), W_OK) != 0) {
+			last_error = ERR_FILE_CANT_WRITE;
+			return last_error;
+		}
+
 		// Create a temporary file in the same directory as the target file.
 		path = path + "-XXXXXX";
 		CharString cs = path.utf8();

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -138,11 +138,12 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 			}
 		}
 		save_path = is_link ? link : path;
+		const CharString save_path_utf8 = save_path.utf8();
 
 		// Fail if file exists and is not writable. Renaming a file to a target file
 		// in POSIX only cares about folder permissions, not file permissions, and is
 		// thus confusing to users if we overwrite it regardless.
-		if (access(save_path.utf8().get_data(), F_OK) == 0 && access(save_path.utf8().get_data(), W_OK) != 0) {
+		if (access(save_path_utf8.get_data(), F_OK) == 0 && access(save_path_utf8.get_data(), W_OK) != 0) {
 			last_error = ERR_FILE_CANT_WRITE;
 			return last_error;
 		}
@@ -157,7 +158,7 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 		}
 
 		struct stat file_stat = {};
-		int error = stat(save_path.utf8().get_data(), &file_stat);
+		int error = stat(save_path_utf8.get_data(), &file_stat);
 		if (!error) {
 			fchmod(fd, file_stat.st_mode & 0xFFF); // Mask to remove file type
 		} else {


### PR DESCRIPTION
When backup saves are enabled in Godot, which they are by default, file saves are written to a temporary file first and then moved to the target file. If the target file lacks write permissions on Linux, the operation succeeds anyway, confusing users.

This is by design in POSIX for `rename`:

> Write access permission is required for the directory containing old and the directory containing new.

It does not check file permissions on the target.

Fix file access on Linux by first checking if the target path exists and is writable. Return `ERR_FILE_CANT_WRITE` if not, resulting in an error dialog for the user.

This does not happen on Windows because that API (`ReplaceFileW`) checks for write permissions on the target file.

Tested with a read-only scene file and making basic edits. After the fix it correctly shows an error dialog if the scene file is read-only. Saving writable files works as it always has.

Fixes #114014