### PR TITLE
Remove physics process update from NavigationLink

### DIFF
--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -114,11 +114,6 @@ void NavigationLink2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			set_physics_process_internal(true);
-		} break;
-
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			set_physics_process_internal(false);
 			_link_update_transform();
 		} break;
 
@@ -247,7 +242,7 @@ void NavigationLink2D::set_start_position(Vector2 p_position) {
 		return;
 	}
 
-	NavigationServer2D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
+	NavigationServer2D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
 
 	update_configuration_warnings();
 
@@ -267,7 +262,7 @@ void NavigationLink2D::set_end_position(Vector2 p_position) {
 		return;
 	}
 
-	NavigationServer2D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+	NavigationServer2D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 
 	update_configuration_warnings();
 
@@ -351,10 +346,8 @@ void NavigationLink2D::_link_enter_navigation_map() {
 		NavigationServer2D::get_singleton()->link_set_map(link, get_world_2d()->get_navigation_map());
 	}
 
-	current_global_transform = get_global_transform();
-
-	NavigationServer2D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
-	NavigationServer2D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+	NavigationServer2D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
+	NavigationServer2D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 	NavigationServer2D::get_singleton()->link_set_enabled(link, enabled);
 
 	queue_redraw();
@@ -369,13 +362,10 @@ void NavigationLink2D::_link_update_transform() {
 		return;
 	}
 
-	Transform2D new_global_transform = get_global_transform();
-	if (current_global_transform != new_global_transform) {
-		current_global_transform = new_global_transform;
-		NavigationServer2D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
-		NavigationServer2D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
-		queue_redraw();
-	}
+	NavigationServer2D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
+	NavigationServer2D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
+
+	queue_redraw();
 }
 
 #ifdef DEBUG_ENABLED

--- a/scene/2d/navigation/navigation_link_2d.h
+++ b/scene/2d/navigation/navigation_link_2d.h
@@ -45,8 +45,6 @@ class NavigationLink2D : public Node2D {
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
 
-	Transform2D current_global_transform;
-
 #ifdef DEBUG_ENABLED
 	void _update_debug_mesh();
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -172,7 +172,7 @@ void NavigationLink3D::_update_debug_mesh() {
 		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
 	}
 
-	RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
+	RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
 }
 #endif // DEBUG_ENABLED
 
@@ -254,11 +254,6 @@ void NavigationLink3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			set_physics_process_internal(true);
-		} break;
-
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			set_physics_process_internal(false);
 			_link_update_transform();
 		} break;
 
@@ -409,7 +404,7 @@ void NavigationLink3D::set_start_position(Vector3 p_position) {
 		return;
 	}
 
-	NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
+	NavigationServer3D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
 
 #ifdef DEBUG_ENABLED
 	_update_debug_mesh();
@@ -430,7 +425,7 @@ void NavigationLink3D::set_end_position(Vector3 p_position) {
 		return;
 	}
 
-	NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+	NavigationServer3D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 
 #ifdef DEBUG_ENABLED
 	_update_debug_mesh();
@@ -515,9 +510,8 @@ void NavigationLink3D::_link_enter_navigation_map() {
 		NavigationServer3D::get_singleton()->link_set_map(link, get_world_3d()->get_navigation_map());
 	}
 
-	current_global_transform = get_global_transform();
-	NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
-	NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+	NavigationServer3D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
+	NavigationServer3D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 	NavigationServer3D::get_singleton()->link_set_enabled(link, enabled);
 
 #ifdef DEBUG_ENABLED
@@ -541,15 +535,11 @@ void NavigationLink3D::_link_update_transform() {
 		return;
 	}
 
-	Transform3D new_global_transform = get_global_transform();
-	if (current_global_transform != new_global_transform) {
-		current_global_transform = new_global_transform;
-		NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
-		NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+	NavigationServer3D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
+	NavigationServer3D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 #ifdef DEBUG_ENABLED
-		if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
-			_update_debug_mesh();
-		}
-#endif // DEBUG_ENABLED
+	if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+		_update_debug_mesh();
 	}
+#endif // DEBUG_ENABLED
 }

--- a/scene/3d/navigation/navigation_link_3d.h
+++ b/scene/3d/navigation/navigation_link_3d.h
@@ -47,8 +47,6 @@ class NavigationLink3D : public Node3D {
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
 
-	Transform3D current_global_transform;
-
 #ifdef DEBUG_ENABLED
 	RID debug_instance;
 	Ref<ArrayMesh> debug_mesh;


### PR DESCRIPTION
Removes the dependency on the physics process callback inside NavigationLinks to update their transforms and changes it back to just default transform notifications.

See similar region PR https://github.com/godotengine/godot/pull/119361 for more details.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
