### PR TITLE
Add offscreen display server rendering path

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -60,6 +60,8 @@ if env["metal"]:
         Exit(255)
     SConscript("metal/SCsub")
 
+SConscript("offscreen/SCsub")
+
 # Input drivers
 if env["sdl"] and env["platform"] in ["linuxbsd", "macos", "windows", "ios", "visionos"]:
     # TODO: Evaluate support for Android and Web.

--- a/drivers/offscreen/SCsub
+++ b/drivers/offscreen/SCsub
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+
+env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/offscreen/display_server_offscreen.cpp
+++ b/drivers/offscreen/display_server_offscreen.cpp
@@ -1,0 +1,340 @@
+/**************************************************************************/
+/*  display_server_offscreen.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+
+#include "display_server_offscreen.h"
+
+#include "core/os/os.h"
+#include "servers/rendering/rendering_context_driver.h"
+
+#ifdef RD_ENABLED
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#include "servers/rendering/rendering_device.h"
+#endif
+
+#ifdef VULKAN_ENABLED
+#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#endif
+
+DisplayServerOffscreen::VirtualWindow *DisplayServerOffscreen::_get_window(DisplayServerEnums::WindowID p_window) {
+	return p_window == DisplayServerEnums::MAIN_WINDOW_ID ? &main_window : nullptr;
+}
+
+const DisplayServerOffscreen::VirtualWindow *DisplayServerOffscreen::_get_window(DisplayServerEnums::WindowID p_window) const {
+	return p_window == DisplayServerEnums::MAIN_WINDOW_ID ? &main_window : nullptr;
+}
+
+Size2i DisplayServerOffscreen::_sanitize_size(const Size2i &p_size) const {
+	return Size2i(MAX(1, p_size.width), MAX(1, p_size.height));
+}
+
+Vector<String> DisplayServerOffscreen::get_rendering_drivers_func() {
+	Vector<String> drivers;
+#ifdef VULKAN_ENABLED
+	drivers.push_back("vulkan");
+#endif
+	return drivers;
+}
+
+DisplayServer *DisplayServerOffscreen::create_func(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error) {
+	DisplayServerOffscreen *ds = memnew(DisplayServerOffscreen(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, r_error));
+	if (r_error != OK) {
+		memdelete(ds);
+		return nullptr;
+	}
+	return ds;
+}
+
+void DisplayServerOffscreen::register_offscreen_driver() {
+	for (int i = 0; i < get_create_function_count(); i++) {
+		if (String(get_create_function_name(i)) == "offscreen") {
+			return;
+		}
+	}
+	register_create_function("offscreen", create_func, get_rendering_drivers_func, false);
+}
+
+void DisplayServerOffscreen::_initialize_rendering(const String &p_rendering_driver, Error &r_error) {
+#ifndef RD_ENABLED
+	r_error = ERR_UNAVAILABLE;
+	ERR_PRINT("The offscreen display server requires RenderingDevice support.");
+	return;
+#else
+	if (p_rendering_driver != "vulkan") {
+		r_error = ERR_UNAVAILABLE;
+		ERR_PRINT(vformat("The offscreen display server only supports the Vulkan rendering driver in this build, not '%s'.", p_rendering_driver));
+		return;
+	}
+
+#ifndef VULKAN_ENABLED
+	r_error = ERR_UNAVAILABLE;
+	ERR_PRINT("The offscreen display server requires Vulkan support in this build.");
+	return;
+#else
+	rendering_context = memnew(RenderingContextDriverVulkan);
+	if (rendering_context->initialize() != OK) {
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+		r_error = ERR_UNAVAILABLE;
+		ERR_PRINT("Could not initialize the offscreen Vulkan rendering context.");
+		return;
+	}
+
+	rendering_device = memnew(RenderingDevice);
+	if (rendering_device->initialize(rendering_context, DisplayServerEnums::INVALID_WINDOW_ID) != OK) {
+		memdelete(rendering_device);
+		rendering_device = nullptr;
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+		r_error = ERR_UNAVAILABLE;
+		ERR_PRINT("Could not initialize the offscreen RenderingDevice.");
+		return;
+	}
+
+	Error err = rendering_device->screen_create_virtual(DisplayServerEnums::MAIN_WINDOW_ID, main_window.size);
+	if (err != OK) {
+		memdelete(rendering_device);
+		rendering_device = nullptr;
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+		r_error = err;
+		ERR_PRINT("Could not create the offscreen virtual screen.");
+		return;
+	}
+
+	rendering_screen_created = true;
+	RendererCompositorRD::make_current();
+	r_error = OK;
+#endif
+#endif
+}
+
+Point2i DisplayServerOffscreen::screen_get_position(int p_screen) const {
+	return Point2i();
+}
+
+Size2i DisplayServerOffscreen::screen_get_size(int p_screen) const {
+	return main_window.size;
+}
+
+Rect2i DisplayServerOffscreen::screen_get_usable_rect(int p_screen) const {
+	return Rect2i(Point2i(), main_window.size);
+}
+
+Vector<DisplayServerEnums::WindowID> DisplayServerOffscreen::get_window_list() const {
+	Vector<DisplayServerEnums::WindowID> windows;
+	windows.push_back(DisplayServerEnums::MAIN_WINDOW_ID);
+	return windows;
+}
+
+DisplayServerEnums::WindowID DisplayServerOffscreen::create_sub_window(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, bool p_exclusive, DisplayServerEnums::WindowID p_transient_parent) {
+	ERR_PRINT_ONCE("Sub-windows are not supported by the offscreen display server.");
+	return DisplayServerEnums::INVALID_WINDOW_ID;
+}
+
+DisplayServerEnums::WindowID DisplayServerOffscreen::get_window_at_screen_position(const Point2i &p_position) const {
+	Rect2i rect(main_window.position, main_window.size);
+	return rect.has_point(p_position) ? DisplayServerEnums::MAIN_WINDOW_ID : DisplayServerEnums::INVALID_WINDOW_ID;
+}
+
+void DisplayServerOffscreen::window_attach_instance_id(ObjectID p_instance, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->attached_instance_id = p_instance;
+}
+
+ObjectID DisplayServerOffscreen::window_get_attached_instance_id(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->attached_instance_id : ObjectID();
+}
+
+void DisplayServerOffscreen::window_set_rect_changed_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->rect_changed_callback = p_callable;
+}
+
+void DisplayServerOffscreen::window_set_window_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->window_event_callback = p_callable;
+}
+
+void DisplayServerOffscreen::window_set_input_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->input_event_callback = p_callable;
+}
+
+void DisplayServerOffscreen::window_set_input_text_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->input_text_callback = p_callable;
+}
+
+void DisplayServerOffscreen::window_set_drop_files_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->drop_files_callback = p_callable;
+}
+
+void DisplayServerOffscreen::window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->title = p_title;
+}
+
+int DisplayServerOffscreen::window_get_current_screen(DisplayServerEnums::WindowID p_window) const {
+	return _get_window(p_window) ? 0 : DisplayServerEnums::INVALID_SCREEN;
+}
+
+Point2i DisplayServerOffscreen::window_get_position(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->position : Point2i();
+}
+
+Point2i DisplayServerOffscreen::window_get_position_with_decorations(DisplayServerEnums::WindowID p_window) const {
+	return window_get_position(p_window);
+}
+
+void DisplayServerOffscreen::window_set_position(const Point2i &p_position, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	if (window->position == p_position) {
+		return;
+	}
+	window->position = p_position;
+	if (window->rect_changed_callback.is_valid()) {
+		window->rect_changed_callback.call(Rect2i(window->position, window->size));
+	}
+}
+
+void DisplayServerOffscreen::window_set_max_size(const Size2i p_size, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->max_size = p_size;
+}
+
+Size2i DisplayServerOffscreen::window_get_max_size(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->max_size : Size2i();
+}
+
+void DisplayServerOffscreen::window_set_min_size(const Size2i p_size, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->min_size = p_size;
+}
+
+Size2i DisplayServerOffscreen::window_get_min_size(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->min_size : Size2i();
+}
+
+void DisplayServerOffscreen::window_set_size(const Size2i p_size, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+
+	Size2i size = _sanitize_size(p_size);
+	if (window->size == size) {
+		return;
+	}
+
+#ifdef RD_ENABLED
+	if (rendering_device && rendering_screen_created) {
+		Error err = rendering_device->screen_resize_virtual(p_window, size);
+		ERR_FAIL_COND_MSG(err != OK, "Unable to resize the offscreen virtual screen.");
+	}
+#endif
+
+	window->size = size;
+	if (window->rect_changed_callback.is_valid()) {
+		window->rect_changed_callback.call(Rect2i(window->position, window->size));
+	}
+}
+
+Size2i DisplayServerOffscreen::window_get_size(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->size : Size2i();
+}
+
+Size2i DisplayServerOffscreen::window_get_size_with_decorations(DisplayServerEnums::WindowID p_window) const {
+	return window_get_size(p_window);
+}
+
+void DisplayServerOffscreen::window_set_mode(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->mode = p_mode;
+}
+
+DisplayServerEnums::WindowMode DisplayServerOffscreen::window_get_mode(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->mode : DisplayServerEnums::WINDOW_MODE_WINDOWED;
+}
+
+void DisplayServerOffscreen::window_set_vsync_mode(DisplayServerEnums::VSyncMode p_vsync_mode, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	window->vsync_mode = p_vsync_mode;
+}
+
+DisplayServerEnums::VSyncMode DisplayServerOffscreen::window_get_vsync_mode(DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? window->vsync_mode : DisplayServerEnums::VSYNC_DISABLED;
+}
+
+void DisplayServerOffscreen::window_set_flag(DisplayServerEnums::WindowFlags p_flag, bool p_enabled, DisplayServerEnums::WindowID p_window) {
+	VirtualWindow *window = _get_window(p_window);
+	ERR_FAIL_NULL(window);
+	if (p_enabled) {
+		window->flags |= (1 << p_flag);
+	} else {
+		window->flags &= ~(1 << p_flag);
+	}
+}
+
+bool DisplayServerOffscreen::window_get_flag(DisplayServerEnums::WindowFlags p_flag, DisplayServerEnums::WindowID p_window) const {
+	const VirtualWindow *window = _get_window(p_window);
+	return window ? (window->flags & (1 << p_flag)) != 0 : false;
+}
+
+bool DisplayServerOffscreen::window_is_focused(DisplayServerEnums::WindowID p_window) const {
+	return _get_window(p_window) != nullptr;
+}
+
+bool DisplayServerOffscreen::window_can_draw(DisplayServerEnums::WindowID p_window) const {
+	return _get_window(p_window) != nullptr;
+}
+
+DisplayServerOffscreen::DisplayServerOffscreen(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, Error &r_error) {
+	main_window.size = _sanitize_size(p_resolution);
+	main_window.position = p_position ? *p_position : Point2i();
+	main_window.mode = p_mode;
+	main_window.vsync_mode = p_vsync_mode;
+	main_window.flags = p_flags;
+
+	_initialize_rendering(p_rendering_driver, r_error);
+}
+
+DisplayServerOffscreen::~DisplayServerOffscreen() {
+#ifdef RD_ENABLED
+	if (rendering_device) {
+		if (rendering_screen_created) {
+			rendering_device->screen_free(DisplayServerEnums::MAIN_WINDOW_ID);
+			rendering_screen_created = false;
+		}
+		memdelete(rendering_device);
+		rendering_device = nullptr;
+	}
+#endif
+
+	if (rendering_context) {
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+	}
+}

--- a/drivers/offscreen/display_server_offscreen.h
+++ b/drivers/offscreen/display_server_offscreen.h
@@ -1,0 +1,111 @@
+/**************************************************************************/
+/*  display_server_offscreen.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+
+#pragma once
+
+#include "servers/display/display_server_headless.h"
+
+class RenderingContextDriver;
+class RenderingDevice;
+
+class DisplayServerOffscreen : public DisplayServerHeadless {
+	GDSOFTCLASS(DisplayServerOffscreen, DisplayServerHeadless);
+
+	struct VirtualWindow {
+		Size2i size;
+		Size2i min_size;
+		Size2i max_size;
+		Point2i position;
+		String title;
+		DisplayServerEnums::WindowMode mode = DisplayServerEnums::WINDOW_MODE_WINDOWED;
+		DisplayServerEnums::VSyncMode vsync_mode = DisplayServerEnums::VSYNC_DISABLED;
+		uint32_t flags = 0;
+		ObjectID attached_instance_id;
+		Callable rect_changed_callback;
+		Callable window_event_callback;
+		Callable input_event_callback;
+		Callable input_text_callback;
+		Callable drop_files_callback;
+	};
+
+	VirtualWindow main_window;
+	RenderingContextDriver *rendering_context = nullptr;
+	RenderingDevice *rendering_device = nullptr;
+	bool rendering_screen_created = false;
+
+	VirtualWindow *_get_window(DisplayServerEnums::WindowID p_window);
+	const VirtualWindow *_get_window(DisplayServerEnums::WindowID p_window) const;
+	Size2i _sanitize_size(const Size2i &p_size) const;
+	void _initialize_rendering(const String &p_rendering_driver, Error &r_error);
+
+	static Vector<String> get_rendering_drivers_func();
+	static DisplayServer *create_func(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error);
+
+public:
+	static void register_offscreen_driver();
+
+	bool has_feature(DisplayServerEnums::Feature p_feature) const override { return false; }
+	String get_name() const override { return "offscreen"; }
+
+	int get_screen_count() const override { return 1; }
+	int get_primary_screen() const override { return 0; }
+	Point2i screen_get_position(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	Size2i screen_get_size(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	Rect2i screen_get_usable_rect(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	int screen_get_dpi(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override { return 96; }
+	float screen_get_scale(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override { return 1.0f; }
+	float screen_get_max_scale() const override { return 1.0f; }
+	float screen_get_refresh_rate(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override { return SCREEN_REFRESH_RATE_FALLBACK; }
+
+	Vector<DisplayServerEnums::WindowID> get_window_list() const override;
+	DisplayServerEnums::WindowID create_sub_window(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i(), bool p_exclusive = false, DisplayServerEnums::WindowID p_transient_parent = DisplayServerEnums::INVALID_WINDOW_ID) override;
+	void delete_sub_window(DisplayServerEnums::WindowID p_id) override {}
+	DisplayServerEnums::WindowID get_window_at_screen_position(const Point2i &p_position) const override;
+
+	void window_attach_instance_id(ObjectID p_instance, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	ObjectID window_get_attached_instance_id(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_rect_changed_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	void window_set_window_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	void window_set_input_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	void window_set_input_text_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	void window_set_drop_files_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+
+	void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	int window_get_current_screen(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_current_screen(int p_screen, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override {}
+	Point2i window_get_position(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	Point2i window_get_position_with_decorations(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_position(const Point2i &p_position, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	void window_set_transient(DisplayServerEnums::WindowID p_window, DisplayServerEnums::WindowID p_parent) override {}
+	void window_set_max_size(const Size2i p_size, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	Size2i window_get_max_size(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_min_size(const Size2i p_size, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	Size2i window_get_min_size(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_size(const Size2i p_size, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	Size2i window_get_size(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	Size2i window_get_size_with_decorations(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_mode(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	DisplayServerEnums::WindowMode window_get_mode(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_set_vsync_mode(DisplayServerEnums::VSyncMode p_vsync_mode, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	DisplayServerEnums::VSyncMode window_get_vsync_mode(DisplayServerEnums::WindowID p_window) const override;
+	bool window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override { return false; }
+	bool window_is_hdr_output_requested(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override { return false; }
+	bool window_is_hdr_output_enabled(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override { return false; }
+	bool window_is_maximize_allowed(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override { return false; }
+	void window_set_flag(DisplayServerEnums::WindowFlags p_flag, bool p_enabled, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
+	bool window_get_flag(DisplayServerEnums::WindowFlags p_flag, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	void window_request_attention(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override {}
+	void window_move_to_foreground(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override {}
+	bool window_is_focused(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	DisplayServerEnums::WindowID get_focused_window() const override { return DisplayServerEnums::MAIN_WINDOW_ID; }
+	bool window_can_draw(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override;
+	bool can_any_window_draw() const override { return true; }
+
+	DisplayServerOffscreen(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Point2i *p_position, const Size2i &p_resolution, Error &r_error);
+	~DisplayServerOffscreen();
+};

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -31,6 +31,7 @@
 #include "register_driver_types.h"
 
 #include "core/io/resource_saver.h"
+#include "drivers/offscreen/display_server_offscreen.h"
 #include "drivers/png/image_loader_png.h"
 #include "drivers/png/resource_saver_png.h"
 
@@ -42,6 +43,8 @@ static Ref<ImageLoaderPNG> image_loader_png;
 static Ref<ResourceSaverPNG> resource_saver_png;
 
 void register_core_driver_types() {
+	DisplayServerOffscreen::register_offscreen_driver();
+
 #ifdef ACCESSKIT_ENABLED
 	AccessibilityServerAccessKit::register_create_func();
 #endif
@@ -62,6 +65,7 @@ void unregister_core_driver_types() {
 }
 
 void register_driver_types() {
+	DisplayServerOffscreen::register_offscreen_driver();
 }
 
 void unregister_driver_types() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -298,6 +298,7 @@ bool profile_gpu = false;
 // Constants.
 
 static const String NULL_DISPLAY_DRIVER("headless");
+static const String OFFSCREEN_DISPLAY_DRIVER("offscreen");
 static const String EMBEDDED_DISPLAY_DRIVER("embedded");
 static const String NULL_AUDIO_DRIVER("Dummy");
 
@@ -621,6 +622,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--text-driver <driver>", "Text driver (used for font rendering, bidirectional support and shaping).\n");
 	print_help_option("--tablet-driver <driver>", "Pen tablet input driver.\n");
 	print_help_option("--headless", "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
+	print_help_option("--offscreen", "Enable offscreen rendering mode (--display-driver offscreen). Rendering stays enabled, but no native window is shown.\n");
 	print_help_option("--log-file <file>", "Write output/error log to the specified path instead of the default location defined by the project.\n");
 	print_help_option("", "<file> path should be absolute or relative to the project directory.\n");
 	print_help_option("--write-movie <file>", "Write a video to the specified path (usually with .avi or .png extension).\n");
@@ -1129,6 +1131,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String default_renderer = "";
 	String default_renderer_mobile = "";
 	String renderer_hints = "";
+	bool headless_mode_requested = false;
+	bool offscreen_mode_requested = false;
 
 	packed_data = PackedData::get_singleton();
 	if (!packed_data) {
@@ -1280,6 +1284,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			if (N) {
 				display_driver = N->get();
+				if (display_driver == NULL_DISPLAY_DRIVER) {
+					headless_mode_requested = true;
+				} else if (display_driver == OFFSCREEN_DISPLAY_DRIVER) {
+					offscreen_mode_requested = true;
+				}
 
 				bool found = false;
 				for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
@@ -1496,8 +1505,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (arg == "--headless") { // enable headless mode (no audio, no rendering).
 
+			headless_mode_requested = true;
 			audio_driver = NULL_AUDIO_DRIVER;
 			display_driver = NULL_DISPLAY_DRIVER;
+
+		} else if (arg == "--offscreen") { // enable offscreen mode (no native window, rendering enabled).
+
+			offscreen_mode_requested = true;
+			display_driver = OFFSCREEN_DISPLAY_DRIVER;
 
 		} else if (arg == "--embedded") { // Enable embedded mode.
 #ifdef MACOS_ENABLED
@@ -2047,6 +2062,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 
 		I = N;
+	}
+
+	if (headless_mode_requested && offscreen_mode_requested) {
+		OS::get_singleton()->print("Error: --headless and --offscreen are mutually exclusive.\n");
+		goto error;
+	}
+
+	if (offscreen_mode_requested && rendering_driver.is_empty()) {
+#ifdef VULKAN_ENABLED
+		rendering_driver = "vulkan";
+		rendering_driver_source = OS::RenderingSource::RENDERING_SOURCE_DEFAULT;
+#else
+		OS::get_singleton()->print("Error: --offscreen requires a build with Vulkan support.\n");
+		goto error;
+#endif
 	}
 
 #ifdef TOOLS_ENABLED
@@ -2766,12 +2796,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	DEV_ASSERT(NULL_DISPLAY_DRIVER == DisplayServer::get_create_function_name(DisplayServer::get_create_function_count() - 1));
 
 	GLOBAL_DEF_NOVAL("display/display_server/driver", "default");
-	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.windows", PROPERTY_HINT_ENUM, "default,windows,headless"), "default");
-	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.linuxbsd", PROPERTY_HINT_ENUM, "default,x11,wayland,headless"), "default");
+	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.windows", PROPERTY_HINT_ENUM, "default,windows,offscreen,headless"), "default");
+	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.linuxbsd", PROPERTY_HINT_ENUM, "default,x11,wayland,offscreen,headless"), "default");
 	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.android", PROPERTY_HINT_ENUM, "default,android,headless"), "default");
 	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.ios", PROPERTY_HINT_ENUM, "default,iOS,headless"), "default");
 	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.visionos", PROPERTY_HINT_ENUM, "default,visionOS,headless"), "default");
-	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.macos", PROPERTY_HINT_ENUM, "default,macos,headless"), "default");
+	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::STRING, "display/display_server/driver.macos", PROPERTY_HINT_ENUM, "default,macos,offscreen,headless"), "default");
 
 	GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
 	if (audio_driver.is_empty()) { // Specified in project.godot.
@@ -3227,7 +3257,15 @@ Error Main::setup2(bool p_show_boot_logo) {
 		int display_driver_idx = -1;
 
 		if (display_driver.is_empty() || display_driver == "default") {
-			display_driver_idx = 0;
+			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
+				if (DisplayServer::get_create_function_fallback_eligible(i)) {
+					display_driver_idx = i;
+					break;
+				}
+			}
+			if (display_driver_idx < 0) {
+				display_driver_idx = 0;
+			}
 		} else {
 			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 				String name = DisplayServer::get_create_function_name(i);
@@ -3238,9 +3276,17 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 
 			if (display_driver_idx < 0) {
-				// If the requested driver wasn't found, pick the first entry.
+				// If the requested driver wasn't found, pick the first fallback-eligible entry.
 				// If all else failed it would be the headless server.
-				display_driver_idx = 0;
+				for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
+					if (DisplayServer::get_create_function_fallback_eligible(i)) {
+						display_driver_idx = i;
+						break;
+					}
+				}
+				if (display_driver_idx < 0) {
+					display_driver_idx = 0;
+				}
 			}
 		}
 
@@ -3296,7 +3342,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 				accessibility_driver_name = "accesskit";
 			}
 		}
-		if (display_driver == NULL_DISPLAY_DRIVER || display_driver == EMBEDDED_DISPLAY_DRIVER || accessibility_mode == AccessibilityServerEnums::AccessibilityMode::ACCESSIBILITY_DISABLED) {
+		if (display_driver == NULL_DISPLAY_DRIVER || display_driver == OFFSCREEN_DISPLAY_DRIVER || display_driver == EMBEDDED_DISPLAY_DRIVER || accessibility_mode == AccessibilityServerEnums::AccessibilityMode::ACCESSIBILITY_DISABLED) {
 			accessibility_driver_name = "dummy";
 		}
 		int accessibility_driver_idx = -1;
@@ -3341,15 +3387,18 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 		String rendering_driver = OS::get_singleton()->get_current_rendering_driver_name();
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, init_embed_parent_window_id, err);
-		if (err != OK || display_server == nullptr) {
+		if ((err != OK || display_server == nullptr) && DisplayServer::get_create_function_fallback_eligible(display_driver_idx)) {
 			String last_name = DisplayServer::get_create_function_name(display_driver_idx);
 
 			// We can't use this display server, try other ones as fallback.
-			// Skip headless (always last registered) because that's not what users
-			// would expect if they didn't request it explicitly.
-			for (int i = 0; i < DisplayServer::get_create_function_count() - 1; i++) {
+			// Skip explicit-only display servers such as headless and offscreen because
+			// that's not what users would expect if they didn't request them explicitly.
+			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 				if (i == display_driver_idx) {
 					continue; // Don't try the same twice.
+				}
+				if (!DisplayServer::get_create_function_fallback_eligible(i)) {
+					continue;
 				}
 				String name = DisplayServer::get_create_function_name(i);
 				WARN_PRINT(vformat("Display driver %s failed, falling back to %s.", last_name, name));

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -65,7 +65,7 @@ bool DisplayServer::window_early_clear_override_enabled = false;
 Color DisplayServer::window_early_clear_override_color = Color(0, 0, 0, 0);
 
 DisplayServer::DisplayServerCreate DisplayServer::server_create_functions[DisplayServer::MAX_SERVERS] = {
-	{ "headless", &DisplayServerHeadless::create_func, &DisplayServerHeadless::get_rendering_drivers_func }
+	{ "headless", &DisplayServerHeadless::create_func, &DisplayServerHeadless::get_rendering_drivers_func, false }
 };
 
 int DisplayServer::server_create_count = 1;
@@ -2024,13 +2024,14 @@ Ref<Image> DisplayServer::_get_cursor_image_from_resource(const Ref<Resource> &p
 	return image;
 }
 
-void DisplayServer::register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers) {
+void DisplayServer::register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers, bool p_fallback_eligible) {
 	ERR_FAIL_COND(server_create_count == MAX_SERVERS);
 	// Headless display server is always last
 	server_create_functions[server_create_count] = server_create_functions[server_create_count - 1];
 	server_create_functions[server_create_count - 1].name = p_name;
 	server_create_functions[server_create_count - 1].create_function = p_function;
 	server_create_functions[server_create_count - 1].get_rendering_drivers_function = p_get_drivers;
+	server_create_functions[server_create_count - 1].fallback_eligible = p_fallback_eligible;
 	server_create_count++;
 }
 
@@ -2046,6 +2047,11 @@ const char *DisplayServer::get_create_function_name(int p_index) {
 Vector<String> DisplayServer::get_create_function_rendering_drivers(int p_index) {
 	ERR_FAIL_INDEX_V(p_index, server_create_count, Vector<String>());
 	return server_create_functions[p_index].get_rendering_drivers_function();
+}
+
+bool DisplayServer::get_create_function_fallback_eligible(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, server_create_count, false);
+	return server_create_functions[p_index].fallback_eligible;
 }
 
 DisplayServer *DisplayServer::create(int p_index, const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error) {

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -83,16 +83,18 @@ private:
 		const char *name;
 		CreateFunction create_function;
 		GetRenderingDriversFunction get_rendering_drivers_function;
+		bool fallback_eligible = true;
 	};
 
 	static DisplayServerCreate server_create_functions[MAX_SERVERS];
 	static int server_create_count;
 
 public:
-	static void register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers);
+	static void register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers, bool p_fallback_eligible = true);
 	static int get_create_function_count();
 	static const char *get_create_function_name(int p_index);
 	static Vector<String> get_create_function_rendering_drivers(int p_index);
+	static bool get_create_function_fallback_eligible(int p_index);
 	static DisplayServer *create(int p_index, const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error);
 
 	DisplayServer();

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5349,6 +5349,8 @@ uint32_t RenderingDevice::_get_swap_chain_desired_count() const {
 Error RenderingDevice::screen_create(DisplayServerEnums::WindowID p_screen) {
 	_THREAD_SAFE_METHOD_
 
+	ERR_FAIL_COND_V_MSG(virtual_screens.has(p_screen), ERR_CANT_CREATE, "A virtual screen was already created for the screen.");
+
 	RenderingContextDriver::SurfaceID surface = context->surface_get_from_window(p_screen);
 	ERR_FAIL_COND_V_MSG(surface == 0, ERR_CANT_CREATE, "A surface was not created for the screen.");
 
@@ -5363,8 +5365,115 @@ Error RenderingDevice::screen_create(DisplayServerEnums::WindowID p_screen) {
 	return OK;
 }
 
+Error RenderingDevice::screen_create_virtual(DisplayServerEnums::WindowID p_screen, const Size2i &p_size, DataFormat p_format) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V_MSG(p_size.width <= 0 || p_size.height <= 0, ERR_INVALID_PARAMETER, "A virtual screen must have a positive size.");
+	ERR_FAIL_COND_V_MSG(screen_swap_chains.has(p_screen), ERR_CANT_CREATE, "A native swap chain was already created for the screen.");
+	ERR_FAIL_COND_V_MSG(virtual_screens.has(p_screen), ERR_CANT_CREATE, "A virtual screen was already created for the screen.");
+
+	const uint32_t usage_bits = TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | TEXTURE_USAGE_SAMPLING_BIT | TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+	if (!texture_is_format_supported_for_usage(p_format, usage_bits)) {
+		p_format = DATA_FORMAT_R8G8B8A8_UNORM;
+		ERR_FAIL_COND_V_MSG(!texture_is_format_supported_for_usage(p_format, usage_bits), ERR_CANT_CREATE, "No supported texture format was found for a virtual screen.");
+	}
+
+	TextureFormat texture_format;
+	texture_format.format = p_format;
+	texture_format.width = p_size.width;
+	texture_format.height = p_size.height;
+	texture_format.texture_type = TEXTURE_TYPE_2D;
+	texture_format.usage_bits = usage_bits;
+
+	TextureView texture_view;
+	RID texture = texture_create(texture_format, texture_view);
+	ERR_FAIL_COND_V_MSG(texture.is_null(), ERR_CANT_CREATE, "Unable to create a virtual screen texture.");
+
+	Vector<RID> attachments;
+	attachments.push_back(texture);
+	RID framebuffer = framebuffer_create(attachments);
+	if (framebuffer.is_null()) {
+		free_rid(texture);
+		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Unable to create a virtual screen framebuffer.");
+	}
+
+	VirtualScreen virtual_screen;
+	virtual_screen.texture = texture;
+	virtual_screen.framebuffer = framebuffer;
+	virtual_screen.size = p_size;
+	virtual_screen.format = p_format;
+	virtual_screen.framebuffer_format = framebuffer_get_format(framebuffer);
+	virtual_screens[p_screen] = virtual_screen;
+
+	return OK;
+}
+
+Error RenderingDevice::screen_resize_virtual(DisplayServerEnums::WindowID p_screen, const Size2i &p_size) {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator it = virtual_screens.find(p_screen);
+	ERR_FAIL_COND_V_MSG(it == virtual_screens.end(), ERR_DOES_NOT_EXIST, "A virtual screen was not created for the screen.");
+	ERR_FAIL_COND_V_MSG(p_size.width <= 0 || p_size.height <= 0, ERR_INVALID_PARAMETER, "A virtual screen must have a positive size.");
+
+	if (it->value.size == p_size) {
+		return OK;
+	}
+
+	DataFormat format = it->value.format;
+	RID old_framebuffer = it->value.framebuffer;
+	RID old_texture = it->value.texture;
+	virtual_screens.erase(p_screen);
+
+	_flush_and_stall_for_all_frames();
+	if (old_framebuffer.is_valid()) {
+		free_rid(old_framebuffer);
+	}
+	if (old_texture.is_valid()) {
+		free_rid(old_texture);
+	}
+
+	const uint32_t usage_bits = TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | TEXTURE_USAGE_SAMPLING_BIT | TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+	if (!texture_is_format_supported_for_usage(format, usage_bits)) {
+		format = DATA_FORMAT_R8G8B8A8_UNORM;
+		ERR_FAIL_COND_V_MSG(!texture_is_format_supported_for_usage(format, usage_bits), ERR_CANT_CREATE, "No supported texture format was found for a virtual screen.");
+	}
+
+	TextureFormat texture_format;
+	texture_format.format = format;
+	texture_format.width = p_size.width;
+	texture_format.height = p_size.height;
+	texture_format.texture_type = TEXTURE_TYPE_2D;
+	texture_format.usage_bits = usage_bits;
+
+	TextureView texture_view;
+	RID texture = texture_create(texture_format, texture_view);
+	ERR_FAIL_COND_V_MSG(texture.is_null(), ERR_CANT_CREATE, "Unable to create a virtual screen texture.");
+
+	Vector<RID> attachments;
+	attachments.push_back(texture);
+	RID framebuffer = framebuffer_create(attachments);
+	if (framebuffer.is_null()) {
+		free_rid(texture);
+		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Unable to create a virtual screen framebuffer.");
+	}
+
+	VirtualScreen virtual_screen;
+	virtual_screen.texture = texture;
+	virtual_screen.framebuffer = framebuffer;
+	virtual_screen.size = p_size;
+	virtual_screen.format = format;
+	virtual_screen.framebuffer_format = framebuffer_get_format(framebuffer);
+	virtual_screens[p_screen] = virtual_screen;
+
+	return OK;
+}
+
 Error RenderingDevice::screen_prepare_for_drawing(DisplayServerEnums::WindowID p_screen) {
 	_THREAD_SAFE_METHOD_
+
+	if (virtual_screens.has(p_screen)) {
+		return OK;
+	}
 
 	// After submitting work, acquire the swapchain image(s).
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
@@ -5416,6 +5525,11 @@ Error RenderingDevice::screen_prepare_for_drawing(DisplayServerEnums::WindowID p
 int RenderingDevice::screen_get_width(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
 
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		return virtual_it->value.size.width;
+	}
+
 	RenderingContextDriver::SurfaceID surface = context->surface_get_from_window(p_screen);
 	ERR_FAIL_COND_V_MSG(surface == 0, 0, "A surface was not created for the screen.");
 	return context->surface_get_width(surface);
@@ -5423,6 +5537,11 @@ int RenderingDevice::screen_get_width(DisplayServerEnums::WindowID p_screen) con
 
 int RenderingDevice::screen_get_height(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		return virtual_it->value.size.height;
+	}
 
 	RenderingContextDriver::SurfaceID surface = context->surface_get_from_window(p_screen);
 	ERR_FAIL_COND_V_MSG(surface == 0, 0, "A surface was not created for the screen.");
@@ -5432,6 +5551,10 @@ int RenderingDevice::screen_get_height(DisplayServerEnums::WindowID p_screen) co
 int RenderingDevice::screen_get_pre_rotation_degrees(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
 
+	if (virtual_screens.has(p_screen)) {
+		return 0;
+	}
+
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
 	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), ERR_CANT_CREATE, "A swap chain was not created for the screen.");
 
@@ -5440,6 +5563,11 @@ int RenderingDevice::screen_get_pre_rotation_degrees(DisplayServerEnums::WindowI
 
 RenderingDevice::FramebufferFormatID RenderingDevice::screen_get_framebuffer_format(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		return virtual_it->value.framebuffer_format;
+	}
 
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
 	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), INVALID_ID, "Screen was never prepared.");
@@ -5459,6 +5587,11 @@ RenderingDevice::FramebufferFormatID RenderingDevice::screen_get_framebuffer_for
 RenderingDevice::ColorSpace RenderingDevice::screen_get_color_space(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
 
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		return virtual_it->value.color_space;
+	}
+
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
 	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), COLOR_SPACE_MAX, "Screen was never prepared.");
 
@@ -5470,6 +5603,10 @@ RenderingDevice::ColorSpace RenderingDevice::screen_get_color_space(DisplayServe
 bool RenderingDevice::screen_get_hdr_output_supported(DisplayServerEnums::WindowID p_screen) const {
 	_THREAD_SAFE_METHOD_
 
+	if (virtual_screens.has(p_screen)) {
+		return false;
+	}
+
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
 	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), false, "Screen was never prepared.");
 
@@ -5478,6 +5615,24 @@ bool RenderingDevice::screen_get_hdr_output_supported(DisplayServerEnums::Window
 
 Error RenderingDevice::screen_free(DisplayServerEnums::WindowID p_screen) {
 	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::Iterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		_flush_and_stall_for_all_frames();
+
+		const RID framebuffer = virtual_it->value.framebuffer;
+		const RID texture = virtual_it->value.texture;
+		virtual_screens.erase(p_screen);
+
+		if (framebuffer.is_valid()) {
+			free_rid(framebuffer);
+		}
+		if (texture.is_valid()) {
+			free_rid(texture);
+		}
+
+		return OK;
+	}
 
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
 	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), FAILED, "Screen was never created.");
@@ -5504,6 +5659,13 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin_for_screen(DisplayS
 	ERR_FAIL_COND_V_MSG(draw_list.active, INVALID_ID, "Only one draw list can be active at the same time.");
 	ERR_FAIL_COND_V_MSG(compute_list.active, INVALID_ID, "Only one draw/compute list can be active at the same time.");
 	ERR_FAIL_COND_V_MSG(raytracing_list.active, INVALID_ID, "Only one draw/raytracing list can be active at the same time.");
+
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen>::ConstIterator virtual_it = virtual_screens.find(p_screen);
+	if (virtual_it != virtual_screens.end()) {
+		Vector<Color> clear_colors;
+		clear_colors.push_back(p_clear_color);
+		return draw_list_begin(virtual_it->value.framebuffer, DRAW_CLEAR_COLOR_0, clear_colors, 1.0f, 0, Rect2(), RDD::BreadcrumbMarker::BLIT_PASS);
+	}
 
 	RenderingContextDriver::SurfaceID surface = context->surface_get_from_window(p_screen);
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID>::ConstIterator sc_it = screen_swap_chains.find(p_screen);
@@ -8298,7 +8460,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 
 	Error err;
 	RenderingContextDriver::SurfaceID main_surface = 0;
-	is_main_instance = (singleton == this) && (p_main_window != DisplayServerEnums::INVALID_WINDOW_ID);
+	is_main_instance = singleton == this;
 	if (p_main_window != DisplayServerEnums::INVALID_WINDOW_ID) {
 		// Retrieve the surface from the main window if it was specified.
 		main_surface = p_context->surface_get_from_window(p_main_window);
@@ -8848,6 +9010,26 @@ void RenderingDevice::finalize() {
 
 	// Delete everything the graph has created.
 	draw_graph.finalize();
+
+	LocalVector<DisplayServerEnums::WindowID> virtual_screen_ids;
+	for (const KeyValue<DisplayServerEnums::WindowID, VirtualScreen> &it : virtual_screens) {
+		virtual_screen_ids.push_back(it.key);
+	}
+	for (DisplayServerEnums::WindowID window_id : virtual_screen_ids) {
+		HashMap<DisplayServerEnums::WindowID, VirtualScreen>::Iterator virtual_it = virtual_screens.find(window_id);
+		if (virtual_it != virtual_screens.end()) {
+			RID framebuffer = virtual_it->value.framebuffer;
+			RID texture = virtual_it->value.texture;
+			virtual_screens.erase(window_id);
+
+			if (framebuffer.is_valid()) {
+				free_rid(framebuffer);
+			}
+			if (texture.is_valid()) {
+				free_rid(texture);
+			}
+		}
+	}
 
 	// Free all resources.
 	_free_rids(render_pipeline_owner, "Pipeline");

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1299,13 +1299,25 @@ private:
 	/****************/
 	/**** SCREEN ****/
 	/****************/
+	struct VirtualScreen {
+		RID texture;
+		RID framebuffer;
+		Size2i size;
+		DataFormat format = DATA_FORMAT_B8G8R8A8_UNORM;
+		ColorSpace color_space = COLOR_SPACE_REC709_NONLINEAR_SRGB;
+		FramebufferFormatID framebuffer_format = INVALID_ID;
+	};
+
 	HashMap<DisplayServerEnums::WindowID, RDD::SwapChainID> screen_swap_chains;
 	HashMap<DisplayServerEnums::WindowID, RDD::FramebufferID> screen_framebuffers;
+	HashMap<DisplayServerEnums::WindowID, VirtualScreen> virtual_screens;
 
 	uint32_t _get_swap_chain_desired_count() const;
 
 public:
 	Error screen_create(DisplayServerEnums::WindowID p_screen = DisplayServerEnums::MAIN_WINDOW_ID);
+	Error screen_create_virtual(DisplayServerEnums::WindowID p_screen, const Size2i &p_size, DataFormat p_format = DATA_FORMAT_B8G8R8A8_UNORM);
+	Error screen_resize_virtual(DisplayServerEnums::WindowID p_screen, const Size2i &p_size);
 	Error screen_prepare_for_drawing(DisplayServerEnums::WindowID p_screen = DisplayServerEnums::MAIN_WINDOW_ID);
 	int screen_get_width(DisplayServerEnums::WindowID p_screen = DisplayServerEnums::MAIN_WINDOW_ID) const;
 	int screen_get_height(DisplayServerEnums::WindowID p_screen = DisplayServerEnums::MAIN_WINDOW_ID) const;

--- a/tests/rendering/offscreen_compare/capture_scene.gd
+++ b/tests/rendering/offscreen_compare/capture_scene.gd
@@ -1,0 +1,92 @@
+extends Node3D
+
+const DEFAULT_OUTPUT := "user://offscreen_compare_capture.png"
+
+func _ready() -> void:
+	_build_scene()
+
+	await RenderingServer.frame_post_draw
+	await RenderingServer.frame_post_draw
+
+	var image := get_viewport().get_texture().get_image()
+	var output_path := _get_user_arg_value("--capture-output", DEFAULT_OUTPUT)
+	var err := image.save_png(output_path)
+	if image.is_empty() or err != OK:
+		push_error("Failed to save capture to %s, image empty: %s, error: %s" % [output_path, image.is_empty(), error_string(err)])
+		get_tree().quit(1)
+	else:
+		print("CAPTURE_PATH=", output_path)
+		print("CAPTURE_SIZE=", image.get_width(), "x", image.get_height())
+
+	get_tree().quit()
+
+func _build_scene() -> void:
+	var world := WorldEnvironment.new()
+	var env := Environment.new()
+	env.background_mode = Environment.BG_COLOR
+	env.background_color = Color(0.06, 0.08, 0.11)
+	env.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+	env.ambient_light_color = Color(0.24, 0.28, 0.34)
+	env.ambient_light_energy = 0.7
+	world.environment = env
+	add_child(world)
+
+	var camera := Camera3D.new()
+	camera.look_at_from_position(Vector3(0.0, 1.25, 5.0), Vector3(0.0, 0.5, 0.0))
+	camera.current = true
+	add_child(camera)
+
+	var light := DirectionalLight3D.new()
+	light.rotation_degrees = Vector3(-45.0, -35.0, 0.0)
+	light.light_energy = 2.5
+	add_child(light)
+
+	var cube := MeshInstance3D.new()
+	cube.mesh = BoxMesh.new()
+	cube.position = Vector3(-0.95, 0.6, 0.0)
+	cube.rotation_degrees = Vector3(22.0, 35.0, 0.0)
+	cube.material_override = _make_material(Color(0.95, 0.22, 0.16))
+	add_child(cube)
+
+	var sphere := MeshInstance3D.new()
+	sphere.mesh = SphereMesh.new()
+	sphere.position = Vector3(0.9, 0.55, 0.0)
+	sphere.material_override = _make_material(Color(0.1, 0.65, 1.0))
+	add_child(sphere)
+
+	var plane := MeshInstance3D.new()
+	var plane_mesh := PlaneMesh.new()
+	plane_mesh.size = Vector2(5.0, 3.0)
+	plane.mesh = plane_mesh
+	plane.position = Vector3(0.0, -0.05, 0.0)
+	plane.material_override = _make_material(Color(0.18, 0.22, 0.18))
+	add_child(plane)
+
+	var overlay := Control.new()
+	overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(overlay)
+
+	var banner := ColorRect.new()
+	banner.color = Color(0.0, 0.0, 0.0, 0.45)
+	banner.position = Vector2(18.0, 18.0)
+	banner.size = Vector2(282.0, 58.0)
+	overlay.add_child(banner)
+
+	var label := Label.new()
+	label.text = "OFFSCREEN RD VISUAL"
+	label.position = Vector2(32.0, 34.0)
+	overlay.add_child(label)
+
+func _make_material(color: Color) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = color
+	mat.roughness = 0.55
+	mat.metallic = 0.0
+	return mat
+
+func _get_user_arg_value(name: String, default_value: String) -> String:
+	var args := OS.get_cmdline_user_args()
+	for i in range(args.size()):
+		if args[i] == name and i + 1 < args.size():
+			return args[i + 1]
+	return default_value

--- a/tests/rendering/offscreen_compare/compare_images.gd
+++ b/tests/rendering/offscreen_compare/compare_images.gd
@@ -1,0 +1,91 @@
+extends SceneTree
+
+func _initialize() -> void:
+	var reference_path := _get_required_arg("--reference")
+	var candidate_path := _get_required_arg("--candidate")
+	var diff_path := _get_user_arg_value("--diff", "")
+	var max_channel_delta := _get_user_arg_value("--max-channel-delta", "0").to_int()
+	var max_different_pixels := _get_user_arg_value("--max-different-pixels", "0").to_int()
+
+	var reference := Image.new()
+	var candidate := Image.new()
+	var err := reference.load(reference_path)
+	if err != OK:
+		_fail("Failed to load reference image: %s (%s)" % [reference_path, error_string(err)])
+		return
+
+	err = candidate.load(candidate_path)
+	if err != OK:
+		_fail("Failed to load candidate image: %s (%s)" % [candidate_path, error_string(err)])
+		return
+
+	if reference.get_width() != candidate.get_width() or reference.get_height() != candidate.get_height():
+		_fail("Image sizes differ: reference=%dx%d candidate=%dx%d" % [reference.get_width(), reference.get_height(), candidate.get_width(), candidate.get_height()])
+		return
+
+	reference.convert(Image.FORMAT_RGBA8)
+	candidate.convert(Image.FORMAT_RGBA8)
+
+	var width := reference.get_width()
+	var height := reference.get_height()
+	var reference_data := reference.get_data()
+	var candidate_data := candidate.get_data()
+	var diff: Image = null
+	if not diff_path.is_empty():
+		diff = Image.create(width, height, false, Image.FORMAT_RGBA8)
+
+	var different_pixels := 0
+	var max_delta := 0
+	var total_delta := 0
+	var channel_count := width * height * 4
+	for y in range(height):
+		for x in range(width):
+			var data_index := (y * width + x) * 4
+			var pixel_delta := 0
+			for channel in range(4):
+				var delta: int = abs(reference_data[data_index + channel] - candidate_data[data_index + channel])
+				pixel_delta = max(pixel_delta, delta)
+				max_delta = max(max_delta, delta)
+				total_delta += delta
+
+			if pixel_delta > max_channel_delta:
+				different_pixels += 1
+
+			if diff != null:
+				var diff_value := float(pixel_delta) / 255.0
+				diff.set_pixel(x, y, Color(diff_value, diff_value, diff_value, 1.0))
+
+	if diff != null:
+		var diff_err := diff.save_png(diff_path)
+		if diff_err != OK:
+			_fail("Failed to save diff image: %s (%s)" % [diff_path, error_string(diff_err)])
+			return
+
+	var mean_delta := float(total_delta) / float(channel_count)
+	print("IMAGE_COMPARE_SIZE=", width, "x", height)
+	print("IMAGE_COMPARE_DIFFERENT_PIXELS=", different_pixels)
+	print("IMAGE_COMPARE_MAX_DELTA=", max_delta)
+	print("IMAGE_COMPARE_MEAN_DELTA=", mean_delta)
+
+	if different_pixels > max_different_pixels:
+		_fail("Images differ beyond tolerance: different_pixels=%d max_different_pixels=%d max_channel_delta=%d max_delta=%d" % [different_pixels, max_different_pixels, max_channel_delta, max_delta])
+		return
+
+	quit(0)
+
+func _get_required_arg(name: String) -> String:
+	var value := _get_user_arg_value(name, "")
+	if value.is_empty():
+		_fail("Missing required argument: %s" % name)
+	return value
+
+func _get_user_arg_value(name: String, default_value: String) -> String:
+	var args := OS.get_cmdline_user_args()
+	for i in range(args.size()):
+		if args[i] == name and i + 1 < args.size():
+			return args[i + 1]
+	return default_value
+
+func _fail(message: String) -> void:
+	printerr(message)
+	quit(1)

--- a/tests/rendering/offscreen_compare/main.tscn
+++ b/tests/rendering/offscreen_compare/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://capture_scene.gd" id="1_capture"]
+
+[node name="Main" type="Node3D"]
+script = ExtResource("1_capture")

--- a/tests/rendering/offscreen_compare/project.godot
+++ b/tests/rendering/offscreen_compare/project.godot
@@ -1,0 +1,15 @@
+config_version=5
+
+[application]
+
+config/name="OffscreenCompare"
+run/main_scene="res://main.tscn"
+
+[display]
+
+window/size/viewport_width=640
+window/size/viewport_height=360
+
+[rendering]
+
+renderer/rendering_method="forward_plus"

--- a/tests/rendering/offscreen_compare/run_offscreen_compare.py
+++ b/tests/rendering/offscreen_compare/run_offscreen_compare.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run_command(command: list[str], cwd: Path, timeout: int) -> None:
+    print("+", " ".join(command))
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+    if completed.stdout:
+        print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def require_file(path: Path) -> None:
+    if not path.is_file():
+        raise SystemExit(f"Expected output file was not created: {path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare a normal rendered frame against an offscreen rendered frame."
+    )
+    parser.add_argument("--godot-bin", required=True, type=Path, help="Path to a Godot executable.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(tempfile.gettempdir()) / "godot_offscreen_compare",
+        help="Directory where captures and diff output will be written.",
+    )
+    parser.add_argument("--resolution", default="640x360", help="Viewport resolution used for both captures.")
+    parser.add_argument("--rendering-driver", default="vulkan", help="Rendering driver used for both captures.")
+    parser.add_argument(
+        "--normal-display-driver",
+        default="",
+        help="Optional display driver for the normal capture. Defaults to the platform display driver.",
+    )
+    parser.add_argument("--max-channel-delta", type=int, default=0, help="Per-channel tolerance for a pixel.")
+    parser.add_argument(
+        "--max-different-pixels",
+        type=int,
+        default=0,
+        help="Number of pixels allowed to exceed --max-channel-delta.",
+    )
+    parser.add_argument("--timeout", type=int, default=60, help="Timeout in seconds for each Godot invocation.")
+    args = parser.parse_args()
+
+    project_dir = Path(__file__).resolve().parent
+    godot_bin = args.godot_bin.resolve()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    normal_png = output_dir / "normal.png"
+    offscreen_png = output_dir / "offscreen.png"
+    diff_png = output_dir / "diff.png"
+
+    common_capture_args = [
+        str(godot_bin),
+        "--path",
+        str(project_dir),
+        "--rendering-driver",
+        args.rendering_driver,
+        "--resolution",
+        args.resolution,
+        "--disable-crash-handler",
+        "--quit-after",
+        "120",
+    ]
+
+    normal_command = common_capture_args.copy()
+    if args.normal_display_driver:
+        normal_command[1:1] = ["--display-driver", args.normal_display_driver]
+    normal_command += ["--", "--capture-output", str(normal_png)]
+
+    offscreen_command = common_capture_args.copy()
+    offscreen_command[1:1] = ["--offscreen"]
+    offscreen_command += ["--", "--capture-output", str(offscreen_png)]
+
+    compare_command = [
+        str(godot_bin),
+        "--headless",
+        "--path",
+        str(project_dir),
+        "--script",
+        "res://compare_images.gd",
+        "--",
+        "--reference",
+        str(normal_png),
+        "--candidate",
+        str(offscreen_png),
+        "--diff",
+        str(diff_png),
+        "--max-channel-delta",
+        str(args.max_channel_delta),
+        "--max-different-pixels",
+        str(args.max_different_pixels),
+    ]
+
+    run_command(normal_command, project_dir, args.timeout)
+    require_file(normal_png)
+    run_command(offscreen_command, project_dir, args.timeout)
+    require_file(offscreen_png)
+    run_command(compare_command, project_dir, args.timeout)
+    require_file(diff_png)
+
+    print("NORMAL_CAPTURE=", normal_png)
+    print("OFFSCREEN_CAPTURE=", offscreen_png)
+    print("DIFF_CAPTURE=", diff_png)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This adds an explicit `--offscreen` display mode backed by a small virtual `DisplayServer` and an RD virtual screen/backbuffer texture.

See https://github.com/godotengine/godot-proposals/issues/5790


`--headless` remains unchanged: it still creates no window and does not initialize GPU rendering. The new `--offscreen` mode creates no visible native OS window, but keeps RD rendering enabled so the main viewport can render, be captured, and feed Movie Maker output.

## Design

The implementation has three main pieces:

- Add `--offscreen`, mutually exclusive with `--headless`.
- Add `DisplayServerOffscreen`, a small virtual display server that exposes one virtual screen and one virtual main window without creating native OS windows or surfaces.
- Add RD virtual screen support, where the screen is backed by an internal GPU texture/framebuffer instead of a swapchain. Preparing the screen succeeds, drawing targets the texture, and presentation is effectively a no-op.

DisplayServer registration now carries fallback metadata. `headless` and `offscreen` are explicit-only drivers and are not selected as ordinary fallback targets if a platform display driver fails.

## Tradeoffs

This intentionally avoids copying a platform DisplayServer implementation such as Windows/X11/Wayland/macOS. The offscreen server only preserves the small amount of virtual window/screen state needed by the engine.

The rendering side uses a texture-backed virtual screen instead of a fake native surface/swapchain. This keeps the model closer to RD abstractions and avoids depending on platform WSI behavior.

The first backend implementation is Vulkan-only. D3D12 and Metal can be wired into the same virtual screen abstraction later.

## Limitations

This first pass supports:

- Project runtime, not the editor.
- RD renderers, currently Vulkan.
- Main virtual window/screen.
- Viewport capture and Movie Maker output.

Not supported in this initial version:

- Compatibility/OpenGL.
- Editor offscreen mode.
- Native input, IME, clipboard, native menus, cursor integration.
- Complex multi-window behavior.
- Automatic fallback to offscreen when a platform DisplayServer fails.

## Test Plan

Validated locally on macOS arm64 with Vulkan/MoltenVK:

- Built editor dev binary:
  - `.venv/bin/scons platform=macos target=editor dev_build=yes arch=arm64 -j8`
- Verified CLI help includes:
  - `"offscreen" ("vulkan")`
  - `--offscreen`
- Verified invalid mode combination:
  - `--headless --offscreen` exits with `Error: --headless and --offscreen are mutually exclusive.`
- Verified offscreen viewport capture:
  - `--offscreen --path /tmp/godot_offscreen_min`
  - captured `320x180`, non-empty image
- Verified resolution override:
  - `--offscreen --resolution 640x360`
  - captured `640x360`, non-empty image
- Verified Movie Maker output:
  - `--offscreen --write-movie /tmp/godot_offscreen_min/out.avi --fixed-fps 1`
  - produced a valid AVI
- Added and ran an integration comparison fixture:
  - `tests/rendering/offscreen_compare/run_offscreen_compare.py --godot-bin bin/godot.macos.editor.dev.arm64 --output-dir /tmp/godot_offscreen_compare`
  - normal window render and offscreen render were pixel-identical:
    - `IMAGE_COMPARE_SIZE=640x360`
    - `IMAGE_COMPARE_DIFFERENT_PIXELS=0`
    - `IMAGE_COMPARE_MAX_DELTA=0`
    - `IMAGE_COMPARE_MEAN_DELTA=0.0`
