### PR TITLE
Clear `request_data` in `HTTPRequest` after a request is finished

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -215,6 +215,7 @@ void HTTPRequest::cancel_request() {
 	decompressor.unref();
 	client->close();
 	body.clear();
+	request_data.clear();
 	got_response = false;
 	response_code = -1;
 	request_sent = false;


### PR DESCRIPTION
Closes #119377

Clears `request_data` on a HTTPRequest Node when the request is completed or canceled, because after that point it is useless and just takes up memory.

**Testing:** Works as expected, even when manipulating the data that was passed to the `request()` function in the script.

**Technical overview:** `cancel_request()` is called even if the request completes successfully, so clearing request_data there covers all cases.