### PR TITLE
Improve explanation for offline mode in export template manager

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -830,10 +830,10 @@ void ExportTemplateManager::_update_install_button() {
 
 	install_button->set_disabled(!_can_download_templates());
 	if (install_button->is_disabled()) {
-		if (mirrors_empty) {
-			install_button->set_tooltip_text(TTRC("No mirrors available for download."));
-		} else if (!_is_online()) {
+		if (!_is_online()) {
 			install_button->set_tooltip_text(TTRC("Download not available in offline mode."));
+		} else if (mirrors_empty) {
+			install_button->set_tooltip_text(TTRC("No mirrors available for download."));
 		} else {
 			install_button->set_tooltip_text(TTRC("Downloads are only available for the current Godot version."));
 		}
@@ -1331,6 +1331,8 @@ void ExportTemplateManager::_notification(int p_what) {
 			delete_all_button->set_button_icon(get_editor_theme_icon("Remove"));
 			tpz_button->set_button_icon(get_editor_theme_icon("FileBrowse"));
 
+			offline_mode_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+
 			theme_cache.install_icon = get_editor_theme_icon("AssetStore");
 			theme_cache.remove_icon = get_editor_theme_icon("Remove");
 			theme_cache.repair_icon = get_editor_theme_icon("Tools");
@@ -1658,11 +1660,12 @@ ExportTemplateManager::ExportTemplateManager() {
 	offline_container->hide();
 	main_vb->add_child(offline_container);
 
-	Label *offline_mode_label = memnew(Label(TTRC("Offline mode, some functionality is not available.")));
+	offline_mode_label = memnew(Label(TTRC("Offline mode, some functionality is not available.")));
 	offline_container->add_child(offline_mode_label);
 
 	LinkButton *enable_online_button = memnew(LinkButton);
 	enable_online_button->set_text(TTRC("Go Online"));
+	enable_online_button->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	offline_container->add_child(enable_online_button);
 	enable_online_button->connect(SceneStringName(pressed), callable_mp(this, &ExportTemplateManager::_force_online_mode));
 

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -38,6 +38,7 @@ class EditorExportPreset;
 class EditorFileDialog;
 class ItemList;
 class HBoxContainer;
+class Label;
 class OptionButton;
 class Texture2D;
 class Tree;
@@ -199,6 +200,7 @@ class ExportTemplateManager : public AcceptDialog {
 	Button *delete_all_button = nullptr;
 	Button *tpz_button = nullptr;
 	HBoxContainer *offline_container = nullptr;
+	Label *offline_mode_label = nullptr;
 	ConfirmationDialog *confirm_delete = nullptr;
 	EditorFileDialog *tpz_selection_dialog = nullptr;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14818

The goal is to make the hint more noticeable because it is far away from where the disabled button would be.

Let me know what you think.

I also wonder if putting a warning icon (like we put elsewhere in the project) would be a better idea, but this is less invasive and seemed like a good start.

Before:

<img width="790" height="671" alt="Screenshot 2026-05-10 at 20 19 52" src="https://github.com/user-attachments/assets/87dc53dc-c668-4072-9337-1fb5e40dfad1" />

After:

<img width="733" height="703" alt="Screenshot 2026-05-10 at 20 26 28" src="https://github.com/user-attachments/assets/892f81ba-4e96-4f2b-b91c-324b7d42f975" />





<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
