### PR TITLE
Fix ordering of notes in the description of the `seed()` function in `RandomNumberGenerator`

### DIFF
--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -86,8 +86,8 @@
 		<member name="seed" type="int" setter="set_seed" getter="get_seed" default="0">
 			Initializes the random number generator state based on the given seed value. A given seed will give a reproducible sequence of pseudo-random numbers.
 			[b]Note:[/b] The RNG does not have an avalanche effect, and can output similar random streams given similar seeds. Consider using a hash function to improve your seed quality if they're sourced externally.
-			[b]Note:[/b] Setting this property produces a side effect of changing the internal [member state], so make sure to initialize the seed [i]before[/i] modifying the [member state]:
 			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
+			[b]Note:[/b] Setting this property produces a side effect of changing the internal [member state], so make sure to initialize the seed [i]before[/i] modifying the [member state]:
 			[codeblock]
 			var rng = RandomNumberGenerator.new()
 			rng.seed = hash("Godot")


### PR DESCRIPTION
Moved `[b]Note:[/b] Setting this property ....` down by one, so that the semicolon makes sense, because currently between the semicolon and the codeblock there is another note.

**Before:**
<img width="1080" height="478" alt="image" src="https://github.com/user-attachments/assets/37a2fa5b-ff76-4011-9c8d-4f48c34e6ab7" />

**After:**
<img width="1089" height="449" alt="image" src="https://github.com/user-attachments/assets/070c02d5-dc73-4088-8d51-31ae2462fcec" />
