### PR TITLE
Fix internationalized domain names

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -62,6 +62,8 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, Ref<TLSOp
 		conn_host = conn_host.substr(8);
 	}
 
+	conn_host = conn_host.idna_encode();
+
 	ERR_FAIL_COND_V(tls_options.is_valid() && tls_options->is_server(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V_MSG(tls_options.is_valid() && !StreamPeerTLS::is_available(), ERR_UNAVAILABLE, "HTTPS is not available in this build.");
 	ERR_FAIL_COND_V(conn_host.length() < HOST_MIN_LEN, ERR_INVALID_PARAMETER);

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -125,7 +125,7 @@ constexpr bool is_ascii_identifier_char(char32_t p_char) {
 }
 
 constexpr bool is_ascii_char(char32_t p_char) {
-	return (p_char >= 0 && p_char <= 0x7f);
+	return p_char <= 0x7f;
 }
 
 constexpr bool is_symbol(char32_t p_char) {

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -124,6 +124,10 @@ constexpr bool is_ascii_identifier_char(char32_t p_char) {
 	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9') || p_char == '_';
 }
 
+constexpr bool is_ascii_char(char32_t p_char) {
+	return (p_char > 0x20 && p_char < 0x7f);
+}
+
 constexpr bool is_symbol(char32_t p_char) {
 	return p_char != '_' && ((p_char >= '!' && p_char <= '/') || (p_char >= ':' && p_char <= '@') || (p_char >= '[' && p_char <= '`') || (p_char >= '{' && p_char <= '~') || p_char == '\t' || p_char == ' ');
 }

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -125,7 +125,7 @@ constexpr bool is_ascii_identifier_char(char32_t p_char) {
 }
 
 constexpr bool is_ascii_char(char32_t p_char) {
-	return (p_char > 0x20 && p_char < 0x7f);
+	return (p_char >= 0 && p_char <= 0x7f);
 }
 
 constexpr bool is_symbol(char32_t p_char) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4450,11 +4450,11 @@ static String _punycode_decode_label(const char32_t *p_label, int p_label_len) {
 
 			char32_t c = p_label[src++];
 			int digit;
-			if (c >= 'a' && c <= 'z') {
+			if (is_ascii_lower_case(c)) {
 				digit = c - 'a';
-			} else if (c >= 'A' && c <= 'Z') {
+			} else if (is_ascii_upper_case(c)) {
 				digit = c - 'A';
-			} else if (c >= '0' && c <= '9') {
+			} else if (is_digit(c)) {
 				digit = c - '0' + TMAX;
 			} else {
 				return String();

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4389,6 +4389,258 @@ bool String::is_valid_string() const {
 	return valid;
 }
 
+// RFC 3492 §6.1: Bias adaptation function.
+static _FORCE_INLINE_ int _punycode_adapt_bias(int p_delta, int p_num_points, bool p_first_time) {
+	constexpr int BASE = 36;
+	constexpr int TMIN = 1;
+	constexpr int TMAX = 26;
+	constexpr int SKEW = 38;
+	constexpr int DAMP = 700;
+
+	p_delta = p_first_time ? p_delta / DAMP : p_delta / 2;
+	p_delta += p_delta / p_num_points;
+
+	int k = 0;
+	while (p_delta > ((BASE - TMIN) * TMAX) / 2) {
+		p_delta /= (BASE - TMIN);
+		k += BASE;
+	}
+	return k + (((BASE - TMIN + 1) * p_delta) / (p_delta + SKEW));
+}
+
+// RFC 3492 §6.2: Decode a single Punycode-encoded label. Returns an empty string on failure.
+static String _punycode_decode_label(const char32_t *p_label, int p_label_len) {
+	constexpr int BASE = 36;
+	constexpr int TMIN = 1;
+	constexpr int TMAX = 26;
+	constexpr int INITIAL_N = 128;
+	constexpr int INITIAL_BIAS = 72;
+
+	int delimiter_pos = -1;
+	for (int i = p_label_len - 1; i >= 0; i--) {
+		if (p_label[i] == '-') {
+			delimiter_pos = i;
+			break;
+		}
+	}
+
+	String output;
+	int basic_end = (delimiter_pos >= 0) ? delimiter_pos : 0;
+	for (int i = 0; i < basic_end; i++) {
+		if (p_label[i] >= 128) {
+			return String();
+		}
+		output += String::chr(p_label[i]);
+	}
+
+	int src = (delimiter_pos > 0) ? delimiter_pos + 1 : 0;
+
+	int n = INITIAL_N;
+	int i = 0;
+	int bias = INITIAL_BIAS;
+
+	while (src < p_label_len) {
+		int old_i = i;
+		int w = 1;
+
+		for (int k = BASE;; k += BASE) {
+			if (src >= p_label_len) {
+				return String();
+			}
+
+			char32_t c = p_label[src++];
+			int digit;
+			if (c >= 'a' && c <= 'z') {
+				digit = c - 'a';
+			} else if (c >= 'A' && c <= 'Z') {
+				digit = c - 'A';
+			} else if (c >= '0' && c <= '9') {
+				digit = c - '0' + TMAX;
+			} else {
+				return String();
+			}
+
+			i += digit * w;
+
+			int t = CLAMP(k - bias, TMIN, TMAX);
+
+			if (digit < t) {
+				break;
+			}
+
+			w *= BASE - t;
+		}
+
+		int output_len = output.length() + 1;
+		bias = _punycode_adapt_bias(i - old_i, output_len, old_i == 0);
+		n += i / output_len;
+		i = i % output_len;
+
+		if (n < INITIAL_N) {
+			return String();
+		}
+
+		output = output.insert(i, String::chr(n));
+		i++;
+	}
+
+	return output;
+}
+
+// RFC 3492 §6.3: Encode a single non-ASCII label using Punycode.
+static String _punycode_encode_label(const char32_t *p_label, int p_label_len) {
+	constexpr int BASE = 36;
+	constexpr int TMIN = 1;
+	constexpr int TMAX = 26;
+	constexpr int INITIAL_N = 128;
+	constexpr int INITIAL_BIAS = 72;
+
+	String out = "xn--";
+
+	int num_basic = 0;
+	for (int i = 0; i < p_label_len; i++) {
+		if (p_label[i] < INITIAL_N) {
+			out += String::chr(p_label[i]);
+			num_basic++;
+		}
+	}
+	if (num_basic > 0) {
+		out += "-";
+	}
+
+	int n = INITIAL_N;
+	int delta = 0;
+	int bias = INITIAL_BIAS;
+	int h = num_basic;
+
+	while (h < p_label_len) {
+		int m = 0x7FFFFFFF;
+		for (int i = 0; i < p_label_len; i++) {
+			if (p_label[i] >= (char32_t)n && p_label[i] < (char32_t)m) {
+				m = p_label[i];
+			}
+		}
+
+		delta += (m - n) * (h + 1);
+		n = m;
+
+		for (int i = 0; i < p_label_len; i++) {
+			if (p_label[i] < (char32_t)n) {
+				delta++;
+			} else if (p_label[i] == (char32_t)n) {
+				int q = delta;
+				for (int k = BASE;; k += BASE) {
+					int t = k - bias;
+					t = CLAMP(t, TMIN, TMAX);
+					if (q < t) {
+						break;
+					}
+					int digit = t + (q - t) % (BASE - t);
+					out += String::chr(digit < TMAX ? digit + 'a' : digit - TMAX + '0');
+					q = (q - t) / (BASE - t);
+				}
+				out += String::chr(q < TMAX ? q + 'a' : q - TMAX + '0');
+
+				bias = _punycode_adapt_bias(delta, h + 1, h == num_basic);
+				delta = 0;
+				h++;
+			}
+		}
+		delta++;
+		n++;
+	}
+
+	return out;
+}
+
+String String::idna_decode() const {
+	// Fast path: no label starts with "xn--", nothing to decode.
+	if (!to_lower().contains("xn--")) {
+		return *this;
+	}
+
+	Vector<String> parts = split(".");
+	String res;
+
+	for (int i = 0; i < parts.size(); i++) {
+		if (i > 0) {
+			res += ".";
+		}
+
+		const String &part = parts[i];
+		if (part.is_empty()) {
+			continue;
+		}
+
+		if (!part.to_lower().begins_with("xn--")) {
+			res += part;
+			continue;
+		}
+
+		constexpr int ACE_PREFIX_LEN = 4;
+		String encoded = part.substr(ACE_PREFIX_LEN);
+		String decoded = _punycode_decode_label(encoded.ptr(), encoded.length());
+
+		if (decoded.is_empty() && !encoded.is_empty()) {
+			return String();
+		}
+
+		res += decoded;
+	}
+
+	return res;
+}
+
+String String::idna_encode() const {
+	// Fast path: pure ASCII requires no encoding.
+	const char32_t *str = ptr();
+	int len = length();
+
+	bool is_ascii = true;
+	for (int i = 0; i < len; i++) {
+		if (!is_ascii_char(str[i])) {
+			is_ascii = false;
+			break;
+		}
+	}
+	if (is_ascii) {
+		return *this;
+	}
+
+	Vector<String> parts = split(".");
+	String res;
+
+	for (int i = 0; i < parts.size(); i++) {
+		if (i > 0) {
+			res += ".";
+		}
+
+		const String &part = parts[i];
+		if (part.is_empty()) {
+			continue;
+		}
+
+		bool part_is_ascii = true;
+		const char32_t *part_str = part.ptr();
+		int part_len = part.length();
+
+		for (int j = 0; j < part_len; j++) {
+			if (!is_ascii_char(part_str[j])) {
+				part_is_ascii = false;
+				break;
+			}
+		}
+
+		if (part_is_ascii) {
+			res += part;
+		} else {
+			res += _punycode_encode_label(part_str, part_len);
+		}
+	}
+
+	return res;
+}
+
 String String::uri_encode() const {
 	const CharString temp = utf8();
 	String res;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4427,7 +4427,7 @@ static String _punycode_decode_label(const char32_t *p_label, int p_label_len) {
 	String output;
 	int basic_end = (delimiter_pos >= 0) ? delimiter_pos : 0;
 	for (int i = 0; i < basic_end; i++) {
-		if (p_label[i] >= 128) {
+		if (!is_ascii_char(p_label[i])) {
 			return String();
 		}
 		output += String::chr(p_label[i]);

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -626,6 +626,8 @@ public:
 	String uri_encode() const;
 	String uri_decode() const;
 	String uri_file_decode() const;
+	String idna_encode() const;
+	String idna_decode() const;
 	String c_escape() const;
 	String c_escape_multiline() const;
 	String c_unescape() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2092,6 +2092,8 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(xml_unescape, sarray(), varray());
 	bind_string_method(uri_encode, sarray(), varray());
 	bind_string_method(uri_decode, sarray(), varray());
+	bind_string_method(idna_encode, sarray(), varray());
+	bind_string_method(idna_decode, sarray(), varray());
 	bind_string_method(uri_file_decode, sarray(), varray());
 	bind_string_method(c_escape, sarray(), varray());
 	bind_string_method(c_unescape, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -1164,6 +1164,36 @@
 				See also [method chr], [method @GDScript.char], and [method @GDScript.ord].
 			</description>
 		</method>
+		<method name="idna_decode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Decodes a string in Internationalized Domain Names in Applications (IDNA) format back to its Unicode representation. Punycode-encoded labels (prefixed with [code]xn--[/code]) are decoded to their original Unicode characters. Labels that are not Punycode-encoded are passed through unchanged.
+				[codeblocks]
+				[gdscript]
+				print("xn--yp9h.example.com".idna_decode()) # Prints "🤖.example.com"
+				[/gdscript]
+				[csharp]
+				GD.Print("xn--yp9h.example.com".IdnaDecode()); // Prints "🤖.example.com"
+				[/csharp]
+				[/codeblocks]
+				Returns an empty string if decoding fails. See also [method idna_encode].
+			</description>
+		</method>
+		<method name="idna_encode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Encodes a Unicode string to Internationalized Domain Names in Applications (IDNA) format. Each dot-separated label that contains non-ASCII characters is encoded using Punycode and prefixed with [code]xn--[/code]. Pure ASCII labels are passed through unchanged.
+				[codeblocks]
+				[gdscript]
+				print("🤖.example.com".idna_encode()) # Prints "xn--yp9h.example.com"
+				[/gdscript]
+				[csharp]
+				GD.Print("🤖.example.com".IdnaEncode()); // Prints "xn--yp9h.example.com"
+				[/csharp]
+				[/codeblocks]
+				See also [method idna_decode].
+			</description>
+		</method>
 		<method name="uri_decode" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -524,6 +524,12 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_string_to_kebab_case(scoped in godot_string p_self,
             out godot_string r_kebab_case);
 
+        public static partial void godotsharp_string_idna_encode(scoped in godot_string p_self,
+            out godot_string r_idna_encoded);
+
+        public static partial void godotsharp_string_idna_decode(scoped in godot_string p_self,
+            out godot_string r_idna_decoded);
+
         // NodePath
 
         public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1793,5 +1793,36 @@ namespace Godot
         {
             return SecurityElement.FromString(instance)?.Text;
         }
+
+        /// <summary>
+        /// Encodes a Unicode string to Internationalized Domain Names in Applications (IDNA) format.
+        /// Each dot-separated label that contains non-ASCII characters is encoded using Punycode and
+        /// prefixed with <c>xn--</c>. Pure ASCII labels are passed through unchanged.
+        /// </summary>
+        /// <param name="instance">The string to encode.</param>
+        /// <returns>The encoded string.</returns>
+        public static string IdnaEncode(this string instance)
+        {
+            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+            NativeFuncs.godotsharp_string_idna_encode(instanceStr, out godot_string idnaEncoded);
+            using (idnaEncoded)
+                return Marshaling.ConvertStringToManaged(idnaEncoded);
+        }
+
+        /// <summary>
+        /// Decodes a string in Internationalized Domain Names in Applications (IDNA) format back to its
+        /// Unicode representation. Punycode-encoded labels (prefixed with <c>xn--</c>) are decoded to
+        /// their original Unicode characters. Labels that are not Punycode-encoded are passed through
+        /// unchanged. Returns an empty string if decoding fails.
+        /// </summary>
+        /// <param name="instance">The string to decode.</param>
+        /// <returns>The decoded string.</returns>
+        public static string IdnaDecode(this string instance)
+        {
+            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+            NativeFuncs.godotsharp_string_idna_decode(instanceStr, out godot_string idnaDecoded);
+            using (idnaDecoded)
+                return Marshaling.ConvertStringToManaged(idnaDecoded);
+        }
     }
 }

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1357,6 +1357,14 @@ void godotsharp_string_to_kebab_case(const String *p_self, String *r_kebab_case)
 	memnew_placement(r_kebab_case, String(p_self->to_kebab_case()));
 }
 
+void godotsharp_string_idna_encode(const String *p_self, String *r_idna_encoded) {
+	memnew_placement(r_idna_encoded, String(p_self->idna_encode()));
+}
+
+void godotsharp_string_idna_decode(const String *p_self, String *r_idna_decoded) {
+	memnew_placement(r_idna_decoded, String(p_self->idna_decode()));
+}
+
 void godotsharp_node_path_get_as_property_path(const NodePath *p_ptr, NodePath *r_dest) {
 	memnew_placement(r_dest, NodePath(p_ptr->get_as_property_path()));
 }
@@ -1812,6 +1820,8 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_string_to_pascal_case,
 	(void *)godotsharp_string_to_snake_case,
 	(void *)godotsharp_string_to_kebab_case,
+	(void *)godotsharp_string_idna_encode,
+	(void *)godotsharp_string_idna_decode,
 	(void *)godotsharp_node_path_get_as_property_path,
 	(void *)godotsharp_node_path_get_concatenated_names,
 	(void *)godotsharp_node_path_get_concatenated_subnames,

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -2245,4 +2245,186 @@ TEST_CASE("[String][URL] Parse URL") {
 #undef CHECK_URL
 }
 
+TEST_CASE("[String] IDNA encode: ASCII-only domain is a no-op") {
+	CHECK(String("godotengine.org").idna_encode() == "godotengine.org");
+	CHECK(String("sub.example.com").idna_encode() == "sub.example.com");
+	CHECK(String("localhost").idna_encode() == "localhost");
+	CHECK(String("192.168.1.1").idna_encode() == "192.168.1.1");
+}
+
+TEST_CASE("[String] IDNA encode: single non-ASCII label") {
+	// räksmörgås  ->  xn--rksmrgs-5wao1o
+	CHECK(String(U"r\u00e4ksm\u00f6rg\u00e5s").idna_encode() == "xn--rksmrgs-5wao1o");
+	// lüfter  ->  xn--lfter-kva
+	CHECK(String(U"l\u00fcfter").idna_encode() == "xn--lfter-kva");
+}
+
+TEST_CASE("[String] IDNA encode: mixed domain with one non-ASCII label") {
+	// räksmörgås.josefsson.org -> xn--rksmrgs-5wao1o.josefsson.org
+	CHECK(String(U"r\u00e4ksm\u00f6rg\u00e5s.josefsson.org").idna_encode() == "xn--rksmrgs-5wao1o.josefsson.org");
+	// something.lüfter  ->  something.xn--lfter-kva
+	CHECK(String(U"something.l\u00fcfter").idna_encode() == "something.xn--lfter-kva");
+}
+
+TEST_CASE("[String] IDNA encode: multiple non-ASCII labels") {
+	// bücher.münchen.de  ->  xn--bcher-kva.xn--mnchen-3ya.de
+	CHECK(String(U"b\u00fccher.m\u00fcnchen.de").idna_encode() == "xn--bcher-kva.xn--mnchen-3ya.de");
+}
+
+TEST_CASE("[String] IDNA encode: label with mixed ASCII and non-ASCII") {
+	// résumé  ->  xn--rsum-bpad
+	CHECK(String(U"r\u00e9sum\u00e9").idna_encode() == "xn--rsum-bpad");
+}
+
+TEST_CASE("[String] IDNA encode: RFC 3492 test vectors") {
+	// All examples taken from RFC 3492 Appendix B.
+	// The ACE prefix "xn--" is included in the expected output.
+
+	// (A) Arabic (Egyptian)
+	CHECK(String(U"\u0644\u064A\u0647\u0645\u0627\u0628\u062A\u0643\u0644\u0645\u0648\u0634\u0639\u0631\u0628\u064A\u061F").idna_encode() == "xn--egbpdaj6bu4bxfgehfvwxn");
+
+	// (B) Chinese (simplified)
+	CHECK(String(U"\u4ED6\u4EEC\u4E3A\u4EC0\u4E48\u4E0D\u8BF4\u4E2D\u6587").idna_encode() == "xn--ihqwcrb4cv8a8dqg056pqjye");
+
+	// (C) Chinese (traditional)
+	CHECK(String(U"\u4ED6\u5011\u7232\u4EC0\u9EBD\u4E0D\u8AAA\u4E2D\u6587").idna_encode() == "xn--ihqwctvzc91f659drss3x8bo0yb");
+
+	// (D) Czech: Pro<ccaron>prost<ecaron>nemluv<iacute><ccaron>esky
+	CHECK(String(U"Pro\u010Dprost\u011Bnemluv\u00ED\u010Desky").idna_encode() == "xn--Proprostnemluvesky-uyb24dma41a");
+
+	// (E) Hebrew
+	CHECK(String(U"\u05DC\u05DE\u05D4\u05D4\u05DD\u05E4\u05E9\u05D5\u05D8\u05DC\u05D0\u05DE\u05D3\u05D1\u05E8\u05D9\u05DD\u05E2\u05D1\u05E8\u05D9\u05EA").idna_encode() == "xn--4dbcagdahymbxekheh6e0a7fei0b");
+
+	// (F) Hindi (Devanagari)
+	CHECK(String(U"\u092F\u0939\u0932\u094B\u0917\u0939\u093F\u0928\u094D\u0926\u0940\u0915\u094D\u092F\u094B\u0902\u0928\u0939\u0940\u0902\u092C\u094B\u0932\u0938\u0915\u0924\u0947\u0939\u0948\u0902").idna_encode() == "xn--i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd");
+
+	// (G) Japanese (kanji and hiragana)
+	CHECK(String(U"\u306A\u305C\u307F\u3093\u306A\u65E5\u672C\u8A9E\u3092\u8A71\u3057\u3066\u304F\u308C\u306A\u3044\u306E\u304B").idna_encode() == "xn--n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa");
+
+	// (H) Korean (Hangul syllables)
+	CHECK(String(U"\uC138\uACC4\uC758\uBAA8\uB4E0\uC0AC\uB78C\uB4E4\uC774\uD55C\uAD6D\uC5B4\uB97C\uC774\uD574\uD55C\uB2E4\uBA74\uC5BC\uB9C8\uB098\uC88B\uC744\uAE4C").idna_encode() == "xn--989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c");
+
+	// (I) Russian (Cyrillic)
+	// Technically not the same comparison string as in the RFC. It uses 'b1abfaaepdrnnbgefbaDotcwatmq2g4l' instead of 'b1abfaaepdrnnbgefbadotcwatmq2g4l' (upper case D in the middle).
+	// This shouldn't be an issue tho, since the *decoder* is case insensitive by spec.
+	CHECK(String(U"\u043F\u043E\u0447\u0435\u043C\u0443\u0436\u0435\u043E\u043D\u0438\u043D\u0435\u0433\u043E\u0432\u043E\u0440\u044F\u0442\u043F\u043E\u0440\u0443\u0441\u0441\u043A\u0438").idna_encode() == "xn--b1abfaaepdrnnbgefbadotcwatmq2g4l");
+
+	// (J) Spanish: Porqu<eacute>nopuedensimplementehablarenEspa<ntilde>ol
+	CHECK(String(U"Porqu\u00E9nopuedensimplementehablarenEspa\u00F1ol").idna_encode() == "xn--PorqunopuedensimplementehablarenEspaol-fmd56a");
+
+	// (K) Vietnamese
+	CHECK(String(U"T\u1EA1isaoh\u1ECDkh\u00F4ngth\u1EC3ch\u1EC9n\u00F3iti\u1EBFngVi\u1EC7t").idna_encode() == "xn--TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g");
+
+	// (L) 3<nen>B<gumi><kinpachi><sensei>
+	CHECK(String(U"3\u5E74B\u7D44\u91D1\u516B\u5148\u751F").idna_encode() == "xn--3B-ww4c5e180e575a65lsy2b");
+
+	// (M) <amuro><namie>-with-SUPER-MONKEYS
+	CHECK(String(U"\u5B89\u5BA4\u5948\u7F8E\u6075-with-SUPER-MONKEYS").idna_encode() == "xn---with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n");
+
+	// (N) Hello-Another-Way-<sorezore><no><basho>
+	CHECK(String(U"Hello-Another-Way-\u305D\u308C\u305E\u308C\u306E\u5834\u6240").idna_encode() == "xn--Hello-Another-Way--fc4qua05auwb3674vfr0b");
+
+	// (O) <hitotsu><yane><no><shita>2
+	CHECK(String(U"\u3072\u3068\u3064\u5C4B\u6839\u306E\u4E0B\u0032").idna_encode() == "xn--2-u9tlzr9756bt3uc0v");
+
+	// (P) Maji<de>Koi<suru>5<byou><mae>
+	CHECK(String(U"Maji\u3067Koi\u3059\u308B5\u79D2\u524D").idna_encode() == "xn--MajiKoi5-783gue6qz075azm5e");
+
+	// (Q) <pafii>de<runba>
+	CHECK(String(U"\u30D1\u30D5\u30A3\u30FCde\u30EB\u30F3\u30D0").idna_encode() == "xn--de-jg4avhby1noc0d");
+
+	// (R) <sono><supiido><de>
+	CHECK(String(U"\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067").idna_encode() == "xn--d9juau41awczczp");
+}
+
+TEST_CASE("[String] IDNA decode: ASCII-only domain is a no-op") {
+	CHECK(String("godotengine.org").idna_decode() == "godotengine.org");
+	CHECK(String("sub.example.com").idna_decode() == "sub.example.com");
+	CHECK(String("localhost").idna_decode() == "localhost");
+	CHECK(String("192.168.1.1").idna_decode() == "192.168.1.1");
+}
+
+TEST_CASE("[String] IDNA decode: single non-ASCII label") {
+	// xn--rksmrgs-5wao1o  ->  räksmörgås
+	CHECK(String("xn--rksmrgs-5wao1o").idna_decode() == U"r\u00e4ksm\u00f6rg\u00e5s");
+	// xn--lfter-kva  ->  lüfter
+	CHECK(String("xn--lfter-kva").idna_decode() == U"l\u00fcfter");
+}
+
+TEST_CASE("[String] IDNA decode: mixed domain with one non-ASCII label") {
+	// xn--rksmrgs-5wao1o.josefsson.org  ->  räksmörgås.josefsson.org
+	CHECK(String("xn--rksmrgs-5wao1o.josefsson.org").idna_decode() == U"r\u00e4ksm\u00f6rg\u00e5s.josefsson.org");
+	// something.xn--lfter-kva  ->  something.lüfter
+	CHECK(String("something.xn--lfter-kva").idna_decode() == U"something.l\u00fcfter");
+}
+
+TEST_CASE("[String] IDNA decode: multiple non-ASCII labels") {
+	// xn--bcher-kva.xn--mnchen-3ya.de  ->  bücher.münchen.de
+	CHECK(String("xn--bcher-kva.xn--mnchen-3ya.de").idna_decode() == U"b\u00fccher.m\u00fcnchen.de");
+}
+
+TEST_CASE("[String] IDNA decode: label with mixed ASCII and non-ASCII") {
+	// xn--rsum-bpad  ->  résumé
+	CHECK(String("xn--rsum-bpad").idna_decode() == U"r\u00e9sum\u00e9");
+}
+
+TEST_CASE("[String] IDNA decode: RFC 3492 test vectors") {
+	// All examples taken from RFC 3492 Appendix B.
+	// The ACE prefix "xn--" is included in the input.
+
+	// (A) Arabic (Egyptian)
+	CHECK(String("xn--egbpdaj6bu4bxfgehfvwxn").idna_decode() == U"\u0644\u064A\u0647\u0645\u0627\u0628\u062A\u0643\u0644\u0645\u0648\u0634\u0639\u0631\u0628\u064A\u061F");
+
+	// (B) Chinese (simplified)
+	CHECK(String("xn--ihqwcrb4cv8a8dqg056pqjye").idna_decode() == U"\u4ED6\u4EEC\u4E3A\u4EC0\u4E48\u4E0D\u8BF4\u4E2D\u6587");
+
+	// (C) Chinese (traditional)
+	CHECK(String("xn--ihqwctvzc91f659drss3x8bo0yb").idna_decode() == U"\u4ED6\u5011\u7232\u4EC0\u9EBD\u4E0D\u8AAA\u4E2D\u6587");
+
+	// (D) Czech: Pro<ccaron>prost<ecaron>nemluv<iacute><ccaron>esky
+	CHECK(String("xn--Proprostnemluvesky-uyb24dma41a").idna_decode() == U"Pro\u010Dprost\u011Bnemluv\u00ED\u010Desky");
+
+	// (E) Hebrew
+	CHECK(String("xn--4dbcagdahymbxekheh6e0a7fei0b").idna_decode() == U"\u05DC\u05DE\u05D4\u05D4\u05DD\u05E4\u05E9\u05D5\u05D8\u05DC\u05D0\u05DE\u05D3\u05D1\u05E8\u05D9\u05DD\u05E2\u05D1\u05E8\u05D9\u05EA");
+
+	// (F) Hindi (Devanagari)
+	CHECK(String("xn--i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd").idna_decode() == U"\u092F\u0939\u0932\u094B\u0917\u0939\u093F\u0928\u094D\u0926\u0940\u0915\u094D\u092F\u094B\u0902\u0928\u0939\u0940\u0902\u092C\u094B\u0932\u0938\u0915\u0924\u0947\u0939\u0948\u0902");
+
+	// (G) Japanese (kanji and hiragana)
+	CHECK(String("xn--n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa").idna_decode() == U"\u306A\u305C\u307F\u3093\u306A\u65E5\u672C\u8A9E\u3092\u8A71\u3057\u3066\u304F\u308C\u306A\u3044\u306E\u304B");
+
+	// (H) Korean (Hangul syllables)
+	CHECK(String("xn--989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c").idna_decode() == U"\uC138\uACC4\uC758\uBAA8\uB4E0\uC0AC\uB78C\uB4E4\uC774\uD55C\uAD6D\uC5B4\uB97C\uC774\uD574\uD55C\uB2E4\uBA74\uC5BC\uB9C8\uB098\uC88B\uC744\uAE4C");
+
+	// (I) Russian (Cyrillic)
+	CHECK(String("xn--b1abfaaepdrnnbgefbaDotcwatmq2g4l").idna_decode() == U"\u043F\u043E\u0447\u0435\u043C\u0443\u0436\u0435\u043E\u043D\u0438\u043D\u0435\u0433\u043E\u0432\u043E\u0440\u044F\u0442\u043F\u043E\u0440\u0443\u0441\u0441\u043A\u0438");
+
+	// (J) Spanish: Porqu<eacute>nopuedensimplementehablarenEspa<ntilde>ol
+	CHECK(String("xn--PorqunopuedensimplementehablarenEspaol-fmd56a").idna_decode() == U"Porqu\u00E9nopuedensimplementehablarenEspa\u00F1ol");
+
+	// (K) Vietnamese
+	CHECK(String("xn--TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g").idna_decode() == U"T\u1EA1isaoh\u1ECDkh\u00F4ngth\u1EC3ch\u1EC9n\u00F3iti\u1EBFngVi\u1EC7t");
+
+	// (L) 3<nen>B<gumi><kinpachi><sensei>
+	CHECK(String("xn--3B-ww4c5e180e575a65lsy2b").idna_decode() == U"3\u5E74B\u7D44\u91D1\u516B\u5148\u751F");
+
+	// (M) <amuro><namie>-with-SUPER-MONKEYS
+	CHECK(String("xn---with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n").idna_decode() == U"\u5B89\u5BA4\u5948\u7F8E\u6075-with-SUPER-MONKEYS");
+
+	// (N) Hello-Another-Way-<sorezore><no><basho>
+	CHECK(String("xn--Hello-Another-Way--fc4qua05auwb3674vfr0b").idna_decode() == U"Hello-Another-Way-\u305D\u308C\u305E\u308C\u306E\u5834\u6240");
+
+	// (O) <hitotsu><yane><no><shita>2
+	CHECK(String("xn--2-u9tlzr9756bt3uc0v").idna_decode() == U"\u3072\u3068\u3064\u5C4B\u6839\u306E\u4E0B\u0032");
+
+	// (P) Maji<de>Koi<suru>5<byou><mae>
+	CHECK(String("xn--MajiKoi5-783gue6qz075azm5e").idna_decode() == U"Maji\u3067Koi\u3059\u308B5\u79D2\u524D");
+
+	// (Q) <pafii>de<runba>
+	CHECK(String("xn--de-jg4avhby1noc0d").idna_decode() == U"\u30D1\u30D5\u30A3\u30FCde\u30EB\u30F3\u30D0");
+
+	// (R) <sono><supiido><de>
+	CHECK(String("xn--d9juau41awczczp").idna_decode() == U"\u305D\u306E\u30B9\u30D4\u30FC\u30C9\u3067");
+}
+
 } // namespace TestString


### PR DESCRIPTION
Fixes #94927.

Mostly based on rfc3492, aswell as loosly based on rfc3490. I added the conversion to ustring, simply because it already had various en/decoders, so that seemed fitting.

Checklist for new contributors:

- [x] Test your pull request.  
  - I have tested this PR (csharp and gdscript), and included cpp unit tests for the base functionality.
- [x] Disclose the use of AI.
  - I wrote the code myself, then feed it into multiple AI models to get feedback on it and if the code adheres to the codestyle guidelines and has a similar style to the modified files, then applied suggestions that seemed senseable by hand. The xml documentation was completly generated, since im not so good with correct spelling, grammar and stuff, but was proofread, so its not blindly commited.
- [x] Set up local style checks. 
  - Yes.
- [x] Keep it simple. 
  - I hope i did? Im not a professional Cpp Developer, but a CSharp Developer so i hope this is fine.
- [x] Adapt to the style of surrounding code. 
  - Same as above.