### PR TITLE
Update `qoa.h` to `1bf9bc0467`

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -180,7 +180,7 @@ void AudioStreamPlaybackWAV::decode_samples(const Depth *p_src, AudioFrame *p_ds
 			if (p_qoa->data_ofs != new_data_ofs) {
 				p_qoa->data_ofs = new_data_ofs;
 				const uint8_t *ofs_src = (uint8_t *)p_src + p_qoa->data_ofs;
-				qoa_decode_frame(ofs_src, p_qoa->frame_len, &p_qoa->desc, p_qoa->dec.ptr(), &p_qoa->dec_len);
+				qoa_decode_frame(ofs_src, p_qoa->frame_len, &p_qoa->desc, p_qoa->dec.ptr(), nullptr);
 			}
 
 			uint32_t dec_idx = pos % QOA_FRAME_LEN << (is_stereo ? 1 : 0);

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -55,7 +55,6 @@ class AudioStreamPlaybackWAV : public AudioStreamPlaybackResampled {
 		uint64_t data_ofs = 0;
 		uint32_t frame_len = 0;
 		TightLocalVector<int16_t> dec;
-		uint32_t dec_len = 0;
 	} qoa;
 
 	int64_t offset = 0;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -844,7 +844,7 @@ Collection of single-file libraries used in Godot components.
     - `polypartition-0002-shadow-warning.patch` ([GH-66808](https://github.com/godotengine/godot/pull/66808))
 - `qoa.{c,h}`
   * Upstream: https://github.com/phoboslab/qoa
-  * Version: git (ae07b57deb98127a5b40916cb57775823d7437d2, 2025)
+  * Version: git (1bf9bc04673df55dc554021b768006836f69d53a, 2026)
   * License: MIT
   * Modifications: Added implementation through `qoa.c`.
 - `r128.{c,h}`

--- a/thirdparty/misc/qoa.h
+++ b/thirdparty/misc/qoa.h
@@ -580,7 +580,9 @@ unsigned int qoa_decode_header(const unsigned char *bytes, int size, qoa_desc *q
 
 unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa_desc *qoa, short *sample_data, unsigned int *frame_len) {
 	unsigned int p = 0;
-	*frame_len = 0;
+	if (frame_len) {
+		*frame_len = 0;
+	}
 
 	if (size < 8 + QOA_LMS_LEN * 4 * qoa->channels) {
 		return 0;
@@ -645,7 +647,9 @@ unsigned int qoa_decode_frame(const unsigned char *bytes, unsigned int size, qoa
 		}
 	}
 
-	*frame_len = samples;
+	if (frame_len) {
+		*frame_len = samples;
+	}
 	return p;
 }
 


### PR DESCRIPTION
Updates `qoa.h` to the latest `git`.

Before, `qoa_decode_frame()` had a mandatory `*frame_len` param, used to write to a variable how many frames were decoded. `AudioStreamPlaybackWAV::QOA_State::dec_len` was used solely to comply with it and isn't used anywhere else.

But this update makes `frame_len` optional as it now checks for validity before writing, so I went ahead and replaced the variable with `nullptr`.
