### PR TITLE
Fix GraphFrame `autoshrink_changed` signal arguments

### DIFF
--- a/doc/classes/GraphFrame.xml
+++ b/doc/classes/GraphFrame.xml
@@ -41,6 +41,7 @@
 	</members>
 	<signals>
 		<signal name="autoshrink_changed">
+			<param index="0" name="size" type="Vector2" />
 			<description>
 				Emitted when [member autoshrink_enabled] or [member autoshrink_margin] changes.
 			</description>

--- a/scene/gui/graph_frame.cpp
+++ b/scene/gui/graph_frame.cpp
@@ -199,7 +199,7 @@ void GraphFrame::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tint_color_enabled"), "set_tint_color_enabled", "is_tint_color_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "tint_color"), "set_tint_color", "get_tint_color");
 
-	ADD_SIGNAL(MethodInfo("autoshrink_changed"));
+	ADD_SIGNAL(MethodInfo("autoshrink_changed", PropertyInfo(Variant::VECTOR2, "size")));
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, GraphFrame, panel);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, GraphFrame, panel_selected);


### PR DESCRIPTION
The `autoshrink_changed` signal definition for `GraphFrame` is incorrect and does not document that it includes the frame size as an argument. This leads to random signal errors like:
```
ERROR: Error calling from signal 'autoshrink_changed' to callable: 'MyClass::': Method expected 0 argument(s), but called with 1.
```