### PR TITLE
Add `screen_texture` mipmaps for the compatibilty render for spatial shaders

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2886,17 +2886,26 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		GLuint backbuffer_depth = rb->get_backbuffer_depth();
 
 		if (backbuffer_fbo != 0) {
-			glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
-			glReadBuffer(GL_COLOR_ATTACHMENT0);
-			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, backbuffer_fbo);
 			if (scene_state.used_screen_texture) {
+				glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+				glReadBuffer(GL_COLOR_ATTACHMENT0);
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, backbuffer_fbo);
+
 				glBlitFramebuffer(0, 0, size.x, size.y,
 						0, 0, size.x, size.y,
 						GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+				int mipmaps = Image::get_image_required_mipmaps(size.x, size.y, Image::FORMAT_RGBA8);
+				GLES3::CopyEffects::get_singleton()->gaussian_blur(backbuffer, mipmaps, Rect2i(0, 0, size.x, size.y), size);
+
 				glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 6);
 				glBindTexture(GL_TEXTURE_2D, backbuffer);
 			}
 			if (scene_state.used_depth_texture) {
+				glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+				glReadBuffer(GL_COLOR_ATTACHMENT0);
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, backbuffer_fbo);
+
 				glBlitFramebuffer(0, 0, size.x, size.y,
 						0, 0, size.x, size.y,
 						GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -476,22 +476,34 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 	GLenum depth_format = GL_DEPTH24_STENCIL8;
 	uint32_t depth_format_size = 4;
 
+	int mipmaps = Image::get_image_required_mipmaps(internal_size.x, internal_size.y, Image::FORMAT_RGBA8);
+	uint32_t total_pixels = 0;
+	GLsizei width = internal_size.x;
+	GLsizei height = internal_size.y;
+
 	if (backbuffer3d.color == 0 && p_need_color) {
 		glGenTextures(1, &backbuffer3d.color);
 		glBindTexture(texture_target, backbuffer3d.color);
 
-		if (use_multiview) {
-			glTexImage3D(texture_target, 0, color_internal_format, internal_size.x, internal_size.y, view_count, 0, color_format, color_type, nullptr);
-		} else {
-			glTexImage2D(texture_target, 0, color_internal_format, internal_size.x, internal_size.y, 0, color_format, color_type, nullptr);
+		for (int level = 0; level < mipmaps; level++) {
+			if (use_multiview) {
+				glTexImage3D(texture_target, level, color_internal_format, width, height, view_count, 0, color_format, color_type, nullptr);
+			} else {
+				glTexImage2D(texture_target, level, color_internal_format, width, height, 0, color_format, color_type, nullptr);
+			}
+
+			total_pixels += width * height * view_count;
+			width = MAX(1, width >> 1);
+			height = MAX(1, height >> 1);
 		}
 
 		glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 		glTexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glTexParameteri(texture_target, GL_TEXTURE_MAX_LEVEL, mipmaps - 1);
 
-		GLES3::Utilities::get_singleton()->texture_allocated_data(backbuffer3d.color, internal_size.x * internal_size.y * view_count * color_format_size, "3D Back buffer color texture");
+		GLES3::Utilities::get_singleton()->texture_allocated_data(backbuffer3d.color, total_pixels * color_format_size, "3D Back buffer color texture");
 
 #ifndef IOS_ENABLED
 		if (use_multiview) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/119300

I'm not sure if I've done it 100% right but I kept added code to a minimum, so I reused `get_image_required_mipmaps` and `gaussian_blur` that I found being used for canvas shaders.

I had to rebind the framebuffer for the depth texture because `gaussian_blur` seems to mess up the call stack, otherwise I'd get nothing out of depth texture.