### PR TITLE
Fix Resources loaded using `ResourceLoader.load_threaded_get` are never unloaded

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -517,8 +517,6 @@ String ResourceLoader::_validate_local_path(const String &p_path) {
 
 Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
 	Ref<ResourceLoader::LoadToken> token = _load_start(p_path, p_type_hint, p_use_sub_threads ? LOAD_THREAD_DISTRIBUTE : LOAD_THREAD_SPAWN_SINGLE, p_cache_mode, true);
-	// We need to keep at least one reference to the token until it is done.
-	token->reference();
 	return token.is_valid() ? OK : FAILED;
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

This fixes #119374
#118085 still works
#111202 still works
#115069 still works

An additional reference was being created on master causing a memory leak :)