### PR TITLE
Area2D: Document that set_monitoring(false) emits exited signals

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -106,6 +106,7 @@
 		</member>
 		<member name="monitoring" type="bool" setter="set_monitoring" getter="is_monitoring" default="true">
 			If [code]true[/code], the area detects bodies or areas entering and exiting it.
+			Setting this property to [code]false[/code] will cause [signal area_exited], [signal area_shape_exited], [signal body_exited], and [signal body_shape_exited] to be emitted for all areas and bodies currently within this area.
 		</member>
 		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="0">
 			The area's priority. Higher priority areas are processed first. The [World2D]'s physics is always processed last, after all areas.


### PR DESCRIPTION
Arguably it should be obvious that, if an Area2D is intersecting any areas or bodies when monitoring is set to false, it must emit `area_exited`, `body_exited`, etc. But I wasn't sure it would be the case. Document that, happily, it is.