### PR TITLE
WIP: Add Web C# export pipeline pieces

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -36,6 +36,8 @@
       <Link>Sdk\SdkPackageVersions.props</Link>
     </None>
     <None Include="Sdk\Android.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Browser.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\Browser.targets" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOS.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOS.targets" Pack="true" PackagePath="Sdk" />
   </ItemGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -36,6 +36,7 @@
       <Link>Sdk\SdkPackageVersions.props</Link>
     </None>
     <None Include="Sdk\Android.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\BrowserMain.cs" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\Browser.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\Browser.targets" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOS.props" Pack="true" PackagePath="Sdk" />

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <StartupObject>GodotPlugins.Game.BrowserMain</StartupObject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseAppHost>false</UseAppHost>
     <WasmBuildNative>true</WasmBuildNative>
     <WasmGenerateAppBundle>true</WasmGenerateAppBundle>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>false</UseAppHost>
+    <WasmBuildNative>true</WasmBuildNative>
+    <WasmGenerateAppBundle>true</WasmGenerateAppBundle>
+    <WasmRuntimeAssetsLocation Condition=" '$(WasmRuntimeAssetsLocation)' == '' ">_framework</WasmRuntimeAssetsLocation>
+    <InvariantGlobalization Condition=" '$(InvariantGlobalization)' == '' ">true</InvariantGlobalization>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
@@ -8,5 +8,6 @@
 
   <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'browser-wasm' and '$(GodotWebNativeLibrary)' != '' and Exists('$(GodotWebNativeLibrary)') ">
     <NativeFileReference Include="$(GodotWebNativeLibrary)" />
+    <Compile Include="$(MSBuildThisFileDirectory)\BrowserMain.cs" Link="GodotWebMain.g.cs" />
   </ItemGroup>
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="CheckGodotWebNativeLibrary"
+          BeforeTargets="Build"
+          Condition=" '$(RuntimeIdentifier)' == 'browser-wasm' ">
+    <Error Text="Godot Web C# exports require the GodotWebNativeLibrary MSBuild property to point to a WebAssembly static library built from Godot with library_type=static_library."
+           Condition=" '$(GodotWebNativeLibrary)' == '' or !Exists('$(GodotWebNativeLibrary)') " />
+  </Target>
+
+  <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'browser-wasm' and '$(GodotWebNativeLibrary)' != '' and Exists('$(GodotWebNativeLibrary)') ">
+    <NativeFileReference Include="$(GodotWebNativeLibrary)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/BrowserMain.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/BrowserMain.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GodotPlugins.Game
+{
+    internal static class BrowserMain
+    {
+        [DllImport("__Internal")]
+        private static extern unsafe int libgodot_web_main(int argc, byte** argv);
+
+        [DllImport("__Internal")]
+        private static extern byte libgodot_web_iteration();
+
+        public static unsafe async Task<int> Main(string[] args)
+        {
+            int argc = args.Length + 1;
+            byte** argv = stackalloc byte*[argc];
+            IntPtr[] allocatedArgs = new IntPtr[argc];
+
+            try
+            {
+                allocatedArgs[0] = StringToNativeUtf8("godot");
+                argv[0] = (byte*)allocatedArgs[0];
+                for (int i = 0; i < args.Length; i++)
+                {
+                    allocatedArgs[i + 1] = StringToNativeUtf8(args[i]);
+                    argv[i + 1] = (byte*)allocatedArgs[i + 1];
+                }
+
+                int exitCode = libgodot_web_main(argc, argv);
+                if (exitCode != 0)
+                    return exitCode;
+
+                while (libgodot_web_iteration() != 0)
+                {
+                    await Task.Delay(1);
+                }
+
+                return 0;
+            }
+            finally
+            {
+                foreach (IntPtr allocatedArg in allocatedArgs)
+                {
+                    if (allocatedArg != IntPtr.Zero)
+                        Marshal.FreeHGlobal(allocatedArg);
+                }
+            }
+        }
+
+        private static IntPtr StringToNativeUtf8(string value)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            IntPtr buffer = Marshal.AllocHGlobal(bytes.Length + 1);
+            Marshal.Copy(bytes, 0, buffer, bytes.Length);
+            Marshal.WriteByte(buffer, bytes.Length, 0);
+            return buffer;
+        }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -105,4 +105,5 @@
 
   <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOS.props" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
+  <Import Project="$(MSBuildThisFileDirectory)\Browser.props" Condition=" '$(GodotTargetPlatform)' == 'web' " />
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -50,5 +50,6 @@
 
   <!-- iOS-specific build targets -->
   <Import Project="$(MSBuildThisFileDirectory)\iOS.targets" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
+  <Import Project="$(MSBuildThisFileDirectory)\Browser.targets" Condition=" '$(GodotTargetPlatform)' == 'web' " />
 
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -293,7 +293,8 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            IEnumerable<string>? customProperties = null
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
@@ -309,6 +310,9 @@ namespace GodotTools.Build
 
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
+
+            if (customProperties != null)
+                buildInfo.CustomProperties.AddRange(customProperties);
 
             return buildInfo;
         }
@@ -329,9 +333,10 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
-            bool includeDebugSymbols = true
+            bool includeDebugSymbols = true,
+            IEnumerable<string>? customProperties = null
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols, customProperties));
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -179,7 +179,7 @@ namespace GodotTools.Export
             if (!TryDeterminePlatformFromOSName(osName, out string? platform))
                 throw new NotSupportedException("Target platform not supported.");
 
-            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS }
+            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.Web }
                     .Contains(platform))
             {
                 throw new NotImplementedException("Target platform not yet implemented.");
@@ -214,6 +214,11 @@ namespace GodotTools.Export
             if (features.Contains("arm32"))
             {
                 publishConfig.Archs.Add("arm32");
+            }
+
+            if (features.Contains("wasm32"))
+            {
+                publishConfig.Archs.Add("wasm32");
             }
 
             if (features.Contains("universal"))
@@ -283,8 +288,19 @@ namespace GodotTools.Export
                         Directory.CreateDirectory(publishOutputDir);
 
                     // Execute dotnet publish.
+                    List<string>? customProperties = null;
+                    if (platform == OS.Platforms.Web)
+                    {
+                        customProperties = new List<string>();
+                        string? nativeLibraryPath = FindWebNativeLibrary(buildConfig);
+                        if (!string.IsNullOrEmpty(nativeLibraryPath))
+                        {
+                            customProperties.Add($"GodotWebNativeLibrary={nativeLibraryPath}");
+                        }
+                    }
+
                     if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
-                            runtimeIdentifier, publishOutputDir, includeDebugSymbols))
+                            runtimeIdentifier, publishOutputDir, includeDebugSymbols, customProperties))
                     {
                         throw new InvalidOperationException("Failed to build project. Check MSBuild panel for details.");
                     }
@@ -300,7 +316,7 @@ namespace GodotTools.Export
                     string nativeAotPath = Path.Combine(publishOutputDir,
                         $"{GodotSharpDirs.ProjectAssemblyName}.{soExt}");
 
-                    if (!File.Exists(assemblyPath) && !File.Exists(nativeAotPath))
+                    if (!File.Exists(assemblyPath) && !File.Exists(nativeAotPath) && !WebPublishHasOutput(platform, publishOutputDir))
                     {
                         throw new NotSupportedException(
                             $"Publish succeeded but project assembly not found at '{assemblyPath}' or '{nativeAotPath}'.");
@@ -349,6 +365,12 @@ namespace GodotTools.Export
                             // We get called back for both directories and files, but we only package files for now.
                             if (isFile)
                             {
+                                if (platform == OS.Platforms.Web)
+                                {
+                                    AddSharedObject(path, tags: null, target: SanitizeSlashes(Path.GetRelativePath(publishOutputDir, path)));
+                                    return;
+                                }
+
                                 if (embedBuildResults)
                                 {
                                     if (platform == OS.Platforms.Android)
@@ -510,8 +532,31 @@ namespace GodotTools.Export
                 "arm64-v8a" => "arm64",
                 "arm32" => "arm",
                 "arm64" => "arm64",
+                "wasm32" => "wasm",
                 _ => throw new ArgumentOutOfRangeException(nameof(arch), arch, "Unexpected architecture")
             };
+        }
+
+        private static bool WebPublishHasOutput(string platform, string publishOutputDir)
+        {
+            if (platform != OS.Platforms.Web || !Directory.Exists(publishOutputDir))
+                return false;
+
+            return System.IO.Directory.EnumerateFiles(publishOutputDir, "*.wasm", SearchOption.AllDirectories).Any() ||
+                   System.IO.Directory.EnumerateFiles(publishOutputDir, "*.dll", SearchOption.AllDirectories).Any();
+        }
+
+        private static string? FindWebNativeLibrary(string buildConfig)
+        {
+            string[] candidates =
+            [
+                Path.Combine(GodotSharpDirs.DataEditorToolsDir, "web", buildConfig, "libgodot.a"),
+                Path.Combine(GodotSharpDirs.DataEditorToolsDir, "web", "libgodot.a"),
+                Path.Combine(GodotSharpDirs.DataEditorToolsDir, "libgodot.web.a"),
+                Path.Combine(GodotSharpDirs.DataEditorToolsDir, "libgodot.a")
+            ];
+
+            return candidates.FirstOrDefault(File.Exists);
         }
 
         public override void _ExportEnd()

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -78,6 +78,10 @@ typedef int(CORECLR_DELEGATE_CALLTYPE *coreclr_initialize_fn)(const char *exePat
 coreclr_create_delegate_fn coreclr_create_delegate = nullptr;
 coreclr_initialize_fn coreclr_initialize = nullptr;
 
+#ifdef WEB_ENABLED
+extern "C" bool godotsharp_game_main_init(void *p_godot_dll_handle, GDMonoCache::ManagedCallbacks *r_managed_callbacks, const void **p_unmanaged_callbacks, int32_t p_unmanaged_callbacks_size);
+#endif
+
 #ifdef ANDROID_ENABLED
 mono_install_assembly_preload_hook_fn mono_install_assembly_preload_hook = nullptr;
 mono_assembly_name_get_name_fn mono_assembly_name_get_name = nullptr;
@@ -521,6 +525,14 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 #endif
 
 #ifndef TOOLS_ENABLED
+#ifdef WEB_ENABLED
+godot_plugins_initialize_fn initialize_browser_wasm_and_godot_plugins(bool &r_runtime_initialized) {
+	r_runtime_initialized = true;
+	print_verbose(".NET: browser-wasm runtime initialized");
+	return &godotsharp_game_main_init;
+}
+#endif
+
 #ifdef ANDROID_ENABLED
 MonoAssembly *load_assembly_from_pck(MonoAssemblyName *p_assembly_name, char **p_assemblies_path, void *p_user_data) {
 	constexpr bool ref_only = false;
@@ -643,7 +655,7 @@ void GDMono::initialize() {
 
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
-#if !defined(APPLE_EMBEDDED_ENABLED)
+#if !defined(APPLE_EMBEDDED_ENABLED) && !defined(WEB_ENABLED)
 	// Check that the .NET assemblies directory exists before trying to use it.
 	if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
 		OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
@@ -651,6 +663,9 @@ void GDMono::initialize() {
 	}
 #endif
 
+#if defined(WEB_ENABLED) && !defined(TOOLS_ENABLED)
+	godot_plugins_initialize = initialize_browser_wasm_and_godot_plugins(runtime_initialized);
+#else
 	if (load_hostfxr(hostfxr_dll_handle)) {
 		godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(runtime_initialized);
 		ERR_FAIL_NULL(godot_plugins_initialize);
@@ -676,6 +691,7 @@ void GDMono::initialize() {
 		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 #endif
 	}
+#endif
 
 	int32_t interop_funcs_size = 0;
 	const void **interop_funcs = godotsharp::get_runtime_interop_funcs(interop_funcs_size);

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -26,9 +26,13 @@ web_files = [
     "display_server_web.cpp",
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",
-    "web_main.cpp",
     "os_web.cpp",
 ]
+
+if env["library_type"] == "executable":
+    web_files += ["web_main.cpp"]
+else:
+    web_files += ["libgodot_web.cpp"]
 
 if env["target"] == "editor":
     env.add_source_files(web_files, "editor/*.cpp")
@@ -75,57 +79,63 @@ if len(env["EXPORTED_RUNTIME_METHODS"]):
     sys_env.Append(LINKFLAGS=["-sEXPORTED_RUNTIME_METHODS=" + repr(sorted(list(set(env["EXPORTED_RUNTIME_METHODS"]))))])
 
 build = []
-build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
-if env["dlink_enabled"]:
-    # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
-    sys_env["LIBS"] = []
-    # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
-    sys_env.Append(LIBS=["idbfs.js"])
-    # Configure it as a main module (dynamic linking support).
-    sys_env["CCFLAGS"].remove("-sSIDE_MODULE=2")
-    sys_env["LINKFLAGS"].remove("-sSIDE_MODULE=2")
-    sys_env.Append(CCFLAGS=["-s", "MAIN_MODULE=1"])
-    sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
-    sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
-    sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
-    sys_env["CCFLAGS"].remove("-fvisibility=hidden")
-    sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
-
-    # The main emscripten runtime, with exported standard libraries.
-    sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
-
-    # The side library, containing all Godot code.
-    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
-    build = sys + [wasm[0]]
+if env["library_type"] == "static_library":
+    build = env.add_library("#bin/godot", web_files)
+elif env["library_type"] == "shared_library":
+    print_error("Shared library builds are not supported for the Web platform.")
+    Exit(255)
 else:
-    # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
-    sys_env.Append(LIBS=["idbfs.js"])
-    build = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
+    build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
+    if env["dlink_enabled"]:
+        # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
+        sys_env["LIBS"] = []
+        # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
+        sys_env.Append(LIBS=["idbfs.js"])
+        # Configure it as a main module (dynamic linking support).
+        sys_env["CCFLAGS"].remove("-sSIDE_MODULE=2")
+        sys_env["LINKFLAGS"].remove("-sSIDE_MODULE=2")
+        sys_env.Append(CCFLAGS=["-s", "MAIN_MODULE=1"])
+        sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
+        sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
+        sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
+        sys_env["CCFLAGS"].remove("-fvisibility=hidden")
+        sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
 
-sys_env.Depends(build[0], sys_env["JS_LIBS"])
-sys_env.Depends(build[0], sys_env["JS_PRE"])
-sys_env.Depends(build[0], sys_env["JS_POST"])
-sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
+        # The main emscripten runtime, with exported standard libraries.
+        sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
 
-engine = [
-    "js/engine/features.js",
-    "js/engine/preloader.js",
-    "js/engine/config.js",
-    "js/engine/engine.js",
-]
-externs = [env.File("#platform/web/js/engine/engine.externs.js")]
-js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
-env.Depends(js_engine, externs)
+        # The side library, containing all Godot code.
+        wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
+        build = sys + [wasm[0]]
+    else:
+        # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
+        sys_env.Append(LIBS=["idbfs.js"])
+        build = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
 
-wrap_list = [
-    build[0],
-    js_engine,
-]
-js_wrapped = env.NoCache(
-    env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
-)
+    sys_env.Depends(build[0], sys_env["JS_LIBS"])
+    sys_env.Depends(build[0], sys_env["JS_PRE"])
+    sys_env.Depends(build[0], sys_env["JS_POST"])
+    sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
 
-# 0 - unwrapped js file (use wrapped one instead)
-# 1 - wasm file
-# 2 - wasm side (when dlink is enabled).
-env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)
+    engine = [
+        "js/engine/features.js",
+        "js/engine/preloader.js",
+        "js/engine/config.js",
+        "js/engine/engine.js",
+    ]
+    externs = [env.File("#platform/web/js/engine/engine.externs.js")]
+    js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, externs, env["threads"])
+    env.Depends(js_engine, externs)
+
+    wrap_list = [
+        build[0],
+        js_engine,
+    ]
+    js_wrapped = env.NoCache(
+        env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
+    )
+
+    # 0 - unwrapped js file (use wrapped one instead)
+    # 1 - wasm file
+    # 2 - wasm side (when dlink is enabled).
+    env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -79,6 +79,7 @@ def get_flags():
     return {
         "arch": "wasm32",
         "target": "template_debug",
+        "supported": ["library"],
         "builtin_pcre2_with_jit": False,
         "vulkan": False,
         # Embree is heavy and requires too much memory (GH-70621).

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -422,13 +422,6 @@ Ref<Texture2D> EditorExportPlatformWeb::get_logo() const {
 }
 
 bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
-#ifdef MODULE_MONO_ENABLED
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
-	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	return false;
-#else
-
 	String err;
 	bool valid = false;
 	bool extensions = (bool)p_preset->get("variant/extensions_support");
@@ -459,7 +452,6 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
-#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
@@ -531,10 +523,16 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	{
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		for (int i = 0; i < shared_objects.size(); i++) {
-			String dst = base_dir.path_join(shared_objects[i].path.get_file());
+			String dst = shared_objects[i].target.is_empty() ? shared_objects[i].path.get_file() : shared_objects[i].target;
+			dst = base_dir.path_join(dst);
+			Error mkdir_err = da->make_dir_recursive(dst.get_base_dir());
+			if (mkdir_err != OK) {
+				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not create folder: \"%s\"."), dst.get_base_dir()));
+				return mkdir_err;
+			}
 			error = da->copy(shared_objects[i].path, dst);
 			if (error != OK) {
-				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not write file: \"%s\"."), shared_objects[i].path.get_file()));
+				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not write file: \"%s\"."), dst));
 				return error;
 			}
 		}

--- a/platform/web/libgodot_web.cpp
+++ b/platform/web/libgodot_web.cpp
@@ -1,0 +1,127 @@
+/**************************************************************************/
+/*  libgodot_web.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "display_server_web.h"
+#include "godot_js.h"
+#include "os_web.h"
+
+#include "core/config/engine.h"
+#include "core/extension/godot_instance.h"
+#include "core/extension/libgodot.h"
+#include "core/io/resource_loader.h"
+#include "core/os/os.h"
+#include "core/profiling/profiling.h"
+#include "core/string/print_string.h"
+#include "main/main.h"
+
+#include <cstdlib>
+
+static OS_Web *os = nullptr;
+static GodotInstance *instance = nullptr;
+
+#ifndef PROXY_TO_PTHREAD_ENABLED
+static uint64_t target_ticks = 0;
+#endif
+
+static void print_web_header() {
+	char *emscripten_version_char = godot_js_emscripten_get_version();
+	String emscripten_version = vformat("Emscripten %s", emscripten_version_char);
+	free(emscripten_version_char);
+
+	String thread_support = OS::get_singleton()->has_feature("threads") ? "multi-threaded" : "single-threaded";
+	String extensions_support = OS::get_singleton()->has_feature("web_extensions") ? "GDExtension support" : "no GDExtension support";
+
+	Vector<String> build_configuration = { emscripten_version, thread_support, extensions_support };
+	print_line(vformat("Build configuration: %s.", String(", ").join(build_configuration)));
+}
+
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+
+	godot_init_profiler();
+	os = new OS_Web();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	instance = memnew(GodotInstance);
+	if (!instance->initialize(p_init_func)) {
+		memdelete(instance);
+		instance = nullptr;
+		return nullptr;
+	}
+
+	print_web_header();
+	ResourceLoader::set_abort_on_missing_resources(false);
+
+	return static_cast<GDExtensionObjectPtr>(instance);
+}
+
+void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	GodotInstance *godot_instance = static_cast<GodotInstance *>(p_godot_instance);
+	if (instance == godot_instance) {
+		godot_instance->stop();
+		memdelete(godot_instance);
+		instance = nullptr;
+		Main::cleanup();
+		memdelete(os);
+		os = nullptr;
+		godot_cleanup_profiler();
+	}
+}
+
+extern "C" LIBGODOT_API GDExtensionBool libgodot_web_iteration() {
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	uint64_t current_ticks = os->get_ticks_usec();
+#endif
+
+	bool force_draw = DisplayServerWeb::get_singleton()->check_size_force_redraw();
+	if (force_draw) {
+		Main::force_redraw();
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	} else if (current_ticks < target_ticks) {
+		return false;
+#endif
+	}
+
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	int max_fps = Engine::get_singleton()->get_max_fps();
+	if (max_fps > 0) {
+		if (current_ticks - target_ticks > 1000000) {
+			target_ticks = current_ticks;
+		}
+		target_ticks += (uint64_t)(1000000 / max_fps);
+	}
+#endif
+
+	return os->main_loop_iterate();
+}

--- a/platform/web/libgodot_web.cpp
+++ b/platform/web/libgodot_web.cpp
@@ -45,6 +45,7 @@
 
 static OS_Web *os = nullptr;
 static GodotInstance *instance = nullptr;
+static bool main_started = false;
 
 #ifndef PROXY_TO_PTHREAD_ENABLED
 static uint64_t target_ticks = 0;
@@ -86,6 +87,35 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 	return static_cast<GDExtensionObjectPtr>(instance);
 }
 
+extern "C" LIBGODOT_API int libgodot_web_main(int p_argc, char *p_argv[]) {
+	ERR_FAIL_COND_V_MSG(main_started, EXIT_FAILURE, "Only one Godot Web main loop may be started.");
+
+	godot_init_profiler();
+	os = new OS_Web();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1]);
+	if (err != OK) {
+		if (err == ERR_HELP) {
+			return EXIT_SUCCESS;
+		}
+		return EXIT_FAILURE;
+	}
+
+	print_web_header();
+	ResourceLoader::set_abort_on_missing_resources(false);
+
+	main_started = true;
+
+	int ret = Main::start();
+	os->set_exit_code(ret);
+	if (ret != EXIT_SUCCESS) {
+		return ret;
+	}
+
+	os->get_main_loop()->initialize();
+	return EXIT_SUCCESS;
+}
+
 void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 	GodotInstance *godot_instance = static_cast<GodotInstance *>(p_godot_instance);
 	if (instance == godot_instance) {
@@ -100,6 +130,8 @@ void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
 }
 
 extern "C" LIBGODOT_API GDExtensionBool libgodot_web_iteration() {
+	ERR_FAIL_NULL_V(os, false);
+
 #ifndef PROXY_TO_PTHREAD_ENABLED
 	uint64_t current_ticks = os->get_ticks_usec();
 #endif


### PR DESCRIPTION
## Summary
- add a Web libgodot static-library entrypoint for browser-hosted runtimes
- add browser-wasm Godot.NET.Sdk props/targets and NativeFileReference wiring
- allow the C# export plugin to publish Web projects and preserve _framework publish output paths in Web exports

## Current status
This is an implementation step toward restoring Web C# exports, not yet a complete end-to-end solution. It still needs validation and likely follow-up work for the full browser bootstrap/runtime path before it should be considered mergeable as a fix for godotengine/godot#70796.

## Testing
- PYTHONPYCACHEPREFIX=/Users/ADMIN/Documents/Codex/2026-05-10/lets-do-this-bounty-https-app/.pycache python3 -m py_compile platform/web/SCsub platform/web/detect.py
- python3 -m xml.etree.ElementTree modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
- python3 -m xml.etree.ElementTree modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
- git diff --check

Local environment did not have dotnet, scons, or emcc available, so an end-to-end browser export still needs validation in a Godot Web/.NET toolchain environment.
