### PR TITLE
Tweak default property value display in descriptions in the editor help

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2161,15 +2161,11 @@ void EditorHelp::_update_doc() {
 
 			if (!prop.default_value.is_empty()) {
 				class_desc->push_color(theme_cache.symbol_color);
-				class_desc->add_text(" [" + TTR("default:") + " ");
+				class_desc->add_text(" = ");
 				class_desc->pop(); // color
 
 				class_desc->push_color(theme_cache.value_color);
 				class_desc->add_text(_fix_constant(prop.default_value));
-				class_desc->pop(); // color
-
-				class_desc->push_color(theme_cache.symbol_color);
-				class_desc->add_text("]");
 				class_desc->pop(); // color
 			}
 


### PR DESCRIPTION
The default value display *in descriptions* now better matches the online class reference. The list of properties is left unchanged.

- See https://github.com/godotengine/godot-proposals/discussions/14789#discussioncomment-16830579.

## Preview

### Editor

Before | After
-|-
<img width="834" height="607" alt="Screenshot_20260511_192222" src="https://github.com/user-attachments/assets/e232e129-861e-4ed6-9b54-ad3825074b40" /> | <img width="834" height="607" alt="Screenshot_20260511_193145" src="https://github.com/user-attachments/assets/f677a6f3-ffaa-4b89-be62-9d8f0e8379f0" />

### Online class reference (for comparison)

<img width="400" alt="Screenshot_20260511_193153" src="https://github.com/user-attachments/assets/2e666864-f8bc-4e88-8dbc-70fb7735a3c9" />
