### PR TITLE
Fix incorrect tooltips in `PopupMenu` when the search bar is enabled

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3230,10 +3230,15 @@ bool PopupMenu::get_allow_search() const {
 }
 
 String PopupMenu::get_tooltip(const Point2 &p_pos) const {
-	int over = _get_mouse_over(p_pos);
+	Point2 pos = p_pos;
+	// Adjust for the top style margin and search bar.
+	pos.y += scroll_container->get_global_position().y;
+
+	int over = _get_mouse_over(pos);
 	if (over < 0 || over >= items.size()) {
 		return "";
 	}
+
 	return items[over].tooltip;
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1567,19 +1567,13 @@ void Viewport::_gui_cancel_tooltip() {
 String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Control **r_tooltip_owner) {
 	Vector2 pos = p_pos;
 	String tooltip;
+	PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 
 	while (p_control) {
-		tooltip = p_control->get_tooltip(pos);
-
-		// Temporary solution for PopupMenus.
-		PopupMenu *menu = Object::cast_to<PopupMenu>(this);
 		if (menu) {
-			Ref<StyleBox> sb = menu->get_theme_stylebox(SceneStringName(panel));
-			if (sb.is_valid()) {
-				pos.y += sb->get_margin(SIDE_TOP);
-			}
-
 			tooltip = menu->get_tooltip(pos);
+		} else {
+			tooltip = p_control->get_tooltip(pos);
 		}
 
 		if (r_tooltip_owner) {


### PR DESCRIPTION
If the search bar for the `PopupMenu` is enabled, the tooltip for the wrong item can be shown when hovering it. This PR fixes that.
*Bugsquad edit:* Fixes #119407