### PR TITLE
Add project setting to disable new Volumetric fog blending behavior

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2919,6 +2919,9 @@
 		<member name="rendering/environment/defaults/default_environment" type="String" setter="" getter="" default="&quot;&quot;">
 			[Environment] that will be used as a fallback environment in case a scene does not specify its own environment. The default environment is loaded in at scene load time regardless of whether you have set an environment or not. If you do not rely on the fallback environment, you do not need to set this property.
 		</member>
+		<member name="rendering/environment/fog/use_legacy_blending" type="bool" setter="" getter="" default="false">
+			Enables legacy fog blending behavior from version 4.5 and earlier. This is intended for users who are developing on pre-4.6 versions and want to upgrade to 4.6 with the smallest possible change to their visuals.
+		</member>
 		<member name="rendering/environment/glow/upscale_mode" type="int" setter="" getter="" default="1" keywords="bicubic">
 			Sets how the glow effect is upscaled before being copied onto the screen. Linear is faster, but looks blocky. Bicubic is slower but looks smooth.
 			[b]Note:[/b] [member rendering/environment/glow/upscale_mode] is only effective when using the Forward+ or Mobile rendering methods, as Compatibility uses a different glow implementation.

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1223,6 +1223,7 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 
 	sky_scene_state.ubo.fog_sky_affect = RendererSceneRenderRD::get_singleton()->environment_get_fog_sky_affect(p_render_data->environment);
 	sky_scene_state.ubo.volumetric_fog_sky_affect = RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_sky_affect(p_render_data->environment);
+	sky_scene_state.ubo.fog_use_legacy_blending = RendererSceneRenderRD::get_singleton()->fog_use_legacy_blending_get();
 
 	RD::get_singleton()->buffer_update(sky_scene_state.uniform_buffer, 0, sizeof(SkySceneState::UBO), &sky_scene_state.ubo);
 }

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -158,8 +158,8 @@ public:
 
 			float z_far; // 4 - 340
 			uint32_t directional_light_count; // 4 - 344
-			uint32_t pad1; // 4 - 348
-			uint32_t pad2; // 4 - 352
+			uint32_t fog_use_legacy_blending; // 4 - 348
+			uint32_t pad1; // 4 - 352
 		};
 
 		UBO ubo;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -4990,6 +4990,7 @@ void RenderForwardClustered::_update_shader_quality_settings() {
 	specialization.directional_soft_shadow_samples = directional_soft_shadow_samples_get();
 	specialization.directional_penumbra_shadow_samples = directional_penumbra_shadow_samples_get();
 	specialization.use_lightmap_bicubic_filter = lightmap_filter_bicubic_get();
+	specialization.fog_use_legacy_blending = fog_use_legacy_blending_get();
 	scene_shader.set_default_specialization(specialization);
 
 	base_uniforms_changed(); //also need this

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -126,6 +126,7 @@ public:
 				uint32_t multimesh_format_2d : 1;
 				uint32_t multimesh_has_color : 1;
 				uint32_t multimesh_has_custom_data : 1;
+				uint32_t fog_use_legacy_blending : 1;
 			};
 		};
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1741,6 +1741,7 @@ void RendererSceneRenderRD::init() {
 
 	environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
 	environment_set_volumetric_fog_filter_active(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter"));
+	fog_use_legacy_blending = GLOBAL_GET("rendering/environment/fog/use_legacy_blending");
 
 	decals_set_filter(RSE::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
 	light_projectors_set_filter(RSE::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -162,6 +162,9 @@ private:
 
 	uint32_t max_cluster_elements = 512;
 
+	/* Fog */
+	bool fog_use_legacy_blending = false;
+
 	/* Volumetric Fog */
 
 	uint32_t volumetric_fog_size = 128;
@@ -323,6 +326,10 @@ public:
 
 	_FORCE_INLINE_ bool material_use_debanding_get() const {
 		return material_use_debanding;
+	}
+
+	_FORCE_INLINE_ bool fog_use_legacy_blending_get() const {
+		return fog_use_legacy_blending;
 	}
 
 	int get_roughness_layers() const;

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -78,8 +78,8 @@ layout(set = 0, binding = 2, std140) uniform SkySceneData {
 
 	float z_far; // 4 - 52
 	uint directional_light_count; // 4 - 56
-	uint pad1; // 4 - 60
-	uint pad2; // 4 - 64
+	bool fog_use_legacy_blending; // 4 - 60
+	uint pad1; // 4 - 64
 }
 sky_scene_data;
 
@@ -286,8 +286,12 @@ void main() {
 
 	if (sky_scene_data.volumetric_fog_enabled) {
 		vec4 fog = volumetric_fog_process(uv);
-		fog.rgb = frag_color.rgb * fog.a + fog.rgb;
-		frag_color.rgb = mix(frag_color.rgb, fog.rgb, sky_scene_data.volumetric_fog_sky_affect);
+		if (sky_scene_data.fog_use_legacy_blending) {
+			frag_color.rgb = mix(frag_color.rgb, fog.rgb, (1.0 - fog.a) * sky_scene_data.volumetric_fog_sky_affect);
+		} else {
+			fog.rgb = frag_color.rgb * fog.a + fog.rgb;
+			frag_color.rgb = mix(frag_color.rgb, fog.rgb, sky_scene_data.volumetric_fog_sky_affect);
+		}
 	}
 
 	if (custom_fog.a > 0.0) {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1505,10 +1505,18 @@ void fragment_shader(in SceneData scene_data) {
 		vec4 res = vec4(0.0);
 		if (bool(scene_data.flags & SCENE_DATA_FLAGS_USE_FOG)) {
 			//must use the full blending equation here to blend fogs
-			res.a = fog.a * volumetric_fog.a;
-			res.rgb = fog.rgb * volumetric_fog.a + volumetric_fog.rgb;
+			if (sc_fog_use_legacy_blending()) {
+				res.a = mix(0.0, fog.a, volumetric_fog.a);
+				res.rgb = mix(volumetric_fog.rgb, fog.rgb, volumetric_fog.a);
+			} else {
+				res.a = fog.a * volumetric_fog.a;
+				res.rgb = fog.rgb * volumetric_fog.a + volumetric_fog.rgb;
+			}
 		} else {
 			res = volumetric_fog;
+			if (sc_fog_use_legacy_blending()) {
+				res.rgb *= 1.0 - res.a;
+			}
 		}
 		fog = res;
 	}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -138,6 +138,10 @@ bool sc_multimesh_has_custom_data() {
 	return ((sc_packed_1() >> 3) & 1U) != 0;
 }
 
+bool sc_fog_use_legacy_blending() {
+	return ((sc_packed_1() >> 4) & 1U) != 0;
+}
+
 float sc_luminance_multiplier() {
 	// Not used in clustered renderer but we share some code with the mobile renderer that requires this.
 	return 1.0;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3789,6 +3789,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_converge", PROPERTY_HINT_ENUM, "5 (Less Latency but Lower Quality),10,15,20,25,30 (More Latency but Higher Quality)"), 5);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_update_lights", PROPERTY_HINT_ENUM, "1 (Slower),2,4,8,16 (Faster)"), 2);
 
+	GLOBAL_DEF_RST("rendering/environment/fog/use_legacy_blending", false);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_size", PROPERTY_HINT_RANGE, "16,512,1"), 64);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_depth", PROPERTY_HINT_RANGE, "16,512,1"), 64);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/use_filter", PROPERTY_HINT_ENUM, "No (Faster),Yes (Higher Quality)"), 1);


### PR DESCRIPTION
This change effectively reverts https://github.com/godotengine/godot/pull/111998 and https://github.com/godotengine/godot/pull/112494 which changed the fog blending equation to one that is more robust and can handle the case of light colored fog (see https://github.com/godotengine/godot/issues/101514). The previous behaviour was incorrect. 

That being said, just because the old behaviour was _technically_ wrong, doesn't mean it didn't look acceptable. Many projects in 4.5 and earlier tweaked the fog to look great for their game. Thus the subsequent bug fix for 4.6 broke their game. We knew this was a breaking change (see https://github.com/godotengine/godot/issues/114989, https://github.com/godotengine/tps-demo/pull/212, etc.) but we decided that it was not a big deal since we thought that the old behaviour could be matched by tweaking settings (see https://github.com/godotengine/godot/issues/114989, and https://github.com/godotengine/godot/issues/112468). 

However, as it turns out, in some cases, the exact behaviour can't be restored simply by modifying settings. That means that some projects are left with the choice between reverting these PRs manually and using a fork of Godot, or living with a fog result that they like less than the old version. Both are bad choices. 

This PR seeks to create a middle ground for projects that really hate the new blending equation and can't upgrade. It uses a specialization constant to handle the setting so there is no run time performance cost to having this setting. The setting also requires a restart so it will enforce setting early and not touching it. 

See for example https://x.com/WaterMuseum_/status/2047064911159705618, https://www.reddit.com/r/godot/comments/1qq5ta8/whats_up_with_materials_looking_significantly/, https://www.reddit.com/r/godot/comments/1qnmjnj/comment/o2j27dc/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

CC @RPicster @pirey0

_this PR with setting on_
<img width="2175" height="1227" alt="Screenshot from 2026-05-11 18-55-44" src="https://github.com/user-attachments/assets/fef42003-5447-43b4-95fc-71b3778e6fa3" />

_Master with new blending function reverted_
<img width="2175" height="1227" alt="Screenshot from 2026-05-11 18-52-10" src="https://github.com/user-attachments/assets/c5267cd7-f479-4038-b591-7c93621172d7" />

_this PR with setting on_
<img width="2175" height="1227" alt="Screenshot from 2026-05-11 18-33-19" src="https://github.com/user-attachments/assets/8eb2edb1-3541-4a71-8653-cb632963295e" />

_Master with new blending function reverted_
<img width="2175" height="1227" alt="Screenshot from 2026-05-11 18-39-10" src="https://github.com/user-attachments/assets/59db3836-df44-482f-b6da-9eecf634bc56" />

As you can see from the screenshots, there is a very tiny increase in brightness in some cases with this PR compared to master with the PRs reverted. I have confirmed that that change comes from a difference in rounding behaviour and should be very minor in all cases. 