### PR TITLE
Always disable `all_tabs_in_front` in `TabContainer`

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -206,7 +206,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="all_tabs_in_front" type="bool" setter="set_all_tabs_in_front" getter="is_all_tabs_in_front" default="false" deprecated="Due to internal changes this doesn&apos;t do anything anymore, as they&apos;re always in front.">
+		<member name="all_tabs_in_front" type="bool" setter="set_all_tabs_in_front" getter="is_all_tabs_in_front" deprecated="Due to internal changes this doesn&apos;t do anything anymore, as they&apos;re always in front.">
 			This doesn't do anything.
 		</member>
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -835,14 +835,13 @@ bool TabContainer::are_tabs_visible() const {
 
 #ifndef DISABLE_DEPRECATED
 void TabContainer::set_all_tabs_in_front(bool p_in_front) {
-	all_tabs_in_front = p_in_front;
-	if (all_tabs_in_front) {
+	if (p_in_front) {
 		WARN_PRINT_ONCE("Due to internal changes, `all_tabs_in_front` doesn't do anything anymore, as they're always in front.");
 	}
 }
 
 bool TabContainer::is_all_tabs_in_front() const {
-	return all_tabs_in_front;
+	return false;
 }
 #endif
 
@@ -1255,7 +1254,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_tabs"), "set_clip_tabs", "get_clip_tabs");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tabs_visible"), "set_tabs_visible", "are_tabs_visible");
 #ifndef DISABLE_DEPRECATED
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_all_tabs_in_front", "is_all_tabs_in_front");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_all_tabs_in_front", "is_all_tabs_in_front");
 #endif
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "switch_on_drag_hover"), "set_switch_on_drag_hover", "get_switch_on_drag_hover");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -54,9 +54,6 @@ private:
 	Button *popup_button = nullptr;
 
 	bool tabs_visible = true;
-#ifndef DISABLE_DEPRECATED
-	bool all_tabs_in_front = false;
-#endif
 	TabPosition tabs_position = POSITION_TOP;
 	mutable ObjectID popup_obj_id;
 	bool use_hidden_tabs_for_min_size = false;


### PR DESCRIPTION
One small thing I forgot with #118623, is that now since the property doesn't show up in the inspector anymore, there is no way to disable it from the editor if it was enabled before hand, meaning that the warning about it will always show up in that case.

This PR makes so that it will always return `false` when fetched. The warning will still show up if someone tries to enable it via the property.