### PR TITLE
Fix Android plugin signal regression

### DIFF
--- a/platform/android/api/jni_singleton.cpp
+++ b/platform/android/api/jni_singleton.cpp
@@ -36,6 +36,15 @@ void JNISingleton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_java_method", "method"), &JNISingleton::has_java_method);
 }
 
+bool JNISingleton::_get(const StringName &p_name, Variant &r_property) const {
+	if (has_signal(p_name)) {
+		r_property = Signal(this, p_name);
+		return true;
+	}
+
+	return false;
+}
+
 Variant JNISingleton::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	// Godot methods take precedence.
 	Variant ret = Object::callp(p_method, p_args, p_argcount, r_error);

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -48,6 +48,7 @@ class JNISingleton : public Object {
 
 protected:
 	static void _bind_methods();
+	bool _get(const StringName &p_name, Variant &r_property) const;
 
 public:
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;

--- a/platform/android/java/app/src/instrumented/assets/test/android_plugin/signal_tests.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/android_plugin/signal_tests.gd
@@ -15,6 +15,7 @@ func run_tests():
 
 	__exec_test(test_plugin_exists)
 	__exec_test(test_signal_registration)
+	__exec_test(test_signal_connection)
 	await __exec_test(test_signal_emission)
 
 	print("Android plugin signal tests completed.")
@@ -32,6 +33,21 @@ func test_signal_registration() -> bool:
 
 	var launch_signal_registered = _plugin.has_signal(launch_test_signal)
 	assert_true(launch_signal_registered)
+
+	return true
+
+func test_signal_connection() -> bool:
+	_plugin.connect(emission_test_signal, _on_emission_test_signal_emitted)
+	assert_equal(_plugin.has_connections(emission_test_signal), true)
+
+	_plugin.disconnect(emission_test_signal, _on_emission_test_signal_emitted)
+	assert_equal(_plugin.has_connections(emission_test_signal), false)
+
+	_plugin.emission_test_signal.connect(_on_emission_test_signal_emitted)
+	assert_equal(_plugin.has_connections(emission_test_signal), true)
+
+	_plugin.emission_test_signal.disconnect(_on_emission_test_signal_emitted)
+	assert_equal(_plugin.has_connections(emission_test_signal), false)
 
 	return true
 


### PR DESCRIPTION
Fixes regression caused by https://github.com/godotengine/godot/pull/119233. Connecting signal using `_plugin_singleton.connected.connect(_on_plugin_connected)`, started throwing error `Invalid access to property or key 'connected' on a base object of type 'JNISingleton'`