### PR TITLE
Phase out `RefCounted` singletons as UB pitfalls

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -34,7 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
-#include "core/object/ref_counted.h"
+#include "core/object/object.h"
 #include "core/variant/typed_array.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_device.h"
@@ -326,6 +326,11 @@ void Engine::print_header_rich(const String &p_string) const {
 
 void Engine::add_singleton(const Singleton &p_singleton) {
 	ERR_FAIL_COND_MSG(singleton_ptrs.has(p_singleton.name), vformat("Can't register singleton '%s' because it already exists.", p_singleton.name));
+#ifdef DEBUG_ENABLED
+	if (p_singleton.ptr && p_singleton.ptr->is_ref_counted()) {
+		WARN_PRINT(vformat("RefCounted singleton '%s' will be disallowed soon; raw pointer will dangle when last Ref is released. Use Object singleton.", p_singleton.name));
+	}
+#endif
 	singletons.push_back(p_singleton);
 	singleton_ptrs[p_singleton.name] = p_singleton.ptr;
 }
@@ -445,10 +450,4 @@ Engine::Singleton::Singleton(const StringName &p_name, Object *p_ptr, const Stri
 		name(p_name),
 		ptr(p_ptr),
 		class_name(p_class_name) {
-#ifdef DEBUG_ENABLED
-	RefCounted *rc = Object::cast_to<RefCounted>(p_ptr);
-	if (rc && !rc->is_referenced()) {
-		WARN_PRINT("You must use Ref<> to ensure the lifetime of a RefCounted object intended to be used as a singleton.");
-	}
-#endif
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119426

## Additional information

Registered singletons only store an `Object *`. Registering a `RefCounted` singleton only works if some external `Ref<>` keeps it alive. This pattern is fragile and invites UB:
- Whenever the last `Ref` is destroyed, the singleton becomes dangling. 
- For temporary objects à la `RefCounted.new()`, destruction happens immediately, the singleton is dead-on-arrival.
- A previous `!is_referenced()` condition allowed more leniency when outside `Ref`s were pre-existing, but this just hides the problem: if the last `Ref` drops before the singleton, the dead object is back.

TLDR: Godot isn't prepared to handle `RefCounted` singletons, and the workarounds add complexity without solving the underlying logic errors, which manifest as UB at least in GDExtension.

## Migration approach

For now I added warnings, to allow this PR to be used in patch versions, and give time to migrate. I would suggest that `RefCounted` singletons become a hard error in an upcoming minor version, _unless_ we get significant user feedback that justify their use.

If hard errors are preferred already now, I can also update the PR.