### PR TITLE
[Windows] Remove `await` MSVC flags.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -94,11 +94,6 @@ if env["winrt"]:
     else:
         cc_version = get_compiler_version(env)
         cc_version_major = cc_version["major"]
-        if not env["use_llvm"]:
-            if cc_version_major >= 18:
-                env_winrt.Append(CXXFLAGS=["/await:strict"])  # /await is deprecated in MSVC 2026+
-            else:
-                env_winrt.Append(CXXFLAGS=["/await"])
         if "/std:c++17" in env_winrt["CXXFLAGS"]:
             env_winrt["CXXFLAGS"].remove("/std:c++17")
         env_winrt.Append(CXXFLAGS=["/std:c++20"])


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/119278

`/await` flag was added in attempt to allow building with `VS2019 + SDK 10.0.19041`, which was working for initial OneCore TTS, but with HDR support code it is no longer sufficient. After #119278, min supported SDK (`VS2019 + SDK 10.0.22621`) is new enough to not require this flag.