### PR TITLE
Up default cube subdivisions to 2, so that tests scenes with area light dont look broken

### DIFF
--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -163,9 +163,9 @@ class BoxMesh : public PrimitiveMesh {
 
 private:
 	Vector3 size = Vector3(1, 1, 1);
-	int subdivide_w = 0;
-	int subdivide_h = 0;
-	int subdivide_d = 0;
+	int subdivide_w = 2;
+	int subdivide_h = 2;
+	int subdivide_d = 2;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This already happened more than once. Dual paraboloid shadows, which are optional in omnilight and default for area lights, don't behave well with large triangles on screen. The issue is difficult to spot because at a glance area lights look broken, but it's really just an issue of dual paraoboloid not working well with non-subdivided meshes.

This is meant to catch in advance a bunch of bug reports that are ultimately a documentation problem.

Fixes https://github.com/godotengine/godot/issues/119183