### PR TITLE
Implement get_latency method for coreaudio on MacOS

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -100,6 +100,8 @@ public:
 	virtual int get_input_mix_rate() const override;
 	virtual SpeakerMode get_speaker_mode() const override;
 
+	virtual float get_latency() override;
+
 	virtual void lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
@@ -122,6 +124,11 @@ public:
 
 	AudioDriverCoreAudio();
 	~AudioDriverCoreAudio() {}
+
+#ifdef MACOS_ENABLED
+private:
+	OSStatus _get_macos_audio_output_property(AudioObjectID object_id, AudioObjectPropertySelector selector, void *data, UInt32 *data_size);
+#endif
 };
 
 #endif // COREAUDIO_ENABLED

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -37,6 +37,8 @@
 #include "core/math/math_funcs_binary.h"
 #include "core/os/os.h"
 
+#include <vector>
+
 #define kOutputBus 0
 #define kInputBus 1
 
@@ -301,6 +303,88 @@ int AudioDriverCoreAudio::get_input_mix_rate() const {
 
 AudioDriver::SpeakerMode AudioDriverCoreAudio::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
+}
+
+float AudioDriverCoreAudio::get_latency() {
+#ifdef MACOS_ENABLED
+	// On MacOS, output latency comes from four different values which need to be combined for the total latency in frames:
+	// buffer size, safety offset, device latency, and stream latency
+	OSStatus result;
+	UInt32 data_size;
+
+	// get device id
+	AudioDeviceID device_id;
+	data_size = sizeof(AudioDeviceID);
+	result = _get_macos_audio_output_property(kAudioObjectSystemObject, kAudioHardwarePropertyDefaultOutputDevice, &device_id, &data_size);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+
+	// buffer size
+	UInt32 output_buffer_frames = 0;
+	data_size = sizeof(output_buffer_frames);
+	result = _get_macos_audio_output_property(device_id, kAudioDevicePropertyBufferFrameSize, &output_buffer_frames, &data_size);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+
+	// safety offset
+	UInt32 safety_offset = 0;
+	data_size = sizeof(safety_offset);
+	result = _get_macos_audio_output_property(device_id, kAudioDevicePropertySafetyOffset, &safety_offset, &data_size);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+
+	// device latency
+	UInt32 device_latency = 0;
+	data_size = sizeof(device_latency);
+	result = _get_macos_audio_output_property(device_id, kAudioDevicePropertyLatency, &device_latency, &data_size);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+
+	// Stream latency
+	UInt32 max_stream_latency = 0;
+	UInt32 streams_bytesize;
+	int stream_count = 0;
+
+	AudioObjectPropertyAddress property_address;
+	property_address.mElement = kAudioObjectPropertyElementMain;
+	property_address.mScope = kAudioDevicePropertyScopeOutput;
+	property_address.mSelector = kAudioDevicePropertyStreams;
+
+	// Get the number of streams, and then loop through them to find the maximum latency reported by any stream
+	// Generally there will only be one stream, and most external audio devices report stream latency as zero
+	// but finding the maximum latency seems like the safest approach
+	result = AudioObjectGetPropertyDataSize(device_id, &property_address, 0, nullptr, &streams_bytesize);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+	stream_count = streams_bytesize / sizeof(AudioStreamID);
+
+	if (stream_count > 0) {
+		std::vector<AudioStreamID> streams(stream_count);
+		data_size = stream_count * sizeof(AudioStreamID);
+		result = _get_macos_audio_output_property(device_id, kAudioDevicePropertyStreams, streams.data(), &data_size);
+		ERR_FAIL_COND_V(result != noErr, FAILED);
+
+		UInt32 stream_latency = 0;
+		data_size = sizeof(stream_latency);
+
+		for (int i = 0; i < stream_count; i++) {
+			result = _get_macos_audio_output_property(streams[i], kAudioStreamPropertyLatency, &stream_latency, &data_size);
+
+			if (result == noErr) {
+				max_stream_latency = MAX(max_stream_latency, stream_latency);
+			}
+		}
+	}
+
+	UInt32 total_latency_frames = output_buffer_frames + safety_offset + device_latency + max_stream_latency;
+
+	double hw_mix_rate;
+	data_size = sizeof(hw_mix_rate);
+	result = _get_macos_audio_output_property(device_id, kAudioDevicePropertyNominalSampleRate, &hw_mix_rate, &data_size);
+	ERR_FAIL_COND_V(result != noErr, FAILED);
+
+	// convert latency from frames to seconds
+	float latency = (float)total_latency_frames / (float)hw_mix_rate;
+
+	return latency;
+#else
+	return 0;
+#endif
 }
 
 void AudioDriverCoreAudio::lock() {
@@ -719,6 +803,19 @@ void AudioDriverCoreAudio::set_input_device(const String &p_name) {
 	if (active) {
 		_set_device(input_device_name, true);
 	}
+}
+
+OSStatus AudioDriverCoreAudio::_get_macos_audio_output_property(AudioObjectID object_id, AudioObjectPropertySelector selector, void *data, UInt32 *data_size) {
+	OSStatus result;
+
+	AudioObjectPropertyAddress property_address;
+	property_address.mElement = kAudioObjectPropertyElementMain;
+	property_address.mScope = kAudioDevicePropertyScopeOutput;
+	property_address.mSelector = selector;
+
+	result = AudioObjectGetPropertyData(object_id, &property_address, 0, nullptr, data_size, data);
+
+	return result;
 }
 
 #endif


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently calling `AudioServer.get_output_latency()` on a Mac will always return `0`, as the `get_latency()` function is not defined in the CoreAudio driver, so it falls back to the virtual function in `audio_server.h`, which just returns `0`

This PR adds the `get_latency()` function in CoreAudio (for Mac only, other devices using CoreAudio, such as iOS, will still report 0 - I'll tackle that in a future PR)

I've tested this on a 2023 M3 MacBook Pro running MacOS 15, and a 2017 Intel MacBook Pro running MacOS 13, with a few different audio devices on each (built in speakers, headphones, USB interfaces), and the latency reported appeared correct in all instances

## Additional information

The basis for the latency calculations came from this discussion on the [JUCE framework forum](https://forum.juce.com/t/macos-round-trip-latency/45278), as well as the CoreAudio docs and my own experimentation

Regarding stream latency, in an ideal world when there are multiple streams we'd figure out which stream was currently being used, however I couldn't find a reliable way to do that. The approach here of using the maximum reported stream latency seems like a safe compromise, especially considering every single external audio device I tested reported a stream latency of zero anyway

In my testing only the built in audio devices actually report a stream latency, and they only ever have the one stream 🤷

## AI disclosure

I didn't use any AI in the development of this