### PR TITLE
Suppress GCC 16's `sfinae-incomplete` warning

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -986,6 +986,9 @@ else:  # GCC, Clang
             common_warnings += ["-Wno-return-type"]
         if cc_version_major >= 11:
             common_warnings += ["-Wenum-conversion"]
+        if cc_version_major >= 16:
+            # GCC 16 flags type-incompleteness assertions on their intended behavior, see GH-119269.
+            env.AppendUnique(CXXFLAGS=["-Wno-sfinae-incomplete"])
     elif methods.using_clang(env) or methods.using_emcc(env):
         common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
         # We often implement `operator<` for structs of pointers as a requirement


### PR DESCRIPTION
Addresses part of #119269

`sfinae-incomplete` was introduced in GCC 16, which is meant to catch definitions of types that failed to be complete in an SFINAE context.

At the moment, this happens with the `STATIC_ASSERT_INCOMPLETE_TYPE()` macro followed by completing that type, which is a context we ***do*** want the type to be incomplete, meaning the warning is a false positive.

**Note**: it has to be done with `env.AppendUnique` instead of adding to `common_warnings` as `cc1` will spam warnings otherwise.