### PR TITLE
Handle invalid AudioStream playback positions

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -51,8 +51,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : mp3_stream->loop;
 
-	bool beat_loop = use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
-	if (beat_loop) {
+	if (is_beat_loop()) {
 		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
 	}
 
@@ -70,7 +69,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 			--todo;
 			++frames_mixed;
 
-			if (beat_loop && (int)frames_mixed >= beat_length_frames) {
+			if (is_beat_loop() && (int)frames_mixed >= beat_length_frames) {
 				for (int i = 0; i < FADE_SIZE; i++) {
 					samples_mixed = drmp3_read_pcm_frames_f32(&mp3d, 1, buf_frame);
 					loop_fade[i] = AudioFrame(buf_frame[0], buf_frame[mp3d.channels - 1]);
@@ -135,8 +134,13 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= mp3_stream->get_length()) {
-		p_time = 0;
+	double real_length = is_beat_loop() ? 60.0 / mp3_stream->get_bpm() * mp3_stream->beat_count : mp3_stream->get_length();
+
+	if (p_time > real_length || p_time < 0) {
+		stop();
+		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+	} else if (p_time == real_length) {
+		p_time = real_length - 0.001;
 	}
 
 	frames_mixed = uint32_t(mp3_stream->sample_rate * p_time);
@@ -183,6 +187,11 @@ Variant AudioStreamPlaybackMP3::get_parameter(const StringName &p_name) const {
 		return looping;
 	}
 	return Variant();
+}
+
+bool AudioStreamPlaybackMP3::is_beat_loop() const {
+	bool use_loop = looping_override ? looping : mp3_stream->loop;
+	return use_loop && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
 }
 
 AudioStreamPlaybackMP3::~AudioStreamPlaybackMP3() {

--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -51,7 +51,8 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : mp3_stream->loop;
 
-	if (is_beat_loop()) {
+	bool beat_loop = is_beat_loop();
+	if (beat_loop) {
 		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
 	}
 
@@ -69,7 +70,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 			--todo;
 			++frames_mixed;
 
-			if (is_beat_loop() && (int)frames_mixed >= beat_length_frames) {
+			if (beat_loop && (int)frames_mixed >= beat_length_frames) {
 				for (int i = 0; i < FADE_SIZE; i++) {
 					samples_mixed = drmp3_read_pcm_frames_f32(&mp3d, 1, buf_frame);
 					loop_fade[i] = AudioFrame(buf_frame[0], buf_frame[mp3d.channels - 1]);
@@ -134,11 +135,12 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 		return;
 	}
 
-	double real_length = is_beat_loop() ? 60.0 / mp3_stream->get_bpm() * mp3_stream->beat_count : mp3_stream->get_length();
+	bool beat_loop = is_beat_loop();
+	double real_length = beat_loop ? 60.0 / mp3_stream->get_bpm() * mp3_stream->beat_count : mp3_stream->get_length();
 
 	if (p_time > real_length || p_time < 0) {
 		stop();
-		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+		ERR_FAIL_MSG(vformat("Seek of value %f is out of bounds (0.0 to %f). Stopping the stream %s.", p_time, real_length, mp3_stream->get_path().get_file()));
 	} else if (p_time == real_length) {
 		p_time = real_length - 0.001;
 	}

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -83,6 +83,8 @@ public:
 	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;
 	virtual Variant get_parameter(const StringName &p_name) const override;
 
+	bool is_beat_loop() const;
+
 	AudioStreamPlaybackMP3() {}
 	~AudioStreamPlaybackMP3();
 };

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -48,7 +48,8 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : vorbis_stream->loop;
 
-	if (is_beat_loop()) {
+	bool beat_loop = is_beat_loop();
+	if (beat_loop) {
 		beat_length_frames = vorbis_stream->get_beat_count() * vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
 	}
 
@@ -284,11 +285,12 @@ void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 		return;
 	}
 
-	double real_length = is_beat_loop() ? 60.0 / vorbis_stream->get_bpm() * vorbis_stream->beat_count : vorbis_stream->get_length();
+	bool beat_loop = is_beat_loop();
+	double real_length = beat_loop ? 60.0 / vorbis_stream->get_bpm() * vorbis_stream->beat_count : vorbis_stream->get_length();
 
 	if (p_time > real_length || p_time < 0) {
 		stop();
-		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+		ERR_FAIL_MSG(vformat("Seek of value %f is out of bounds (0.0 to %f). Stopping the stream %s.", p_time, real_length, vorbis_stream->get_path().get_file()));
 	} else if (p_time == real_length) {
 		p_time = real_length - 0.001;
 	}

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -48,7 +48,7 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 	int beat_length_frames = -1;
 	bool use_loop = looping_override ? looping : vorbis_stream->loop;
 
-	if (use_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0) {
+	if (is_beat_loop()) {
 		beat_length_frames = vorbis_stream->get_beat_count() * vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
 	}
 
@@ -284,8 +284,13 @@ void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 		return;
 	}
 
-	if (p_time >= vorbis_stream->get_length()) {
-		p_time = 0;
+	double real_length = is_beat_loop() ? 60.0 / vorbis_stream->get_bpm() * vorbis_stream->beat_count : vorbis_stream->get_length();
+
+	if (p_time > real_length || p_time < 0) {
+		stop();
+		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+	} else if (p_time == real_length) {
+		p_time = real_length - 0.001;
 	}
 
 	frames_mixed = uint32_t(vorbis_data->get_sampling_rate() * p_time);
@@ -393,6 +398,11 @@ void AudioStreamPlaybackOggVorbis::set_sample_playback(const Ref<AudioSamplePlay
 	if (sample_playback.is_valid()) {
 		sample_playback->stream_playback = Ref<AudioStreamPlayback>(this);
 	}
+}
+
+bool AudioStreamPlaybackOggVorbis::is_beat_loop() const {
+	bool use_loop = looping_override ? looping : vorbis_stream->loop;
+	return use_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0;
 }
 
 AudioStreamPlaybackOggVorbis::~AudioStreamPlaybackOggVorbis() {

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -47,6 +47,7 @@ class AudioStreamPlaybackOggVorbis : public AudioStreamPlaybackResampled {
 	bool looping_override = false;
 	bool looping = false;
 	int loops = 0;
+	bool beat_loop = false;
 
 	enum {
 		FADE_SIZE = 256
@@ -107,6 +108,8 @@ public:
 	virtual bool get_is_sample() const override;
 	virtual Ref<AudioSamplePlayback> get_sample_playback() const override;
 	virtual void set_sample_playback(const Ref<AudioSamplePlayback> &p_playback) override;
+
+	bool is_beat_loop() const;
 
 	AudioStreamPlaybackOggVorbis() {}
 	~AudioStreamPlaybackOggVorbis();

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -47,7 +47,6 @@ class AudioStreamPlaybackOggVorbis : public AudioStreamPlaybackResampled {
 	bool looping_override = false;
 	bool looping = false;
 	int loops = 0;
-	bool beat_loop = false;
 
 	enum {
 		FADE_SIZE = 256

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -38,6 +38,9 @@ const float TRIM_DB_LIMIT = -50;
 const int TRIM_FADE_OUT_FRAMES = 500;
 
 void AudioStreamPlaybackWAV::start(double p_from_pos) {
+	sign = 1;
+	active = true;
+
 	if (base->format == AudioStreamWAV::FORMAT_IMA_ADPCM) {
 		//no seeking in IMA_ADPCM
 		for (int i = 0; i < 2; i++) {
@@ -55,8 +58,6 @@ void AudioStreamPlaybackWAV::start(double p_from_pos) {
 		seek(p_from_pos);
 	}
 
-	sign = 1;
-	active = true;
 	begin_resample();
 }
 
@@ -81,11 +82,13 @@ void AudioStreamPlaybackWAV::seek(double p_time) {
 		return; //no seeking in ima-adpcm
 	}
 
-	double max = base->get_length();
-	if (p_time < 0) {
-		p_time = 0;
-	} else if (p_time >= max) {
-		p_time = max - 0.001;
+	double real_length = base->loop_mode == AudioStreamWAV::LOOP_DISABLED ? base->get_length() : base->get_loop_end() / base->get_mix_rate();
+
+	if (p_time > real_length || p_time < 0) {
+		stop();
+		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+	} else if (p_time == real_length) {
+		p_time = real_length - 0.001;
 	}
 
 	offset = int64_t(p_time * base->mix_rate);

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -86,7 +86,7 @@ void AudioStreamPlaybackWAV::seek(double p_time) {
 
 	if (p_time > real_length || p_time < 0) {
 		stop();
-		ERR_FAIL_MSG("Seeking out of bounds. Stopping the stream.");
+		ERR_FAIL_MSG(vformat("Seek of value %f is out of bounds (0.0 to %f). Stopping the stream %s.", p_time, real_length, base->get_path().get_file()));
 	} else if (p_time == real_length) {
 		p_time = real_length - 0.001;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes: https://github.com/godotengine/godot/issues/117817
- Fixes: https://github.com/godotengine/godot/issues/98192 (if merged with https://github.com/godotengine/godot/pull/119084)
- Fixes: https://github.com/godotengine/godot/issues/89390
- Possibly supersedes: https://github.com/godotengine/godot/pull/117856
- Supersedes: https://github.com/godotengine/godot/pull/96384

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This pull request is an alternative to https://github.com/godotengine/godot/pull/119120 , where instead of `seek()` and `play()` functions allowing invalid playback positions, and just setting them to `0`, they instead stop playback and return with an error message. This alternative exists after it was discussed in an audio meeting that invalid playback positions should be handled with an error, so the user can handle possible unexpected values.
I changed the order of some lines in the `start()` function of `AudioStreamWAV`, but it seems to function the same. I did this to avoid code repetition.
I tested this by using both functions directly in a player. I set the stream to Ogg, MP3, and WAV streams. I tried play with loop disabled and enabled, with loop offset and beat count at different values, and playing from the stream importer window too. Because of the large amount of cases, I could possibly have missed a case, but having dealt with this before on the other PR, I believe everything looks fine.

Read [this PR](https://github.com/godotengine/godot/pull/119120) for more info about my original attempt at fixing the issue, and why I'm handling it in the `seek()` function