### PR TITLE
Fix FileSystem dock styles across split modes

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -533,23 +533,13 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 
 			tree->show();
 			tree->set_v_size_flags(SIZE_EXPAND_FILL);
-			if (is_vertical) {
-				tree->set_theme_type_variation("");
-				tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
-				tree_mc->set_theme_type_variation(horizontal ? "NoBorderBottomPanel" : "NoBorderHorizontal");
+			tree->set_theme_type_variation("TreeSecondary");
+			tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
+			tree_mc->set_theme_type_variation("");
 
-				files->set_theme_type_variation(horizontal ? "ItemListSecondary" : "");
-				files->set_scroll_hint_mode(horizontal ? ItemList::SCROLL_HINT_MODE_DISABLED : ItemList::SCROLL_HINT_MODE_TOP);
-				files_mc->set_theme_type_variation(horizontal ? "" : "NoBorderHorizontalBottom");
-			} else {
-				tree->set_theme_type_variation("TreeSecondary");
-				tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
-				tree_mc->set_theme_type_variation("");
-
-				files->set_theme_type_variation("ItemListSecondary");
-				files->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_DISABLED);
-				files_mc->set_theme_type_variation("");
-			}
+			files->set_theme_type_variation("ItemListSecondary");
+			files->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_DISABLED);
+			files_mc->set_theme_type_variation("");
 			tree->ensure_cursor_is_visible();
 
 			// Properly allocate the selections between the views.


### PR DESCRIPTION
Two commits for scroll hints had impact on FileSystem dock style:

- f187b8b2bf introduced `TreeSecondary` for the tree pane, but only applied it in horizontal split mode.
- a45bdce763 removed the existing `ItemListSecondary` from the file list in vertical split mode.

The combination results in vertical split and tree-only not having background styles while horizontal split does.

Apply `TreeSecondary` and `ItemListSecondary` styles in horizontal and vertical split modes. Do not style single-view to keep it consistent with other editor docks.

Fixes #119359