### PR TITLE
[Metal] Restrict residency set support to Apple6+ GPUs.

### DIFF
--- a/drivers/metal/metal_device_properties.cpp
+++ b/drivers/metal/metal_device_properties.cpp
@@ -164,10 +164,8 @@ void MetalDeviceProperties::init_features(MTL::Device *p_device) {
 		features.supports_native_image_atomics = false;
 	}
 
-	if (OS::get_singleton()->get_processor_name().contains("Virtual")) {
-		features.supports_residency_sets = false;
-	} else if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, *)) {
-		features.supports_residency_sets = true;
+	if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, *)) {
+		features.supports_residency_sets = p_device->supportsFamily(MTL::GPUFamilyApple6);
 	} else {
 		features.supports_residency_sets = false;
 	}

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2519,7 +2519,7 @@ Error RenderingDeviceDriverMetal::_copy_queue_initialize() {
 	copy_queue_buffer.get()->setLabel(MTLSTR("Copy Command Scratch Buffer"));
 
 	if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 1.0, *)) {
-		if (!OS::get_singleton()->get_processor_name().contains("Virtual")) {
+		if (device_properties->features.supports_residency_sets) {
 			MTL::ResidencySetDescriptor *rs_desc = MTL::ResidencySetDescriptor::alloc()->init();
 			rs_desc->setInitialCapacity(2);
 			rs_desc->setLabel(MTLSTR("Copy Queue Residency Set"));


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/119447

Restrict residency set support to Apple6+ GPUs (A13 and newer).

Also remove hacky "Virtual" in the CPU name check for virtual machines detection (emulate Apple5 family).

Note: I do not have any A12 device to check (only A14, M1 and M4).

Based on MoltenVK check for the smae feature - https://github.com/slp/MoltenVK/blob/main/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm#L2521
