### PR TITLE
Allow group descriptions to be edited in the groups dock

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -450,9 +450,9 @@ void GroupsEditor::_menu_id_pressed(int p_id) {
 				_show_remove_group_dialog();
 			}
 		} break;
-		case RENAME_GROUP: {
+		case EDIT_GROUP: {
 			if (!is_local || scene_groups[group_name]) {
-				_show_rename_group_dialog();
+				_show_edit_group_dialog();
 			}
 		} break;
 		case CONVERT_GROUP: {
@@ -519,7 +519,7 @@ void GroupsEditor::_item_mouse_selected(const Vector2 &p_pos, MouseButton p_mous
 		String group_name = ti->get_meta("__name");
 		if (global_groups.has(group_name) || scene_groups[group_name]) {
 			menu->add_separator();
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("groups_editor/rename"), RENAME_GROUP);
+			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("groups_editor/edit"), EDIT_GROUP);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Remove")), ED_GET_SHORTCUT("groups_editor/delete"), DELETE_GROUP);
 		}
 
@@ -570,7 +570,7 @@ void GroupsEditor::_confirm_add() {
 	tree->grab_focus(true);
 }
 
-void GroupsEditor::_confirm_rename() {
+void GroupsEditor::_confirm_edit() {
 	TreeItem *ti = tree->get_selected();
 	if (!ti) {
 		return;
@@ -579,12 +579,15 @@ void GroupsEditor::_confirm_rename() {
 	String old_name = ti->get_meta("__name");
 	String new_name = rename_group->get_text().strip_edges();
 
-	if (old_name == new_name) {
+	String old_description = ti->get_meta("__description");
+	String new_description = edit_description->get_text();
+
+	if (old_name == new_name && old_description == new_description) {
 		return;
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Rename Group"));
+	undo_redo->create_action(TTR("Edit Group"));
 
 	if (!global_groups.has(old_name)) {
 		undo_redo->add_do_method(this, "_rename_scene_group", old_name, new_name);
@@ -593,13 +596,16 @@ void GroupsEditor::_confirm_rename() {
 		String property_new_name = GLOBAL_GROUP_PREFIX + new_name;
 		String property_old_name = GLOBAL_GROUP_PREFIX + old_name;
 
-		String description = ti->get_meta("__description");
+		if (old_name != new_name) {
+			undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, new_description);
+			undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, description);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
-
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, description);
+			undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
+			undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, old_description);
+		} else {
+			undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, new_description);
+			undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, old_description);
+		}
 
 		if (rename_check_box->is_pressed()) {
 			undo_redo->add_do_method(ProjectSettingsEditor::get_singleton()->get_group_settings(), "rename_references", old_name, new_name);
@@ -730,29 +736,40 @@ void GroupsEditor::_show_add_group_dialog() {
 	add_group_name->grab_focus();
 }
 
-void GroupsEditor::_show_rename_group_dialog() {
-	if (!rename_group_dialog) {
-		rename_group_dialog = memnew(ConfirmationDialog);
-		rename_group_dialog->set_title(TTR("Rename Group"));
-		rename_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupsEditor::_confirm_rename));
+void GroupsEditor::_show_edit_group_dialog() {
+	if (!edit_group_dialog) {
+		edit_group_dialog = memnew(ConfirmationDialog);
+		edit_group_dialog->set_title(TTR("Edit Group"));
+		edit_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupsEditor::_confirm_edit));
 
 		VBoxContainer *vbc = memnew(VBoxContainer);
-		rename_group_dialog->add_child(vbc);
+		edit_group_dialog->add_child(vbc);
 
 		HBoxContainer *hbc = memnew(HBoxContainer);
 		hbc->add_child(memnew(Label(TTR("Name:"))));
 
 		rename_group = memnew(LineEdit);
 		rename_group->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
+		rename_group->set_h_size_flags(SIZE_EXPAND_FILL);
 		hbc->add_child(rename_group);
 		vbc->add_child(hbc);
 
-		rename_group_dialog->register_text_enter(rename_group);
+		description_hb = memnew(HBoxContainer);
+		description_hb->add_child(memnew(Label(TTR("Description:"))));
+
+		edit_description = memnew(LineEdit);
+		edit_description->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+		edit_description->set_h_size_flags(SIZE_EXPAND_FILL);
+		description_hb->add_child(edit_description);
+		vbc->add_child(description_hb);
+
+		edit_group_dialog->register_text_enter(rename_group);
+		edit_group_dialog->register_text_enter(edit_description);
 
 		rename_validation_panel = memnew(EditorValidationPanel);
 		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group name is valid."));
 		rename_validation_panel->set_update_callback(callable_mp(this, &GroupsEditor::_check_rename));
-		rename_validation_panel->set_accept_button(rename_group_dialog->get_ok_button());
+		rename_validation_panel->set_accept_button(edit_group_dialog->get_ok_button());
 
 		rename_group->connect(SceneStringName(text_changed), callable_mp(rename_validation_panel, &EditorValidationPanel::update).unbind(1));
 
@@ -762,7 +779,7 @@ void GroupsEditor::_show_rename_group_dialog() {
 		rename_check_box->set_text(TTR("Rename references in all scenes"));
 		vbc->add_child(rename_check_box);
 
-		add_child(rename_group_dialog);
+		add_child(edit_group_dialog);
 	}
 
 	TreeItem *ti = tree->get_selected();
@@ -774,15 +791,21 @@ void GroupsEditor::_show_rename_group_dialog() {
 	rename_check_box->set_visible(is_global);
 	rename_check_box->set_pressed(false);
 
+	description_hb->set_visible(is_global);
+
+	String description = ti->get_meta("__description");
+
+	edit_description->set_text(description);
+
 	String name = ti->get_meta("__name");
 
 	rename_group->set_text(name);
-	rename_group_dialog->set_meta("__name", name);
+	edit_group_dialog->set_meta("__name", name);
 
 	rename_validation_panel->update();
 
-	rename_group_dialog->reset_size();
-	rename_group_dialog->popup_centered();
+	edit_group_dialog->reset_size();
+	edit_group_dialog->popup_centered();
 	rename_group->select_all();
 	rename_group->grab_focus();
 }
@@ -828,7 +851,7 @@ void GroupsEditor::_check_add() {
 
 void GroupsEditor::_check_rename() {
 	String group_name = rename_group->get_text().strip_edges();
-	String old_name = rename_group_dialog->get_meta("__name");
+	String old_name = edit_group_dialog->get_meta("__name");
 
 	if (group_name == old_name) {
 		return;
@@ -849,8 +872,8 @@ void GroupsEditor::_groups_gui_input(Ref<InputEvent> p_event) {
 	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
 		if (ED_IS_SHORTCUT("groups_editor/delete", p_event)) {
 			_menu_id_pressed(DELETE_GROUP);
-		} else if (ED_IS_SHORTCUT("groups_editor/rename", p_event)) {
-			_menu_id_pressed(RENAME_GROUP);
+		} else if (ED_IS_SHORTCUT("groups_editor/edit", p_event)) {
+			_menu_id_pressed(EDIT_GROUP);
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			filter->grab_focus();
 			filter->select_all();
@@ -892,8 +915,8 @@ GroupsEditor::GroupsEditor() {
 	scene_tree = SceneTree::get_singleton();
 
 	ED_SHORTCUT("groups_editor/delete", TTRC("Delete"), Key::KEY_DELETE);
-	ED_SHORTCUT("groups_editor/rename", TTRC("Rename"), Key::F2);
-	ED_SHORTCUT_OVERRIDE("groups_editor/rename", "macos", Key::ENTER);
+	ED_SHORTCUT("groups_editor/edit", TTRC("Edit"), Key::F2);
+	ED_SHORTCUT_OVERRIDE("groups_editor/edit", "macos", Key::ENTER);
 
 	holder = memnew(VBoxContainer);
 	holder->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/docks/groups_editor.h
+++ b/editor/docks/groups_editor.h
@@ -62,8 +62,10 @@ class GroupsEditor : public VBoxContainer {
 	CheckButton *global_group_button = nullptr;
 	EditorValidationPanel *add_validation_panel = nullptr;
 
-	ConfirmationDialog *rename_group_dialog = nullptr;
+	ConfirmationDialog *edit_group_dialog = nullptr;
 	LineEdit *rename_group = nullptr;
+	HBoxContainer *description_hb = nullptr;
+	LineEdit *edit_description = nullptr;
 	CheckBox *rename_check_box = nullptr;
 	EditorValidationPanel *rename_validation_panel = nullptr;
 
@@ -89,7 +91,7 @@ class GroupsEditor : public VBoxContainer {
 	void _cache_scene_groups(const ObjectID &p_id);
 
 	void _show_add_group_dialog();
-	void _show_rename_group_dialog();
+	void _show_edit_group_dialog();
 	void _show_remove_group_dialog();
 
 	void _check_add();
@@ -109,7 +111,7 @@ class GroupsEditor : public VBoxContainer {
 	void _set_group_checked(const String &p_name, bool p_checked);
 
 	void _confirm_add();
-	void _confirm_rename();
+	void _confirm_edit();
 	void _confirm_delete();
 
 	void _item_edited();
@@ -137,7 +139,7 @@ public:
 	enum ModifyButton {
 		DELETE_GROUP,
 		COPY_GROUP,
-		RENAME_GROUP,
+		EDIT_GROUP,
 		CONVERT_GROUP,
 	};
 

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -123,7 +123,7 @@ String GroupSettingsEditor::_check_new_group_name(const String &p_name) {
 
 void GroupSettingsEditor::_check_rename() {
 	String new_name = rename_group->get_text().strip_edges();
-	String old_name = rename_group_dialog->get_meta("__name");
+	String old_name = edit_group_dialog->get_meta("__name");
 
 	if (new_name == old_name) {
 		return;
@@ -327,7 +327,7 @@ void GroupSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs_d
 	p_fs_dock->connect("file_removed", callable_mp(ProjectSettings::get_singleton(), &ProjectSettings::remove_scene_groups_cache));
 }
 
-void GroupSettingsEditor::_confirm_rename() {
+void GroupSettingsEditor::_confirm_edit() {
 	TreeItem *ti = tree->get_selected();
 	if (!ti) {
 		return;
@@ -336,23 +336,29 @@ void GroupSettingsEditor::_confirm_rename() {
 	String old_name = ti->get_meta("__name");
 	String new_name = rename_group->get_text().strip_edges();
 
-	if (old_name == new_name) {
+	String old_description = ti->get_meta("__description");
+	String new_description = edit_description->get_text();
+
+	if (old_name == new_name && old_description == new_description) {
 		return;
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Rename Group"));
+	undo_redo->create_action(TTR("Edit Group"));
 
 	String property_new_name = GLOBAL_GROUP_PREFIX + new_name;
 	String property_old_name = GLOBAL_GROUP_PREFIX + old_name;
 
-	String description = ti->get_meta("__description");
+	if (old_name != new_name) {
+		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, new_description);
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, description);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
-
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, description);
+		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, old_description);
+	} else {
+		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, new_description);
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, old_description);
+	}
 
 	if (rename_check_box->is_pressed()) {
 		undo_redo->add_do_method(this, "rename_references", old_name, new_name);
@@ -433,29 +439,40 @@ void GroupSettingsEditor::_show_remove_dialog() {
 	remove_dialog->popup_centered();
 }
 
-void GroupSettingsEditor::_show_rename_dialog() {
-	if (!rename_group_dialog) {
-		rename_group_dialog = memnew(ConfirmationDialog);
-		rename_group_dialog->set_title(TTRC("Rename Group"));
-		rename_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupSettingsEditor::_confirm_rename));
+void GroupSettingsEditor::_show_edit_dialog() {
+	if (!edit_group_dialog) {
+		edit_group_dialog = memnew(ConfirmationDialog);
+		edit_group_dialog->set_title(TTRC("Edit Group"));
+		edit_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupSettingsEditor::_confirm_edit));
 
 		VBoxContainer *vbc = memnew(VBoxContainer);
-		rename_group_dialog->add_child(vbc);
+		edit_group_dialog->add_child(vbc);
 
 		HBoxContainer *hbc = memnew(HBoxContainer);
 		hbc->add_child(memnew(Label(TTRC("Name:"))));
 
 		rename_group = memnew(LineEdit);
 		rename_group->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
+		rename_group->set_h_size_flags(SIZE_EXPAND_FILL);
 		hbc->add_child(rename_group);
 		vbc->add_child(hbc);
 
-		rename_group_dialog->register_text_enter(rename_group);
+		HBoxContainer *description_hb = memnew(HBoxContainer);
+		description_hb->add_child(memnew(Label(TTR("Description:"))));
+
+		edit_description = memnew(LineEdit);
+		edit_description->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+		edit_description->set_h_size_flags(SIZE_EXPAND_FILL);
+		description_hb->add_child(edit_description);
+		vbc->add_child(description_hb);
+
+		edit_group_dialog->register_text_enter(rename_group);
+		edit_group_dialog->register_text_enter(edit_description);
 
 		rename_validation_panel = memnew(EditorValidationPanel);
 		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group name is valid."));
 		rename_validation_panel->set_update_callback(callable_mp(this, &GroupSettingsEditor::_check_rename));
-		rename_validation_panel->set_accept_button(rename_group_dialog->get_ok_button());
+		rename_validation_panel->set_accept_button(edit_group_dialog->get_ok_button());
 
 		rename_group->connect(SceneStringName(text_changed), callable_mp(rename_validation_panel, &EditorValidationPanel::update).unbind(1));
 
@@ -465,7 +482,7 @@ void GroupSettingsEditor::_show_rename_dialog() {
 		rename_check_box->set_text(TTRC("Rename references in all scenes"));
 		vbc->add_child(rename_check_box);
 
-		add_child(rename_group_dialog);
+		add_child(edit_group_dialog);
 	}
 
 	TreeItem *ti = tree->get_selected();
@@ -475,15 +492,19 @@ void GroupSettingsEditor::_show_rename_dialog() {
 
 	rename_check_box->set_pressed(false);
 
+	String description = ti->get_meta("__description");
+
+	edit_description->set_text(description);
+
 	String name = ti->get_meta("__name");
 
 	rename_group->set_text(name);
-	rename_group_dialog->set_meta("__name", name);
+	edit_group_dialog->set_meta("__name", name);
 
 	rename_validation_panel->update();
 
-	rename_group_dialog->reset_size();
-	rename_group_dialog->popup_centered();
+	edit_group_dialog->reset_size();
+	edit_group_dialog->popup_centered();
 	rename_group->select_all();
 	rename_group->grab_focus();
 }
@@ -548,7 +569,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	tree->set_column_expand(2, false);
 
 	tree->connect("item_edited", callable_mp(this, &GroupSettingsEditor::_item_edited));
-	tree->connect("item_activated", callable_mp(this, &GroupSettingsEditor::_show_rename_dialog));
+	tree->connect("item_activated", callable_mp(this, &GroupSettingsEditor::_show_edit_dialog));
 	tree->connect("button_clicked", callable_mp(this, &GroupSettingsEditor::_item_button_pressed));
 
 	mc->add_child(tree, true);

--- a/editor/scene/group_settings_editor.h
+++ b/editor/scene/group_settings_editor.h
@@ -59,13 +59,14 @@ class GroupSettingsEditor : public VBoxContainer {
 	CheckBox *remove_check_box = nullptr;
 	Label *remove_label = nullptr;
 
-	ConfirmationDialog *rename_group_dialog = nullptr;
+	ConfirmationDialog *edit_group_dialog = nullptr;
 	LineEdit *rename_group = nullptr;
+	LineEdit *edit_description = nullptr;
 	CheckBox *rename_check_box = nullptr;
 	EditorValidationPanel *rename_validation_panel = nullptr;
 
 	void _show_remove_dialog();
-	void _show_rename_dialog();
+	void _show_edit_dialog();
 
 	String _check_new_group_name(const String &p_name);
 	void _check_rename();
@@ -75,7 +76,7 @@ class GroupSettingsEditor : public VBoxContainer {
 
 	void _modify_references(const StringName &p_name, const StringName &p_new_name, bool p_is_rename);
 
-	void _confirm_rename();
+	void _confirm_edit();
 	void _confirm_delete();
 
 	void _text_submitted(const String &p_text);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14840

Currently in the Groups dock, we can't edit descriptions for global groups after we've created them. While it is possible to edit descriptions by going into Project settings -> Globals -> Groups and then editing the description there, it's slightly inconvenient. 

~This PR allows users to also change the description of a global group when they want to rename them.~

Edit: This PR allows users to change the description of a global group in the groups dock of the editor, and changes the **Rename** option to **Edit**.

<img width="685" height="284" alt="image" src="https://github.com/user-attachments/assets/793bdb4e-5ab1-41cf-a146-2135e21c456e" />

<img width="663" height="469" alt="image" src="https://github.com/user-attachments/assets/6a516f9b-b056-4a77-9d0c-5265ce5f1d2f" />
