### PR TITLE
Add an editor setting to hide property setters/getters in the class reference to save space

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1638,6 +1638,9 @@
 		<member name="text_editor/help/show_help_index" type="bool" setter="" getter="">
 			If [code]true[/code], displays a table of contents at the left of the editor help (at the location where the members overview would appear when editing a script).
 		</member>
+		<member name="text_editor/help/show_property_setters_and_getters" type="bool" setter="" getter="">
+			If [code]true[/code], shows property setters and getters from the editor help.
+		</member>
 		<member name="text_editor/help/sort_functions_alphabetically" type="bool" setter="" getter="">
 			If [code]true[/code], the script's method list in the Script Editor is sorted alphabetically.
 		</member>

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2203,64 +2203,66 @@ void EditorHelp::_update_doc() {
 			class_desc->pop(); // cell
 
 			// Script doc doesn't have setter, getter.
-			if (!cd.is_script_doc) {
-				HashMap<String, DocData::MethodDoc> method_map;
-				for (int j = 0; j < methods.size(); j++) {
-					method_map[methods[j].name] = methods[j];
-				}
-
-				if (!prop.setter.is_empty()) {
-					class_desc->push_cell();
-					class_desc->pop(); // cell
-
-					class_desc->push_cell();
-					_push_code_font();
-					class_desc->push_color(theme_cache.text_color);
-
-					if (method_map[prop.setter].arguments.size() > 1) {
-						// Setters with additional arguments are exposed in the method list, so we link them here for quick access.
-						class_desc->push_meta("@method " + prop.setter);
-						class_desc->add_text(prop.setter + TTR("(value)"));
-						class_desc->pop(); // meta
-					} else {
-						class_desc->add_text(prop.setter + TTR("(value)"));
+			if (EDITOR_GET("text_editor/help/show_property_setters_and_getters")) {
+				if (!cd.is_script_doc) {
+					HashMap<String, DocData::MethodDoc> method_map;
+					for (int j = 0; j < methods.size(); j++) {
+						method_map[methods[j].name] = methods[j];
 					}
 
-					class_desc->pop(); // color
-					class_desc->push_color(theme_cache.comment_color);
-					class_desc->add_text(" setter");
-					class_desc->pop(); // color
-					_pop_code_font();
-					class_desc->pop(); // cell
+					if (!prop.setter.is_empty()) {
+						class_desc->push_cell();
+						class_desc->pop(); // cell
 
-					method_line[prop.setter] = property_line[prop.name];
-				}
+						class_desc->push_cell();
+						_push_code_font();
+						class_desc->push_color(theme_cache.text_color);
 
-				if (!prop.getter.is_empty()) {
-					class_desc->push_cell();
-					class_desc->pop(); // cell
+						if (method_map[prop.setter].arguments.size() > 1) {
+							// Setters with additional arguments are exposed in the method list, so we link them here for quick access.
+							class_desc->push_meta("@method " + prop.setter);
+							class_desc->add_text(prop.setter + TTR("(value)"));
+							class_desc->pop(); // meta
+						} else {
+							class_desc->add_text(prop.setter + TTR("(value)"));
+						}
 
-					class_desc->push_cell();
-					_push_code_font();
-					class_desc->push_color(theme_cache.text_color);
+						class_desc->pop(); // color
+						class_desc->push_color(theme_cache.comment_color);
+						class_desc->add_text(" setter");
+						class_desc->pop(); // color
+						_pop_code_font();
+						class_desc->pop(); // cell
 
-					if (!method_map[prop.getter].arguments.is_empty()) {
-						// Getters with additional arguments are exposed in the method list, so we link them here for quick access.
-						class_desc->push_meta("@method " + prop.getter);
-						class_desc->add_text(prop.getter + "()");
-						class_desc->pop(); // meta
-					} else {
-						class_desc->add_text(prop.getter + "()");
+						method_line[prop.setter] = property_line[prop.name];
 					}
 
-					class_desc->pop(); // color
-					class_desc->push_color(theme_cache.comment_color);
-					class_desc->add_text(" getter");
-					class_desc->pop(); // color
-					_pop_code_font();
-					class_desc->pop(); // cell
+					if (!prop.getter.is_empty()) {
+						class_desc->push_cell();
+						class_desc->pop(); // cell
 
-					method_line[prop.getter] = property_line[prop.name];
+						class_desc->push_cell();
+						_push_code_font();
+						class_desc->push_color(theme_cache.text_color);
+
+						if (!method_map[prop.getter].arguments.is_empty()) {
+							// Getters with additional arguments are exposed in the method list, so we link them here for quick access.
+							class_desc->push_meta("@method " + prop.getter);
+							class_desc->add_text(prop.getter + "()");
+							class_desc->pop(); // meta
+						} else {
+							class_desc->add_text(prop.getter + "()");
+						}
+
+						class_desc->pop(); // color
+						class_desc->push_color(theme_cache.comment_color);
+						class_desc->add_text(" getter");
+						class_desc->pop(); // color
+						_pop_code_font();
+						class_desc->pop(); // cell
+
+						method_line[prop.getter] = property_line[prop.name];
+					}
 				}
 			}
 
@@ -3297,6 +3299,9 @@ void EditorHelp::_notification(int p_what) {
 				need_update = true;
 			}
 #endif
+			if (!need_update && EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/show_property_setters_and_getters")) {
+				need_update = true;
+			}
 			if (!need_update) {
 				break;
 			}

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -883,6 +883,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_title_font_size", 23, "8,64,1")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/help/class_reference_examples", 0, "GDScript,C#,GDScript and C#")
 	_initial_set("text_editor/help/sort_functions_alphabetically", true);
+	_initial_set("text_editor/help/show_property_setters_and_getters", false);
 
 	/* Editors */
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14828

This PR adds a new Editor settings
<img width="1171" height="911" alt="image" src="https://github.com/user-attachments/assets/712a88d3-f997-4c95-8f43-789f81ecab9b" />
Also adds a new toggle button to script editor when docs is active to quickly swtich bettween on and off
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/828dc6cc-736f-4ef7-9491-31e447aba988" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/45bb6331-8ae7-4f4a-8866-e8671497b042" />
the toggle button later can be moved to popupmenu if more customation added to docs