### PR TITLE
[Windows] Check if used SCons version supports requested MSVC.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -184,6 +184,13 @@ def get_tools(env: "SConsEnvironment"):
         if env.get("msvc_version"):
             msvc_ver = env.get("msvc_version")
 
+        if msvc_ver == "14.3" and env.scons_version < (4, 8, 0):
+            print_error("Visual Studio 2022 requires SCons 4.8.0+, please update your SCons version.")
+            sys.exit(255)
+        elif msvc_ver == "14.5" and env.scons_version < (4, 10, 1):
+            print_error("Visual Studio 2026 requires SCons 4.10.1+, please update your SCons version.")
+            sys.exit(255)
+
         env["TARGET_ARCH"] = msvc_arch_aliases.get(env["arch"], env["arch"])
         env["MSVC_VERSION"] = env["MSVS_VERSION"] = env.get("msvc_version")
         env["MSVC_SDK_VERSION"] = check_mssdk_version(env, env.get("mssdk_version"), msvc_ver)


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/119278

Since we now use SDK/MSVC version detection, it might fail if old version of SCons is used with newer MSVC install.