### PR TITLE
[DRAFT] GDExtension: Undeprecate `array_ref` and add `dictionary_ref`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1294,13 +1294,11 @@ static GDExtensionVariantPtr gdextension_array_operator_index_const(GDExtensionC
 	return (GDExtensionVariantPtr)&self->operator[](p_index);
 }
 
-#ifndef DISABLE_DEPRECATED
 void gdextension_array_ref(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from) {
 	Array *self = (Array *)p_self;
 	const Array *from = (const Array *)p_from;
 	self->Array::operator=(*from);
 }
-#endif // DISABLE_DEPRECATED
 
 void gdextension_array_set_typed(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script) {
 	Array *self = reinterpret_cast<Array *>(p_self);
@@ -1319,6 +1317,12 @@ static GDExtensionVariantPtr gdextension_dictionary_operator_index(GDExtensionTy
 static GDExtensionVariantPtr gdextension_dictionary_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionConstVariantPtr p_key) {
 	const Dictionary *self = (const Dictionary *)p_self;
 	return (GDExtensionVariantPtr)&self->operator[](*(const Variant *)p_key);
+}
+
+void gdextension_dictionary_ref(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from) {
+	Dictionary *self = (Dictionary *)p_self;
+	const Dictionary *from = (const Dictionary *)p_from;
+	self->Dictionary::operator=(*from);
 }
 
 void gdextension_dictionary_set_typed(GDExtensionTypePtr p_self, GDExtensionVariantType p_key_type, GDExtensionConstStringNamePtr p_key_class_name, GDExtensionConstVariantPtr p_key_script, GDExtensionVariantType p_value_type, GDExtensionConstStringNamePtr p_value_class_name, GDExtensionConstVariantPtr p_value_script) {
@@ -1832,12 +1836,11 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(packed_vector4_array_operator_index_const);
 	REGISTER_INTERFACE_FUNC(array_operator_index);
 	REGISTER_INTERFACE_FUNC(array_operator_index_const);
-#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(array_ref);
-#endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(array_set_typed);
 	REGISTER_INTERFACE_FUNC(dictionary_operator_index);
 	REGISTER_INTERFACE_FUNC(dictionary_operator_index_const);
+	REGISTER_INTERFACE_FUNC(dictionary_ref);
 	REGISTER_INTERFACE_FUNC(dictionary_set_typed);
 	REGISTER_INTERFACE_FUNC(object_method_bind_call);
 	REGISTER_INTERFACE_FUNC(object_method_bind_ptrcall);

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -7473,11 +7473,7 @@
             "description": [
                 "Sets an Array to be a reference to another Array object."
             ],
-            "since": "4.1",
-            "deprecated": {
-                "since": "4.5",
-                "message": "Removed from interface. Use copy constructor instead."
-            }
+            "since": "4.1"
         },
         {
             "name": "array_set_typed",
@@ -7573,6 +7569,29 @@
                 "Gets a const pointer to a Variant in a Dictionary with the given key."
             ],
             "since": "4.1"
+        },
+        {
+            "name": "dictionary_ref",
+            "arguments": [
+                {
+                    "name": "p_self",
+                    "type": "GDExtensionTypePtr",
+                    "description": [
+                        "A pointer to the Dictionary object to update."
+                    ]
+                },
+                {
+                    "name": "p_from",
+                    "type": "GDExtensionConstTypePtr",
+                    "description": [
+                        "A pointer to the Dictionary object to reference."
+                    ]
+                }
+            ],
+            "description": [
+                "Sets a Dictionary to be a reference to another Dictionary object."
+            ],
+            "since": "4.8"
         },
         {
             "name": "dictionary_set_typed",


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/119440

## Additional information

Marked as DRAFT for now, because I haven't had a chance to test this with godot-cpp yet, and I'm not 100% sure it's the solution we should persue