### PR TITLE
Add an option to run the project upgrade tool when updating to a new Godot version 

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1505,6 +1505,13 @@ void EditorNode::_sources_changed(bool p_exist) {
 
 		OS::get_singleton()->benchmark_end_measure("Editor", "First Scan");
 
+		for (const String &arg : OS::get_singleton()->get_cmdline_args()) {
+			if (arg == "--run-upgrade-tool") {
+				project_upgrade_tool->prepare_upgrade();
+				return;
+			}
+		}
+
 		// Reload the global shader variables, but this time
 		// loading textures, as they are now properly imported.
 		RenderingServer::get_singleton()->global_shader_parameters_load_settings(true);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -105,6 +105,7 @@ public:
 	void set_unsupported_features(PackedStringArray p_features);
 
 	bool should_load_project_icon() const;
+	bool is_older_version() const { return version_match_type == VersionMatchType::PROJECT_USES_OLDER_MAJOR || version_match_type == VersionMatchType::PROJECT_USES_OLDER_MINOR; }
 	void set_selected(bool p_selected, bool p_hide_focus = false);
 
 	void set_is_favorite(bool p_favorite);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -592,6 +592,10 @@ void ProjectManager::_open_selected_projects() {
 			args.push_back("--verbose");
 		}
 
+		if (ask_upgrade_tool->is_pressed()) {
+			args.push_back("--run-upgrade-tool");
+		}
+
 		Error err = OS::get_singleton()->create_instance(args);
 		if (err != OK) {
 			loading_label->hide();
@@ -632,9 +636,11 @@ void ProjectManager::_open_selected_projects_check_warnings() {
 
 	ask_update_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT); // Reset in case of previous center align.
 	ask_update_backup->set_pressed(false);
+	ask_upgrade_tool->set_pressed(false);
 	full_convert_button->hide();
 	migration_guide_button->hide();
 	ask_update_backup->hide();
+	ask_upgrade_tool->hide();
 
 	ask_update_settings->get_ok_button()->set_text("OK");
 
@@ -681,7 +687,10 @@ void ProjectManager::_open_selected_projects_check_warnings() {
 				i--;
 			} else if (ProjectList::project_feature_looks_like_version(feature)) {
 				ask_update_backup->show();
-				migration_guide_button->show();
+				if (project.control->is_older_version()) {
+					ask_upgrade_tool->show();
+					migration_guide_button->show();
+				}
 				version_convert_feature = feature;
 				warning_message += vformat(TTR("Warning: This project was last edited in Godot %s. Opening will change it to Godot %s.\n\n"), Variant(feature), Variant(GODOT_VERSION_BRANCH));
 				unsupported_features.remove_at(i);
@@ -742,6 +751,7 @@ void ProjectManager::_open_selected_projects_with_migration() {
 	}
 #endif
 	_open_selected_projects();
+	ask_upgrade_tool->set_pressed(false);
 }
 
 void ProjectManager::_install_project(const String &p_zip_path, const String &p_title) {
@@ -1832,6 +1842,11 @@ ProjectManager::ProjectManager() {
 		ask_update_backup->set_text(TTRC("Backup project first"));
 		ask_update_backup->set_h_size_flags(SIZE_SHRINK_CENTER);
 		ask_update_vb->add_child(ask_update_backup);
+		ask_upgrade_tool = memnew(CheckBox);
+		ask_upgrade_tool->set_text(TTRC("Upgrade All Project Files"));
+		ask_upgrade_tool->set_tooltip_text(TTRC("Automatically runs the upgrade tool. This may take a while to finish. The project will be restarted once in the process."));
+		ask_upgrade_tool->set_h_size_flags(SIZE_SHRINK_CENTER);
+		ask_update_vb->add_child(ask_upgrade_tool);
 		ask_update_settings->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_open_selected_projects_with_migration));
 		int ed_swap_cancel_ok = EDITOR_GET("interface/editor/appearance/accept_dialog_cancel_ok_buttons");
 		if (ed_swap_cancel_ok == 0) {

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -247,6 +247,7 @@ class ProjectManager : public Control {
 	VBoxContainer *ask_update_vb = nullptr;
 	Label *ask_update_label = nullptr;
 	CheckBox *ask_update_backup = nullptr;
+	CheckBox *ask_upgrade_tool = nullptr;
 	Button *full_convert_button = nullptr;
 	Button *migration_guide_button = nullptr;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14272

<img width="425" height="262" alt="image" src="https://github.com/user-attachments/assets/c4c98d02-513a-4089-aae5-00b0fc8f1b25" />

Does not include the formatting changes dialog. It requires an actual list of formatting changes, and no such thing exists.

Also makes Show Migration Guide appear only when upgrading to newer versions.