### PR TITLE
SCons: Migrate from `os.system` to `subprocess`

### DIFF
--- a/misc/scripts/dotnet_format.py
+++ b/misc/scripts/dotnet_format.py
@@ -2,6 +2,7 @@
 
 import glob
 import os
+import subprocess
 import sys
 
 if len(sys.argv) < 2:
@@ -30,4 +31,4 @@ projects = {
 # Run dotnet format on all projects with more than 0 modified files.
 for path, files in projects.items():
     if files:
-        os.system(f"dotnet format {path} --include {files}")
+        subprocess.run(["dotnet", "format", path, "--include", files])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 
@@ -18,8 +19,7 @@ def can_build():
     if os.name != "posix" or sys.platform == "darwin":
         return False
 
-    pkgconf_error = os.system("pkg-config --version > /dev/null")
-    if pkgconf_error:
+    if subprocess.run(["pkg-config", "--version"], capture_output=True).returncode != 0:
         print_error("pkg-config not found. Aborting.")
         return False
 
@@ -237,7 +237,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(CPPDEFINES=["SOWRAP_ENABLED"])
 
     if env["wayland"]:
-        if os.system("wayland-scanner -v 2>/dev/null") != 0:
+        if subprocess.run(["wayland-scanner"], capture_output=True).returncode != 0:
             print_warning("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 
@@ -311,7 +311,7 @@ def configure(env: "SConsEnvironment"):
     if not env["builtin_mbedtls"]:
         # mbedTLS only provides a pkgconfig file since 3.6.0, but we still support 2.28.x,
         # so fallback to manually specifying LIBS if it fails.
-        if os.system("pkg-config --exists mbedtls") == 0:  # 0 means found
+        if subprocess.run(["pkg-config", "--exists", "mbedtls"], capture_output=True).returncode == 0:
             env.ParseConfig("pkg-config mbedtls mbedcrypto mbedx509 --cflags --libs")
         else:
             env.Append(LIBS=["mbedtls", "mbedcrypto", "mbedx509"])
@@ -339,7 +339,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["fontconfig"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists fontconfig") == 0:  # 0 means found
+            if subprocess.run(["pkg-config", "--exists", "fontconfig"], capture_output=True).returncode == 0:
                 env.ParseConfig("pkg-config fontconfig --cflags --libs")
                 env.Append(CPPDEFINES=["FONTCONFIG_ENABLED"])
             else:
@@ -350,7 +350,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["alsa"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists alsa") == 0:  # 0 means found
+            if subprocess.run(["pkg-config", "--exists", "alsa"], capture_output=True).returncode == 0:
                 env.ParseConfig("pkg-config alsa --cflags --libs")
                 env.Append(CPPDEFINES=["ALSA_ENABLED", "ALSAMIDI_ENABLED"])
             else:
@@ -361,7 +361,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["pulseaudio"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists libpulse") == 0:  # 0 means found
+            if subprocess.run(["pkg-config", "--exists", "libpulse"], capture_output=True).returncode == 0:
                 env.ParseConfig("pkg-config libpulse --cflags --libs")
                 env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             else:
@@ -372,7 +372,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["dbus"] and env["threads"]:  # D-Bus functionality expects threads.
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists dbus-1") == 0:  # 0 means found
+            if subprocess.run(["pkg-config", "--exists", "dbus-1"], capture_output=True).returncode == 0:
                 env.ParseConfig("pkg-config dbus-1 --cflags --libs")
                 env.Append(CPPDEFINES=["DBUS_ENABLED"])
             else:
@@ -383,7 +383,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["speechd"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists speech-dispatcher") == 0:  # 0 means found
+            if subprocess.run(["pkg-config", "--exists", "speech-dispatcher"], capture_output=True).returncode == 0:
                 env.ParseConfig("pkg-config speech-dispatcher --cflags --libs")
                 env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
             else:
@@ -393,7 +393,7 @@ def configure(env: "SConsEnvironment"):
             env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
 
     if not env["use_sowrap"]:
-        if os.system("pkg-config --exists xkbcommon") == 0:  # 0 means found
+        if subprocess.run(["pkg-config", "--exists", "xkbcommon"], capture_output=True).returncode == 0:
             env.ParseConfig("pkg-config xkbcommon --cflags --libs")
             env.Append(CPPDEFINES=["XKB_ENABLED"])
         else:
@@ -410,7 +410,7 @@ def configure(env: "SConsEnvironment"):
     if platform.system() == "Linux":
         if env["udev"]:
             if not env["use_sowrap"]:
-                if os.system("pkg-config --exists libudev") == 0:  # 0 means found
+                if subprocess.run(["pkg-config", "--exists", "libudev"], capture_output=True).returncode == 0:
                     env.ParseConfig("pkg-config libudev --cflags --libs")
                     env.Append(CPPDEFINES=["UDEV_ENABLED"])
                 else:
@@ -424,7 +424,7 @@ def configure(env: "SConsEnvironment"):
     if env["sdl"]:
         if env["builtin_sdl"]:
             env.Append(CPPDEFINES=["SDL_ENABLED"])
-        elif os.system("pkg-config --exists sdl3") == 0:  # 0 means found
+        elif subprocess.run(["pkg-config", "--exists", "sdl3"], capture_output=True).returncode == 0:
             env.ParseConfig("pkg-config sdl3 --cflags --libs")
             env.Append(CPPDEFINES=["SDL_ENABLED"])
         else:
@@ -451,31 +451,31 @@ def configure(env: "SConsEnvironment"):
 
     if env["x11"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists x11"):
+            if subprocess.run(["pkg-config", "--exists", "x11"], capture_output=True).returncode != 0:
                 print_error("X11 libraries not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config x11 --cflags --libs")
-            if os.system("pkg-config --exists xcursor"):
+            if subprocess.run(["pkg-config", "--exists", "xcursor"], capture_output=True).returncode != 0:
                 print_error("Xcursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xcursor --cflags --libs")
-            if os.system("pkg-config --exists xinerama"):
+            if subprocess.run(["pkg-config", "--exists", "xinerama"], capture_output=True).returncode != 0:
                 print_error("Xinerama library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xinerama --cflags --libs")
-            if os.system("pkg-config --exists xext"):
+            if subprocess.run(["pkg-config", "--exists", "xext"], capture_output=True).returncode != 0:
                 print_error("Xext library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xext --cflags --libs")
-            if os.system("pkg-config --exists xrandr"):
+            if subprocess.run(["pkg-config", "--exists", "xrandr"], capture_output=True).returncode != 0:
                 print_error("XrandR library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrandr --cflags --libs")
-            if os.system("pkg-config --exists xrender"):
+            if subprocess.run(["pkg-config", "--exists", "xrender"], capture_output=True).returncode != 0:
                 print_error("XRender library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xrender --cflags --libs")
-            if os.system("pkg-config --exists xi"):
+            if subprocess.run(["pkg-config", "--exists", "xi"], capture_output=True).returncode != 0:
                 print_error("Xi library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config xi --cflags --libs")
@@ -483,20 +483,20 @@ def configure(env: "SConsEnvironment"):
 
     if env["wayland"]:
         if not env["use_sowrap"]:
-            if os.system("pkg-config --exists libdecor-0"):
+            if subprocess.run(["pkg-config", "--exists", "libdecor-0"], capture_output=True).returncode != 0:
                 print_warning("libdecor development libraries not found. Disabling client-side decorations.")
                 env["libdecor"] = False
             else:
                 env.ParseConfig("pkg-config libdecor-0 --cflags --libs")
-            if os.system("pkg-config --exists wayland-client"):
+            if subprocess.run(["pkg-config", "--exists", "wayland-client"], capture_output=True).returncode != 0:
                 print_error("Wayland client library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-client --cflags --libs")
-            if os.system("pkg-config --exists wayland-cursor"):
+            if subprocess.run(["pkg-config", "--exists", "wayland-cursor"], capture_output=True).returncode != 0:
                 print_error("Wayland cursor library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-cursor --cflags --libs")
-            if os.system("pkg-config --exists wayland-egl"):
+            if subprocess.run(["pkg-config", "--exists", "wayland-egl"], capture_output=True).returncode != 0:
                 print_error("Wayland EGL library not found. Aborting.")
                 sys.exit(255)
             env.ParseConfig("pkg-config wayland-egl --cflags --libs")

--- a/platform/linuxbsd/platform_linuxbsd_builders.py
+++ b/platform/linuxbsd/platform_linuxbsd_builders.py
@@ -1,10 +1,10 @@
 """Functions used to generate source files during build time"""
 
-import os
+import subprocess
 
 
 def make_debug_linuxbsd(target, source, env):
     dst = str(target[0])
-    os.system('objcopy --only-keep-debug "{0}" "{0}.debugsymbols"'.format(dst))
-    os.system('strip --strip-debug --strip-unneeded "{0}"'.format(dst))
-    os.system('objcopy --add-gnu-debuglink="{0}.debugsymbols" "{0}"'.format(dst))
+    subprocess.run(["objcopy", "--only-keep-debug", dst, f"{dst}.debugsymbols"], check=True)
+    subprocess.run(["strip", "--strip-debug", "--strip-unneeded", dst], check=True)
+    subprocess.run(["objcopy", f"--add-gnu-debuglink={dst}.debugsymbols", dst], check=True)

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -117,7 +117,8 @@ def make_debug_macos(target, source, env):
     if env["macports_clang"] != "no":
         mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
         mpclangver = env["macports_clang"]
-        os.system(mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-dsymutil {0} -o {0}.dSYM".format(dst))
+        dsymutil = f"{mpprefix}/libexec/llvm-{mpclangver}/bin/llvm-dsymutil"
     else:
-        os.system("dsymutil {0} -o {0}.dSYM".format(dst))
-    os.system("strip -u -r {0}".format(dst))
+        dsymutil = "dsymutil"
+    subprocess.run([dsymutil, dst, "-o", f"{dst}.dSYM"], check=True)
+    subprocess.run(["strip", "-u", "-r", dst], check=True)

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -1,12 +1,13 @@
 """Functions used to generate source files during build time"""
 
 import os
+import subprocess
 
 
 def make_debug_mingw(target, source, env):
     dst = str(target[0])
     # Force separate debug symbols if executable size is larger than 1.9 GB.
     if env["separate_debug_symbols"] or os.stat(dst).st_size >= 2040109465:
-        os.system("{0} --only-keep-debug {1} {1}.debugsymbols".format(env["OBJCOPY"], dst))
-        os.system("{0} --strip-debug --strip-unneeded {1}".format(env["STRIP"], dst))
-        os.system("{0} --add-gnu-debuglink={1}.debugsymbols {1}".format(env["OBJCOPY"], dst))
+        subprocess.run([env["OBJCOPY"], "--only-keep-debug", dst, f"{dst}.debugsymbols"], check=True)
+        subprocess.run([env["STRIP"], "--strip-debug", "--strip-unneeded", dst], check=True)
+        subprocess.run([env["OBJCOPY"], f"--add-gnu-debuglink={dst}.debugsymbols", dst], check=True)


### PR DESCRIPTION
`os.system` is considered soft-deprecated, recommending instances of it be replaced with `subprocess` functions instead. This implements exactly that, replacing all `os.system` calls with `subprocess.run` equivalents.