### PR TITLE
Fix out of order acceptance of duplicate keys in .gdextension files

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -295,7 +295,12 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 		}
 
 		if (!assign.is_empty()) {
-			set_value(section, assign, value);
+			if (has_section_key(section, assign)) {
+				WARN_PRINT(vformat("Duplicate key found at %s:%d: %s", p_path, lines, assign));
+			}
+			else {
+				set_value(section, assign, value);
+			}
 		} else if (!next_tag.name.is_empty()) {
 			section = next_tag.name.replace("\\]", "]");
 		}


### PR DESCRIPTION
If duplicate keys are present in a `.gdextension` file, log a warning and _don't_ overwrite the previous value

## What problem(s) does this PR solve?

- Closes #119471

## Additional information

Duplicate keys in `.gdextension` files can cause unintuitive results. This change ensures that the first value for a given key is always the value used. See linked issue for more details. 
