### PR TITLE
Fix various editor state related regressions

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -342,7 +342,7 @@ Dictionary EditorData::get_scene_editor_states_with_selection(int p_idx) const {
 		for (Node *node : es.selection) {
 			selected_paths.push_back(root->get_path_to(node));
 		}
-		states["selected_nodes"] = selected_paths;
+		states["$selected_nodes"] = selected_paths;
 	}
 	return states;
 }
@@ -356,19 +356,10 @@ void EditorData::set_editor_plugin_states(const Dictionary &p_states) {
 	}
 
 	for (const KeyValue<Variant, Variant> &kv : p_states) {
-		String name = kv.key;
-		int idx = -1;
-		for (int i = 0; i < editor_plugins.size(); i++) {
-			if (editor_plugins[i]->get_plugin_name() == name) {
-				idx = i;
-				break;
-			}
+		EditorPlugin *plugin = get_editor_by_name(kv.key);
+		if (plugin) {
+			plugin->set_state(kv.value);
 		}
-
-		if (idx == -1) {
-			continue;
-		}
-		editor_plugins[idx]->set_state(kv.value);
 	}
 }
 
@@ -407,8 +398,8 @@ void EditorData::load_editor_plugin_states_from_config(const Ref<ConfigFile> &p_
 	es.editor_states = states;
 
 	const Node *root = es.root;
-	if (root && p_config_file->has_section_key("editor_states", "selected_nodes")) {
-		TypedArray<NodePath> node_paths = p_config_file->get_value("editor_states", "selected_nodes");
+	if (root && p_config_file->has_section_key("editor_states", "$selected_nodes")) {
+		TypedArray<NodePath> node_paths = p_config_file->get_value("editor_states", "$selected_nodes");
 		List<Node *> nodes;
 
 		for (const Variant &np : node_paths) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2138,7 +2138,7 @@ void EditorNode::_save_editor_states(const String &p_file, int p_idx) {
 		for (Node *selected_node : selection) {
 			selection_paths.push_back(scene->get_path_to(selected_node));
 		}
-		cf->set_value("editor_states", "selected_nodes", selection_paths);
+		cf->set_value("editor_states", "$selected_nodes", selection_paths);
 	} else {
 		md = editor_data.get_scene_editor_states_with_selection(p_idx);
 	}
@@ -6456,7 +6456,7 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 	const String current_scene = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene", String());
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		if (editor_data.get_scene_path(i) == current_scene) {
-			_set_current_scene_nocheck(i);
+			_set_current_scene_nocheck(i, true);
 			current_scene_found = true;
 			break;
 		}

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -415,12 +415,12 @@ void EditorSceneTabs::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
 			int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
 			next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
-			_scene_tab_changed(next_tab);
+			set_current_tab(next_tab);
 		}
 		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
 			int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
 			next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
-			_scene_tab_changed(next_tab);
+			set_current_tab(next_tab);
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #116905
- Fixed dummy scene state overwriting the first scene (fixes #119442)
- Fixed scene tabs not updating on next/prev tab (fixes #119470)
- Renamed `selected_nodes` state key to `$selected_nodes`
  - Avoids errors after upgrading (see https://github.com/godotengine/godot/pull/116905#issuecomment-4454797600)
  - The new name makes more sense, because other keys are editor plugin names. This one is special
- Loosely related cleanup of one method

<br>

* Bugsquad edit: Fixes #119492