### PR TITLE
Add search bar to export options

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -122,12 +122,14 @@ void ProjectExportDialog::_notification(int p_what) {
 			duplicate_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Duplicate")));
 			delete_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Remove")));
 			patch_add_btn->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			parameters_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 		} break;
 
 		case NOTIFICATION_READY: {
 			duplicate_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Duplicate")));
 			delete_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Remove")));
 			patch_add_btn->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			parameters_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			connect(SceneStringName(confirmed), callable_mp(this, &ProjectExportDialog::_export_pck_zip));
 			_update_export_all();
 		} break;
@@ -1650,12 +1652,25 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	// Main preset parameters.
 
+	VBoxContainer *parameters_vb = memnew(VBoxContainer);
+	parameters_vb->set_name(TTRC("Options"));
+	sections->add_child(parameters_vb);
+
+	parameters_search_box = memnew(LineEdit);
+	parameters_search_box->set_placeholder(TTRC("Filter Options"));
+	parameters_search_box->set_accessibility_name(TTRC("Filter Options"));
+	parameters_search_box->set_virtual_keyboard_show_on_focus(false);
+	parameters_search_box->set_clear_button_enabled(true);
+	parameters_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	parameters_vb->add_child(parameters_search_box);
+
 	parameters = memnew(EditorInspector);
-	parameters->set_name(TTRC("Options"));
 	parameters->set_mark_unsaved(false);
 	parameters->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	parameters->set_use_doc_hints(true);
-	sections->add_child(parameters);
+	parameters->set_use_filter(true);
+	parameters->register_text_enter(parameters_search_box);
+	parameters_vb->add_child(parameters);
 	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 	EditorExport::get_singleton()->connect("export_presets_updated", callable_mp(this, &ProjectExportDialog::_force_update_current_preset_parameters));
 

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -86,6 +86,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	LineEdit *name = nullptr;
 	EditorPropertyPath *export_path = nullptr;
 	EditorInspector *parameters = nullptr;
+	LineEdit *parameters_search_box = nullptr;
 	CheckButton *runnable = nullptr;
 	CheckButton *advanced_options = nullptr;
 


### PR DESCRIPTION
It adds a search bar to the top of the export options to filter them, I copied the code from the settings search to make sure it works well.I did it because when exporting to android finding the options took ages. AI was used to make sure i wasn't breaking anything.

## What problem(s) does this PR solve?
Finding export options

## Testings
I built this and could not find any errors

## Image
<img width="694" height="135" alt="image" src="https://github.com/user-attachments/assets/23463be7-af60-487d-b962-5889cd5597e7" />
