### PR TITLE
Wayland: Fix logical and physical window size handling on KDE Plasma

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4347,11 +4347,29 @@ void WaylandThread::window_create(DisplayServerEnums::WindowID p_window_id, cons
 	ws.registry = &registry;
 	ws.wayland_thread = this;
 
-	ws.rect.size = p_size.maxi(1);
+	// Inherit scale from the parent window if available
+	WindowState *parent_ws = windows.getptr(p_parent_id);
+	if (!parent_ws && p_window_id != DisplayServerEnums::MAIN_WINDOW_ID) {
+		parent_ws = windows.getptr(DisplayServerEnums::MAIN_WINDOW_ID);
+	}
+
+	if (parent_ws) {
+		ws.preferred_fractional_scale = parent_ws->preferred_fractional_scale;
+		ws.fractional_scale = parent_ws->fractional_scale;
+		ws.buffer_scale = parent_ws->fractional_scale > 0 ? 1 : parent_ws->buffer_scale;
+	}
+
+	// Convert physical size to logical size
+	double scale = window_state_get_scale_factor(&ws);
+	ws.rect.size = scale_vector2i(p_size, scale > 0 ? 1.0 / scale : 1.0).maxi(1);
 
 	ws.wl_surface = wl_compositor_create_surface(registry.wl_compositor);
 	wl_proxy_tag_godot((struct wl_proxy *)ws.wl_surface);
 	wl_surface_add_listener(ws.wl_surface, &wl_surface_listener, &ws);
+
+	if (ws.buffer_scale != 1) {
+		wl_surface_set_buffer_scale(ws.wl_surface, ws.buffer_scale);
+	}
 
 	if (registry.wp_viewporter) {
 		ws.wp_viewport = wp_viewporter_get_viewport(registry.wp_viewporter, ws.wl_surface);
@@ -4449,7 +4467,7 @@ void WaylandThread::window_create_popup(DisplayServerEnums::WindowID p_window_id
 	// the resizing routines will get confused and scale once more.
 	ws.preferred_fractional_scale = parent.preferred_fractional_scale;
 	ws.fractional_scale = parent.fractional_scale;
-	ws.buffer_scale = parent.buffer_scale;
+	ws.buffer_scale = parent.fractional_scale > 0 ? 1 : parent.buffer_scale;
 
 	ws.id = p_window_id;
 	ws.parent_id = p_parent_id;
@@ -4461,6 +4479,10 @@ void WaylandThread::window_create_popup(DisplayServerEnums::WindowID p_window_id
 	ws.wl_surface = wl_compositor_create_surface(registry.wl_compositor);
 	wl_proxy_tag_godot((struct wl_proxy *)ws.wl_surface);
 	wl_surface_add_listener(ws.wl_surface, &wl_surface_listener, &ws);
+
+	if (ws.buffer_scale != 1) {
+		wl_surface_set_buffer_scale(ws.wl_surface, ws.buffer_scale);
+	}
 
 	if (registry.wp_viewporter) {
 		ws.wp_viewport = wp_viewporter_get_viewport(registry.wp_viewporter, ws.wl_surface);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -375,6 +375,10 @@ int Window::get_current_screen() const {
 void Window::set_position(const Point2i &p_position) {
 	ERR_MAIN_THREAD_GUARD;
 
+	if (window_id == DisplayServerEnums::INVALID_WINDOW_ID && position != p_position) {
+		self_fitting_restore_position_valid = false;
+	}
+
 	position = p_position;
 
 	if (embedder) {
@@ -418,6 +422,10 @@ void Window::set_size(const Size2i &p_size) {
 		return;
 	}
 #endif
+
+	if (window_id == DisplayServerEnums::INVALID_WINDOW_ID && size != p_size) {
+		self_fitting_restore_size_valid = false;
+	}
 
 	size = p_size;
 	_update_window_size();
@@ -716,6 +724,23 @@ void Window::_make_window() {
 	}
 
 	DisplayServerEnums::VSyncMode vsync_mode = DisplayServer::get_singleton()->window_get_vsync_mode(DisplayServerEnums::MAIN_WINDOW_ID);
+
+	// If the display server has self fitting feature, restore the window physical size and position.
+	if ((self_fitting_restore_size_valid || self_fitting_restore_position_valid) && DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS)) {
+		DisplayServerEnums::WindowID parent_id = DisplayServerEnums::MAIN_WINDOW_ID;
+		if (transient_parent && transient_parent->window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+			parent_id = transient_parent->window_id;
+		}
+
+		float win_scale = DisplayServer::get_singleton()->window_get_scale(parent_id);
+		if (self_fitting_restore_size_valid) {
+			size = Size2i(Math::round(self_fitting_restore_size.x * win_scale), Math::round(self_fitting_restore_size.y * win_scale)).maxi(1);
+		}
+		if (self_fitting_restore_position_valid) {
+			position = Point2i(Math::round(self_fitting_restore_position.x * win_scale), Math::round(self_fitting_restore_position.y * win_scale));
+		}
+	}
+
 	Rect2i window_rect;
 	if (initial_position == WINDOW_INITIAL_POSITION_ABSOLUTE) {
 		window_rect = Rect2i(position, size);
@@ -770,13 +795,15 @@ void Window::_clear_window() {
 
 	bool had_focus = has_focus();
 
+	// If the display server has self fitting feature, store the window logical size and position.
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS)) {
 		float win_scale = DisplayServer::get_singleton()->window_get_scale(window_id);
 
-		Size2i adjusted_size = Size2i(size.width / win_scale, size.height / win_scale);
-		Size2i adjusted_pos = Size2i(position.x / win_scale, position.y / win_scale);
+		self_fitting_restore_size = Size2i(Math::round(size.x / win_scale), Math::round(size.y / win_scale)).maxi(1);
+		self_fitting_restore_position = Point2i(Math::round(position.x / win_scale), Math::round(position.y / win_scale));
 
-		_rect_changed_callback(Rect2i(adjusted_pos, adjusted_size));
+		self_fitting_restore_size_valid = true;
+		self_fitting_restore_position_valid = true;
 	}
 
 	if (transient_parent && transient_parent->window_id != DisplayServerEnums::INVALID_WINDOW_ID) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -166,6 +166,11 @@ private:
 	String accessibility_name;
 	String accessibility_description;
 
+	Point2i self_fitting_restore_position;
+	Size2i self_fitting_restore_size;
+	bool self_fitting_restore_position_valid = false;
+	bool self_fitting_restore_size_valid = false;
+
 	void _make_window();
 	void _clear_window();
 	void _update_from_window();


### PR DESCRIPTION
## Details
Fixes several logical/physical window size conversion issues in Wayland HiDPI environments.

Godot internally uses physical window sizes, while Wayland protocols use logical sizes.
Several conversions between these coordinate spaces were missing or inconsistent, causing incorrect popup sizing ~~and IME positioning~~ under Wayland fractional scaling.

This PR also removes code that attempted to compensate for previously stored incorrect window sizes.
Existing saved window geometry values may still contain invalid data in project and might need to be reset manually.

This resolves a large portion of Wayland HiDPI popup and window sizing issues.
~~However, floating game window sizing during editor execution is still not fully fixed. Addressing this properly will require additional changes to the Wayland fractional scaling implementation and will be handled in a separate PR.~~(This issue is no longer reproducible now)

Tested on ArchLinux KDE Plasma 6.6.5 3840x2400 scale 250%

## What problem(s) does this PR solve?
~~- Fixes incorrect IME popup positioning under fractional scaling~~(I split this out into PR #121571)
- Fixes inconsistent logical/physical window size handling on Wayland
