### PR TITLE
Add --log-format=json and --inspect-scene for headless automation

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -33,9 +33,11 @@
 #include "core/core_globals.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/json.h"
 #include "core/object/script_backtrace.h"
 #include "core/os/time.h"
 #include "core/templates/rb_set.h"
+#include "core/variant/dictionary.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 
@@ -235,6 +237,91 @@ void StdLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 			fflush(stdout);
 		}
 	}
+}
+
+static String _json_logger_format_message(const char *p_format, va_list p_list) {
+	const int static_buf_size = 1024;
+	char static_buf[static_buf_size];
+	char *buf = static_buf;
+	va_list list_copy;
+	va_copy(list_copy, p_list);
+	int len = vsnprintf(buf, static_buf_size, p_format, p_list);
+	if (len >= static_buf_size) {
+		buf = (char *)Memory::alloc_static(len + 1);
+		vsnprintf(buf, len + 1, p_format, list_copy);
+	}
+	va_end(list_copy);
+
+	String result = String::utf8(buf);
+	if (len >= static_buf_size) {
+		Memory::free_static(buf);
+	}
+	// Strip a single trailing newline (Godot's print paths append "\n" but each
+	// NDJSON record is already line-delimited by us writing one "\n" below).
+	if (result.ends_with("\n")) {
+		result = result.substr(0, result.length() - 1);
+	}
+	return result;
+}
+
+static void _json_logger_emit(const Dictionary &p_record) {
+	String line = JSON::stringify(p_record, "", false, true);
+	fwrite(line.utf8().get_data(), 1, line.utf8().length(), stdout);
+	fputc('\n', stdout);
+	fflush(stdout);
+}
+
+void JSONLogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+
+	Dictionary record;
+	record["ts"] = Time::get_singleton()->get_datetime_string_from_system(true);
+	record["level"] = p_err ? "error" : "info";
+	record["msg"] = _json_logger_format_message(p_format, p_list);
+	_json_logger_emit(record);
+}
+
+void JSONLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	Dictionary record;
+	record["ts"] = Time::get_singleton()->get_datetime_string_from_system(true);
+	switch (p_type) {
+		case ERR_WARNING:
+			record["level"] = "warning";
+			break;
+		case ERR_SCRIPT:
+			record["level"] = "script_error";
+			break;
+		case ERR_SHADER:
+			record["level"] = "shader_error";
+			break;
+		case ERR_ERROR:
+		default:
+			record["level"] = "error";
+			break;
+	}
+	record["function"] = String::utf8(p_function ? p_function : "");
+	record["file"] = String::utf8(p_file ? p_file : "");
+	record["line"] = p_line;
+	record["code"] = String::utf8(p_code ? p_code : "");
+	record["rationale"] = String::utf8(p_rationale ? p_rationale : "");
+	record["editor_notify"] = p_editor_notify;
+
+	Array backtraces;
+	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
+		if (backtrace.is_valid() && !backtrace->is_empty()) {
+			backtraces.push_back(backtrace->format(0));
+		}
+	}
+	if (!backtraces.is_empty()) {
+		record["backtrace"] = backtraces;
+	}
+	_json_logger_emit(record);
 }
 
 CompositeLogger::CompositeLogger(const Vector<Logger *> &p_loggers) :

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -103,6 +103,17 @@ public:
 };
 
 /**
+ * Writes messages as newline-delimited JSON (NDJSON) to stdout — one JSON object per log call.
+ * Designed for tools and editors that consume Godot's output programmatically.
+ */
+class JSONLogger : public Logger {
+public:
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces = {}) override;
+	virtual ~JSONLogger() {}
+};
+
+/**
  * Writes messages to the specified file. If the file already exists, creates a copy (backup)
  * of it with timestamp appended to the file name. Maximum number of backups is configurable.
  * When maximum is reached, the oldest backups are erased. With the maximum being equal to 1,

--- a/core/io/scene_inspector.cpp
+++ b/core/io/scene_inspector.cpp
@@ -1,0 +1,100 @@
+/**************************************************************************/
+/*  scene_inspector.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "scene_inspector.h"
+
+#include "core/io/json.h"
+#include "core/io/resource_loader.h"
+#include "core/object/object.h"
+#include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
+
+Dictionary SceneInspector::inspect(const String &p_scene_path) {
+	Dictionary result;
+	result["scene"] = p_scene_path;
+
+	Error err = OK;
+	Ref<PackedScene> ps = ResourceLoader::load(p_scene_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+	if (ps.is_null() || err != OK) {
+		result["error"] = vformat("Failed to load PackedScene from '%s' (error %d).", p_scene_path, (int)err);
+		return result;
+	}
+
+	Node *root = ps->instantiate(PackedScene::GEN_EDIT_STATE_DISABLED);
+	if (!root) {
+		result["error"] = vformat("Failed to instantiate scene '%s'.", p_scene_path);
+		return result;
+	}
+
+	result["root"] = dump_node(root);
+	memdelete(root);
+	return result;
+}
+
+String SceneInspector::inspect_to_json(const String &p_scene_path) {
+	Dictionary d = inspect(p_scene_path);
+	return JSON::stringify(d, "", false, true);
+}
+
+Dictionary SceneInspector::dump_node(Node *p_node) {
+	Dictionary d;
+	d["name"] = String(p_node->get_name());
+	d["class"] = p_node->get_class();
+
+	Dictionary props;
+	List<PropertyInfo> plist;
+	p_node->get_property_list(&plist);
+	for (const PropertyInfo &pi : plist) {
+		// Skip non-data entries (groups, categories, subgroups, and internal-only fields).
+		const uint32_t skip_mask = PROPERTY_USAGE_GROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL;
+		if (pi.usage & skip_mask) {
+			continue;
+		}
+		// Only editor-visible properties — keeps output focused on what a human/tool would care about.
+		if (!(pi.usage & PROPERTY_USAGE_EDITOR)) {
+			continue;
+		}
+		Variant value = p_node->get(pi.name);
+		props[pi.name] = value;
+	}
+	if (!props.is_empty()) {
+		d["properties"] = props;
+	}
+
+	int child_count = p_node->get_child_count();
+	if (child_count > 0) {
+		Array children;
+		for (int i = 0; i < child_count; i++) {
+			children.push_back(dump_node(p_node->get_child(i)));
+		}
+		d["children"] = children;
+	}
+	return d;
+}

--- a/core/io/scene_inspector.h
+++ b/core/io/scene_inspector.h
@@ -1,0 +1,56 @@
+/**************************************************************************/
+/*  scene_inspector.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
+
+class Node;
+
+/**
+ * Loads a packed scene from disk, instantiates it without entering the SceneTree,
+ * and dumps the resulting node hierarchy (node names, classes, editor-visible
+ * properties, children) as a structured Dictionary. Intended for the
+ * `--inspect-scene` command-line tool used by external tooling/agents.
+ */
+class SceneInspector {
+public:
+	// Returns a Dictionary describing the scene at p_scene_path. On error, the
+	// returned Dictionary has an "error" key with a human-readable message
+	// (and no "root" key).
+	static Dictionary inspect(const String &p_scene_path);
+
+	// Convenience: inspect() then JSON-stringify the result (compact form).
+	static String inspect_to_json(const String &p_scene_path);
+
+private:
+	static Dictionary dump_node(Node *p_node);
+};

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -91,6 +91,12 @@ void OS::add_logger(Logger *p_logger) {
 	}
 }
 
+void OS::reset_logger(Logger *p_replacement) {
+	Vector<Logger *> loggers;
+	loggers.push_back(p_replacement);
+	_set_logger(memnew(CompositeLogger(loggers)));
+}
+
 String OS::get_identifier() const {
 	return get_name().to_lower();
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -386,6 +386,7 @@ public:
 	virtual Error setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path);
 
 	void add_logger(Logger *p_logger);
+	void reset_logger(Logger *p_replacement);
 
 	enum PreferredTextureFormat {
 		PREFERRED_TEXTURE_FORMAT_S3TC_BPTC,

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -218,6 +218,7 @@ static bool project_manager = false;
 static bool cmdline_tool = false;
 static String locale;
 static String log_file;
+static String log_format;
 static bool show_help = false;
 static uint64_t quit_after = 0;
 static ProcessID editor_pid = 0;
@@ -622,6 +623,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--tablet-driver <driver>", "Pen tablet input driver.\n");
 	print_help_option("--headless", "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
 	print_help_option("--log-file <file>", "Write output/error log to the specified path instead of the default location defined by the project.\n");
+	print_help_option("--log-format <text|json>", "Output format for stdout/stderr log lines. 'text' (default) is human-readable; 'json' emits one JSON object per line (NDJSON) with timestamp, level, message, and error context.\n");
 	print_help_option("", "<file> path should be absolute or relative to the project directory.\n");
 	print_help_option("--write-movie <file>", "Write a video to the specified path (usually with .avi or .png extension).\n");
 	print_help_option("", "--fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
@@ -1513,6 +1515,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing log file path argument, aborting.\n");
+				goto error;
+			}
+		} else if (arg == "--log-format") { // output format for stdout/stderr
+
+			if (N) {
+				log_format = N->get();
+				N = N->next();
+				if (log_format == "json") {
+					OS::get_singleton()->reset_logger(memnew(JSONLogger));
+				} else if (log_format != "text") {
+					OS::get_singleton()->print("Invalid --log-format value '%s'. Valid values: text, json. Aborting.\n", log_format.utf8().get_data());
+					goto error;
+				}
+			} else {
+				OS::get_singleton()->print("Missing --log-format value. Valid values: text, json. Aborting.\n");
 				goto error;
 			}
 		} else if (arg == "--profiling") { // enable profiling

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -48,6 +48,7 @@
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/scene_inspector.h"
 #include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
@@ -219,6 +220,7 @@ static bool cmdline_tool = false;
 static String locale;
 static String log_file;
 static String log_format;
+static String inspect_scene_path;
 static bool show_help = false;
 static uint64_t quit_after = 0;
 static ProcessID editor_pid = 0;
@@ -624,6 +626,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--headless", "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
 	print_help_option("--log-file <file>", "Write output/error log to the specified path instead of the default location defined by the project.\n");
 	print_help_option("--log-format <text|json>", "Output format for stdout/stderr log lines. 'text' (default) is human-readable; 'json' emits one JSON object per line (NDJSON) with timestamp, level, message, and error context.\n");
+	print_help_option("--inspect-scene <path>", "Load the scene at <path> headlessly, dump its node tree (names, classes, editor-visible properties, children) to stdout as JSON, then exit.\n");
 	print_help_option("", "<file> path should be absolute or relative to the project directory.\n");
 	print_help_option("--write-movie <file>", "Write a video to the specified path (usually with .avi or .png extension).\n");
 	print_help_option("", "--fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
@@ -1532,6 +1535,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing --log-format value. Valid values: text, json. Aborting.\n");
 				goto error;
 			}
+		} else if (arg == "--inspect-scene") { // dump scene tree as JSON and exit
+
+			if (N) {
+				inspect_scene_path = N->get();
+				N = N->next();
+				cmdline_tool = true;
+			} else {
+				OS::get_singleton()->print("Missing --inspect-scene path argument, aborting.\n");
+				goto error;
+			}
 		} else if (arg == "--profiling") { // enable profiling
 
 			use_debug_profiler = true;
@@ -2332,7 +2345,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	if (main_args.is_empty() && String(GLOBAL_GET("application/run/main_scene")) == "") {
 #ifdef TOOLS_ENABLED
-		if (!editor && !project_manager) {
+		if (!editor && !project_manager && !cmdline_tool) {
 #endif
 			const String error_msg = "Error: Can't run project: no main scene defined in the project.\n";
 			OS::get_singleton()->print("%s", error_msg.utf8().get_data());
@@ -4007,6 +4020,12 @@ int Main::start() {
 	OS::get_singleton()->benchmark_begin_measure("Startup", "Main::Start");
 
 	ERR_FAIL_COND_V(!_start_success, EXIT_FAILURE);
+
+	if (!inspect_scene_path.is_empty()) {
+		String json = SceneInspector::inspect_to_json(inspect_scene_path);
+		OS::get_singleton()->print("%s\n", json.utf8().get_data());
+		return EXIT_SUCCESS;
+	}
 
 	bool has_icon = false;
 	String positional_arg;


### PR DESCRIPTION
Two small, additive command-line flags aimed at the headless / agentic-automation use case described in proposal [#13048](https://github.com/godotengine/godot-proposals/issues/13048), and following the same shape as proposal [#4958](https://github.com/godotengine/godot-proposals/issues/4958).

Both flags are opt-in — default behavior is unchanged.

## 1. `--log-format <text|json>`

Addresses [godot-proposals#13048](https://github.com/godotengine/godot-proposals/issues/13048).

When `json` is selected, every log line on stdout becomes a single newline-delimited JSON record:

\`\`\`bash
godot --headless --log-format json --script my_script.gd
\`\`\`

Output schema:
- info / print: \`{\"ts\",\"level\":\"info\",\"msg\"}\`
- errors / warnings: \`{\"ts\",\"level\",\"function\",\"file\",\"line\",\"code\",\"rationale\",\"editor_notify\",\"backtrace\"?}\`

\`level\` ∈ \`info | error | warning | script_error | shader_error\`.

This gives CI runners and automation tools machine-readable parser/compiler errors with file/line/rationale, which is currently the main pain point in #13048 (\"errors are not consistently structured and often lack file names, line numbers, and clear error boundaries\").

Implementation: a new \`JSONLogger : public Logger\` in \`core/io/logger.{h,cpp}\`, swapped in via a small \`OS::reset_logger()\` helper when the CLI flag is parsed in \`main.cpp\`. The default StdLogger path is untouched.

## 2. \`--inspect-scene <path>\`

Sibling of [godot-proposals#4958](https://github.com/godotengine/godot-proposals/issues/4958) (\`--script-dump-ast\`) — same pattern (cmdline → JSON to stdout → quit), different subject (scene tree instead of GDScript AST).

\`\`\`bash
godot --headless --path /my/project --inspect-scene res://main.tscn
\`\`\`

Loads a \`.tscn\` without launching the editor, walks the node tree, prints a single nested JSON object to stdout, exits. Each node has \`name\`, \`class\`, optional \`properties\` (editor-visible only), optional \`children\`. Useful for scripted scene analysis, CI checks, and (in our case) AI agents that need to read scene structure without a running editor.

Implementation: a new \`SceneInspector\` helper in \`core/io/scene_inspector.{h,cpp}\` and a hook early in \`Main::start()\`.

This commit also includes one drive-by macOS fix: the \"no main scene defined\" check used to fire a modal \`NSAlert\` on macOS even for cmdline tools that legitimately have no main scene. The guard now respects \`cmdline_tool\` so headless invocations don't hang waiting for a dismiss.

## Why both together

I considered splitting into two PRs but they share the same motivating use case (closing the loop for headless / scripted Godot workflows) and touch disjoint files (\`core/io/logger.{h,cpp}\` vs \`core/io/scene_inspector.{h,cpp}\`). Happy to split if reviewers prefer.

## Test plan

- \`scons platform=linuxbsd target=editor\` and \`platform=macos target=editor\` (verified locally on macOS arm64)
- \`godot --headless --log-format json --script test.gd\` — verify NDJSON output, one JSON object per line
- \`godot --headless --log-format json --script broken.gd\` — verify parse/compile errors emit structured records with \`file\`, \`line\`, \`code\`
- \`godot --headless --path proj --inspect-scene res://main.tscn\` — verify tree dump, exits cleanly
- Default invocations unchanged (regression check)