### PR TITLE
[Export] Remove unused export code for dynamically linked ANGLE and AccessKit.

### DIFF
--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -75,12 +75,6 @@ Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset>
 			return ERR_CANT_CREATE;
 		}
 	}
-
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	if (da->file_exists(template_path.get_base_dir().path_join("libaccesskit." + arch + ".so"))) {
-		da->copy(template_path.get_base_dir().path_join("libaccesskit." + arch + ".so"), p_path.get_base_dir().path_join("libaccesskit." + arch + ".so"), get_chmod_flags());
-	}
-
 	bool export_as_zip = p_path.ends_with("zip");
 
 	String pkg_name;

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -29,9 +29,6 @@
 		<member name="application/copyright_localized" type="Dictionary" setter="" getter="">
 			Copyright notice for the bundle visible to the user (localized).
 		</member>
-		<member name="application/export_angle" type="int" setter="" getter="">
-			If set to [code]1[/code], ANGLE libraries are exported with the exported application. If set to [code]0[/code], ANGLE libraries are exported only if [member ProjectSettings.rendering/gl_compatibility/driver] is set to [code]"opengl3_angle"[/code].
-		</member>
 		<member name="application/icon" type="String" setter="" getter="">
 			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/macos_native_icon], and then to [member ProjectSettings.application/config/icon].
 		</member>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -360,7 +360,6 @@ bool EditorExportPlatformMacOS::get_export_option_visibility(const EditorExportP
 				p_option == "custom_template/debug" ||
 				p_option == "custom_template/release" ||
 				p_option == "application/additional_plist_content" ||
-				p_option == "application/export_angle" ||
 				p_option == "application/icon_interpolation" ||
 				p_option == "application/signature" ||
 				p_option == "display/high_res" ||
@@ -492,7 +491,6 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "application/copyright_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "10.12"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_arm64"), "11.00"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_angle", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), true));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "shader_baker/enabled"), false));
@@ -1893,14 +1891,6 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 	// Now process our template.
 	bool found_binary = false;
 
-	int export_angle = p_preset->get("application/export_angle");
-	bool include_angle_libs = false;
-	if (export_angle == 0) {
-		include_angle_libs = String(get_project_setting(p_preset, "rendering/gl_compatibility/driver.macos")) == "opengl3_angle";
-	} else if (export_angle == 1) {
-		include_angle_libs = true;
-	}
-
 	while (ret == UNZ_OK && err == OK) {
 		// Get filename.
 		unz_file_info info;
@@ -1946,20 +1936,6 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 			ret = unzGoToNextFile(src_pkg_zip);
 			continue; // next
-		}
-
-		if (file == "Contents/Frameworks/libEGL.dylib") {
-			if (!include_angle_libs) {
-				ret = unzGoToNextFile(src_pkg_zip);
-				continue; // skip
-			}
-		}
-
-		if (file == "Contents/Frameworks/libGLESv2.dylib") {
-			if (!include_angle_libs) {
-				ret = unzGoToNextFile(src_pkg_zip);
-				continue; // skip
-			}
 		}
 
 		if (file == "Contents/Info.plist") {

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -22,9 +22,6 @@
 		<member name="application/d3d12_agility_sdk_multiarch" type="bool" setter="" getter="">
 			If [code]true[/code], and [member application/export_d3d12] is set, the Agility SDK DLLs will be stored in arch-specific subdirectories.
 		</member>
-		<member name="application/export_angle" type="int" setter="" getter="">
-			If set to [code]1[/code], ANGLE libraries are exported with the exported application. If set to [code]0[/code], ANGLE libraries are exported only if [member ProjectSettings.rendering/gl_compatibility/driver] is set to [code]"opengl3_angle"[/code].
-		</member>
 		<member name="application/export_d3d12" type="int" setter="" getter="">
 			If set to [code]1[/code], the Direct3D 12 runtime libraries (Agility SDK, PIX) are exported with the exported application. If set to [code]0[/code], Direct3D 12 libraries are exported only if [member ProjectSettings.rendering/rendering_device/driver] is set to [code]"d3d12"[/code].
 		</member>

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -251,25 +251,6 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 	}
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	int export_angle = p_preset->get("application/export_angle");
-	bool include_angle_libs = false;
-	if (export_angle == 0) {
-		include_angle_libs = (String(get_project_setting(p_preset, "rendering/gl_compatibility/driver.windows")) == "opengl3_angle") && (String(get_project_setting(p_preset, "rendering/renderer/rendering_method")) == "gl_compatibility");
-	} else if (export_angle == 1) {
-		include_angle_libs = true;
-	}
-	if (include_angle_libs) {
-		if (da->file_exists(template_path.get_base_dir().path_join("libEGL." + arch + ".dll"))) {
-			da->copy(template_path.get_base_dir().path_join("libEGL." + arch + ".dll"), path.get_base_dir().path_join("libEGL.dll"), get_chmod_flags());
-		}
-		if (da->file_exists(template_path.get_base_dir().path_join("libGLESv2." + arch + ".dll"))) {
-			da->copy(template_path.get_base_dir().path_join("libGLESv2." + arch + ".dll"), path.get_base_dir().path_join("libGLESv2.dll"), get_chmod_flags());
-		}
-	}
-	if (da->file_exists(template_path.get_base_dir().path_join("accesskit." + arch + ".dll"))) {
-		da->copy(template_path.get_base_dir().path_join("accesskit." + arch + ".dll"), path.get_base_dir().path_join("accesskit." + arch + ".dll"), get_chmod_flags());
-	}
-
 	int export_d3d12 = p_preset->get("application/export_d3d12");
 	bool agility_sdk_multiarch = p_preset->get("application/d3d12_agility_sdk_multiarch");
 	bool include_d3d12_extra_libs = false;
@@ -432,7 +413,7 @@ bool EditorExportPlatformWindows::get_export_option_visibility(const EditorExpor
 
 	// Hide resources.
 	bool mod_res = p_preset->get("application/modify_resources");
-	if (!mod_res && p_option != "application/modify_resources" && p_option != "application/export_angle" && p_option != "application/export_d3d12" && p_option != "application/d3d12_agility_sdk_multiarch" && p_option.begins_with("application/")) {
+	if (!mod_res && p_option != "application/modify_resources" && p_option != "application/export_d3d12" && p_option != "application/d3d12_agility_sdk_multiarch" && p_option.begins_with("application/")) {
 		return false;
 	}
 
@@ -446,7 +427,6 @@ bool EditorExportPlatformWindows::get_export_option_visibility(const EditorExpor
 			p_option == "custom_template/debug" ||
 			p_option == "custom_template/release" ||
 			p_option == "application/d3d12_agility_sdk_multiarch" ||
-			p_option == "application/export_angle" ||
 			p_option == "application/export_d3d12" ||
 			p_option == "application/icon_interpolation") {
 		return advanced_options_enabled;
@@ -480,7 +460,6 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/file_description"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/trademarks"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_angle", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_d3d12", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/d3d12_agility_sdk_multiarch"), true, true));
 


### PR DESCRIPTION
Removes export code unused after https://github.com/godotengine/godot/pull/117313 and https://github.com/godotengine/godot/pull/117445