### PR TITLE
Update `get_closest_point` documentation in `Curve2D/3D`

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -51,8 +51,8 @@
 			<return type="Vector2" />
 			<param index="0" name="to_point" type="Vector2" />
 			<description>
-				Returns the closest point on baked segments (in curve's local space) to [param to_point].
-				[param to_point] must be in this curve's local space.
+				Returns the closest point on the baked segments (in curve's local space) to [param to_point].
+				Note that this point may not match any of the baked points, but can instead lie somewhere along the straight line segments connecting them.
 			</description>
 		</method>
 		<method name="get_point_in" qualifiers="const">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -64,8 +64,8 @@
 			<return type="Vector3" />
 			<param index="0" name="to_point" type="Vector3" />
 			<description>
-				Returns the closest point on baked segments (in curve's local space) to [param to_point].
-				[param to_point] must be in this curve's local space.
+				Returns the closest point on the baked segments (in curve's local space) to [param to_point].
+				Note that this point may not match any of the baked points, but can instead lie somewhere along the straight line segments connecting them.
 			</description>
 		</method>
 		<method name="get_point_in" qualifiers="const">


### PR DESCRIPTION
**Summary of changes:**
Updated the documentation for the `get_closest_point` method in both `Curve2D.xml` and `Curve3D.xml`. Clarified that the method returns an interpolated point on the curve, not necessarily one of the pre-calculated baked points.
Fixes godotengine/godot-docs#5894.

**Motivation:**
The previous documentation was misleading and could cause confusion for developers expecting strictly baked points.
So i wanted to make my first appearance in open source world with this project.

