### PR TITLE
Add link to SDL2 controller mapping format for `Input.add_joy_mapping()` documentation

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -35,7 +35,8 @@
 			<param index="0" name="mapping" type="String" />
 			<param index="1" name="update_existing" type="bool" default="false" />
 			<description>
-				Adds a new mapping entry (in SDL2 format) to the mapping database. Optionally update already connected devices.
+				Adds a new mapping entry in SDL2 format to the mapping database. This can also be used to update already-connected devices.
+				See the [url=https://wiki.libsdl.org/SDL2/SDL_GameControllerAddMapping#remarks]SDL2 documentation on mapping controllers[/url] for more specifics on the mapping format.
 			</description>
 		</method>
 		<method name="clear_joy_motion_sensors_calibration" experimental="">


### PR DESCRIPTION
This PR adds a link in the `Input.add_joy_mapping()` description to the page of the SDL2 documentation that describes the mapping format itself, https://wiki.libsdl.org/SDL2/SDL_GameControllerAddMapping#remarks. This was the closest thing to a "primary source" for the specification I could find (that is also user-friendly).