### PR TITLE
Fix a couple of issues when deleting presets in the export dialog

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -268,6 +268,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		delete_preset->set_disabled(true);
 		patches->clear();
 		export_error->hide();
+		export_warning->hide();
 		export_templates_error->hide();
 		export_texture_format_error->hide();
 		return;
@@ -790,8 +791,8 @@ void ProjectExportDialog::_delete_preset() {
 
 void ProjectExportDialog::_delete_preset_confirm() {
 	int idx = presets->get_current();
-	_edit_preset(idx - 1);
 	EditorExport::get_singleton()->remove_export_preset(idx);
+	_edit_preset(idx > 0 || presets->get_item_count() == 1 ? idx - 1 : 0);
 	_update_presets();
 
 	if (presets->get_item_count() == 0) {


### PR DESCRIPTION
- Fix the options panel being blank when deleting the first preset when multiple ones are present.
- Fix warnings not being hidden after deleting all presets.