### PR TITLE
Editor UI: Hide AudioStream filename in the inspector if it's width is negative or zero

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1761,7 +1761,11 @@ void EditorAudioStreamPicker::_preview_draw() {
 	}
 
 	stream_preview_rect->draw_texture(icon, Point2i(EDSCALE * 4, rect.position.y + (rect.size.height - icon->get_height()) / 2), icon_modulate);
-	stream_preview_rect->draw_string(font, Point2i(EDSCALE * 4 + icon->get_width(), rect.position.y + font->get_ascent(font_size) + (rect.size.height - font->get_height(font_size)) / 2), text, HORIZONTAL_ALIGNMENT_CENTER, size.width - 4 * EDSCALE - icon->get_width(), font_size, get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
+
+	float text_width = size.width - 4 * EDSCALE - icon->get_width();
+	if (text_width > 0) {
+		stream_preview_rect->draw_string(font, Point2i(EDSCALE * 4 + icon->get_width(), rect.position.y + font->get_ascent(font_size) + (rect.size.height - font->get_height(font_size)) / 2), text, HORIZONTAL_ALIGNMENT_CENTER, text_width, font_size, get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
+	}
 }
 
 EditorAudioStreamPicker::EditorAudioStreamPicker() :


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119491 (my own issue)

## Overview of changes

Renders the text only if it's width is larger than 0, as the clipping functionality doesn't work with negative and zero values.

## Before

<img width="229" height="257" alt="image" src="https://github.com/user-attachments/assets/ac0beb77-e122-447e-93d1-a99bf929d94e" />

## After

<img width="221" height="240" alt="image" src="https://github.com/user-attachments/assets/221161db-a79c-433b-91a7-ad54665d3c38" />