### PR TITLE
Prevent re-entrant script class update mutation

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -862,7 +862,7 @@ bool EditorFileSystem::_update_scan_actions() {
 
 	// We need to update the script global class names before the reimports to be sure that
 	// all the importer classes that depends on class names will work.
-	_update_script_classes();
+	_process_update_pending(false);
 
 	bool fs_changed = false;
 
@@ -2160,7 +2160,13 @@ void EditorFileSystem::_update_files_icon_path(EditorFileSystemDirectory *edp) {
 }
 
 void EditorFileSystem::_update_script_classes() {
-	if (update_script_paths.is_empty()) {
+	HashMap<String, ScriptClassInfoUpdate> script_paths_to_update;
+	{
+		MutexLock update_script_lock(update_script_mutex);
+		script_paths_to_update = std::move(update_script_paths);
+	}
+
+	if (script_paths_to_update.is_empty()) {
 		// Ensure the global class file is always present; it's essential for exports to work.
 		if (!FileAccess::exists(ProjectSettings::get_singleton()->get_global_class_list_path())) {
 			ScriptServer::save_global_classes();
@@ -2168,31 +2174,25 @@ void EditorFileSystem::_update_script_classes() {
 		return;
 	}
 
-	{
-		MutexLock update_script_lock(update_script_mutex);
-
-		EditorProgress *ep = nullptr;
-		if (update_script_paths.size() > 1) {
-			if (MessageQueue::get_singleton()->is_flushing()) {
-				// Use background progress when message queue is flushing.
-				ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size(), false, true));
-			} else {
-				ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), update_script_paths.size()));
-			}
+	EditorProgress *ep = nullptr;
+	if (script_paths_to_update.size() > 1) {
+		if (MessageQueue::get_singleton()->is_flushing()) {
+			// Use background progress when message queue is flushing.
+			ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), script_paths_to_update.size(), false, true));
+		} else {
+			ep = memnew(EditorProgress("update_scripts_classes", TTR("Registering global classes..."), script_paths_to_update.size()));
 		}
-
-		int step_count = 0;
-		for (const KeyValue<String, ScriptClassInfoUpdate> &E : update_script_paths) {
-			_register_global_class_script(E.key, E.key, E.value);
-			if (ep) {
-				ep->step(E.value.name, step_count++, false);
-			}
-		}
-
-		memdelete_notnull(ep);
-
-		update_script_paths.clear();
 	}
+
+	int step_count = 0;
+	for (const KeyValue<String, ScriptClassInfoUpdate> &E : script_paths_to_update) {
+		_register_global_class_script(E.key, E.key, E.value);
+		if (ep) {
+			ep->step(E.value.name, step_count++, false);
+		}
+	}
+
+	memdelete_notnull(ep);
 
 	EditorNode::get_editor_data().script_class_save_global_classes();
 
@@ -2208,24 +2208,28 @@ void EditorFileSystem::_update_script_classes() {
 }
 
 void EditorFileSystem::_update_script_documentation() {
-	if (update_script_paths_documentation.is_empty()) {
+	HashSet<String> script_paths_to_update_documentation;
+	{
+		MutexLock update_script_lock(update_script_mutex);
+		script_paths_to_update_documentation = std::move(update_script_paths_documentation);
+	}
+
+	if (script_paths_to_update_documentation.is_empty()) {
 		return;
 	}
 
-	MutexLock update_script_lock(update_script_mutex);
-
 	EditorProgress *ep = nullptr;
-	if (update_script_paths_documentation.size() > 1) {
+	if (script_paths_to_update_documentation.size() > 1) {
 		if (MessageQueue::get_singleton()->is_flushing()) {
 			// Use background progress when message queue is flushing.
-			ep = memnew(EditorProgress("update_script_paths_documentation", TTR("Updating scripts documentation"), update_script_paths_documentation.size(), false, true));
+			ep = memnew(EditorProgress("update_script_paths_documentation", TTR("Updating scripts documentation"), script_paths_to_update_documentation.size(), false, true));
 		} else {
-			ep = memnew(EditorProgress("update_script_paths_documentation", TTR("Updating scripts documentation"), update_script_paths_documentation.size()));
+			ep = memnew(EditorProgress("update_script_paths_documentation", TTR("Updating scripts documentation"), script_paths_to_update_documentation.size()));
 		}
 	}
 
 	int step_count = 0;
-	for (const String &path : update_script_paths_documentation) {
+	for (const String &path : script_paths_to_update_documentation) {
 		int index = -1;
 		EditorFileSystemDirectory *efd = find_file(path, &index);
 
@@ -2287,8 +2291,6 @@ void EditorFileSystem::_update_script_documentation() {
 	}
 
 	memdelete_notnull(ep);
-
-	update_script_paths_documentation.clear();
 }
 
 bool EditorFileSystem::_should_reload_script(const String &p_path) {
@@ -2310,14 +2312,33 @@ bool EditorFileSystem::_should_reload_script(const String &p_path) {
 	return true;
 }
 
-void EditorFileSystem::_process_update_pending() {
-	_update_script_classes();
-	// Parse documentation second, as it requires the class names to be loaded
-	// because _update_script_documentation loads the scripts completely.
-	if (!EditorNode::is_cmdline_mode()) {
-		_update_script_documentation();
-		_update_pending_scene_groups();
+void EditorFileSystem::_process_update_pending(bool p_process_documentation) {
+	if (update_pending_active) {
+		update_pending_queued = true;
+		return;
 	}
+
+	update_pending_active = true;
+
+	do {
+		update_pending_queued = false;
+
+		_update_script_classes();
+		if (update_pending_queued) {
+			// More classes were queued during this pass; finish classes before docs,
+			// since _update_script_documentation depends on the global class names.
+			continue;
+		}
+
+		// Parse documentation second, as it requires the class names to be loaded
+		// because _update_script_documentation loads the scripts completely.
+		if (p_process_documentation && !EditorNode::is_cmdline_mode()) {
+			_update_script_documentation();
+			_update_pending_scene_groups();
+		}
+	} while (update_pending_queued);
+
+	update_pending_active = false;
 }
 
 void EditorFileSystem::_queue_update_script_class(const String &p_path, const ScriptClassInfoUpdate &p_script_update) {

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -314,10 +314,12 @@ class EditorFileSystem : public Node {
 	Mutex update_script_mutex;
 	HashMap<String, ScriptClassInfoUpdate> update_script_paths;
 	HashSet<String> update_script_paths_documentation;
+	bool update_pending_active = false;
+	bool update_pending_queued = false;
 	void _queue_update_script_class(const String &p_path, const ScriptClassInfoUpdate &p_script_update);
 	void _update_script_classes();
 	void _update_script_documentation();
-	void _process_update_pending();
+	void _process_update_pending(bool p_process_documentation = true);
 	void _process_removed_files(const HashSet<String> &p_processed_files);
 	bool _should_reload_script(const String &p_path);
 


### PR DESCRIPTION
## Problem

This follows up on the closed #115460 symptom report with a minimized repro and an `EditorFileSystem`-side root-cause fix. The earlier 4.6 stable workaround addressed the reported regression, but the re-entry hazard described here is still reproducible on current `master` before this patch. This PR does not change `ProgressDialog` behavior globally.

This was found while developing and stress testing `godot-ai`, which exercises editor automation paths that repeatedly update tool scripts during editor startup. The minimal repro reduces that workload to a small `@tool` script that calls `EditorFileSystem.update_file()` during editor processing:

https://github.com/dsarno/godot-115460-gdscript-repro

`EditorFileSystem::_update_script_classes()` and `_update_script_documentation()` create `EditorProgress` tasks when more than one script is pending. In the GUI editor, `EditorProgress` can pump `Main::iteration()` through `ProgressDialog::_update_ui()`.

That nested editor frame can run `@tool` script code and recursively enter pending script update processing while the outer pass is still active. For script class updates, this lets an inner `_update_script_classes()` mutate or clear `update_script_paths` while an outer `_update_script_classes()` range loop is still iterating it.

The crash can surface later while registering/removing global classes, but the corrupting invariant is the re-entrant mutation of the live pending container. The same re-entry path can also duplicate the documentation progress task.

## Fix

- Move-drain `update_script_paths` into a local `HashMap` before creating `EditorProgress` or iterating script class updates.
- Move-drain `update_script_paths_documentation` into a local `HashSet` before creating its progress task.
- Add an `_process_update_pending()` re-entry guard with a pending-rerun bit, so updates queued by nested editor frames are preserved for a later pass instead of being processed recursively.
- Route the pre-reimport script class update path through the same guard while preserving the existing class-before-documentation ordering.

If a tool script continuously queues new script class updates during every pumped editor frame, documentation updates can still be delayed until that update stream settles. This PR keeps the fix scoped to pending script update processing instead of changing progress dialog behavior globally.

## Testing

Built locally:

```sh
scons platform=macos target=editor dev_build=yes arch=arm64 vulkan=no tests=yes -j8
```

Focused doctest suites:

```sh
bin/godot.macos.editor.dev.arm64 --headless --test --test-suite='*[GDScript]*,*[Editor]*'
```

Result: 6 test cases passed, 58,688 assertions passed.

Regression repro verification with the MRP linked above:

- `GENERATED_SCRIPT_COUNT := 2`, `MAX_TICKS := 80`: finished without crash, no duplicate `update_scripts_classes`, no duplicate `update_script_paths_documentation`, no `!tasks.has` assertion.
- `GENERATED_SCRIPT_COUNT := 2`, `MAX_TICKS := 0`: smooth editor load, finished without crash, `max_re_entry=1`.
- `GENERATED_SCRIPT_COUNT := 1`, headless control: finished without crash, `max_re_entry=1`.

No automated regression test is included because the proven failure mechanism requires GUI `ProgressDialog` pumping `Main::iteration()` during editor filesystem processing. The current headless doctest harness does not directly exercise that GUI progress re-entry path without a synthetic editor integration harness.

**AI Disclosure**: this PR was  implemented with assistance from AI-powered tools. I, a human, was in the loop to guide the tools, review their process, craft explanations and ensure overall quality as best I could. I view them and try to use them as a way to make myself a more productive and valuable contributor. And I'm always open to feedback. 🙂