### PR TITLE
Editor: Fix 'Reparent to New Node' when selecting from bottom to top

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3179,6 +3179,9 @@ void SceneTreeDock::_create() {
 					if (only_one_top_node && top_node->get_parent() != n->get_parent()) {
 						only_one_top_node = false;
 					}
+					if (only_one_top_node && n->get_index(false) < top_node->get_index(false)) {
+						top_node = n;
+					}
 					if (center_parent) {
 						top_level_nodes.append(n);
 					}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes godotengine/godot/issues/119406

**The Problem:**
When using the "Reparent to New Node" tool on multiple sibling nodes, the engine calculates an `original_position` to place the newly created parent node. This position is determined by finding the `top_node` from the user's selection.

However, `editor_selection->get_top_selected_node_list()` returns the nodes in the chronological order they were clicked.If the user does not select the highest node in the scene tree first, the first element in the list will not be the actual top node. In the existing `for` loop, `top_node` is only updated if the `path_length` to the scene root is strictly smaller. It does not compare the index of nodes that share the same parent. As a result, `original_position` takes the index of the first node clicked.

**The Error:**
If you select 3 siblings from bottom to top, `original_position` gets set to the bottom-most index. When the engine moves those selected nodes into the new parent, the original parent's child array shrinks. Finally, when the UndoRedo system calls `move_child` to place the new parent at `original_position`, it causes an out-of-bounds crash (`Invalid new child index`).

**The Solution:**
Added a check inside the `else if (smaller_path_to_top == path_length)` block:
```cpp
if (only_one_top_node && n->get_index(false) < top_node->get_index(false)) {
    top_node = n;
}
```
This guarantees that when comparing nodes at the exact same tree level, top_node will always resolve to the node with the lowest visual index.

**AI Disclosure:**
*During the preparation of this Pull Request, I utilized an AI assistant to learn how to navigate and use the `gdb` debugger (as this was my first time debugging a C++ codebase) and to proofread and polish the English text of this description to ensure it was free of grammatical errors and typos. All the logic and the code were written entirely by me (3 lines but still something ahah).*