### PR TITLE
Fix mouse dragging in `Tree` node on touchscreen devices

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3834,6 +3834,15 @@ Rect2 Tree::_get_content_rect() const {
 void Tree::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
+	using_native_touch = false;
+	if (p_event->get_device() != InputEvent::DEVICE_ID_EMULATION) {
+		Ref<InputEventScreenTouch> touch = p_event;
+		Ref<InputEventScreenDrag> drag = p_event;
+		if (touch.is_valid() || drag.is_valid()) {
+			using_native_touch = true;
+		}
+	}
+
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid() && k->get_keycode() == Key::SHIFT && !k->is_pressed()) {
@@ -6939,7 +6948,7 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 }
 
 bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (drag_touching) {
+	if (using_native_touch) {
 		// Disable data drag & drop when touch dragging.
 		return false;
 	}
@@ -6948,7 +6957,7 @@ bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
 }
 
 Variant Tree::get_drag_data(const Point2 &p_point) {
-	if (drag_touching) {
+	if (using_native_touch) {
 		// Disable data drag & drop when touch dragging.
 		return Variant();
 	}

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -770,6 +770,7 @@ private:
 	bool click_handled = false;
 	bool allow_rmb_select = false;
 	bool scrolling = false;
+	bool using_native_touch = true;
 
 	ScrollHintMode scroll_hint_mode = SCROLL_HINT_MODE_DISABLED;
 	bool tile_scroll_hint = false;


### PR DESCRIPTION
Currently, dragging in `Tree` node is disabled on touchscreen devices and doesn't work even when using a mouse.

This PR enables dragging when a mouse[^1] is used.

[^1]: To enable dragging with touch input, I still need to brainstorm a workflow that allows both dragging and touch scrolling to coexist. Normally, apps starts drag-n-drop on long press, but it's currently used to show the context menu.