### PR TITLE
Editor: Ensure `project.godot` exists before running the project

### DIFF
--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -265,6 +265,18 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 
 	_reset_play_buttons();
 
+	String resource_path = ProjectSettings::get_singleton()->get_resource_path();
+	if (!resource_path.is_empty()) {
+		String project_file_path = resource_path.path_join("project.godot");
+		if (!FileAccess::exists(project_file_path)) {
+			// TODO: Try to recover the "project.godot" file using ProjectSettings::get_singleton()->save()
+			EditorNode::get_singleton()->show_warning(
+					TTRC("Failed to run the project because the project.godot file is missing."),
+					TTRC("Error!"));
+			return;
+		}
+	}
+
 	String write_movie_file;
 	if (is_movie_maker_enabled()) {
 		if (current_mode == RUN_CURRENT) {


### PR DESCRIPTION
## What problem does this PR solve?

- Closes #119503

## Overview

When running a scene in the editor, it checks if the `project.godot` file exists. If not, it displays an error, that `project.godot` is missing, so the project failed to run. 

Without these checks, it would use the `project.godot` of the editor, which definitely isn't the scene that the user requested to run.