### PR TITLE
Make Bone Follower classes' FTI off as default, add warning

### DIFF
--- a/doc/classes/ModifierBoneTarget3D.xml
+++ b/doc/classes/ModifierBoneTarget3D.xml
@@ -16,5 +16,6 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 	</members>
 </class>

--- a/doc/classes/SpringBoneCollision3D.xml
+++ b/doc/classes/SpringBoneCollision3D.xml
@@ -26,6 +26,7 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 		<member name="position_offset" type="Vector3" setter="set_position_offset" getter="get_position_offset">
 			The offset of the position from [Skeleton3D]'s [member bone] pose position.
 		</member>

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -34,6 +34,7 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 
 void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 	if (Engine::get_singleton()->is_editor_hint() && p_property.name == "bone_name") {
@@ -78,6 +79,10 @@ PackedStringArray BoneAttachment3D::get_configuration_warnings() const {
 
 	if (bone_idx == -1) {
 		warnings.push_back(RTR("BoneAttachment3D node is not bound to any bones! Please select a bone to attach this node."));
+	}
+
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
+		warnings.push_back(RTR("BoneAttachment3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 	}
 
 	return warnings;

--- a/scene/3d/modifier_bone_target_3d.cpp
+++ b/scene/3d/modifier_bone_target_3d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 
 void ModifierBoneTarget3D::_validate_bone_names() {
 	// Prior bone name.
@@ -40,6 +41,16 @@ void ModifierBoneTarget3D::_validate_bone_names() {
 	} else if (bone != -1) {
 		set_bone(bone);
 	}
+}
+
+PackedStringArray ModifierBoneTarget3D::get_configuration_warnings() const {
+	PackedStringArray warnings = SkeletonModifier3D::get_configuration_warnings();
+
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
+		warnings.push_back(RTR("ModifierBoneTarget3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
+	}
+
+	return warnings;
 }
 
 void ModifierBoneTarget3D::set_bone_name(const String &p_bone_name) {
@@ -107,4 +118,8 @@ void ModifierBoneTarget3D::_process_modification(double p_delta) {
 	}
 
 	set_transform(skeleton->get_bone_global_pose(bone));
+}
+
+ModifierBoneTarget3D::ModifierBoneTarget3D() {
+	set_physics_interpolation_mode(PHYSICS_INTERPOLATION_MODE_OFF);
 }

--- a/scene/3d/modifier_bone_target_3d.h
+++ b/scene/3d/modifier_bone_target_3d.h
@@ -48,8 +48,12 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual bool is_processed_on_saving() const override { return true; }
 #endif
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	void set_bone_name(const String &p_bone_name);
 	String get_bone_name() const;
 	void set_bone(int p_bone);
 	int get_bone() const;
+
+	ModifierBoneTarget3D();
 };

--- a/scene/3d/spring_bone_collision_3d.cpp
+++ b/scene/3d/spring_bone_collision_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/3d/spring_bone_simulator_3d.h"
+#include "scene/main/scene_tree.h"
 
 PackedStringArray SpringBoneCollision3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node3D::get_configuration_warnings();
@@ -40,6 +41,10 @@ PackedStringArray SpringBoneCollision3D::get_configuration_warnings() const {
 	SpringBoneSimulator3D *parent = Object::cast_to<SpringBoneSimulator3D>(get_parent());
 	if (!parent) {
 		warnings.push_back(RTR("Parent node should be a SpringBoneSimulator3D node."));
+	}
+
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
+		warnings.push_back(RTR("SpringBoneCollision3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 	}
 
 	return warnings;
@@ -199,4 +204,8 @@ Vector3 SpringBoneCollision3D::collide(const Transform3D &p_center, float p_bone
 
 Vector3 SpringBoneCollision3D::_collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const {
 	return Vector3(0, 0, 0);
+}
+
+SpringBoneCollision3D::SpringBoneCollision3D() {
+	set_physics_interpolation_mode(PHYSICS_INTERPOLATION_MODE_OFF);
 }

--- a/scene/3d/spring_bone_collision_3d.h
+++ b/scene/3d/spring_bone_collision_3d.h
@@ -69,4 +69,6 @@ public:
 	Transform3D get_transform_from_skeleton(const Transform3D &p_center) const;
 
 	Vector3 collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const;
+
+	SpringBoneCollision3D();
 };

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -105,10 +105,10 @@ PackedStringArray XRCamera3D::get_configuration_warnings() const {
 		if (parent && origin == nullptr) {
 			warnings.push_back(RTR("XRCamera3D may not function as expected without an XROrigin3D node as its parent."));
 		};
+	}
 
-		if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
-			warnings.push_back(RTR("XRCamera3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
-		}
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
+		warnings.push_back(RTR("XRCamera3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 	}
 
 	return warnings;
@@ -514,10 +514,10 @@ PackedStringArray XRNode3D::get_configuration_warnings() const {
 		if (pose_name == "") {
 			warnings.push_back(RTR("No pose is set."));
 		}
+	}
 
-		if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
-			warnings.push_back(RTR("XRNode3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
-		}
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
+		warnings.push_back(RTR("XRNode3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 	}
 
 	return warnings;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -675,7 +675,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Marker3D);
 	GDREGISTER_CLASS(RootMotionView);
 	GDREGISTER_VIRTUAL_CLASS(SkeletonModifier3D);
-	GDREGISTER_CLASS(ModifierBoneTarget3D);
 	GDREGISTER_CLASS(RetargetModifier3D);
 	GDREGISTER_VIRTUAL_CLASS(JointLimitation3D);
 	GDREGISTER_CLASS(JointLimitationCone3D);
@@ -698,6 +697,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(JacobianIK3D);
 	GDREGISTER_CLASS(LimitAngularVelocityModifier3D);
 	GDREGISTER_CLASS(BoneTwistDisperser3D);
+	GDREGISTER_CLASS(ModifierBoneTarget3D);
 
 #ifndef XR_DISABLED
 	GDREGISTER_CLASS(XRCamera3D);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/100655 (Maybe)

## Additional information

Since Skeleton changes children's transform in a deferred process, some classes may conflict with FTI. We should set FTI `OFF` by default in classes that might conflict, as the same way with BoneAttachement change in #104269.

This includes a minor break in compatibility; the default FTI settings for classes have been changed, and a warning (same with xr class) will be displayed if a user has intentionally enabled FTI for these classes.