### PR TITLE
open_dynamic_library(String(), library, &data) should only be called for apple

### DIFF
--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -200,7 +200,10 @@ Error GDExtensionLibraryLoader::open_library(const String &p_path) {
 	// Apple has a complex lookup system which goes beyond looking up the filename, so we try that first.
 	err = OS::get_singleton()->open_dynamic_library(abs_path, library, &data);
 	if (err != OK) {
+#ifdef APPLE_EMBEDDED_ENABLED
 		err = OS::get_singleton()->open_dynamic_library(String(), library, &data);
+#endif
+
 		if (err != OK) {
 			return err;
 		}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -480,11 +480,10 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	if (!FileAccess::exists(path)) {
 		//this code exists so gdextension can load .dll files from within the executable path
 		path = get_executable_path().get_base_dir().path_join(p_path.get_file());
+		ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
 	}
 	// Path to load from may be different from original if we make copies.
 	String load_path = path;
-
-	ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
 
 	// Here we want a copy to be loaded.
 	// This is so the original file isn't locked and can be updated by a compiler.


### PR DESCRIPTION
I am seeing that this call err = OS::get_singleton()->open_dynamic_library(String(), library, &data);
``
https://github.com/godotengine/godot/pull/112784/files#diff-e2d7d89fb250a3270c869172ceda504df5eb1f49801a1ba1cd4d2ff34e1f05ccR201

on Windows is giving me a confusing error messages, which partially masks the real problem.

```
  ERROR: Can't open dynamic library: C:/Users/Ivan.Shakhov/RiderProjects/Godot4/addons/Godot4Ext/bin/./windows/Godot4Ext.windows.template_debug.x86_64.dll. Error: Error 126: The specified module could not be found..
  ERROR: platform/windows/os_windows.cpp:487 - Condition "!FileAccess::exists(path)" is true. Returning: ERR_FILE_NOT_FOUND
  ERROR: GDExtension dynamic library not found: 'res://addons/Godot4Ext/bin/Godot4Ext.gdextension'.
```
In this message, the line
```
ERROR: platform/windows/os_windows.cpp:487 - Condition "!FileAccess::exists(path)" is true. Returning: ERR_FILE_NOT_FOUND
```

is the misleading one, which should not be shown.