### PR TITLE
Fix repositioning using collisions for CollisionShape3D

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -5566,10 +5566,8 @@ AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, boo
 			Vector2 min_p = pts[0];
 			Vector2 max_p = pts[0];
 			for (int i = 1; i < pts.size(); i++) {
-				min_p.x = MIN(min_p.x, pts[i].x);
-				min_p.y = MIN(min_p.y, pts[i].y);
-				max_p.x = MAX(max_p.x, pts[i].x);
-				max_p.y = MAX(max_p.y, pts[i].y);
+				min_p = min_p.min(pts[i]);
+				max_p = max_p.max(pts[i]);
 			}
 			float depth = collision_polygon->get_depth();
 			// Build the AABB using the minimum point and the calculated size.

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -95,6 +95,7 @@
 #include "scene/3d/decal.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/physics/collision_polygon_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/physics_body_3d.h"
 #include "scene/3d/sprite_3d.h"
@@ -5430,8 +5431,20 @@ void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
 
 	if (co) {
 		rids.insert(co->get_rid());
-	} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
-		rids.insert(node->call("_get_root_collision_instance"));
+	} else {
+		// Nodes like `CollisionShape3D` and `CollisionPolygon3D` do not possess their own `RID`.
+		// We must extract the `RID` from their parent `CollisionObject3D` to exclude them.
+		CollisionShape3D *shape = Object::cast_to<CollisionShape3D>(node);
+		CollisionPolygon3D *polygon = Object::cast_to<CollisionPolygon3D>(node);
+		if (shape || polygon) {
+			CollisionObject3D *parent_co = Object::cast_to<CollisionObject3D>(node->get_parent());
+
+			if (parent_co) {
+				rids.insert(parent_co->get_rid());
+			}
+		} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
+			rids.insert(node->call("_get_root_collision_instance"));
+		}
 	}
 
 	for (int i = 0; i < node->get_child_count(); i++) {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -5431,20 +5431,15 @@ void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
 
 	if (co) {
 		rids.insert(co->get_rid());
-	} else {
-		// Nodes like `CollisionShape3D` and `CollisionPolygon3D` do not possess their own `RID`.
-		// We must extract the `RID` from their parent `CollisionObject3D` to exclude them.
-		CollisionShape3D *shape = Object::cast_to<CollisionShape3D>(node);
-		CollisionPolygon3D *polygon = Object::cast_to<CollisionPolygon3D>(node);
-		if (shape || polygon) {
-			CollisionObject3D *parent_co = Object::cast_to<CollisionObject3D>(node->get_parent());
-
-			if (parent_co) {
-				rids.insert(parent_co->get_rid());
-			}
-		} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
-			rids.insert(node->call("_get_root_collision_instance"));
+	} else if (Object::cast_to<CollisionShape3D>(node) || Object::cast_to<CollisionPolygon3D>(node)) {
+		// Nodes like CollisionShape3D and CollisionPolygon3D do not possess their own RID.
+		// Extract the RID from their parent CollisionObject3D so the raycast doesn't self-hit.
+		CollisionObject3D *parent_co = Object::cast_to<CollisionObject3D>(node->get_parent());
+		if (parent_co) {
+			rids.insert(parent_co->get_rid());
 		}
+	} else if (node->is_class("CSGShape3D")) { // HACK: We should avoid referencing module logic.
+		rids.insert(node->call("_get_root_collision_instance"));
 	}
 
 	for (int i = 0; i < node->get_child_count(); i++) {
@@ -5554,8 +5549,32 @@ AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, boo
 	}
 
 	const VisualInstance3D *visual_instance = Object::cast_to<VisualInstance3D>(p_parent);
+	const CollisionShape3D *collision_shape = Object::cast_to<CollisionShape3D>(p_parent);
+	const CollisionPolygon3D *collision_polygon = Object::cast_to<CollisionPolygon3D>(p_parent);
+
 	if (visual_instance) {
 		bounds = visual_instance->get_aabb();
+	} else if (collision_shape && collision_shape->get_shape().is_valid()) {
+		// Extract the bounding box from the collision shape's debug mesh.
+		bounds = collision_shape->get_shape()->get_debug_mesh()->get_aabb();
+	} else if (collision_polygon) {
+		// Manually calculate the AABB for the collision polygon using its 2D points and depth.
+		Vector<Vector2> pts = collision_polygon->get_polygon();
+		if (pts.is_empty()) {
+			bounds = AABB();
+		} else {
+			Vector2 min_p = pts[0];
+			Vector2 max_p = pts[0];
+			for (int i = 1; i < pts.size(); i++) {
+				min_p.x = MIN(min_p.x, pts[i].x);
+				min_p.y = MIN(min_p.y, pts[i].y);
+				max_p.x = MAX(max_p.x, pts[i].x);
+				max_p.y = MAX(max_p.y, pts[i].y);
+			}
+			float depth = collision_polygon->get_depth();
+			// Build the AABB using the minimum point and the calculated size.
+			bounds = AABB(Vector3(min_p.x, min_p.y, -depth / 2.0), Vector3(max_p.x - min_p.x, max_p.y - min_p.y, depth));
+		}
 	} else {
 		bounds = AABB();
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3687,10 +3687,20 @@ void Node3DEditorViewport::_notification(int p_what) {
 					t_offset.basis = t_offset.basis * aabb_s;
 				}
 
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+				if (se->sbox_instance.is_valid()) {
+					RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
+				}
+				if (se->sbox_instance_offset.is_valid()) {
+					RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
+				}
+				if (se->sbox_instance_xray.is_valid()) {
+					RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
+				}
+				if (se->sbox_instance_xray_offset.is_valid()) {
+					RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+				}
+
+				}
 			}
 
 			if (changed || (spatial_editor->is_gizmo_visible() && !exist)) {
@@ -7517,11 +7527,13 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	Node3DEditorSelectedItem *si = memnew(Node3DEditorSelectedItem);
 
 	si->sp = sp;
+	bool is_collision_shape = Object::cast_to<CollisionShape3D>(sp) != nullptr || Object::cast_to<CollisionPolygon3D>(sp) != nullptr;
+	if (!is_collision_shape) {
 	si->sbox_instance = RenderingServer::get_singleton()->instance_create2(
 			selection_box->get_rid(),
 			sp->get_world_3d()->get_scenario());
 	si->sbox_instance_offset = RenderingServer::get_singleton()->instance_create2(
-			selection_box->get_rid(),
+			->get_rid(),
 			sp->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
 			si->sbox_instance,
@@ -7557,7 +7569,7 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-
+	}
 	return si;
 }
 


### PR DESCRIPTION
Fixes #118667 

Description:
As detailed in the commit message, this PR resolves an issue where using the "Reposition Using Collisions" shortcut (`Shift+G`) on a `CollisionShape3D` caused the shape to snap to itself and move towards the camera abruptly, which is especially noticeable when using the Jolt physics engine.

The logic in `_insert_rid_recursive` has been updated to explicitly check for `CollisionShape3D` and `CollisionPolygon3D`, extract their parent's RID (`CollisionObject3D`), and add it to the exclude array.

Steps to test:
1. Create a `StaticBody3D` (Floor) with a `BoxShape3D` acting as the ground.
2. Create a separate `StaticBody3D` (Object) with a `SphereShape3D` placed in the air above the floor.
3. Select the `SphereShape3D` in the scene tree.
4. Hover the 3D viewport and press `Shift+G`. The sphere now correctly snaps to the floor below it.