### PR TITLE
🤖 Web: Fix pitch_scale for AudioStreamPlaybackPolyphonic sample playback

### DIFF
--- a/scene/resources/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio_stream_polyphonic.cpp
@@ -254,6 +254,7 @@ AudioStreamPlaybackPolyphonic::ID AudioStreamPlaybackPolyphonic::play_stream(con
 				sp->volume_vector.write[2] = AudioFrame(linear_volume, linear_volume);
 				sp->volume_vector.write[3] = AudioFrame(linear_volume, linear_volume);
 				sp->bus = p_bus;
+				sp->pitch_scale = p_pitch_scale;
 
 				if (streams[i].stream_playback->get_sample_playback().is_valid()) {
 					AudioServer::get_singleton()->stop_playback_stream(streams[i].stream_playback);
@@ -314,6 +315,14 @@ void AudioStreamPlaybackPolyphonic::set_stream_pitch_scale(ID p_stream_id, float
 		return;
 	}
 	s->pitch_scale = p_pitch_scale;
+	// Web uses PLAYBACK_TYPE_SAMPLE, which bypasses the engine mixer entirely —
+	// pitch must be forwarded to the platform audio driver explicitly.
+	if (s->stream_playback.is_valid() && s->stream_playback->get_is_sample()) {
+		Ref<AudioSamplePlayback> sample_playback = s->stream_playback->get_sample_playback();
+		if (sample_playback.is_valid()) {
+			AudioServer::get_singleton()->update_sample_playback_pitch_scale(sample_playback, p_pitch_scale);
+		}
+	}
 }
 
 bool AudioStreamPlaybackPolyphonic::is_stream_playing(ID p_stream_id) const {


### PR DESCRIPTION
## Summary

`AudioStreamPlaybackPolyphonic.play_stream()` silently ignores the `pitch_scale` parameter on web exports. Every polyphonic voice plays at 1.0x pitch regardless of the argument. Native builds work correctly.

**Root cause:** On web, polyphonic playback uses `PLAYBACK_TYPE_SAMPLE`, which hands audio to the Web Audio API and bypasses the engine mixer entirely. The `AudioSamplePlayback` object was never given the caller's `pitch_scale` value (defaulting to 1.0), and dynamic updates via `set_stream_pitch_scale()` were never forwarded to the platform audio driver.

**Fix:**
- Set `sp->pitch_scale = p_pitch_scale` when creating the `AudioSamplePlayback` in `play_stream()`
- Forward `set_stream_pitch_scale()` calls to `AudioServer::update_sample_playback_pitch_scale()` for sample-based streams

Fixes #95850
Related: #97704, #94724, #89210, #91605

## Test plan

- Export a project using `AudioStreamPlaybackPolyphonic.play_stream()` with varying `pitch_scale` values to web
- Verify notes play at correct, distinct pitches (e.g. C major arpeggio: C4, E4, G4, C5)
- Verify native builds still work correctly (no regression)
- Verify `set_stream_pitch_scale()` updates pitch dynamically on web

> [!NOTE]
> *AI disclosure*: This contribution was authored with assistance from an autonomous AI agent, on behalf of a user to fix a confirmed web audio bug.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)