### PR TITLE
Fix WASAPI capture stream rate setup

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -196,6 +196,19 @@ GODOT_GCC_WARNING_POP
 
 static CMMNotificationClient notif_client;
 
+AudioDriverWASAPI::AudioClientSetup AudioDriverWASAPI::get_audio_client_setup(bool p_input, int p_configured_mix_rate, int p_device_mix_rate) {
+	AudioClientSetup setup;
+	setup.stream_mix_rate = p_device_mix_rate;
+
+	// AUDCLNT_STREAMFLAGS_RATEADJUST is only valid for render endpoints.
+	if (!p_input && p_configured_mix_rate != p_device_mix_rate) {
+		setup.stream_flags |= AUDCLNT_STREAMFLAGS_RATEADJUST;
+		setup.stream_mix_rate = p_configured_mix_rate;
+	}
+
+	return setup;
+}
+
 Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_input, bool p_reinit, bool p_no_audio_client_3) {
 	// This function can be called recursively, so clean up before starting:
 	audio_device_finish(p_device);
@@ -383,13 +396,12 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 	}
 
 	if (!using_audio_client_3) {
-		DWORD streamflags = 0;
-		if ((DWORD)mix_rate != pwfex->nSamplesPerSec) {
-			streamflags |= AUDCLNT_STREAMFLAGS_RATEADJUST;
-			pwfex->nSamplesPerSec = mix_rate;
+		const AudioClientSetup client_setup = get_audio_client_setup(p_input, mix_rate, pwfex->nSamplesPerSec);
+		if (client_setup.stream_mix_rate != (int)pwfex->nSamplesPerSec) {
+			pwfex->nSamplesPerSec = client_setup.stream_mix_rate;
 			pwfex->nAvgBytesPerSec = pwfex->nSamplesPerSec * pwfex->nChannels * (pwfex->wBitsPerSample / 8);
 		}
-		hr = p_device->audio_client->Initialize(AUDCLNT_SHAREMODE_SHARED, streamflags, p_input ? REFTIMES_PER_SEC : 0, 0, pwfex, nullptr);
+		hr = p_device->audio_client->Initialize(AUDCLNT_SHAREMODE_SHARED, client_setup.stream_flags, p_input ? REFTIMES_PER_SEC : 0, 0, pwfex, nullptr);
 
 		if (p_reinit) {
 			// In case we're trying to re-initialize the device, prevent throwing this error on the console,
@@ -490,6 +502,11 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
+	if (p_input) {
+		input_mix_rate = pwfex->nSamplesPerSec;
+		print_verbose("WASAPI: input mix_rate = " + itos(input_mix_rate));
+	}
+
 	// Free memory
 	CoTaskMemFree(pwfex);
 
@@ -586,7 +603,9 @@ Error AudioDriverWASAPI::finish_output_device() {
 }
 
 Error AudioDriverWASAPI::finish_input_device() {
-	return audio_device_finish(&audio_input);
+	Error err = audio_device_finish(&audio_input);
+	input_mix_rate = 0;
+	return err;
 }
 
 Error AudioDriverWASAPI::init() {
@@ -606,6 +625,10 @@ Error AudioDriverWASAPI::init() {
 
 int AudioDriverWASAPI::get_mix_rate() const {
 	return mix_rate;
+}
+
+int AudioDriverWASAPI::get_input_mix_rate() const {
+	return input_mix_rate > 0 ? input_mix_rate : mix_rate;
 }
 
 float AudioDriverWASAPI::get_latency() {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -42,6 +42,10 @@
 #include <audioclient.h>
 #include <mmdeviceapi.h>
 
+#ifdef TESTS_ENABLED
+class TestAudioDriverWASAPIAccessor;
+#endif
+
 class AudioDriverWASAPI : public AudioDriver {
 	class AudioDeviceWASAPI {
 	public:
@@ -64,6 +68,15 @@ class AudioDriverWASAPI : public AudioDriver {
 	AudioDeviceWASAPI audio_input;
 	AudioDeviceWASAPI audio_output;
 
+#ifdef TESTS_ENABLED
+	friend class TestAudioDriverWASAPIAccessor;
+#endif
+
+	struct AudioClientSetup {
+		DWORD stream_flags = 0;
+		int stream_mix_rate = 0;
+	};
+
 	Mutex mutex;
 	Thread thread;
 
@@ -71,6 +84,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	unsigned int channels = 0;
 	int mix_rate = 0;
+	int input_mix_rate = 0;
 	int buffer_frames = 0;
 	int target_latency_ms = 0;
 	float real_latency = 0.0;
@@ -78,6 +92,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	SafeFlag exit_thread;
 
+	static AudioClientSetup get_audio_client_setup(bool p_input, int p_configured_mix_rate, int p_device_mix_rate);
 	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample);
 	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);
 	static void thread_func(void *p_udata);
@@ -100,6 +115,7 @@ public:
 	virtual Error init() override;
 	virtual void start() override;
 	virtual int get_mix_rate() const override;
+	virtual int get_input_mix_rate() const override;
 	virtual SpeakerMode get_speaker_mode() const override;
 	virtual float get_latency() override;
 

--- a/tests/drivers/test_audio_driver_wasapi.cpp
+++ b/tests/drivers/test_audio_driver_wasapi.cpp
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  test_audio_driver_wasapi.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_audio_driver_wasapi)
+
+#ifdef WASAPI_ENABLED
+
+#include "drivers/wasapi/audio_driver_wasapi.h"
+
+class TestAudioDriverWASAPIAccessor {
+public:
+	static DWORD get_stream_flags(bool p_input, int p_configured_mix_rate, int p_device_mix_rate) {
+		return AudioDriverWASAPI::get_audio_client_setup(p_input, p_configured_mix_rate, p_device_mix_rate).stream_flags;
+	}
+
+	static int get_stream_mix_rate(bool p_input, int p_configured_mix_rate, int p_device_mix_rate) {
+		return AudioDriverWASAPI::get_audio_client_setup(p_input, p_configured_mix_rate, p_device_mix_rate).stream_mix_rate;
+	}
+};
+
+namespace TestAudioDriverWASAPI {
+
+TEST_CASE("[Audio][WASAPI] input streams use the capture endpoint mix rate") {
+	CHECK(TestAudioDriverWASAPIAccessor::get_stream_flags(true, 48000, 44100) == 0);
+	CHECK(TestAudioDriverWASAPIAccessor::get_stream_mix_rate(true, 48000, 44100) == 44100);
+}
+
+TEST_CASE("[Audio][WASAPI] render streams use rate adjustment for non-default mix rates") {
+	const DWORD stream_flags = TestAudioDriverWASAPIAccessor::get_stream_flags(false, 48000, 44100);
+
+	CHECK((stream_flags & AUDCLNT_STREAMFLAGS_RATEADJUST) != 0);
+	CHECK(TestAudioDriverWASAPIAccessor::get_stream_mix_rate(false, 48000, 44100) == 48000);
+}
+
+} // namespace TestAudioDriverWASAPI
+
+#endif // WASAPI_ENABLED


### PR DESCRIPTION

  Fixes godotengine/godot#119498

  ## Summary
  - Keep WASAPI capture streams on the capture endpoint's mix rate.
  - Avoid `AUDCLNT_STREAMFLAGS_RATEADJUST` for capture endpoints.
  - Expose the actual WASAPI input mix rate through `get_input_mix_rate()`.
  - Add unit coverage for capture vs render stream setup behavior.

  ## Root cause
  Godot initialized WASAPI capture streams with the configured output mix rate when it differed from the input endpoint
  mix rate. That path also applied `AUDCLNT_STREAMFLAGS_RATEADJUST`, which Microsoft documents as valid only for
  rendering devices. With SteelSeries Sonar active, this appears to produce correctly sized but silent capture buffers.

  ## Testing
  - `python misc\scripts\file_format.py drivers\wasapi\audio_driver_wasapi.cpp drivers\wasapi\audio_driver_wasapi.h
  tests\drivers\test_audio_driver_wasapi.cpp`
  - `git diff --check`
  - Attempted Windows test build with `scons platform=windows target=editor tests=yes dev_build=yes accesskit=no
  d3d12=no angle=no`, but local Windows SDK tools/headers are missing (`rc`, `windows.h`).

  ## AI agent usage
  - Used an AI coding agent to prepare this patch; I reviewed the changes and verification output.