### PR TITLE
🤖 Polygon2D: Warn when polygon triangulation fails

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -326,6 +326,9 @@ void Polygon2D::_notification(int p_what) {
 
 			if (invert || polygons.is_empty()) {
 				index_array = Geometry2D::triangulate_polygon(points);
+				if (index_array.is_empty()) {
+					WARN_PRINT_ONCE_ED("Polygon2D failed to triangulate polygon. Polygon data may be invalid, degenerate, or self-intersecting.");
+				}
 			} else {
 				//draw individual polygons
 				for (int i = 0; i < polygons.size(); i++) {
@@ -346,6 +349,10 @@ void Polygon2D::_notification(int p_what) {
 					}
 					Vector<int> indices = Geometry2D::triangulate_polygon(tmp_points);
 					int ic2 = indices.size();
+					if (ic2 == 0) {
+						WARN_PRINT_ONCE_ED("Polygon2D failed to triangulate a sub-polygon. Polygon data may be invalid, degenerate, or self-intersecting.");
+						continue;
+					}
 					const int *r2 = indices.ptr();
 
 					int bic = index_array.size();


### PR DESCRIPTION
## Summary

This PR adds debug warning messages when `Geometry2D::triangulate_polygon()` fails in `Polygon2D._notification()`.

When a `Polygon2D` is given invalid, degenerate, or self-intersecting polygon data, `triangulate_polygon()` silently returns an empty index array and the polygon simply does not render. There is no console output to help the user understand why.

This PR adds `WARN_PRINT_ONCE_ED` calls at both triangulation sites so users get a clear warning in the console/editor output explaining what went wrong.

> [!INFO]
> *AI disclosure*: This contribution was authored by an autonomous AI agent (Sulphur Swarm).

## Changes

- `scene/2d/polygon_2d.cpp`: Added `WARN_PRINT_ONCE_ED` after both `Geometry2D::triangulate_polygon()` calls in `_notification()`:
  1. The main polygon path (`if (invert || polygons.is_empty())`)
  2. The individual sub-polygons path (the `else` branch loop)

## Related

Note: There is an existing open PR #118057 that covers only the first triangulation site. This PR extends the fix to both triangulation call sites.