### PR TITLE
Fix frozen rigidbody picking

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -314,6 +314,7 @@ void GodotBody2D::set_state(PhysicsServer2D::BodyState p_state, const Variant &p
 				_set_transform(p_variant);
 				_set_inv_transform(get_transform().affine_inverse());
 				wakeup_neighbours();
+				_update_transform_dependent();
 			} else {
 				Transform2D t = p_variant;
 				t.orthonormalize();

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -301,6 +301,10 @@ void RigidBody2D::set_freeze_enabled(bool p_freeze) {
 
 	freeze = p_freeze;
 	_apply_body_mode();
+	set_notify_transform(freeze);
+	if (!freeze) {
+		PhysicsServer2D::get_singleton()->body_set_state(get_rid(), PhysicsServer2D::BODY_STATE_SLEEPING, false);
+	}
 }
 
 bool RigidBody2D::is_freeze_enabled() const {


### PR DESCRIPTION
Fixes #119416 

### Description

When a `RigidBody2D` is set to `freeze = true`, it is internally treated as a `STATIC` body by the physics server. Moving it manually (via code or mouse dragging) caused two severe issues:
1. **Raycast & Picking Failure:** The scene tree did not notify the physics server of transform changes while frozen. Even if it did, the physics server ignored updating the broadphase BVH for `STATIC` bodies, causing `mouse_enter` and raycasts to trigger at the old location.
2. **Teleportation:** Unfreezing the body caused it to snap back to its previous physics transform because the server's internal state was never updated during the manual movement.

**The Fix:**
* `scene/2d/physics/rigid_body_2d.cpp`: 
  - Added `set_notify_transform(freeze)` to allow the node to send transform updates to the physics server while frozen. 
  - When unfreezing, it now forces a transform sync (`BODY_STATE_TRANSFORM`) and disables the sleeping state (`BODY_STATE_SLEEPING`) to ensure the body falls naturally from its new position without teleporting.
* `modules/godot_physics_2d/godot_body_2d.cpp`: 
  - Added `_update_transform_dependent()` to the `BODY_MODE_STATIC` case inside `set_state`. This ensures the spatial index (BVH) is correctly updated when the server is forced to move a static/frozen body.

### Steps to test
1. Run the MRP provided in the original issue.
2. Freeze the `RigidBody2D` and drag it with the mouse to a new location.
3. Observe that mouse picking stays accurate during the drag (no old location triggers).
4. Unfreeze the body and observe that it falls immediately from the new position without snapping back.