### PR TITLE
Invalidate class icon cache when replacing node

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3275,6 +3275,18 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 	Node *oldnode = p_node;
 	Node *newnode = p_by_node;
 
+	// Invalidate the cached class icon for the node's script.
+	Ref<Script> old_script = oldnode->get_script();
+	if (old_script.is_valid()) {
+		String script_class = old_script->get_global_name();
+		if (script_class.is_empty()) {
+			script_class = old_script->get_path();
+		}
+		if (!script_class.is_empty()) {
+			EditorNode::get_singleton()->invalidate_class_icon(script_class);
+		}
+	}
+
 	if (p_keep_properties) {
 		Node *default_oldnode = nullptr;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5894,6 +5894,19 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	return icon;
 }
 
+void EditorNode::invalidate_class_icon(const String &p_class) {
+	Vector<Pair<String, String>> to_remove;
+	for (const KeyValue<Pair<String, String>, Ref<Texture2D>> &kv : class_icon_cache) {
+		// Remove all entries for the class, regardless of fallback value
+		if (kv.key.first == p_class) {
+			to_remove.push_back(kv.key);
+		}
+	}
+	for (const Pair<String, String> &key : to_remove) {
+		class_icon_cache.erase(key);
+	}
+}
+
 bool EditorNode::is_object_of_custom_type(const Object *p_object, const StringName &p_class) {
 	ERR_FAIL_NULL_V(p_object, false);
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -964,6 +964,7 @@ public:
 	StringName get_object_custom_type_name(const Object *p_object) const;
 	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "");
 	Ref<Texture2D> get_class_icon(const String &p_class, const String &p_fallback = "");
+	void invalidate_class_icon(const String &p_class);
 
 	bool is_object_of_custom_type(const Object *p_object, const StringName &p_class);
 


### PR DESCRIPTION
When a node is replaced via "Change Type" or "Paste as Replacement", invalidate the cached class icon for the node's script.

Nodes with attached scripts are keyed by their class name or the script path. Changing the node type affects neither of those keys, resulting in stale data.

Fixes #118716