### PR TITLE
Speed up and improve precision of editor particle visibility rect/AABB generation

### DIFF
--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -391,7 +391,31 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 
 	EditorProgress ep("gen_vrect", TTR("Generating Visibility Rect (Waiting for Particle Simulation)"), int(time));
 
-	bool was_emitting = particles->is_emitting();
+	const float previous_amount = edited_node->get("amount");
+	const float previous_speed_scale = edited_node->get("speed_scale");
+	const int previous_fixed_fps = edited_node->get("fixed_fps");
+	const float previous_explosiveness = edited_node->get("explosiveness");
+	const float previous_interp_to_end = edited_node->get("interp_to_end");
+	const int previous_interpolate = edited_node->get("interpolate");
+	// Increase particle amount temporarily (up to a reasonable limit) to improve the rect's coverage.
+	// Also increase simulation speed to reduce time to generate the rect,
+	// This also allows particles with short lifetimes to be simulated multiple cycles, further improving the rect's coverage.
+	//
+	// Fixed FPS always set to improve determinism regardless of the FPS the editor is running at.
+	// Since increasing speed scale also increases fixed FPS, we compensate for this to avoid FPS drops
+	// (which impact simulation accuracy).
+	// Also disable explosiveness and Interp to End, which negatively impact the accuracy of the generated rect.
+	//
+	// Lastly, disable interpolation temporarily so that the preview more accurately reflects the rect that will be generated.
+	edited_node->set("amount", MIN(previous_amount * 20.0, 20000));
+	const float temp_speed_scale = MAX(20.0, previous_speed_scale * 20.0);
+	edited_node->set("speed_scale", temp_speed_scale);
+	edited_node->set("fixed_fps", MAX(1, Math::round(60.0 / temp_speed_scale)));
+	edited_node->set("explosiveness", 0.0);
+	edited_node->set("interp_to_end", 0.0);
+	edited_node->set("interpolate", false);
+
+	const bool was_emitting = particles->is_emitting();
 	if (!was_emitting) {
 		particles->set_emitting(true);
 		OS::get_singleton()->delay_usec(1000);
@@ -416,6 +440,14 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 	if (!was_emitting) {
 		particles->set_emitting(false);
 	}
+
+	// Restore properties used before AABB generation.
+	edited_node->set("amount", previous_amount);
+	edited_node->set("speed_scale", previous_speed_scale);
+	edited_node->set("fixed_fps", previous_fixed_fps);
+	edited_node->set("explosiveness", previous_explosiveness);
+	edited_node->set("interp_to_end", previous_interp_to_end);
+	edited_node->set("interpolate", previous_interpolate);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Generate Visibility Rect"));

--- a/editor/scene/3d/particles_3d_editor_plugin.cpp
+++ b/editor/scene/3d/particles_3d_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/scene_tree_editor.h"
+#include "editor/themes/editor_scale.h"
 #include "scene/3d/cpu_particles_3d.h"
 #include "scene/3d/gpu_particles_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -51,7 +52,31 @@ void Particles3DEditorPlugin::_generate_aabb() {
 
 	EditorProgress ep("gen_aabb", TTR("Generating Visibility AABB (Waiting for Particle Simulation)"), int(time));
 
-	bool was_emitting = edited_node->get("emitting");
+	const float previous_amount = edited_node->get("amount");
+	const float previous_speed_scale = edited_node->get("speed_scale");
+	const int previous_fixed_fps = edited_node->get("fixed_fps");
+	const float previous_explosiveness = edited_node->get("explosiveness");
+	const float previous_interp_to_end = edited_node->get("interp_to_end");
+	const int previous_interpolate = edited_node->get("interpolate");
+	// Increase particle amount temporarily (up to a reasonable limit) to improve the AABB's coverage.
+	// Also increase simulation speed to reduce time to generate the AABB,
+	// This also allows particles with short lifetimes to be simulated multiple cycles, further improving the AABB's coverage.
+	//
+	// Fixed FPS always set to improve determinism regardless of the FPS the editor is running at.
+	// Since increasing speed scale also increases fixed FPS, we compensate for this to avoid FPS drops
+	// (which impact simulation accuracy).
+	// Also disable explosiveness and Interp to End, which negatively impact the accuracy of the generated AABB.
+	//
+	// Lastly, disable interpolation temporarily so that the preview more accurately reflects the AABB that will be generated.
+	edited_node->set("amount", MIN(previous_amount * 20.0, 20000));
+	const float temp_speed_scale = MAX(20.0, previous_speed_scale * 20.0);
+	edited_node->set("speed_scale", temp_speed_scale);
+	edited_node->set("fixed_fps", MAX(1, Math::round(60.0 / temp_speed_scale)));
+	edited_node->set("explosiveness", 0.0);
+	edited_node->set("interp_to_end", 0.0);
+	edited_node->set("interpolate", false);
+
+	const bool was_emitting = edited_node->get("emitting");
 	if (!was_emitting) {
 		edited_node->set("emitting", true);
 		OS::get_singleton()->delay_usec(1000);
@@ -78,6 +103,14 @@ void Particles3DEditorPlugin::_generate_aabb() {
 	if (!was_emitting) {
 		edited_node->set("emitting", false);
 	}
+
+	// Restore properties used before AABB generation.
+	edited_node->set("amount", previous_amount);
+	edited_node->set("speed_scale", previous_speed_scale);
+	edited_node->set("fixed_fps", previous_fixed_fps);
+	edited_node->set("explosiveness", previous_explosiveness);
+	edited_node->set("interp_to_end", previous_interp_to_end);
+	edited_node->set("interpolate", previous_interpolate);
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Generate Visibility AABB"));
@@ -119,7 +152,7 @@ void Particles3DEditorPlugin::_node_selected(const NodePath &p_path) {
 			w[i].vertex[j] = geom_xform.xform(w[i].vertex[j]);
 		}
 	}
-	emission_dialog->popup_centered(Size2(300, 130));
+	emission_dialog->popup_centered(Size2(300, 130) * EDSCALE);
 }
 
 void Particles3DEditorPlugin::_menu_callback(int p_idx) {

--- a/editor/scene/particles_editor_plugin.cpp
+++ b/editor/scene/particles_editor_plugin.cpp
@@ -62,7 +62,11 @@ void ParticlesEditorPlugin::_notification(int p_what) {
 
 bool ParticlesEditorPlugin::need_show_lifetime_dialog(SpinBox *p_seconds) {
 	// Add one second to the default generation lifetime, since the progress is updated every second.
-	p_seconds->set_value(MAX(1.0, std::trunc(edited_node->get("lifetime").operator double()) + 1.0));
+	// For particles with a lifetime lower than 20 seconds, we simulate them for at least 1 second in real time
+	// to allow for multiple cycles to be emitted.
+	// For particles with a lifetime greater than 20 seconds, we increase the simulation duration
+	// to allow the entire lifetime to be simulated.
+	p_seconds->set_value(MAX(1.0, std::trunc(edited_node->get("lifetime").operator double()) * 0.05));
 
 	if (p_seconds->get_value() >= 11.0 + CMP_EPSILON) {
 		// Only pop up the time dialog if the particle's lifetime is long enough to warrant shortening it.


### PR DESCRIPTION
- Use 20x simulation speed to ensure short-lived particles emit for multiple cycles, and reduce the time needed to wait for rect/AABB generation on particles with longer lifetimes.
  - Particles with speed scale set to 0 now have their speed scale increased for correct visibility rect/AABB generation.
- Increase particle amount temporarily to ensure we cover as many cases of randomness as possible.
- Always use positive fixed FPS to improve determinism of rect/AABB generation, so that it doesn't depend on the framerate the editor is currently rendering at. The fixed FPS value is scaled according to the speed scale property, so that it doesn't grow too high.
- Disable explosiveness and Interp to End during generation to further improve accuracy.
- Disable particle interpolation during rect/AABB generation for more accurate preview (it doesn't impact the generated rect/AABB).

This also adds a missing `EDSCALE` in the visibility AABB generation dialog.

Please test on your own particle setups to make sure it generates good AABBs without freezing up the editor completely, even on slower machines. (Keep in mind the progress bar only refreshes once a second, even with a very simple particle setup, so you need to look at the background to see how fast the editor is rendering.)

- See https://github.com/godotengine/godot-proposals/issues/14547.

**Testing project:** [test_particle_aabb_generation.zip](https://github.com/user-attachments/files/27965905/test_particle_aabb_generation.zip)

## Preview

### 2D

https://github.com/user-attachments/assets/dfc10e88-f908-41ae-ac18-bffd77b7e3ce

### 3D

https://github.com/user-attachments/assets/319b7003-fdf8-482f-8801-590b72899268

## TODO

- [ ] Factor out the code to the common ParticlesEditorPlugin, since it's basically identical across 2D and 3D.