### PR TITLE
[ios] Fix missing UIScene URL lifecycle events for app delegate services

### DIFF
--- a/drivers/apple_embedded/godot_app_delegate.mm
+++ b/drivers/apple_embedded/godot_app_delegate.mm
@@ -120,6 +120,36 @@ static NSMutableArray<GDTAppDelegateServiceProtocol *> *services = nil;
 - (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
 }
 
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTAppDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service scene:scene willConnectToSession:session options:connectionOptions];
+	}
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTAppDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service scene:scene openURLContexts:URLContexts];
+	}
+}
+
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTAppDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service scene:scene continueUserActivity:userActivity];
+	}
+}
+
 // MARK: Life-Cycle
 
 - (void)sceneDidDisconnect:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #118600

## Additional information

Since the migration to the scene-based iOS lifecycle introduced in #116395, `UIKit` no longer dispatches certain lifecycle events through `UIApplicationDelegate`. As a result, callbacks such as `application:openURL:options:` are no longer invoked in the new scene-based approach, preventing iOS plugins registered through `GDTApplicationDelegate` from receiving deeplink and user activity events.

This PR forwards the relevant `UISceneDelegate` lifecycle callbacks to registered `GDTAppDelegateServiceProtocol` services, restoring support for custom URL schemes and user activity handling in iOS services such as [DeeplinkService](https://github.com/godot-mobile-plugins/godot-deeplink/blob/1666a58e6d375e817d7d93180089f6eb60f7bc5f/ios/src/deeplink_service.h#L10).

## Backward Compatibility

Compatibility changes were already introduced by #116395, requiring services to adopt `UIWindowSceneDelegate` in addition to `UIApplicationDelegate`.

Given that service implementations already require code-level changes, this PR intentionally exposes the scene-based lifecycle callbacks directly rather than attempting to translate them back into deprecated `UIApplicationDelegate`-style events.

## Docs

https://developer.apple.com/documentation/uikit/uiscenedelegate
