### PR TITLE
Fix typo `#undef END_SECTIOn` in scene_tree_dock.cpp

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4138,7 +4138,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	END_SECTION()
 
 #undef BEGIN_SECTION
-#undef END_SECTIOn
+#undef END_SECTION
 
 	Vector<String> p_paths;
 	Node *root = EditorNode::get_singleton()->get_edited_scene();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/119549

Changes:
- Fixes typo `END_SECTIOn` to `END_SECTION`.