### PR TITLE
Marker3D: Add gizmo texture to 3D editor plugin

### DIFF
--- a/doc/classes/Marker3D.xml
+++ b/doc/classes/Marker3D.xml
@@ -4,13 +4,16 @@
 		Generic 3D position hint for editing.
 	</brief_description>
 	<description>
-		Generic 3D position hint for editing. It's just like a plain [Node3D], but it displays as a cross in the 3D editor at all times.
+		Generic 3D position hint for editing. It's just like a plain [Node3D], but it displays as a cross in the 3D editor or an image of your choice.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="gizmo_extents" type="float" setter="set_gizmo_extents" getter="get_gizmo_extents" default="0.25">
 			Size of the gizmo cross that appears in the editor.
+		</member>
+		<member name="gizmo_texture" type="Texture2D" setter="set_gizmo_texture" getter="get_gizmo_texture">
+			Image texture of the gizmo that appears in the editor.
 		</member>
 	</members>
 </class>

--- a/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
@@ -33,6 +33,10 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "scene/3d/marker_3d.h"
+#include "scene/resources/material.h"
+#include "scene/resources/mesh.h"
+#include "scene/resources/texture.h"
+#include "servers/rendering/rendering_server_enums.h"
 
 Marker3DGizmoPlugin::Marker3DGizmoPlugin() {
 	pos3d_mesh.instantiate();
@@ -91,6 +95,27 @@ Marker3DGizmoPlugin::Marker3DGizmoPlugin() {
 	d[Mesh::ARRAY_COLOR] = cursor_colors;
 	pos3d_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, d);
 	pos3d_mesh->surface_set_material(0, mat);
+
+	//Texture mesh if used
+	tex3d_mesh.instantiate();
+	Vector<Vector3> tex3d_points;
+	Vector<Vector2> uv = {
+		Vector2(0, 0), Vector2(1, 0), Vector2(1, 1),
+		Vector2(0, 0), Vector2(1, 1), Vector2(0, 1)
+	};
+	tex3d_points.push_back(Vector3(-cs, cs, 0));
+	tex3d_points.push_back(Vector3(cs, cs, 0));
+	tex3d_points.push_back(Vector3(cs, -cs, 0));
+
+	tex3d_points.push_back(Vector3(-cs, cs, 0));
+	tex3d_points.push_back(Vector3(cs, -cs, 0));
+	tex3d_points.push_back(Vector3(-cs, -cs, 0));
+
+	Array d2;
+	d2.resize(RSE::ARRAY_MAX);
+	d2[Mesh::ARRAY_VERTEX] = tex3d_points;
+	d2[Mesh::ARRAY_TEX_UV] = uv;
+	tex3d_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, d2);
 }
 
 bool Marker3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -108,10 +133,27 @@ int Marker3DGizmoPlugin::get_priority() const {
 void Marker3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Marker3D *marker = Object::cast_to<Marker3D>(p_gizmo->get_node_3d());
 	const real_t extents = marker->get_gizmo_extents();
-	const Transform3D xform(Basis::from_scale(Vector3(extents, extents, extents)));
 
 	p_gizmo->clear();
-	p_gizmo->add_mesh(pos3d_mesh, Ref<Material>(), xform);
+
+	Ref<Texture2D> tex = marker->get_gizmo_texture();
+	const Transform3D xform(Basis::from_scale(Vector3(extents, extents, extents)));
+	if (tex.is_valid()) {
+		ObjectID tex_id = tex->get_instance_id();
+		if (!tex3d_materials.has(tex_id)) {
+			Ref<StandardMaterial3D> m = memnew(StandardMaterial3D);
+			m->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+			m->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+			m->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+			m->set_billboard_mode(StandardMaterial3D::BILLBOARD_ENABLED);
+			m->set_flag(StandardMaterial3D::FLAG_BILLBOARD_KEEP_SCALE, true);
+			m->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, tex);
+			tex3d_materials[tex_id] = m;
+		}
+		p_gizmo->add_mesh(tex3d_mesh, tex3d_materials[tex_id], xform);
+	} else {
+		p_gizmo->add_mesh(pos3d_mesh, Ref<Material>(), xform);
+	}
 
 	const Vector<Vector3> points = {
 		Vector3(-extents, 0, 0),

--- a/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.h
@@ -30,12 +30,17 @@
 
 #pragma once
 
+#include "core/templates/hash_map.h"
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
+
+class StandardMaterial3D;
 
 class Marker3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Marker3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 	Ref<ArrayMesh> pos3d_mesh;
+	Ref<ArrayMesh> tex3d_mesh;
+	HashMap<ObjectID, Ref<StandardMaterial3D>> tex3d_materials;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/scene/3d/marker_3d.cpp
+++ b/scene/3d/marker_3d.cpp
@@ -31,6 +31,7 @@
 #include "marker_3d.h"
 
 #include "core/object/class_db.h"
+#include "scene/resources/texture.h"
 
 void Marker3D::set_gizmo_extents(real_t p_extents) {
 	if (Math::is_equal_approx(gizmo_extents, p_extents)) {
@@ -44,11 +45,26 @@ real_t Marker3D::get_gizmo_extents() const {
 	return gizmo_extents;
 }
 
+void Marker3D::set_gizmo_texture(const Ref<Texture2D> &p_texture) {
+	if (gizmo_texture == p_texture) {
+		return;
+	}
+	gizmo_texture = p_texture;
+	update_gizmos();
+}
+
+Ref<Texture2D> Marker3D::get_gizmo_texture() const {
+	return gizmo_texture;
+}
+
 void Marker3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_gizmo_extents", "extents"), &Marker3D::set_gizmo_extents);
 	ClassDB::bind_method(D_METHOD("get_gizmo_extents"), &Marker3D::get_gizmo_extents);
+	ClassDB::bind_method(D_METHOD("set_gizmo_texture", "texture"), &Marker3D::set_gizmo_texture);
+	ClassDB::bind_method(D_METHOD("get_gizmo_texture"), &Marker3D::get_gizmo_texture);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gizmo_extents", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater,suffix:m"), "set_gizmo_extents", "get_gizmo_extents");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "gizmo_texture", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), "set_gizmo_texture", "get_gizmo_texture");
 }
 
 Marker3D::Marker3D() {

--- a/scene/3d/marker_3d.h
+++ b/scene/3d/marker_3d.h
@@ -32,10 +32,13 @@
 
 #include "scene/3d/node_3d.h"
 
+class Texture2D;
+
 class Marker3D : public Node3D {
 	GDCLASS(Marker3D, Node3D);
 
 	real_t gizmo_extents = 0.25;
+	Ref<Texture2D> gizmo_texture;
 
 protected:
 	static void _bind_methods();
@@ -43,6 +46,9 @@ protected:
 public:
 	void set_gizmo_extents(real_t p_extents);
 	real_t get_gizmo_extents() const;
+
+	void set_gizmo_texture(const Ref<Texture2D> &p_texture);
+	Ref<Texture2D> get_gizmo_texture() const;
 
 	Marker3D();
 };


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
- AI was used to help with git commands. 
- AI was used to help search/explain codebase
## What problem(s) does this PR solve?

- Closes (partially) https://github.com/godotengine/godot-proposals/issues/14764

## Additional information
<img width="3450" height="950" alt="image" src="https://github.com/user-attachments/assets/b6353ba3-5673-4739-9609-912becb8e812" />

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Adds the ability to add a custom icon for marker3D. One concern I have is that gizmo extents is used for both the current 3d gizmo and the texture. Not sure if they need to be seperate. It seems that currently all gizmos use .05 or something for their size so perhaps changing the size is not needed for the texture?