### PR TITLE
Call `finish_transform` on 3D subgizmo commit to reset rotation state

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2606,6 +2606,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							}
 
 							se->gizmo->commit_subgizmos(ids, restore, false);
+							finish_transform();
 						} else {
 							if (_edit.original_mouse_pos != _edit.mouse_pos) {
 								commit_transform();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119559

## Additional information

* Regression from: https://github.com/godotengine/godot/pull/116075

Subgizmo commits never went through `finish_transform()`, so rotation state (initial_click_vector, previous_rotation_vector, accumulated_rotation_angle) leaked between drags, making the next bone rotation snap to a wrong start. 

The fix is to route the subgizmo commit path through `finish_transform()` like the regular transform gizmo path already does.

Demo:

https://github.com/user-attachments/assets/5f9d8019-41f4-4597-a4ae-8d996c89d82c



<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
