### PR TITLE
[Import] Fix empty columns importing as invalid English translation.

### DIFF
--- a/core/string/optimized_translation.compat.inc
+++ b/core/string/optimized_translation.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  optimized_translation.compat.inc                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "optimized_translation.h"
+
+#include "core/object/class_db.h"
+
+void OptimizedTranslation::_generate_bind_compat_119563(const Ref<Translation> &p_from) {
+	generate(p_from);
+}
+
+void OptimizedTranslation::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("generate", "from"), &OptimizedTranslation::_generate_bind_compat_119563);
+}
+
+#endif

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "optimized_translation.h"
+#include "optimized_translation.compat.inc"
 
 #include "core/object/class_db.h"
 #include "core/templates/pair.h"
@@ -43,11 +44,11 @@ struct CompressedString {
 	int offset = 0;
 };
 
-void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
+bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	// This method compresses a Translation instance.
 	// Right now, it doesn't handle context or plurals.
 #ifdef TOOLS_ENABLED
-	ERR_FAIL_COND(p_from.is_null());
+	ERR_FAIL_COND_V(p_from.is_null(), false);
 
 	List<StringName> keys;
 	{
@@ -150,7 +151,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		bucket_table_size += 2 + b.size() * 4;
 	}
 
-	ERR_FAIL_COND(bucket_table_size == 0);
+	ERR_FAIL_COND_V(bucket_table_size == 0, false);
 
 	hash_table.resize(size);
 	bucket_table.resize(bucket_table_size);
@@ -189,9 +190,12 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		memcpy(&cw[compressed[i].offset], compressed[i].compressed.get_data(), compressed[i].compressed.size());
 	}
 
-	ERR_FAIL_COND(btindex != bucket_table_size);
+	ERR_FAIL_COND_V(btindex != bucket_table_size, false);
 	set_locale(p_from->get_locale());
 
+	return true;
+#else
+	return false;
 #endif
 }
 

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -91,11 +91,17 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _generate_bind_compat_119563(const Ref<Translation> &p_from);
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	virtual Vector<String> get_translated_message_list() const override;
-	void generate(const Ref<Translation> &p_from);
+	bool generate(const Ref<Translation> &p_from);
 
 	virtual void get_message_list(List<StringName> *r_messages) const override;
 	virtual int get_message_count() const override;

--- a/doc/classes/OptimizedTranslation.xml
+++ b/doc/classes/OptimizedTranslation.xml
@@ -11,10 +11,10 @@
 	</tutorials>
 	<methods>
 		<method name="generate">
-			<return type="void" />
+			<return type="bool" />
 			<param index="0" name="from" type="Translation" />
 			<description>
-				Generates and sets an optimized translation from the given [Translation] resource.
+				Generates and sets an optimized translation from the given [Translation] resource. Returns [code]true[/code] if successful.
 				[b]Note:[/b] Messages in [param from] should not use context or plural forms.
 				[b]Note:[/b] This method is intended to be used in the editor. It does nothing when called from an exported project.
 			</description>

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -235,10 +235,18 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 	for (KeyValue<int, Ref<Translation>> E : column_to_translation) {
 		Ref<Translation> xlt = E.value;
 
+		if (xlt->get_message_count() == 0) {
+			WARN_PRINT(vformat("Locale '%s' does not contain any translation. This locale will be ignored.", xlt->get_locale()));
+			continue;
+		}
+
 		if (compress) {
 			Ref<OptimizedTranslation> cxl = memnew(OptimizedTranslation);
-			cxl->generate(xlt);
-			xlt = cxl;
+			if (cxl->generate(xlt)) {
+				xlt = cxl;
+			} else {
+				WARN_PRINT(vformat("Failed to compress locale '%s'.", xlt->get_locale()));
+			}
 		}
 
 		String save_path = p_source_file.get_basename() + "." + xlt->get_locale() + ".translation";

--- a/misc/extension_api_validation/4.6-stable/GH-119563.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-119563.txt
@@ -1,0 +1,5 @@
+GH-119563
+---------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OptimizedTranslation/methods/generate': return_value
+
+Return value changed from "void" to "bool". Compatibility method registered.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119548

Adds return value to `OptimizedTranslation::generate` and extra checks in the exporter.

Empty columns (or other cases when translation compression fails) were saved as `en` locale, overwriting existing translation.