### PR TITLE
Skip UTF-8 BOM when loading TRES.

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1124,6 +1124,17 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	lines = 1;
 	f = p_f;
 
+	// Skip UTF-8 BOM.
+	{
+		uint64_t pos = f->get_position();
+		if (pos == 0 && f->get_length() > 3) {
+			uint8_t bom[3] = {};
+			if (f->get_buffer(&bom[0], 3) != 3 || bom[0] != 0xef || bom[1] != 0xbb || bom[2] != 0xbf) {
+				f->seek(pos); // Wasn't a BOM; reset position.
+			}
+		}
+	}
+
 	stream.f = f;
 	is_scene = false;
 	ignore_resource_parsing = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/85948
Fixes https://github.com/godotengine/godot/issues/119562

Godot does not save files with BOM, and UTF-8 BOM is not recommended, but it is a valid UTF-8 and text files should support it.