### PR TITLE
Tests: add unit tests for BBcode parsing in `RichTextLabel`

### DIFF
--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -138,15 +138,10 @@ TEST_CASE("[SceneTree][RichTextLabel] Sizing with fit content") {
 }
 
 // RichTextLabel
-RichTextLabel *make_label(SceneTree *tree) {
-	RichTextLabel *label = memnew(RichTextLabel);
-	tree->get_root()->add_child(label);
-	label->set_use_bbcode(true);
-	return label;
-}
-
 TEST_CASE("[SceneTree][RichTextLabel] append_text simple case") {
-	RichTextLabel *label = make_label(SceneTree::get_singleton());
+	RichTextLabel *label = memnew(RichTextLabel);
+	SceneTree::get_singleton()->get_root()->add_child(label);
+	label->set_use_bbcode(true);
 
 	label->append_text("Hello, World!");
 	CHECK(label->get_parsed_text() == "Hello, World!");
@@ -155,7 +150,9 @@ TEST_CASE("[SceneTree][RichTextLabel] append_text simple case") {
 }
 
 TEST_CASE("[SceneTree][RichTextLabel] append_text brackets") {
-	RichTextLabel *label = make_label(SceneTree::get_singleton());
+	RichTextLabel *label = memnew(RichTextLabel);
+	SceneTree::get_singleton()->get_root()->add_child(label);
+	label->set_use_bbcode(true);
 
 	label->set_text("[lb]test");
 	label->append_text("[rb]");
@@ -165,7 +162,9 @@ TEST_CASE("[SceneTree][RichTextLabel] append_text brackets") {
 }
 
 TEST_CASE("[SceneTree][RichTextLabel] append_text with unordered list") {
-	RichTextLabel *label = make_label(SceneTree::get_singleton());
+	RichTextLabel *label = memnew(RichTextLabel);
+	SceneTree::get_singleton()->get_root()->add_child(label);
+	label->set_use_bbcode(true);
 
 	label->append_text("[ul]item 1[/ul]");
 	CHECK(label->get_parsed_text() == "\titem 1\n");
@@ -179,7 +178,9 @@ TEST_CASE("[SceneTree][RichTextLabel] append_text with unordered list") {
 }
 
 TEST_CASE("[SceneTree][RichTextLabel] append_text mismatched brackets") {
-	RichTextLabel *label = make_label(SceneTree::get_singleton());
+	RichTextLabel *label = memnew(RichTextLabel);
+	SceneTree::get_singleton()->get_root()->add_child(label);
+	label->set_use_bbcode(true);
 
 	label->set_text("[b]test");
 	label->append_text("[/i]");
@@ -189,7 +190,9 @@ TEST_CASE("[SceneTree][RichTextLabel] append_text mismatched brackets") {
 }
 
 TEST_CASE("[SceneTree][RichTextLabel] append_text brackets with incorrect case") {
-	RichTextLabel *label = make_label(SceneTree::get_singleton());
+	RichTextLabel *label = memnew(RichTextLabel);
+	SceneTree::get_singleton()->get_root()->add_child(label);
+	label->set_use_bbcode(true);
 
 	label->set_text("[b]test");
 	label->append_text("[/B]");

--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -137,6 +137,67 @@ TEST_CASE("[SceneTree][RichTextLabel] Sizing with fit content") {
 	memdelete(test_label);
 }
 
+// RichTextLabel
+RichTextLabel *make_label(SceneTree *tree) {
+	RichTextLabel *label = memnew(RichTextLabel);
+	tree->get_root()->add_child(label);
+	label->set_use_bbcode(true);
+	return label;
+}
+
+TEST_CASE("[SceneTree][RichTextLabel] append_text simple case") {
+	RichTextLabel *label = make_label(SceneTree::get_singleton());
+
+	label->append_text("Hello, World!");
+	CHECK(label->get_parsed_text() == "Hello, World!");
+
+	memdelete(label);
+}
+
+TEST_CASE("[SceneTree][RichTextLabel] append_text brackets") {
+	RichTextLabel *label = make_label(SceneTree::get_singleton());
+
+	label->set_text("[lb]test");
+	label->append_text("[rb]");
+	CHECK(label->get_parsed_text() == "[test]");
+
+	memdelete(label);
+}
+
+TEST_CASE("[SceneTree][RichTextLabel] append_text with unordered list") {
+	RichTextLabel *label = make_label(SceneTree::get_singleton());
+
+	label->append_text("[ul]item 1[/ul]");
+    CHECK(label->get_parsed_text() == "\titem 1\n");
+
+	label->set_text("");
+	label->append_text("[ul]\n[/ul]");
+	// Should not add extra newlines for empty list items.
+    CHECK(label->get_parsed_text() == "\t\n");
+
+    memdelete(label);
+}
+
+TEST_CASE("[SceneTree][RichTextLabel] append_text mismatched brackets") {
+	RichTextLabel *label = make_label(SceneTree::get_singleton());
+
+	label->set_text("[b]test");
+	label->append_text("[/i]");
+	CHECK(label->get_parsed_text() == "test[/i]");
+
+	memdelete(label);
+}
+
+TEST_CASE("[SceneTree][RichTextLabel] append_text brackets with incorrect case") {
+	RichTextLabel *label = make_label(SceneTree::get_singleton());
+
+	label->set_text("[b]test");
+	label->append_text("[/B]");
+	CHECK(label->get_parsed_text() == "test[/B]");
+
+	memdelete(label);
+}
+
 } // namespace TestRichTextLabel
 
 #endif // ADVANCED_GUI_DISABLED

--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -168,14 +168,14 @@ TEST_CASE("[SceneTree][RichTextLabel] append_text with unordered list") {
 	RichTextLabel *label = make_label(SceneTree::get_singleton());
 
 	label->append_text("[ul]item 1[/ul]");
-    CHECK(label->get_parsed_text() == "\titem 1\n");
+	CHECK(label->get_parsed_text() == "\titem 1\n");
 
 	label->set_text("");
 	label->append_text("[ul]\n[/ul]");
 	// Should not add extra newlines for empty list items.
-    CHECK(label->get_parsed_text() == "\t\n");
+	CHECK(label->get_parsed_text() == "\t\n");
 
-    memdelete(label);
+	memdelete(label);
 }
 
 TEST_CASE("[SceneTree][RichTextLabel] append_text mismatched brackets") {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- RichTextLabel::append_text has a high cyclomatic complexity and a low test coverage.
- small contribution for unit testing on RichTextLabel::append_text.

## Additional information

- i had open a similar PR last week, however it was comparing to my master branch.
