### PR TITLE
Fix connection sorting with same source object

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -311,7 +311,7 @@ bool Callable::operator<(const Callable &p_callable) const {
 
 		} else {
 			if (object == p_callable.object) {
-				return method < p_callable.method;
+				return String(method) < String(p_callable.method);
 			} else {
 				return object < p_callable.object;
 			}
@@ -511,7 +511,7 @@ bool Signal::operator!=(const Signal &p_signal) const {
 
 bool Signal::operator<(const Signal &p_signal) const {
 	if (object == p_signal.object) {
-		return name < p_signal.name;
+		return String(name) < String(p_signal.name);
 	} else {
 		return object < p_signal.object;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119532

## Additional information

PackedScene was already sorting connections when packing them, the problem was that in case of equal object, the `<` operator was falling back to name comparison, which does StringName comparison, which compares pointers.