### PR TITLE
[4.5] [Android] Make use of activity-alias as the launcher mechanism for the Godot editor and the Godot app template

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2497,7 +2497,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	print_verbose(output);
 	if (err || rv != 0 || output.contains("Error: Activity not started")) {
 		// The implicit launch failed, let's try an explicit launch by specifying the component name before giving up.
-		const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotApp";
+		const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotAppLauncher";
 		print_line("Implicit launch failed.. Trying explicit launch using", component_name);
 		args.erase(get_package_name(p_preset, package_name));
 		args.push_back("-n");

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -31,6 +31,7 @@
 #include "gradle_export_util.h"
 
 #include "core/config/project_settings.h"
+#include "modules/regex/regex.h"
 
 int _get_android_orientation_value(DisplayServer::ScreenOrientation screen_orientation) {
 	switch (screen_orientation) {
@@ -272,6 +273,19 @@ String _get_screen_sizes_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug) {
+	String export_plugins_activity_element_contents;
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	for (int i = 0; i < export_plugins.size(); i++) {
+		if (export_plugins[i]->supports_platform(p_export_platform)) {
+			const String contents = export_plugins[i]->get_android_manifest_activity_element_contents(p_export_platform, p_debug);
+			if (!contents.is_empty()) {
+				export_plugins_activity_element_contents += contents;
+				export_plugins_activity_element_contents += "\n";
+			}
+		}
+	}
+
+	// Update the GodotApp activity tag.
 	String orientation = _get_android_orientation_label(DisplayServer::ScreenOrientation(int(p_export_platform->get_project_setting(p_preset, "display/window/handheld/orientation"))));
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\".GodotApp\" "
@@ -283,6 +297,21 @@ String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, con
 			bool_to_string(p_preset->get("package/exclude_from_recents")),
 			orientation,
 			bool_to_string(bool(p_export_platform->get_project_setting(p_preset, "display/window/size/resizable"))));
+
+	// *LAUNCHER and *HOME categories should only go to the activity-alias.
+	Ref<RegEx> activity_content_to_remove_regex = RegEx::create_from_string(R"delim(<category\s+android:name\s*=\s*"\S+(LAUNCHER|HOME)"\s*\/>)delim");
+	String updated_export_plugins_activity_element_contents = activity_content_to_remove_regex->sub(export_plugins_activity_element_contents, "", true);
+
+	manifest_activity_text += updated_export_plugins_activity_element_contents;
+
+	manifest_activity_text += "        </activity>\n";
+
+	// Update the GodotAppLauncher activity tag.
+	manifest_activity_text += "        <activity-alias\n"
+							  "            tools:node=\"mergeOnlyAttributes\"\n"
+							  "            android:name=\".GodotAppLauncher\"\n"
+							  "            android:targetActivity=\".GodotApp\"\n"
+							  "            android:exported=\"true\">\n";
 
 	manifest_activity_text += "            <intent-filter>\n"
 							  "                <action android:name=\"android.intent.action.MAIN\" />\n"
@@ -305,18 +334,12 @@ String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, con
 
 	manifest_activity_text += "            </intent-filter>\n";
 
-	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
-	for (int i = 0; i < export_plugins.size(); i++) {
-		if (export_plugins[i]->supports_platform(p_export_platform)) {
-			const String contents = export_plugins[i]->get_android_manifest_activity_element_contents(p_export_platform, p_debug);
-			if (!contents.is_empty()) {
-				manifest_activity_text += contents;
-				manifest_activity_text += "\n";
-			}
-		}
-	}
+	// Hybrid categories should only go to the actual 'GodotApp' activity.
+	Ref<RegEx> activity_alias_content_to_remove_regex = RegEx::create_from_string(R"delim(<category\s+android:name\s*=\s*"org.godotengine.xr.hybrid.(IMMERSIVE|PANEL)"\s*\/>)delim");
+	String updated_export_plugins_activity_alias_element_contents = activity_alias_content_to_remove_regex->sub(export_plugins_activity_element_contents, "", true);
+	manifest_activity_text += updated_export_plugins_activity_alias_element_contents;
 
-	manifest_activity_text += "        </activity>\n";
+	manifest_activity_text += "        </activity-alias>\n";
 	return manifest_activity_text;
 }
 

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -31,23 +31,26 @@
 
         <activity
             android:name=".GodotApp"
-            android:label="@string/godot_project_name_string"
             android:theme="@style/GodotAppSplashTheme"
             android:launchMode="singleInstancePerTask"
             android:excludeFromRecents="false"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             android:windowSoftInputMode="adjustResize"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:resizeableActivity="false"
-            tools:ignore="UnusedAttribute" >
+            tools:ignore="UnusedAttribute" />
+        <activity-alias
+            android:name=".GodotAppLauncher"
+            android:targetActivity=".GodotApp"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
     </application>
 

--- a/platform/android/java/editor/src/horizonos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/horizonos/AndroidManifest.xml
@@ -47,20 +47,31 @@
 
         <activity
             android:name=".GodotEditor"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             tools:node="merge"
             tools:replace="android:screenOrientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="com.oculus.intent.category.2D" />
             </intent-filter>
 
             <meta-data android:name="com.oculus.vrshell.free_resizing_lock_aspect_ratio" android:value="true"/>
         </activity>
+        <activity-alias
+            android:name=".ProjectManager"
+            android:exported="true"
+            tools:node="merge"
+            android:targetActivity=".GodotEditor">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="com.oculus.intent.category.2D" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".GodotXRGame"
             android:exported="false"

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -46,20 +46,13 @@
         <activity
             android:name=".GodotEditor"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
-            android:exported="true"
+            android:exported="false"
             android:icon="@mipmap/themed_icon"
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape">
             <layout
                 android:defaultWidth="@dimen/editor_default_window_width"
                 android:defaultHeight="@dimen/editor_default_window_height" />
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
 
             <!-- Intent filter used to intercept hybrid PANEL launch for the current editor project, and route it
             properly through the editor 'run' logic (e.g: debugger setup) -->
@@ -77,6 +70,18 @@
                 <category android:name="org.godotengine.xr.hybrid.IMMERSIVE" />
             </intent-filter>
         </activity>
+        <activity-alias
+            android:name=".ProjectManager"
+            android:exported="true"
+            android:icon="@mipmap/themed_icon"
+            android:targetActivity=".GodotEditor">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".GodotGame"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -241,7 +241,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	override fun onNewIntent(newIntent: Intent) {
 		if (newIntent.hasCategory(HYBRID_APP_PANEL_CATEGORY) || newIntent.hasCategory(HYBRID_APP_IMMERSIVE_CATEGORY)) {
-			val params = newIntent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+			val params = retrieveCommandLineParamsFromLaunchIntent(newIntent)
 			Log.d(TAG, "Received hybrid transition intent $newIntent with parameters ${params.contentToString()}")
 			// Override EXTRA_NEW_LAUNCH so the editor is not restarted
 			newIntent.putExtra(EXTRA_NEW_LAUNCH, false)
@@ -251,7 +251,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				var scene = ""
 				var xrMode = XR_MODE_DEFAULT
 				var path = ""
-				if (params != null) {
+				if (params.isNotEmpty()) {
 					val sceneIndex = params.indexOf(SCENE_ARG)
 					if (sceneIndex != -1 && sceneIndex + 1 < params.size) {
 						scene = params[sceneIndex +1]

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -62,20 +62,18 @@ abstract class BaseGodotGame: GodotEditor() {
 
 		// Check if we should be running in XR instead (if available) as it's possible we were
 		// launched from the project manager which doesn't have that information.
-		val launchingArgs = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
-		if (launchingArgs != null) {
-			val editorWindowInfo = retrieveEditorWindowInfo(launchingArgs, getEditorGameEmbedMode())
-			if (editorWindowInfo != getEditorWindowInfo()) {
-				val relaunchIntent = getNewGodotInstanceIntent(editorWindowInfo, launchingArgs)
-				relaunchIntent.putExtra(EXTRA_NEW_LAUNCH, true)
-					.putExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD, intent.getBundleExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD))
+		val launchingArgs = retrieveCommandLineParamsFromLaunchIntent()
+		val editorWindowInfo = retrieveEditorWindowInfo(launchingArgs, getEditorGameEmbedMode())
+		if (editorWindowInfo != getEditorWindowInfo()) {
+			val relaunchIntent = getNewGodotInstanceIntent(editorWindowInfo, launchingArgs)
+			relaunchIntent.putExtra(EXTRA_NEW_LAUNCH, true)
+				.putExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD, intent.getBundleExtra(EditorMessageDispatcher.EXTRA_MSG_DISPATCHER_PAYLOAD))
 
-				Log.d(TAG, "Relaunching XR project using ${editorWindowInfo.windowClassName} with parameters ${launchingArgs.contentToString()}")
-				Godot.getInstance(applicationContext).destroyAndKillProcess {
-					ProcessPhoenix.triggerRebirth(this, relaunchIntent)
-				}
-				return
+			Log.d(TAG, "Relaunching XR project using ${editorWindowInfo.windowClassName} with parameters ${launchingArgs.contentToString()}")
+			Godot.getInstance(applicationContext).destroyAndKillProcess {
+				ProcessPhoenix.triggerRebirth(this, relaunchIntent)
 			}
+			return
 		}
 
 		// Request project runtime permissions if necessary.

--- a/platform/android/java/editor/src/picoos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/picoos/AndroidManifest.xml
@@ -16,16 +16,10 @@
 
         <activity
             android:name=".GodotEditor"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="landscape"
             tools:node="merge"
-            tools:replace="android:screenOrientation">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            tools:replace="android:screenOrientation"/>
 
         <activity
             android:name=".GodotXRGame"

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
@@ -72,18 +72,48 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	protected var godotFragment: GodotFragment? = null
 		private set
 
+	/**
+	 * Strip out the command line parameters from intent targeting exported activities.
+	 */
+	protected fun sanitizeLaunchIntent(launchIntent: Intent = intent): Intent {
+		val targetComponent = launchIntent.component ?: componentName
+		val activityInfo = packageManager.getActivityInfo(targetComponent, 0)
+		if (activityInfo.exported) {
+			launchIntent.removeExtra(EXTRA_COMMAND_LINE_PARAMS)
+		}
+
+		return launchIntent
+	}
+
+	/**
+	 * Only retrieve the command line parameters from the intent from non-exported activities.
+	 * This ensures only internal components can configure how the engine is run.
+	 */
+	protected fun retrieveCommandLineParamsFromLaunchIntent(launchIntent: Intent = intent): Array<String> {
+		val targetComponent = launchIntent.component ?: componentName
+		val activityInfo = packageManager.getActivityInfo(targetComponent, 0)
+		if (!activityInfo.exported) {
+			val params = launchIntent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+			return params ?: emptyArray()
+		}
+		return emptyArray()
+	}
+
 	@CallSuper
 	override fun onCreate(savedInstanceState: Bundle?) {
+		intent = sanitizeLaunchIntent(intent)
+
 		val assetsCommandLine = try {
 			CommandLineFileParser.parseCommandLine(assets.open("_cl_"))
-		} catch (ignored: Exception) {
+		} catch (_: Exception) {
 			mutableListOf()
 		}
+		Log.d(TAG, "Project command line parameters: $assetsCommandLine")
 		commandLineParams.addAll(assetsCommandLine)
 
-		val params = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
-		Log.d(TAG, "Starting intent $intent with parameters ${params.contentToString()}")
-		commandLineParams.addAll(params ?: emptyArray())
+		val intentCommandLine = retrieveCommandLineParamsFromLaunchIntent()
+		Log.d(TAG, "Launch intent $intent with parameters ${intentCommandLine.contentToString()}")
+		commandLineParams.addAll(intentCommandLine)
 
 		super.onCreate(savedInstanceState)
 
@@ -167,10 +197,9 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	}
 
 	override fun onNewIntent(newIntent: Intent) {
-		super.onNewIntent(newIntent)
-		intent = newIntent
-
-		handleStartIntent(newIntent, false)
+		intent = sanitizeLaunchIntent(newIntent)
+		super.onNewIntent(intent)
+		handleStartIntent(intent, false)
 	}
 
 	private fun handleStartIntent(intent: Intent, newLaunch: Boolean) {


### PR DESCRIPTION
Cherry-pick of https://github.com/godotengine/godot/pull/112679 for Godot 4.5.

This update improves the launch flow for the Godot Android editor and the Godot Android app template by leveraging [`activity-alias`](https://developer.android.com/guide/topics/manifest/activity-alias-element) to act as the app's entry point.

This provides several benefits, most importantly, the ability to limit the app's public surface area, and the flexibility to change the internal app launch logic without changing its manifest declaration.


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
