### PR TITLE
Fix oversized "Edit" button in the Project Manager on low scale

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1659,11 +1659,12 @@ ProjectManager::ProjectManager() {
 			sidebar_scroll_containter->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 			sidebar_scroll_containter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 			project_list_sidebar->add_child(sidebar_scroll_containter);
+
 			VBoxContainer *sidebar_buttons_containter = memnew(VBoxContainer);
+			sidebar_buttons_containter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			sidebar_scroll_containter->add_child(sidebar_buttons_containter);
 
 			open_btn_container = memnew(HBoxContainer);
-			open_btn_container->set_anchors_preset(Control::PRESET_FULL_RECT);
 			sidebar_buttons_containter->add_child(open_btn_container);
 
 			open_btn = memnew(Button);
@@ -1686,8 +1687,6 @@ ProjectManager::ProjectManager() {
 			open_options_popup->add_item(TTRC("Edit in recovery mode"));
 			open_options_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ProjectManager::_on_open_options_selected));
 			open_options_btn->add_child(open_options_popup);
-
-			open_btn_container->set_custom_minimum_size(Size2(120, open_btn->get_combined_minimum_size().y));
 
 			run_btn = memnew(Button);
 			run_btn->set_text(TTRC("Run"));


### PR DESCRIPTION
Fixes this:

<img width="381" height="231" alt="Screenshot_20260519_201154" src="https://github.com/user-attachments/assets/e9e9637d-1ff7-4efa-8022-a2b6d8dd592a" />
<br>

The editor scale needs to be set very low in order for this to be really noticeable.