### PR TITLE
Add ability to fold categories in Profiler

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -189,6 +189,20 @@ void EditorProfiler::_item_edited() {
 	_update_plot();
 }
 
+void EditorProfiler::_item_collapsed(TreeItem *p_item) {
+	if (!p_item) {
+		return;
+	}
+	StringName signature = p_item->get_metadata(0);
+	bool collapsed = p_item->is_collapsed();
+
+	if (collapsed) {
+		collapsed_categories.insert(signature);
+	} else {
+		collapsed_categories.erase(signature);
+	}
+}
+
 void EditorProfiler::_update_plot() {
 	const int w = MAX(1, graph->get_size().width); // Clamp to 1 to prevent from crashing when profiler is autostarted.
 	const int h = MAX(1, graph->get_size().height);
@@ -364,6 +378,10 @@ void EditorProfiler::_update_frame() {
 		category->set_text(0, String(m.categories[i].name));
 		category->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		category->set_text(1, _get_time_as_text(m, m.categories[i].total_time, 1));
+
+		if (collapsed_categories.has(m.categories[i].signature)) {
+			category->set_collapsed(true);
+		}
 
 		if (plot_sigs.has(m.categories[i].signature)) {
 			category->set_checked(0, true);
@@ -758,7 +776,6 @@ EditorProfiler::EditorProfiler() {
 
 	variables = memnew(Tree);
 	variables->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
-	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
 	variables->set_columns(3);
@@ -777,6 +794,7 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
+	variables->connect("item_collapsed", callable_mp(this, &EditorProfiler::_item_collapsed));
 
 	graph = memnew(TextureRect);
 	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -111,6 +111,7 @@ private:
 	HSplitContainer *h_split = nullptr;
 
 	HashSet<StringName> plot_sigs;
+	HashSet<StringName> collapsed_categories;
 
 	OptionButton *display_mode = nullptr;
 	OptionButton *display_time = nullptr;
@@ -147,6 +148,7 @@ private:
 
 	void _make_metric_ptrs(Metric &m);
 	void _item_edited();
+	void _item_collapsed(TreeItem *p_item);
 
 	void _update_plot();
 


### PR DESCRIPTION
Fixes [godotengine/godot-proposals/issues/14809](https://github.com/godotengine/godot-proposals/issues/14809) 

Categories with subcategories can be collapsed for better readability. They're expanded by default, allowing users to determine the relevance of variables before folding. 

![fold_categories_in_profiler](https://github.com/user-attachments/assets/2feff484-be15-4425-96e7-d3cbcb3559b3)



