### PR TITLE
Underline GDScript warnings and errors in editor

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -233,8 +233,12 @@ public:
 	struct Warning {
 		/// One-based.
 		int start_line = 0;
+		int start_column = -1;
+
 		/// One-based.
 		int end_line = 0;
+		int end_column = -1;
+
 		int code;
 		String string_code;
 		String message;
@@ -242,10 +246,11 @@ public:
 
 	struct ScriptError {
 		String path;
-		/// One-based.
-		int line = -1;
-		/// One-based.
-		int column = -1;
+		/// All one-based.
+		int start_line = -1;
+		int start_column = -1;
+		int end_line = -1;
+		int end_column = -1;
 		String message;
 	};
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -383,8 +383,10 @@ public:
 				if (err.has("path")) {
 					serr.path = err["path"];
 				}
-				serr.line = err["line"];
-				serr.column = err["column"];
+				serr.start_line = err["line"];
+				serr.start_column = err["column"];
+				serr.end_line = err["line"];
+				serr.end_column = err["column"];
 				serr.message = err["message"];
 
 				r_errors->push_back(serr);

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1757,6 +1757,9 @@
 		<member name="text_editor/theme/highlighting/engine_type_color" type="Color" setter="" getter="">
 			The script editor's engine type color ([Object], [Mesh], [Node], ...).
 		</member>
+		<member name="text_editor/theme/highlighting/error_underline_color" type="Color" setter="" getter="">
+			The script editor's color for the squiggly lines shown under code producing errors.
+		</member>
 		<member name="text_editor/theme/highlighting/executing_line_color" type="Color" setter="" getter="">
 			The script editor's color for the debugger's executing line icon (displayed in the gutter).
 		</member>
@@ -1838,6 +1841,9 @@
 		</member>
 		<member name="text_editor/theme/highlighting/warning_color" type="Color" setter="" getter="">
 			The script editor's background color for lines with warnings. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/current_line_color].
+		</member>
+		<member name="text_editor/theme/highlighting/warning_underline_color" type="Color" setter="" getter="">
+			The script editor's color for the squiggly lines shown under code producing warnings.
 		</member>
 		<member name="text_editor/theme/highlighting/word_highlighted_color" type="Color" setter="" getter="">
 			The script editor's color for words highlighted by selecting them. Only visible if [member text_editor/appearance/caret/highlight_all_occurrences] is [code]true[/code].

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -268,6 +268,22 @@ void ScriptTextEditor::_load_theme_settings() {
 		folded_code_region_color = updated_folded_code_region_color;
 	}
 
+	Color updated_warning_underline_color = EDITOR_GET("text_editor/theme/highlighting/warning_underline_color");
+	Color updated_error_underline_color = EDITOR_GET("text_editor/theme/highlighting/error_underline_color");
+
+	bool warning_underline_color_updated = updated_warning_underline_color != warning_underline_color;
+	bool error_underline_color_updated = updated_error_underline_color != error_underline_color;
+
+	if (warning_underline_color_updated) {
+		text_edit->update_underline_color(warning_underline_color, updated_warning_underline_color);
+		warning_underline_color = updated_warning_underline_color;
+	}
+
+	if (error_underline_color_updated) {
+		text_edit->update_underline_color(error_underline_color, updated_error_underline_color);
+		error_underline_color = updated_error_underline_color;
+	}
+
 	Ref<StyleBoxFlat> drag_info_sb = drag_info_label->get_theme_stylebox(CoreStringName(normal));
 	drag_info_sb->set_bg_color(EDITOR_GET("text_editor/theme/highlighting/completion_background_color"));
 	Color info_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
@@ -661,32 +677,51 @@ void ScriptTextEditor::_update_background_color() {
 		te->set_line_background_color(i, is_folded_code_region ? folded_code_region_color : Color(0, 0, 0, 0));
 	}
 
+	te->clear_underlines();
+
 	// Set the warning background.
-	if (warning_line_color.a != 0.0) {
+	if (warning_line_color.a != 0.0 || warning_underline_color.a != 0.0) {
 		for (const ScriptLanguage::Warning &warning : warnings) {
 			int warning_start_line = CLAMP(warning.start_line - 1, 0, te->get_line_count() - 1);
+			int warning_start_column = warning.start_column - 1;
 			int warning_end_line = CLAMP(warning.end_line - 1, 0, te->get_line_count() - 1);
+			int warning_end_column = warning.end_column - 1;
 			int folded_line_header = te->get_folded_line_header(warning_start_line);
 
-			// If the warning highlight is too long, only highlight the start line.
-			const int warning_max_lines = 20;
+			if (warning_underline_color.a != 0.0) {
+				te->add_underline(warning_underline_color, warning_start_line, warning_start_column, warning_end_line, warning_end_column);
+			}
 
-			te->set_line_background_color(folded_line_header, warning_line_color);
-			if (warning_end_line - warning_start_line < warning_max_lines) {
-				for (int i = warning_start_line + 1; i <= warning_end_line; i++) {
-					te->set_line_background_color(i, warning_line_color);
+			if (warning_line_color.a != 0.0) {
+				// If the warning highlight is too long, only highlight the start line.
+				const int warning_max_lines = 20;
+
+				te->set_line_background_color(folded_line_header, warning_line_color);
+				if (warning_end_line - warning_start_line < warning_max_lines) {
+					for (int i = warning_start_line + 1; i <= warning_end_line; i++) {
+						te->set_line_background_color(i, warning_line_color);
+					}
 				}
 			}
 		}
 	}
 
 	// Set the error background.
-	if (marked_line_color.a != 0.0) {
+	if (marked_line_color.a != 0.0 || error_underline_color.a != 0.0) {
 		for (const ScriptLanguage::ScriptError &error : errors) {
-			int error_line = CLAMP(error.line - 1, 0, te->get_line_count() - 1);
-			int folded_line_header = te->get_folded_line_header(error_line);
+			int error_start_line = CLAMP(error.start_line - 1, 0, te->get_line_count() - 1);
+			int error_start_column = error.start_column - 1;
+			int error_end_line = CLAMP(error.end_line - 1, 0, te->get_line_count() - 1);
+			int error_end_column = error.end_column - 1;
+			int folded_line_header = te->get_folded_line_header(error_start_line);
 
-			te->set_line_background_color(folded_line_header, marked_line_color);
+			if (error_underline_color.a != 0.0) {
+				te->add_underline(error_underline_color, error_start_line, error_start_column, error_end_line, error_end_column);
+			}
+
+			if (marked_line_color.a != 0.0) {
+				te->set_line_background_color(folded_line_header, marked_line_color);
+			}
 		}
 	}
 }
@@ -791,10 +826,10 @@ Ref<Texture2D> ScriptTextEditor::get_theme_icon() {
 
 struct ScriptErrorLineComparator {
 	bool operator()(const ScriptLanguage::ScriptError &p_a, const ScriptLanguage::ScriptError &p_b) const {
-		if (p_a.line != p_b.line) {
-			return p_a.line < p_b.line;
+		if (p_a.start_line != p_b.start_line) {
+			return p_a.start_line < p_b.start_line;
 		}
-		return p_a.column < p_b.column;
+		return p_a.start_column < p_b.start_column;
 	}
 };
 
@@ -824,7 +859,7 @@ void ScriptTextEditor::_validate_script() {
 		}
 
 		if (errors.size() > 0) {
-			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
+			code_editor->set_error_pos(errors.front()->get().start_line - 1, errors.front()->get().start_column - 1);
 			const String message = errors.front()->get().message.replace("[", "[lb]");
 			const Point2i display_pos = code_editor->get_pos_for_display(code_editor->get_error_pos());
 			const String error_text = vformat(TTR("Error at ([hint=Line %d, column %d]%d, %d[/hint]):"), display_pos.x, display_pos.y, display_pos.x, display_pos.y) + " " + message;
@@ -929,9 +964,9 @@ void ScriptTextEditor::_update_errors() {
 	errors_panel->push_table(2);
 	for (const ScriptLanguage::ScriptError &err : errors) {
 		errors_panel->push_cell();
-		errors_panel->push_meta(err.line - 1);
+		errors_panel->push_meta(err.start_line - 1);
 		errors_panel->push_color(warnings_panel->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-		errors_panel->add_text(vformat(TTR("Line %d:"), err.line));
+		errors_panel->add_text(vformat(TTR("Line %d:"), err.start_line));
 		errors_panel->pop(); // Color.
 		errors_panel->pop(); // Meta goto.
 		errors_panel->pop(); // Cell.
@@ -960,13 +995,13 @@ void ScriptTextEditor::_update_errors() {
 		for (const ScriptLanguage::ScriptError &err : KV.value) {
 			Dictionary click_meta;
 			click_meta["path"] = KV.key;
-			click_meta["line"] = err.line - 1;
-			click_meta["column"] = err.column - 1;
+			click_meta["line"] = err.start_line - 1;
+			click_meta["column"] = err.start_column - 1;
 
 			errors_panel->push_cell();
 			errors_panel->push_meta(click_meta);
 			errors_panel->push_color(errors_panel->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-			errors_panel->add_text(vformat(TTR("Line %d:"), err.line));
+			errors_panel->add_text(vformat(TTR("Line %d:"), err.start_line));
 			errors_panel->pop(); // Color.
 			errors_panel->pop(); // Meta goto.
 			errors_panel->pop(); // Cell.

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -93,6 +93,9 @@ class ScriptTextEditor : public CodeEditorBase {
 	Color warning_line_color = Color(1, 1, 1);
 	Color folded_code_region_color = Color(1, 1, 1);
 
+	Color warning_underline_color = Color(1, 1, 1);
+	Color error_underline_color = Color(1, 1, 1);
+
 	PopupPanel *color_panel = nullptr;
 	ColorPicker *color_picker = nullptr;
 	Vector3i color_position;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -741,7 +741,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Theme
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "text_editor/theme/color_theme", "Default", "Default,Godot 2,Custom")
 
-	// Theme: Highlighting
+	// Theme: Highlighting and Underlining
 	const LocalVector<StringName> basic_text_editor_settings = {
 		"text_editor/theme/highlighting/symbol_color",
 		"text_editor/theme/highlighting/keyword_color",
@@ -769,6 +769,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		"text_editor/theme/highlighting/function_color",
 		"text_editor/theme/highlighting/member_variable_color",
 		"text_editor/theme/highlighting/mark_color",
+		"text_editor/theme/highlighting/warning_underline_color",
+		"text_editor/theme/highlighting/error_underline_color",
 	};
 	// These values will be overwritten by EditorThemeManager, but can still be seen in some edge cases.
 	const HashMap<StringName, Color> text_colors = get_godot2_text_editor_theme();
@@ -1954,6 +1956,9 @@ HashMap<StringName, Color> EditorSettings::get_godot2_text_editor_theme() {
 	colors["text_editor/theme/highlighting/comment_markers/critical_color"] = Color(0.77, 0.35, 0.35);
 	colors["text_editor/theme/highlighting/comment_markers/warning_color"] = Color(0.72, 0.61, 0.48);
 	colors["text_editor/theme/highlighting/comment_markers/notice_color"] = Color(0.56, 0.67, 0.51);
+
+	colors["text_editor/theme/highlighting/warning_underline_color"] = Color(0.89, 0.7, 0.2);
+	colors["text_editor/theme/highlighting/error_underline_color"] = Color(1.0, 0.0, 0.0);
 	return colors;
 }
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -540,6 +540,8 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/folded_code_region_color"] = Color(0.68, 0.46, 0.77, 0.2);
 			colors["text_editor/theme/highlighting/search_result_color"] = alpha1;
 			colors["text_editor/theme/highlighting/search_result_border_color"] = p_config.dark_icon_and_font ? Color(0.41, 0.61, 0.91, 0.38) : Color(0, 0.4, 1, 0.38);
+			colors["text_editor/theme/highlighting/warning_underline_color"] = Color(0.89, 0.7, 0.2);
+			colors["text_editor/theme/highlighting/error_underline_color"] = Color(1.0, 0.0, 0.0);
 
 			if (p_config.dark_icon_and_font) {
 				colors["text_editor/theme/highlighting/gdscript/function_definition_color"] = Color(0.4, 0.9, 1.0);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -166,7 +166,9 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 			const GDScriptWarning &warn = E;
 			ScriptLanguage::Warning w;
 			w.start_line = warn.start_line;
+			w.start_column = warn.start_column;
 			w.end_line = warn.end_line;
+			w.end_column = warn.end_column;
 			w.code = (int)warn.code;
 			w.string_code = GDScriptWarning::get_name_from_code(warn.code);
 			w.message = warn.get_message();
@@ -179,8 +181,10 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 			for (const GDScriptParser::ParserError &pe : parser.get_errors()) {
 				ScriptLanguage::ScriptError e;
 				e.path = p_path;
-				e.line = pe.start_line;
-				e.column = pe.start_column;
+				e.start_line = pe.start_line;
+				e.start_column = pe.start_column;
+				e.end_line = pe.end_line;
+				e.end_column = pe.end_column;
 				e.message = pe.message;
 				r_errors->push_back(e);
 			}
@@ -190,8 +194,10 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 				for (const GDScriptParser::ParserError &pe : depended_parser->get_errors()) {
 					ScriptLanguage::ScriptError e;
 					e.path = E.key;
-					e.line = pe.start_line;
-					e.column = pe.start_column;
+					e.start_line = pe.start_line;
+					e.start_column = pe.start_column;
+					e.end_line = pe.end_line;
+					e.end_column = pe.end_column;
 					e.message = pe.message;
 					r_errors->push_back(e);
 				}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1830,6 +1830,84 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
+					for (const Underline &u : underlines) {
+						if (line < u.start_line || line > u.end_line) {
+							continue;
+						}
+
+						int start_column = u.start_column;
+						int end_column = u.end_column;
+
+						if (line != u.start_line) {
+							start_column = 0;
+						}
+						if (line != u.end_line) {
+							end_column = last_visible_char;
+						}
+
+						const Vector<Vector2> underline = TS->shaped_text_get_selection(rid, start_column, end_column);
+						Rect2 combined_rect;
+						for (int j = 0; j < underline.size(); j++) {
+							Rect2 rect = Rect2(
+									underline[j].x + char_margin,
+									ofs_y + theme_cache.font->get_underline_position(theme_cache.font_size),
+									underline[j].y - underline[j].x,
+									theme_cache.font_size * 0.1);
+
+							combined_rect = j == 0 ? rect : combined_rect.merge(rect);
+						}
+
+						PackedVector2Array points;
+						PackedColorArray colors;
+
+						float squiggle_top_y = combined_rect.position.y;
+						float squiggle_center_y = combined_rect.position.y + (combined_rect.size.y / 2.0);
+						float squiggle_bottom_y = combined_rect.position.y + combined_rect.size.y;
+
+						float distance = combined_rect.position.x;
+						float end_position = combined_rect.position.x + combined_rect.size.x;
+
+						bool use_top_squiggle = false;
+
+						// Add first point.
+						if (distance >= xmargin_beg && distance <= xmargin_end) {
+							points.append(Vector2(distance, squiggle_center_y));
+							distance += char_w * 0.25;
+						}
+
+						while (true) {
+							if (distance >= xmargin_beg && distance <= xmargin_end) {
+								float y_pos = use_top_squiggle ? squiggle_top_y : squiggle_bottom_y;
+								// Ensure the underline ends at the end of the text.
+								if (distance >= end_position) {
+									if (points.is_empty()) {
+										break;
+									}
+									Vector2 prev_point = points.get(points.size() - 1);
+									float prev_distance = prev_point.x;
+									float ratio_across = (end_position - prev_distance) / (distance - prev_distance);
+									float prev_y = prev_point.y;
+									float mid_y = Math::lerp(prev_y, y_pos, ratio_across);
+									points.append(Vector2(end_position, mid_y));
+									break;
+								}
+								points.append(Vector2(distance, y_pos));
+							}
+							if (distance >= end_position) {
+								break;
+							}
+							distance += char_w * 0.5;
+							use_top_squiggle = !use_top_squiggle;
+						}
+
+						if (points.size() >= 2) {
+							colors.append(u.color);
+							// theme_cache.base_scale is not necessary here, as font size is already dependent on editor scale.
+							// See https://github.com/godotengine/godot/pull/119588#pullrequestreview-4618459305 for more info.
+							RS::get_singleton()->canvas_item_add_polyline(text_ci, points, colors, MAX(theme_cache.font->get_underline_thickness(theme_cache.font_size), 1), true);
+						}
+					}
+
 					cache_entry.first_visible_chars.push_back(first_visible_char);
 					cache_entry.last_visible_chars.push_back(last_visible_char);
 
@@ -3592,6 +3670,7 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 			collapse_carets(get_caret_line(caret_index), 0, get_caret_line(caret_index), caret_current_column);
 			set_caret_column(0, caret_index == 0, caret_index);
 			_offset_carets_after(get_caret_line(caret_index), caret_current_column, get_caret_line(caret_index), 0);
+			_offset_underlines_after(get_caret_line(caret_index), caret_current_column, get_caret_line(caret_index), 0);
 			continue;
 		}
 
@@ -3624,6 +3703,7 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 			collapse_carets(get_caret_line(caret_index), column, get_caret_line(caret_index), from_column);
 			set_caret_column(column, caret_index == 0, caret_index);
 			_offset_carets_after(get_caret_line(caret_index), from_column, get_caret_line(caret_index), column);
+			_offset_underlines_after(get_caret_line(caret_index), from_column, get_caret_line(caret_index), column);
 		}
 	}
 
@@ -3699,6 +3779,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 		_remove_text(get_caret_line(caret_index), get_caret_column(caret_index), next_line, next_column);
 		collapse_carets(get_caret_line(caret_index), get_caret_column(caret_index), next_line, next_column);
 		_offset_carets_after(next_line, next_column, get_caret_line(caret_index), get_caret_column(caret_index));
+		_offset_underlines_after(next_line, next_column, get_caret_line(caret_index), get_caret_column(caret_index));
 	}
 
 	end_multicaret_edit();
@@ -4501,6 +4582,18 @@ void TextEdit::set_line(int p_line, const String &p_new_text) {
 	// Don't offset carets that were on the old line.
 	_offset_carets_after(p_line, old_column, new_line, new_column, false, false);
 
+	// Shift underline start and end columns.
+	int col_delta = new_column - old_column;
+	for (Underline &u : underlines) {
+		if (u.start_line == new_line) {
+			u.start_column += col_delta;
+		}
+
+		if (u.end_line == new_line) {
+			u.end_column += col_delta;
+		}
+	}
+
 	// Set the caret lines to update the column to match visually.
 	for (int i = 0; i < get_caret_count(); i++) {
 		if (_is_line_col_in_range(get_caret_line(i), get_caret_column(i), p_line, 0, p_line, old_column)) {
@@ -4615,6 +4708,9 @@ void TextEdit::swap_lines(int p_from_line, int p_to_line) {
 
 	String from_line_text = get_line(p_from_line);
 	String to_line_text = get_line(p_to_line);
+	Vector<Underline> from_line_underlines = _get_underline_data_for_line(p_from_line);
+	Vector<Underline> to_line_underlines = _get_underline_data_for_line(p_to_line);
+
 	begin_complex_operation();
 	begin_multicaret_edit();
 	// Don't use set_line to avoid clamping and updating carets.
@@ -4638,11 +4734,168 @@ void TextEdit::swap_lines(int p_from_line, int p_to_line) {
 			select(origin_new_line, origin_column, get_caret_line(i), get_caret_column(i), i);
 		}
 	}
+
+	// Swap underlines.
+	LocalVector<Underline> new_underlines;
+	for (const Underline &ul : underlines) {
+		if (!ul.contains_line(p_from_line) && !ul.contains_line(p_to_line)) {
+			new_underlines.push_back(ul);
+		}
+
+		else if (ul.contains_line(p_from_line) && !ul.contains_line(p_to_line)) {
+			for (const Underline &new_ul : _cut_line_from_underline(ul, p_from_line)) {
+				new_underlines.push_back(new_ul);
+			}
+		}
+
+		else if (!ul.contains_line(p_from_line) && ul.contains_line(p_to_line)) {
+			for (const Underline &new_ul : _cut_line_from_underline(ul, p_to_line)) {
+				new_underlines.push_back(new_ul);
+			}
+		}
+
+		else {
+			for (const Underline &new_ul : _cut_line_from_underline(ul, p_from_line)) {
+				for (const Underline &new_ul_2 : _cut_line_from_underline(new_ul, p_to_line)) {
+					new_underlines.push_back(new_ul_2);
+				}
+			}
+		}
+	}
+
+	for (Underline &ul : from_line_underlines) {
+		ul.start_line = p_to_line;
+		ul.end_line = p_to_line;
+		new_underlines.push_back(ul);
+	}
+
+	for (Underline &ul : to_line_underlines) {
+		ul.start_line = p_from_line;
+		ul.end_line = p_from_line;
+		new_underlines.push_back(ul);
+	}
+
+	underlines = new_underlines;
+
 	// If only part of a selection was changed, it may now overlap.
 	merge_overlapping_carets();
 
 	end_multicaret_edit();
 	end_complex_operation();
+}
+
+Vector<TextEdit::Underline> TextEdit::_cut_line_from_underline(const Underline &p_ul, int p_line) {
+	Vector<Underline> out;
+	// If this underline doesn't contain the line we want to cut,
+	// then the result is just the original underline unchanged.
+	if (!p_ul.contains_line(p_line)) {
+		out.push_back(p_ul);
+	}
+
+	// If this underline is only on the line we want to cut,
+	// then the result is no underline at all.
+	else if (p_ul.start_line == p_line && p_ul.end_line == p_line) {
+		return out;
+	}
+
+	// If this underline starts on the line we want to cut,
+	// then the result is a single underline starting at the beginning of the
+	// original underline's second line.
+	else if (p_ul.start_line == p_line) {
+		Underline new_ul;
+		new_ul.start_line = p_ul.start_line + 1;
+		new_ul.start_column = 0;
+		new_ul.end_line = p_ul.end_line;
+		new_ul.end_column = p_ul.end_column;
+		new_ul.color = p_ul.color;
+		out.push_back(new_ul);
+	}
+
+	// If this underline ends on the line we want to cut,
+	// then the result is a single underline ending just before the original
+	// underline's last line.
+	else if (p_ul.end_line == p_line) {
+		Underline new_ul;
+		new_ul.start_line = p_ul.start_line;
+		new_ul.start_column = p_ul.start_column;
+		new_ul.end_line = p_ul.end_line - 1;
+		new_ul.end_column = text[p_ul.end_line - 1].length();
+		new_ul.color = p_ul.color;
+		out.push_back(new_ul);
+	}
+
+	// At this point, the line we want to cut must be in the middle of the
+	// underline range. So the result will be two underlines: one going from
+	// the original underline's first line to just before the cut line, and
+	// another going from just after the cut line to the original's last line.
+	else {
+		Underline ul_start_to_cut;
+		ul_start_to_cut.start_line = p_ul.start_line;
+		ul_start_to_cut.start_column = p_ul.start_column;
+		ul_start_to_cut.end_line = p_line - 1;
+		ul_start_to_cut.end_column = text[p_line - 1].length();
+		ul_start_to_cut.color = p_ul.color;
+		out.push_back(ul_start_to_cut);
+
+		Underline ul_cut_to_end;
+		ul_cut_to_end.start_line = p_line + 1;
+		ul_cut_to_end.start_column = text[p_line + 1].length();
+		ul_cut_to_end.end_line = p_ul.end_line;
+		ul_cut_to_end.end_column = p_ul.end_column;
+		ul_cut_to_end.color = p_ul.color;
+		out.push_back(ul_cut_to_end);
+	}
+
+	return out;
+}
+
+Vector<TextEdit::Underline> TextEdit::_get_underline_data_for_line(int p_line) {
+	Vector<Underline> out;
+	for (const Underline &ul : underlines) {
+		// Underline doesn't contain this line at all; skip it.
+		if (!ul.contains_line(p_line)) {
+			continue;
+		}
+
+		// Underline is entirely on this line; copy it all over.
+		else if (ul.start_line == p_line && ul.end_line == p_line) {
+			out.push_back(ul);
+		}
+
+		// Underline starts on this line, but does not end here; copy the first line.
+		else if (ul.start_line == p_line) {
+			Underline new_ul;
+			new_ul.start_line = ul.start_line;
+			new_ul.start_column = ul.start_column;
+			new_ul.end_line = ul.start_line;
+			new_ul.end_column = text[ul.start_line].length();
+			new_ul.color = ul.color;
+			out.push_back(new_ul);
+		}
+
+		// Underline ends on this line, but starts before it; copy the last line.
+		else if (ul.end_line == p_line) {
+			Underline new_ul;
+			new_ul.start_line = ul.end_line;
+			new_ul.start_column = 0;
+			new_ul.end_line = ul.end_line;
+			new_ul.end_column = ul.end_column;
+			new_ul.color = ul.color;
+			out.push_back(new_ul);
+		}
+
+		// This line is in the middle of the underline; just highlight the whole line.
+		else {
+			Underline new_ul;
+			new_ul.start_line = p_line;
+			new_ul.start_column = 0;
+			new_ul.end_line = p_line;
+			new_ul.end_column = text[p_line].length();
+			new_ul.color = ul.color;
+			out.push_back(new_ul);
+		}
+	}
+	return out;
 }
 
 void TextEdit::insert_line_at(int p_line, const String &p_text) {
@@ -4654,6 +4907,7 @@ void TextEdit::insert_line_at(int p_line, const String &p_text) {
 	int new_line, new_column;
 	_insert_text(p_line, 0, p_text + "\n", &new_line, &new_column);
 	_offset_carets_after(p_line, 0, new_line, new_column);
+	_offset_underlines_after(p_line, 0, new_line, new_column);
 
 	end_complex_operation();
 }
@@ -4715,6 +4969,7 @@ void TextEdit::remove_line_at(int p_line, bool p_move_carets_down) {
 		merge_overlapping_carets();
 	}
 	_offset_carets_after(next_line, next_column, from_line, from_column);
+	_offset_underlines_after(next_line, next_column, from_line, from_column);
 	end_multicaret_edit();
 	end_complex_operation();
 
@@ -4744,6 +4999,7 @@ void TextEdit::insert_text_at_caret(const String &p_text, int p_caret) {
 		_insert_text(from_line, from_col, p_text, &new_line, &new_column);
 		_update_scrollbars();
 		_offset_carets_after(from_line, from_col, new_line, new_column);
+		_offset_underlines_after(from_line, from_col, new_line, new_column);
 
 		set_caret_line(new_line, false, true, -1, i);
 		set_caret_column(new_column, i == 0, i);
@@ -4767,6 +5023,7 @@ void TextEdit::insert_text(const String &p_text, int p_line, int p_column, bool 
 	_insert_text(p_line, p_column, p_text, &new_line, &new_column);
 
 	_offset_carets_after(p_line, p_column, new_line, new_column, p_before_selection_begin, p_before_selection_end);
+	_offset_underlines_after(p_line, p_column, new_line, new_column);
 
 	end_complex_operation();
 }
@@ -4784,6 +5041,7 @@ void TextEdit::remove_text(int p_from_line, int p_from_column, int p_to_line, in
 	_remove_text(p_from_line, p_from_column, p_to_line, p_to_column);
 	collapse_carets(p_from_line, p_from_column, p_to_line, p_to_column);
 	_offset_carets_after(p_to_line, p_to_column, p_from_line, p_from_column);
+	_offset_underlines_after(p_to_line, p_to_column, p_from_line, p_from_column);
 
 	end_complex_operation();
 }
@@ -6772,6 +7030,7 @@ void TextEdit::delete_selection(int p_caret) {
 
 		_remove_text(selection_from_line, selection_from_column, selection_to_line, selection_to_column);
 		_offset_carets_after(selection_to_line, selection_to_column, selection_from_line, selection_from_column);
+		_offset_underlines_after(selection_to_line, selection_to_column, selection_from_line, selection_from_column);
 		merge_overlapping_carets();
 
 		deselect(i);
@@ -8295,6 +8554,7 @@ void TextEdit::_backspace_internal(int p_caret) {
 		_remove_text(from_line, from_column, to_line, to_column);
 		collapse_carets(from_line, from_column, to_line, to_column);
 		_offset_carets_after(to_line, to_column, from_line, from_column);
+		_offset_underlines_after(to_line, to_column, from_line, from_column);
 
 		set_caret_line(from_line, false, true, -1, i);
 		set_caret_column(from_column, i == 0, i);
@@ -8850,6 +9110,49 @@ void TextEdit::_offset_carets_after(int p_old_line, int p_old_column, int p_new_
 	if (!p_include_selection_begin && p_include_selection_end && has_selection()) {
 		// It is possible that two adjacent selections now overlap.
 		merge_overlapping_carets();
+	}
+}
+
+void TextEdit::_offset_underlines_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column) {
+	int edit_height = p_new_line - p_old_line;
+	int edit_size = p_new_column - p_old_column;
+	if (edit_height == 0 && edit_size == 0) {
+		return;
+	}
+
+	// We only want to move the end of a highlight's range if the edit being performed
+	// is removing text.
+	bool include_end = edit_height == 0 ? edit_size < 0 : edit_height < 0;
+
+	for (Underline &u : underlines) {
+		int ul_start_line = u.start_line;
+		int ul_start_column = u.start_column;
+		bool ul_start_after = ul_start_line > p_old_line || (ul_start_line == p_old_line && ul_start_column > p_old_column);
+		bool ul_start_at = ul_start_line == p_old_line && ul_start_column == p_old_column;
+		if (ul_start_after || ul_start_at) {
+			ul_start_line += edit_height;
+			if (ul_start_line == p_new_line) {
+				ul_start_column += edit_size;
+			}
+
+			u.start_line = ul_start_line;
+			u.start_column = ul_start_column;
+		}
+
+		// Now for end side of underline!
+		int ul_end_line = u.end_line;
+		int ul_end_column = u.end_column;
+		bool ul_end_after = ul_end_line > p_old_line || (ul_end_line == p_old_line && ul_end_column > p_old_column);
+		bool ul_end_at = ul_end_line == p_old_line && ul_end_column == p_old_column;
+		if (ul_end_after || (ul_end_at && include_end)) {
+			ul_end_line += edit_height;
+			if (ul_end_line == p_new_line) {
+				ul_end_column += edit_size;
+			}
+
+			u.end_line = ul_end_line;
+			u.end_column = ul_end_column;
+		}
 	}
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -307,6 +307,22 @@ private:
 	String ime_text = "";
 	Point2 ime_selection;
 
+	// Underline effects.
+	struct Underline {
+		Color color;
+		int start_line;
+		int start_column;
+		int end_line;
+		int end_column;
+
+		bool contains_line(int p_line) const {
+			return start_line <= p_line && p_line <= end_line;
+		}
+	};
+	LocalVector<Underline> underlines;
+	Vector<Underline> _cut_line_from_underline(const Underline &p_ul, int p_line);
+	Vector<Underline> _get_underline_data_for_line(int p_line);
+
 	// Placeholder
 	String placeholder_text = "";
 	Array placeholder_bidi_override;
@@ -489,6 +505,7 @@ private:
 	bool _is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_include_edges = true) const;
 
 	void _offset_carets_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column, bool p_include_selection_begin = true, bool p_include_selection_end = true);
+	void _offset_underlines_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column);
 
 	void _cancel_drag_and_drop_text();
 
@@ -808,6 +825,24 @@ protected:
 	GDVIRTUAL1(_paste_primary_clipboard, int)
 
 public:
+	void clear_underlines() { underlines.clear(); }
+	void add_underline(const Color &p_color, int p_start_line, int p_start_column, int p_end_line, int p_end_column) {
+		Underline u;
+		u.color = p_color;
+		u.start_line = p_start_line;
+		u.start_column = p_start_column;
+		u.end_line = p_end_line;
+		u.end_column = p_end_column;
+		underlines.push_back(u);
+	}
+	void update_underline_color(const Color &p_original_color, const Color &p_new_color) {
+		for (Underline &ul : underlines) {
+			if (ul.color == p_original_color) {
+				ul.color = p_new_color;
+			}
+		}
+	}
+
 	/* General overrides. */
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14875 .

This PR adds an underline to the portions of lines triggering GDScript warnings in the built-in code editor:

<img width="375" height="117" alt="CleanShot 2026-06-07 at 10 44 06@2x" src="https://github.com/user-attachments/assets/00ef7918-f547-48e3-878f-7ee8db136f91" />

Errors are similarly underlined with red:

<img width="405" height="137" alt="CleanShot 2026-06-27 at 21 26 07@2x" src="https://github.com/user-attachments/assets/e1e4d1b1-d7a3-4df3-9798-299f5eff15ad" />
