### PR TITLE
Unify dock split registration

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -789,23 +789,13 @@ void EditorDockManager::set_tab_icon_max_width(int p_max_width) {
 	}
 }
 
+void EditorDockManager::_register_split(DockSplitContainer **p_var, DockSplitContainer *p_split) {
+	*p_var = p_split;
+	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
+}
+
 void EditorDockManager::add_vsplit(DockSplitContainer *p_split) {
 	vsplits.push_back(p_split);
-	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
-}
-
-void EditorDockManager::set_main_vsplit(DockSplitContainer *p_split) {
-	main_vsplit = p_split;
-	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
-}
-
-void EditorDockManager::set_main_hsplit(DockSplitContainer *p_split) {
-	main_hsplit = p_split;
-	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
-}
-
-void EditorDockManager::set_bottom_hsplit(DockSplitContainer *p_split) {
-	bottom_hsplit = p_split;
 	p_split->connect("dragged", callable_mp(this, &EditorDockManager::_dock_split_dragged));
 }
 

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -126,6 +126,8 @@ private:
 	void _queue_update_tab_style(EditorDock *p_dock);
 	void _update_dirty_dock_tabs();
 
+	void _register_split(DockSplitContainer **p_var, DockSplitContainer *p_split);
+
 public:
 	static EditorDockManager *get_singleton() { return singleton; }
 
@@ -134,9 +136,9 @@ public:
 	void set_tab_icon_max_width(int p_max_width);
 
 	void add_vsplit(DockSplitContainer *p_split);
-	void set_main_vsplit(DockSplitContainer *p_split);
-	void set_main_hsplit(DockSplitContainer *p_split);
-	void set_bottom_hsplit(DockSplitContainer *p_split);
+	void set_main_vsplit(DockSplitContainer *p_split) { _register_split(&main_vsplit, p_split); }
+	void set_main_hsplit(DockSplitContainer *p_split) { _register_split(&main_hsplit, p_split); }
+	void set_bottom_hsplit(DockSplitContainer *p_split) { _register_split(&bottom_hsplit, p_split); }
 	void register_dock_slot(DockTabContainer *p_tab_container);
 	int get_vsplit_count() const;
 	PopupMenu *get_docks_menu();


### PR DESCRIPTION
This PR does some basic unification of the contents inside the `set_*_*split()` functions for dock managing.

Addresses https://github.com/godotengine/godot/pull/119502#discussion_r3267325620.