### PR TITLE
Implement and expose property hint in TileSet custom data layer

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -138,6 +138,20 @@
 				Returns the name of the custom data layer identified by the given index.
 			</description>
 		</method>
+		<method name="get_custom_data_layer_property_hint" qualifiers="const">
+			<return type="int" enum="PropertyHint" />
+			<param index="0" name="layer_index" type="int" />
+			<description>
+				Returns the property hint of the custom data layer identified by the given index.
+			</description>
+		</method>
+		<method name="get_custom_data_layer_property_hint_string" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="layer_index" type="int" />
+			<description>
+				Returns the property hint string of the custom data layer identified by the given index.
+			</description>
+		</method>
 		<method name="get_custom_data_layer_type" qualifiers="const">
 			<return type="int" enum="Variant.Type" />
 			<param index="0" name="layer_index" type="int" />
@@ -518,6 +532,22 @@
 			<param index="1" name="layer_name" type="String" />
 			<description>
 				Sets the name of the custom data layer identified by the given index. Names are identifiers of the layer therefore if the name is already taken it will fail and raise an error.
+			</description>
+		</method>
+		<method name="set_custom_data_layer_property_hint">
+			<return type="void" />
+			<param index="0" name="layer_index" type="int" />
+			<param index="1" name="layer_hint" type="int" enum="PropertyHint" />
+			<description>
+				Sets the property hint of the custom data layer identified by the given index.
+			</description>
+		</method>
+		<method name="set_custom_data_layer_property_hint_string">
+			<return type="void" />
+			<param index="0" name="layer_index" type="int" />
+			<param index="1" name="layer_hint_string" type="String" />
+			<description>
+				Sets the property hint string of the custom data layer identified by the given index.
 			</description>
 		</method>
 		<method name="set_custom_data_layer_type">

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1325,10 +1325,12 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 	}
 }
 
-void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label, const Variant &p_default_value) {
+void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label, const Variant &p_default_value, const PropertyHint p_property_hint, const String &p_property_hint_string) {
 	ERR_FAIL_COND_MSG(!property.is_empty(), "Cannot setup TileDataDefaultEditor twice");
 	property = p_property;
 	property_type = p_type;
+	property_hint = p_property_hint;
+	property_hint_string = p_property_hint_string;
 
 	// Update everything.
 	if (property_editor) {
@@ -1349,7 +1351,7 @@ void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, const St
 	}
 
 	// Create and setup the property editor.
-	property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, p_type, p_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
+	property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, p_type, p_property, p_property_hint, p_property_hint_string, PROPERTY_USAGE_DEFAULT);
 	property_editor->set_object_and_property(dummy_object, p_property);
 	if (p_label.is_empty()) {
 		property_editor->set_label(EditorPropertyNameProcessor::get_singleton()->process_name(p_property, EditorPropertyNameProcessor::get_default_inspector_style(), p_property));
@@ -1374,6 +1376,14 @@ void TileDataDefaultEditor::_notification(int p_what) {
 
 Variant::Type TileDataDefaultEditor::get_property_type() {
 	return property_type;
+}
+
+PropertyHint TileDataDefaultEditor::get_property_hint() {
+	return property_hint;
+}
+
+String TileDataDefaultEditor::get_property_hint_string() {
+	return property_hint_string;
 }
 
 TileDataDefaultEditor::TileDataDefaultEditor() {

--- a/editor/scene/2d/tiles/tile_data_editors.h
+++ b/editor/scene/2d/tiles/tile_data_editors.h
@@ -225,6 +225,8 @@ protected:
 	StringName type;
 	String property;
 	Variant::Type property_type;
+	PropertyHint property_hint;
+	String property_hint_string;
 	void _notification(int p_what);
 
 	virtual Variant _get_painted_value();
@@ -241,8 +243,10 @@ public:
 	virtual void forward_painting_alternatives_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) override;
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
 
-	void setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label = "", const Variant &p_default_value = Variant());
+	void setup_property_editor(Variant::Type p_type, const String &p_property, const String &p_label = "", const Variant &p_default_value = Variant(), const PropertyHint p_property_hint = PROPERTY_HINT_NONE, const String &p_property_hint_string = "");
 	Variant::Type get_property_type();
+	PropertyHint get_property_hint();
+	String get_property_hint_string();
 
 	TileDataDefaultEditor();
 	~TileDataDefaultEditor();

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -805,6 +805,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		String editor_name = vformat("custom_data_%d", i);
 		String prop_name = tile_set->get_custom_data_layer_name(i);
 		Variant::Type prop_type = tile_set->get_custom_data_layer_type(i);
+		PropertyHint prop_hint = tile_set->get_custom_data_layer_property_hint(i);
+		String prop_hint_string = tile_set->get_custom_data_layer_property_hint_string(i);
 
 		if (prop_name.is_empty()) {
 			ADD_TILE_DATA_EDITOR(group, vformat(TTR("Custom Data %d"), i), editor_name);
@@ -813,16 +815,22 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 			item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		}
 
-		// If the type of the edited property has been changed, delete the
+		// If the type or hint of the edited property has been changed, delete the
 		// editor and create a new one.
-		if (tile_data_editors.has(editor_name) && ((TileDataDefaultEditor *)tile_data_editors[editor_name])->get_property_type() != prop_type) {
-			tile_data_editors[vformat("custom_data_%d", i)]->queue_free();
-			tile_data_editors.erase(vformat("custom_data_%d", i));
+		if (tile_data_editors.has(editor_name)) {
+			Variant::Type original_type = ((TileDataDefaultEditor *)tile_data_editors[editor_name])->get_property_type();
+			PropertyHint original_hint = ((TileDataDefaultEditor *)tile_data_editors[editor_name])->get_property_hint();
+			String original_hint_string = ((TileDataDefaultEditor *)tile_data_editors[editor_name])->get_property_hint_string();
+
+			if (original_type != prop_type || original_hint != prop_hint || original_hint_string != prop_hint_string) {
+				tile_data_editors[editor_name]->queue_free();
+				tile_data_editors.erase(editor_name);
+			}
 		}
 		if (!tile_data_editors.has(editor_name)) {
 			TileDataDefaultEditor *tile_data_custom_data_editor = memnew(TileDataDefaultEditor());
 			tile_data_custom_data_editor->hide();
-			tile_data_custom_data_editor->setup_property_editor(prop_type, editor_name, prop_name);
+			tile_data_custom_data_editor->setup_property_editor(prop_type, editor_name, prop_name, Variant(), prop_hint, prop_hint_string);
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 			tile_data_editors[editor_name] = tile_data_custom_data_editor;
@@ -2973,12 +2981,14 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 		// Custom data layers.
 		int layer_index = components[0].trim_prefix("custom_data_").to_int();
 		ERR_FAIL_COND_V(layer_index < 0, false);
-		EditorProperty *ep = EditorInspectorDefaultPlugin::get_editor_for_property(p_object, p_type, p_path, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 		const TileSetAtlasSourceEditor::AtlasTileProxyObject *proxy_obj = Object::cast_to<TileSetAtlasSourceEditor::AtlasTileProxyObject>(p_object);
 		const TileSetAtlasSource *atlas_source = *proxy_obj->get_edited_tile_set_atlas_source();
 		ERR_FAIL_NULL_V(atlas_source, false);
 		const TileSet *tile_set = atlas_source->get_tile_set();
 		ERR_FAIL_NULL_V(tile_set, false);
+		PropertyHint hint = tile_set->get_custom_data_layer_property_hint(layer_index);
+		String hint_string = tile_set->get_custom_data_layer_property_hint_string(layer_index);
+		EditorProperty *ep = EditorInspectorDefaultPlugin::get_editor_for_property(p_object, p_type, p_path, hint, hint_string, PROPERTY_USAGE_DEFAULT);
 		add_property_editor(p_path, ep, false, tile_set->get_custom_data_layer_name(layer_index));
 		return true;
 	}

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -1161,6 +1161,34 @@ Variant::Type TileSet::get_custom_data_layer_type(int p_layer_id) const {
 	return custom_data_layers[p_layer_id].type;
 }
 
+void TileSet::set_custom_data_layer_property_hint(int p_layer_id, const PropertyHint p_hint) {
+	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
+	custom_data_layers.write[p_layer_id].property_hint = p_hint;
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
+	}
+	emit_changed();
+}
+
+void TileSet::set_custom_data_layer_property_hint_string(int p_layer_id, const String &p_hint_string) {
+	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
+	custom_data_layers.write[p_layer_id].property_hint_string = p_hint_string;
+	for (KeyValue<int, Ref<TileSetSource>> &E_source : sources) {
+		E_source.value->notify_tile_data_properties_should_change();
+	}
+	emit_changed();
+}
+
+PropertyHint TileSet::get_custom_data_layer_property_hint(int p_layer_id) const {
+	ERR_FAIL_INDEX_V(p_layer_id, custom_data_layers.size(), PROPERTY_HINT_NONE);
+	return custom_data_layers[p_layer_id].property_hint;
+}
+
+String TileSet::get_custom_data_layer_property_hint_string(int p_layer_id) const {
+	ERR_FAIL_INDEX_V(p_layer_id, custom_data_layers.size(), "");
+	return custom_data_layers[p_layer_id].property_hint_string;
+}
+
 void TileSet::set_source_level_tile_proxy(int p_source_from, int p_source_to) {
 	ERR_FAIL_COND(p_source_from == TileSet::INVALID_SOURCE || p_source_to == TileSet::INVALID_SOURCE);
 
@@ -4350,6 +4378,10 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_custom_data_layer_name", "layer_index"), &TileSet::get_custom_data_layer_name);
 	ClassDB::bind_method(D_METHOD("set_custom_data_layer_type", "layer_index", "layer_type"), &TileSet::set_custom_data_layer_type);
 	ClassDB::bind_method(D_METHOD("get_custom_data_layer_type", "layer_index"), &TileSet::get_custom_data_layer_type);
+	ClassDB::bind_method(D_METHOD("set_custom_data_layer_property_hint", "layer_index", "layer_hint"), &TileSet::set_custom_data_layer_property_hint);
+	ClassDB::bind_method(D_METHOD("get_custom_data_layer_property_hint", "layer_index"), &TileSet::get_custom_data_layer_property_hint);
+	ClassDB::bind_method(D_METHOD("set_custom_data_layer_property_hint_string", "layer_index", "layer_hint_string"), &TileSet::set_custom_data_layer_property_hint_string);
+	ClassDB::bind_method(D_METHOD("get_custom_data_layer_property_hint_string", "layer_index"), &TileSet::get_custom_data_layer_property_hint_string);
 
 	// Tile proxies
 	ClassDB::bind_method(D_METHOD("set_source_level_tile_proxy", "source_from", "source_to"), &TileSet::set_source_level_tile_proxy);

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -370,6 +370,8 @@ private:
 	struct CustomDataLayer {
 		String name;
 		Variant::Type type = Variant::NIL;
+		PropertyHint property_hint = PROPERTY_HINT_NONE;
+		String property_hint_string;
 	};
 	Vector<CustomDataLayer> custom_data_layers;
 	HashMap<String, int> custom_data_layers_by_name;
@@ -506,6 +508,10 @@ public:
 	String get_custom_data_layer_name(int p_layer_id) const;
 	void set_custom_data_layer_type(int p_layer_id, Variant::Type p_value);
 	Variant::Type get_custom_data_layer_type(int p_layer_id) const;
+	void set_custom_data_layer_property_hint(int p_layer_id, const PropertyHint p_hint);
+	void set_custom_data_layer_property_hint_string(int p_layer_id, const String &p_hint_string);
+	PropertyHint get_custom_data_layer_property_hint(int p_layer_id) const;
+	String get_custom_data_layer_property_hint_string(int p_layer_id) const;
 
 	// Tiles proxies.
 	void set_source_level_tile_proxy(int p_source_from, int p_source_to);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/14874
- Closes https://github.com/godotengine/godot-proposals/issues/6346
- Closes https://github.com/godotengine/godot-proposals/issues/8749

This PR implements and exposes `PropertyHint` and hint string information for custom data layers in TileSet through scripting, so that developers will be able to have greater control over the editing and validation of custom data, such as specifying enums or resource type. It introduces 4 new methods to `TileSet`; getters and setters for `hint` and `hint_string` in the same fashion as the existing `name` and `type` properties:

```gdscript
set_custom_data_layer_property_hint(layer_index: int, hint: PropertyHint) -> void
set_custom_data_layer_property_hint_string(layer_index: int, hint_string: String) -> void

get_custom_data_layer_property_hint(layer_index: int) -> PropertyHint
get_custom_data_layer_property_hint_string(layer_index: int) -> String
```

Here's an example of how it can be used:

https://github.com/user-attachments/assets/161df484-3a4b-4c88-be80-810179dbdff1

In its current state, it is best used in a custom resource class, with the setters called in `_get_property_list()` to prevent caching issues.

Note that unlike `custom_data_layer_x/name` and `custom_data_layer_x/type`, hint and hint string are **not** listed in `get_property_list()` since it doesn't need to be serialized for runtime. However, this can be added later if we do implement editor features.

## Additional information

This is intentionally a barebones implementation; there is no attempt to make a user-friendly editor or scripting API beyond exposing the raw values. 

The goal is to expose the feature for advanced users and addon creators, similar to `_validate_property()`. If addons are insufficient or if the community wants further UX improvements, further improvements could easily be built on top of this change as editor and/or scripting implementation (I go into a bit more detail in https://github.com/godotengine/godot-proposals/issues/14874).

Once this PR is merged, I'll add further documentation as follow-ups to elaborate on how the new APIs should be used, i.e. why it should be called in `_get_property_list()` and in a tool script, etc.