### PR TITLE
Android: Fix NPE in JavaClassWrapper proxy when interface method has no arguments

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
@@ -86,7 +86,7 @@ class AndroidRuntimePlugin(godot: Godot) : GodotPlugin(godot) {
 
 					// Invocation for the interface single abstract method falls here and is dispatched to the
 					// Godot [Callable].
-					else -> godotCallable.call(*args)
+					else -> godotCallable.call(*(args ?: emptyArray()))
 				}
 			}
 		}
@@ -111,7 +111,7 @@ class AndroidRuntimePlugin(godot: Godot) : GodotPlugin(godot) {
 
 					// Invocation for the remaining interface(s) methods falls here and is dispatched to the
 					// Godot Object.
-					else -> Callable.call(godotObjectID, methodName, *args)
+					else -> Callable.call(godotObjectID, methodName, *(args ?: emptyArray()))
 				}
 			}
 		}


### PR DESCRIPTION
The `InvocationHandler` lambdas in `AndroidRuntimePlugin` use `*args` directly. Per the [`InvocationHandler.invoke` contract](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/reflect/InvocationHandler.html#invoke(java.lang.Object,java.lang.reflect.Method,java.lang.Object%5B%5D)), `args` is `null` when the interface method takes no arguments, so spreading throws NPE.                      

Repro: define `interface Foo { fun onTick() }`, wire it through `JavaClassWrapper.create_proxy`, call `onTick()` from Kotlin → crash:

```
java.lang.NullPointerException: Attempt to get length of null array at AndroidRuntimePlugin$Companion.createProxyFromGodotObjectID$lambda$2(AndroidRuntimePlugin.kt:114)
```

Fix: `*args` → `*(args ?: emptyArray())` in both proxy paths. Affects #115498.

The `args[0]` in the `"equals"` branches is left alone — `Object.equals` always passes one argument.