### PR TITLE
Fix shader parsing of unary minus inside unbracketed math expressions

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -7753,6 +7753,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 					_set_error(vformat(RTR("Invalid arguments to unary operator '%s': %s."), get_operator_text(op->op), at));
 					return nullptr;
 				}
+				expression.write[i].node = _reduce_expression(p_block, expression.write[i].node);
 				expression.remove_at(i + 1);
 			}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Closes #119576

When passing a multiplication with a negative number not isolated in brackets to `hint_range` in the shader language, such as `instance uniform float desired : hint_range(-2.0 * PI, 2.0 * PI, 0.1) = 0.0;`, the parser throws the error `Expected a valid numeric expression.`.

Based on what I could understand from the debugging, `_parse_expression` handles the AST construction. During this process, when an `OP_NEGATE` node is validated, it remains an unreduced `OperatorNode`. Therefore, when the downstream `OP_MUL` node is constructed, its left or right operand (or both) is this unreduced unary node.

Then the parser passes the AST to `_reduce_expression`, but since it is limited (as the comment at line `:7897` states: `//for now only reduce simple constructors`) and does not support evaluating binary operators like `OP_MUL`, it returns the tree unreduced. This leaves the `OperatorNode` with an empty values vector, causing `_parse_numeric_constant_expression` to reject it at line `:9201`:

```cpp
if (values.is_empty()) {
    return false; // To prevent possible crash.
}
```

## Additional information
*Fix:*
In `godot/servers/rendering/shader_language.cpp` within `_parse_expression` (inside the `is_unary` evaluation loop), adding a call to `_reduce_expression` immediately after a unary operator passes `_validate_operator` resolves the problem:
```cpp
if (!_validate_operator(p_block, p_function_info, op, &op->return_cache, &op->return_array_size)) { /* ... */ }
expression.write[i].node = _reduce_expression(p_block, expression.write[i].node); // new line
expression.remove_at(i + 1);
```

The intent is to achieve the same behavior of the bracketed expression (e.g., `(-2.0) * PI` works correctly because closing a parenthesis triggers an immediate reduction on its contents) by folding the unary node into a `ConstantNode` directly during the expression parsing phase.

*Test:*
Now shaders using `hint_range(-2.0 * PI, 2.0 * PI, 0.1)` no longer trigger parsing errors, and the slider in the Inspector is correctly populated with its minimum and maximum ranges.