### PR TITLE
Open script list menu on empty space clicks

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3116,13 +3116,19 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void ScriptEditor::_script_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index) {
+void ScriptEditor::_script_list_clicked(int p_item, const Vector2 &p_local_mouse_pos, MouseButton p_mouse_button_index) {
 	if (p_mouse_button_index == MouseButton::MIDDLE) {
 		script_list->select(p_item);
 		_script_selected(p_item);
 		_menu_option(FILE_MENU_CLOSE);
 	}
 
+	if (p_mouse_button_index == MouseButton::RIGHT) {
+		_make_script_list_context_menu();
+	}
+}
+
+void ScriptEditor::_script_list_empty_clicked(const Vector2 &p_local_mouse_pos, MouseButton p_mouse_button_index) {
 	if (p_mouse_button_index == MouseButton::RIGHT) {
 		_make_script_list_context_menu();
 	}
@@ -3861,6 +3867,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_list->set_allow_rmb_select(true);
 	scripts_vbox->add_child(script_list);
 	script_list->connect("item_clicked", callable_mp(this, &ScriptEditor::_script_list_clicked), CONNECT_DEFERRED);
+	script_list->connect("empty_clicked", callable_mp(this, &ScriptEditor::_script_list_empty_clicked), CONNECT_DEFERRED);
 	SET_DRAG_FORWARDING_GCD(script_list, ScriptEditor);
 
 	context_menu = memnew(PopupMenu);

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -345,7 +345,8 @@ class ScriptEditor : public PanelContainer {
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
-	void _script_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
+	void _script_list_clicked(int p_item, const Vector2 &p_local_mouse_pos, MouseButton p_mouse_button_index);
+	void _script_list_empty_clicked(const Vector2 &p_local_mouse_pos, MouseButton p_mouse_button_index);
 	void _make_script_list_context_menu();
 
 	void _calculate_script_name_button_size();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

If you don't have many scripts open, it's difficult to bring the script list context menu.

## Additional information

<img width="474" height="623" alt="image" src="https://github.com/user-attachments/assets/7ff54e28-976f-4c21-833f-e09f7c3b4898" />
The menu uses currently selected item for options, so it looks the same when clicking empty space.