### PR TITLE
Limit Smoothing without Position Smoothing

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -165,7 +165,7 @@
 			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
 		</member>
 		<member name="limit_smoothed_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
-			Speed in pixels per second of the camera's smoothing effect when [member limit_smoothing_enabled] is [code]true[/code].
+			Speed in pixels per second of the camera's smoothing effect when [member limit_smoothed] is [code]true[/code].
 			[b]Note:[/b] This is one and the same as [member position_smoothing_speed].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -159,12 +159,12 @@
 		<member name="limit_right" type="int" setter="set_limit" getter="get_limit" default="10000000">
 			Right scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
-		<member name="limit_smoothing_enabled" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
+		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly moves when it's limits change.
 			This property has no effect if [member limit_enabled] is [code]false[/code].
 			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
 		</member>
-		<member name="limit_smoothing_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
+		<member name="limit_smoothed_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
 			Speed in pixels per second of the camera's smoothing effect when [member limit_smoothing_enabled] is [code]true[/code].
 			[b]Note:[/b] This is one and the same as [member position_smoothing_speed].
 		</member>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -159,10 +159,14 @@
 		<member name="limit_right" type="int" setter="set_limit" getter="get_limit" default="10000000">
 			Right scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
-		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
-			If [code]true[/code], the camera smoothly stops when reaches its limits.
-			This property has no effect if [member position_smoothing_enabled] is [code]false[/code].
+		<member name="limit_smoothing_enabled" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
+			If [code]true[/code], the camera smoothly moves when it's limits change.
+			This property has no effect if [member limit_enabled] is [code]false[/code].
 			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
+		</member>
+		<member name="limit_smoothing_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
+			Speed in pixels per second of the camera's smoothing effect when [member limit_smoothing_enabled] is [code]true[/code].
+			[b]Note:[/b] This is one and the same as [member position_smoothing_speed].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
 			Top scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -165,29 +165,33 @@ Transform2D Camera2D::get_camera_transform() {
 		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom_scale) : Point2());
 		Rect2 screen_rect(-screen_offset + camera_pos, screen_size * zoom_scale);
 
+		// Adjusts camera_pos to respect the current limits.
+		// This has the effect that next time we create screen_rect, that rect will also respect
+		// the limits.
+		//
 		if (limit_enabled && limit_smoothing_enabled) {
 			// Apply horizontal limiting.
-			if (limit[SIDE_LEFT] > limit[SIDE_RIGHT] - screen_rect.size.x) {
-				// Split the limit difference horizontally.
-				camera_pos.x -= screen_rect.position.x + (screen_rect.size.x - limit[SIDE_RIGHT] - limit[SIDE_LEFT]) / 2;
-			} else if (screen_rect.position.x < limit[SIDE_LEFT]) {
-				// Only apply left limit.
-				camera_pos.x -= screen_rect.position.x - limit[SIDE_LEFT];
-			} else if (screen_rect.position.x + screen_rect.size.x > limit[SIDE_RIGHT]) {
-				// Only apply the right limit.
-				camera_pos.x -= screen_rect.position.x + screen_rect.size.x - limit[SIDE_RIGHT];
+			if (smooth_limit[SIDE_LEFT] > smooth_limit[SIDE_RIGHT] - screen_rect.size.x) {
+				// Split the smooth_limit difference horizontally.
+				camera_pos.x -= screen_rect.position.x + (screen_rect.size.x - smooth_limit[SIDE_RIGHT] - smooth_limit[SIDE_LEFT]) / 2;
+			} else if (screen_rect.position.x < smooth_limit[SIDE_LEFT]) {
+				// Only apply left smooth_limit.
+				camera_pos.x -= screen_rect.position.x - smooth_limit[SIDE_LEFT];
+			} else if (screen_rect.position.x + screen_rect.size.x > smooth_limit[SIDE_RIGHT]) {
+				// Only apply the right smooth_limit.
+				camera_pos.x -= screen_rect.position.x + screen_rect.size.x - smooth_limit[SIDE_RIGHT];
 			}
 
-			// Apply vertical limiting.
-			if (limit[SIDE_TOP] > limit[SIDE_BOTTOM] - screen_rect.size.y) {
-				// Split the limit difference vertically.
-				camera_pos.y -= screen_rect.position.y + (screen_rect.size.y - limit[SIDE_BOTTOM] - limit[SIDE_TOP]) / 2;
-			} else if (screen_rect.position.y < limit[SIDE_TOP]) {
-				// Only apply the top limit.
-				camera_pos.y -= screen_rect.position.y - limit[SIDE_TOP];
-			} else if (screen_rect.position.y + screen_rect.size.y > limit[SIDE_BOTTOM]) {
-				// Only apply the bottom limit.
-				camera_pos.y -= screen_rect.position.y + screen_rect.size.y - limit[SIDE_BOTTOM];
+			// Apply vertical smooth_limiting.
+			if (smooth_limit[SIDE_TOP] > smooth_limit[SIDE_BOTTOM] - screen_rect.size.y) {
+				// Split the smooth_limit difference vertically.
+				camera_pos.y -= screen_rect.position.y + (screen_rect.size.y - smooth_limit[SIDE_BOTTOM] - smooth_limit[SIDE_TOP]) / 2;
+			} else if (screen_rect.position.y < smooth_limit[SIDE_TOP]) {
+				// Only apply the top smooth_limit.
+				camera_pos.y -= screen_rect.position.y - smooth_limit[SIDE_TOP];
+			} else if (screen_rect.position.y + screen_rect.size.y > smooth_limit[SIDE_BOTTOM]) {
+				// Only apply the bottom smooth_limit.
+				camera_pos.y -= screen_rect.position.y + screen_rect.size.y - smooth_limit[SIDE_BOTTOM];
 			}
 		}
 
@@ -196,15 +200,27 @@ Transform2D Camera2D::get_camera_transform() {
 		// It may be called MULTIPLE TIMES on certain frames,
 		// therefore smoothing is not currently applied only once per frame / tick,
 		// which will result in some haphazard results.
+		bool physics_process = (process_callback == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
+		real_t delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
+		real_t c = position_smoothing_speed * delta;
 		if (position_smoothing_enabled && !is_part_of_edited_scene()) {
-			bool physics_process = (process_callback == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
-			real_t delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
-			real_t c = position_smoothing_speed * delta;
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
 			//camera_pos=camera_pos*(1.0-position_smoothing_speed)+new_camera_pos*position_smoothing_speed;
 		} else {
 			ret_camera_pos = smoothed_camera_pos = camera_pos;
+		}
+
+		// Perform limit smoothing independent of position smoothing.
+		// Position Smoothing handles smooth limits naturally, so we can skip this if we're using
+		// position smoothing.
+		//
+		// Note: This requires access to the unconstrained screen_rect, so we do it here
+		// since screen_rect was initially created with the unconstrained camera_pos
+		//
+		if (limit_smoothing_enabled && !position_smoothing_enabled && !is_part_of_edited_scene()) {
+			Rect2 constrained_rect(-screen_offset + camera_pos, screen_size * zoom_scale);
+			_move_smooth_limits(screen_rect, constrained_rect, delta);
 		}
 
 	} else {
@@ -226,7 +242,10 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom_scale);
 
-	if (limit_enabled && (!position_smoothing_enabled || !limit_smoothing_enabled)) {
+	// Overrides screen_rect to immediately snap to the limits, which we only do
+	// if we're not using position smoothing
+	//
+	if (limit_enabled && !limit_smoothing_enabled) {
 		Point2 bottom_right_corner = Point2(screen_rect.position + 2.0 * (ret_camera_pos - screen_rect.position));
 		// Apply horizontal limiting.
 		if (limit[SIDE_LEFT] > limit[SIDE_RIGHT] - (bottom_right_corner.x - screen_rect.position.x)) {
@@ -267,6 +286,95 @@ Transform2D Camera2D::get_camera_transform() {
 	camera_screen_center = xform.xform(0.5 * screen_size);
 
 	return xform.affine_inverse();
+}
+
+void Camera2D::_move_smooth_limits(const Rect2 &screen_rect, const Rect2 &constrained_rect, double delta) {
+	for (int i = 0; i < 4; ++i) {
+		//
+		// If our smooth_limit equals our limit target, there's nothing to be done
+		//
+		if (limit[i] == smooth_limit[i]) {
+			continue;
+		}
+
+		// Helps us normalize positions so we can always use > (gt) to determine
+		// if something is further away from us or not
+		//
+		int dir = (i == SIDE_LEFT || i == SIDE_TOP) ? -1 : 1;
+
+		// We need to know the edge of the viewport with and without limit constraints
+		int free_edge = _get_limit_viewport_edge(i, screen_rect);
+		int constrained_edge = _get_limit_viewport_edge(i, constrained_rect);
+
+		// Whichever viewport edge is further away from us is the one we use for distance measurement,
+		// otherwise we incorrectly move our limit to a spot further inward of the screen than
+		// we should, resulting in limits snapping prematurely
+		//
+		int viewport_edge = free_edge * dir >= constrained_edge * dir ? free_edge : constrained_edge;
+
+		// We need to determine where the cameras limits are in relation to
+		// the limit constrained viewport. This helps us decide how to move our
+		// smooth limit towards the limit target `limit[i]`.
+		//
+		bool limit_outside = limit[i] * dir > constrained_edge * dir;
+		bool smooth_outside = smooth_limit[i] * dir > constrained_edge * dir;
+
+		// Grab the distance from our smooth limit to the viewport edge and limit target
+		int viewport_dist = (viewport_edge - smooth_limit[i]);
+		int limit_dist = (limit[i] - smooth_limit[i]);
+
+		// If both limits are inside our viewport, just go to the limit.
+		int dist = limit_dist;
+
+		// If both limits are outside the viewport, we can't see them, so
+		// we can just update smooth_limit and be done
+		//
+		if (smooth_outside && limit_outside) {
+			smooth_limit[i] = limit[i];
+			continue;
+		}
+		// If the limit is outside, but smooth is inside, go to whichever is closer
+		// either the new viewport edge, or the limit
+		//
+		else if (limit_outside && !smooth_outside) {
+			dist = abs(viewport_dist) <= abs(limit_dist) ? viewport_dist : limit_dist;
+		}
+		// If the limit is inside, but the smooth is outside, move smooth to the
+		// constrained viewport edge immediately, then it finishes moving towards limit
+		// like normal
+		//
+		else if (!limit_outside && smooth_outside) {
+			smooth_limit[i] = constrained_edge;
+			dist = limit[i] - smooth_limit[i];
+		}
+
+		// Once the smooth limit has reached its target location, (which might be
+		// the actual limit, or just the edge of the viewport), we move it to
+		// the real limit and we're done
+		if (dist == 0) {
+			smooth_limit[i] = limit[i];
+			continue;
+		}
+
+		// Move the smooth limit towards the true limit
+		int inc = dist * (5 * delta);
+		smooth_limit[i] += inc != 0 ? inc : (dist >= 0 ? 1 : -1);
+	}
+}
+
+int Camera2D::_get_limit_viewport_edge(int i, const Rect2 &screen_rect) {
+	switch (i) {
+		case SIDE_LEFT:
+			return screen_rect.position.x;
+		case SIDE_RIGHT:
+			return screen_rect.position.x + screen_rect.size.x;
+		case SIDE_TOP:
+			return screen_rect.position.y;
+		case SIDE_BOTTOM:
+			return screen_rect.position.y + screen_rect.size.y;
+		default:
+			return 0;
+	}
 }
 
 void Camera2D::_ensure_update_interpolation_data() {
@@ -626,6 +734,14 @@ void Camera2D::set_limit(Side p_side, int p_limit) {
 		return;
 	}
 	limit[p_side] = p_limit;
+
+	// smooth_limit only applies to limit_smoothing only scenarios,
+	// so if were using position_smoothing_enabled, or not using limit smoothing,
+	// we just keep it in sync with limit
+	if (position_smoothing_enabled || !limit_smoothing_enabled) {
+		smooth_limit[p_side] = limit[p_side];
+	}
+
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -243,7 +243,7 @@ Transform2D Camera2D::get_camera_transform() {
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom_scale);
 
 	// Overrides screen_rect to immediately snap to the limits, which we only do
-	// if we're not using position smoothing
+	// if we're not using limit smoothing
 	//
 	if (limit_enabled && !limit_smoothing_enabled) {
 		Point2 bottom_right_corner = Point2(screen_rect.position + 2.0 * (ret_camera_pos - screen_rect.position));
@@ -348,16 +348,19 @@ void Camera2D::_move_smooth_limits(const Rect2 &screen_rect, const Rect2 &constr
 			dist = limit[i] - smooth_limit[i];
 		}
 
-		// Once the smooth limit has reached its target location, (which might be
-		// the actual limit, or just the edge of the viewport), we move it to
+		// Calculate how far of an increment to move the smooth limit
+		int inc = dist * position_smoothing_speed * delta;
+
+		// Once the smooth limit has reached its target location (which might be
+		// the actual limit, or just the edge of the viewport), or the distance to move
+		// is smaller than the remaining increment (prevents overshooting), we move it to
 		// the real limit and we're done
-		if (dist == 0) {
+		if (dist == 0 || abs(dist) <= abs(inc)) {
 			smooth_limit[i] = limit[i];
 			continue;
 		}
 
-		// Move the smooth limit towards the true limit
-		int inc = dist * (5 * delta);
+		// Move the smooth limit towards its target
 		smooth_limit[i] += inc != 0 ? inc : (dist >= 0 ? 1 : -1);
 	}
 }
@@ -789,6 +792,9 @@ void Camera2D::force_update_scroll() {
 void Camera2D::reset_smoothing() {
 	_update_scroll();
 	smoothed_camera_pos = camera_pos;
+	for (int i = 0; i < 4; ++i) {
+		smooth_limit[i] = limit[i];
+	}
 }
 
 void Camera2D::align() {
@@ -1090,7 +1096,10 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_top", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_TOP);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_right", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_bottom", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_BOTTOM);
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothed"), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
+
+	ADD_GROUP("Limit Smoothing", "limit_smoothing_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "limit_smoothing_speed", PROPERTY_HINT_NONE, "suffix:px/s"), "set_position_smoothing_speed", "get_position_smoothing_speed");
 
 	ADD_GROUP("Position Smoothing", "position_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "position_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_position_smoothing_enabled", "is_position_smoothing_enabled");

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -1097,9 +1097,9 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_right", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_bottom", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_BOTTOM);
 
-	ADD_GROUP("Limit Smoothing", "limit_smoothing_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "limit_smoothing_speed", PROPERTY_HINT_NONE, "suffix:px/s"), "set_position_smoothing_speed", "get_position_smoothing_speed");
+	ADD_GROUP("Limit Smoothing", "limit_smoothed_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothed", PROPERTY_HINT_GROUP_ENABLE), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "limit_smoothed_speed", PROPERTY_HINT_NONE, "suffix:px/s"), "set_position_smoothing_speed", "get_position_smoothing_speed");
 
 	ADD_GROUP("Position Smoothing", "position_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "position_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_position_smoothing_enabled", "is_position_smoothing_enabled");

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -74,6 +74,7 @@ protected:
 
 	bool limit_enabled = true;
 	int limit[4] = { -10000000, -10000000, 10000000, 10000000 }; // Left, top, right, bottom.
+	int smooth_limit[4] = { -10000000, -10000000, 10000000, 10000000 }; // Left, top, right, bottom.
 	bool limit_smoothing_enabled = false;
 
 	real_t drag_margin[4] = { 0.2, 0.2, 0.2, 0.2 };
@@ -88,6 +89,9 @@ protected:
 	bool _is_editing_in_editor() const;
 	void _update_process_callback();
 	void _update_scroll();
+
+	void _move_smooth_limits(const Rect2 &screen_rect, const Rect2 &constrained_rect, double delta);
+	int _get_limit_viewport_edge(int i, const Rect2 &screen_rect);
 
 #ifdef TOOLS_ENABLED
 	void _project_settings_changed();


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR solves a missing use case in the 2d camera system - limit smoothing without position smoothing.

The camera system supported 3 of 4 scenarios natively:
1. No position smoothing, no limit smoothing ✅ 
2. Position smoothing, but no limit smoothing ✅ 
3. Position smoothing *and* limit smoothing ✅ 

But didn't support the 4th
4. No Position smoothing, but limit smoothing ❌ 

This PR adds in the ability to support this 4th mode of movement. See the following video for a visual demonstration

https://github.com/user-attachments/assets/edc4357a-2668-4784-bf53-2108f3800820

Its a feature I was wanting for my own game, and initially implemented it in my own custom camera class, but I was thinking this seems sensible enough that it'd make sense if the camera could function this way natively - it's also a bit simpler to implement in the native camera since we have more access to internal camera data.

This feature shouldn't have any backwards compatible conflicts since limit_smoothing without position_smoothing did nothing before, and in theory no one should be using that combination (unless they're doing some sort of workaround)
The feature does require a bit of calculation to make the camera scroll smoothly for limit changes, but this cost is only paid if `limit_smoothing` is enabled and `position_smoothing` is disabled. Otherwise, all other modes of camera movement are unchanged.

# Additional Info

I tried implementing this a number of ways, originally trying to leverage the smooth movement to limits already provided by position_smoothing, but the camera looks too jittery selectively toggling on and off the camera smoothing code; ultimately, I think its better to keep the logic for limit smoothing separate from position smoothing.

I've done plenty of testing on the feature in various scenarios (full screen width limit changes, small limit changes, etc) and it seems to be functioning without any glitches.

One possibly important note: I added a new field property called "limit_smoothing_speed" that allows users to set their own limit speed - conceptually similar to position_smoothing_speed - and in fact are actually using the same variable. I thought this made sense since position_smoothing + limit smoothing uses position_smoothing_speed already - we wouldn't want to burden the user with an extra speed variable that isn't used in that scenario; and vice versa, position_smoothing_speed is unused if position_smoothing is off, so there doesn't seem to be any conflict there. But if the maintainers feel an independent variable is warranted, I can add it in.

All code is hand written. I consult the AI for ideas on how to implement features, but I never use code generation.

Hopefully nothing is majorly off with this PR, but if there are any concerns, I'm happy to address them.

Thanks!

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/14881*