### PR TITLE
Document ImageFormatLoader LoaderFlags Constants

### DIFF
--- a/doc/classes/ImageFormatLoader.xml
+++ b/doc/classes/ImageFormatLoader.xml
@@ -10,10 +10,13 @@
 	</tutorials>
 	<constants>
 		<constant name="FLAG_NONE" value="0" enum="LoaderFlags" is_bitfield="true">
+			Default loading behavior. No processing is applied to the image.
 		</constant>
 		<constant name="FLAG_FORCE_LINEAR" value="1" enum="LoaderFlags" is_bitfield="true">
+			If set, the image is converted from sRGB to linear encoding.
 		</constant>
 		<constant name="FLAG_CONVERT_COLORS" value="2" enum="LoaderFlags" is_bitfield="true">
+			If set, a predefined color map is applied to the image. Used when [member ResourceImporterTexture.editor/convert_colors_with_editor_theme] is [code]true[/code].
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The `LoaderFlags` enum constants on `ImageFormatLoader` (`FLAG_NONE`, `FLAG_FORCE_LINEAR`, `FLAG_CONVERT_COLORS`) do not have descriptions. This PR documents all three, which are the only undocumented items on the class.

## Additional information

Verified each flag by reading its consuming code rather than inferring behavior from the flag names:

- `FLAG_FORCE_LINEAR` triggers `srgb_to_linear()` in the PNG, HDR, TinyEXR, and SVG loaders. Set by the texture importer (`resource_importer_texture.cpp`).
- `FLAG_CONVERT_COLORS` applies the forced color map in the SVG loader (`image_loader_svg.cpp`), set by the texture importer when `convert_editor_colors` is enabled.
- `FLAG_NONE` is the zero/default value.

A note for reviewers: `FLAG_CONVERT_COLORS` is currently only consumed by the SVG loader. If the intent is more general, I'm happy to adjust the wording.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

## AI Disclosure

I used Claude Opus 4.7 (Anthropic) as a learning and editing aid while writing these descriptions. Specifically, it helped me with the LoaderFlags bitfield concept and walked me through the Git/PR workflow as a first-time contributor. I identified which image loaders use each flag and verified their behavior by reading their source code myself. The final wording is my own.
