### PR TITLE
Select the first visible item in PopupMenu when pressing Enter while searching

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1123,6 +1123,20 @@ void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 	_menu_changed();
 }
 
+void PopupMenu::_search_bar_text_submitted(const String &p_new_text) {
+	if (p_new_text.is_empty()) {
+		return;
+	}
+
+	// Select the first visible search result when pressing Enter.
+	for (PopupMenu::Item &item : items) {
+		if (item.visible) {
+			activate_item(item.id);
+			break;
+		}
+	}
+}
+
 void PopupMenu::_search_bar_focus_entered() {
 	prev_mouse_over = mouse_over;
 	mouse_over = -1;
@@ -3786,6 +3800,7 @@ PopupMenu::PopupMenu() {
 	search_bar->set_placeholder(ETR("Search"));
 	search_bar->set_keep_editing_on_text_submit(true);
 	search_bar->connect(SceneStringName(text_changed), callable_mp(this, &PopupMenu::_search_bar_text_changed));
+	search_bar->connect(SceneStringName(text_submitted), callable_mp(this, &PopupMenu::_search_bar_text_submitted));
 	search_bar->connect(SceneStringName(focus_entered), callable_mp(this, &PopupMenu::_search_bar_focus_entered));
 	vbox_container->add_child(search_bar, false, INTERNAL_MODE_FRONT);
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -248,6 +248,7 @@ class PopupMenu : public Popup {
 	void _update_search_bar_visibility();
 	void _items_focus_entered();
 	void _search_bar_text_changed(const String &p_new_text);
+	void _search_bar_text_submitted(const String &p_new_text);
 	void _search_bar_focus_entered();
 	void _filter_items(const String &p_query);
 


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/118571.

This streamlines keyboard-based PopupMenu usage, no longer requiring a down arrow press to focus on the first item to activate it.

## Preview

https://github.com/user-attachments/assets/33393fd0-95d2-48d4-8960-ad772366e040

