### PR TITLE
Fix possible freeze when running project with floating script editor

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -46,6 +46,7 @@
 #include "editor/run/editor_run_bar.h"
 #include "editor/run/embedded_process.h"
 #include "editor/run/run_instances_dialog.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -1769,7 +1770,7 @@ void GameViewPluginBase::_save_last_editor(const String &p_editor) {
 
 void GameViewPluginBase::_focus_another_editor() {
 	if (_is_window_wrapper_enabled()) {
-		if (last_editor.is_empty()) {
+		if (last_editor.is_empty() || (last_editor == "Script" && ScriptEditor::get_singleton()->is_editor_floating())) {
 			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_2D);
 		} else {
 			EditorInterface::get_singleton()->set_main_screen_editor(last_editor);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #106706

Currently, the editor will freeze if project is ran while both the game workspace and script editor are floating and the last two (non-floating) main screen plugins selected were the game view and the script editor.

This can only occur with this order of inputs:
1. select game view 
2. select script editor
3. make script editor floating
4. run project

This causes the game view and script editor to infinitely switch to each other, freezing the engine and eventually leading to a crash.

Fixed by not having the game view switch to the script editor when they are both floating.
