### PR TITLE
Disable auto brace completion within comments

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -926,10 +926,9 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 
 		const char32_t chr[2] = { (char32_t)p_unicode, 0 };
 
-		if (auto_brace_completion_enabled) {
-			int cl = get_caret_line(i);
-			int cc = get_caret_column(i);
-
+		int cl = get_caret_line(i);
+		int cc = get_caret_column(i);
+		if (auto_brace_completion_enabled && is_in_comment(cl, cc) == -1) {
 			if (had_selection) {
 				insert_text_at_caret(chr, i);
 
@@ -1012,7 +1011,7 @@ void CodeEdit::_backspace_internal(int p_caret) {
 
 		merge_gutters(from_line, to_line);
 
-		if (auto_brace_completion_enabled && to_column > 0) {
+		if (auto_brace_completion_enabled && to_column > 0 && is_in_comment(to_line, to_column) == -1) {
 			int idx = _get_auto_brace_pair_open_at_pos(to_line, to_column);
 			if (idx != -1) {
 				from_column = to_column - auto_brace_completion_pairs[idx].open_key.length();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14872

This PR prevents closing parentheses/brackets/braces from being skipped over when writing comments if inputted before another closing one.

For example, before this change, inputting `)` where the cursor is would result in `)` being skipped over instead of adding another `)` in the example below.

<img width="223" height="73" alt="image" src="https://github.com/user-attachments/assets/c64b3da2-4e87-4e9e-a3b1-27db721a1426" />

Additionally, this change will also stop braces from being auto-deleted when deleting closing parentheses/brackets/braces. So in the top example, if `(` were deleted with the cursor in that position with backspace, it would no longer remove `)` as well.