### PR TITLE
Make `MeshLibrary` use `PropertyListHelper` internally

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -133,7 +133,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="category" type="StringName" />
 			<description>
-				Sets the [param category] for a specific item [param id] for organization in the [GridMap] editor. A category can include [code]/[/code] as a delimiter to create sub categories.
+				Sets the [param category] for a specific item [param id] for organization in the [GridMap] editor. A category can include [code]/[/code] as a delimiter to create subcategories.
 			</description>
 		</method>
 		<method name="set_item_mesh">
@@ -211,4 +211,36 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="item/{index}/category" type="String" setter="" getter="" default="&amp;&quot;&quot;">
+			The item's category. Used to organize meshes in the [GridMap] editor. A category can include [code]/[/code] as a delimiter to create subcategories.
+		</member>
+		<member name="item/{index}/mesh" type="Mesh" setter="" getter="">
+			The item's mesh. Used by other parts of the engine (e.g. [GridMap], which displays them in a 3D tile).
+		</member>
+		<member name="item/{index}/mesh_cast_shadow" type="int" setter="" getter="" default="1">
+			The shadow casting mode used by the item's mesh. See [enum RenderingServer.ShadowCastingSetting].
+		</member>
+		<member name="item/{index}/mesh_transform" type="Transform3D" setter="" getter="" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+			The transform to apply to the item's mesh.
+		</member>
+		<member name="item/{index}/name" type="String" setter="" getter="" default="&quot;&quot;">
+			The item's name, shown in the editor. It can also be used to look up the item later using [method MeshLibrary.find_item_by_name].
+		</member>
+		<member name="item/{index}/navigation_layers" type="int" setter="" getter="" default="1">
+			The item's navigation layers bitmask.
+		</member>
+		<member name="item/{index}/navigation_mesh" type="NavigationMesh" setter="" getter="">
+			The item's navigation mesh.
+		</member>
+		<member name="item/{index}/navigation_mesh_transform" type="Transform3D" setter="" getter="" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+			The transform to apply to the item's navigation mesh.
+		</member>
+		<member name="item/{index}/preview" type="Texture2D" setter="" getter="">
+			The texture to use as the item's preview icon in the editor.
+		</member>
+		<member name="item/{index}/shapes" type="Array" setter="" getter="" default="[]">
+			The item's collision shapes. The array should consist of [Shape3D] objects, each followed by a [Transform3D] that will be applied to it. For shapes that should not have a transform, use [constant Transform3D.IDENTITY].
+		</member>
+	</members>
 </class>

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "editor/doc/editor_help.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_interface.h"
@@ -90,7 +91,7 @@ bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Va
 		}
 #ifndef PHYSICS_3D_DISABLED
 	} else if (p_name == "shapes") {
-		mesh_library->call("set_item_shapes", mesh_id, p_value);
+		mesh_library->_set_item_shapes(mesh_id, p_value);
 #endif // PHYSICS_3D_DISABLED
 	} else if (p_name == "preview") {
 		mesh_library->set_item_preview(mesh_id, p_value);
@@ -124,7 +125,7 @@ bool MeshLibraryEditor::MeshLibraryItem::_get(const StringName &p_name, Variant 
 		r_ret = (int)mesh_library->get_item_mesh_cast_shadow(mesh_id);
 #ifndef PHYSICS_3D_DISABLED
 	} else if (p_name == "shapes") {
-		r_ret = mesh_library->call("get_item_shapes", mesh_id);
+		r_ret = mesh_library->_get_item_shapes(mesh_id);
 #endif // PHYSICS_3D_DISABLED
 	} else if (p_name == "navigation_mesh") {
 		r_ret = mesh_library->get_item_navigation_mesh(mesh_id);
@@ -645,9 +646,20 @@ void MeshLibraryEditor::_mesh_items_input(const Ref<InputEvent> &p_event) {
 }
 
 void MeshLibraryEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_THEME_CHANGED) {
-		add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-		remove_item->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
+	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			DocData::ClassDoc *meshlib_docs = EditorHelp::get_doc_data()->class_list.getptr("MeshLibrary");
+			if (meshlib_docs) {
+				for (const DocData::PropertyDoc &prop : meshlib_docs->properties) {
+					inspector->add_custom_property_description("MeshLibraryItem", prop.name.replace_first("item/{index}/", ""), DTR(prop.description));
+				}
+			}
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			remove_item->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
+		} break;
 	}
 }
 
@@ -748,17 +760,6 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	inspector->set_stretch_ratio(0.3);
 	inspector->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	item_split->add_child(inspector);
-
-	inspector->add_custom_property_description("MeshLibraryItem", "name", TTRC("The item's name, shown in the editor. It can also be used to look up the item later using [method MeshLibrary.find_item_by_name]."));
-	inspector->add_custom_property_description("MeshLibraryItem", "category", TTRC("The item's category, used to organize meshes in the [GridMap] editor. A category can include [code]/[/code] as a delimiter to create sub categories."));
-	inspector->add_custom_property_description("MeshLibraryItem", "mesh", TTRC("The item's mesh. Used by other parts of the engine (e.g. [GridMap], which displays them in a 3D tile)."));
-	inspector->add_custom_property_description("MeshLibraryItem", "mesh_transform", TTRC("The transform to apply to the item's mesh."));
-	inspector->add_custom_property_description("MeshLibraryItem", "mesh_cast_shadow", TTRC("The shadow casting mode used by the item's mesh. See [enum RenderingServer.ShadowCastingSetting]."));
-	inspector->add_custom_property_description("MeshLibraryItem", "shapes", TTRC("The item's collision shapes.\nThe array should consist of [Shape3D] objects, each followed by a [Transform3D] that will be applied to it. For shapes that should not have a transform, use [constant Transform3D.IDENTITY]."));
-	inspector->add_custom_property_description("MeshLibraryItem", "navigation_mesh", TTRC("The item's navigation mesh."));
-	inspector->add_custom_property_description("MeshLibraryItem", "navigation_mesh_transform", TTRC("The transform to apply to the item's navigation mesh."));
-	inspector->add_custom_property_description("MeshLibraryItem", "navigation_layers", TTRC("The item's navigation layers bitmask."));
-	inspector->add_custom_property_description("MeshLibraryItem", "preview", TTRC("The texture to use as the item's preview icon in the editor."));
 
 	empty_lib = memnew(Label);
 	empty_lib->set_text(TTRC("No items found inside the MeshLibrary.\nYou can add some by using the Add button on the left, or by importing them from a scene file via the Import menu."));

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -146,30 +146,35 @@ bool PropertyListHelper::is_property_valid(const String &p_property, int *r_inde
 	return property_list.has(components[1]);
 }
 
+void PropertyListHelper::add_properties_for_index(int p_index, List<PropertyInfo> *p_list) const {
+	for (const KeyValue<String, Property> &E : property_list) {
+		const Property &property = E.value;
+		if (property_filter) {
+			Callable::CallError ce;
+			Variant args[] = { property.info.name, p_index };
+			const Variant *argptrs[] = { &args[0], &args[1] };
+
+			bool property_valid = property_filter->call(object, argptrs, 2, ce);
+			if (!property_valid) {
+				continue;
+			}
+		}
+
+		PropertyInfo info = property.info;
+		if (!(info.usage & PROPERTY_USAGE_STORE_IF_NULL) && _call_getter(&property, p_index) == property.default_value) {
+			info.usage &= (~PROPERTY_USAGE_STORAGE);
+		}
+
+		info.name = vformat("%s%d/%s", prefix, p_index, info.name);
+		p_list->push_back(info);
+	}
+}
+
 void PropertyListHelper::get_property_list(List<PropertyInfo> *p_list) const {
+	DEV_ASSERT(array_length_getter);
 	const int property_count = _call_array_length_getter();
 	for (int i = 0; i < property_count; i++) {
-		for (const KeyValue<String, Property> &E : property_list) {
-			const Property &property = E.value;
-			if (property_filter) {
-				Callable::CallError ce;
-				Variant args[] = { property.info.name, i };
-				const Variant *argptrs[] = { &args[0], &args[1] };
-
-				bool property_valid = property_filter->call(object, argptrs, 2, ce);
-				if (!property_valid) {
-					continue;
-				}
-			}
-
-			PropertyInfo info = property.info;
-			if (!(info.usage & PROPERTY_USAGE_STORE_IF_NULL) && _call_getter(&property, i) == property.default_value) {
-				info.usage &= (~PROPERTY_USAGE_STORAGE);
-			}
-
-			info.name = vformat("%s%d/%s", prefix, i, info.name);
-			p_list->push_back(info);
-		}
+		add_properties_for_index(i, p_list);
 	}
 }
 

--- a/scene/property_list_helper.h
+++ b/scene/property_list_helper.h
@@ -89,6 +89,7 @@ public:
 	bool is_initialized() const;
 	void setup_for_instance(const PropertyListHelper &p_base, Object *p_object);
 	bool is_property_valid(const String &p_property, int *r_index = nullptr) const;
+	void add_properties_for_index(int p_index, List<PropertyInfo> *p_list) const;
 
 	void get_property_list(List<PropertyInfo> *p_list) const;
 	bool property_get_value(const String &p_property, Variant &r_ret) const;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -38,135 +38,80 @@
 #include "scene/resources/3d/box_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
-bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
-	String prop_name = p_name;
-
-	if (prop_name.begins_with("item/")) {
-		int idx = prop_name.get_slicec('/', 1).to_int();
-		String what = prop_name.get_slicec('/', 2);
-		if (!item_map.has(idx)) {
-			create_item(idx);
+bool MeshLibrary::_validate_index(int p_idx) {
+	if (unlikely(!item_map.has(p_idx))) {
+		if (!init_property) {
+			ERR_FAIL_V_MSG(false, vformat("Requested for nonexistent MeshLibrary item '%d'.", p_idx));
 		}
-
-		if (what == "name") {
-			set_item_name(idx, p_value);
-		} else if (what == "category") {
-			set_item_category(idx, p_value);
-		} else if (what == "mesh") {
-			set_item_mesh(idx, p_value);
-		} else if (what == "mesh_transform") {
-			set_item_mesh_transform(idx, p_value);
-		} else if (what == "mesh_cast_shadow") {
-			switch ((int)p_value) {
-				case 0: {
-					set_item_mesh_cast_shadow(idx, RSE::ShadowCastingSetting::SHADOW_CASTING_SETTING_OFF);
-				} break;
-				case 1: {
-					set_item_mesh_cast_shadow(idx, RSE::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-				case 2: {
-					set_item_mesh_cast_shadow(idx, RSE::ShadowCastingSetting::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
-				} break;
-				case 3: {
-					set_item_mesh_cast_shadow(idx, RSE::ShadowCastingSetting::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
-				} break;
-				default: {
-					set_item_mesh_cast_shadow(idx, RSE::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-			}
-#ifndef PHYSICS_3D_DISABLED
-		} else if (what == "shape") {
-			Vector<ShapeData> shapes;
-			ShapeData sd;
-			sd.shape = p_value;
-			shapes.push_back(sd);
-			set_item_shapes(idx, shapes);
-		} else if (what == "shapes") {
-			_set_item_shapes(idx, p_value);
-#endif // PHYSICS_3D_DISABLED
-		} else if (what == "preview") {
-			set_item_preview(idx, p_value);
-		} else if (what == "navigation_mesh") {
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navigation_mesh_transform") {
-			set_item_navigation_mesh_transform(idx, p_value);
-#ifndef DISABLE_DEPRECATED
-		} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh_transform(idx, p_value);
-#endif // DISABLE_DEPRECATED
-		} else if (what == "navigation_layers") {
-			set_item_navigation_layers(idx, p_value);
-		} else {
-			return false;
-		}
-	} else {
-		return false;
+		create_item(p_idx);
 	}
 
 	return true;
 }
 
-bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
-	String prop_name = p_name;
+bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
+	init_property = true;
+	if (property_helper.property_set_value(p_name, p_value)) {
+		return true;
+	}
+	init_property = false;
 
-	if (prop_name.begins_with("item/")) {
-		int idx = prop_name.get_slicec('/', 1).to_int();
-		ERR_FAIL_COND_V(!item_map.has(idx), false);
-		String what = prop_name.get_slicec('/', 2);
-
-		if (what == "name") {
-			r_ret = get_item_name(idx);
-		} else if (what == "category") {
-			r_ret = get_item_category(idx);
-		} else if (what == "mesh") {
-			r_ret = get_item_mesh(idx);
-		} else if (what == "mesh_transform") {
-			r_ret = get_item_mesh_transform(idx);
-		} else if (what == "mesh_cast_shadow") {
-			r_ret = (int)get_item_mesh_cast_shadow(idx);
-#ifndef PHYSICS_3D_DISABLED
-		} else if (what == "shapes") {
-			r_ret = _get_item_shapes(idx);
-#endif // PHYSICS_3D_DISABLED
-		} else if (what == "navigation_mesh") {
-			r_ret = get_item_navigation_mesh(idx);
-		} else if (what == "navigation_mesh_transform") {
-			r_ret = get_item_navigation_mesh_transform(idx);
 #ifndef DISABLE_DEPRECATED
-		} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
-			r_ret = get_item_navigation_mesh(idx);
-		} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
-			r_ret = get_item_navigation_mesh_transform(idx);
-#endif // DISABLE_DEPRECATED
-		} else if (what == "navigation_layers") {
-			r_ret = get_item_navigation_layers(idx);
-		} else if (what == "preview") {
-			r_ret = get_item_preview(idx);
-		} else {
-			return false;
-		}
-	} else {
+	const String sname = p_name;
+	if (!sname.begins_with("item/")) {
 		return false;
 	}
 
-	return true;
+	Vector<String> components = sname.split("/", true, 2);
+	if (components.size() < 2 || !components[1].is_valid_int()) {
+		return false;
+	}
+
+	int index = components[1].to_int();
+	if (components[2] == "navmesh") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh(index, p_value);
+		return true;
+	} else if (components[2] == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh_transform(index, p_value);
+		return true;
+	}
+#endif // DISABLE_DEPRECATED
+
+	return false;
+}
+
+bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
+	if (property_helper.property_get_value(p_name, r_ret)) {
+		return true;
+	}
+
+#ifndef DISABLE_DEPRECATED
+	const String sname = p_name;
+	if (!sname.begins_with("item/")) {
+		return false;
+	}
+
+	Vector<String> components = sname.split("/", true, 2);
+	if (components.size() < 2 || !components[1].is_valid_int()) {
+		return false;
+	}
+
+	int index = components[1].to_int();
+	if (components[2] == "navmesh") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh(index);
+		return true;
+	} else if (components[2] == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh_transform(index);
+		return true;
+	}
+#endif // DISABLE_DEPRECATED
+
+	return false;
 }
 
 void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const KeyValue<int, Item> &E : item_map) {
-		String prop_name = vformat("%s/%d/", PNAME("item"), E.key);
-		p_list->push_back(PropertyInfo(Variant::STRING, prop_name + PNAME("name"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::STRING_NAME, prop_name + PNAME("category"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, Mesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION, "", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
+		property_helper.add_properties_for_index(E.key, p_list);
 	}
 }
 
@@ -179,66 +124,76 @@ void MeshLibrary::create_item(int p_item) {
 }
 
 void MeshLibrary::set_item_name(int p_item, const String &p_name) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].name = p_name;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].name = p_name;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_category(int p_item, const StringName &p_category) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].category = p_category;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].category = p_category;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].mesh = p_mesh;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].mesh = p_mesh;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_transform) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].mesh_transform = p_transform;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].mesh_transform = p_transform;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_mesh_cast_shadow(int p_item, RSE::ShadowCastingSetting p_shadow_casting_setting) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].mesh_cast_shadow = p_shadow_casting_setting;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].mesh_cast_shadow = p_shadow_casting_setting;
+		emit_changed();
+	}
 }
 
 #ifndef PHYSICS_3D_DISABLED
 void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].shapes = p_shapes;
-	emit_changed();
-	notify_property_list_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].shapes = p_shapes;
+		emit_changed();
+		notify_property_list_changed();
+	}
 }
 #endif // PHYSICS_3D_DISABLED
 
 void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].navigation_mesh = p_navigation_mesh;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].navigation_mesh = p_navigation_mesh;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].navigation_mesh_transform = p_transform;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].navigation_mesh_transform = p_transform;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_layers) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].navigation_layers = p_navigation_layers;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].navigation_layers = p_navigation_layers;
+		emit_changed();
+	}
 }
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].preview = p_preview;
-	emit_changed();
+	if (_validate_index(p_item)) {
+		item_map[p_item].preview = p_preview;
+		emit_changed();
+	}
 }
 
 String MeshLibrary::get_item_name(int p_item) const {
@@ -427,4 +382,27 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_list"), &MeshLibrary::get_item_list);
 	ClassDB::bind_method(D_METHOD("get_item_count"), &MeshLibrary::get_item_count);
 	ClassDB::bind_method(D_METHOD("get_last_unused_item_id"), &MeshLibrary::get_last_unused_item_id);
+
+	Item defaults;
+
+	base_property_helper.set_prefix("item/");
+	base_property_helper.set_array_length_getter(&MeshLibrary::get_item_count);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), defaults.name, &MeshLibrary::set_item_name, &MeshLibrary::get_item_name);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("category"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), defaults.category, &MeshLibrary::set_item_category, &MeshLibrary::get_item_category);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, Mesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.mesh, &MeshLibrary::set_item_mesh, &MeshLibrary::get_item_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR), defaults.mesh_transform, &MeshLibrary::set_item_mesh_transform, &MeshLibrary::get_item_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only", PROPERTY_USAGE_NO_EDITOR), defaults.mesh_cast_shadow, &MeshLibrary::set_item_mesh_cast_shadow, &MeshLibrary::get_item_mesh_cast_shadow);
+#ifndef PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::ARRAY, PNAME("shapes"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Array(), &MeshLibrary::_set_item_shapes, &MeshLibrary::_get_item_shapes);
+#endif // PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.navigation_mesh, &MeshLibrary::set_item_navigation_mesh, &MeshLibrary::get_item_navigation_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR), defaults.navigation_mesh_transform, &MeshLibrary::set_item_mesh_transform, &MeshLibrary::get_item_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION, "", PROPERTY_USAGE_NO_EDITOR), defaults.navigation_layers, &MeshLibrary::set_item_navigation_layers, &MeshLibrary::get_item_navigation_layers);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.preview, &MeshLibrary::set_item_preview, &MeshLibrary::get_item_preview);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
+}
+
+MeshLibrary::MeshLibrary() {
+	property_helper.setup_for_instance(base_property_helper, this);
+	property_helper.enable_out_of_bounds_assign();
 }

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -32,6 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/rb_map.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/navigation_mesh.h"
 #include "servers/rendering/rendering_server_enums.h"
@@ -43,6 +44,12 @@
 class MeshLibrary : public Resource {
 	GDCLASS(MeshLibrary, Resource);
 	RES_BASE_EXTENSION("meshlib");
+
+	static inline PropertyListHelper base_property_helper;
+	PropertyListHelper property_helper;
+	bool init_property = false;
+
+	bool _validate_index(int p_idx);
 
 public:
 #ifndef PHYSICS_3D_DISABLED
@@ -67,17 +74,21 @@ public:
 		uint32_t navigation_layers = 1;
 	};
 
-	RBMap<int, Item> item_map;
-
+// Version used by scripts.
 #ifndef PHYSICS_3D_DISABLED
 	void _set_item_shapes(int p_item, const Array &p_shapes);
 	Array _get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
 
+private:
+	RBMap<int, Item> item_map;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 
 	virtual void reset_state() override;
 	static void _bind_methods();
@@ -96,6 +107,7 @@ public:
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
+
 	String get_item_name(int p_item) const;
 	StringName get_item_category(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
@@ -119,4 +131,6 @@ public:
 	Vector<int> get_item_list() const;
 	int get_item_count() const { return item_map.size(); }
 	int get_last_unused_item_id() const;
+
+	MeshLibrary();
 };


### PR DESCRIPTION
The main benefit of this is that item properties are now documented in the `MeshLibrary` page.