### PR TITLE
Remove one indent when inserting line after 'return' statement

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1320,6 +1320,7 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 		// Append current indentation.
 		int space_count = 0;
 		int line_col = 0;
+		const String dedent_words[] = { "return", "break", "continue" };
 		for (; line_col < cc; line_col++) {
 			if (line[line_col] == '\t') {
 				ins += indent_text;
@@ -1335,6 +1336,14 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 					space_count = 0;
 				}
 				continue;
+			} else {
+				// The first word on the line was return, either just "return" or "return some_value".
+				for (const String &word : dedent_words) {
+					if (line.substr(line_col, word.length()) == word && (line_col + word.length() == get_line(get_caret_line(i)).length() || line[line_col + word.length()] == ' ')) {
+						ins = ins.trim_suffix(indent_text);
+						break;
+					}
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Makes it so that pressing enter on a line with "return" dedents once (you weren't gonna put unreachable statements at the same indent as return )

~Currently builds on the changes I made in https://github.com/godotengine/godot/pull/117536 (I thought there might be conflicts, but if we only want the "return" commit, I can separate it)~

I ended up rebasing off of master rather than my other PR 

https://github.com/user-attachments/assets/9d7a8f9b-8199-4400-83f2-f3945e5c8f07



