### PR TITLE
[iOS] Fix resource directory path when using `godot_path`.

### DIFF
--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -445,7 +445,11 @@ String OS_AppleEmbedded::get_bundle_resource_dir() const {
 	if (!str) {
 		return OS_Unix::get_bundle_resource_dir();
 	} else {
-		return String::utf8([str cStringUsingEncoding:NSUTF8StringEncoding]);
+		String res_path = String::utf8([str cStringUsingEncoding:NSUTF8StringEncoding]);
+		if (res_path.is_relative_path()) {
+			res_path = String::utf8([[[NSBundle mainBundle] bundlePath] cStringUsingEncoding:NSUTF8StringEncoding]).path_join(res_path);
+		}
+		return res_path;
 	}
 }
 


### PR DESCRIPTION
Fixes issue mentioned in the [comment](https://github.com/godotengine/godot/issues/116139#issuecomment-3974000505) (Note: base issue is not related and not reproducible in current 4.7).

`godot_path` is usually relative to the bundle root, it was resolved correctly while loading resources, but not after project is started, since cwd is changing.