### PR TITLE
Android: Fix ClassCastException in proxy hashCode when ObjectID is returned as Long

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
@@ -107,7 +107,7 @@ class AndroidRuntimePlugin(godot: Godot) : GodotPlugin(godot) {
 					// and provide consistency.
 					"toString" -> "Godot Object Proxy for ${interfaces.joinToString(",")}"
 					"equals" -> proxy == args[0]
-					"hashCode" -> godotObjectID
+					"hashCode" -> godotObjectID.hashCode()
 
 					// Invocation for the remaining interface(s) methods falls here and is dispatched to the
 					// Godot Object.


### PR DESCRIPTION
The proxy `InvocationHandler` in `createProxyFromGodotObjectID` returns `godotObjectID` (a `Long`) for `hashCode`, but `Object.hashCode()` must return `Int`. 
The auto-generated proxy then does `(Integer) result` on a `java.lang.Long` and throws:

```
java.lang.ClassCastException: Couldn't convert result of type long to int at $Proxy3.hashCode(Unknown Source) at java.util.concurrent.ConcurrentHashMap.containsKey(...)
```

Repro: put a proxy returned by `JavaClassWrapper.create_proxy` into any `HashMap` / `ConcurrentHashMap` (or just call 
`.hashCode()` on it). On the Kotlin side this is the natural pattern for tracking per-listener state.

Fix: call `Long.hashCode()` to fold the 64-bit ObjectID into a 32-bit `Int`. The companion `createProxyFromGodotCallable`
already does the equivalent (`godotCallable.hashCode()`), so this just brings the two proxy paths in line.

Affects #115498. Follow-up to #119601.