### PR TITLE
[CODEOWNERS] Update `/drivers/apple*`.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,8 @@
 /drivers/vulkan/                              @godotengine/rendering
 
 ## OS
-/drivers/apple*/                              @godotengine/macos
+/drivers/apple/                               @godotengine/macos @godotengine/ios
+/drivers/apple_embedded/                      @godotengine/ios
 /drivers/unix/                                @godotengine/linux-bsd
 /drivers/windows/                             @godotengine/windows
 


### PR DESCRIPTION
`/drivers/apple/` code is used for both iOS/visionOS and macOS.
`/drivers/apple_embedded/` used only for iOS/visionOS, but not macOS.