### PR TITLE
TextServerFB: Fix zero-width space detection and rendering

### DIFF
--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -4937,7 +4937,8 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 				for (int j = span.end - 1; j >= span.start; j--) {
 					last_non_zero_w = j;
 					uint32_t idx = (int32_t)sd->text[j - sd->start];
-					if (!is_control(idx) && !(idx >= 0x200B && idx <= 0x200D)) {
+					bool zero_w_idx = (sd->preserve_control) ? (idx == 0x200B || idx == 0xFEFF) : ((idx >= 0x200B && idx <= 0x200D) || idx == 0x2060 || idx == 0xFEFF);
+					if (!is_control(idx) && !zero_w_idx) {
 						break;
 					}
 				}
@@ -4952,7 +4953,7 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 				gl.count = 1;
 				gl.font_size = span.font_size;
 				gl.index = (int32_t)sd->text[j - sd->start]; // Use codepoint.
-				bool zw = (gl.index >= 0x200b && gl.index <= 0x200d);
+				bool zw = (sd->preserve_control) ? (gl.index == 0x200B || gl.index == 0xFEFF) : ((gl.index >= 0x200B && gl.index <= 0x200D) || gl.index == 0x2060 || gl.index == 0xFEFF);
 				if (gl.index == 0x0009 || gl.index == 0x000b || zw) {
 					gl.index = 0x0020;
 				}
@@ -5038,6 +5039,10 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
 						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
 					}
+				}
+				if (zw) {
+					gl.index = 0;
+					gl.advance = 0.0;
 				}
 				sd->width += gl.advance;
 				sd->glyphs.push_back(gl);


### PR DESCRIPTION
The fallback text server renders visible spaces in place of zero-width spaces at the end of labels:

* It lacks detection for `0x2060` (⁠WORD JOINER) and `0xFEFF` (ZERO WIDTH NO-BREAK SPACE)
* It did not respect "preserve_control" when detecting these
* It does not hard-reset "advance" after falling back to a regular space for calculations
* It does not hard-reset the glyph index to 0 to not render the glyph at all

This fixes both visible spaces if the font has it, and hex-box glyph fallbacks if the font has no `0x0020` space.

## What problem(s) does this PR solve?

- Closes #119623

## Additional information

* I copied the bugfix of #111014 as I understood it
* I tested manually as described in the reproducer in #119623
* I did use Claude to help me navigate/understand the change and be ready to "defend it"
* Any issue, pr, comment I post is written manually with my human brain
