### PR TITLE
Remove colon from Favorites in FileSystem

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -391,7 +391,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 	// Handles the favorites.
 	favorites_item = tree->create_item(root);
 	favorites_item->set_icon(0, get_editor_theme_icon(SNAME("Favorites")));
-	favorites_item->set_text(0, TTRC("Favorites:"));
+	favorites_item->set_text(0, TTRC("Favorites"));
 	favorites_item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_ALWAYS);
 	favorites_item->set_metadata(0, "Favorites");
 	favorites_item->set_collapsed(!p_uncollapsed_paths.has("Favorites"));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The Favorites "directory" in FileSystem dock had colon for no reason.

## Additional information

|Before|After|
|-|-|
|<img width="329" height="121" alt="image" src="https://github.com/user-attachments/assets/41d3f5c3-e4df-4240-b645-a631e514886f" />|<img width="330" height="126" alt="image" src="https://github.com/user-attachments/assets/2a83ca2f-bfff-4a19-ad7a-8fe0d9c9d82d" />|
