### PR TITLE
[HarfBuzz] Fix typo in 13.0.0-14.1.0 branch.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1473,7 +1473,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 #if HB_VERSION_ATLEAST(14, 2, 0)
 						hb_raster_draw_glyph(p_font_data->hb_mono, fd->hb_handle, (hb_codepoint_t)glyph_index);
 #else
-						hb_raster_draw_glyph(p_font_data->hb_mono, fd->hb_handle, (hb_codepoint_t)glyph_index), 0, 0;
+						hb_raster_draw_glyph(p_font_data->hb_mono, fd->hb_handle, (hb_codepoint_t)glyph_index, 0, 0);
 #endif
 						hb_raster_image_t *img = hb_raster_draw_render(p_font_data->hb_mono);
 						hb_raster_extents_t ext = { 0, 0, 0, 0, 0 };


### PR DESCRIPTION
Fixes wrong bracket placement introduced in https://github.com/godotengine/godot/pull/118785

This code branch is only used when building with specific version range of system HarfBuzz library.