### PR TITLE
[Accessibility] Add methods to set names for the tabs without text. Set item name in the theme editor.

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -42,6 +42,13 @@
 				Returns the previously active tab index.
 			</description>
 		</method>
+		<method name="get_tab_accessibility_name" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the human-readable tab name that is reported to assistive apps.
+			</description>
+		</method>
 		<method name="get_tab_button_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />
@@ -157,6 +164,14 @@
 			<return type="bool" />
 			<description>
 				Selects the first available tab with lower index than the currently selected. Returns [code]true[/code] if tab selection changed.
+			</description>
+		</method>
+		<method name="set_tab_accessibility_name">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Sets the human-readable tab name that is reported to assistive apps.
 			</description>
 		</method>
 		<method name="set_tab_button_icon">
@@ -281,6 +296,9 @@
 		</member>
 		<member name="tab_count" type="int" setter="set_tab_count" getter="get_tab_count" default="0">
 			The number of tabs currently in the bar.
+		</member>
+		<member name="tab_{index}/accessibility_name" type="String" setter="" getter="" default="&quot;&quot;">
+			The human-readable tab name that is reported to assistive apps.
 		</member>
 		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the tab at [code]index[/code] is disabled.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -30,6 +30,13 @@
 				Returns the previously active tab index.
 			</description>
 		</method>
+		<method name="get_tab_accessibility_name" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the human-readable tab name that is reported to assistive apps.
+			</description>
+		</method>
 		<method name="get_tab_bar" qualifiers="const">
 			<return type="TabBar" />
 			<description>
@@ -139,6 +146,14 @@
 				If set on a [Popup] node instance, a popup menu icon appears in the top-right corner of the [TabContainer] (setting it to [code]null[/code] will make it go away). Clicking it will expand the [Popup] node.
 			</description>
 		</method>
+		<method name="set_tab_accessibility_name">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Sets the human-readable tab name that is reported to assistive apps.
+			</description>
+		</method>
 		<method name="set_tab_button_icon">
 			<return type="void" />
 			<param index="0" name="tab_idx" type="int" />
@@ -231,6 +246,9 @@
 		</member>
 		<member name="tab_focus_mode" type="int" setter="set_tab_focus_mode" getter="get_tab_focus_mode" enum="Control.FocusMode" default="2">
 			The focus access mode for the internal [TabBar] node.
+		</member>
+		<member name="tab_{index}/accessibility_name" type="String" setter="" getter="" default="&quot;&quot;">
+			The human-readable tab name that is reported to assistive apps.
 		</member>
 		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the tab at [code]index[/code] is disabled.

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2006,6 +2006,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	HBoxContainer *edit_add_type_hb = memnew(HBoxContainer);
 	edit_dialog_side_vb->add_child(edit_add_type_hb);
 	edit_add_type_value = memnew(LineEdit);
+	edit_add_type_value->set_accessibility_name(TTRC("Add Type"));
 	edit_add_type_value->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	edit_add_type_value->connect(SceneStringName(text_submitted), callable_mp(this, &ThemeItemEditorDialog::_add_theme_type).unbind(1));
 	edit_add_type_hb->add_child(edit_add_type_value);
@@ -2360,6 +2361,7 @@ VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 	LineEdit *item_add_edit = memnew(LineEdit);
 	item_add_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	item_add_hb->add_child(item_add_edit);
+	item_add_edit->set_accessibility_name(TTRC("Item Name"));
 	item_add_edit->connect(SceneStringName(text_submitted), callable_mp(this, &ThemeTypeEditor::_item_add_lineedit_cbk).bind(p_data_type, item_add_edit));
 	Button *item_add_button = memnew(Button);
 	item_add_button->set_text(TTR("Add"));
@@ -2527,6 +2529,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 	item_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	item_name->set_clip_text(true);
 	item_name->set_text(p_item_name);
+	item_name->set_focus_mode(FOCUS_ACCESSIBILITY);
 	// `|` separators used in `EditorHelpBit`.
 	item_name->set_tooltip_text("theme_item|" + edited_type + "|" + p_item_name);
 	item_name->set_mouse_filter(Control::MOUSE_FILTER_STOP);
@@ -2536,6 +2539,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		LineEdit *item_name_edit = memnew(LineEdit);
 		item_name_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 		item_name_edit->set_text(p_item_name);
+		item_name_edit->set_accessibility_name(TTRC("Item Name"));
 		item_name_container->add_child(item_name_edit);
 		item_name_edit->connect(SceneStringName(text_submitted), callable_mp(this, &ThemeTypeEditor::_item_rename_entered).bind(p_data_type, p_item_name, item_name_container));
 		item_name_edit->hide();
@@ -2543,6 +2547,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		Button *item_rename_button = memnew(Button);
 		item_rename_button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 		item_rename_button->set_tooltip_text(TTR("Rename Item"));
+		item_rename_button->set_accessibility_name(vformat(TTRC("Rename Item %s"), p_item_name));
 		item_rename_button->set_flat(true);
 		item_name_container->add_child(item_rename_button);
 		item_rename_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeTypeEditor::_item_rename_cbk).bind(p_data_type, p_item_name, item_name_container));
@@ -2550,6 +2555,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		Button *item_remove_button = memnew(Button);
 		item_remove_button->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
 		item_remove_button->set_tooltip_text(TTR("Remove Item"));
+		item_remove_button->set_accessibility_name(vformat(TTRC("Remove Item %s"), p_item_name));
 		item_remove_button->set_flat(true);
 		item_name_container->add_child(item_remove_button);
 		item_remove_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeTypeEditor::_item_remove_cbk).bind(p_data_type, p_item_name));
@@ -2575,6 +2581,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		Button *item_override_button = memnew(Button);
 		item_override_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		item_override_button->set_tooltip_text(TTR("Override Item"));
+		item_override_button->set_accessibility_name(vformat(TTRC("Override Item %s"), p_item_name));
 		item_override_button->set_flat(true);
 		item_name_container->add_child(item_override_button);
 		item_override_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeTypeEditor::_item_override_cbk).bind(p_data_type, p_item_name));
@@ -2604,6 +2611,7 @@ void ThemeTypeEditor::_update_type_items() {
 		for (const KeyValue<StringName, bool> &E : color_items) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_COLOR, E.key, E.value);
 			ColorPickerButton *item_editor = memnew(ColorPickerButton);
+			item_editor->set_accessibility_name(vformat(TTRC("Color %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_control->add_child(item_editor);
 
@@ -2633,6 +2641,7 @@ void ThemeTypeEditor::_update_type_items() {
 		for (const KeyValue<StringName, bool> &E : constant_items) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_CONSTANT, E.key, E.value);
 			EditorSpinSlider *item_editor = memnew(EditorSpinSlider);
+			item_editor->set_accessibility_name(vformat(TTRC("Constant %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_min(-100000);
 			item_editor->set_max(100000);
@@ -2667,6 +2676,7 @@ void ThemeTypeEditor::_update_type_items() {
 		for (const KeyValue<StringName, bool> &E : font_items) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_FONT, E.key, E.value);
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_accessibility_name(vformat(TTRC("Font %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_base_type("Font");
 			item_editor->set_resource_owner(*edited_theme);
@@ -2707,6 +2717,7 @@ void ThemeTypeEditor::_update_type_items() {
 		for (const KeyValue<StringName, bool> &E : font_size_items) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_FONT_SIZE, E.key, E.value);
 			EditorSpinSlider *item_editor = memnew(EditorSpinSlider);
+			item_editor->set_accessibility_name(vformat(TTRC("Font Size %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_min(-100000);
 			item_editor->set_max(100000);
@@ -2741,6 +2752,7 @@ void ThemeTypeEditor::_update_type_items() {
 		for (const KeyValue<StringName, bool> &E : icon_items) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_ICON, E.key, E.value);
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_accessibility_name(vformat(TTRC("Icon %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_base_type("Texture2D");
 			item_editor->set_resource_owner(*edited_theme);
@@ -2780,6 +2792,7 @@ void ThemeTypeEditor::_update_type_items() {
 		if (leading_stylebox.pinned) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_STYLEBOX, leading_stylebox.item_name, true);
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_accessibility_name(vformat(TTRC("StyleBox %s"), leading_stylebox.item_name));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_stretch_ratio(1.5);
 			item_editor->set_base_type("StyleBox");
@@ -2816,6 +2829,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_STYLEBOX, E.key, E.value);
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
+			item_editor->set_accessibility_name(vformat(TTRC("StyleBox %s"), E.key));
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_stretch_ratio(1.5);
 			item_editor->set_base_type("StyleBox");
@@ -3510,6 +3524,14 @@ void ThemeTypeEditor::_notification(int p_what) {
 			data_type_tabs->set_tab_icon(5, get_editor_theme_icon(SNAME("StyleBoxFlat")));
 			data_type_tabs->set_tab_icon(6, get_editor_theme_icon(SNAME("Tools")));
 
+			data_type_tabs->set_tab_accessibility_name(0, TTRC("Colors"));
+			data_type_tabs->set_tab_accessibility_name(1, TTRC("Constants"));
+			data_type_tabs->set_tab_accessibility_name(2, TTRC("Fonts"));
+			data_type_tabs->set_tab_accessibility_name(3, TTRC("Font Sizes"));
+			data_type_tabs->set_tab_accessibility_name(4, TTRC("Icons"));
+			data_type_tabs->set_tab_accessibility_name(5, TTRC("Styleboxes"));
+			data_type_tabs->set_tab_accessibility_name(6, TTRC("Tools"));
+
 			type_variation_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 	}
@@ -3672,6 +3694,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	type_variation_edit = memnew(LineEdit);
 	type_variation_hb->add_child(type_variation_edit);
 	type_variation_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	type_variation_edit->set_accessibility_name(TTRC("Theme Variation Name"));
 	type_variation_edit->connect(SceneStringName(text_changed), callable_mp(this, &ThemeTypeEditor::_type_variation_changed));
 	type_variation_edit->connect(SceneStringName(focus_exited), callable_mp(this, &ThemeTypeEditor::_update_type_items));
 	type_variation_edit->set_accessibility_name(TTRC("Base Type"));

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -467,7 +467,15 @@ void TabBar::_notification(int p_what) {
 					AccessibilityServer::get_singleton()->update_add_action(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityAction::ACTION_FOCUS, callable_mp(this, &TabBar::_accessibility_action_focus).bind(i));
 
 					AccessibilityServer::get_singleton()->update_set_list_item_index(item.accessibility_item_element, i);
-					AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, atr(item.text));
+					if (!item.ac_name.is_empty()) {
+						AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, atr(item.ac_name));
+					} else if (!item.text.is_empty()) {
+						AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, atr(item.text));
+					} else if (!item.tooltip.is_empty()) {
+						AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, atr(item.tooltip));
+					} else {
+						AccessibilityServer::get_singleton()->update_set_name(item.accessibility_item_element, vformat(atr("Tab %d"), i + 1));
+					}
 					AccessibilityServer::get_singleton()->update_set_list_item_selected(item.accessibility_item_element, i == current);
 					AccessibilityServer::get_singleton()->update_set_flag(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_DISABLED, item.disabled);
 					AccessibilityServer::get_singleton()->update_set_flag(item.accessibility_item_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, item.hidden);
@@ -947,6 +955,23 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 String TabBar::get_tab_title(int p_tab) const {
 	ERR_FAIL_INDEX_V(p_tab, tabs.size(), "");
 	return tabs[p_tab].text;
+}
+
+void TabBar::set_tab_accessibility_name(int p_tab, const String &p_name) {
+	ERR_FAIL_INDEX(p_tab, tabs.size());
+
+	if (tabs[p_tab].ac_name == p_name) {
+		return;
+	}
+
+	tabs.write[p_tab].ac_name = p_name;
+
+	queue_accessibility_update();
+}
+
+String TabBar::get_tab_accessibility_name(int p_tab) const {
+	ERR_FAIL_INDEX_V(p_tab, tabs.size(), "");
+	return tabs[p_tab].ac_name;
 }
 
 void TabBar::set_tab_tooltip(int p_tab, const String &p_tooltip) {
@@ -2165,6 +2190,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("select_next_available"), &TabBar::select_next_available);
 	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabBar::set_tab_title);
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabBar::get_tab_title);
+	ClassDB::bind_method(D_METHOD("set_tab_accessibility_name", "tab_idx", "name"), &TabBar::set_tab_accessibility_name);
+	ClassDB::bind_method(D_METHOD("get_tab_accessibility_name", "tab_idx"), &TabBar::get_tab_accessibility_name);
 	ClassDB::bind_method(D_METHOD("set_tab_tooltip", "tab_idx", "tooltip"), &TabBar::set_tab_tooltip);
 	ClassDB::bind_method(D_METHOD("get_tab_tooltip", "tab_idx"), &TabBar::get_tab_tooltip);
 	ClassDB::bind_method(D_METHOD("set_tab_text_direction", "tab_idx", "direction"), &TabBar::set_tab_text_direction);
@@ -2294,6 +2321,7 @@ void TabBar::_bind_methods() {
 	base_property_helper.set_prefix("tab_");
 	base_property_helper.set_array_length_getter(&TabBar::get_tab_count);
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "title"), defaults.text, &TabBar::set_tab_title, &TabBar::get_tab_title);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, "accessibility_name"), defaults.ac_name, &TabBar::set_tab_accessibility_name, &TabBar::get_tab_accessibility_name);
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "tooltip"), defaults.tooltip, &TabBar::set_tab_tooltip, &TabBar::get_tab_tooltip);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabBar::set_tab_icon, &TabBar::get_tab_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabBar::set_tab_disabled, &TabBar::is_tab_disabled);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -71,6 +71,7 @@ private:
 		Color font_color_overrides[DrawMode::DRAW_MAX] = { Color(0, 0, 0, 0), Color(0, 0, 0, 0), Color(0, 0, 0, 0), Color(0, 0, 0, 0) };
 
 		String text;
+		String ac_name;
 		String tooltip;
 
 		String language;
@@ -232,6 +233,9 @@ public:
 
 	void set_tab_title(int p_tab, const String &p_title);
 	String get_tab_title(int p_tab) const;
+
+	void set_tab_accessibility_name(int p_tab, const String &p_name);
+	String get_tab_accessibility_name(int p_tab) const;
 
 	void set_tab_tooltip(int p_tab, const String &p_tooltip);
 	String get_tab_tooltip(int p_tab) const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -593,6 +593,9 @@ void TabContainer::add_child_notify(Node *p_child) {
 		if (tab.has_title) {
 			set_tab_title(idx, tab.title);
 		}
+		if (tab.has_ac_name) {
+			set_tab_accessibility_name(idx, tab.ac_name);
+		}
 		set_tab_icon(idx, tab.icon);
 		set_tab_disabled(idx, tab.disabled);
 		set_tab_hidden(idx, tab.hidden);
@@ -873,6 +876,27 @@ void TabContainer::set_tab_title(int p_tab, const String &p_title) {
 
 String TabContainer::get_tab_title(int p_tab) const {
 	return tab_bar->get_tab_title(p_tab);
+}
+
+void TabContainer::set_tab_accessibility_name(int p_tab, const String &p_name) {
+	Control *child = get_tab_control(p_tab);
+	if (!child && !is_ready()) {
+		CachedTab &tab = get_pending_tab(p_tab);
+		tab.ac_name = p_name;
+		tab.has_ac_name = true;
+		return;
+	}
+	ERR_FAIL_NULL(child);
+
+	if (tab_bar->get_tab_accessibility_name(p_tab) == p_name) {
+		return;
+	}
+
+	tab_bar->set_tab_accessibility_name(p_tab, p_name);
+}
+
+String TabContainer::get_tab_accessibility_name(int p_tab) const {
+	return tab_bar->get_tab_accessibility_name(p_tab);
 }
 
 void TabContainer::set_tab_tooltip(int p_tab, const String &p_tooltip) {
@@ -1208,6 +1232,8 @@ void TabContainer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabContainer::set_tab_title);
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabContainer::get_tab_title);
+	ClassDB::bind_method(D_METHOD("set_tab_accessibility_name", "tab_idx", "name"), &TabContainer::set_tab_accessibility_name);
+	ClassDB::bind_method(D_METHOD("get_tab_accessibility_name", "tab_idx"), &TabContainer::get_tab_accessibility_name);
 	ClassDB::bind_method(D_METHOD("set_tab_tooltip", "tab_idx", "tooltip"), &TabContainer::set_tab_tooltip);
 	ClassDB::bind_method(D_METHOD("get_tab_tooltip", "tab_idx"), &TabContainer::get_tab_tooltip);
 	ClassDB::bind_method(D_METHOD("set_tab_icon", "tab_idx", "icon"), &TabContainer::set_tab_icon);
@@ -1316,6 +1342,7 @@ void TabContainer::_bind_methods() {
 	base_property_helper.set_prefix("tab_");
 	base_property_helper.set_array_length_getter(&TabContainer::get_tab_count);
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "title"), defaults.title, &TabContainer::set_tab_title, &TabContainer::get_tab_title);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, "accessibility_name"), defaults.ac_name, &TabContainer::set_tab_accessibility_name, &TabContainer::get_tab_accessibility_name);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabContainer::set_tab_icon, &TabContainer::get_tab_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabContainer::set_tab_disabled, &TabContainer::is_tab_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "hidden"), defaults.hidden, &TabContainer::set_tab_hidden, &TabContainer::is_tab_hidden);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -109,6 +109,8 @@ private:
 	struct CachedTab {
 		bool has_title = false;
 		String title;
+		bool has_ac_name = false;
+		String ac_name;
 		Ref<Texture2D> icon;
 		bool disabled = false;
 		bool hidden = false;
@@ -197,6 +199,9 @@ public:
 
 	void set_tab_title(int p_tab, const String &p_title);
 	String get_tab_title(int p_tab) const;
+
+	void set_tab_accessibility_name(int p_tab, const String &p_name);
+	String get_tab_accessibility_name(int p_tab) const;
 
 	void set_tab_tooltip(int p_tab, const String &p_tooltip);
 	String get_tab_tooltip(int p_tab) const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119511