### PR TITLE
Clarify `hash_compare` semantics on `Variant`.

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -825,7 +825,7 @@ public:
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 
-	// By default, performs a semantic comparison. Otherwise, numeric/binary comparison (if appropriate).
+	// Performs a semantic comparison (where NaN == NaN). Falls back to normal equality comparison (OP_EQUAL) when no special handling is needed.
 	bool hash_compare(const Variant &p_variant, int recursion_count = 0, bool semantic_comparison = true) const;
 	bool identity_compare(const Variant &p_variant) const;
 	bool booleanize() const;


### PR DESCRIPTION
> [!NOTE]
> AI DIsclosure: Claude found the difference between the two methods, which I verified myself. I wrote the comment.

## What problem(s) does this PR solve?

Clarifies a comment that left @HolonProduction and me confused - the difference between `hash_compare` and `OP_EQUAL` on `Variant`.
