### PR TITLE
Fix deadlock when `cancel_request()` is called with `use_threads = true` in `HTTPRequest`

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -154,6 +154,7 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_response_headers_as_dictionary"), &HTTPClient::_get_response_headers_as_dictionary);
 	ClassDB::bind_method(D_METHOD("get_response_body_length"), &HTTPClient::get_response_body_length);
 	ClassDB::bind_method(D_METHOD("read_response_body_chunk"), &HTTPClient::read_response_body_chunk);
+	ClassDB::bind_method(D_METHOD("cancel_response_read"), &HTTPClient::cancel_response_read);
 	ClassDB::bind_method(D_METHOD("set_read_chunk_size", "bytes"), &HTTPClient::set_read_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_read_chunk_size"), &HTTPClient::get_read_chunk_size);
 

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -182,6 +182,7 @@ public:
 	virtual int64_t get_response_body_length() const = 0;
 
 	virtual PackedByteArray read_response_body_chunk() = 0; // Can't get body as partial text because of most encodings UTF8, gzip, etc.
+	virtual void cancel_response_read() = 0;
 
 	virtual void set_blocking_mode(bool p_enable) = 0; // Useful mostly if running in a thread
 	virtual bool is_blocking_mode_enabled() const = 0;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -217,6 +217,8 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 	status = STATUS_REQUESTING;
 	head_request = p_method == METHOD_HEAD;
 
+	flag_cancel_read.clear();
+
 	return OK;
 }
 
@@ -469,6 +471,11 @@ Error HTTPClientTCP::poll() {
 				uint8_t byte;
 				int rec = 0;
 				Error err = _get_http_data(&byte, 1, rec);
+				if (err == ERR_SKIP) {
+					close();
+					status = STATUS_DISCONNECTED;
+					return ERR_UNCONFIGURED;
+				}
 				if (err != OK) {
 					close();
 					status = STATUS_CONNECTION_ERROR;
@@ -587,6 +594,9 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 				if (rec == 0) {
 					break;
 				}
+				if (err == ERR_SKIP) {
+					break;
+				}
 
 				chunk.push_back(b);
 				int cs = chunk.size();
@@ -609,6 +619,9 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 				err = _get_http_data(&b, 1, rec);
 
 				if (rec == 0) {
+					break;
+				}
+				if (err == ERR_SKIP) {
 					break;
 				}
 
@@ -658,9 +671,14 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 			} else {
 				int rec = 0;
 				err = _get_http_data(&chunk.write[chunk.size() - chunk_left], chunk_left, rec);
+
 				if (rec == 0) {
 					break;
 				}
+				if (err == ERR_SKIP) {
+					break;
+				}
+
 				chunk_left -= rec;
 
 				if (chunk_left == 0) {
@@ -711,8 +729,8 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 	if (err != OK) {
 		close();
 
-		if (err == ERR_FILE_EOF) {
-			status = STATUS_DISCONNECTED; // Server disconnected.
+		if (err == ERR_FILE_EOF || err == ERR_SKIP) {
+			status = STATUS_DISCONNECTED; // Server disconnected or cancel_response_read() was called.
 		} else {
 			status = STATUS_CONNECTION_ERROR;
 		}
@@ -744,6 +762,9 @@ Error HTTPClientTCP::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_recei
 		int left = p_bytes;
 		r_received = 0;
 		while (left > 0) {
+			if (flag_cancel_read.is_set()) {
+				return ERR_SKIP;
+			}
 			err = connection->get_partial_data(p_buffer + r_received, left, read);
 			if (err == OK) {
 				r_received += read;
@@ -788,6 +809,10 @@ void HTTPClientTCP::set_https_proxy(const String &p_host, int p_port) {
 		https_proxy_host = p_host;
 		https_proxy_port = p_port;
 	}
+}
+
+void HTTPClientTCP::cancel_response_read() {
+	flag_cancel_read.set();
 }
 
 HTTPClientTCP::HTTPClientTCP() {

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -71,6 +71,8 @@ private:
 	Ref<StreamPeer> connection;
 	Ref<HTTPClientTCP> proxy_client; // Negotiate with proxy server.
 
+	SafeFlag flag_cancel_read;
+
 	int response_num = 0;
 	Vector<String> response_headers;
 	// 64 KiB by default (favors fast download speeds at the cost of memory usage).
@@ -94,6 +96,7 @@ public:
 	Error get_response_headers(List<String> *r_response) override;
 	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
+	void cancel_response_read() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;
 	void set_read_chunk_size(int p_size) override;

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -20,6 +20,14 @@
 		<link title="TLS certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
+		<method name="cancel_response_read">
+			<return type="void" />
+			<description>
+				Signals to the worker thread to break out of any read loop currently waiting on data from the peer, in order to unblock it from being stuck in [method read_response_body_chunk]. This method has no effect if blocking mode is disabled (see [member blocking_mode_enabled]).
+				[b]Warning:[/b] As a side effect, this closes the current connection, resulting in [constant STATUS_DISCONNECTED].
+				[b]Note:[/b] This method does nothing on the Web platform.
+			</description>
+		</method>
 		<method name="close">
 			<return type="void" />
 			<description>

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -272,6 +272,10 @@ Error HTTPClientWeb::poll() {
 	return OK;
 }
 
+void HTTPClientWeb::cancel_response_read() {
+	// Do nothing.
+}
+
 HTTPClient *HTTPClientWeb::_create_func(bool p_notify_postinitialize) {
 	return static_cast<HTTPClient *>(ClassDB::creator<HTTPClientWeb>(p_notify_postinitialize));
 }

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -95,6 +95,7 @@ public:
 	Error get_response_headers(List<String> *r_response) override;
 	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
+	void cancel_response_read() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;
 	void set_read_chunk_size(int p_size) override;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -200,6 +200,7 @@ void HTTPRequest::cancel_request() {
 		set_process_internal(false);
 	} else {
 		thread_request_quit.set();
+		client->cancel_response_read();
 		if (thread.is_started()) {
 			thread.wait_to_finish();
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #118666 
- Closes #119782

## Summary of changes

When `HTTPRequest.cancel_request()` is called, it sets a flag in `HTTPClient`, which is checked by the thread that is reading from data from the peer in blocking mode, and if it's set, then it returns, breaking an endless loop. This prevents a deadlock when for example the Ethernet cable is unplugged during the request, and then it is cancelled, which would freeze the main thread.

```
HTTPRequest.cancel_request() -> HTTPClient.cancel_response_read() -> break infinite while loop
```

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119782*