### PR TITLE
Autocompletion: Search get node literals in base class

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3255,21 +3255,26 @@ static bool _get_subscript_type(GDScriptParser::CompletionContext &p_context, co
 
 			switch (identifier_node->source) {
 				case GDScriptParser::IdentifierNode::Source::MEMBER_VARIABLE: {
-					if (p_context.current_class != nullptr) {
-						const StringName &member_name = identifier_node->name;
-						const GDScriptParser::ClassNode *current_class = p_context.current_class;
+					const StringName &member_name = identifier_node->name;
 
-						if (current_class->has_member(member_name)) {
-							const GDScriptParser::ClassNode::Member &member = current_class->get_member(member_name);
+					GDScriptParser::ClassNode *cls = p_context.current_class;
+					for (int cycle_guard = 0; cycle_guard < 10 && cls != nullptr; cycle_guard++) {
+						if (!cls->has_member(member_name)) {
+							cls = cls->base_type.class_type;
+							continue;
+						}
 
-							if (member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
-								const GDScriptParser::VariableNode *variable = static_cast<GDScriptParser::VariableNode *>(member.variable);
+						const GDScriptParser::ClassNode::Member &member = cls->get_member(member_name);
 
-								if (variable->initializer && variable->initializer->type == GDScriptParser::Node::GET_NODE) {
-									get_node = static_cast<GDScriptParser::GetNodeNode *>(variable->initializer);
-								}
+						if (member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
+							const GDScriptParser::VariableNode *variable = static_cast<GDScriptParser::VariableNode *>(member.variable);
+
+							if (variable->initializer && variable->initializer->type == GDScriptParser::Node::GET_NODE) {
+								get_node = static_cast<GDScriptParser::GetNodeNode *>(variable->initializer);
 							}
 						}
+
+						break;
 					}
 				} break;
 				case GDScriptParser::IdentifierNode::Source::LOCAL_VARIABLE: {

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.gd
@@ -1,0 +1,5 @@
+extends "./play_inherited.notest.gd"
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.notest.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inherited.notest.gd
@@ -1,0 +1,3 @@
+extends Node
+
+@onready var anim: AnimationPlayer = $AnimationPlayer


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80601

by also considering the base class when searching for `$GetNode` literals to take into consideration for completion.

Depth is intentionally limited to 10, in order to prevent issues in weird edge cases with partially invalid scripts that contain cyclic inheritance.