### PR TITLE
 Improve AnimationTree issue handling, and clean up.

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -331,7 +331,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 		}
 	}
 
-	bool does_include_invalid_key = false;
 	points.clear();
 	for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
 		float point = blend_space->get_blend_point_position(i);
@@ -356,7 +355,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			Ref<AnimationNodeAnimation> anim_node = node;
 			if (anim_node.is_null()) {
 				is_key_valid = false;
-				does_include_invalid_key = true;
 			}
 		}
 		Vector2 gui_point = (ofs + Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
@@ -377,9 +375,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
-			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
-			: String();
 
 	// blend position
 	{
@@ -775,11 +770,6 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible_in_tree()) {
-				AnimationTreeEditor::get_singleton()->current_playback_error = String();
-			}
 		} break;
 	}
 }

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -630,7 +630,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 		blend_space_draw->draw_primitive(bl_points, colors, Vector<Vector2>());
 	}
 
-	bool does_include_invalid_key = false;
 	points.clear();
 	for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
 		Vector2 point = blend_space->get_blend_point_position(i);
@@ -656,7 +655,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			Ref<AnimationNodeAnimation> anim_node = node;
 			if (anim_node.is_null()) {
 				is_key_valid = false;
-				does_include_invalid_key = true;
 			}
 		}
 		Vector2 gui_point = (ofs + point - icon->get_size() / 2).floor();
@@ -682,9 +680,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
-			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
-			: String();
 
 	if (making_triangle.size()) {
 		Vector<Vector2> bl_points;
@@ -1020,11 +1015,6 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible_in_tree()) {
-				AnimationTreeEditor::get_singleton()->current_playback_error = String();
-			}
 		} break;
 	}
 }

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -1062,10 +1062,8 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 			blend_tree->get_node_connections(&conns);
 			for (const AnimationNodeBlendTree::NodeConnection &E : conns) {
 				float activity = 0;
-				StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
-				if (!tree->is_state_invalid()) {
-					activity = tree->get_connection_activity(path, E.input_index);
-				}
+				StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node + "/";
+				activity = tree->get_connection_activity(path, E.input_index);
 				graph->set_connection_activity(E.output_node, 0, E.input_node, E.input_index, activity);
 			}
 

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -108,12 +108,65 @@ void AnimationTreeEditor::_meta_clicked(Variant p_meta) {
 	}
 }
 
-void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
-	const String editor_error_message = tree->get_editor_error_message();
-	const AHashMap<StringName, AnimationNode::InvalidInstance> &invalid_instances = tree->get_invalid_instances();
+// RAII helper for RichTextLabel push/pop calls.
+struct RTLScope {
+	RichTextLabel *label;
 
-	static String last_error_key;
-	if (editor_error_message.is_empty() && invalid_instances.is_empty() && (!p_other_errors || p_other_errors->is_empty())) {
+	template <typename PushFunc>
+	RTLScope(RichTextLabel *p_label, PushFunc &&p_func) :
+			label(p_label) {
+		std::forward<PushFunc>(p_func)(label);
+	}
+
+	RTLScope(const RTLScope &) = delete;
+	RTLScope &operator=(const RTLScope &) = delete;
+
+	~RTLScope() {
+		label->pop();
+	}
+};
+
+#define CONCAT2(a, b) a##b
+#define CONCAT(a, b) CONCAT2(a, b)
+#define RTL(label, method, ...) \
+	RTLScope CONCAT(_rtl_, __LINE__) { \
+		label, [&](RichTextLabel *__p_label) { \
+			__p_label->method(__VA_ARGS__); \
+		} \
+	}
+
+AHashMap<StringName, LocalVector<AnimationTreeEditor::NodeIssue>> AnimationTreeEditor::_normalize_issues(const AHashMap<StringName, AnimationNode::InvalidInstance> &p_warnings, const AHashMap<StringName, AnimationNode::InvalidInstance> &p_errors) {
+	AHashMap<StringName, LocalVector<NodeIssue>> normalized;
+	HashSet<Pair<StringName, String>> seen_issues; // <node_path+issue_message>
+
+	for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : p_errors) {
+		for (const AnimationNode::InvalidInstance::Issue &issue : kv.value.issues) {
+			const Pair key(kv.key, issue.message + itos(issue.input_index));
+			seen_issues.insert(key);
+			normalized[kv.key].push_back({ issue.message, Severity::ERROR, issue.input_index });
+		}
+	}
+
+	for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : p_warnings) {
+		for (const AnimationNode::InvalidInstance::Issue &issue : kv.value.issues) {
+			const Pair key(kv.key, issue.message + itos(issue.input_index));
+			if (seen_issues.has(key)) {
+				continue;
+			}
+			normalized[kv.key].push_back({ issue.message, Severity::WARNING, issue.input_index });
+		}
+	}
+
+	return normalized;
+}
+
+void AnimationTreeEditor::_update_error_message(const String &p_other_errors) {
+	const String editor_error_message = tree->get_editor_error_message();
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &instance_warnings = tree->get_warning_issues();
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &instance_errors = tree->get_error_issues();
+	AHashMap<StringName, LocalVector<NodeIssue>> invalid_instances = _normalize_issues(instance_warnings, instance_errors);
+
+	if (editor_error_message.is_empty() && invalid_instances.is_empty() && p_other_errors.is_empty()) {
 		last_error_key = String();
 		error_button->hide();
 		error_scroll->hide();
@@ -124,24 +177,7 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 	// Cheaper to do this, than rebuild rich text label every frame.
 	// Though it would be better, to only call this when the tree changes.
 	{
-		StringBuffer k;
-		k += get_base_path();
-		k += editor_error_message;
-		if (p_other_errors) {
-			k += *p_other_errors;
-		}
-		for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
-			k += kv.key;
-			for (const String &reason : kv.value.errors) {
-				k += reason;
-			}
-			for (const AnimationNode::InvalidInstance::InputError &E : kv.value.input_errors) {
-				k += itos(E.index);
-				k += E.error;
-			}
-		}
-
-		String error_key = k.as_string();
+		String error_key = _create_cache_key(invalid_instances, p_other_errors, editor_error_message);
 		if (error_key == last_error_key) {
 			return;
 		}
@@ -165,29 +201,29 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 
 	error_label->clear();
 	int count = 0;
+	Severity max_severity = instance_errors.size() > 0 ? Severity::ERROR : Severity::WARNING;
 	bool scope_error_found = false;
 	StringName fallback_key;
 	StringName downstream_key;
 
 	if (!editor_error_message.is_empty()) {
-		error_label->append_text(editor_error_message);
-		error_label->add_newline();
 		count++;
+		max_severity = Severity::ERROR;
 	}
 
-	if (p_other_errors) {
-		error_label->append_text(*p_other_errors);
+	if (!p_other_errors.is_empty()) {
+		error_label->append_text(p_other_errors);
 		error_label->add_newline();
 		count++;
-
+		max_severity = Severity::ERROR;
 		scope_error_found = true;
 	}
 
-	error_label->push_table(2);
-	for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
+	error_label->push_table(1);
+	for (const KeyValue<StringName, LocalVector<NodeIssue>> &kv : invalid_instances) {
 		Ref<AnimationNode> node = tree->get_animation_node_by_path(kv.key);
 		ERR_CONTINUE(node.is_null());
-		count++;
+		count += kv.value.size();
 		if (!scope_error_found && current_node.is_valid()) {
 			if (fallback_key.is_empty()) {
 				fallback_key = kv.key;
@@ -215,66 +251,127 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 			}
 		}
 
-		error_label->push_cell();
-		error_label->push_color(error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-		error_label->append_text(vformat(RTR("%s at "), node->get_class()));
-		error_label->push_meta(String(kv.key));
-		error_label->append_text(vformat(RTR("'%s':"), kv.key));
-		error_label->pop(); // Meta.
-		error_label->pop(); // Color.
-		error_label->pop(); // Cell.
-
-		error_label->push_cell();
-		error_label->push_color(error_label->get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
-		for (const String &reason : kv.value.errors) {
-			error_label->append_text(reason);
-			error_label->add_newline();
-		}
-
-		const String input_error_base = String(kv.key) + "::";
-		for (const AnimationNode::InvalidInstance::InputError &input_error : kv.value.input_errors) {
-			const String input_name = node->get_input_name(input_error.index);
-			error_label->append_text(input_error.error + " ");
-			error_label->push_meta(input_error_base + itos(input_error.index));
-			error_label->append_text(vformat(RTR("input %d '%s'."), input_error.index, input_name));
-			error_label->pop(); // Meta.
-			error_label->append_text(" ");
-		}
-		error_label->pop(); // Color.
-		error_label->pop(); // Cell.
+		_draw_node_issues(kv, node);
 	}
 	error_label->pop(); // Table.
 
 	current_scope_error_label->clear();
-	if (p_other_errors) {
-		current_scope_error_label->push_color(current_scope_error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-		current_scope_error_label->append_text(TTR("Error: ") + *p_other_errors);
-		current_scope_error_label->pop(); // Color.
+	if (!editor_error_message.is_empty()) {
+		RTL(current_scope_error_label, push_color, styles.error_color);
+		current_scope_error_label->append_text(editor_error_message);
+	} else if (!p_other_errors.is_empty()) {
+		RTL(current_scope_error_label, push_color, styles.error_color);
+		current_scope_error_label->append_text(TTR("Error: ") + p_other_errors);
 	} else {
 		const StringName display_key = scope_error_found ? fallback_key : (!downstream_key.is_empty() ? downstream_key : fallback_key);
 		if (!display_key.is_empty()) {
-			const AnimationNode::InvalidInstance &inst = invalid_instances.get(display_key);
+			const LocalVector<NodeIssue> &issues = invalid_instances.get(display_key);
 			Ref<AnimationNode> node = tree->get_animation_node_by_path(display_key);
-			const String input_error_base = String(display_key) + "::";
-			current_scope_error_label->push_color(current_scope_error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-			current_scope_error_label->append_text(TTR("Error: "));
-			if (!inst.errors.is_empty()) {
-				current_scope_error_label->push_meta(String(display_key));
-				current_scope_error_label->append_text(inst.errors[0]);
-				current_scope_error_label->pop(); // Meta.
-			} else if (!inst.input_errors.is_empty() && node.is_valid()) {
-				current_scope_error_label->push_meta(input_error_base + itos(inst.input_errors[0].index));
-				current_scope_error_label->append_text(inst.input_errors[0].error + " ");
-				current_scope_error_label->append_text(vformat(RTR("input %d '%s'."), inst.input_errors[0].index, node->get_input_name(inst.input_errors[0].index)));
-				current_scope_error_label->pop(); // Meta.
+			if (!issues.is_empty()) {
+				_draw_compact_node_issue(current_scope_error_label, String(display_key), issues[0], node);
 			}
-			current_scope_error_label->pop(); // Color.
 		}
 	}
 
-	error_button->set_text(itos(count));
+	error_button->set_button_icon(styles.get_issue_icon(max_severity));
+	error_button->add_theme_color_override(SceneStringName(font_color), styles.get_issue_color(max_severity));
+	error_button->set_text(_format_issue_count(count));
 	error_button->show();
 }
+
+String AnimationTreeEditor::_create_cache_key(const AHashMap<StringName, LocalVector<NodeIssue>> &p_invalid_instances, const String &p_other_errors, const String &p_editor_error_message) {
+	StringBuffer k;
+	k += get_base_path();
+	k += p_editor_error_message;
+	if (!p_other_errors.is_empty()) {
+		k += p_other_errors;
+	}
+	for (const KeyValue<StringName, LocalVector<NodeIssue>> &kv : p_invalid_instances) {
+		k += kv.key;
+		for (const NodeIssue &issue : kv.value) {
+			k += issue.message;
+			k += itos(static_cast<int>(issue.severity));
+			k += issue.input_index;
+		}
+	}
+
+	return k.as_string();
+}
+
+String AnimationTreeEditor::_format_issue_count(int p_count) const {
+	return vformat(TTRN("%d Issue", "%d Issues", p_count), p_count);
+}
+
+AnimationTreeEditor::Styles AnimationTreeEditor::Styles::load(const Control &control) {
+	return {
+		/*.error_icon =*/(control.get_editor_theme_icon(SNAME("StatusError"))),
+		/*.warning_icon =*/(control.get_editor_theme_icon(SNAME("NodeWarning"))),
+		/*.error_color =*/(control.get_theme_color(SNAME("error_color"), EditorStringName(Editor))),
+		/*.warning_color =*/(control.get_theme_color(SNAME("warning_color"), EditorStringName(Editor))),
+		/*.primary_text_color =*/(control.get_theme_color(SNAME("font_color"), EditorStringName(Editor))),
+		/*.secondary_text_color =*/(control.get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)))
+	};
+}
+
+void AnimationTreeEditor::_draw_node_issues(const KeyValue<StringName, LocalVector<NodeIssue>> &p_instance, const Ref<AnimationNode> &p_node) const {
+	RTL(error_label, push_cell);
+
+	// Header for the affected node.
+	error_label->add_image(EditorNode::get_singleton()->get_class_icon(p_node->get_class(), "Object"));
+	{
+		RTL(error_label, push_color, styles.primary_text_color);
+		error_label->append_text(vformat(RTR(" %s at "), p_node->get_class()));
+		{
+			RTL(error_label, push_meta, String(p_instance.key));
+			error_label->append_text(vformat(RTR("'%s'"), p_instance.key));
+		}
+		{
+			RTL(error_label, push_color, styles.secondary_text_color);
+			error_label->append_text(" (" + _format_issue_count(p_instance.value.size()) + ")");
+		}
+	}
+	error_label->add_newline();
+
+	const String input_error_base = String(p_instance.key) + "::";
+	for (const NodeIssue &issue : p_instance.value) {
+		_draw_node_issue(error_label, input_error_base, issue, p_node);
+	}
+}
+
+void AnimationTreeEditor::_draw_node_issue(RichTextLabel *p_label, const String &p_input_error_base, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const {
+	RTL(p_label, push_color, styles.get_issue_color(p_issue.severity));
+	p_label->append_text("\t");
+	p_label->add_image(styles.get_issue_icon(p_issue.severity));
+
+	p_label->append_text(" " + p_issue.message + " ");
+	_draw_node_issue_input(p_label, p_input_error_base, p_issue, p_node);
+	p_label->add_newline();
+}
+
+void AnimationTreeEditor::_draw_compact_node_issue(RichTextLabel *p_label, const String &p_node_meta, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const {
+	RTL(p_label, push_color, styles.get_issue_color(p_issue.severity));
+	{
+		RTL(p_label, push_meta, p_node_meta);
+		p_label->append_text(p_issue.severity == Severity::ERROR ? TTR("Error: ") : TTR("Warning: "));
+	}
+
+	RTL(p_label, push_meta, p_node_meta);
+	p_label->append_text(p_issue.message + " ");
+	const String input_error_base = String(p_node_meta) + "::";
+	_draw_node_issue_input(p_label, input_error_base, p_issue, p_node);
+}
+
+void AnimationTreeEditor::_draw_node_issue_input(RichTextLabel *p_label, const String &p_input_error_base, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const {
+	if (p_issue.input_index >= 0 && p_node.is_valid()) {
+		int index = p_issue.input_index;
+		RTL(p_label, push_meta, p_input_error_base + itos(index));
+		p_label->append_text(vformat(RTR("input %d '%s'."), index, p_node->get_input_name(index)));
+	}
+}
+
+#undef RTL
+#undef CONCAT
+#undef CONCAT2
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 	if (p_tree && !p_tree->is_connected("animation_list_changed", callable_mp(this, &AnimationTreeEditor::_animation_list_changed))) {
@@ -391,7 +488,7 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 	}
 
 	_update_path();
-	_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
+	_update_error_message(current_playback_error);
 }
 
 void AnimationTreeEditor::_clear_editors() {
@@ -418,16 +515,17 @@ void AnimationTreeEditor::enter_editor(const String &p_path) {
 void AnimationTreeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
+			styles = Styles::load(*this);
 			Ref<StyleBoxEmpty> empty_style;
 			empty_style.instantiate();
 			error_scroll->add_theme_style_override(SceneStringName(panel), empty_style);
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-			error_button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
-			error_button->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), styles.error_color);
 			current_scope_error_label->add_theme_font_override(SNAME("normal_font"), get_theme_font(SNAME("main"), EditorStringName(EditorFonts)));
 			current_scope_error_label->add_theme_font_size_override(SNAME("normal_font_size"), get_theme_font_size(SNAME("main_size"), EditorStringName(EditorFonts)));
-			current_scope_error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			current_scope_error_label->add_theme_color_override(SNAME("default_color"), styles.error_color);
 			current_scope_error_label->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Label")));
+			// Force refresh of error messages to update icons and colors.
+			last_error_key = String();
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -445,7 +543,7 @@ void AnimationTreeEditor::_notification(int p_what) {
 			}
 
 			if (tree) {
-				_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
+				_update_error_message(current_playback_error);
 			}
 		} break;
 
@@ -567,7 +665,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	error_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
 	error_button->hide();
 	error_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationTreeEditor::_toggle_error_panel));
-	error_button->set_tooltip_text(TTRC("Errors"));
+	error_button->set_tooltip_text(TTRC("Issues"));
 	status_bar->add_child(error_button);
 
 	add_plugin(memnew(AnimationNodeBlendTreeEditor));

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -47,9 +47,6 @@ class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
-
-private:
-	String last_error_key;
 };
 
 class AnimationTreeEditor : public EditorDock {
@@ -64,6 +61,37 @@ class AnimationTreeEditor : public EditorDock {
 
 	AnimationTree *tree = nullptr;
 	MarginContainer *editor_base = nullptr;
+	String last_error_key;
+
+	enum class Severity {
+		ERROR,
+		WARNING,
+	};
+
+	struct NodeIssue {
+		String message;
+		Severity severity;
+		int input_index;
+	};
+
+	struct Styles {
+		Ref<Texture2D> error_icon;
+		Ref<Texture2D> warning_icon;
+		Color error_color;
+		Color warning_color;
+		Color primary_text_color;
+		Color secondary_text_color;
+
+		const Ref<Texture2D> &get_issue_icon(const Severity &severity) const {
+			return severity == Severity::ERROR ? error_icon : warning_icon;
+		}
+
+		const Color &get_issue_color(const Severity &severity) const {
+			return severity == Severity::ERROR ? error_color : warning_color;
+		}
+
+		static Styles load(const Control &control);
+	} styles;
 
 	Vector<String> button_path;
 	Vector<String> edited_path;
@@ -77,7 +105,16 @@ class AnimationTreeEditor : public EditorDock {
 	void _animation_list_changed();
 
 	void _toggle_error_panel();
-	void _update_error_message(const String *p_other_errors = nullptr);
+
+	AHashMap<StringName, LocalVector<NodeIssue>> _normalize_issues(const AHashMap<StringName, AnimationNode::InvalidInstance> &p_warnings, const AHashMap<StringName, AnimationNode::InvalidInstance> &p_errors);
+	void _update_error_message(const String &p_other_errors);
+	String _create_cache_key(const AHashMap<StringName, LocalVector<NodeIssue>> &p_invalid_instances, const String &p_other_errors, const String &p_editor_error_message);
+	String _format_issue_count(int p_count) const;
+
+	void _draw_node_issues(const KeyValue<StringName, LocalVector<NodeIssue>> &p_instance, const Ref<AnimationNode> &p_node) const;
+	void _draw_node_issue(RichTextLabel *p_label, const String &p_input_error_base, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const;
+	void _draw_compact_node_issue(RichTextLabel *p_label, const String &p_node_meta, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const;
+	void _draw_node_issue_input(RichTextLabel *p_label, const String &p_input_error_base, const NodeIssue &p_issue, const Ref<AnimationNode> &p_node) const;
 
 	static LocalVector<StringName> get_animation_list();
 

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -34,6 +34,25 @@
 #include "core/object/class_db.h"
 #include "scene/animation/animation_blend_tree.h"
 
+#if TOOLS_ENABLED
+#include "core/config/engine.h"
+
+void AnimationNodeBlendSpace1D::push_issues(AnimationTree *p_tree, const StringName &p_path) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	if (blend_points_used == 0) {
+		p_tree->push_issue(p_path, TTR("No blend points exist, so blending cannot take place."));
+	}
+
+	if (is_contain_invalid_point) {
+		p_tree->push_issue(p_path, TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length."));
+	}
+}
+
+#endif
+
 void AnimationNodeBlendSpace1D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_position));
@@ -74,12 +93,12 @@ void AnimationNodeBlendSpace1D::_animation_node_removed(const ObjectID &p_oid, c
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
-void AnimationNodeBlendSpace1D::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
-	AnimationRootNode::validate_node(p_tree, p_path);
-
-	if (get_blend_point_count() == 0) {
-		add_validation_error(p_tree, p_path, RTR("No blend points exist, so blending cannot take place."));
-	}
+void AnimationNodeBlendSpace1D::prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {
+	AnimationRootNode::prepare(p_tree, p_instance);
+	_check_can_sync();
+#ifdef TOOLS_ENABLED
+	push_issues(p_tree, p_instance.path);
+#endif
 }
 
 void AnimationNodeBlendSpace1D::_bind_methods() {
@@ -424,6 +443,9 @@ void AnimationNodeBlendSpace1D::_check_can_sync() {
 
 AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	if (!blend_points_used || is_contain_invalid_point) {
+#ifdef TOOLS_ENABLED
+		push_issues(p_process_state.tree, p_instance.path);
+#endif
 		return NodeTimeInfo();
 	}
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -35,6 +35,10 @@
 class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace1D, AnimationRootNode);
 
+#ifdef TOOLS_ENABLED
+	void push_issues(AnimationTree *p_tree, const StringName &p_path);
+#endif
+
 public:
 	enum BlendMode {
 		BLEND_MODE_INTERPOLATED,
@@ -100,7 +104,7 @@ protected:
 #endif
 
 public:
-	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) override;
 
 	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -36,6 +36,31 @@
 #include "core/object/class_db.h"
 #include "scene/animation/animation_blend_tree.h"
 
+#ifdef TOOLS_ENABLED
+#include "core/config/engine.h"
+
+void AnimationNodeBlendSpace2D::push_issues(AnimationTree *p_tree, const StringName &p_path) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	if (blend_mode == BLEND_MODE_INTERPOLATED) {
+		if (get_triangle_count() == 0) {
+			p_tree->push_issue(p_path, TTR("No triangles exist, so blending cannot take place."));
+		}
+	} else {
+		if (blend_points_used == 0) {
+			p_tree->push_issue(p_path, TTR("No blend points exist, so blending cannot take place."));
+		}
+	}
+
+	if (is_contain_invalid_point) {
+		p_tree->push_issue(p_path, TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length."));
+	}
+}
+
+#endif
+
 void AnimationNodeBlendSpace2D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::VECTOR2, blend_position));
@@ -572,6 +597,9 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_
 	_update_triangles();
 
 	if (!blend_points_used || is_contain_invalid_point) {
+#ifdef TOOLS_ENABLED
+		push_issues(p_process_state.tree, p_instance.path);
+#endif
 		return NodeTimeInfo();
 	}
 
@@ -838,13 +866,14 @@ void AnimationNodeBlendSpace2D::_animation_node_removed(const ObjectID &p_oid, c
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }
 
-void AnimationNodeBlendSpace2D::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
-	AnimationRootNode::validate_node(p_tree, p_path);
+void AnimationNodeBlendSpace2D::prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {
+	AnimationRootNode::prepare(p_tree, p_instance);
 
-	const_cast<AnimationNodeBlendSpace2D *>(this)->_update_triangles();
-	if (get_triangle_count() == 0) {
-		add_validation_error(p_tree, p_path, RTR("No triangles exist, so blending cannot take place."));
-	}
+	_check_can_sync();
+	_update_triangles();
+#ifdef TOOLS_ENABLED
+	push_issues(p_tree, p_instance.path);
+#endif
 }
 
 void AnimationNodeBlendSpace2D::_bind_methods() {

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -35,6 +35,10 @@
 class AnimationNodeBlendSpace2D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace2D, AnimationRootNode);
 
+#ifdef TOOLS_ENABLED
+	void push_issues(AnimationTree *p_tree, const StringName &p_path);
+#endif
+
 public:
 	enum BlendMode {
 		BLEND_MODE_INTERPOLATED,
@@ -115,7 +119,7 @@ protected:
 #endif
 
 public:
-	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) override;
 
 	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -35,6 +35,16 @@
 #include "core/object/class_db.h"
 #include "scene/resources/animation.h"
 
+#ifdef TOOLS_ENABLED
+void AnimationNodeAnimation::push_issues(AnimationTree *p_tree, const StringName &p_path) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	p_tree->push_issue(p_path, vformat(TTR("Animation '%s' not found."), animation));
+}
+#endif
+
 void AnimationNodeAnimation::set_animation(const StringName &p_name) {
 	if (animation == p_name) {
 		return;
@@ -53,13 +63,14 @@ StringName AnimationNodeAnimation::get_animation() const {
 
 LocalVector<StringName> (*AnimationNodeAnimation::get_editable_animation_list)() = nullptr;
 
-void AnimationNodeAnimation::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
-	AnimationRootNode::validate_node(p_tree, p_path);
-
-	const Ref<Animation> &animation_resource = p_tree->get_animation_or_null(animation);
-	if (animation_resource.is_null()) {
-		add_validation_error(p_tree, p_path, vformat(RTR("Animation '%s' not found."), animation));
+void AnimationNodeAnimation::prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {
+	AnimationRootNode::prepare(p_tree, p_instance);
+	_update_animation_cache(p_tree, p_instance);
+#ifdef TOOLS_ENABLED
+	if (p_instance.cached_animation.is_null()) {
+		push_issues(p_tree, p_instance.path);
 	}
+#endif
 }
 
 void AnimationNodeAnimation::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
@@ -102,8 +113,12 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const 
 AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	_update_animation_cache(p_process_state.tree, p_instance);
 	const Ref<Animation> &anim = p_instance.cached_animation;
-	// Should not ever happen due to validation earlier.
-	ERR_FAIL_COND_V(anim.is_null(), NodeTimeInfo());
+	if (unlikely(anim.is_null())) {
+#ifdef TOOLS_ENABLED
+		push_issues(p_process_state.tree, p_instance.path);
+#endif
+		return NodeTimeInfo();
+	}
 	double anim_size = anim->get_length();
 
 	double cur_len;
@@ -395,18 +410,12 @@ void AnimationNodeAnimation::_bind_methods() {
 	BIND_ENUM_CONSTANT(PLAY_MODE_BACKWARD);
 }
 
-void AnimationNodeAnimation::_update_animation_cache(AnimationTree *p_tree, AnimationNodeInstance &p_instance) const {
+void AnimationNodeAnimation::_update_animation_cache(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) const {
 	if (p_instance.cached_animation_version == animation_version) {
 		return;
 	}
 
-	const Ref<Animation> &anim = p_tree->get_animation_or_null(animation);
-	if (anim.is_null()) {
-		// I don't think this can even occur with validation now.
-		return;
-	}
-
-	p_instance.cached_animation = anim;
+	p_instance.cached_animation = p_tree->get_animation_or_null(animation);
 	p_instance.cached_animation_version = animation_version;
 }
 
@@ -1828,33 +1837,39 @@ void AnimationNodeBlendTree::reset_state() {
 	emit_signal(SNAME("tree_changed"));
 }
 
-void AnimationNodeBlendTree::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
-	AnimationRootNode::validate_node(p_tree, p_path);
+void AnimationNodeBlendTree::prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {
+	AnimationNode::prepare(p_tree, p_instance);
 
-	// Validate output connection.
-	{
-		const LocalVector<StringName> *output_connections = get_node_connection_array(SceneStringName(output));
-		const StringName &node_name = output_connections->operator[](0);
+	LocalVector<Pair<const StringName *, const Node *>> stack;
+	const StringName &output_name = SceneStringName(output);
+	const Node *output_node = nodes.getptr(output_name);
+	CRASH_COND(output_node == nullptr);
+	stack.push_back(Pair<const StringName *, const Node *>(&output_name, output_node));
 
-		if (const Node *child_node = nodes.getptr(node_name); !child_node) {
-			add_validation_error(p_tree, String(p_path) + SceneStringName(output) + "/", RTR("Nothing connected to output."));
-		}
-	}
+	while (!stack.is_empty()) {
+		const Pair<const StringName *, const Node *> c = stack[stack.size() - 1];
+		stack.remove_at(stack.size() - 1);
 
-	// Rest of children.
-	for (const KeyValue<StringName, Node> &E : nodes) {
-		const Node &child = E.value;
+		const StringName &current_name = *c.first;
+		const Node &current = *c.second;
+		const AnimationNodeInstance &instance = p_instance.get_child_instance_by_path(current_name);
 
-		// Skip output node, already validated.
-		if (E.key == SceneStringName(output)) {
-			continue;
-		}
+		instance.resource->prepare(p_tree, instance);
 
-		for (uint32_t input = 0; input < child.connections.size(); input++) {
-			const StringName &connected_node_name = child.connections[input];
-			if (const Node *connected_to = nodes.getptr(connected_node_name); !connected_to) {
-				StringName path = String(p_path) + String(E.key) + "/";
-				add_validation_error(p_tree, path, "Nothing connected to", input);
+		instance.connection_instances.clear();
+		instance.connection_instances.resize(current.connections.size());
+		for (uint32_t input = 0; input < current.connections.size(); input++) {
+			const StringName &connected_node_name = current.connections[input];
+			const Node *connected_node = nodes.getptr(connected_node_name);
+
+			if (!connected_node) {
+				instance.connection_instances[input] = nullptr;
+#ifdef TOOLS_ENABLED
+				push_blend_input_issue(p_tree, instance.path, input);
+#endif
+			} else {
+				instance.connection_instances[input] = &p_instance.get_child_instance_by_path(connected_node_name);
+				stack.push_back(Pair(&connected_node_name, connected_node));
 			}
 		}
 	}

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -36,6 +36,10 @@
 class AnimationNodeAnimation : public AnimationRootNode {
 	GDCLASS(AnimationNodeAnimation, AnimationRootNode);
 
+#ifdef TOOLS_ENABLED
+	void push_issues(AnimationTree *p_tree, const StringName &p_path);
+#endif
+
 	StringName backward = "backward"; // Only used by pingpong animation.
 
 	StringName animation;
@@ -55,7 +59,7 @@ public:
 		PLAY_MODE_BACKWARD
 	};
 
-	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) override;
 
 	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
@@ -104,7 +108,7 @@ protected:
 private:
 	PlayMode play_mode = PLAY_MODE_FORWARD;
 
-	void _update_animation_cache(AnimationTree *p_tree, AnimationNodeInstance &p_instance) const;
+	void _update_animation_cache(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) const;
 };
 
 VARIANT_ENUM_CAST(AnimationNodeAnimation::PlayMode)
@@ -444,7 +448,7 @@ public:
 		//no need to check for cycles due to tree topology
 	};
 
-	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) override;
 
 	void add_node(const StringName &p_name, const Ref<AnimationNode> &p_node, const Vector2 &p_position = Vector2());
 	Ref<AnimationNode> get_node(const StringName &p_name) const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -34,7 +34,6 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
-#include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
 
 thread_local AnimationNode::ProcessState *AnimationNode::tls_process_state = nullptr;
@@ -120,16 +119,15 @@ AnimationNode::NodeTimeInfo AnimationNode::_pre_process(ProcessState &p_process_
 	return nti;
 }
 
-void AnimationNode::add_validation_error(const AnimationTree *p_tree, const StringName &p_path, const String &p_error, int p_input_index) const {
-	p_tree->_add_validation_error(p_path, p_error, p_input_index);
-}
+#ifdef TOOLS_ENABLED
+void AnimationNode::push_blend_input_issue(AnimationTree *p_tree, const StringName &p_path, int p_input_index) {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
 
-void AnimationNode::make_invalid(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const String &p_reason) {
-	p_process_state.valid = false;
-
-	InvalidInstance &invalid_instance = p_process_state.invalid_instances[p_instance.path];
-	invalid_instance.errors.push_back(p_reason);
+	p_tree->push_issue(p_path, TTR("Nothing connected to"), p_input_index);
 }
+#endif
 
 AnimationNode::NodeTimeInfo AnimationNode::blend_input(ProcessState &p_process_state, AnimationNodeInstance &p_instance, int p_input, const AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
 	ERR_FAIL_INDEX_V(p_input, (int64_t)inputs.size(), NodeTimeInfo());
@@ -138,9 +136,13 @@ AnimationNode::NodeTimeInfo AnimationNode::blend_input(ProcessState &p_process_s
 	if (likely(p_instance.connection_instances.size() > 0)) {
 		node_instance = p_instance.connection_instances[p_input];
 	}
-	// Should not ever happen due to validation earlier.
-	ERR_FAIL_NULL_V(node_instance, NodeTimeInfo());
 
+	if (unlikely(!node_instance)) {
+#ifdef TOOLS_ENABLED
+		push_blend_input_issue(p_process_state.tree, p_instance.path, p_input);
+#endif
+		return NodeTimeInfo();
+	}
 	real_t activity = 0.0;
 
 	NodeTimeInfo nti = _blend_node(p_process_state, p_instance, *node_instance, p_playback_info, p_filter, p_sync, p_test_only, &activity);
@@ -589,6 +591,14 @@ AnimationNode::AnimationNode() {
 
 ////////////////////
 
+void AnimationRootNode::prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {
+	AnimationNode::prepare(p_tree, p_instance);
+
+	for (const KeyValue<StringName, AnimationNodeInstance *> &E : p_instance.child_instances) {
+		E.value->resource->prepare(p_tree, *E.value);
+	}
+}
+
 void AnimationRootNode::_add_node(const Ref<AnimationNode> &p_node) {
 	p_node->connect(SNAME("tree_changed"), callable_mp(this, &AnimationRootNode::_tree_changed), CONNECT_REFERENCE_COUNTED);
 	p_node->connect(SNAME("node_updated"), callable_mp(this, &AnimationRootNode::_node_updated), CONNECT_REFERENCE_COUNTED);
@@ -650,21 +660,17 @@ Ref<AnimationRootNode> AnimationTree::get_root_animation_node() const {
 bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
 	_update_properties(); // If properties need updating, update them.
 
-	bool was_validation_dirty = validation_dirty;
-	if (validation_dirty) {
-		process_state.invalid_instances.clear();
-		validation_successful = true;
-		_validate_animation_graph(Animation::PARAMETERS_BASE_PATH, root_animation_node);
-		validation_dirty = false;
-	}
-	if (!validation_successful) {
+	if (root_animation_node.is_null()) {
 		return false;
-	}
-	if (was_validation_dirty) {
-		_update_connections();
 	}
 
 	AnimationNodeInstance &instance = get_node_instance_by_path(SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data()));
+
+	if (nodes_dirty) {
+		preparation_warnings.clear();
+		root_animation_node->prepare(this, instance);
+		nodes_dirty = false;
+	}
 
 	{ // Setup.
 		process_pass++;
@@ -675,7 +681,6 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 		// Init process state.
 		process_state = AnimationNode::ProcessState();
 		process_state.tree = this;
-		process_state.valid = true;
 		process_state.invalid_instances.clear();
 		process_state.last_pass = process_pass;
 		process_state.track_map = &p_track_map;
@@ -709,10 +714,11 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 		AnimationNode::tls_process_state = &process_state;
 		root_animation_node->_pre_process(process_state, instance, pi, false);
 		AnimationNode::tls_process_state = nullptr;
-	}
-
-	if (!process_state.valid) {
-		return false; // State is not valid, abort process.
+#ifdef TOOLS_ENABLED
+		if (process_state.invalid_instances.size() > 0) {
+			update_configuration_warnings();
+		}
+#endif
 	}
 
 	return true;
@@ -731,19 +737,27 @@ NodePath AnimationTree::get_advance_expression_base_node() const {
 	return advance_expression_base_node;
 }
 
-bool AnimationTree::is_state_invalid() const {
-	return !process_state.valid;
+#ifdef TOOLS_ENABLED
+void AnimationTree::push_issue(const StringName &p_path, const String &p_message, int p_input_index) {
+	// when tls_process_state is present, it implies the tree is processing.
+	if (AnimationNode::tls_process_state) {
+		process_state.invalid_instances[p_path].issues.push_back({ p_message, p_input_index });
+	} else {
+		preparation_warnings[p_path].issues.push_back({ p_message, p_input_index });
+	}
 }
-
-const AHashMap<StringName, AnimationNode::InvalidInstance> &AnimationTree::get_invalid_instances() const {
-	return process_state.invalid_instances;
-}
+#endif
 
 PackedStringArray AnimationTree::get_configuration_warnings() const {
 	PackedStringArray warnings = AnimationMixer::get_configuration_warnings();
 	if (root_animation_node.is_null()) {
 		warnings.push_back(RTR("No root AnimationNode for the graph is set."));
 	}
+#ifdef TOOLS_ENABLED
+	else if (!process_state.invalid_instances.is_empty()) {
+		warnings.push_back(RTR("The AnimationTree contains errors, check the dock for more details."));
+	}
+#endif
 	return warnings;
 }
 
@@ -761,7 +775,7 @@ void AnimationTree::_node_updated(const ObjectID &p_oid) {
 	// or a connection in AnimationNodeBlendTree changes.
 
 	// Ideally, we would only validate relevant instances, but for now, revalidate all.
-	validation_dirty = true;
+	nodes_dirty = true;
 }
 
 void AnimationTree::_animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) {
@@ -864,7 +878,7 @@ void AnimationTree::_update_properties() const {
 	}
 
 	// if properties are dirty, so is the validation state.
-	validation_dirty = true;
+	nodes_dirty = true;
 	properties.clear();
 	instance_map.clear();
 	instance_paths.clear();
@@ -908,69 +922,6 @@ void AnimationTree::_update_properties() const {
 	properties_dirty = false;
 
 	const_cast<AnimationTree *>(this)->notify_property_list_changed();
-}
-
-void AnimationTree::_validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const {
-	if (p_node.is_null()) {
-		validation_successful = false;
-		return;
-	}
-
-	p_node->validate_node(this, p_path);
-	// We will continue even if the validation is not successful, to gather all errors.
-
-	LocalVector<AnimationNode::ChildNode> children;
-	p_node->get_child_nodes(&children);
-
-	for (const AnimationNode::ChildNode &E : children) {
-		const StringName child_path = String(p_path) + E.name + "/";
-		_validate_animation_graph(child_path, E.node);
-	}
-}
-
-void AnimationTree::_update_connections() {
-	for (KeyValue<StringName, AnimationNodeInstance> &E : instance_map) {
-		AnimationNodeInstance &parent_instance = E.value;
-
-		const AnimationNodeBlendTree *blend_tree = Object::cast_to<AnimationNodeBlendTree>(parent_instance.resource.ptr());
-
-		if (!blend_tree) {
-			continue;
-		}
-
-		{
-			const LocalVector<StringName> *output_connections = blend_tree->get_node_connection_array(SceneStringName(output));
-			parent_instance.connection_instances.resize(1);
-			AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(output_connections->operator[](0));
-			parent_instance.connection_instances[0] = connected_instance;
-			CRASH_COND(!connected_instance); // Will never happen.
-		}
-
-		for (const KeyValue<StringName, AnimationNodeInstance *> &kv : parent_instance.child_instances) {
-			AnimationNodeInstance *child_instance = kv.value;
-			const LocalVector<StringName> &child_connections = *blend_tree->get_node_connection_array(kv.key);
-			child_instance->connection_instances.clear();
-			child_instance->connection_instances.resize(child_connections.size());
-			for (uint32_t input = 0; input < child_connections.size(); input++) {
-				const StringName &connected_node_name = child_connections[input];
-				AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(connected_node_name);
-				child_instance->connection_instances[input] = connected_instance;
-				CRASH_COND(!connected_instance); // Will never happen.
-			}
-		}
-	}
-}
-
-void AnimationTree::_add_validation_error(const StringName &p_path, const String &p_error, int p_input_index) const {
-	validation_successful = false;
-
-	AnimationNode::InvalidInstance &invalid_instance = process_state.invalid_instances[p_path];
-
-	if (p_input_index == -1) {
-		invalid_instance.errors.push_back(p_error);
-	} else {
-		invalid_instance.input_errors.push_back({ p_input_index, p_error });
-	}
 }
 
 void AnimationTree::_notification(int p_what) {

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -100,14 +100,12 @@ public:
 	};
 
 	struct InvalidInstance {
-		LocalVector<String> errors;
-
-		struct InputError {
-			int index;
-			String error;
+		struct Issue {
+			String message;
+			int input_index;
 		};
 
-		LocalVector<InputError> input_errors;
+		LocalVector<Issue> issues;
 	};
 
 	// Temporary state for blending process which needs to be started in the AnimationTree, pass through the AnimationNodes, and then return to the AnimationTree.
@@ -116,7 +114,6 @@ public:
 		const AHashMap<NodePath, int> *track_map; // TODO: Is there a better way to manage filter/tracks?
 		bool track_map_updated = false;
 		bool is_testing = false;
-		bool valid = false;
 		mutable AHashMap<StringName, InvalidInstance> invalid_instances;
 		uint64_t last_pass = 0;
 	};
@@ -136,13 +133,19 @@ public:
 
 	friend class AnimationNodeBlendTree;
 
-	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const {}
+	// Called when the animation graph needs to refresh cached state, or update issues.
+	// For performance reasons, this should only be invoked when there is a change.
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) {}
 	// The time information is passed from upstream to downstream by AnimationMixer::PlaybackInfo::p_playback_info until AnimationNodeAnimation processes it.
 	// Conversely, AnimationNodeAnimation returns the processed result as NodeTimeInfo from downstream to upstream.
 	NodeTimeInfo _blend_node(ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeInstance &p_other, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false, real_t *r_activity = nullptr);
 	NodeTimeInfo _pre_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false);
 
 protected:
+#ifdef TOOLS_ENABLED
+	void push_blend_input_issue(AnimationTree *p_tree, const StringName &p_path, int p_input_index);
+#endif
+
 	StringName current_length = "current_length";
 	StringName current_position = "current_position";
 	StringName current_delta = "current_delta";
@@ -162,9 +165,6 @@ protected:
 	void blend_animation_ex(const StringName &p_animation, double p_time, double p_delta, bool p_seeked, bool p_is_external_seeking, real_t p_blend, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE);
 	double blend_node_ex(const StringName &p_sub_path, const Ref<AnimationNode> &p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
 	double blend_input_ex(int p_input, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
-
-	void add_validation_error(const AnimationTree *p_tree, const StringName &p_path, const String &p_error, int p_input_index = -1) const;
-	void make_invalid(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const String &p_reason);
 
 	static void _bind_methods();
 
@@ -237,6 +237,9 @@ VARIANT_ENUM_CAST(AnimationNode::FilterAction)
 class AnimationRootNode : public AnimationNode {
 	GDCLASS(AnimationRootNode, AnimationNode);
 
+public:
+	virtual void prepare(AnimationTree *p_tree, const AnimationNodeInstance &p_instance) override;
+
 protected:
 	void _add_node(const Ref<AnimationNode> &p_node);
 	void _remove_node(const Ref<AnimationNode> &p_node);
@@ -289,9 +292,9 @@ struct AnimationNodeInstance {
 	LocalVector<Activity> input_activity;
 #endif
 
-	// Cache for AnimationNodeAnimation
-	Ref<Animation> cached_animation;
-	uint32_t cached_animation_version = 0;
+	// Cache for AnimationNodeAnimation (Nullable)
+	mutable Ref<Animation> cached_animation;
+	mutable uint32_t cached_animation_version = 0;
 
 	// Macro to define all slots.
 	// slot index, enum name, member name, variant type, native type
@@ -421,7 +424,7 @@ struct AnimationNodeInstance {
 		return instance;
 	}
 
-	_FORCE_INLINE_ AnimationNodeInstance &get_child_instance_by_path(const StringName &p_path) {
+	_FORCE_INLINE_ AnimationNodeInstance &get_child_instance_by_path(const StringName &p_path) const {
 		AnimationNodeInstance **instance_ptr = child_instances.getptr(p_path);
 		CRASH_COND_MSG(!instance_ptr, "No child instance found for path: \"" + String(p_path) + "\".");
 		AnimationNodeInstance *instance = *instance_ptr;
@@ -446,6 +449,9 @@ private:
 	Ref<AnimationRootNode> root_animation_node;
 	NodePath advance_expression_base_node = NodePath(String("."));
 
+	// Preparation issues are stored separately from process state issues
+	// so warnings persist between process frames.
+	mutable AHashMap<StringName, AnimationNode::InvalidInstance> preparation_warnings;
 	AnimationNode::ProcessState process_state;
 	uint64_t process_pass = 1;
 	uint64_t last_track_map_version = 0;
@@ -460,13 +466,9 @@ private:
 	mutable AHashMap<ObjectID, HashSet<StringName>> instance_paths;
 
 	mutable bool properties_dirty = true;
-	mutable bool validation_dirty = true;
-	mutable bool validation_successful = false;
+	mutable bool nodes_dirty = true;
 
 	void _update_properties() const;
-	void _validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const;
-	void _update_connections();
-	void _add_validation_error(const StringName &p_path, const String &p_error, int p_input_index = -1) const;
 	void _update_properties_for_node(const StringName &p_base_path, const Ref<AnimationNode> &p_node) const;
 
 	void _tree_changed();
@@ -544,8 +546,17 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
-	bool is_state_invalid() const;
-	const AHashMap<StringName, AnimationNode::InvalidInstance> &get_invalid_instances() const;
+#ifdef TOOLS_ENABLED
+	void push_issue(const StringName &p_path, const String &p_message, int p_input_index = -1);
+
+public:
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &get_warning_issues() const {
+		return preparation_warnings;
+	}
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &get_error_issues() const {
+		return process_state.invalid_instances;
+	}
+#endif
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/119341

This PR makes `AnimationTree` validation less strict in cases where an issue does not necessarily affect playback.

Previously, some errors were reported even when the affected node or input was not actually used in the active path (in `AnimationNodeBlendTree`). This would cause the whole `AnimationTree` to be considered invalid too eagerly.


## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->


`AnimationNodeBlendTree` now only prepares/checks nodes that are connected to the output path, instead of every child node in the blend tree.
- This means disconnected nodes are no longer considered in warnings or errors.

Missing input connections in `AnimationNodeBlendTree` are now reported as warnings during preparation.
- If an invalid input is in the active blend path during runtime, the warning is promoted to an error.

`animation_not_set` issue in `AnimationNodeAnimation` will only error at runtime.

Other notable changes:
- Introduced `AnimationNode::Issue`
- `AnimationTree::_update_connections` has been removed in favour of a single pass in `AnimationNodeBlendTree::prepare`.
- `AnimationTreeEditor` has been cleaned up, and updated to support warnings.