### PR TITLE
[Buildsystem] Add flag to select x86_64 target ISA extensions.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -165,6 +165,18 @@ opts.Add(
     )
 )
 opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectures, architecture_aliases, ignorecase=2))
+# On 64-bit x86, enable SSE 4.2 and prior instruction sets (SSE3/SSSE3/SSE4/SSE4.1) to improve performance.
+# This is supported on most CPUs released after 2009-2011 (Intel Nehalem, AMD Bulldozer).
+# AVX and AVX2 aren't enabled because they aren't available on more recent low-end Intel CPUs.
+opts.Add(
+    EnumVariable(
+        "extension",
+        "CPU architecture extension (x86_64 architecture only)",
+        "sse42",
+        ["sse2", "sse42", "avx", "avx2", "avx512"],
+        ignorecase=2,
+    )
+)
 opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
 opts.Add(
     EnumVariable(
@@ -794,15 +806,35 @@ elif env.msvc:
 
 # Set x86 CPU instruction sets to use by the compiler's autovectorization.
 if env["arch"] == "x86_64":
-    # On 64-bit x86, enable SSE 4.2 and prior instruction sets (SSE3/SSSE3/SSE4/SSE4.1) to improve performance.
-    # This is supported on most CPUs released after 2009-2011 (Intel Nehalem, AMD Bulldozer).
-    # AVX and AVX2 aren't enabled because they aren't available on more recent low-end Intel CPUs.
     if env.msvc and not methods.using_clang(env):
-        # https://stackoverflow.com/questions/64053597/how-do-i-enable-sse4-1-and-sse3-but-not-avx-in-msvc/69328426
-        env.Append(CCFLAGS=["/d2archSSE42"])
+        if env["extension"] == "sse42":
+            env.Append(CCFLAGS=["/arch:SSE4.2"])
+            env.Append(CPPDEFINES=["GODOT_SSE42"])
+        elif env["extension"] == "avx":
+            env.Append(CCFLAGS=["/arch:AVX"])
+            env.Append(CPPDEFINES=["GODOT_AVX"])
+        elif env["extension"] == "avx2":
+            env.Append(CCFLAGS=["/arch:AVX2"])
+            env.Append(CPPDEFINES=["GODOT_AVX2"])
+        elif env["extension"] == "avx512":
+            env.Append(CCFLAGS=["/arch:AVX512"])
+            env.Append(CPPDEFINES=["GODOT_AVX512"])
     else:
         # `-msse2` is implied when compiling for x86_64.
-        env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
+        if env["extension"] == "sse42":
+            env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
+            env.Append(CPPDEFINES=["GODOT_SSE42"])
+        elif env["extension"] == "avx":
+            env.Append(CCFLAGS=["-mavx"])
+            env.Append(CPPDEFINES=["GODOT_AVX"])
+        elif env["extension"] == "avx2":
+            env.Append(CCFLAGS=["-mavx2", "-mfma", "-mf16c", "-mlzcnt", "-mbmi", "-mbmi2"])
+            env.Append(CPPDEFINES=["GODOT_AVX2"])
+        elif env["extension"] == "avx512":
+            env.Append(
+                CCFLAGS=["-mavx512f", "-mavx512dq", "-mavx512vl", "-mfma", "-mf16c", "-mlzcnt", "-mbmi", "-mbmi2"]
+            )
+            env.Append(CPPDEFINES=["GODOT_AVX512"])
 elif env["arch"] == "x86_32":
     # Be more conservative with instruction sets on 32-bit x86 to improve compatibility.
     # SSE and SSE2 are present on all CPUs that support 64-bit, even if running a 32-bit OS.

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -24,6 +24,46 @@ env_etcpak.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_etcpak.Clone()
 env_thirdparty.disable_warnings()
+
+if env["arch"] == "x86_64" and env["extension"] == "sse42" and env.msvc:
+    env_thirdparty.Append(CPPDEFINES=["__SSE3__", "__SSSE3__", "__SSE4_1__", "__SSE4_2__"])
+
+if env["arch"] == "x86_64" and env["extension"] == "avx" and env.msvc:
+    env_thirdparty.Append(CPPDEFINES=["__SSE3__", "__SSSE3__", "__SSE4_1__", "__SSE4_2__", "__AVX__"])
+
+if env["arch"] == "x86_64" and env["extension"] == "avx2" and env.msvc:
+    env_thirdparty.Append(
+        CPPDEFINES=[
+            "__SSE3__",
+            "__SSSE3__",
+            "__SSE4_1__",
+            "__SSE4_2__",
+            "__AVX__",
+            "__AVX2__",
+            "__F16C__",
+            "__FMA__",
+            "__BMI2__",
+        ]
+    )
+
+if env["arch"] == "x86_64" and env["extension"] == "avx512" and env.msvc:
+    env_thirdparty.Append(
+        CPPDEFINES=[
+            "__SSE3__",
+            "__SSSE3__",
+            "__SSE4_1__",
+            "__SSE4_2__",
+            "__AVX__",
+            "__AVX2__",
+            "__F16C__",
+            "__FMA__",
+            "__BMI2__",
+            "__AVX512F__",
+            "__AVX512DQ__",
+            "__AVX512VL__",
+        ]
+    )
+
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj
 

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -60,10 +60,42 @@ if env["builtin_embree"]:
         "kernels/bvh/bvh_intersector_hybrid4_bvh4.cpp",
     ]
 
+    if env["arch"] == "x86_64" and (
+        env["extension"] == "avx" or env["extension"] == "avx2" or env["extension"] == "avx512"
+    ):
+        embree_src += [
+            "kernels/geometry/primitive8.cpp",
+            "kernels/bvh/bvh_intersector1_bvh8.cpp",
+            "kernels/bvh/bvh_intersector_hybrid4_bvh8.cpp",
+            "kernels/bvh/bvh_intersector_hybrid8_bvh4.cpp",
+            "kernels/bvh/bvh_intersector_hybrid8_bvh8.cpp",
+        ]
+
+    if env["arch"] == "x86_64" and env["extension"] == "avx512":
+        embree_src += [
+            "kernels/bvh/bvh_intersector_hybrid16_bvh4.cpp",
+            "kernels/bvh/bvh_intersector_hybrid16_bvh8.cpp",
+        ]
+
     thirdparty_sources = [thirdparty_dir + file for file in embree_src]
 
     env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
-    env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
+    if env["arch"] == "x86_64":
+        if env["extension"] == "sse42":
+            env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE42"])
+        elif env["extension"] == "avx":
+            env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_AVX"])
+        elif env["extension"] == "avx2":
+            env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_AVX2"])
+        elif env["extension"] == "avx512":
+            env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_AVX512"])
+        else:
+            env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2"])
+    else:
+        env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2"])
+
+    env_raycast.Append(CPPDEFINES=["EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
+
     env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 
     if env["platform"] == "windows":
@@ -88,8 +120,44 @@ if env["builtin_embree"]:
         # Embree needs those; it will automatically use SSE2NEON in ARM.
         env_thirdparty.Append(CPPDEFINES=["__SSE__", "__SSE2__"])
 
-    if env["arch"] == "x86_64" and env.msvc:
+    if env["arch"] == "x86_64" and env["extension"] == "sse42" and env.msvc:
         env_thirdparty.Append(CPPDEFINES=["__SSE3__", "__SSSE3__", "__SSE4_1__", "__SSE4_2__"])
+
+    if env["arch"] == "x86_64" and env["extension"] == "avx" and env.msvc:
+        env_thirdparty.Append(CPPDEFINES=["__SSE3__", "__SSSE3__", "__SSE4_1__", "__SSE4_2__", "__AVX__"])
+
+    if env["arch"] == "x86_64" and env["extension"] == "avx2" and env.msvc:
+        env_thirdparty.Append(
+            CPPDEFINES=[
+                "__SSE3__",
+                "__SSSE3__",
+                "__SSE4_1__",
+                "__SSE4_2__",
+                "__AVX__",
+                "__AVX2__",
+                "__F16C__",
+                "__FMA__",
+                "__BMI2__",
+            ]
+        )
+
+    if env["arch"] == "x86_64" and env["extension"] == "avx512" and env.msvc:
+        env_thirdparty.Append(
+            CPPDEFINES=[
+                "__SSE3__",
+                "__SSSE3__",
+                "__SSE4_1__",
+                "__SSE4_2__",
+                "__AVX__",
+                "__AVX2__",
+                "__F16C__",
+                "__FMA__",
+                "__BMI2__",
+                "__AVX512F__",
+                "__AVX512DQ__",
+                "__AVX512VL__",
+            ]
+        )
 
     if env["platform"] == "web":
         env_thirdparty.Append(CXXFLAGS=["-msimd128"])

--- a/modules/raycast/godot_update_embree.py
+++ b/modules/raycast/godot_update_embree.py
@@ -56,6 +56,7 @@ cpp_files = [
     "kernels/common/geometry.cpp",
     "kernels/common/scene_triangle_mesh.cpp",
     "kernels/geometry/primitive4.cpp",
+    "kernels/geometry/primitive8.cpp",
     "kernels/builders/primrefgen.cpp",
     "kernels/bvh/bvh.cpp",
     "kernels/bvh/bvh_statistics.cpp",
@@ -72,7 +73,13 @@ cpp_files = [
     "kernels/bvh/bvh_builder_twolevel.cpp",
     "kernels/bvh/bvh_intersector1.cpp",
     "kernels/bvh/bvh_intersector1_bvh4.cpp",
+    "kernels/bvh/bvh_intersector1_bvh8.cpp",
     "kernels/bvh/bvh_intersector_hybrid4_bvh4.cpp",
+    "kernels/bvh/bvh_intersector_hybrid4_bvh8.cpp",
+    "kernels/bvh/bvh_intersector_hybrid8_bvh4.cpp",
+    "kernels/bvh/bvh_intersector_hybrid8_bvh8.cpp",
+    "kernels/bvh/bvh_intersector_hybrid16_bvh4.cpp",
+    "kernels/bvh/bvh_intersector_hybrid16_bvh8.cpp",
     "kernels/bvh/bvh_intersector_hybrid.cpp",
 ]
 

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -14,6 +14,34 @@ common_linuxbsd = [
 ]
 
 if env["library_type"] == "executable":
+    env_cpp_check = env.Clone()
+    env_cpp_check.add_source_files(common_linuxbsd, ["cpu_feature_validation.c"])
+    if "-msse4.2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-msse4.2")
+    if "-mpopcnt" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mpopcnt")
+    if "-mavx" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx")
+    if "-mavx2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx2")
+    if "-mfma" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mfma")
+    if "-mf16c" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mf16c")
+    if "-mlzcnt" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mlzcnt")
+    if "-mbmi" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mbmi")
+    if "-mbmi2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mbmi2")
+    if "-mavx512f" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512f")
+    if "-mavx512dq" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512dq")
+    if "-mavx512vl" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512vl")
+
+if env["library_type"] == "executable":
     common_linuxbsd += ["godot_linuxbsd.cpp"]
 else:
     common_linuxbsd += ["libgodot_linuxbsd.cpp"]

--- a/platform/linuxbsd/cpu_feature_validation.c
+++ b/platform/linuxbsd/cpu_feature_validation.c
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include <windows.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-#ifdef _MSC_VER
-#include <intrin.h> // For builtin __cpuid/__cpuidex.
-#else
+#if defined(__x86_64) || defined(__x86_64__)
 void __cpuid(int *r_cpuinfo, int p_info) {
 	// Note: Some compilers have a buggy `__cpuid` intrinsic, using inline assembly (based on LLVM-20 implementation) instead.
 	__asm__ __volatile__(
@@ -52,7 +52,6 @@ void __cpuidex(int *r_cpuinfo, int p_info, int p_count) {
 			: "=a"(r_cpuinfo[0]), "=r"(r_cpuinfo[1]), "=c"(r_cpuinfo[2]), "=d"(r_cpuinfo[3])
 			: "0"(p_info), "2"(p_count));
 }
-#endif
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -60,20 +59,20 @@ void __cpuidex(int *r_cpuinfo, int p_info, int p_count) {
 #endif
 
 #define ARCH_EXT_ERROR(m_ext) \
-	MessageBoxW(NULL, L"A CPU with " _STR(m_ext) " instruction set support is required.", L"Godot Engine", MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
+	printf("A CPU with " _STR(m_ext) " instruction set support is required.\n"); \
+	int ret = system("zenity --warning --title \"Godot Engine\" --text \"A CPU with " _STR(m_ext) " instruction set support is required.\" 2> /dev/null"); \
+	if (ret != 0) { \
+		ret = system("kdialog --title \"Godot Engine\" --sorry \"A CPU with " _STR(m_ext) " instruction set support is required.\" 2> /dev/null"); \
+	} \
+	if (ret != 0) { \
+		ret = system("Xdialog --title \"Godot Engine\" --msgbox \"A CPU with " _STR(m_ext) " instruction set support is required.\" 0 0 2> /dev/null"); \
+	} \
+	if (ret != 0) { \
+		ret = system("xmessage -center -title \"Godot Engine\" \"A CPU with " _STR(m_ext) " instruction set support is required.\" 2> /dev/null"); \
+	}
 
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-extern int WINAPI mainCRTStartup();
-#else
-extern int WINAPI WinMainCRTStartup();
-#endif
-
-#if defined(__GNUC__) || defined(__clang__)
-extern int WINAPI ShimMainCRTStartup() __attribute__((used));
-#endif
-
-extern int WINAPI ShimMainCRTStartup() {
-	BOOL cpuid_supported = FALSE;
+__attribute__((constructor)) void cpu_validation_shim() {
+	bool cpuid_supported = false;
 
 #if defined(GODOT_SSE42)
 	int cpuinfo[4];
@@ -96,7 +95,7 @@ extern int WINAPI ShimMainCRTStartup() {
 	__cpuidex(cpuinfo, 0x07, 0x00);
 	cpuid_supported = cpuid_supported && (cpuinfo[1] & (1 << 16)) && (cpuinfo[1] & (1 << 17)) && (cpuinfo[1] & (1 << 31)) && (cpuinfo[1] & (1 << 3)) && (cpuinfo[1] & (1 << 8)); // AVX512-F + AVX512-DQ + AVX512-VL + BMI + BMI2
 #else
-	cpuid_supported = TRUE;
+	cpuid_supported = true;
 #endif
 
 	if (!cpuid_supported) {
@@ -109,12 +108,7 @@ extern int WINAPI ShimMainCRTStartup() {
 #elif defined(GODOT_AVX512)
 		ARCH_EXT_ERROR("AVX512");
 #endif
-		return -1;
-	} else {
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-		return mainCRTStartup();
-#else
-		return WinMainCRTStartup();
-#endif
+		abort();
 	}
 }
+#endif

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -43,18 +43,6 @@
 #include <sys/resource.h>
 #endif
 
-#if defined(__x86_64) || defined(__x86_64__)
-void __cpuid(int *r_cpuinfo, int p_info) {
-	// Note: Some compilers have a buggy `__cpuid` intrinsic, using inline assembly (based on LLVM-20 implementation) instead.
-	__asm__ __volatile__(
-			"xchgq %%rbx, %q1;"
-			"cpuid;"
-			"xchgq %%rbx, %q1;"
-			: "=a"(r_cpuinfo[0]), "=r"(r_cpuinfo[1]), "=c"(r_cpuinfo[2]), "=d"(r_cpuinfo[3])
-			: "0"(p_info));
-}
-#endif
-
 // For export templates, add a section; the exporter will patch it to enclose
 // the data appended to the executable (bundled PCK).
 #if !defined(TOOLS_ENABLED) && defined(__GNUC__)
@@ -68,27 +56,6 @@ extern "C" const char *pck_section_dummy_call() {
 #endif
 
 int main(int argc, char *argv[]) {
-#if defined(__x86_64) || defined(__x86_64__)
-	int cpuinfo[4];
-	__cpuid(cpuinfo, 0x01);
-
-	if (!(cpuinfo[2] & (1 << 20))) {
-		printf("A CPU with SSE4.2 instruction set support is required.\n");
-
-		int ret = system("zenity --warning --title \"Godot Engine\" --text \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		if (ret != 0) {
-			ret = system("kdialog --title \"Godot Engine\" --sorry \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		}
-		if (ret != 0) {
-			ret = system("Xdialog --title \"Godot Engine\" --msgbox \"A CPU with SSE4.2 instruction set support is required.\" 0 0 2> /dev/null");
-		}
-		if (ret != 0) {
-			ret = system("xmessage -center -title \"Godot Engine\" \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		}
-		abort();
-	}
-#endif
-
 #if defined(ASAN_ENABLED)
 	// Note: Set stack size to be at least 30 MB (vs 8 MB default) to avoid overflow, address sanitizer can increase stack usage up to 3 times.
 	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -30,6 +30,34 @@ files = [
     "godot_progress_view.mm",
 ]
 
+if env["library_type"] == "executable":
+    env_cpp_check = env.Clone()
+    env_cpp_check.add_source_files(files, ["cpu_feature_validation.c"])
+    if "-msse4.2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-msse4.2")
+    if "-mpopcnt" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mpopcnt")
+    if "-mavx" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx")
+    if "-mavx2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx2")
+    if "-mfma" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mfma")
+    if "-mf16c" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mf16c")
+    if "-mlzcnt" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mlzcnt")
+    if "-mbmi" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mbmi")
+    if "-mbmi2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mbmi2")
+    if "-mavx512f" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512f")
+    if "-mavx512dq" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512dq")
+    if "-mavx512vl" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mavx512vl")
+
 if env["angle"]:
     files += ["gl_manager_macos_angle.mm"]
 

--- a/platform/macos/cpu_feature_validation.c
+++ b/platform/macos/cpu_feature_validation.c
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include <windows.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-#ifdef _MSC_VER
-#include <intrin.h> // For builtin __cpuid/__cpuidex.
-#else
+#if defined(__x86_64) || defined(__x86_64__)
 void __cpuid(int *r_cpuinfo, int p_info) {
 	// Note: Some compilers have a buggy `__cpuid` intrinsic, using inline assembly (based on LLVM-20 implementation) instead.
 	__asm__ __volatile__(
@@ -52,7 +52,6 @@ void __cpuidex(int *r_cpuinfo, int p_info, int p_count) {
 			: "=a"(r_cpuinfo[0]), "=r"(r_cpuinfo[1]), "=c"(r_cpuinfo[2]), "=d"(r_cpuinfo[3])
 			: "0"(p_info), "2"(p_count));
 }
-#endif
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -60,20 +59,11 @@ void __cpuidex(int *r_cpuinfo, int p_info, int p_count) {
 #endif
 
 #define ARCH_EXT_ERROR(m_ext) \
-	MessageBoxW(NULL, L"A CPU with " _STR(m_ext) " instruction set support is required.", L"Godot Engine", MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
+	printf("A CPU with " _STR(m_ext) " instruction set support is required.\n"); \
+	system("osascript -e \"display alert \\\"Godot Engine\\\" message \\\"A CPU with " _STR(m_ext) " instruction set support is required.\\\"\"");
 
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-extern int WINAPI mainCRTStartup();
-#else
-extern int WINAPI WinMainCRTStartup();
-#endif
-
-#if defined(__GNUC__) || defined(__clang__)
-extern int WINAPI ShimMainCRTStartup() __attribute__((used));
-#endif
-
-extern int WINAPI ShimMainCRTStartup() {
-	BOOL cpuid_supported = FALSE;
+__attribute__((constructor)) void cpu_validation_shim() {
+	bool cpuid_supported = false;
 
 #if defined(GODOT_SSE42)
 	int cpuinfo[4];
@@ -96,7 +86,7 @@ extern int WINAPI ShimMainCRTStartup() {
 	__cpuidex(cpuinfo, 0x07, 0x00);
 	cpuid_supported = cpuid_supported && (cpuinfo[1] & (1 << 16)) && (cpuinfo[1] & (1 << 17)) && (cpuinfo[1] & (1 << 31)) && (cpuinfo[1] & (1 << 3)) && (cpuinfo[1] & (1 << 8)); // AVX512-F + AVX512-DQ + AVX512-VL + BMI + BMI2
 #else
-	cpuid_supported = TRUE;
+	cpuid_supported = true;
 #endif
 
 	if (!cpuid_supported) {
@@ -109,12 +99,7 @@ extern int WINAPI ShimMainCRTStartup() {
 #elif defined(GODOT_AVX512)
 		ARCH_EXT_ERROR("AVX512");
 #endif
-		return -1;
-	} else {
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-		return mainCRTStartup();
-#else
-		return WinMainCRTStartup();
-#endif
+		abort();
 	}
 }
+#endif

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -48,12 +48,40 @@ if env["arch"] == "x86_64" and env["library_type"] == "executable":
     env_cpp_check = env.Clone()
     env_cpp_check.add_source_files(sources, ["cpu_feature_validation.c"])
     if env.msvc:
-        if "/d2archSSE42" in env_cpp_check["CCFLAGS"]:
-            env_cpp_check["CCFLAGS"].remove("/d2archSSE42")
+        if "/arch:SSE4.2" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("/arch:SSE4.2")
+        if "/arch:AVX" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("/arch:AVX")
+        if "/arch:AVX2" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("/arch:AVX2")
+        if "/arch:AVX512" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("/arch:AVX512")
         env.Append(LINKFLAGS=["/ENTRY:ShimMainCRTStartup"])
     else:
         if "-msse4.2" in env_cpp_check["CCFLAGS"]:
             env_cpp_check["CCFLAGS"].remove("-msse4.2")
+        if "-mpopcnt" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mpopcnt")
+        if "-mavx" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mavx")
+        if "-mavx2" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mavx2")
+        if "-mfma" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mfma")
+        if "-mf16c" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mf16c")
+        if "-mlzcnt" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mlzcnt")
+        if "-mbmi" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mbmi")
+        if "-mbmi2" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mbmi2")
+        if "-mavx512f" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mavx512f")
+        if "-mavx512dq" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mavx512dq")
+        if "-mavx512vl" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mavx512vl")
         env.Append(LINKFLAGS=["-Wl,--entry=ShimMainCRTStartup"])
 
 

--- a/thirdparty/embree/kernels/bvh/bvh_intersector1_bvh8.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector1_bvh8.cpp
@@ -1,0 +1,60 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector1.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH8Intersector1 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR1(BVH8OBBVirtualCurveIntersector1,BVHNIntersector1<8 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersector1 >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR1(BVH8OBBVirtualCurveIntersector1MB,BVHNIntersector1<8 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersector1 >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR1(BVH8OBBVirtualCurveIntersectorRobust1,BVHNIntersector1<8 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersector1 >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR1(BVH8OBBVirtualCurveIntersectorRobust1MB,BVHNIntersector1<8 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersector1 >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4Intersector1Moeller,  BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<TriangleMIntersector1Moeller  <4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4iIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<TriangleMiIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4vIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersector1<TriangleMvIntersector1Pluecker<4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4iIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersector1<TriangleMiIntersector1Pluecker<4 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4vIntersector1Woop,  BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<TriangleMvIntersector1Woop  <4 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4vMBIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<TriangleMvMBIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4iMBIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<TriangleMiMBIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4vMBIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersector1<TriangleMvMBIntersector1Pluecker<4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(BVH8Triangle4iMBIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersector1<TriangleMiMBIntersector1Pluecker<4 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4vIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<QuadMvIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4iIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<QuadMiIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4vIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersector1<QuadMvIntersector1Pluecker<4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4iIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersector1<QuadMiIntersector1Pluecker<4 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4iMBIntersector1Moeller, BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<QuadMiMBIntersector1Moeller <4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(BVH8Quad4iMBIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersector1<QuadMiMBIntersector1Pluecker<4 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(QBVH8Triangle4iIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_QN1 COMMA false COMMA ArrayIntersector1<TriangleMiIntersector1Pluecker<4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR1(QBVH8Triangle4Intersector1Moeller,BVHNIntersector1<8 COMMA BVH_QN1 COMMA false COMMA ArrayIntersector1<TriangleMIntersector1Moeller  <4 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR1(QBVH8Quad4iIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_QN1 COMMA false COMMA ArrayIntersector1<QuadMiIntersector1Pluecker<4 COMMA true> > >));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR1(BVH8VirtualIntersector1,BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<ObjectIntersector1<false>> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR1(BVH8VirtualMBIntersector1,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<ObjectIntersector1<true>> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR1(BVH8InstanceIntersector1,BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<InstanceIntersector1> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR1(BVH8InstanceMBIntersector1,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<InstanceIntersector1MB> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR1(BVH8InstanceArrayIntersector1,BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersector1<InstanceArrayIntersector1> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR1(BVH8InstanceArrayMBIntersector1,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersector1<InstanceArrayIntersector1MB> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR1(BVH8GridIntersector1Moeller,BVHNIntersector1<8 COMMA BVH_AN1 COMMA false COMMA SubGridIntersector1Moeller<8 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR1(BVH8GridMBIntersector1Moeller,BVHNIntersector1<8 COMMA BVH_AN2_AN4D COMMA true COMMA SubGridMBIntersector1Pluecker<8 COMMA true> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR1(BVH8GridIntersector1Pluecker,BVHNIntersector1<8 COMMA BVH_AN1 COMMA true COMMA SubGridIntersector1Pluecker<8 COMMA true> >));
+
+  }
+}

--- a/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid16_bvh4.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid16_bvh4.cpp
@@ -1,0 +1,58 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector_hybrid.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH4Intersector16 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4Intersector16HybridMoeller,         BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMIntersectorKMoeller  <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4Intersector16HybridMoellerNoFilter, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMIntersectorKMoeller  <4 COMMA 16 COMMA false> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4iIntersector16HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMiIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4vIntersector16HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMvIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4iIntersector16HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMiIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4vMBIntersector16HybridMoeller,  BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMvMBIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4iMBIntersector16HybridMoeller,  BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMiMBIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4vMBIntersector16HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMvMBIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH4Triangle4iMBIntersector16HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMiMBIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4vIntersector16HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4vIntersector16HybridMoellerNoFilter,BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKMoeller <4 COMMA 16 COMMA false> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4iIntersector16HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMiIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4vIntersector16HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4iIntersector16HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMiIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4iMBIntersector16HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMiMBIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH4Quad4iMBIntersector16HybridPluecker,BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMiMBIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH4OBBVirtualCurveIntersector16Hybrid, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersectorK<16> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH4OBBVirtualCurveIntersector16HybridMB,BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersectorK<16> >));
+ 
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH4OBBVirtualCurveIntersectorRobust16Hybrid, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersectorK<16> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH4OBBVirtualCurveIntersectorRobust16HybridMB,BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersectorK<16> >));
+ 
+    IF_ENABLED_SUBDIV(DEFINE_INTERSECTOR16(BVH4SubdivPatch1Intersector16, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true COMMA SubdivPatch1Intersector16>));
+    IF_ENABLED_SUBDIV(DEFINE_INTERSECTOR16(BVH4SubdivPatch1MBIntersector16, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA SubdivPatch1MBIntersector16>));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR16(BVH4VirtualIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA ObjectIntersector16> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR16(BVH4VirtualMBIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA ObjectIntersector16MB> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR16(BVH4InstanceIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceIntersectorK<16>> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR16(BVH4InstanceMBIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceIntersectorKMB<16>> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR16(BVH4InstanceArrayIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceArrayIntersectorK<16>> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR16(BVH4InstanceArrayMBIntersector16Chunk, BVHNIntersectorKChunk<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceArrayIntersectorKMB<16>> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR16(BVH4GridIntersector16HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA false COMMA SubGridIntersectorKMoeller <4 COMMA 16 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR16(BVH4GridMBIntersector16HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN2_AN4D COMMA true COMMA SubGridMBIntersectorKPluecker <4 COMMA 16 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR16(BVH4GridIntersector16HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 16 COMMA BVH_AN1 COMMA true COMMA SubGridIntersectorKPluecker <4 COMMA 16 COMMA true> >));
+
+  }
+}
+

--- a/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid16_bvh8.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid16_bvh8.cpp
@@ -1,0 +1,54 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector_hybrid.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH8Intersector16 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4Intersector16HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMIntersectorKMoeller  <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4Intersector16HybridMoellerNoFilter,BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMIntersectorKMoeller  <4 COMMA 16 COMMA false> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4iIntersector16HybridMoeller,       BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMiIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4vIntersector16HybridPluecker,      BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMvIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4iIntersector16HybridPluecker,      BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMiIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4vMBIntersector16HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMvMBIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4iMBIntersector16HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA TriangleMiMBIntersectorKMoeller <4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4vMBIntersector16HybridPluecker,BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMvMBIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR16(BVH8Triangle4iMBIntersector16HybridPluecker,BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA TriangleMiMBIntersectorKPluecker<4 COMMA 16 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4vIntersector16HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4vIntersector16HybridMoellerNoFilter,BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKMoeller <4 COMMA 16 COMMA false> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4iIntersector16HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMiIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4vIntersector16HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMvIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4iIntersector16HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMiIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4iMBIntersector16HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA QuadMiMBIntersectorKMoeller <4 COMMA 16 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR16(BVH8Quad4iMBIntersector16HybridPluecker,BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<16 COMMA QuadMiMBIntersectorKPluecker<4 COMMA 16 COMMA true > > >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH8OBBVirtualCurveIntersector16Hybrid, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersectorK<16> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH8OBBVirtualCurveIntersector16HybridMB, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersectorK<16> >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH8OBBVirtualCurveIntersectorRobust16Hybrid, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersectorK<16> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR16(BVH8OBBVirtualCurveIntersectorRobust16HybridMB, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersectorK<16> >));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR16(BVH8VirtualIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA ObjectIntersector16> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR16(BVH8VirtualMBIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA ObjectIntersector16MB> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR16(BVH8InstanceIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceIntersectorK<16>> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR16(BVH8InstanceMBIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceIntersectorKMB<16>> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR16(BVH8InstanceArrayIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceArrayIntersectorK<16>> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR16(BVH8InstanceArrayMBIntersector16Chunk, BVHNIntersectorKChunk<8 COMMA 16 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<16 COMMA InstanceArrayIntersectorKMB<16>> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR16(BVH8GridIntersector16HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA false COMMA SubGridIntersectorKMoeller <8 COMMA 16 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR16(BVH8GridIntersector16HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 16 COMMA BVH_AN1 COMMA true COMMA SubGridIntersectorKPluecker <8 COMMA 16 COMMA true> >));
+
+  }
+}
+

--- a/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid4_bvh8.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid4_bvh8.cpp
@@ -1,0 +1,54 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector_hybrid.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH8Intersector4 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4Intersector4HybridMoeller,         BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA TriangleMIntersectorKMoeller  <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4Intersector4HybridMoellerNoFilter, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA TriangleMIntersectorKMoeller  <4 COMMA 4 COMMA false> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4iIntersector4HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA TriangleMiIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4vIntersector4HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<4 COMMA TriangleMvIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4iIntersector4HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<4 COMMA TriangleMiIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4vMBIntersector4HybridMoeller,  BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA TriangleMvMBIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4iMBIntersector4HybridMoeller,  BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA TriangleMiMBIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4vMBIntersector4HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<4 COMMA TriangleMvMBIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR4(BVH8Triangle4iMBIntersector4HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<4 COMMA TriangleMiMBIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4vIntersector4HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA QuadMvIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4vIntersector4HybridMoellerNoFilter,BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA QuadMvIntersectorKMoeller <4 COMMA 4 COMMA false> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4iIntersector4HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA QuadMiIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4vIntersector4HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<4 COMMA QuadMvIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4iIntersector4HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<4 COMMA QuadMiIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4iMBIntersector4HybridMoeller,      BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA QuadMiMBIntersectorKMoeller <4 COMMA 4 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR4(BVH8Quad4iMBIntersector4HybridPluecker,     BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<4 COMMA QuadMiMBIntersectorKPluecker<4 COMMA 4 COMMA true> > >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR4(BVH8OBBVirtualCurveIntersector4Hybrid, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersectorK<4> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR4(BVH8OBBVirtualCurveIntersector4HybridMB, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersectorK<4> >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR4(BVH8OBBVirtualCurveIntersectorRobust4Hybrid, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersectorK<4> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR4(BVH8OBBVirtualCurveIntersectorRobust4HybridMB, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersectorK<4> >));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR4(BVH8VirtualIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA ObjectIntersector4> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR4(BVH8VirtualMBIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA ObjectIntersector4MB> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR4(BVH8InstanceIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA InstanceIntersectorK<4>> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR4(BVH8InstanceMBIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA InstanceIntersectorKMB<4>> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR4(BVH8InstanceArrayIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<4 COMMA InstanceArrayIntersectorK<4>> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR4(BVH8InstanceArrayMBIntersector4Chunk, BVHNIntersectorKChunk<8 COMMA 4 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<4 COMMA InstanceArrayIntersectorKMB<4>> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR4(BVH8GridIntersector4HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA false COMMA SubGridIntersectorKMoeller <8 COMMA 4 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR4(BVH8GridIntersector4HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 4 COMMA BVH_AN1 COMMA true COMMA SubGridIntersectorKPluecker <8 COMMA 4 COMMA true> >));
+
+  }
+}
+

--- a/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid8_bvh4.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid8_bvh4.cpp
@@ -1,0 +1,59 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector_hybrid.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH4Intersector8 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4Intersector8HybridMoeller,         BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMIntersectorKMoeller  <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4Intersector8HybridMoellerNoFilter, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMIntersectorKMoeller  <4 COMMA 8 COMMA false> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4iIntersector8HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMiIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4vIntersector8HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMvIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4iIntersector8HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMiIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4vMBIntersector8HybridMoeller,  BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMvMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4iMBIntersector8HybridMoeller,  BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMiMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4vMBIntersector8HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMvMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH4Triangle4iMBIntersector8HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMiMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4vIntersector8HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKMoeller<4 COMMA 8 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4vIntersector8HybridMoellerNoFilter,BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKMoeller<4 COMMA 8 COMMA false> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4iIntersector8HybridMoeller,        BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMiIntersectorKMoeller<4 COMMA 8 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4vIntersector8HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKPluecker<4 COMMA 8 COMMA true > > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4iIntersector8HybridPluecker,       BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA QuadMiIntersectorKPluecker<4 COMMA 8 COMMA true > > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4iMBIntersector8HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMiMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH4Quad4iMBIntersector8HybridPluecker,BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA true COMMA ArrayIntersectorK_1<8 COMMA QuadMiMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH4OBBVirtualCurveIntersector8Hybrid, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersectorK<8> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH4OBBVirtualCurveIntersector8HybridMB,BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersectorK<8> >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH4OBBVirtualCurveIntersectorRobust8Hybrid, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersectorK<8> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH4OBBVirtualCurveIntersectorRobust8HybridMB,BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersectorK<8> >));
+    
+    IF_ENABLED_SUBDIV(DEFINE_INTERSECTOR8(BVH4SubdivPatch1Intersector8, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true COMMA SubdivPatch1Intersector8>));
+    IF_ENABLED_SUBDIV(DEFINE_INTERSECTOR8(BVH4SubdivPatch1MBIntersector8, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA SubdivPatch1MBIntersector8>));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR8(BVH4VirtualIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA ObjectIntersector8> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR8(BVH4VirtualMBIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA ObjectIntersector8MB> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR8(BVH4InstanceIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceIntersectorK<8>> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR8(BVH4InstanceMBIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceIntersectorKMB<8>> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR8(BVH4InstanceArrayIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceArrayIntersectorK<8>> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR8(BVH4InstanceArrayMBIntersector8Chunk, BVHNIntersectorKChunk<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceArrayIntersectorKMB<8>> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR8(BVH4GridIntersector8HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA false COMMA SubGridIntersectorKMoeller <4 COMMA 8 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR8(BVH4GridMBIntersector8HybridMoeller, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN2_AN4D COMMA true COMMA SubGridMBIntersectorKPluecker <4 COMMA 8 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR8(BVH4GridIntersector8HybridPluecker, BVHNIntersectorKHybrid<4 COMMA 8 COMMA BVH_AN1 COMMA true COMMA SubGridIntersectorKPluecker <4 COMMA 8 COMMA true> >));
+
+  }
+
+
+}

--- a/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid8_bvh8.cpp
+++ b/thirdparty/embree/kernels/bvh/bvh_intersector_hybrid8_bvh8.cpp
@@ -1,0 +1,54 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bvh_intersector_hybrid.cpp"
+
+namespace embree
+{
+  namespace isa
+  {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// BVH8Intersector8 Definitions
+    ////////////////////////////////////////////////////////////////////////////////
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4Intersector8HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMIntersectorKMoeller  <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4Intersector8HybridMoellerNoFilter,BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMIntersectorKMoeller  <4 COMMA 8 COMMA false> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4iIntersector8HybridMoeller,       BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMiIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4vIntersector8HybridPluecker,      BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMvIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4iIntersector8HybridPluecker,      BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMiIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4vMBIntersector8HybridMoeller,  BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMvMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4iMBIntersector8HybridMoeller,  BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA TriangleMiMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4vMBIntersector8HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMvMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_TRIS(DEFINE_INTERSECTOR8(BVH8Triangle4iMBIntersector8HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA true  COMMA ArrayIntersectorK_1<8 COMMA TriangleMiMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4vIntersector8HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4vIntersector8HybridMoellerNoFilter,BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKMoeller <4 COMMA 8 COMMA false> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4iIntersector8HybridMoeller,        BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMiIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4vIntersector8HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA QuadMvIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4iIntersector8HybridPluecker,       BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA true  COMMA ArrayIntersectorK_1<8 COMMA QuadMiIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4iMBIntersector8HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA QuadMiMBIntersectorKMoeller <4 COMMA 8 COMMA true> > >));
+    IF_ENABLED_QUADS(DEFINE_INTERSECTOR8(BVH8Quad4iMBIntersector8HybridPluecker,BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA true COMMA ArrayIntersectorK_1<8 COMMA QuadMiMBIntersectorKPluecker<4 COMMA 8 COMMA true> > >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH8OBBVirtualCurveIntersector8Hybrid, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1_UN1 COMMA false COMMA VirtualCurveIntersectorK<8> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH8OBBVirtualCurveIntersector8HybridMB, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D_UN2 COMMA false COMMA VirtualCurveIntersectorK<8> >));
+
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH8OBBVirtualCurveIntersectorRobust8Hybrid, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1_UN1 COMMA true COMMA VirtualCurveIntersectorK<8> >));
+    IF_ENABLED_CURVES_OR_POINTS(DEFINE_INTERSECTOR8(BVH8OBBVirtualCurveIntersectorRobust8HybridMB, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN2_AN4D_UN2 COMMA true COMMA VirtualCurveIntersectorK<8> >));
+
+    IF_ENABLED_USER(DEFINE_INTERSECTOR8(BVH8VirtualIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA ObjectIntersector8> >));
+    IF_ENABLED_USER(DEFINE_INTERSECTOR8(BVH8VirtualMBIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA ObjectIntersector8MB> >));
+
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR8(BVH8InstanceIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceIntersectorK<8>> >));
+    IF_ENABLED_INSTANCE(DEFINE_INTERSECTOR8(BVH8InstanceMBIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceIntersectorKMB<8>> >));
+
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR8(BVH8InstanceArrayIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceArrayIntersectorK<8>> >));
+    IF_ENABLED_INSTANCE_ARRAY(DEFINE_INTERSECTOR8(BVH8InstanceArrayMBIntersector8Chunk, BVHNIntersectorKChunk<8 COMMA 8 COMMA BVH_AN2_AN4D COMMA false COMMA ArrayIntersectorK_1<8 COMMA InstanceArrayIntersectorKMB<8>> >));
+
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR8(BVH8GridIntersector8HybridMoeller, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA false COMMA SubGridIntersectorKMoeller <8 COMMA 8 COMMA true> >));
+    IF_ENABLED_GRIDS(DEFINE_INTERSECTOR8(BVH8GridIntersector8HybridPluecker, BVHNIntersectorKHybrid<8 COMMA 8 COMMA BVH_AN1 COMMA true COMMA SubGridIntersectorKPluecker <8 COMMA 8 COMMA true> >));
+
+  }
+}
+

--- a/thirdparty/embree/kernels/geometry/primitive8.cpp
+++ b/thirdparty/embree/kernels/geometry/primitive8.cpp
@@ -1,0 +1,170 @@
+// Copyright 2009-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "primitive.h"
+#include "curveNv.h"
+#include "curveNi.h"
+#include "curveNi_mb.h"
+#include "linei.h"
+#include "triangle.h"
+#include "trianglev.h"
+#include "trianglev_mb.h"
+#include "trianglei.h"
+#include "quadv.h"
+#include "quadi.h"
+#include "subdivpatch1.h"
+#include "object.h"
+#include "instance.h"
+#include "instance_array.h"
+#include "subgrid.h"
+
+namespace embree
+{
+  /********************** Curve8v **************************/
+
+  template<>
+  const char* Curve8v::Type::name () const {
+    return "curve8v";
+  }
+
+  template<>
+  size_t Curve8v::Type::sizeActive(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return ((Line8i*)This)->size();
+    else
+      return ((Curve8v*)This)->N;
+  }
+
+  template<>
+  size_t Curve8v::Type::sizeTotal(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return 8;
+    else
+      return ((Curve8v*)This)->N;
+  }
+
+  template<>
+  size_t Curve8v::Type::getBytes(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+       return Line8i::bytes(sizeActive(This));
+     else
+       return Curve8v::bytes(sizeActive(This));
+  }
+
+  /********************** Curve8i **************************/
+
+  template<>
+  const char* Curve8i::Type::name () const {
+    return "curve8i";
+  }
+
+  template<>
+  size_t Curve8i::Type::sizeActive(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return ((Line8i*)This)->size();
+    else
+      return ((Curve8i*)This)->N;
+  }
+
+  template<>
+  size_t Curve8i::Type::sizeTotal(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return 8;
+    else
+      return ((Curve8i*)This)->N;
+  }
+
+  template<>
+  size_t Curve8i::Type::getBytes(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+       return Line8i::bytes(sizeActive(This));
+     else
+       return Curve8i::bytes(sizeActive(This));
+  }
+
+  /********************** Curve8iMB **************************/
+
+  template<>
+  const char* Curve8iMB::Type::name () const {
+    return "curve8imb";
+  }
+
+  template<>
+  size_t Curve8iMB::Type::sizeActive(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return ((Line8i*)This)->size();
+    else
+      return ((Curve8iMB*)This)->N;
+  }
+
+  template<>
+  size_t Curve8iMB::Type::sizeTotal(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+      return 8;
+    else
+      return ((Curve8iMB*)This)->N;
+  }
+
+  template<>
+  size_t Curve8iMB::Type::getBytes(const char* This) const
+  {
+    if ((*This & Geometry::GType::GTY_BASIS_MASK) == Geometry::GType::GTY_BASIS_LINEAR)
+       return Line8i::bytes(sizeActive(This));
+     else
+       return Curve8iMB::bytes(sizeActive(This));
+  }
+
+  /********************** SubGridQBVH8 **************************/
+
+  template<>
+  const char* SubGridQBVH8::Type::name () const {
+    return "SubGridQBVH8";
+  }
+
+  template<>
+  size_t SubGridQBVH8::Type::sizeActive(const char* This) const {
+    return 1;
+  }
+
+  template<>
+  size_t SubGridQBVH8::Type::sizeTotal(const char* This) const {
+    return 1;
+  }
+
+  template<>
+  size_t SubGridQBVH8::Type::getBytes(const char* This) const {
+    return sizeof(SubGridQBVH8);
+  }
+
+  /********************** Instance Array **************************/
+#if 0
+  template<>
+  const char* InstanceArrayPrimitive<8>::Type::name () const {
+    return "instance_array_8";
+  }
+
+  template<>
+  size_t InstanceArrayPrimitive<8>::Type::sizeActive(const char* This) const {
+    return ((InstanceArrayPrimitive<8>*)This)->size();
+  }
+
+  template<>
+  size_t InstanceArrayPrimitive<8>::Type::sizeTotal(const char* This) const {
+    return 8;
+  }
+
+  template<>
+  size_t InstanceArrayPrimitive<8>::Type::getBytes(const char* This) const {
+    return sizeof(InstanceArrayPrimitive<8>);
+  }
+#endif
+
+}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/discussions/13644

Adds `extension=sse2/sse42/avx/avx2/avx512` flag to select specific ISA extensions (defaults to `sse42` as it is now). Runtime checks for them. And enable Embree support for these configs.

TODO
- [x] Test build on x86-64 macOS.
- [x] Test build on Linux.
- [x] Test build on Windows / MinGW.
- [x] Test build on Windows / MSVC.
- [ ] Test performance with different configs.


<details>
<summary>CPU compatibility list (from Wikipedia)</summary>

### CPUs with AVX

- Intel
  - Sandy Bridge processors (Q1 2011) and newer, except models branded as Celeron and Pentium.
  - Pentium and Celeron branded processors starting with Tiger Lake (Q3 2020) and newer.
- AMD
  - Bulldozer processors (Q4 2011) [11] and newer, including Jaguar and Puma.

### CPUs with AVX2

- Intel
  - Haswell processors (Q2 2013) and newer, except models branded as Celeron and Pentium.
  - Celeron and Pentium branded processors starting with Tiger Lake (Q3 2020) and newer.
- AMD
  - Excavator processors (Q2 2015) and newer.

### CPUs with AVX512 F+DQ+VL
- Intel
  - Skylake-SP, Skylake-X (2017)
  - Cannon Lake (2018)
  - Cascade Lake-SP (2019)
  - Cooper Lake (2020)
  - Ice Lake (2019)
  - Tiger Lake (2020)
  - Rocket Lake (2021)
  - Sapphire Rapids (2023)
- AMD
  - Zen 4 (2022)
  - Zen 5 (2024)
  - Zen 6 (TBD)

</details>