### PR TITLE
Check PhysicsDirectBodyState sleep state before running _integrate_forces

### DIFF
--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -169,7 +169,7 @@ void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
 void RigidBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	lock_callback();
 
-	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+	if (!p_state->is_sleeping() && GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
 		Transform2D old_transform = get_global_transform();

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -807,7 +807,7 @@ void PhysicalBone3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 		return;
 	}
 
-	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+	if (!p_state->is_sleeping() && GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
 		Transform3D old_transform = get_global_transform();

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -170,7 +170,7 @@ void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
 void RigidBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	lock_callback();
 
-	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+	if (!p_state->is_sleeping() && GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
 		_sync_body_state(p_state);
 
 		Transform3D old_transform = get_global_transform();


### PR DESCRIPTION
Fixes #108656 

What happens is that the RigidBody sleeps and wake up indefinitely.
The bug appears when a value under the sleep threshold is assigned to `linear/angular_velocity` properties in `_integrate_forces`, and that the PhysicsDirectBodyState has been still for long enough.

0) At the end of the previous physics step, the PhysicsDirectBodyState is put to sleep
1) Next physics step : its associated RigidBody is put to sleep too in the `_body_state_changed` function
2) Still in `_body_state_changed`, an assignation to `linear_velocity` or `angular_velocity` in `_integrate_forces` wakes up the PhysicsDirectBodyState and then the RigidBody
3) Since it's now awake, the RigidBody is added to `state_query_list`, so `_body_state_changed` will be called next frame
4) The PhysicsDirectBodyState is put to sleep again and the cycle keeps going to infinity!

My solution is to call `_integrate_forces` only if the PhysicsDirectBodyState is awake. This function is not supposed to be called if the RigidBody is asleep.