### PR TITLE
Make theme previews scale with the editor

### DIFF
--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -57,6 +57,34 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/theme/theme_db.h"
 
+void ScalableContainer::_notification(int p_what) {
+	if (EDSCALE == 1 || p_what != NOTIFICATION_SORT_CHILDREN) {
+		return;
+	}
+
+	Size2 size = get_size() / EDSCALE;
+	size.width -= get_margin_size(SIDE_LEFT) + get_margin_size(SIDE_RIGHT);
+	size.height -= get_margin_size(SIDE_TOP) + get_margin_size(SIDE_BOTTOM);
+
+	for (Node *child : iterate_children()) {
+		Control *control = as_sortable_control(child);
+		if (control) {
+			fit_child_in_rect(control, Rect2(control->get_position(), size));
+		}
+	}
+}
+
+Size2 ScalableContainer::get_minimum_size() const {
+	return MarginContainer::get_minimum_size() * EDSCALE;
+}
+
+ScalableContainer::ScalableContainer() {
+	set_offset_transform_enabled(true);
+	set_offset_transform_pivot_ratio(Point2());
+	set_offset_transform_visual_only(false);
+	set_offset_transform_scale(Size2(EDSCALE, EDSCALE));
+}
+
 void ThemeEditorPreview::set_preview_theme(const Ref<Theme> &p_theme) {
 	preview_content->set_theme(p_theme);
 }
@@ -237,7 +265,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	preview_bg->set_color(GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 	preview_root->add_child(preview_bg);
 
-	preview_content = memnew(MarginContainer);
+	preview_content = memnew(ScalableContainer);
 	preview_content->add_theme_constant_override("margin_right", 4 * EDSCALE);
 	preview_content->add_theme_constant_override("margin_top", 4 * EDSCALE);
 	preview_content->add_theme_constant_override("margin_left", 4 * EDSCALE);
@@ -261,7 +289,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 void DefaultThemeEditorPreview::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			test_color_picker_button->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor))));
+			test_color_picker_button->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor))) / EDSCALE);
 		} break;
 	}
 }
@@ -271,20 +299,20 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	preview_content->add_child(main_panel);
 
 	MarginContainer *main_mc = memnew(MarginContainer);
-	main_mc->add_theme_constant_override("margin_right", 4 * EDSCALE);
-	main_mc->add_theme_constant_override("margin_top", 4 * EDSCALE);
-	main_mc->add_theme_constant_override("margin_left", 4 * EDSCALE);
-	main_mc->add_theme_constant_override("margin_bottom", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_right", 4);
+	main_mc->add_theme_constant_override("margin_top", 4);
+	main_mc->add_theme_constant_override("margin_left", 4);
+	main_mc->add_theme_constant_override("margin_bottom", 4);
 	preview_content->add_child(main_mc);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
 	main_mc->add_child(main_hb);
-	main_hb->add_theme_constant_override("separation", 20 * EDSCALE);
+	main_hb->add_theme_constant_override("separation", 20);
 
 	VBoxContainer *first_vb = memnew(VBoxContainer);
 	main_hb->add_child(first_vb);
 	first_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	first_vb->add_theme_constant_override("separation", 10 * EDSCALE);
+	first_vb->add_theme_constant_override("separation", 10);
 
 	first_vb->add_child(memnew(Label("Label")));
 
@@ -344,7 +372,7 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	VBoxContainer *second_vb = memnew(VBoxContainer);
 	second_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	main_hb->add_child(second_vb);
-	second_vb->add_theme_constant_override("separation", 10 * EDSCALE);
+	second_vb->add_theme_constant_override("separation", 10);
 	LineEdit *le = memnew(LineEdit);
 	le->set_text("LineEdit");
 	second_vb->add_child(le);
@@ -354,13 +382,13 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	second_vb->add_child(le);
 	TextEdit *te = memnew(TextEdit);
 	te->set_text("TextEdit");
-	te->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	te->set_custom_minimum_size(Size2(0, 100));
 	second_vb->add_child(te);
 	second_vb->add_child(memnew(SpinBox));
 
 	HBoxContainer *vhb = memnew(HBoxContainer);
 	second_vb->add_child(vhb);
-	vhb->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	vhb->set_custom_minimum_size(Size2(0, 100));
 	vhb->add_child(memnew(VSlider));
 	VScrollBar *vsb = memnew(VScrollBar);
 	vsb->set_page(25);
@@ -384,12 +412,12 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 
 	VBoxContainer *third_vb = memnew(VBoxContainer);
 	third_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	third_vb->add_theme_constant_override("separation", 10 * EDSCALE);
+	third_vb->add_theme_constant_override("separation", 10);
 	main_hb->add_child(third_vb);
 
 	TabContainer *tc = memnew(TabContainer);
 	third_vb->add_child(tc);
-	tc->set_custom_minimum_size(Size2(0, 135) * EDSCALE);
+	tc->set_custom_minimum_size(Size2(0, 135));
 	Control *tcc = memnew(Control);
 	tcc->set_name(TTR("Tab 1"));
 	tc->add_child(tcc);
@@ -403,7 +431,7 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 
 	Tree *test_tree = memnew(Tree);
 	third_vb->add_child(test_tree);
-	test_tree->set_custom_minimum_size(Size2(0, 175) * EDSCALE);
+	test_tree->set_custom_minimum_size(Size2(0, 175));
 
 	TreeItem *item = test_tree->create_item();
 	item->set_text(0, "Tree");

--- a/editor/scene/gui/theme_editor_preview.h
+++ b/editor/scene/gui/theme_editor_preview.h
@@ -31,14 +31,26 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
+#include "scene/gui/margin_container.h"
 #include "scene/resources/theme.h"
 
 class Button;
 class ColorPickerButton;
 class ColorRect;
-class MarginContainer;
 class PackedScene;
 class ScrollContainer;
+
+class ScalableContainer : public MarginContainer {
+	GDCLASS(ScalableContainer, MarginContainer);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	virtual Size2 get_minimum_size() const override;
+
+	ScalableContainer();
+};
 
 class ThemeEditorPreview : public VBoxContainer {
 	GDCLASS(ThemeEditorPreview, VBoxContainer);
@@ -69,7 +81,7 @@ class ThemeEditorPreview : public VBoxContainer {
 
 protected:
 	HBoxContainer *preview_toolbar = nullptr;
-	MarginContainer *preview_content = nullptr;
+	ScalableContainer *preview_content = nullptr;
 	Button *picker_button = nullptr;
 
 	void add_preview_overlay(Control *p_overlay);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #118481.

## Additional information

This PR introduces an internal class in the theme editor named `ScalableContainer`, with scales whatever is inside with the editor's scale. Theme previews are now all placed inside of it.

One small caveat is that on very large scales, the UI elements will appear a little blurry.