### PR TITLE
Add `directional_shadow_min_fov` to DirectionalLight3D

### DIFF
--- a/doc/classes/DirectionalLight3D.xml
+++ b/doc/classes/DirectionalLight3D.xml
@@ -21,6 +21,14 @@
 		<member name="directional_shadow_max_distance" type="float" setter="set_param" getter="get_param" default="100.0">
 			The maximum distance for shadow splits. Increasing this value will make directional shadows visible from further away, at the cost of lower overall shadow detail and performance (since more objects need to be included in the directional shadow rendering).
 		</member>
+		<member name="directional_shadow_min_fov" type="float" setter="set_min_shadow_fov" getter="get_min_shadow_fov" default="0.0">
+			The minimum vertical FOV for shadow rendering. Use this to reduce flickering shadows during camera FOV animations at the cost of lower shadow detail. Shadows will appear more stable as long as the camera's vertical FOV does not exceed this value.
+			[b]Note:[/b] This property only affects cameras whose [member Camera3D.projection] is set to [constant Camera3D.PROJECTION_PERSPECTIVE] or [constant Camera3D.PROJECTION_FRUSTUM].
+		</member>
+		<member name="directional_shadow_min_size" type="float" setter="set_min_shadow_size" getter="get_min_shadow_size" default="0.0">
+			The minimum size for shadow rendering. Use this to reduce flickering shadows during camera FOV animations at the cost of lower shadow detail. Shadows will appear more stable as long as the camera's size does not exceed this value.
+			[b]Note:[/b] This property only affects cameras whose [member Camera3D.projection] is set to [constant Camera3D.PROJECTION_ORTHOGONAL].
+		</member>
 		<member name="directional_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="DirectionalLight3D.ShadowMode" default="2">
 			The light's shadow rendering algorithm.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2137,6 +2137,22 @@
 				If [code]true[/code], this directional light will blend between shadow map splits resulting in a smoother transition between them. Equivalent to [member DirectionalLight3D.directional_shadow_blend_splits].
 			</description>
 		</method>
+		<method name="light_directional_set_min_shadow_fov">
+			<return type="void" />
+			<param index="0" name="light" type="RID" />
+			<param index="1" name="fov" type="float" />
+			<description>
+				Sets the minimum vertical FOV for the light camera frustum. Use this to reduce flickering shadows during camera FOV animations at the cost of lower shadow detail. This value is only used for perspective or frustum cameras. Equivalent to [member DirectionalLight3D.directional_shadow_min_fov].
+			</description>
+		</method>
+		<method name="light_directional_set_min_shadow_size">
+			<return type="void" />
+			<param index="0" name="light" type="RID" />
+			<param index="1" name="size" type="float" />
+			<description>
+				Sets the minimum size for the light camera frustum. Use this to reduce flickering shadows during camera FOV animations at the cost of lower shadow detail. This value is only used for orthogonal cameras. Equivalent to [member DirectionalLight3D.directional_shadow_min_size].
+			</description>
+		</method>
 		<method name="light_directional_set_shadow_mode">
 			<return type="void" />
 			<param index="0" name="light" type="RID" />

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -332,6 +332,34 @@ RSE::LightDirectionalSkyMode LightStorage::light_directional_get_sky_mode(RID p_
 	return light->directional_sky_mode;
 }
 
+void LightStorage::light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->directional_min_shadow_fov = p_fov;
+}
+
+real_t LightStorage::light_directional_get_min_shadow_fov(RID p_light) const {
+	const Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL_V(light, 0.0);
+
+	return light->directional_min_shadow_fov;
+}
+
+void LightStorage::light_directional_set_min_shadow_size(RID p_light, real_t p_size) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->directional_min_shadow_size = p_size;
+}
+
+real_t LightStorage::light_directional_get_min_shadow_size(RID p_light) const {
+	const Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL_V(light, 0.0);
+
+	return light->directional_min_shadow_size;
+}
+
 RSE::LightDirectionalShadowMode LightStorage::light_directional_get_shadow_mode(RID p_light) {
 	const Light *light = light_owner.get_or_null(p_light);
 	ERR_FAIL_NULL_V(light, RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL);

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -66,6 +66,8 @@ struct Light {
 	RSE::LightDirectionalShadowMode directional_shadow_mode = RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL;
 	bool directional_blend_splits = false;
 	RSE::LightDirectionalSkyMode directional_sky_mode = RSE::LIGHT_DIRECTIONAL_SKY_MODE_LIGHT_AND_SKY;
+	real_t directional_min_shadow_fov = 0.0;
+	real_t directional_min_shadow_size = 0.0;
 	Vector2 area_size = Vector2(1, 1);
 	bool area_normalize_energy = true;
 	RID area_texture;
@@ -343,6 +345,10 @@ public:
 	virtual bool light_directional_get_blend_splits(RID p_light) const override;
 	virtual void light_directional_set_sky_mode(RID p_light, RSE::LightDirectionalSkyMode p_mode) override;
 	virtual RSE::LightDirectionalSkyMode light_directional_get_sky_mode(RID p_light) const override;
+	virtual void light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) override;
+	virtual real_t light_directional_get_min_shadow_fov(RID p_light) const override;
+	virtual void light_directional_set_min_shadow_size(RID p_light, real_t p_size) override;
+	virtual real_t light_directional_get_min_shadow_size(RID p_light) const override;
 
 	virtual void light_area_set_size(RID p_light, const Vector2 &p_size) override;
 	virtual Vector2 light_area_get_size(RID p_light) const override;

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -556,6 +556,24 @@ DirectionalLight3D::SkyMode DirectionalLight3D::get_sky_mode() const {
 	return sky_mode;
 }
 
+void DirectionalLight3D::set_min_shadow_fov(real_t p_fov) {
+	min_shadow_fov = p_fov;
+	RS::get_singleton()->light_directional_set_min_shadow_fov(light, p_fov);
+}
+
+real_t DirectionalLight3D::get_min_shadow_fov() const {
+	return min_shadow_fov;
+}
+
+void DirectionalLight3D::set_min_shadow_size(real_t p_size) {
+	min_shadow_size = p_size;
+	RS::get_singleton()->light_directional_set_min_shadow_size(light, p_size);
+}
+
+real_t DirectionalLight3D::get_min_shadow_size() const {
+	return min_shadow_size;
+}
+
 void DirectionalLight3D::_validate_property(PropertyInfo &p_property) const {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		if (shadow_mode == SHADOW_ORTHOGONAL && (p_property.name == "directional_shadow_split_1" || p_property.name == "directional_shadow_blend_splits")) {
@@ -588,6 +606,12 @@ void DirectionalLight3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sky_mode", "mode"), &DirectionalLight3D::set_sky_mode);
 	ClassDB::bind_method(D_METHOD("get_sky_mode"), &DirectionalLight3D::get_sky_mode);
 
+	ClassDB::bind_method(D_METHOD("set_min_shadow_fov", "fov"), &DirectionalLight3D::set_min_shadow_fov);
+	ClassDB::bind_method(D_METHOD("get_min_shadow_fov"), &DirectionalLight3D::get_min_shadow_fov);
+
+	ClassDB::bind_method(D_METHOD("set_min_shadow_size", "size"), &DirectionalLight3D::set_min_shadow_size);
+	ClassDB::bind_method(D_METHOD("get_min_shadow_size"), &DirectionalLight3D::get_min_shadow_size);
+
 	ADD_GROUP("Directional Shadow", "directional_shadow_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "directional_shadow_mode", PROPERTY_HINT_ENUM, "Orthogonal (Fast),PSSM 2 Splits (Average),PSSM 4 Splits (Slow)"), "set_shadow_mode", "get_shadow_mode");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_split_1", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_param", "get_param", PARAM_SHADOW_SPLIT_1_OFFSET);
@@ -597,6 +621,8 @@ void DirectionalLight3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_fade_start", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_param", "get_param", PARAM_SHADOW_FADE_START);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_max_distance", PROPERTY_HINT_RANGE, "0,8192,0.1,or_greater,exp"), "set_param", "get_param", PARAM_SHADOW_MAX_DISTANCE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_pancake_size", PROPERTY_HINT_RANGE, "0,1024,0.1,or_greater,exp"), "set_param", "get_param", PARAM_SHADOW_PANCAKE_SIZE);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "directional_shadow_min_fov", PROPERTY_HINT_RANGE, "0,179,0.1,degrees"), "set_min_shadow_fov", "get_min_shadow_fov");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "directional_shadow_min_size", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_min_shadow_size", "get_min_shadow_size");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sky_mode", PROPERTY_HINT_ENUM, "Light and Sky,Light Only,Sky Only"), "set_sky_mode", "get_sky_mode");
 
@@ -620,6 +646,8 @@ DirectionalLight3D::DirectionalLight3D() :
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	blend_splits = false;
 	set_sky_mode(SKY_MODE_LIGHT_AND_SKY);
+	set_min_shadow_fov(0.0);
+	set_min_shadow_size(0.0);
 }
 
 void OmniLight3D::set_shadow_mode(ShadowMode p_mode) {

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -178,6 +178,8 @@ private:
 	bool blend_splits;
 	ShadowMode shadow_mode;
 	SkyMode sky_mode = SKY_MODE_LIGHT_AND_SKY;
+	real_t min_shadow_fov;
+	real_t min_shadow_size;
 
 protected:
 	static void _bind_methods();
@@ -192,6 +194,12 @@ public:
 
 	void set_sky_mode(SkyMode p_mode);
 	SkyMode get_sky_mode() const;
+
+	void set_min_shadow_fov(real_t p_fov);
+	real_t get_min_shadow_fov() const;
+
+	void set_min_shadow_size(real_t p_size);
+	real_t get_min_shadow_size() const;
 
 	DirectionalLight3D();
 };

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -92,6 +92,10 @@ public:
 	virtual bool light_directional_get_blend_splits(RID p_light) const override { return false; }
 	virtual void light_directional_set_sky_mode(RID p_light, RSE::LightDirectionalSkyMode p_mode) override {}
 	virtual RSE::LightDirectionalSkyMode light_directional_get_sky_mode(RID p_light) const override { return RSE::LIGHT_DIRECTIONAL_SKY_MODE_LIGHT_AND_SKY; }
+	virtual void light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) override {}
+	virtual real_t light_directional_get_min_shadow_fov(RID p_light) const override { return 0.0; }
+	virtual void light_directional_set_min_shadow_size(RID p_light, real_t p_size) override {}
+	virtual real_t light_directional_get_min_shadow_size(RID p_light) const override { return 0.0; }
 
 	virtual RSE::LightDirectionalShadowMode light_directional_get_shadow_mode(RID p_light) override { return RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL; }
 	virtual RSE::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) override { return RSE::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID; }

--- a/servers/rendering/renderer_rd/effects/debug_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/debug_effects.cpp
@@ -210,7 +210,11 @@ void DebugEffects::draw_shadow_frustum(RID p_light, const Projection &p_cam_proj
 	if (is_orthogonal) {
 		vp_he = p_cam_projection.get_viewport_half_extents();
 	} else {
-		fov = p_cam_projection.get_fov(); //this is actually yfov, because set aspect tries to keep it
+		fov = p_cam_projection.get_fovy(p_cam_projection.get_fov(), 1.0 / aspect);
+		real_t min_shadow_fov = RSG::light_storage->light_directional_get_min_shadow_fov(base);
+		if (min_shadow_fov > 0.0) {
+			fov = MAX(fov, min_shadow_fov);
+		}
 	}
 	real_t min_distance = p_cam_projection.get_z_near();
 	real_t max_distance = p_cam_projection.get_z_far();
@@ -248,7 +252,7 @@ void DebugEffects::draw_shadow_frustum(RID p_light, const Projection &p_cam_proj
 		if (is_orthogonal) {
 			projection.set_orthogonal(vp_he.y * 2.0, aspect, distances[(split == 0 || !overlap) ? split : split - 1], distances[split + 1], false);
 		} else {
-			projection.set_perspective(fov, aspect, distances[(split == 0 || !overlap) ? split : split - 1], distances[split + 1], true);
+			projection.set_perspective(fov, aspect, distances[(split == 0 || !overlap) ? split : split - 1], distances[split + 1], false);
 		}
 
 		bool res = projection.get_endpoints(p_cam_transform, vw);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -421,6 +421,34 @@ RSE::LightDirectionalSkyMode LightStorage::light_directional_get_sky_mode(RID p_
 	return light->directional_sky_mode;
 }
 
+void LightStorage::light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->directional_min_shadow_fov = p_fov;
+}
+
+real_t LightStorage::light_directional_get_min_shadow_fov(RID p_light) const {
+	const Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL_V(light, 0.0);
+
+	return light->directional_min_shadow_fov;
+}
+
+void LightStorage::light_directional_set_min_shadow_size(RID p_light, real_t p_size) {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL(light);
+
+	light->directional_min_shadow_size = p_size;
+}
+
+real_t LightStorage::light_directional_get_min_shadow_size(RID p_light) const {
+	const Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL_V(light, 0.0);
+
+	return light->directional_min_shadow_size;
+}
+
 RSE::LightDirectionalShadowMode LightStorage::light_directional_get_shadow_mode(RID p_light) {
 	const Light *light = light_owner.get_or_null(p_light);
 	ERR_FAIL_NULL_V(light, RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -78,6 +78,8 @@ private:
 		RSE::LightDirectionalShadowMode directional_shadow_mode = RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL;
 		bool directional_blend_splits = false;
 		RSE::LightDirectionalSkyMode directional_sky_mode = RSE::LIGHT_DIRECTIONAL_SKY_MODE_LIGHT_AND_SKY;
+		real_t directional_min_shadow_fov = 0.0;
+		real_t directional_min_shadow_size = 0.0;
 		Vector2 area_size = Vector2(1, 1);
 		bool area_normalize_energy = true;
 		RID area_texture;
@@ -521,6 +523,10 @@ public:
 	virtual bool light_directional_get_blend_splits(RID p_light) const override;
 	virtual void light_directional_set_sky_mode(RID p_light, RSE::LightDirectionalSkyMode p_mode) override;
 	virtual RSE::LightDirectionalSkyMode light_directional_get_sky_mode(RID p_light) const override;
+	virtual void light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) override;
+	virtual real_t light_directional_get_min_shadow_fov(RID p_light) const override;
+	virtual void light_directional_set_min_shadow_size(RID p_light, real_t p_size) override;
+	virtual real_t light_directional_get_min_shadow_size(RID p_light) const override;
 
 	virtual RSE::LightDirectionalShadowMode light_directional_get_shadow_mode(RID p_light) override;
 	virtual RSE::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) override;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2205,11 +2205,18 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 
 		if (p_cam_orthogonal) {
 			Vector2 vp_he = p_cam_projection.get_viewport_half_extents();
+			real_t min_shadow_size = RSG::light_storage->light_directional_get_min_shadow_size(p_instance->base);
+			real_t size = MAX(vp_he.y * 2.0, min_shadow_size);
 
-			camera_matrix.set_orthogonal(vp_he.y * 2.0, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], false);
+			camera_matrix.set_orthogonal(size, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], false);
 		} else {
-			real_t fov = p_cam_projection.get_fov(); //this is actually yfov, because set aspect tries to keep it
-			camera_matrix.set_perspective(fov, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], true);
+			real_t fov = p_cam_projection.get_fovy(p_cam_projection.get_fov(), 1.0 / aspect);
+			real_t min_shadow_fov = RSG::light_storage->light_directional_get_min_shadow_fov(p_instance->base);
+			if (min_shadow_fov > 0.0) {
+				fov = MAX(fov, min_shadow_fov);
+			}
+
+			camera_matrix.set_perspective(fov, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], false);
 		}
 
 		//obtain the frustum endpoints

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2536,6 +2536,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("light_directional_set_shadow_mode", "light", "mode"), &RenderingServer::light_directional_set_shadow_mode);
 	ClassDB::bind_method(D_METHOD("light_directional_set_blend_splits", "light", "enable"), &RenderingServer::light_directional_set_blend_splits);
 	ClassDB::bind_method(D_METHOD("light_directional_set_sky_mode", "light", "mode"), &RenderingServer::light_directional_set_sky_mode);
+	ClassDB::bind_method(D_METHOD("light_directional_set_min_shadow_fov", "light", "fov"), &RenderingServer::light_directional_set_min_shadow_fov);
+	ClassDB::bind_method(D_METHOD("light_directional_set_min_shadow_size", "light", "size"), &RenderingServer::light_directional_set_min_shadow_size);
 
 	ClassDB::bind_method(D_METHOD("light_area_set_size", "light", "size"), &RenderingServer::light_area_set_size);
 	ClassDB::bind_method(D_METHOD("light_area_set_normalize_energy", "light", "enable"), &RenderingServer::light_area_set_normalize_energy);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -327,6 +327,8 @@ public:
 	virtual void light_directional_set_shadow_mode(RID p_light, RSE::LightDirectionalShadowMode p_mode) = 0;
 	virtual void light_directional_set_blend_splits(RID p_light, bool p_enable) = 0;
 	virtual void light_directional_set_sky_mode(RID p_light, RSE::LightDirectionalSkyMode p_mode) = 0;
+	virtual void light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) = 0;
+	virtual void light_directional_set_min_shadow_size(RID p_light, real_t p_size) = 0;
 
 	virtual void light_area_set_size(RID p_light, const Vector2 &p_size) = 0;
 	virtual void light_area_set_normalize_energy(RID p_light, bool p_enabled) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -500,6 +500,8 @@ public:
 	FUNC2(light_directional_set_shadow_mode, RID, RSE::LightDirectionalShadowMode)
 	FUNC2(light_directional_set_blend_splits, RID, bool)
 	FUNC2(light_directional_set_sky_mode, RID, RSE::LightDirectionalSkyMode)
+	FUNC2(light_directional_set_min_shadow_fov, RID, real_t)
+	FUNC2(light_directional_set_min_shadow_size, RID, real_t)
 
 	FUNC2(light_area_set_size, RID, const Vector2 &)
 	FUNC2(light_area_set_normalize_energy, RID, bool)

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -73,6 +73,10 @@ public:
 	virtual bool light_directional_get_blend_splits(RID p_light) const = 0;
 	virtual void light_directional_set_sky_mode(RID p_light, RSE::LightDirectionalSkyMode p_mode) = 0;
 	virtual RSE::LightDirectionalSkyMode light_directional_get_sky_mode(RID p_light) const = 0;
+	virtual void light_directional_set_min_shadow_fov(RID p_light, real_t p_fov) = 0;
+	virtual real_t light_directional_get_min_shadow_fov(RID p_light) const = 0;
+	virtual void light_directional_set_min_shadow_size(RID p_light, real_t p_size) = 0;
+	virtual real_t light_directional_get_min_shadow_size(RID p_light) const = 0;
 
 	virtual RSE::LightDirectionalShadowMode light_directional_get_shadow_mode(RID p_light) = 0;
 	virtual RSE::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) = 0;


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Partially addresses #72015

## Additional information

This PR adds `directional_shadow_min_fov` to DirectionalLight3D to address the problem of shadow flickering when the camera FOV is animated (e.g. sprinting in an FPS game). This comes at the cost of shadow quality.

~~One change I'm not sure about is to [this line](https://github.com/godotengine/godot/blob/f08e003ff23a667c24c76c0193ba31a02b5dae99/servers/rendering/renderer_scene_cull.cpp#L2211) that passes `Projection::get_fov` as the Y FOV of the light frustum. This seems incorrect to me and computing `Projection::get_fovy` proper appears to produce sharper shadows. This seems like it could be a breaking change - let me know if it needs to be removed or added to a separate PR.~~
Edit: reverted this change


### Master:

https://github.com/user-attachments/assets/96f65be1-bc3c-487b-9bbf-db0fba741b80


### PR (`directional_shadow_min_fov` = 100):

https://github.com/user-attachments/assets/a3394cbf-8ff9-450e-b62f-e40540867a36

