### PR TITLE
Fix Curve point count expansion preserving points

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -53,8 +53,10 @@ void Curve::set_point_count(int p_count) {
 		_points.resize(p_count);
 		mark_dirty();
 	} else {
+		const real_t default_offset = old_size == 0 ? CLAMP((real_t)0.0, _min_domain, _max_domain) : _max_domain;
+		const real_t default_value = CLAMP((real_t)0.0, _min_value, _max_value);
 		for (int i = p_count - old_size; i > 0; i--) {
-			_add_point(Vector2());
+			_add_point(Vector2(default_offset, default_value));
 		}
 	}
 	notify_property_list_changed();

--- a/tests/scene/test_curve.cpp
+++ b/tests/scene/test_curve.cpp
@@ -396,6 +396,40 @@ TEST_CASE("[Curve] Straight line offset test") {
 			"Straight line curve should return different baked values at offset 1 vs offset (1 - 0.5 / bake resolution) .");
 }
 
+TEST_CASE("[Curve] Expanding point count should preserve existing indexed point properties") {
+	Ref<Curve> curve = memnew(Curve);
+	const Vector2 first_position(0.25, 0.25);
+	const Vector2 second_position(0.75, 0.75);
+
+	curve->add_point(first_position);
+	curve->add_point(second_position);
+
+	const Variant first_property = curve->get("point_0/position");
+	const Variant second_property = curve->get("point_1/position");
+
+	curve->set_point_count(3);
+
+	CHECK_MESSAGE(
+			curve->get_point_position(0) == first_position,
+			"Existing first point should keep its indexed position immediately after expanding.");
+	CHECK_MESSAGE(
+			curve->get_point_position(1) == second_position,
+			"Existing second point should keep its indexed position immediately after expanding.");
+
+	curve->set("point_0/position", first_property);
+	curve->set("point_1/position", second_property);
+
+	CHECK_MESSAGE(
+			curve->get_point_count() == 3,
+			"Curve should contain the expected number of points after expanding.");
+	CHECK_MESSAGE(
+			curve->get_point_position(0) == first_position,
+			"Existing first point should keep its indexed position after expanding.");
+	CHECK_MESSAGE(
+			curve->get_point_position(1) == second_position,
+			"Existing second point should keep its indexed position after expanding.");
+}
+
 TEST_CASE("[Curve2D] Linear sampling should return exact value") {
 	Ref<Curve2D> curve = memnew(Curve2D);
 	real_t len = 2048.0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119660

When the Inspector adds a new point to a `Curve`, it stores the current indexed point properties, increases `point_count`, then reapplies those properties. `Curve::set_point_count()` was using `_add_point(Vector2())` for the newly-created slot. Since `_add_point()` keeps points sorted by offset, adding a default `(0, 0)` point could shift existing indexed points before the Inspector restored their values, making the first point appear reset.

This changes `Curve::set_point_count()` to create new points at the end of the curve domain when expanding an existing curve. That keeps existing indexed slots stable while still using `_add_point()` for point initialization, sorting, tangent updates, and dirty-state handling.

AI-assisted contribution: AI tooling was used for issue triage, implementation drafting, and local test orchestration.

Tests:
- `scons platform=macos target=editor tests=yes vulkan=no angle=no accesskit=no ccflags=-fmodules-cache-path=/private/tmp/godot-clang-module-cache -j4`
- `HOME=/private/tmp/godot-test-home ./bin/godot.macos.editor.arm64 --headless --test --test-case="[Curve] Expanding point count should preserve existing indexed point properties"`
- `HOME=/private/tmp/godot-test-home ./bin/godot.macos.editor.arm64 --headless --test --test-case="[Curve]*"`
- `HOME=/private/tmp/godot-test-home ./bin/godot.macos.editor.arm64 --headless --test --test-case="[Curve2D]*" --test-case="[Curve3D]*"`
- `/private/tmp/godot-prek-venv/bin/prek run --show-diff-on-failure --files scene/resources/curve.cpp tests/scene/test_curve.cpp`
- `git diff --check`

## Additional information

The test mirrors the Inspector's property replay sequence: read indexed point properties, expand `point_count`, then set the old indexed properties back. It also checks that the existing indexed positions are preserved immediately after expanding.
