### PR TITLE
Fix autosmooth behavior change caused by performance fix

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -606,8 +606,6 @@ void CSGShape3D::update_shape() {
 	CSGBrush *n = _get_brush();
 	ERR_FAIL_NULL_MSG(n, "Cannot get CSGBrush.");
 
-	AHashMap<Vector3, Vector3> vec_map;
-
 	Vector<int> face_count;
 	face_count.resize(n->materials.size() + 1);
 	face_count.fill(0);
@@ -706,6 +704,7 @@ void CSGShape3D::_build_surfaces_smoothed(CSGBrush *p_brush, Vector<CSGShape3D::
 		for (int i = 0; i < smooth_faces_size; i++) {
 			for (int k = 0; k < 3; k++) {
 				int curr_vert = i * 3 + k;
+				// Skip the other vertices of the face as they will never occupy the same position.
 				Vector3 vert_a = p_brush->faces[i].vertices[k];
 				for (int j = i + 1; j < smooth_faces_size; j++) {
 					// Compare the angles of faces instead of vertices.
@@ -716,39 +715,13 @@ void CSGShape3D::_build_surfaces_smoothed(CSGBrush *p_brush, Vector<CSGShape3D::
 								int curr_j = j * 3 + h;
 								smooth_vertex[curr_vert] += smooth_faces_ptr[j];
 								smooth_vertex[curr_j] += smooth_faces_ptr[i];
+								// Skip the other 2 vertices as only one vertex of each face can connect with one vertex of other face.
 								break;
 							}
 						}
 					}
 				}
 				smooth_vertex[curr_vert].normalize();
-			}
-		}
-	} else {
-		for (int i = 0; i < smooth_faces_size; i++) {
-			bool face_is_smooth = p_brush->faces[i].smooth;
-			if (face_is_smooth) {
-				for (int k = 0; k < 3; k++) {
-					Vector3 vert_a = p_brush->faces[i].vertices[k];
-					int curr_vert = i * 3 + k;
-					// Skip the other vertices of the face as they will never occupy the same position.
-					for (int j = i + 1; j < smooth_faces_size; j++) {
-						// Preparing for when and if we replace Vector of bool for Vector of int smoothing groups. for now, face_is_smooth is always true.
-						if (face_is_smooth == p_brush->faces[j].smooth) {
-							for (int h = 0; h < 3; h++) {
-								Vector3 vert_b = p_brush->faces[j].vertices[h];
-								if (vert_a == vert_b) {
-									int curr_j = j * 3 + h;
-									smooth_vertex[curr_vert] += smooth_faces_ptr[j];
-									smooth_vertex[curr_j] += smooth_faces_ptr[i];
-									// Skip the other 2 vertices as only one vertex of each face can connect with one vertex of other face.
-									break;
-								}
-							}
-						}
-					}
-					smooth_vertex[curr_vert].normalize();
-				}
 			}
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?
https://github.com/godotengine/godot/pull/119551 altered the behavior of `autosmooth` when `angle` is `< 0.1`, it was supposed to make the faces flat, but was changed to use the less performant smoothing instead.
This PR removes a conditional branching, restoring the previous behavior, which was in the original proposal https://github.com/godotengine/godot-proposals/issues/1862:

> If the angle limit is 0 or 180, the smoothing calculation process is skipped since no faces (or all faces) will be considered smooth.

-----

<table><tr><td>4.7 beta 2</td><td>
<img width="973" height="490" alt="Captura desde 2026-05-22 23-23-08" src="https://github.com/user-attachments/assets/534a610d-e6d4-4a6f-a3e5-f23b6644cb43" />
</td></tr>
<tr><td>performance fix</td><td>
<img width="973" height="490" alt="Captura desde 2026-05-22 23-43-15" src="https://github.com/user-attachments/assets/56c9f5cf-3a25-4d15-9308-47e657755590" />
</td></tr>
<tr><td>this PR</td><td><img width="973" height="490" alt="Captura desde 2026-05-22 23-28-44" src="https://github.com/user-attachments/assets/b555b7a4-daeb-4d2b-8eef-726be836d82e" /></td></tr></table>

## Additional information

`vec_map` was also declared first in `update_shape`, and then again locally in the `_build_surfaces_default()` method. The first declaration was removed as it was doing nothing.

No AI used.