### PR TITLE
Fix the documentation for some SkeletonModifier3Ds' rest

### DIFF
--- a/doc/classes/IterateIK3D.xml
+++ b/doc/classes/IterateIK3D.xml
@@ -44,7 +44,8 @@
 				Returns the joint limitation rotation offset at [param joint] in the bone chain's joint list.
 				Rotation is done in the local space which is constructed by the bone direction (in general parent to child) as the +Y axis and [method get_joint_limitation_right_axis_vector] as the +X axis.
 				If the +X and +Y axes are not orthogonal, the +X axis is implicitly modified to make it orthogonal.
-				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the bone rest using the shortest arc that rotates the +Y axis of the bone rest to match the bone direction.
+				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the reference pose using the shortest arc that rotates the +Y axis of the reference pose to match the bone direction.
+				In here, the reference pose is the bone pose immediately before processing IK.
 			</description>
 		</method>
 		<method name="get_joint_rotation_axis" qualifiers="const">
@@ -107,7 +108,8 @@
 				Sets the joint limitation rotation offset at [param joint] in the bone chain's joint list.
 				Rotation is done in the local space which is constructed by the bone direction (in general parent to child) as the +Y axis and [method get_joint_limitation_right_axis_vector] as the +X axis.
 				If the +X and +Y axes are not orthogonal, the +X axis is implicitly modified to make it orthogonal.
-				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the bone rest using the shortest arc that rotates the +Y axis of the bone rest to match the bone direction.
+				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the reference pose using the shortest arc that rotates the +Y axis of the reference pose to match the bone direction.
+				In here, the reference pose is the bone pose immediately before processing IK.
 			</description>
 		</method>
 		<method name="set_joint_rotation_axis">
@@ -117,7 +119,8 @@
 			<param index="2" name="axis" type="int" enum="SkeletonModifier3D.RotationAxis" />
 			<description>
 				Sets the rotation axis at [param joint] in the bone chain's joint list.
-				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				The axes are based on the reference pose's space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				In here, the reference pose is the bone pose immediately before processing IK.
 				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [ChainIK3D] does not factor in twisting forces.
 			</description>
 		</method>

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -93,7 +93,7 @@
 		</member>
 		<member name="relative" type="bool" setter="set_relative" getter="is_relative" default="false">
 			The relative option. If [code]true[/code], the rotation is applied relative to the pose. If [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [LookAtModifier3D]'s result.
-			[b]Note:[/b] This option affects the base angle for [member use_angle_limitation] unlike [IterateIK3D]'s [JointLimitation3D]. Since the [LookAtModifier3D] relies strongly on Euler rotation, the axis that determines the limitation and the actual rotation are strongly tied together.
+			[b]Note:[/b] This option affects the base angle for [member use_angle_limitation]. Since the [LookAtModifier3D] relies strongly on Euler rotation, the axis that determines the limitation and the actual rotation are strongly tied together.
 		</member>
 		<member name="secondary_damp_threshold" type="float" setter="set_secondary_damp_threshold" getter="get_secondary_damp_threshold">
 			The threshold to start damping for [member secondary_limit_angle].

--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -537,7 +537,8 @@
 			<param index="2" name="axis" type="int" enum="SkeletonModifier3D.RotationAxis" />
 			<description>
 				Sets the rotation axis at [param joint] in the bone chain's joint list when [method is_config_individual] is [code]true[/code].
-				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				The axes are based on the reference pose's space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				In here, the reference pose is the bone pose immediately before the simulation.
 				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
 			</description>
 		</method>
@@ -600,7 +601,8 @@
 			<param index="1" name="axis" type="int" enum="SkeletonModifier3D.RotationAxis" />
 			<description>
 				Sets the rotation axis of the bone chain. If set to a specific axis, it acts like a hinge joint. The value is cached in each joint setting in the joint list.
-				The axes are based on the [method Skeleton3D.get_bone_rest]'s space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				The axes are based on the reference pose's space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
+				In here, the reference pose is the bone pose immediately before the simulation.
 				[b]Note:[/b] The rotation axis vector and the forward vector shouldn't be colinear to avoid unintended rotation since [SpringBoneSimulator3D] does not factor in twisting forces.
 			</description>
 		</method>


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related https://github.com/godotengine/godot/issues/119664

Currently, IK treats the bone pose that is not executing IK as the rest pose. This behavior need to be maintained because, as shown in the example https://github.com/godotengine/godot/issues/119664#issuecomment-4522567706, it performs processing such as a Pole Target that directs the root toward a secondary target (in other words, it changes the IK constraint axis with other SkeletonModifiers before the IK processing).

## Additional information

This does not solve the problem, but the documentation needs to be corrected because it does not match the current actual behavior.

In the future:

- The Gizmo needs to be fixed
- The documentation should be changed to indicate that the pose retrieved depends on the option after adding an option to set limits to the rest standard, like `The bone pose refers to "the pose immediately before IK processing" or "the rest" depend on the option.`
