### PR TITLE
Extend output filtering functionality and improve UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 ###########################
 
 /custom.py
+build_and_run.sh
 
 #############################
 ### Godot generated files ###

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 ###########################
 
 /custom.py
-build_and_run.sh
 
 #############################
 ### Godot generated files ###

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -218,7 +218,7 @@ void EditorLog::_set_show_non_search_matches(bool p_state) {
 
 void EditorLog::_set_search_case_sensitive(bool p_state) {
 	search_case_sensitive = p_state;
-	
+
 	log->set_scroll_follow(false);
 	_rebuild_log();
 	log->set_scroll_follow(true);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -439,7 +439,7 @@ void EditorLog::_append_styled_log_line(const Color &p_color_regular, const Colo
 
 		if (keytext_pos == 0) {
 			int last_pos = positions[positions.size() - 1];
-			positions.remove_at(positions.size() - 1);
+			positions.resize(positions.size() - 1);
 			positions.append(last_pos + keytext_length);
 		} else {
 			positions.append(keytext_pos + cursor_position);
@@ -448,7 +448,7 @@ void EditorLog::_append_styled_log_line(const Color &p_color_regular, const Colo
 
 		cursor_position += keytext_pos + keytext_length;
 
-		iterator_line = p_line.substr(cursor_position, p_line.length());
+		iterator_line = p_line.substr(cursor_position);
 	}
 
 	// Imagine p_line "Lullaby" and p_keytext "l".

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -654,21 +654,20 @@ EditorLog::EditorLog() {
 	HFlowContainer *bottom_hf = memnew(HFlowContainer);
 	bottom_hf->set_alignment(FlowContainer::ALIGNMENT_END);
 	vb_left->add_child(bottom_hf);
-
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	bottom_hf->add_child(hbox);
-
+	
 	// Search box
 	search_box = memnew(LineEdit);
-	search_box->set_custom_minimum_size(Vector2(200 * EDSCALE, 0));
+	search_box->set_custom_minimum_size(Vector2(150 * EDSCALE, 0));
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTRC("Filter Messages"));
 	search_box->set_accessibility_name(TTRC("Filter Messages"));
 	search_box->set_clear_button_enabled(true);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
-	hbox->add_child(search_box);
+	bottom_hf->add_child(search_box);
 
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	bottom_hf->add_child(hbox);
+	
 	//Exclude non-filter matches button
 	show_non_search_matches_button = memnew(Button);
 	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
@@ -681,6 +680,8 @@ EditorLog::EditorLog() {
 
 	// Case sensitive button
 	search_case_sensitive_button = memnew(Button);
+	search_case_sensitive_button->set_tooltip_text(TTRC("Toggle case-sensitivity"));
+	search_case_sensitive_button->set_accessibility_name(TTRC("Toggle case-sensitivity"));
 	search_case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
 	search_case_sensitive_button->set_toggle_mode(true);
 	search_case_sensitive_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_case_sensitive));
@@ -707,17 +708,7 @@ EditorLog::EditorLog() {
 	collapse_button->set_pressed(false);
 	collapse_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_collapse));
 	bottom_hf->add_child(collapse_button);
-
-	// Search box
-	search_box = memnew(LineEdit);
-	search_box->set_custom_minimum_size(Vector2(150 * EDSCALE, 0));
-	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	search_box->set_placeholder(TTRC("Filter Messages"));
-	search_box->set_accessibility_name(TTRC("Filter Messages"));
-	search_box->set_clear_button_enabled(true);
-	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
-	bottom_hf->add_child(search_box);
-
+	
 	// Message Type Filters.
 	LogFilter *std_filter = memnew(LogFilter(MSG_TYPE_STD));
 	std_filter->initialize_button(TTRC("Standard Messages"), TTRC("Toggle visibility of standard output messages."), callable_mp(this, &EditorLog::_set_filter_active));

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -654,7 +654,7 @@ EditorLog::EditorLog() {
 	HFlowContainer *bottom_hf = memnew(HFlowContainer);
 	bottom_hf->set_alignment(FlowContainer::ALIGNMENT_END);
 	vb_left->add_child(bottom_hf);
-	
+
 	// Search box
 	search_box = memnew(LineEdit);
 	search_box->set_custom_minimum_size(Vector2(150 * EDSCALE, 0));
@@ -667,7 +667,7 @@ EditorLog::EditorLog() {
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
 	bottom_hf->add_child(hbox);
-	
+
 	//Exclude non-filter matches button
 	show_non_search_matches_button = memnew(Button);
 	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
@@ -708,7 +708,7 @@ EditorLog::EditorLog() {
 	collapse_button->set_pressed(false);
 	collapse_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_collapse));
 	bottom_hf->add_child(collapse_button);
-	
+
 	// Message Type Filters.
 	LogFilter *std_filter = memnew(LogFilter(MSG_TYPE_STD));
 	std_filter->initialize_button(TTRC("Standard Messages"), TTRC("Toggle visibility of standard output messages."), callable_mp(this, &EditorLog::_set_filter_active));

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -213,7 +213,7 @@ void EditorLog::_set_show_non_search_matches(bool p_state) {
 
 	log->set_scroll_follow(false);
 	_rebuild_log();
-	log->set_scroll_follow(false);
+	log->set_scroll_follow(true);
 }
 
 void EditorLog::_set_search_case_sensitive(bool p_state) {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -211,13 +211,17 @@ void EditorLog::_load_state() {
 void EditorLog::_set_show_non_search_matches(bool p_state) {
 	show_non_search_matches = p_state;
 
+	log->set_scroll_follow(false);
 	_rebuild_log();
+	log->set_scroll_follow(false);
 }
 
 void EditorLog::_set_search_case_sensitive(bool p_state) {
 	search_case_sensitive = p_state;
-
+	
+	log->set_scroll_follow(false);
 	_rebuild_log();
+	log->set_scroll_follow(true);
 }
 
 void EditorLog::_set_search_buttons_visibility(bool p_visible) {
@@ -413,7 +417,15 @@ bool EditorLog::_contains_case_sensitive(const String &p_base, const String &p_c
 	}
 }
 
-void EditorLog::_append_styled_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext) {
+int EditorLog::_find_case_sensitive(const String &p_base, const String &p_target) {
+	if (search_case_sensitive) {
+		return p_base.find(p_target);
+	} else {
+		return p_base.findn(p_target);
+	}
+}
+
+void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext) {
 	if (p_keytext.is_empty() || !_contains_case_sensitive(p_line, p_keytext)) {
 		log->push_color(p_color_regular);
 		log->add_text(p_line);
@@ -428,14 +440,14 @@ void EditorLog::_append_styled_log_line(const Color &p_color_regular, const Colo
 	Vector<int> positions; // Array of substring positions. Every pair will be cut into a substring from p_line.
 	positions.append(0);
 
-	if (iterator_line.findn(p_keytext) == 0) {
+	if (_find_case_sensitive(iterator_line, p_keytext) == 0) {
 		positions.append(0);
 		positions.append(0); // This last zero will be replaced in a few lines, which fixes the order in case the first characters are immediately matches.
 	}
 
 	// Map which segments of p_line contain the target string. Every uneven pair of ints will be a non-match, and every even pair will be a match.
 	while (_contains_case_sensitive(iterator_line, p_keytext)) {
-		int keytext_pos = iterator_line.findn(p_keytext);
+		int keytext_pos = _find_case_sensitive(iterator_line, p_keytext);
 
 		if (keytext_pos == 0) {
 			int last_pos = positions[positions.size() - 1];
@@ -558,11 +570,11 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	} else { // For all other message types
 		if (_check_display_message(p_message) && !filter_keytext.is_empty()) {
 			if (p_message.type == MSG_TYPE_ERROR) {
-				_append_styled_log_line(theme_cache.error_color * Color(0.8, 0.8, 0.8), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
+				_add_highlighted_log_line(theme_cache.error_color * Color(0.8, 0.8, 0.8), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
 			} else if (p_message.type == MSG_TYPE_WARNING) {
-				_append_styled_log_line(theme_cache.warning_color * Color(0.8, 0.8, 0.8), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
+				_add_highlighted_log_line(theme_cache.warning_color * Color(0.8, 0.8, 0.8), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
 			} else {
-				_append_styled_log_line(theme_cache.message_color, Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
+				_add_highlighted_log_line(theme_cache.message_color, Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
 			}
 		} else { // If we aren't doing anything special with filtering, just print it as normal
 			log->add_text(p_message.text);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -126,6 +126,8 @@ void EditorLog::_update_theme() {
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
+	show_non_search_matches_button->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
+	search_case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
 	theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
@@ -204,6 +206,23 @@ void EditorLog::_load_state() {
 	collapse_button->set_pressed(EDITOR_DEF("_editor_log_collapse", false));
 
 	is_loading_state = false;
+}
+
+void EditorLog::_set_show_non_search_matches(bool p_state) {
+	show_non_search_matches = p_state;
+
+	_rebuild_log();
+}
+
+void EditorLog::_set_search_case_sensitive(bool p_state) {
+	search_case_sensitive = p_state;
+
+	_rebuild_log();
+}
+
+void EditorLog::_set_search_buttons_visibility(bool p_visible) {
+	show_non_search_matches_button->set_visible(p_visible);
+	search_case_sensitive_button->set_visible(p_visible);
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
@@ -312,8 +331,6 @@ void EditorLog::_rebuild_log() {
 		return;
 	}
 
-	log->clear();
-
 	int line_count = 0;
 	int start_message_index = 0;
 	int initial_skip = 0;
@@ -341,6 +358,7 @@ void EditorLog::_rebuild_log() {
 			break;
 		}
 	}
+	log->clear();
 
 	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
@@ -366,7 +384,7 @@ bool EditorLog::_check_display_message(LogMessage &p_message) {
 		return filter_active;
 	}
 
-	bool search_match = p_message.text.containsn(search_text);
+	bool search_match = _contains_case_sensitive(p_message.text, search_text);
 
 	// If not found and message contains BBCode tags, also check the parsed text
 	if (!search_match && p_message.text.contains_char('[')) {
@@ -380,10 +398,90 @@ bool EditorLog::_check_display_message(LogMessage &p_message) {
 		bbcode_parser->clear();
 		bbcode_parser->parse_bbcode(p_message.text);
 		String parsed_text = bbcode_parser->get_parsed_text();
-		search_match = parsed_text.containsn(search_text);
+
+		search_match = _contains_case_sensitive(parsed_text, search_text);
 	}
 
 	return filter_active && search_match;
+}
+
+bool EditorLog::_contains_case_sensitive(const String &p_base, const String &p_contains) {
+	if (search_case_sensitive) {
+		return p_base.contains(p_contains);
+	} else {
+		return p_base.containsn(p_contains);
+	}
+}
+
+void EditorLog::_append_styled_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext) {
+	if (p_keytext.is_empty() || !_contains_case_sensitive(p_line, p_keytext)) {
+		log->push_color(p_color_regular);
+		log->add_text(p_line);
+		return;
+	}
+
+	int keytext_length = p_keytext.length();
+
+	String iterator_line = p_line;
+	int cursor_position = 0;
+
+	Vector<int> positions; // Array of substring positions. Every pair will be cut into a substring from p_line.
+	positions.append(0);
+
+	if (iterator_line.findn(p_keytext) == 0) {
+		positions.append(0);
+		positions.append(0); // This last zero will be replaced in a few lines, which fixes the order in case the first characters are immediately matches.
+	}
+
+	// Map which segments of p_line contain the target string. Every uneven pair of ints will be a non-match, and every even pair will be a match.
+	while (_contains_case_sensitive(iterator_line, p_keytext)) {
+		int keytext_pos = iterator_line.findn(p_keytext);
+
+		if (keytext_pos == 0) {
+			int last_pos = positions[positions.size() - 1];
+			positions.remove_at(positions.size() - 1);
+			positions.append(last_pos + keytext_length);
+		} else {
+			positions.append(keytext_pos + cursor_position);
+			positions.append(keytext_pos + cursor_position + keytext_length);
+		}
+
+		cursor_position += keytext_pos + keytext_length;
+
+		iterator_line = p_line.substr(cursor_position, p_line.length());
+	}
+
+	// Imagine p_line "Lullaby" and p_keytext "l".
+	// positions will be [0,0,1,2,4].
+	// - The pair 0,0 was inserted due to 20 lines up and is considered not a match.
+	// - The pair 0,1 ("L") is a match
+	// - The pair 1,2 ("u") is not a match
+	// - The pair 2,4 ("ll") is a match once again
+
+	// The last pair always describes a match and in the case p_line does not end with a match, that would cut off p_line after the last match...
+	if (positions[positions.size() - 1] != p_line.size() - 1) {
+		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
+	}
+
+	// Iterate through map in pairs. That's why we start at index 1.
+	for (int i = 1; i < positions.size(); i++) {
+		String substring = p_line.substr(positions[i - 1], positions[i] - positions[i - 1]);
+
+		// Even index means this segment is a match, uneven means the segment is not a match.
+		if (i % 2 == 1) {
+			log->push_color(p_color_regular);
+			log->push_normal();
+			log->add_text(substring);
+		} else {
+			log->push_color(p_color_highlighted);
+			log->push_bold();
+			log->add_text(substring);
+		}
+	}
+
+	log->pop(); // To finish off, we break off the most recently pushed tag. In the case that was push_bold(), the boldening effect is removed.
+
+	// That's it!
 }
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
@@ -397,9 +495,16 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		return;
 	}
 
-	// Only add the message to the log if it passes the filters.
-	if (!_check_display_message(p_message)) {
+	if (!type_filter_map[p_message.type]->is_active()) {
 		return;
+	}
+
+	if (!_check_display_message(p_message)) {
+		// Either darken or remove the message altogether when it does not fit the filter keytext.
+		if (!show_non_search_matches) {
+			return;
+		}
+		log->push_color(Color(1.0, 1.0, 1.0, 0.2));
 	}
 
 	if (p_replace_previous) {
@@ -445,11 +550,23 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->pop();
 	}
 
+	String filter_keytext = search_box->get_text();
+
 	// Note that errors and warnings only support BBCode in the file part of the message.
-	if (p_message.type == MSG_TYPE_STD_RICH || p_message.type == MSG_TYPE_ERROR || p_message.type == MSG_TYPE_WARNING) {
+	if (p_message.type == MSG_TYPE_STD_RICH) {
 		log->append_text(p_message.text);
-	} else {
-		log->add_text(p_message.text);
+	} else { // For all other message types
+		if (_check_display_message(p_message) && !filter_keytext.is_empty()) {
+			if (p_message.type == MSG_TYPE_ERROR) {
+				_append_styled_log_line(theme_cache.error_color * Color(0.8, 0.8, 0.8), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
+			} else if (p_message.type == MSG_TYPE_WARNING) {
+				_append_styled_log_line(theme_cache.warning_color * Color(0.8, 0.8, 0.8), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
+			} else {
+				_append_styled_log_line(theme_cache.message_color, Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
+			}
+		} else { // If we aren't doing anything special with filtering, just print it as normal
+			log->add_text(p_message.text);
+		}
 	}
 	if (p_message.clear || p_message.type != MSG_TYPE_STD_RICH) {
 		log->pop_all(); // Pop all unclosed tags.
@@ -469,13 +586,22 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 }
 
 void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
+	log->set_scroll_follow(false);
+
 	type_filter_map[p_message_type]->set_active(p_active);
 	_start_state_save_timer();
 	_rebuild_log();
+
+	log->set_scroll_follow(true);
 }
 
 void EditorLog::_search_changed(const String &p_text) {
+	log->set_scroll_follow(false); // Prevent the RichTextLabel from autoscrolling due to new messages being added during _rebuild_log().
+
 	_rebuild_log();
+	_set_search_buttons_visibility(!p_text.is_empty());
+
+	log->set_scroll_follow(true);
 }
 
 void EditorLog::_reset_message_counts() {
@@ -529,6 +655,40 @@ EditorLog::EditorLog() {
 	bottom_hf->set_alignment(FlowContainer::ALIGNMENT_END);
 	vb_left->add_child(bottom_hf);
 
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	bottom_hf->add_child(hbox);
+
+	// Search box
+	search_box = memnew(LineEdit);
+	search_box->set_custom_minimum_size(Vector2(200 * EDSCALE, 0));
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_placeholder(TTRC("Filter Messages"));
+	search_box->set_accessibility_name(TTRC("Filter Messages"));
+	search_box->set_clear_button_enabled(true);
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
+	hbox->add_child(search_box);
+
+	//Exclude non-filter matches button
+	show_non_search_matches_button = memnew(Button);
+	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
+	show_non_search_matches_button->set_accessibility_name(TTRC("Show Non-Matches"));
+	show_non_search_matches_button->set_theme_type_variation(SceneStringName(FlatButton));
+	show_non_search_matches_button->set_toggle_mode(true);
+	show_non_search_matches_button->set_pressed(true);
+	show_non_search_matches_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_show_non_search_matches));
+	hbox->add_child(show_non_search_matches_button);
+
+	// Case sensitive button
+	search_case_sensitive_button = memnew(Button);
+	search_case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
+	search_case_sensitive_button->set_toggle_mode(true);
+	search_case_sensitive_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_case_sensitive));
+	hbox->add_child(search_case_sensitive_button);
+
+	// Make show_non_search_matches_button and search_case_sensitive_button invisible
+	_set_search_buttons_visibility(false);
+
 	// Clear.
 	clear_button = memnew(Button);
 	clear_button->set_accessibility_name(TTRC("Clear Log"));
@@ -557,9 +717,6 @@ EditorLog::EditorLog() {
 	search_box->set_clear_button_enabled(true);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorLog::_search_changed));
 	bottom_hf->add_child(search_box);
-
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	bottom_hf->add_child(hbox);
 
 	// Message Type Filters.
 	LogFilter *std_filter = memnew(LogFilter(MSG_TYPE_STD));

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -128,6 +128,7 @@ void EditorLog::_update_theme() {
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
 	show_non_search_matches_button->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
 	search_case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
+	search_parse_bbcode_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
 	theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
@@ -224,9 +225,18 @@ void EditorLog::_set_search_case_sensitive(bool p_state) {
 	log->set_scroll_follow(true);
 }
 
+void EditorLog::_set_search_parse_bbcode(bool p_state) {
+	search_parse_bbcode = p_state;
+
+	log->set_scroll_follow(false);
+	_rebuild_log();
+	log->set_scroll_follow(true);
+}
+
 void EditorLog::_set_search_buttons_visibility(bool p_visible) {
 	show_non_search_matches_button->set_visible(p_visible);
 	search_case_sensitive_button->set_visible(p_visible);
+	search_parse_bbcode_button->set_visible(p_visible);
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
@@ -390,22 +400,6 @@ bool EditorLog::_check_display_message(LogMessage &p_message) {
 
 	bool search_match = _contains_case_sensitive(p_message.text, search_text);
 
-	// If not found and message contains BBCode tags, also check the parsed text
-	if (!search_match && p_message.text.contains_char('[')) {
-		// Lazy initialize the BBCode parser
-		if (!bbcode_parser) {
-			bbcode_parser = memnew(RichTextLabel);
-			bbcode_parser->set_use_bbcode(true);
-		}
-
-		// Ensure clean state for each message
-		bbcode_parser->clear();
-		bbcode_parser->parse_bbcode(p_message.text);
-		String parsed_text = bbcode_parser->get_parsed_text();
-
-		search_match = _contains_case_sensitive(parsed_text, search_text);
-	}
-
 	return filter_active && search_match;
 }
 
@@ -470,7 +464,7 @@ void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Co
 	// - The pair 1,2 ("u") is not a match
 	// - The pair 2,4 ("ll") is a match once again
 
-	// The last pair always describes a match and in the case p_line does not end with a match, that would cut off p_line after the last match...
+	// The last pair will always describe a match and in the case p_line does not end with a match, that would cut off p_line after the last match...
 	if (positions[positions.size() - 1] != p_line.size() - 1) {
 		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
 	}
@@ -480,11 +474,11 @@ void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Co
 		String substring = p_line.substr(positions[i - 1], positions[i] - positions[i - 1]);
 
 		// Even index means this segment is a match, uneven means the segment is not a match.
-		if (i % 2 == 1) {
+		if (i % 2 == 1) { // Uneven
 			log->push_color(p_color_regular);
 			log->push_normal();
 			log->add_text(substring);
-		} else {
+		} else { // Even
 			log->push_color(p_color_highlighted);
 			log->push_bold();
 			log->add_text(substring);
@@ -497,6 +491,8 @@ void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Co
 }
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
+	String filter_keytext = search_box->get_text();
+
 	if (!is_inside_tree()) {
 		// The log will be built all at once when it enters the tree and has its theme items.
 		return;
@@ -516,7 +512,20 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		if (!show_non_search_matches) {
 			return;
 		}
-		log->push_color(Color(1.0, 1.0, 1.0, 0.2));
+	}
+
+	if (search_parse_bbcode && !filter_keytext.is_empty()) {
+		// Lazy initialize the BBCode parser
+		if (!bbcode_parser) {
+			bbcode_parser = memnew(RichTextLabel);
+			bbcode_parser->set_use_bbcode(true);
+		}
+
+		// Ensure clean state for each message
+		bbcode_parser->clear();
+		bbcode_parser->parse_bbcode(p_message.text);
+		String parsed_text = bbcode_parser->get_parsed_text();
+		p_message.text = parsed_text;
 	}
 
 	if (p_replace_previous) {
@@ -562,21 +571,24 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->pop();
 	}
 
-	String filter_keytext = search_box->get_text();
-
 	// Note that errors and warnings only support BBCode in the file part of the message.
-	if (p_message.type == MSG_TYPE_STD_RICH) {
-		log->append_text(p_message.text);
-	} else { // For all other message types
-		if (_check_display_message(p_message) && !filter_keytext.is_empty()) {
+	if (!filter_keytext.is_empty()) {
+		if (_check_display_message(p_message)) {
 			if (p_message.type == MSG_TYPE_ERROR) {
-				_add_highlighted_log_line(theme_cache.error_color * Color(0.8, 0.8, 0.8), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
+				_add_highlighted_log_line(theme_cache.error_color * Color(1.0, 1.0, 1.0, 0.5), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
 			} else if (p_message.type == MSG_TYPE_WARNING) {
-				_add_highlighted_log_line(theme_cache.warning_color * Color(0.8, 0.8, 0.8), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
+				_add_highlighted_log_line(theme_cache.warning_color * Color(1.0, 1.0, 1.0, 0.5), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
 			} else {
 				_add_highlighted_log_line(theme_cache.message_color, Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
 			}
-		} else { // If we aren't doing anything special with filtering, just print it as normal
+		} else {
+			log->push_color(Color(1.0, 1.0, 1.0, 0.2));
+			log->add_text(p_message.text); // Only use add_text instead of append_text for rich messages to force the BBCode tags to be exposed
+		}
+	} else { // If we aren't doing anything special with filtering, just print it as normal
+		if (p_message.type == MSG_TYPE_STD_RICH) {
+			log->append_text(p_message.text);
+		} else {
 			log->add_text(p_message.text);
 		}
 	}
@@ -698,6 +710,15 @@ EditorLog::EditorLog() {
 	search_case_sensitive_button->set_toggle_mode(true);
 	search_case_sensitive_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_case_sensitive));
 	hbox->add_child(search_case_sensitive_button);
+
+	// Parse BBCode button
+	search_parse_bbcode_button = memnew(Button);
+	search_parse_bbcode_button->set_tooltip_text(TTRC("Parse BBCode"));
+	search_parse_bbcode_button->set_accessibility_name(TTRC("Parse BBCode"));
+	search_parse_bbcode_button->set_theme_type_variation(SceneStringName(FlatButton));
+	search_parse_bbcode_button->set_toggle_mode(true);
+	search_parse_bbcode_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_parse_bbcode));
+	hbox->add_child(search_parse_bbcode_button);
 
 	// Make show_non_search_matches_button and search_case_sensitive_button invisible
 	_set_search_buttons_visibility(false);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -690,7 +690,7 @@ EditorLog::EditorLog() {
 	hb->add_child(vb_left);
 
 	// Log - Rich Text Label.
-	log = memnew(RichTextLabel);
+	log = memnew(EditorLogRichTextLabel);
 	log->set_threaded(true);
 	log->set_use_bbcode(true);
 	log->set_scroll_follow(true);
@@ -742,9 +742,9 @@ EditorLog::EditorLog() {
 
 	// Exclude non-filter matches button
 	show_non_search_matches_button = memnew(CheckBox);
-	show_non_search_matches_button->set_text("Show Non-Matches");
-	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
-	show_non_search_matches_button->set_accessibility_name(TTRC("Show Non-Matches"));
+	show_non_search_matches_button->set_text("Show Non-Matching Lines");
+	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matching Lines"));
+	show_non_search_matches_button->set_accessibility_name(TTRC("Show Non-Matching Lines"));
 	show_non_search_matches_button->set_pressed(true);
 	show_non_search_matches_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_show_non_search_matches));
 	extra_filter_options_hbox->add_child(show_non_search_matches_button);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -220,6 +220,7 @@ void EditorLog::_set_show_non_search_matches(bool p_state) {
 
 void EditorLog::_set_search_case_sensitive(bool p_state) {
 	search_case_sensitive = p_state;
+	log->set_filter_case_sensitive(p_state);
 
 	log->set_scroll_follow(false);
 	_rebuild_log();
@@ -445,99 +446,88 @@ int EditorLog::_count_case_sensitive(const String &p_base, const String &p_targe
 String EditorLog::_strip_bbcode_from_message(const String &p_text) {
 	String result;
 
-	// Lazy initialize the BBCode parser
-	if (!bbcode_parser) {
-		bbcode_parser = memnew(RichTextLabel);
-		bbcode_parser->set_use_bbcode(true);
-	}
-
-	// Ensure clean state for each message
 	bbcode_parser->clear();
 	bbcode_parser->parse_bbcode(p_text);
 	result = bbcode_parser->get_parsed_text();
 	return result;
 }
 
-Vector<int> EditorLog::_get_line_search_query_positions(const String &p_line, const String &p_keytext) {
-	int keytext_length = p_keytext.length();
+// Vector<int> EditorLog::_get_line_search_query_positions(const String &p_line, const String &p_keytext) {
+// 	int keytext_length = p_keytext.length();
 
-	String iterator_line = p_line;
-	int cursor_position = 0;
+// 	String iterator_line = p_line;
+// 	int cursor_position = 0;
 
-	Vector<int> positions; // Array of substring positions. Every pair will be cut into a substring from p_line.
-	positions.append(0);
+// 	Vector<int> positions; // Array of substring positions. Every pair will be cut into a substring from p_line.
+// 	positions.append(0);
 
-	if (_find_case_sensitive(iterator_line, p_keytext) == 0) {
-		positions.append(0);
-		positions.append(0); // This last zero will be replaced in a few lines, which fixes the order in case the first characters are immediately matches.
-	}
+// 	if (_find_case_sensitive(iterator_line, p_keytext) == 0) {
+// 		positions.append(0);
+// 		positions.append(0); // This last zero will be replaced in a few lines, which fixes the order in case the first characters are immediately matches.
+// 	}
 
-	// Map which segments of p_line contain the target string. Every uneven pair of ints will be a non-match, and every even pair will be a match.
-	while (_contains_case_sensitive(iterator_line, p_keytext)) {
-		int keytext_pos = _find_case_sensitive(iterator_line, p_keytext);
+// 	// Map which segments of p_line contain the target string. Every uneven pair of ints will be a non-match, and every even pair will be a match.
+// 	while (_contains_case_sensitive(iterator_line, p_keytext)) {
+// 		int keytext_pos = _find_case_sensitive(iterator_line, p_keytext);
 
-		if (keytext_pos == 0) {
-			int last_pos = positions[positions.size() - 1];
-			positions.resize(positions.size() - 1);
-			positions.append(last_pos + keytext_length);
-		} else {
-			positions.append(keytext_pos + cursor_position);
-			positions.append(keytext_pos + cursor_position + keytext_length);
-		}
+// 		if (keytext_pos == 0) {
+// 			int last_pos = positions[positions.size() - 1];
+// 			positions.resize(positions.size() - 1);
+// 			positions.append(last_pos + keytext_length);
+// 		} else {
+// 			positions.append(keytext_pos + cursor_position);
+// 			positions.append(keytext_pos + cursor_position + keytext_length);
+// 		}
 
-		cursor_position += keytext_pos + keytext_length;
+// 		cursor_position += keytext_pos + keytext_length;
 
-		iterator_line = p_line.substr(cursor_position);
-	}
+// 		iterator_line = p_line.substr(cursor_position);
+// 	}
 
-	// Imagine p_line "Lullaby" and p_keytext "l".
-	// positions will be [0,0,1,2,4].
-	// - The pair 0,0 was inserted due to 20 lines up and is considered not a match.
-	// - The pair 0,1 ("L") is a match
-	// - The pair 1,2 ("u") is not a match
-	// - The pair 2,4 ("ll") is a match once again
+// 	// Imagine p_line "Lullaby" and p_keytext "l".
+// 	// positions will be [0,0,1,2,4].
+// 	// - The pair 0,0 was inserted due to 20 lines up and is considered not a match.
+// 	// - The pair 0,1 ("L") is a match
+// 	// - The pair 1,2 ("u") is not a match
+// 	// - The pair 2,4 ("ll") is a match once again
 
-	// The last pair will always describe a match at this point and in the case p_line does not end with a match, that would cut off p_line after the last match...
-	if (positions[positions.size() - 1] != p_line.size() - 1) {
-		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
-	}
+// 	// The last pair will always describe a match at this point and in the case p_line does not end with a match, that would cut off p_line after the last match...
+// 	if (positions[positions.size() - 1] != p_line.size() - 1) {
+// 		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
+// 	}
 
-	return positions;
-}
+// 	return positions;
+// }
 
-void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_keytext) {
-	String parsed_text = _strip_bbcode_from_message(p_line);
+// void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_keytext) {
+// 	String parsed_text = _strip_bbcode_from_message(p_line);
 
-	if (p_keytext.is_empty() || !_contains_case_sensitive(parsed_text, p_keytext)) {
-		log->append_text(p_line);
-		return;
-	}
+// 	if (p_keytext.is_empty() || !_contains_case_sensitive(parsed_text, p_keytext)) {
+// 		log->append_text(p_line);
+// 		return;
+// 	}
 
-	Vector<int> positions = _get_line_search_query_positions(parsed_text, p_keytext);
+// 	Vector<int> positions = _get_line_search_query_positions(parsed_text, p_keytext);
 
-	// Iterate through map in pairs. That's why we start at index 1.
-	for (int i = 1; i < positions.size(); i++) {
-		String substring = parsed_text.substr(positions[i - 1], positions[i] - positions[i - 1]);
+// 	// Iterate through map in pairs. That's why we start at index 1.
+// 	for (int i = 1; i < positions.size(); i++) {
+// 		String substring = parsed_text.substr(positions[i - 1], positions[i] - positions[i - 1]);
 
-		// Even index means this segment is a match, uneven means the segment is not a match.
-		if (i % 2 == 1) { // Not a match
-			log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));
-			log->push_normal();
-			log->add_text(substring);
-		} else { // Match
-			log->push_bgcolor(theme_cache.filter_highlight_active_color);
-			log->add_text(substring);
-		}
-	}
+// 		// Even index means this segment is a match, uneven means the segment is not a match.
+// 		if (i % 2 == 1) { // Not a match
+// 			log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));
+// 			log->push_normal();
+// 			log->add_text(substring);
+// 		} else { // Match
+// 			log->push_bgcolor(theme_cache.filter_highlight_active_color);
+// 			log->add_text(substring);
+// 		}
+// 	}
 
-	log->pop(); // To finish off, we break off the most recently pushed tag. In the case that was push_bold(), the boldening effect is removed.
-
-	// That's it!
-}
+// 	log->pop(); // To finish off, we break off the most recently pushed tag. In the case that was push_bold(), the boldening effect is removed.
+// }
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
-	String filter_keytext = search_box->get_text();
-
 	if (!is_inside_tree()) {
 		// The log will be built all at once when it enters the tree and has its theme items.
 		return;
@@ -548,6 +538,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		return;
 	}
 
+	// Only add the message to the log if it passes the filters.
 	if (!_check_display_message(p_message)) {
 		return;
 	}
@@ -559,7 +550,6 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->remove_paragraph(log->get_paragraph_count() - 2);
 	}
 
-	// Add message type icons
 	switch (p_message.type) {
 		case MSG_TYPE_STD: {
 		} break;
@@ -597,14 +587,11 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	// Note that errors and warnings only support BBCode in the file part of the message.
-
-	if (!filter_keytext.is_empty()) {
-		_add_highlighted_log_line(p_message.text, filter_keytext);
-	} else {
-		log->push_normal();
+	if (p_message.type == MSG_TYPE_STD_RICH || p_message.type == MSG_TYPE_ERROR || p_message.type == MSG_TYPE_WARNING) {
 		log->append_text(p_message.text);
+	} else {
+		log->add_text(p_message.text);
 	}
-
 	if (p_message.clear || p_message.type != MSG_TYPE_STD_RICH) {
 		log->pop_all(); // Pop all unclosed tags.
 	}
@@ -635,6 +622,7 @@ void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
 void EditorLog::_search_changed(const String &p_text) {
 	log->set_scroll_follow(false); // Prevent the RichTextLabel from autoscrolling due to new messages being added during _rebuild_log().
 
+	log->set_filter_keytext(p_text);
 	_rebuild_log();
 	_set_extra_filter_options_visible(!p_text.is_empty());
 
@@ -689,10 +677,14 @@ EditorLog::EditorLog() {
 	vb_left->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(vb_left);
 
+	bbcode_parser = memnew(RichTextLabel);
+	bbcode_parser->set_use_bbcode(true);
+
 	// Log - Rich Text Label.
 	log = memnew(EditorLogRichTextLabel);
 	log->set_threaded(true);
 	log->set_use_bbcode(true);
+	log->set_bbcode_parser(bbcode_parser);
 	log->set_scroll_follow(true);
 	log->set_selection_enabled(true);
 	log->set_context_menu_enabled(true);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -356,8 +356,6 @@ void EditorLog::_rebuild_log() {
 	int initial_skip = 0;
 	int search_matches_count = 0;
 
-	String search_text = search_box->get_text();
-
 	// Search backward for starting place.
 	for (start_message_index = messages.size() - 1; start_message_index >= 0; start_message_index--) {
 		LogMessage msg = messages[start_message_index];
@@ -387,8 +385,6 @@ void EditorLog::_rebuild_log() {
 	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
 
-		search_matches_count += _count_case_sensitive(_strip_bbcode_from_message(msg.text), search_text);
-
 		if (collapse) {
 			// If collapsing, only log one instance of the message.
 			_add_log_line(msg);
@@ -400,8 +396,6 @@ void EditorLog::_rebuild_log() {
 			}
 		}
 	}
-
-	_update_matching_lines_count_label(search_matches_count);
 }
 
 bool EditorLog::_check_display_message(LogMessage &p_message) {
@@ -620,28 +614,44 @@ void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
 }
 
 void EditorLog::_search_changed(const String &p_text) {
-	log->set_scroll_follow(false); // Prevent the RichTextLabel from autoscrolling due to new messages being added during _rebuild_log().
-
 	log->set_filter_keytext(p_text);
-	_rebuild_log();
+
 	_set_extra_filter_options_visible(!p_text.is_empty());
+	_count_matches();
 
-	log->set_scroll_follow(true);
-}
-
-void EditorLog::_update_matching_lines_count_label(int count) {
-	matching_lines_count_label->set_modulate(Color(1.0, 1.0, 1.0));
-
-	if (count == 0) {
-		matching_lines_count_label->set_text("No matches");
-		matching_lines_count_label->set_modulate(theme_cache.error_color);
-		return;
-	} else if (count == 1) {
-		matching_lines_count_label->set_text("1 match");
+	if (show_non_search_matches) {
 		return;
 	}
 
-	matching_lines_count_label->set_text(vformat("%s matches", itos(count)));
+	log->set_scroll_follow(false); // Prevent the RichTextLabel from autoscrolling due to new messages being added during _rebuild_log().
+	_rebuild_log();
+	log->set_scroll_follow(true);
+}
+
+void EditorLog::_count_matches() {
+	int count = 0;
+	const String search_text = search_box->get_text();
+
+	for (const LogMessage &msg : messages) {
+		count += _count_case_sensitive(_strip_bbcode_from_message(msg.text), search_text);
+	}
+
+	_update_matches_count_label(count);
+}
+
+void EditorLog::_update_matches_count_label(int count) {
+	filter_matches_count_label->set_modulate(Color(1.0, 1.0, 1.0));
+
+	if (count == 0) {
+		filter_matches_count_label->set_text("No matches");
+		filter_matches_count_label->set_modulate(theme_cache.error_color);
+		return;
+	} else if (count == 1) {
+		filter_matches_count_label->set_text("1 match");
+		return;
+	}
+
+	filter_matches_count_label->set_text(vformat("%s matches", itos(count)));
 }
 
 void EditorLog::_reset_message_counts() {
@@ -715,8 +725,8 @@ EditorLog::EditorLog() {
 	extra_filter_options_hbox = memnew(HBoxContainer);
 	vb_left->add_child(extra_filter_options_hbox);
 
-	matching_lines_count_label = memnew(Label);
-	extra_filter_options_hbox->add_child(matching_lines_count_label);
+	filter_matches_count_label = memnew(Label);
+	extra_filter_options_hbox->add_child(filter_matches_count_label);
 
 	// Previous filter match button
 	filter_previous_match_button = memnew(Button);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -419,13 +419,39 @@ int EditorLog::_find_case_sensitive(const String &p_base, const String &p_target
 	}
 }
 
-void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext) {
-	if (p_keytext.is_empty() || !_contains_case_sensitive(p_line, p_keytext)) {
-		log->push_color(p_color_regular);
-		log->add_text(p_line);
-		return;
+String EditorLog::_parse_text(const String &p_text) {
+	String result;
+	
+	// Lazy initialize the BBCode parser
+	if (!bbcode_parser) {
+		bbcode_parser = memnew(RichTextLabel);
+		bbcode_parser->set_use_bbcode(true);
 	}
 
+	// Ensure clean state for each message
+	bbcode_parser->clear();
+	bbcode_parser->parse_bbcode(p_text);
+	result = bbcode_parser->get_parsed_text();
+	return result;
+}
+
+HashMap<int, int> EditorLog::_get_line_tag_sizes(const String &p_line) {
+	HashMap<int, int> result;
+
+	String parsed_text = _parse_text(p_line);
+	int parsed_text_length = parsed_text.length();
+
+	int parsed_index = 0;
+	int raw_index = 0;
+
+	while (raw_index < p_line.length()) {
+
+	}
+
+	return result;
+}
+
+Vector<int> EditorLog::_get_line_search_query_positions(const String &p_line, const String &p_keytext) {
 	int keytext_length = p_keytext.length();
 
 	String iterator_line = p_line;
@@ -464,24 +490,36 @@ void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Co
 	// - The pair 1,2 ("u") is not a match
 	// - The pair 2,4 ("ll") is a match once again
 
-	// The last pair will always describe a match and in the case p_line does not end with a match, that would cut off p_line after the last match...
+	// The last pair will always describe a match at this point and in the case p_line does not end with a match, that would cut off p_line after the last match...
 	if (positions[positions.size() - 1] != p_line.size() - 1) {
 		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
 	}
 
+	return positions;
+}
+
+void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_keytext) {
+	String parsed_text = _parse_text(p_line);
+
+	if (p_keytext.is_empty() || !_contains_case_sensitive(parsed_text, p_keytext)) {
+		log->append_text(p_line);
+		return;
+	}
+
+	Vector<int> positions = _get_line_search_query_positions(parsed_text, p_keytext);
+
 	// Iterate through map in pairs. That's why we start at index 1.
 	for (int i = 1; i < positions.size(); i++) {
-		String substring = p_line.substr(positions[i - 1], positions[i] - positions[i - 1]);
+		String substring = parsed_text.substr(positions[i - 1], positions[i] - positions[i - 1]);
 
 		// Even index means this segment is a match, uneven means the segment is not a match.
-		if (i % 2 == 1) { // Uneven
-			log->push_color(p_color_regular);
+		if (i % 2 == 1) { // Not a match
+			log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));
 			log->push_normal();
-			log->add_text(substring);
-		} else { // Even
-			log->push_color(p_color_highlighted);
-			log->push_bold();
-			log->add_text(substring);
+			log->append_text(substring);
+		} else { // Match
+			log->push_bgcolor(EditorSettings::get_singleton()->get_setting("text_editor/theme/highlighting/selection_color"));
+			log->append_text(substring);
 		}
 	}
 
@@ -492,6 +530,7 @@ void EditorLog::_add_highlighted_log_line(const Color &p_color_regular, const Co
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	String filter_keytext = search_box->get_text();
+	String parsed_text = _parse_text(p_message.text);
 
 	if (!is_inside_tree()) {
 		// The log will be built all at once when it enters the tree and has its theme items.
@@ -507,25 +546,8 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		return;
 	}
 
-	if (!_check_display_message(p_message)) {
-		// Either darken or remove the message altogether when it does not fit the filter keytext.
-		if (!show_non_search_matches) {
-			return;
-		}
-	}
-
-	if (search_parse_bbcode && !filter_keytext.is_empty()) {
-		// Lazy initialize the BBCode parser
-		if (!bbcode_parser) {
-			bbcode_parser = memnew(RichTextLabel);
-			bbcode_parser->set_use_bbcode(true);
-		}
-
-		// Ensure clean state for each message
-		bbcode_parser->clear();
-		bbcode_parser->parse_bbcode(p_message.text);
-		String parsed_text = bbcode_parser->get_parsed_text();
-		p_message.text = parsed_text;
+	if (!_check_display_message(p_message) && (!_contains_case_sensitive(parsed_text, filter_keytext) && !show_non_search_matches)) {
+		return;
 	}
 
 	if (p_replace_previous) {
@@ -573,25 +595,20 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	// Note that errors and warnings only support BBCode in the file part of the message.
 	if (!filter_keytext.is_empty()) {
-		if (_check_display_message(p_message)) {
-			if (p_message.type == MSG_TYPE_ERROR) {
-				_add_highlighted_log_line(theme_cache.error_color * Color(1.0, 1.0, 1.0, 0.5), Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
-			} else if (p_message.type == MSG_TYPE_WARNING) {
-				_add_highlighted_log_line(theme_cache.warning_color * Color(1.0, 1.0, 1.0, 0.5), Color(1.0, 0.35, 0.35), p_message.text, filter_keytext);
-			} else {
-				_add_highlighted_log_line(theme_cache.message_color, Color(1.0, 1.0, 0.5), p_message.text, filter_keytext);
-			}
-		} else {
-			log->push_color(Color(1.0, 1.0, 1.0, 0.2));
-			log->add_text(p_message.text); // Only use add_text instead of append_text for rich messages to force the BBCode tags to be exposed
-		}
-	} else { // If we aren't doing anything special with filtering, just print it as normal
-		if (p_message.type == MSG_TYPE_STD_RICH) {
-			log->append_text(p_message.text);
-		} else {
-			log->add_text(p_message.text);
-		}
+		_add_highlighted_log_line(p_message.text, filter_keytext);
+	} else {
+		log->push_normal();
+		log->append_text(p_message.text);
 	}
+
+	// log->push_bgcolor(EditorSettings::get_singleton()->get_setting("text_editor/theme/highlighting/selection_color"));
+	// log->append_text("[b]Bold text");
+	// log->append_text("[/b]");
+	// log->append_text("non-bold text");
+	// log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));	
+	// log->append_text("non-highlighted text");
+	// log->push_normal();
+
 	if (p_message.clear || p_message.type != MSG_TYPE_STD_RICH) {
 		log->pop_all(); // Pop all unclosed tags.
 	}

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -430,7 +430,7 @@ int EditorLog::_find_case_sensitive(const String &p_base, const String &p_target
 
 String EditorLog::_strip_bbcode_from_message(const String &p_text) {
 	String result;
-	
+
 	// Lazy initialize the BBCode parser
 	if (!bbcode_parser) {
 		bbcode_parser = memnew(RichTextLabel);
@@ -588,7 +588,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	// Note that errors and warnings only support BBCode in the file part of the message.
-	
+
 	if (!filter_keytext.is_empty()) {
 		_add_highlighted_log_line(p_message.text, filter_keytext);
 	} else {
@@ -639,8 +639,7 @@ void EditorLog::_update_matching_lines_count_label(int count) {
 		matching_lines_count_label->set_text("No matching lines");
 		matching_lines_count_label->set_modulate(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 		return;
-	}
-	else if (count == 1) {
+	} else if (count == 1) {
 		matching_lines_count_label->set_text("1 matching line");
 		return;
 	}

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -125,9 +125,8 @@ void EditorLog::_update_theme() {
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
-	// show_non_search_matches_button->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
-	// search_case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
-	// search_parse_bbcode_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
+	filter_previous_match_button->set_button_icon(get_editor_theme_icon(SNAME("MoveUp")));
+	filter_next_match_button->set_button_icon(get_editor_theme_icon(SNAME("MoveDown")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
 	theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
@@ -135,6 +134,9 @@ void EditorLog::_update_theme() {
 	theme_cache.warning_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
 	theme_cache.warning_icon = get_editor_theme_icon(SNAME("Warning"));
 	theme_cache.message_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.6);
+	theme_cache.filter_highlight_active_color = EDITOR_GET("text_editor/theme/highlighting/selection_color");
+	theme_cache.filter_highlight_inactive_color = theme_cache.filter_highlight_active_color * Color(1, 1, 1, 0.6);
+	
 }
 
 void EditorLog::_editor_settings_changed() {
@@ -234,6 +236,12 @@ void EditorLog::_set_search_case_sensitive(bool p_state) {
 
 void EditorLog::_set_extra_filter_options_visible(bool p_visible) {
 	extra_filter_options_hbox->set_visible(p_visible);
+}
+
+void EditorLog::_enable_filter_previous_match_button(bool p_enable) {
+}
+
+void EditorLog::_enable_filter_next_match_button(bool p_enable) {
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
@@ -378,9 +386,7 @@ void EditorLog::_rebuild_log() {
 	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
 
-		if (_contains_case_sensitive(_strip_bbcode_from_message(msg.text), search_text) && _check_display_message(msg)) {
-			search_matches_count += 1;
-		}
+		search_matches_count += _count_case_sensitive(_strip_bbcode_from_message(msg.text), search_text);
 
 		if (collapse) {
 			// If collapsing, only log one instance of the message.
@@ -425,6 +431,14 @@ int EditorLog::_find_case_sensitive(const String &p_base, const String &p_target
 		return p_base.find(p_target);
 	} else {
 		return p_base.findn(p_target);
+	}
+}
+
+int EditorLog::_count_case_sensitive(const String &p_base, const String &p_target) {
+	if (search_case_sensitive) {
+		return p_base.count(p_target);
+	} else {
+		return p_base.countn(p_target);
 	}
 }
 
@@ -511,7 +525,7 @@ void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_
 			log->push_normal();
 			log->add_text(substring);
 		} else { // Match
-			log->push_bgcolor(EditorSettings::get_singleton()->get_setting("text_editor/theme/highlighting/selection_color"));
+			log->push_bgcolor(theme_cache.filter_highlight_active_color);
 			log->add_text(substring);
 		}
 	}
@@ -531,10 +545,6 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	if (unlikely(log->is_updating())) {
 		// The new message arrived during log RTL text processing/redraw (invalid BiDi control characters / font error), ignore it to avoid RTL data corruption.
-		return;
-	}
-
-	if (!type_filter_map[p_message.type]->is_active()) {
 		return;
 	}
 
@@ -635,15 +645,15 @@ void EditorLog::_update_matching_lines_count_label(int count) {
 	matching_lines_count_label->set_modulate(Color(1.0, 1.0, 1.0));
 
 	if (count == 0) {
-		matching_lines_count_label->set_text("No matching lines");
-		matching_lines_count_label->set_modulate(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		matching_lines_count_label->set_text("No matches");
+		matching_lines_count_label->set_modulate(theme_cache.error_color);
 		return;
 	} else if (count == 1) {
-		matching_lines_count_label->set_text("1 matching line");
+		matching_lines_count_label->set_text("1 match");
 		return;
 	}
 
-	matching_lines_count_label->set_text(vformat("%s matching lines", itos(count)));
+	matching_lines_count_label->set_text(vformat("%s matches", itos(count)));
 }
 
 void EditorLog::_reset_message_counts() {
@@ -716,12 +726,25 @@ EditorLog::EditorLog() {
 	matching_lines_count_label = memnew(Label);
 	extra_filter_options_hbox->add_child(matching_lines_count_label);
 
-	//Exclude non-filter matches button
+	// Previous filter match button
+	filter_previous_match_button = memnew(Button);
+	filter_previous_match_button->set_tooltip_text(TTRC("Previous filter match"));
+	filter_previous_match_button->set_theme_type_variation(SceneStringName(FlatButton));
+	filter_previous_match_button->set_accessibility_name(TTRC("Previous filter match"));
+	extra_filter_options_hbox->add_child(filter_previous_match_button);
+
+	// Next filter match button
+	filter_next_match_button = memnew(Button);
+	filter_next_match_button->set_tooltip_text(TTRC("Next filter match"));
+	filter_next_match_button->set_theme_type_variation(SceneStringName(FlatButton));
+	filter_next_match_button->set_accessibility_name(TTRC("Next filter match"));
+	extra_filter_options_hbox->add_child(filter_next_match_button);
+
+	// Exclude non-filter matches button
 	show_non_search_matches_button = memnew(CheckBox);
 	show_non_search_matches_button->set_text("Show Non-Matches");
 	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
 	show_non_search_matches_button->set_accessibility_name(TTRC("Show Non-Matches"));
-	// show_non_search_matches_button->set_theme_type_variation(SceneStringName(FlatButton));
 	show_non_search_matches_button->set_pressed(true);
 	show_non_search_matches_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_show_non_search_matches));
 	extra_filter_options_hbox->add_child(show_non_search_matches_button);
@@ -731,7 +754,6 @@ EditorLog::EditorLog() {
 	search_case_sensitive_button->set_text("Match Case");
 	search_case_sensitive_button->set_tooltip_text(TTRC("Toggle case-sensitivity"));
 	search_case_sensitive_button->set_accessibility_name(TTRC("Toggle case-sensitivity"));
-	// search_case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
 	search_case_sensitive_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_case_sensitive));
 	extra_filter_options_hbox->add_child(search_case_sensitive_button);
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -378,7 +378,7 @@ void EditorLog::_rebuild_log() {
 	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
 
-		if (_contains_case_sensitive(_strip_bbcode_from_message(msg.text), search_text)) {
+		if (_contains_case_sensitive(_strip_bbcode_from_message(msg.text), search_text) && _check_display_message(msg)) {
 			search_matches_count += 1;
 		}
 
@@ -633,6 +633,18 @@ void EditorLog::_search_changed(const String &p_text) {
 }
 
 void EditorLog::_update_matching_lines_count_label(int count) {
+	matching_lines_count_label->set_modulate(Color(1.0, 1.0, 1.0));
+
+	if (count == 0) {
+		matching_lines_count_label->set_text("No matching lines");
+		matching_lines_count_label->set_modulate(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		return;
+	}
+	else if (count == 1) {
+		matching_lines_count_label->set_text("1 matching line");
+		return;
+	}
+
 	matching_lines_count_label->set_text(vformat("%s matching lines", itos(count)));
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -45,7 +45,6 @@
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/gui/box_container.h"
 #include "scene/gui/flow_container.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"
@@ -126,9 +125,9 @@ void EditorLog::_update_theme() {
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
-	show_non_search_matches_button->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
-	search_case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
-	search_parse_bbcode_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
+	// show_non_search_matches_button->set_button_icon(get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
+	// search_case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
+	// search_parse_bbcode_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
 	theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
@@ -225,18 +224,16 @@ void EditorLog::_set_search_case_sensitive(bool p_state) {
 	log->set_scroll_follow(true);
 }
 
-void EditorLog::_set_search_parse_bbcode(bool p_state) {
-	search_parse_bbcode = p_state;
+// void EditorLog::_set_search_parse_bbcode(bool p_state) {
+// 	search_parse_bbcode = p_state;
 
-	log->set_scroll_follow(false);
-	_rebuild_log();
-	log->set_scroll_follow(true);
-}
+// 	log->set_scroll_follow(false);
+// 	_rebuild_log();
+// 	log->set_scroll_follow(true);
+// }
 
-void EditorLog::_set_search_buttons_visibility(bool p_visible) {
-	show_non_search_matches_button->set_visible(p_visible);
-	search_case_sensitive_button->set_visible(p_visible);
-	search_parse_bbcode_button->set_visible(p_visible);
+void EditorLog::_set_extra_filter_options_visible(bool p_visible) {
+	extra_filter_options_hbox->set_visible(p_visible);
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
@@ -348,6 +345,9 @@ void EditorLog::_rebuild_log() {
 	int line_count = 0;
 	int start_message_index = 0;
 	int initial_skip = 0;
+	int search_matches_count = 0;
+
+	String search_text = search_box->get_text();
 
 	// Search backward for starting place.
 	for (start_message_index = messages.size() - 1; start_message_index >= 0; start_message_index--) {
@@ -372,10 +372,15 @@ void EditorLog::_rebuild_log() {
 			break;
 		}
 	}
+
 	log->clear();
 
 	for (int msg_idx = start_message_index; msg_idx < messages.size(); msg_idx++) {
 		LogMessage msg = messages[msg_idx];
+
+		if (_contains_case_sensitive(_strip_bbcode_from_message(msg.text), search_text)) {
+			search_matches_count += 1;
+		}
 
 		if (collapse) {
 			// If collapsing, only log one instance of the message.
@@ -388,9 +393,13 @@ void EditorLog::_rebuild_log() {
 			}
 		}
 	}
+
+	_update_matching_lines_count_label(search_matches_count);
 }
 
 bool EditorLog::_check_display_message(LogMessage &p_message) {
+	// Whether a message ought to be displayed in the log according to filtering
+
 	bool filter_active = type_filter_map[p_message.type]->is_active();
 	String search_text = search_box->get_text();
 
@@ -398,7 +407,7 @@ bool EditorLog::_check_display_message(LogMessage &p_message) {
 		return filter_active;
 	}
 
-	bool search_match = _contains_case_sensitive(p_message.text, search_text);
+	bool search_match = _contains_case_sensitive(_strip_bbcode_from_message(p_message.text), search_text) || show_non_search_matches;
 
 	return filter_active && search_match;
 }
@@ -419,7 +428,7 @@ int EditorLog::_find_case_sensitive(const String &p_base, const String &p_target
 	}
 }
 
-String EditorLog::_parse_text(const String &p_text) {
+String EditorLog::_strip_bbcode_from_message(const String &p_text) {
 	String result;
 	
 	// Lazy initialize the BBCode parser
@@ -432,22 +441,6 @@ String EditorLog::_parse_text(const String &p_text) {
 	bbcode_parser->clear();
 	bbcode_parser->parse_bbcode(p_text);
 	result = bbcode_parser->get_parsed_text();
-	return result;
-}
-
-HashMap<int, int> EditorLog::_get_line_tag_sizes(const String &p_line) {
-	HashMap<int, int> result;
-
-	String parsed_text = _parse_text(p_line);
-	int parsed_text_length = parsed_text.length();
-
-	int parsed_index = 0;
-	int raw_index = 0;
-
-	while (raw_index < p_line.length()) {
-
-	}
-
 	return result;
 }
 
@@ -499,7 +492,7 @@ Vector<int> EditorLog::_get_line_search_query_positions(const String &p_line, co
 }
 
 void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_keytext) {
-	String parsed_text = _parse_text(p_line);
+	String parsed_text = _strip_bbcode_from_message(p_line);
 
 	if (p_keytext.is_empty() || !_contains_case_sensitive(parsed_text, p_keytext)) {
 		log->append_text(p_line);
@@ -516,10 +509,10 @@ void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_
 		if (i % 2 == 1) { // Not a match
 			log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));
 			log->push_normal();
-			log->append_text(substring);
+			log->add_text(substring);
 		} else { // Match
 			log->push_bgcolor(EditorSettings::get_singleton()->get_setting("text_editor/theme/highlighting/selection_color"));
-			log->append_text(substring);
+			log->add_text(substring);
 		}
 	}
 
@@ -530,7 +523,7 @@ void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	String filter_keytext = search_box->get_text();
-	String parsed_text = _parse_text(p_message.text);
+	String parsed_text = _strip_bbcode_from_message(p_message.text);
 
 	if (!is_inside_tree()) {
 		// The log will be built all at once when it enters the tree and has its theme items.
@@ -546,7 +539,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		return;
 	}
 
-	if (!_check_display_message(p_message) && (!_contains_case_sensitive(parsed_text, filter_keytext) && !show_non_search_matches)) {
+	if (!_check_display_message(p_message)) {
 		return;
 	}
 
@@ -557,6 +550,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->remove_paragraph(log->get_paragraph_count() - 2);
 	}
 
+	// Add message type icons
 	switch (p_message.type) {
 		case MSG_TYPE_STD: {
 		} break;
@@ -594,20 +588,13 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	// Note that errors and warnings only support BBCode in the file part of the message.
+	
 	if (!filter_keytext.is_empty()) {
 		_add_highlighted_log_line(p_message.text, filter_keytext);
 	} else {
 		log->push_normal();
 		log->append_text(p_message.text);
 	}
-
-	// log->push_bgcolor(EditorSettings::get_singleton()->get_setting("text_editor/theme/highlighting/selection_color"));
-	// log->append_text("[b]Bold text");
-	// log->append_text("[/b]");
-	// log->append_text("non-bold text");
-	// log->push_bgcolor(Color(1.0, 1.0, 1.0, 0.0));	
-	// log->append_text("non-highlighted text");
-	// log->push_normal();
 
 	if (p_message.clear || p_message.type != MSG_TYPE_STD_RICH) {
 		log->pop_all(); // Pop all unclosed tags.
@@ -640,9 +627,13 @@ void EditorLog::_search_changed(const String &p_text) {
 	log->set_scroll_follow(false); // Prevent the RichTextLabel from autoscrolling due to new messages being added during _rebuild_log().
 
 	_rebuild_log();
-	_set_search_buttons_visibility(!p_text.is_empty());
+	_set_extra_filter_options_visible(!p_text.is_empty());
 
 	log->set_scroll_follow(true);
+}
+
+void EditorLog::_update_matching_lines_count_label(int count) {
+	matching_lines_count_label->set_text(vformat("%s matching lines", itos(count)));
 }
 
 void EditorLog::_reset_message_counts() {
@@ -709,36 +700,42 @@ EditorLog::EditorLog() {
 	HBoxContainer *hbox = memnew(HBoxContainer);
 	bottom_hf->add_child(hbox);
 
+	extra_filter_options_hbox = memnew(HBoxContainer);
+	vb_left->add_child(extra_filter_options_hbox);
+
+	matching_lines_count_label = memnew(Label);
+	extra_filter_options_hbox->add_child(matching_lines_count_label);
+
 	//Exclude non-filter matches button
-	show_non_search_matches_button = memnew(Button);
+	show_non_search_matches_button = memnew(CheckBox);
+	show_non_search_matches_button->set_text("Show Non-Matches");
 	show_non_search_matches_button->set_tooltip_text(TTRC("Show Non-Matches"));
 	show_non_search_matches_button->set_accessibility_name(TTRC("Show Non-Matches"));
-	show_non_search_matches_button->set_theme_type_variation(SceneStringName(FlatButton));
-	show_non_search_matches_button->set_toggle_mode(true);
+	// show_non_search_matches_button->set_theme_type_variation(SceneStringName(FlatButton));
 	show_non_search_matches_button->set_pressed(true);
 	show_non_search_matches_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_show_non_search_matches));
-	hbox->add_child(show_non_search_matches_button);
+	extra_filter_options_hbox->add_child(show_non_search_matches_button);
 
 	// Case sensitive button
-	search_case_sensitive_button = memnew(Button);
+	search_case_sensitive_button = memnew(CheckBox);
+	search_case_sensitive_button->set_text("Match Case");
 	search_case_sensitive_button->set_tooltip_text(TTRC("Toggle case-sensitivity"));
 	search_case_sensitive_button->set_accessibility_name(TTRC("Toggle case-sensitivity"));
-	search_case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
-	search_case_sensitive_button->set_toggle_mode(true);
+	// search_case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
 	search_case_sensitive_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_case_sensitive));
-	hbox->add_child(search_case_sensitive_button);
+	extra_filter_options_hbox->add_child(search_case_sensitive_button);
 
-	// Parse BBCode button
-	search_parse_bbcode_button = memnew(Button);
-	search_parse_bbcode_button->set_tooltip_text(TTRC("Parse BBCode"));
-	search_parse_bbcode_button->set_accessibility_name(TTRC("Parse BBCode"));
-	search_parse_bbcode_button->set_theme_type_variation(SceneStringName(FlatButton));
-	search_parse_bbcode_button->set_toggle_mode(true);
-	search_parse_bbcode_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_parse_bbcode));
-	hbox->add_child(search_parse_bbcode_button);
+	// // Parse BBCode button
+	// search_parse_bbcode_button = memnew(Button);
+	// search_parse_bbcode_button->set_tooltip_text(TTRC("Parse BBCode"));
+	// search_parse_bbcode_button->set_accessibility_name(TTRC("Parse BBCode"));
+	// search_parse_bbcode_button->set_theme_type_variation(SceneStringName(FlatButton));
+	// search_parse_bbcode_button->set_toggle_mode(true);
+	// search_parse_bbcode_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_search_parse_bbcode));
+	// extra_filter_options_hbox->add_child(search_parse_bbcode_button);
 
 	// Make show_non_search_matches_button and search_case_sensitive_button invisible
-	_set_search_buttons_visibility(false);
+	_set_extra_filter_options_visible(false);
 
 	// Clear.
 	clear_button = memnew(Button);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -523,7 +523,6 @@ void EditorLog::_add_highlighted_log_line(const String &p_line, const String &p_
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	String filter_keytext = search_box->get_text();
-	String parsed_text = _strip_bbcode_from_message(p_message.text);
 
 	if (!is_inside_tree()) {
 		// The log will be built all at once when it enters the tree and has its theme items.

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -31,6 +31,7 @@
 #include "editor_log.h"
 
 #include "core/io/resource_loader.h"
+#include "core/math/math_funcs.h"
 #include "core/object/callable_mp.h"
 #include "core/object/message_queue.h"
 #include "core/object/undo_redo.h"
@@ -225,6 +226,8 @@ void EditorLog::_set_search_case_sensitive(bool p_state) {
 	log->set_scroll_follow(false);
 	_rebuild_log();
 	log->set_scroll_follow(true);
+
+	_count_matches();
 }
 
 // void EditorLog::_set_search_parse_bbcode(bool p_state) {
@@ -240,9 +243,11 @@ void EditorLog::_set_extra_filter_options_visible(bool p_visible) {
 }
 
 void EditorLog::_enable_filter_previous_match_button(bool p_enable) {
+	filter_previous_match_button->set_disabled(!p_enable);
 }
 
 void EditorLog::_enable_filter_next_match_button(bool p_enable) {
+	filter_next_match_button->set_disabled(!p_enable);
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
@@ -354,7 +359,6 @@ void EditorLog::_rebuild_log() {
 	int line_count = 0;
 	int start_message_index = 0;
 	int initial_skip = 0;
-	int search_matches_count = 0;
 
 	// Search backward for starting place.
 	for (start_message_index = messages.size() - 1; start_message_index >= 0; start_message_index--) {
@@ -613,6 +617,14 @@ void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
 	log->set_scroll_follow(true);
 }
 
+void EditorLog::_filter_view_previous_match() {
+	_set_currently_viewed_match_index(currently_viewed_match_index - 1);
+}
+
+void EditorLog::_filter_view_next_match() {
+	_set_currently_viewed_match_index(currently_viewed_match_index + 1);
+}
+
 void EditorLog::_search_changed(const String &p_text) {
 	log->set_filter_keytext(p_text);
 
@@ -628,30 +640,56 @@ void EditorLog::_search_changed(const String &p_text) {
 	log->set_scroll_follow(true);
 }
 
+void EditorLog::_set_currently_viewed_match_index(int p_index) {
+	currently_viewed_match_index = CLAMP(p_index, 0, match_count - 1);
+
+	_enable_filter_previous_match_button(true);
+	_enable_filter_next_match_button(true);
+
+	if (currently_viewed_match_index == 0) {
+		_enable_filter_previous_match_button(false);
+	}
+	if (currently_viewed_match_index == match_count - 1) {
+		_enable_filter_next_match_button(false);
+	}
+
+	_update_matches_count_label();
+}
+
 void EditorLog::_count_matches() {
 	int count = 0;
 	const String search_text = search_box->get_text();
 
 	for (const LogMessage &msg : messages) {
-		count += _count_case_sensitive(_strip_bbcode_from_message(msg.text), search_text);
+		String message_text = msg.text;
+
+		if (msg.type != MSG_TYPE_STD) {
+			message_text = _strip_bbcode_from_message(message_text);
+		}
+
+		count += _count_case_sensitive(message_text, search_text);
 	}
 
-	_update_matches_count_label(count);
+	match_count = count;
+
+	_set_currently_viewed_match_index(CLAMP(currently_viewed_match_index, 0, count - 1));
+
+	_update_matches_count_label();
 }
 
-void EditorLog::_update_matches_count_label(int count) {
+void EditorLog::_update_matches_count_label() {
 	filter_matches_count_label->set_modulate(Color(1.0, 1.0, 1.0));
 
-	if (count == 0) {
+	if (match_count == 0) {
 		filter_matches_count_label->set_text("No matches");
 		filter_matches_count_label->set_modulate(theme_cache.error_color);
 		return;
-	} else if (count == 1) {
-		filter_matches_count_label->set_text("1 match");
+	} else if (match_count == 1) {
+		filter_matches_count_label->set_text("1 out of 1 match");
 		return;
 	}
 
-	filter_matches_count_label->set_text(vformat("%s matches", itos(count)));
+	filter_matches_count_label->set_text(vformat("%s of %s matches", itos(currently_viewed_match_index + 1), itos(match_count)));
 }
 
 void EditorLog::_reset_message_counts() {
@@ -733,6 +771,7 @@ EditorLog::EditorLog() {
 	filter_previous_match_button->set_tooltip_text(TTRC("Previous filter match"));
 	filter_previous_match_button->set_theme_type_variation(SceneStringName(FlatButton));
 	filter_previous_match_button->set_accessibility_name(TTRC("Previous filter match"));
+	filter_previous_match_button->connect("button_down", callable_mp(this, &EditorLog::_filter_view_previous_match)); 
 	extra_filter_options_hbox->add_child(filter_previous_match_button);
 
 	// Next filter match button
@@ -740,6 +779,7 @@ EditorLog::EditorLog() {
 	filter_next_match_button->set_tooltip_text(TTRC("Next filter match"));
 	filter_next_match_button->set_theme_type_variation(SceneStringName(FlatButton));
 	filter_next_match_button->set_accessibility_name(TTRC("Next filter match"));
+	filter_next_match_button->connect("button_down", callable_mp(this, &EditorLog::_filter_view_next_match));
 	extra_filter_options_hbox->add_child(filter_next_match_button);
 
 	// Exclude non-filter matches button

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -165,10 +165,11 @@ private:
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
 	void _rebuild_log();
-	void _append_styled_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext);
+	void _add_highlighted_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext);
 	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
 	bool _check_display_message(LogMessage &p_message);
 	bool _contains_case_sensitive(const String &p_base, const String &p_contains);
+	int _find_case_sensitive(const String &p_base, const String &p_target);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _search_changed(const String &p_text);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -134,6 +134,16 @@ private:
 
 	Button *clear_button = nullptr;
 
+	Button *show_non_search_matches_button = nullptr;
+	void _set_show_non_search_matches(bool p_state);
+	bool show_non_search_matches = true;
+
+	Button *search_case_sensitive_button = nullptr;
+	void _set_search_case_sensitive(bool p_state);
+	bool search_case_sensitive = false;
+
+	void _set_search_buttons_visibility(bool p_visible);
+
 	Button *collapse_button = nullptr;
 	bool collapse = false;
 
@@ -155,8 +165,10 @@ private:
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
 	void _rebuild_log();
+	void _append_styled_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext);
 	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
 	bool _check_display_message(LogMessage &p_message);
+	bool _contains_case_sensitive(const String &p_base, const String &p_contains);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _search_changed(const String &p_text);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -142,6 +142,10 @@ private:
 	void _set_search_case_sensitive(bool p_state);
 	bool search_case_sensitive = false;
 
+	Button *search_parse_bbcode_button = nullptr;
+	void _set_search_parse_bbcode(bool p_state);
+	bool search_parse_bbcode = false;
+
 	void _set_search_buttons_visibility(bool p_visible);
 
 	Button *collapse_button = nullptr;

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -32,11 +32,11 @@
 
 #include "core/os/thread.h"
 #include "editor/docks/editor_dock.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/rich_text_label.h"
-#include "scene/gui/box_container.h"
 
 class Timer;
 class UndoRedo;

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -143,10 +143,12 @@ private:
 
 	HBoxContainer *extra_filter_options_hbox = nullptr;
 
+	int match_count = 0;
 	int currently_viewed_match_index = 0;
+	void _set_currently_viewed_match_index(int p_index);
 
 	Label *filter_matches_count_label = nullptr;
-	void _update_matches_count_label(int count);
+	void _update_matches_count_label();
 
 	Button *filter_previous_match_button = nullptr;
 	void _enable_filter_previous_match_button(bool p_enable);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -77,6 +77,9 @@ private:
 		Ref<Texture2D> warning_icon;
 
 		Color message_color;
+
+		Color filter_highlight_inactive_color;
+		Color filter_highlight_active_color;
 	} theme_cache;
 
 	// Encapsulates all data and functionality regarding filters.
@@ -144,6 +147,12 @@ private:
 	Label *matching_lines_count_label = nullptr;
 	void _update_matching_lines_count_label(int count);
 
+	Button *filter_previous_match_button = nullptr;
+	void _enable_filter_previous_match_button(bool p_enable);
+
+	Button *filter_next_match_button = nullptr;
+	void _enable_filter_next_match_button(bool p_enable);
+
 	CheckBox *show_non_search_matches_button = nullptr;
 	void _set_show_non_search_matches(bool p_state);
 	bool show_non_search_matches = true;
@@ -186,6 +195,7 @@ private:
 	bool _check_display_message(LogMessage &p_message);
 	bool _contains_case_sensitive(const String &p_base, const String &p_contains);
 	int _find_case_sensitive(const String &p_base, const String &p_target);
+	int _count_case_sensitive(const String &p_base, const String &p_target);
 	String _strip_bbcode_from_message(const String &p_text);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -33,8 +33,10 @@
 #include "core/os/thread.h"
 #include "editor/docks/editor_dock.h"
 #include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/rich_text_label.h"
+#include "scene/gui/box_container.h"
 
 class Timer;
 class UndoRedo;
@@ -134,19 +136,27 @@ private:
 
 	Button *clear_button = nullptr;
 
-	Button *show_non_search_matches_button = nullptr;
+	HBoxContainer *extra_filter_options_hbox = nullptr;
+
+	// int search_matches_count = 0;
+	int currently_viewed_match_index = 0;
+
+	Label *matching_lines_count_label = nullptr;
+	void _update_matching_lines_count_label(int count);
+
+	CheckBox *show_non_search_matches_button = nullptr;
 	void _set_show_non_search_matches(bool p_state);
 	bool show_non_search_matches = true;
 
-	Button *search_case_sensitive_button = nullptr;
+	CheckBox *search_case_sensitive_button = nullptr;
 	void _set_search_case_sensitive(bool p_state);
 	bool search_case_sensitive = false;
 
-	Button *search_parse_bbcode_button = nullptr;
-	void _set_search_parse_bbcode(bool p_state);
-	bool search_parse_bbcode = true;
+	// Button *search_parse_bbcode_button = nullptr;
+	// void _set_search_parse_bbcode(bool p_state);
+	// bool search_parse_bbcode = true;
 
-	void _set_search_buttons_visibility(bool p_visible);
+	void _set_extra_filter_options_visible(bool p_visible);
 
 	Vector<int> _get_line_search_query_positions(const String &p_line, const String &p_keytext);
 
@@ -176,8 +186,7 @@ private:
 	bool _check_display_message(LogMessage &p_message);
 	bool _contains_case_sensitive(const String &p_base, const String &p_contains);
 	int _find_case_sensitive(const String &p_base, const String &p_target);
-	String _parse_text(const String &p_text);
-	HashMap<int, int> _get_line_tag_sizes(const String &p_line);
+	String _strip_bbcode_from_message(const String &p_text);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _search_changed(const String &p_text);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -136,17 +136,17 @@ private:
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	HashMap<MessageType, LogFilter *> type_filter_map;
 
+	//A custom class is used for filter highlighting, since highlight drawing is deeply integrated in RichTextLabel drawing logic.
 	EditorLogRichTextLabel *log = nullptr;
 
 	Button *clear_button = nullptr;
 
 	HBoxContainer *extra_filter_options_hbox = nullptr;
 
-	// int search_matches_count = 0;
 	int currently_viewed_match_index = 0;
 
-	Label *matching_lines_count_label = nullptr;
-	void _update_matching_lines_count_label(int count);
+	Label *filter_matches_count_label = nullptr;
+	void _update_matches_count_label(int count);
 
 	Button *filter_previous_match_button = nullptr;
 	void _enable_filter_previous_match_button(bool p_enable);
@@ -203,6 +203,7 @@ private:
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _search_changed(const String &p_text);
+	void _count_matches();
 
 	void _process_message(const String &p_msg, MessageType p_type, bool p_clear);
 	void _reset_message_counts();

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -144,9 +144,11 @@ private:
 
 	Button *search_parse_bbcode_button = nullptr;
 	void _set_search_parse_bbcode(bool p_state);
-	bool search_parse_bbcode = false;
+	bool search_parse_bbcode = true;
 
 	void _set_search_buttons_visibility(bool p_visible);
+
+	Vector<int> _get_line_search_query_positions(const String &p_line, const String &p_keytext);
 
 	Button *collapse_button = nullptr;
 	bool collapse = false;
@@ -169,11 +171,13 @@ private:
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
 	void _rebuild_log();
-	void _add_highlighted_log_line(const Color &p_color_regular, const Color &p_color_highlighted, const String &p_line, const String &p_keytext);
+	void _add_highlighted_log_line(const String &p_line, const String &p_keytext);
 	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
 	bool _check_display_message(LogMessage &p_message);
 	bool _contains_case_sensitive(const String &p_base, const String &p_contains);
 	int _find_case_sensitive(const String &p_base, const String &p_target);
+	String _parse_text(const String &p_text);
+	HashMap<int, int> _get_line_tag_sizes(const String &p_line);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _search_changed(const String &p_text);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -32,6 +32,7 @@
 
 #include "core/os/thread.h"
 #include "editor/docks/editor_dock.h"
+#include "editor/gui/editor_log_rich_text_label.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
@@ -135,7 +136,7 @@ private:
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	HashMap<MessageType, LogFilter *> type_filter_map;
 
-	RichTextLabel *log = nullptr;
+	EditorLogRichTextLabel *log = nullptr;
 
 	Button *clear_button = nullptr;
 
@@ -149,9 +150,11 @@ private:
 
 	Button *filter_previous_match_button = nullptr;
 	void _enable_filter_previous_match_button(bool p_enable);
+	void _filter_view_previous_match();
 
 	Button *filter_next_match_button = nullptr;
 	void _enable_filter_next_match_button(bool p_enable);
+	void _filter_view_next_match();
 
 	CheckBox *show_non_search_matches_button = nullptr;
 	void _set_show_non_search_matches(bool p_state);

--- a/editor/gui/editor_log_rich_text_label.cpp
+++ b/editor/gui/editor_log_rich_text_label.cpp
@@ -1,18 +1,16 @@
 #include "editor_log_rich_text_label.h"
 #include "servers/rendering/rendering_server.h"
 
-void EditorLogRichTextLabel::_highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
-    // const Ref<TextParagraph> &text_buf = l.text_buf_disp.is_valid() ? l.text_buf_disp : l.text_buf;
-    const String line_text = TS->shaped_get_text(rid);
-
+void EditorLogRichTextLabel::_highlighting_pass_callback(const String &line_text, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
     Vector<int> positions = _get_line_search_query_positions(line_text);
 
-	// Iterate through map in pairs. That's why we start at index 1.
 	for (int i = 2; i + 1 < positions.size(); i = i + 2) {
+		// Start at the first match, so index 2 (a pair consists of elements at index i and index i - 1, so this starts with elements 1 and 2 as a pair).
+		// Then increase by two because we only want to read out matches.
 
         Vector<Vector2> sel = TS->shaped_text_get_selection(rid, positions[i - 1], positions[i]);
         for (int j = 0; j < sel.size(); j++) {
-            Rect2 rect = Rect2(sel[j].x + p_ofs.x + off.x, p_ofs.y + off.y - l_ascent, sel[j].y - sel[j].x, l_size.y);
+            Rect2 rect = Rect2((sel[j].x + p_ofs.x + off.x), p_ofs.y + off.y - l_ascent, (sel[j].y - sel[j].x), l_size.y);
             RenderingServer::get_singleton()->canvas_item_add_rect(ci_rid, rect, highlight_color);
         }
     }

--- a/editor/gui/editor_log_rich_text_label.cpp
+++ b/editor/gui/editor_log_rich_text_label.cpp
@@ -1,15 +1,112 @@
 #include "editor_log_rich_text_label.h"
 #include "servers/rendering/rendering_server.h"
 
-void EditorLogRichTextLabel::_highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
-    Vector<Vector2> sel = TS->shaped_text_get_selection(rid, 0, 1);
-    for (int i = 0; i < sel.size(); i++) {
-		Rect2 rect = Rect2(sel[i].x + p_ofs.x + off.x, p_ofs.y + off.y - l_ascent, sel[i].y - sel[i].x, l_size.y); // Note: use "off" not "off_step", selection is relative to the line start.
-		RenderingServer::get_singleton()->canvas_item_add_rect(ci_rid, rect, highlight_color);
+void EditorLogRichTextLabel::_highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
+    // const Ref<TextParagraph> &text_buf = l.text_buf_disp.is_valid() ? l.text_buf_disp : l.text_buf;
+    const String line_text = TS->shaped_get_text(rid);
+
+    Vector<int> positions = _get_line_search_query_positions(line_text);
+
+	// Iterate through map in pairs. That's why we start at index 1.
+	for (int i = 2; i + 1 < positions.size(); i = i + 2) {
+
+        Vector<Vector2> sel = TS->shaped_text_get_selection(rid, positions[i - 1], positions[i]);
+        for (int j = 0; j < sel.size(); j++) {
+            Rect2 rect = Rect2(sel[j].x + p_ofs.x + off.x, p_ofs.y + off.y - l_ascent, sel[j].y - sel[j].x, l_size.y);
+            RenderingServer::get_singleton()->canvas_item_add_rect(ci_rid, rect, highlight_color);
+        }
     }
+}
+
+Vector<int> EditorLogRichTextLabel::_get_line_search_query_positions(const String &p_line) {
+	int keytext_length = filter_keytext.length();
+
+	String iterator_line = p_line;
+	int cursor_position = 0;
+
+	Vector<int> positions; // Array of substring positions. Every pair will be cut into a substring from p_line.
+	positions.append(0);
+
+	if (_find_case_sensitive(iterator_line, filter_keytext) == 0) {
+		positions.append(0);
+		positions.append(0); // This last zero will be replaced in a few lines, which fixes the order in case the first characters are immediately matches.
+	}
+
+	// Map which segments of p_line contain the target string. Every uneven pair of ints will be a non-match, and every even pair will be a match.
+	while (_contains_case_sensitive(iterator_line, filter_keytext)) {
+		int keytext_pos = _find_case_sensitive(iterator_line, filter_keytext);
+
+		if (keytext_pos == 0) {
+			int last_pos = positions[positions.size() - 1];
+			positions.resize(positions.size() - 1);
+			positions.append(last_pos + keytext_length);
+		} else {
+			positions.append(keytext_pos + cursor_position);
+			positions.append(keytext_pos + cursor_position + keytext_length);
+		}
+
+		cursor_position += keytext_pos + keytext_length;
+
+		iterator_line = p_line.substr(cursor_position);
+	}
+
+	// Imagine p_line "Lullaby" and p_keytext "l".
+	// positions will be [0,0,1,2,4].
+	// - The pair 0,0 was inserted due to 20 lines up and is considered not a match.
+	// - The pair 0,1 ("L") is a match
+	// - The pair 1,2 ("u") is not a match
+	// - The pair 2,4 ("ll") is a match once again
+
+	// The last pair will always describe a match at this point and in the case p_line does not end with a match, that would cut off p_line after the last match...
+	if (positions[positions.size() - 1] != p_line.size() - 1) {
+		positions.append(p_line.size() - 1); // ...so we add a final position. In the case of "Lullaby", it'd append 6 so that positions becomes [0,0,1,2,4,6]. That prevents the mistake described 2 lines up.
+	}
+
+	return positions;
+}
+
+bool EditorLogRichTextLabel::_contains_case_sensitive(const String &p_base, const String &p_contains) {
+	if (filter_case_sensitive) {
+		return p_base.contains(p_contains);
+	} else {
+		return p_base.containsn(p_contains);
+	}
+}
+
+int EditorLogRichTextLabel::_find_case_sensitive(const String &p_base, const String &p_target) {
+	if (filter_case_sensitive) {
+		return p_base.find(p_target);
+	} else {
+		return p_base.findn(p_target);
+	}
+}
+
+int EditorLogRichTextLabel::_count_case_sensitive(const String &p_base, const String &p_target) {
+	if (filter_case_sensitive) {
+		return p_base.count(p_target);
+	} else {
+		return p_base.countn(p_target);
+	}
+}
+
+void EditorLogRichTextLabel::set_bbcode_parser(RichTextLabel *p_label) {
+    bbcode_parser = p_label;
 }
 
 void EditorLogRichTextLabel::set_filter_keytext(const String &p_keytext) {
     filter_keytext = p_keytext;
     queue_redraw();
+}
+
+void EditorLogRichTextLabel::set_filter_case_sensitive(bool p_case_sensitive) {
+    filter_case_sensitive = p_case_sensitive;
+}
+
+String EditorLogRichTextLabel::_strip_bbcode_from_line(const String &p_line) {
+	String result;
+
+	bbcode_parser->clear();
+	bbcode_parser->parse_bbcode(p_line);
+	result = bbcode_parser->get_parsed_text();
+	return result;
 }

--- a/editor/gui/editor_log_rich_text_label.cpp
+++ b/editor/gui/editor_log_rich_text_label.cpp
@@ -1,0 +1,15 @@
+#include "editor_log_rich_text_label.h"
+#include "servers/rendering/rendering_server.h"
+
+void EditorLogRichTextLabel::_highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
+    Vector<Vector2> sel = TS->shaped_text_get_selection(rid, 0, 1);
+    for (int i = 0; i < sel.size(); i++) {
+		Rect2 rect = Rect2(sel[i].x + p_ofs.x + off.x, p_ofs.y + off.y - l_ascent, sel[i].y - sel[i].x, l_size.y); // Note: use "off" not "off_step", selection is relative to the line start.
+		RenderingServer::get_singleton()->canvas_item_add_rect(ci_rid, rect, highlight_color);
+    }
+}
+
+void EditorLogRichTextLabel::set_filter_keytext(const String &p_keytext) {
+    filter_keytext = p_keytext;
+    queue_redraw();
+}

--- a/editor/gui/editor_log_rich_text_label.h
+++ b/editor/gui/editor_log_rich_text_label.h
@@ -10,7 +10,7 @@ public:
     void set_filter_case_sensitive(bool p_case_sensitive);
 
 protected:
-    virtual void _highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) override;
+    virtual void _highlighting_pass_callback(const String &line_text, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) override;
     
 private:
     RichTextLabel *bbcode_parser = nullptr;    

--- a/editor/gui/editor_log_rich_text_label.h
+++ b/editor/gui/editor_log_rich_text_label.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "scene/gui/rich_text_label.h"
+
+class EditorLogRichTextLabel : public RichTextLabel {
+    GDCLASS(EditorLogRichTextLabel, RichTextLabel);
+
+    public:
+        void set_filter_keytext(const String &p_keytext);
+
+    protected:
+        virtual void _highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) override;
+    
+    private:
+        String filter_keytext;
+        bool filter_enabled = false;
+};

--- a/editor/gui/editor_log_rich_text_label.h
+++ b/editor/gui/editor_log_rich_text_label.h
@@ -4,13 +4,26 @@
 class EditorLogRichTextLabel : public RichTextLabel {
     GDCLASS(EditorLogRichTextLabel, RichTextLabel);
 
-    public:
-        void set_filter_keytext(const String &p_keytext);
+public:
+    void set_bbcode_parser(RichTextLabel *p_label);
+    void set_filter_keytext(const String &p_keytext);
+    void set_filter_case_sensitive(bool p_case_sensitive);
 
-    protected:
-        virtual void _highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) override;
+protected:
+    virtual void _highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) override;
     
-    private:
-        String filter_keytext;
-        bool filter_enabled = false;
+private:
+    RichTextLabel *bbcode_parser = nullptr;    
+
+    String filter_keytext;
+    bool filter_enabled = false;
+    bool filter_case_sensitive = false;
+
+    Vector<int> _get_line_search_query_positions(const String &p_line);
+
+    bool _contains_case_sensitive(const String &p_base, const String &p_target);
+    int _find_case_sensitive(const String &p_base, const String &p_target);
+    int _count_case_sensitive(const String &p_base, const String &p_target);
+    String _strip_bbcode_from_line(const String &p_line);
+
 };

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1711,7 +1711,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				}
 			}
 			if (step == DRAW_STEP_BACKGROUND) {
-				_highlighting_pass_callback(l, rid, ci, theme_cache.selection_color, p_ofs, off, l_ascent, l_size); // Used in editor/gui/editor_log_rich_text_label for filter highlighting
+				_highlighting_pass_callback(TS->shaped_get_text(text_buf->get_rid()), rid, ci, theme_cache.selection_color, p_ofs, off, l_ascent, l_size);
 
 				if (sel_start != -1) {
 					Color selection_bg = theme_cache.selection_color;
@@ -1755,8 +1755,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	return line_count;
 }
 
-void RichTextLabel::_highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
-	// Implemented in editor/gui/editor_log_rich_text_label.cpp
+void RichTextLabel::_highlighting_pass_callback(const String &line_text, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
+	// Implemented in editor/gui/editor_log_rich_text_label.cpp for output filter highlighting
 }
 
 void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, ItemFrame **r_click_frame, int *r_click_line, Item **r_click_item, int *r_click_char, bool *r_outside, bool p_meta) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1711,7 +1711,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				}
 			}
 			if (step == DRAW_STEP_BACKGROUND) {
-				_highlighting_pass_callback(&l, rid, ci, theme_cache.selection_color, p_ofs, off, l_ascent, l_size); // Used in editor/gui/editor_log_rich_text_label for filter highlighting
+				_highlighting_pass_callback(l, rid, ci, theme_cache.selection_color, p_ofs, off, l_ascent, l_size); // Used in editor/gui/editor_log_rich_text_label for filter highlighting
 
 				if (sel_start != -1) {
 					Color selection_bg = theme_cache.selection_color;
@@ -1755,7 +1755,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	return line_count;
 }
 
-void RichTextLabel::_highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
+void RichTextLabel::_highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
 	// Implemented in editor/gui/editor_log_rich_text_label.cpp
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1711,6 +1711,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				}
 			}
 			if (step == DRAW_STEP_BACKGROUND) {
+				_highlighting_pass_callback(&l, rid, ci, theme_cache.selection_color, p_ofs, off, l_ascent, l_size); // Used in editor/gui/editor_log_rich_text_label for filter highlighting
+
 				if (sel_start != -1) {
 					Color selection_bg = theme_cache.selection_color;
 					Vector<Vector2> sel = TS->shaped_text_get_selection(rid, sel_start, sel_end);
@@ -1751,6 +1753,10 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	}
 
 	return line_count;
+}
+
+void RichTextLabel::_highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size) {
+	// Implemented in editor/gui/editor_log_rich_text_label.cpp
 }
 
 void RichTextLabel::_find_click(ItemFrame *p_frame, const Point2i &p_click, ItemFrame **r_click_frame, int *r_click_line, Item **r_click_item, int *r_click_char, bool *r_outside, bool p_meta) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -139,6 +139,9 @@ public:
 		IMAGE_UNIT_EM,
 	};
 
+private:
+	struct Item;
+
 protected:
 	virtual void _update_theme_item_cache() override;
 
@@ -162,10 +165,10 @@ protected:
 	void _add_image_bind_compat_112617(const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), const Variant &p_key = Variant(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false, const String &p_alt_text = String());
 	void _update_image_bind_compat_112617(const Variant &p_key, BitField<ImageUpdateMask> p_mask, const Ref<Texture2D> &p_image, int p_width = 0, int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(), bool p_pad = false, const String &p_tooltip = String(), bool p_width_in_percent = false, bool p_height_in_percent = false);
 	static void _bind_compatibility_methods();
-#endif
 
-private:
-	struct Item;
+	// Kept for compatibility from 3.x to 4.0.
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif
 
 	struct Line { // Line is a paragraph.
 		Item *from = nullptr; // `from` is main if this Line is the first Line in the doc, otherwise `from` is the previous Item in the doc of any type.
@@ -201,6 +204,7 @@ private:
 		}
 	};
 
+private:
 	struct Item {
 		int index = 0;
 		int char_ofs = 0;
@@ -236,7 +240,6 @@ private:
 		std::atomic<int> first_invalid_line;
 		std::atomic<int> first_invalid_font_line;
 		std::atomic<int> first_resized_line;
-
 		ItemFrame *parent_frame = nullptr;
 
 		Color odd_row_bg = Color(0, 0, 0, 0);
@@ -671,6 +674,8 @@ private:
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool p_table = false, bool p_meta = false);
 	void _accessibility_update_line(RID p_id, ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep);
 
+	virtual void _highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size);
+
 	String _roman(int p_num, bool p_capitalize) const;
 	String _letters(int p_num, bool p_capitalize) const;
 
@@ -744,10 +749,6 @@ private:
 	static Vector<String> _split_unquoted(const String &p_src, char32_t p_splitter);
 	static String _get_tag_value(const String &p_tag);
 
-#ifndef DISABLE_DEPRECATED
-	// Kept for compatibility from 3.x to 4.0.
-	bool _set(const StringName &p_name, const Variant &p_value);
-#endif
 	bool use_bbcode = false;
 	String text;
 	void _apply_translation();

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -674,7 +674,7 @@ private:
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool p_table = false, bool p_meta = false);
 	void _accessibility_update_line(RID p_id, ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep);
 
-	virtual void _highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size);
+	virtual void _highlighting_pass_callback(const String &line_text, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size);
 
 	String _roman(int p_num, bool p_capitalize) const;
 	String _letters(int p_num, bool p_capitalize) const;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -674,7 +674,7 @@ private:
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool p_table = false, bool p_meta = false);
 	void _accessibility_update_line(RID p_id, ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep);
 
-	virtual void _highlighting_pass_callback(Line *l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size);
+	virtual void _highlighting_pass_callback(Line l, RID rid, RID ci_rid, Color highlight_color, Vector2 p_ofs, Vector2 off, float l_ascent, Vector2 l_size);
 
 	String _roman(int p_num, bool p_capitalize) const;
 	String _letters(int p_num, bool p_capitalize) const;


### PR DESCRIPTION
(This is a duplicate of https://github.com/godotengine/godot/pull/118256, which I have already closed. This version has been rebased properly.)

The editor output text filtering system has been, at least in my experience, pretty horrid. It just removes any message not containing a match with your query text, making it pretty useless since there's no context visible around messages that match the query text.

I have made a few small changes to output filtering to make the experience of trying to find certain strings in the output log a bit smoother. These changes/additions are:

 - Option to show lines that do not contain the target string via a toggle button (Visible to the left of the clear output button). This option is enabled by default.
 - Toggle button for case-sensitivity
 - Highlighting of the target string inside of the lines that contain the target string.
 - Scroll position retention
 - Integration with message type filters

A nice side effect that has come with my changes, is that updating the log when searching for something is not choppy anymore. You may have noticed that when you change the search query, there's a bit of very short flickering before you get your results. I accidentally fixed that in my attempts to get scroll position retention working. The fix was calling `log->set_scroll_follow(false)` before calling `_rebuild_log()`. (And then, of course, reverting with log->set_scroll_follow(true) afterwards)

<img width="800" height="450" alt="filter" src="https://github.com/user-attachments/assets/1ef9f42d-1ee9-4f25-8143-e9565ce99ed6" />

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/10249.*
