### PR TITLE
Autocompletion: Don't suggest internal classes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1624,15 +1624,15 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	_find_built_in_variants(r_result);
 
-	static const char *_keywords[] = {
-		"true", "false", "PI", "TAU", "INF", "NAN", "null", "self", "super",
-		"break", "breakpoint", "continue", "pass", "return",
-		nullptr
-	};
+	// Keywords that represent constants.
+	for (const char *kw : { "true", "false", "PI", "TAU", "INF", "NAN", "null", "self", "super" }) {
+		ScriptLanguage::CodeCompletionOption option(kw, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+		r_result.insert(option.display, option);
+	}
 
-	const char **kw = _keywords;
-	while (*kw) {
-		ScriptLanguage::CodeCompletionOption option(*kw, ScriptLanguage::CODE_COMPLETION_KIND_KEYWORD);
+	// Regular control flow keywords.
+	for (const char *kw : { "break", "breakpoint", "continue", "pass", "return" }) {
+		ScriptLanguage::CodeCompletionOption option(kw, ScriptLanguage::CODE_COMPLETION_KIND_KEYWORD);
 		r_result.insert(option.display, option);
 		kw++;
 	}
@@ -1679,6 +1679,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		r_result.insert(option.display, option);
 	}
 
+	// Autoloads.
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		if (!E.value.is_singleton) {
 			continue;
@@ -1687,21 +1688,29 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		r_result.insert(option.display, option);
 	}
 
-	// Native classes and global constants.
-	for (const KeyValue<StringName, int> &E : GDScriptLanguage::get_singleton()->get_global_map()) {
-		ScriptLanguage::CodeCompletionOption option;
-		if (GDScriptAnalyzer::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
-			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
-		} else {
-			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+	// Native classes.
+	{
+		LocalVector<StringName> native_classes;
+		ClassDB::get_class_list(native_classes);
+		for (const StringName &class_name : native_classes) {
+			if (!GDScriptAnalyzer::class_exists(class_name)) {
+				continue;
+			}
+			ScriptLanguage::CodeCompletionOption option = ScriptLanguage::CodeCompletionOption(class_name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
+			r_result.insert(option.display, option);
 		}
+	}
+
+	// Core constants.
+	for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {
+		ScriptLanguage::CodeCompletionOption option = ScriptLanguage::CodeCompletionOption(CoreConstants::get_global_constant_name(i), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
 		r_result.insert(option.display, option);
 	}
 
-	// Global enums
+	// Global enums.
 	_find_global_enums(r_result);
 
-	// Global classes
+	// Global classes.
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
@@ -25,4 +25,19 @@ include=[
 	{"display": "test_parameter_2"},
 	{"display": "local_test_var_1"},
 	{"display": "local_test_var_2"},
+
+	; Native Class
+	{ "display": "Node2D", "kind": 0 }, ; CODE_COMPLETION_KIND_CLASS
+	{ "display": "ClassDB" },
+
+	; Constants
+	{ "display": "PI", "kind": 6 }, ; CODE_COMPLETION_KIND_CONSTANT
+	{ "display": "null" },
+	{ "display": "PROPERTY_USAGE_DEFAULT", "kind": 6},
+
+	; TODO: Autoloads, class_name -> currently unsupported by the test runner
+]
+exclude=[
+	; Internal class.
+	{"display": "GDScriptFunctionState"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
@@ -25,4 +25,19 @@ include=[
 	{"display": "test_parameter_2"},
 	{"display": "local_test_var_1"},
 	{"display": "local_test_var_2"},
+
+	; Native Class
+	{ "display": "Node2D", "kind": 0 }, ; CODE_COMPLETION_KIND_CLASS
+	{ "display": "ClassDB" },
+
+	; Constants
+	{ "display": "PI", "kind": 6 }, ; CODE_COMPLETION_KIND_CONSTANT
+	{ "display": "null" },
+	{ "display": "PROPERTY_USAGE_DEFAULT", "kind": 6},
+
+	; TODO: Autoloads, class_name -> currently unsupported by the test runner
+]
+exclude=[
+	; Internal class.
+	{"display": "GDScriptFunctionState"},
 ]

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
@@ -25,4 +25,19 @@ include=[
 	{"display": "test_parameter_2"},
 	{"display": "local_test_var_1"},
 	{"display": "local_test_var_2"},
+
+	; Native Class
+	{ "display": "Node2D", "kind": 0 }, ; CODE_COMPLETION_KIND_CLASS
+	{ "display": "ClassDB" },
+
+	; Constants
+	{ "display": "PI", "kind": 6 }, ; CODE_COMPLETION_KIND_CONSTANT
+	{ "display": "null" },
+	{ "display": "PROPERTY_USAGE_DEFAULT", "kind": 6},
+
+	; TODO: Autoloads, class_name -> currently unsupported by the test runner
+]
+exclude=[
+	; Internal class.
+	{"display": "GDScriptFunctionState"},
 ]


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/76918 (the highlighter is already fixed apparently, but those classes still appeared in autocompletion).

The gdscript globals list contains a lot of stuff. Using it for completion isn't a good idea because it becomes hard to distinguish the different kinds of things that are in there. This PR replaces its usage with other solutions for the things in the global list that were not already covered else where. It also splits certain keywords to give them a constant icon, rather than a keyword icon. This is necessary since the original icon was previously overridden through the code handling the global list.
