### PR TITLE
Add UV options for CSGBox3D

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1766,7 +1766,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 		Vector3 vertex_mul = size / 2;
 
-		Vector3 uv_size = uv_repeat ? size : Vector3(1, 1, 1);
+		Vector3 uv_size = use_size_as_uv ? size : Vector3(1, 1, 1);
 		uv_size *= uv_scale;
 
 		{
@@ -1841,8 +1841,8 @@ void CSGBox3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGBox3D::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGBox3D::get_material);
 
-	ClassDB::bind_method(D_METHOD("get_uv_repeat"), &CSGBox3D::get_uv_repeat);
-	ClassDB::bind_method(D_METHOD("set_uv_repeat", "enabled"), &CSGBox3D::set_uv_repeat);
+	ClassDB::bind_method(D_METHOD("get_use_size_as_uv"), &CSGBox3D::get_use_size_as_uv);
+	ClassDB::bind_method(D_METHOD("set_use_size_as_uv", "enabled"), &CSGBox3D::set_use_size_as_uv);
 
 	ClassDB::bind_method(D_METHOD("get_uv_scale"), &CSGBox3D::get_uv_scale);
 	ClassDB::bind_method(D_METHOD("set_uv_scale", "uv_scale"), &CSGBox3D::set_uv_scale);
@@ -1850,7 +1850,7 @@ void CSGBox3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "uv_scale", PROPERTY_HINT_LINK, ""), "set_uv_scale", "get_uv_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uv_repeat", PROPERTY_HINT_NONE, ""), "set_uv_repeat", "get_uv_repeat");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_size_as_uv", PROPERTY_HINT_NONE, ""), "set_use_size_as_uv", "get_use_size_as_uv");
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
@@ -1873,14 +1873,14 @@ Vector3 CSGBox3D::get_uv_scale() const {
 	return uv_scale;
 }
 
-void CSGBox3D::set_uv_repeat(const bool &p_enabled) {
-	uv_repeat = p_enabled;
+void CSGBox3D::set_use_size_as_uv(const bool &p_enabled) {
+	use_size_as_uv = p_enabled;
 	_make_dirty();
 	update_gizmos();
 }
 
-bool CSGBox3D::get_uv_repeat() const {
-	return uv_repeat;
+bool CSGBox3D::get_use_size_as_uv() const {
+	return use_size_as_uv;
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1716,7 +1716,7 @@ CSGSphere3D::CSGSphere3D() {
 }
 
 ///////////////
-static Vector2 _get_box_uv(const Vector3 &p_normalized, const Vector3 &uv_size, int side) {
+static Vector2 _get_box_uv(const Vector3 &p_normalized, const Vector3 &uv_size, const Vector3 &uv_offset, const int side) {
 	const int axis = side % 3;
 
 	const int u_axis = axis == 2 ? 0 : (axis + 2) % 3;
@@ -1729,7 +1729,7 @@ static Vector2 _get_box_uv(const Vector3 &p_normalized, const Vector3 &uv_size, 
 		u = uv_size[u_axis] - u;
 	}
 
-	return Vector2(u, v);
+	return Vector2(u + uv_offset[u_axis], v + uv_offset[v_axis]);
 }
 
 CSGBrush *CSGBox3D::_build_brush() {
@@ -1790,7 +1790,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 				Vector2 u[4];
 				for (int j = 0; j < 4; j++) {
-					u[j] = _get_box_uv(face_points[j], uv_size, i);
+					u[j] = _get_box_uv(face_points[j], uv_size, uv_offset, i);
 				}
 
 				//face 1
@@ -1841,15 +1841,19 @@ void CSGBox3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGBox3D::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGBox3D::get_material);
 
-	ClassDB::bind_method(D_METHOD("get_use_size_as_uv"), &CSGBox3D::get_use_size_as_uv);
-	ClassDB::bind_method(D_METHOD("set_use_size_as_uv", "enabled"), &CSGBox3D::set_use_size_as_uv);
-
 	ClassDB::bind_method(D_METHOD("get_uv_scale"), &CSGBox3D::get_uv_scale);
 	ClassDB::bind_method(D_METHOD("set_uv_scale", "uv_scale"), &CSGBox3D::set_uv_scale);
+
+	ClassDB::bind_method(D_METHOD("get_uv_offset"), &CSGBox3D::get_uv_offset);
+	ClassDB::bind_method(D_METHOD("set_uv_offset", "uv_offset"), &CSGBox3D::set_uv_offset);
+
+	ClassDB::bind_method(D_METHOD("get_use_size_as_uv"), &CSGBox3D::get_use_size_as_uv);
+	ClassDB::bind_method(D_METHOD("set_use_size_as_uv", "enabled"), &CSGBox3D::set_use_size_as_uv);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "uv_scale", PROPERTY_HINT_LINK, ""), "set_uv_scale", "get_uv_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "uv_offset", PROPERTY_HINT_NONE, ""), "set_uv_offset", "get_uv_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_size_as_uv", PROPERTY_HINT_NONE, ""), "set_use_size_as_uv", "get_use_size_as_uv");
 }
 
@@ -1881,6 +1885,16 @@ void CSGBox3D::set_use_size_as_uv(const bool &p_enabled) {
 
 bool CSGBox3D::get_use_size_as_uv() const {
 	return use_size_as_uv;
+}
+
+void CSGBox3D::set_uv_offset(const Vector3 &p_uv_offset) {
+	uv_offset = p_uv_offset;
+	_make_dirty();
+	update_gizmos();
+}
+
+Vector3 CSGBox3D::get_uv_offset() const {
+	return uv_offset;
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1716,6 +1716,21 @@ CSGSphere3D::CSGSphere3D() {
 }
 
 ///////////////
+static Vector2 _get_box_uv(const Vector3 &p_normalized, const Vector3 &uv_size, int side) {
+	const int axis = side % 3;
+
+	const int u_axis = axis == 2 ? 0 : (axis + 2) % 3;
+	const int v_axis = axis == 2 ? 1 : (axis + 1) % 3;
+
+	float u = (p_normalized[u_axis] + 1.0) * 0.5 * uv_size[u_axis];
+	float v = (p_normalized[v_axis] + 1.0) * 0.5 * uv_size[v_axis];
+
+	if (side >= 3) {
+		u = uv_size[u_axis] - u;
+	}
+
+	return Vector2(u, v);
+}
 
 CSGBrush *CSGBox3D::_build_brush() {
 	// set our bounding box
@@ -1751,10 +1766,12 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 		Vector3 vertex_mul = size / 2;
 
+		Vector3 uv_size = uv_repeat ? size : Vector3(1, 1, 1);
+		uv_size *= uv_scale;
+
 		{
 			for (int i = 0; i < 6; i++) {
 				Vector3 face_points[4];
-				float uv_points[8] = { 0, 0, 0, 1, 1, 1, 1, 0 };
 
 				for (int j = 0; j < 4; j++) {
 					float v[3];
@@ -1773,7 +1790,7 @@ CSGBrush *CSGBox3D::_build_brush() {
 
 				Vector2 u[4];
 				for (int j = 0; j < 4; j++) {
-					u[j] = Vector2(uv_points[j * 2 + 0], uv_points[j * 2 + 1]);
+					u[j] = _get_box_uv(face_points[j], uv_size, i);
 				}
 
 				//face 1
@@ -1824,8 +1841,16 @@ void CSGBox3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &CSGBox3D::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &CSGBox3D::get_material);
 
+	ClassDB::bind_method(D_METHOD("get_uv_repeat"), &CSGBox3D::get_uv_repeat);
+	ClassDB::bind_method(D_METHOD("set_uv_repeat", "enabled"), &CSGBox3D::set_uv_repeat);
+
+	ClassDB::bind_method(D_METHOD("get_uv_scale"), &CSGBox3D::get_uv_scale);
+	ClassDB::bind_method(D_METHOD("set_uv_scale", "uv_scale"), &CSGBox3D::set_uv_scale);
+
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "uv_scale", PROPERTY_HINT_LINK, ""), "set_uv_scale", "get_uv_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uv_repeat", PROPERTY_HINT_NONE, ""), "set_uv_repeat", "get_uv_repeat");
 }
 
 void CSGBox3D::set_size(const Vector3 &p_size) {
@@ -1836,6 +1861,26 @@ void CSGBox3D::set_size(const Vector3 &p_size) {
 
 Vector3 CSGBox3D::get_size() const {
 	return size;
+}
+
+void CSGBox3D::set_uv_scale(const Vector3 &p_uv_scale) {
+	uv_scale = p_uv_scale;
+	_make_dirty();
+	update_gizmos();
+}
+
+Vector3 CSGBox3D::get_uv_scale() const {
+	return uv_scale;
+}
+
+void CSGBox3D::set_uv_repeat(const bool &p_enabled) {
+	uv_repeat = p_enabled;
+	_make_dirty();
+	update_gizmos();
+}
+
+bool CSGBox3D::get_uv_repeat() const {
+	return uv_repeat;
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -288,6 +288,8 @@ class CSGBox3D : public CSGPrimitive3D {
 
 	Ref<Material> material;
 	Vector3 size = Vector3(1, 1, 1);
+	Vector3 uv_scale = Vector3(1, 1, 1);
+	bool uv_repeat = false;
 
 protected:
 	static void _bind_methods();
@@ -302,6 +304,12 @@ public:
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
+
+	void set_uv_scale(const Vector3 &p_uv_scale);
+	Vector3 get_uv_scale() const;
+
+	void set_uv_repeat(const bool &p_enabled);
+	bool get_uv_repeat() const;
 
 	CSGBox3D() {}
 };

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -289,7 +289,7 @@ class CSGBox3D : public CSGPrimitive3D {
 	Ref<Material> material;
 	Vector3 size = Vector3(1, 1, 1);
 	Vector3 uv_scale = Vector3(1, 1, 1);
-	bool uv_repeat = false;
+	bool use_size_as_uv = false;
 
 protected:
 	static void _bind_methods();
@@ -308,8 +308,8 @@ public:
 	void set_uv_scale(const Vector3 &p_uv_scale);
 	Vector3 get_uv_scale() const;
 
-	void set_uv_repeat(const bool &p_enabled);
-	bool get_uv_repeat() const;
+	void set_use_size_as_uv(const bool &p_enabled);
+	bool get_use_size_as_uv() const;
 
 	CSGBox3D() {}
 };

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -288,6 +288,7 @@ class CSGBox3D : public CSGPrimitive3D {
 
 	Ref<Material> material;
 	Vector3 size = Vector3(1, 1, 1);
+	Vector3 uv_offset = Vector3(0, 0, 0);
 	Vector3 uv_scale = Vector3(1, 1, 1);
 	bool use_size_as_uv = false;
 
@@ -310,6 +311,9 @@ public:
 
 	void set_use_size_as_uv(const bool &p_enabled);
 	bool get_use_size_as_uv() const;
+
+	void set_uv_offset(const Vector3 &p_uv_offset);
+	Vector3 get_uv_offset() const;
 
 	CSGBox3D() {}
 };

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -20,6 +20,9 @@
 		<member name="uv_scale" type="Vector3" setter="set_uv_scale" getter="get_uv_scale" default="Vector3(1, 1, 1)">
 			Scales the UV coordinates generated for each face of the box. Higher values make the material repeat more often on the corresponding local axis.
 		</member>
+		<member name="uv_offset" type="Vector3" setter="set_uv_offset" getter="get_uv_offset" default="Vector3(0, 0, 0)">
+			Moves the UV coordinates generated for each face of the box along the offset axis.
+		</member>
 		<member name="use_size_as_uv" type="bool" setter="set_uv_repeat" getter="get_uv_repeat" default="false">
 			If [code]true[/code], UV coordinates are scaled by the box's [member size], making the material repeat proportionally to the box dimensions. If [code]false[/code], each face uses the default [code]0.0[/code] to [code]1.0[/code] UV range.
 		</member>

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -17,5 +17,11 @@
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>
+		<member name="uv_scale" type="Vector3" setter="set_uv_scale" getter="get_uv_scale" default="Vector3(1, 1, 1)">
+			Scales the UV coordinates generated for each face of the box. Higher values make the material repeat more often on the corresponding local axis.
+		</member>
+		<member name="uv_repeat" type="bool" setter="set_uv_repeat" getter="get_uv_repeat" default="false">
+			If [code]true[/code], UV coordinates are scaled by the box's [member size], making the material repeat proportionally to the box dimensions. If [code]false[/code], each face uses the default [code]0.0[/code] to [code]1.0[/code] UV range.
+		</member>
 	</members>
 </class>

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -17,14 +17,14 @@
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>
-		<member name="uv_scale" type="Vector3" setter="set_uv_scale" getter="get_uv_scale" default="Vector3(1, 1, 1)">
-			Scales the UV coordinates generated for each face of the box. Higher values make the material repeat more often on the corresponding local axis.
+		<member name="use_size_as_uv" type="bool" setter="set_use_size_as_uv" getter="get_use_size_as_uv" default="false">
+			If [code]true[/code], UV coordinates are scaled by the box's [member size], making the material repeat proportionally to the box dimensions.
 		</member>
 		<member name="uv_offset" type="Vector3" setter="set_uv_offset" getter="get_uv_offset" default="Vector3(0, 0, 0)">
-			Moves the UV coordinates generated for each face of the box along the offset axis.
+			Offsets the UV coordinates generated for each face of the box along the offset axis.
 		</member>
-		<member name="use_size_as_uv" type="bool" setter="set_uv_repeat" getter="get_uv_repeat" default="false">
-			If [code]true[/code], UV coordinates are scaled by the box's [member size], making the material repeat proportionally to the box dimensions. If [code]false[/code], each face uses the default [code]0.0[/code] to [code]1.0[/code] UV range.
+		<member name="uv_scale" type="Vector3" setter="set_uv_scale" getter="get_uv_scale" default="Vector3(1, 1, 1)">
+			Scales the UV coordinates generated for each face of the box. Higher values make the material repeat more often on the corresponding axis.
 		</member>
 	</members>
 </class>

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -20,7 +20,7 @@
 		<member name="uv_scale" type="Vector3" setter="set_uv_scale" getter="get_uv_scale" default="Vector3(1, 1, 1)">
 			Scales the UV coordinates generated for each face of the box. Higher values make the material repeat more often on the corresponding local axis.
 		</member>
-		<member name="uv_repeat" type="bool" setter="set_uv_repeat" getter="get_uv_repeat" default="false">
+		<member name="use_size_as_uv" type="bool" setter="set_uv_repeat" getter="get_uv_repeat" default="false">
 			If [code]true[/code], UV coordinates are scaled by the box's [member size], making the material repeat proportionally to the box dimensions. If [code]false[/code], each face uses the default [code]0.0[/code] to [code]1.0[/code] UV range.
 		</member>
 	</members>


### PR DESCRIPTION
- Related: #115926
- Related: https://github.com/godotengine/godot-proposals/issues/14133

This is a small PR that updates how `CSGBox3D` UVs are generated.
- Added `uv_scale` property
- Added `uv_offset` property
- Added `use_size_as_uv` property


https://github.com/user-attachments/assets/e45ba370-e1b7-4cab-9003-3ef6ac1f132d

https://github.com/user-attachments/assets/c878a2d0-1ab6-47db-afae-a01c826b4900


It also works with flip faces, boolean operations and baked mesh instances.
<img width="1925" height="999" alt="image" src="https://github.com/user-attachments/assets/4d0bd9f2-e824-4f9f-871b-373034ba7108" />
<img width="1165" height="833" alt="image" src="https://github.com/user-attachments/assets/473c1ffb-b6b5-4b77-8bba-e12b7edd1bb3" />
<img width="1920" height="970" alt="image" src="https://github.com/user-attachments/assets/c6c2187a-da09-4875-b473-cb63028c9c22" />

### How it works
Previously, box UVs were generated from a fixed layout, regardless of face orientation.

This changes UV generation to derive coordinates from `face_points`, which contains the normalized vertex positions for the face. The U and V axes are selected based on the side index `i`, where values 0 through 5 correspond to +X, +Y, +Z, -X, -Y, and -Z. Negative sides (`i >= 3`) mirror the U coordinate to keep orientation consistent.

The aligned UVs are then scaled by `uv_size`, which is based on `size` when `use_size_as_uv` is enabled, or `Vector3(1, 1, 1)` otherwise, and finally multiplied by `uv_scale`, with `uv_offset` being applied in the end.

### AI usage
AI was used to rephrase the documentation for the new properties and to help explain the original code, specifically the `face_points` calculations.

### Edit:
(previous title: Add UV scaling and size-based mapping to CSGBox3D)