### PR TITLE
Fix "Paste as Replacement" inconsistently shown/hidden/disabled

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3958,19 +3958,33 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		BEGIN_SECTION()
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCut")), ED_GET_SHORTCUT("scene_tree/cut_node"), TOOL_CUT);
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("scene_tree/copy_node"), TOOL_COPY);
+
 		if (!node_clipboard.is_empty()) {
+			bool is_tool_paste_available = false;
+			bool is_tool_paste_as_sibling_available = false;
+			bool is_tool_paste_as_replacement_available = false;
+
 			if (selection.size() == 1) {
+				is_tool_paste_available = true;
+				is_tool_paste_as_sibling_available = selection.front()->get() != edited_scene;
+			}
+
+			if (selection.size() >= 1) {
+				is_tool_paste_as_replacement_available = (selection.front()->get() != edited_scene) && (can_rename || can_replace);
+			}
+
+			if (is_tool_paste_available || is_tool_paste_as_sibling_available || is_tool_paste_as_replacement_available) {
+				// Show all "paste" options if at least one is available.
 				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
-				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
-				if (selection.front()->get() == edited_scene) {
+				if (!is_tool_paste_available) {
 					menu->set_item_disabled(-1, true);
 				}
-			}
-			if (selection.size() >= 1) {
-				if (can_rename || can_replace) {
-					menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_replacement"), TOOL_PASTE_AS_REPLACEMENT);
+				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
+				if (!is_tool_paste_as_sibling_available) {
+					menu->set_item_disabled(-1, true);
 				}
-				if (selection.front()->get() == edited_scene) {
+				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_replacement"), TOOL_PASTE_AS_REPLACEMENT);
+				if (!is_tool_paste_as_replacement_available) {
 					menu->set_item_disabled(-1, true);
 				}
 			}


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/119674

Changes:
- Scene tree context menu now shows all "paste" options if at least one of them is available.

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="379" height="489" alt="Image" src="https://github.com/user-attachments/assets/95e50236-80e8-46f4-a017-e99c9f9c6e05" /> | <img width="380" height="489" alt="Image 2026-05-23_19-41-04" src="https://github.com/user-attachments/assets/dd9db6dc-dc57-445d-a7e2-57c9ccad3806" /> |
| <img width="380" height="488" alt="Image" src="https://github.com/user-attachments/assets/d9314e10-99e0-4c2b-9774-ee47f02affbd" /> | <img width="381" height="488" alt="Image 2026-05-23_19-41-31" src="https://github.com/user-attachments/assets/90a557bb-079d-467e-882c-f2d1917af385" /> |
| <img width="379" height="490" alt="Image" src="https://github.com/user-attachments/assets/35438d24-0263-4c23-b482-21f401a11a50" /> | <img width="379" height="488" alt="Image 2026-05-23_19-41-47" src="https://github.com/user-attachments/assets/ca860047-05e2-4142-aeb7-191305b52b74" /> |
| <img width="379" height="489" alt="Image" src="https://github.com/user-attachments/assets/c69d4a7c-db8d-4f44-8ba6-318a3ee846b0" /> | <img width="379" height="490" alt="Image 2026-05-23_19-42-09" src="https://github.com/user-attachments/assets/78a5e927-5b7b-4584-b049-11bc44ae45d5" /> |
