### PR TITLE
[iOS] Add AccessKit screen reader support

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -33,7 +33,7 @@ if env["platform"] in ["ios", "visionos"]:
     SConscript("apple_embedded/SCsub")
 
 # Accessibility
-if env["accesskit"] and env["platform"] in ["macos", "windows", "linuxbsd"]:
+if env["accesskit"] and env["platform"] in ["macos", "windows", "linuxbsd", "ios"]:
     SConscript("accesskit/SCsub")
 
 # Midi drivers

--- a/drivers/accesskit/accessibility_server_accesskit.cpp
+++ b/drivers/accesskit/accessibility_server_accesskit.cpp
@@ -67,6 +67,9 @@ bool AccessibilityServerAccessKit::window_create(DisplayServerEnums::WindowID p_
 #ifdef LINUXBSD_ENABLED
 	wd.adapter = accesskit_unix_adapter_new(&_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, &_accessibility_action_callback, (void *)(size_t)p_window_id, &_accessibility_deactivation_callback, (void *)(size_t)p_window_id);
 #endif
+#ifdef APPLE_EMBEDDED_ENABLED
+	wd.adapter = accesskit_ios_subclassing_adapter_new(p_handle, &_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, &_accessibility_action_callback, (void *)(size_t)p_window_id, &_accessibility_deactivation_callback, (void *)(size_t)p_window_id);
+#endif
 	print_verbose(vformat("Accessibility: window %d adapter created.", p_window_id));
 
 	if (wd.adapter == nullptr) {
@@ -94,6 +97,9 @@ void AccessibilityServerAccessKit::window_destroy(DisplayServerEnums::WindowID p
 #endif
 #ifdef LINUXBSD_ENABLED
 	accesskit_unix_adapter_free(wd->adapter);
+#endif
+#ifdef APPLE_EMBEDDED_ENABLED
+	accesskit_ios_subclassing_adapter_free(wd->adapter);
 #endif
 	free_element(wd->root_id);
 
@@ -693,6 +699,12 @@ void AccessibilityServerAccessKit::update_if_active(const Callable &p_callable) 
 #endif
 #ifdef LINUXBSD_ENABLED
 		accesskit_unix_adapter_update_if_active(window.value.adapter, _accessibility_build_tree_update, (void *)(size_t)window.key);
+#endif
+#ifdef APPLE_EMBEDDED_ENABLED
+		accesskit_ios_queued_events *events = accesskit_ios_subclassing_adapter_update_if_active(window.value.adapter, _accessibility_build_tree_update, (void *)(size_t)window.key);
+		if (events) {
+			accesskit_ios_queued_events_raise(events);
+		}
 #endif
 	}
 	update_cb = Callable();

--- a/drivers/accesskit/accessibility_server_accesskit.h
+++ b/drivers/accesskit/accessibility_server_accesskit.h
@@ -71,6 +71,9 @@ class AccessibilityServerAccessKit : public AccessibilityServer {
 #ifdef LINUXBSD_ENABLED
 		accesskit_unix_adapter *adapter = nullptr;
 #endif
+#ifdef APPLE_EMBEDDED_ENABLED
+		accesskit_ios_subclassing_adapter *adapter = nullptr;
+#endif
 
 		RID root_id;
 		bool initial_update_completed = false;

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -150,6 +150,7 @@ public:
 	// MARK: -
 
 	virtual bool has_feature(DisplayServerEnums::Feature p_feature) const override;
+	virtual int accessibility_screen_reader_active() const override;
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -42,6 +42,7 @@
 #import "drivers/apple_embedded/key_mapping_apple_embedded.h"
 #import "drivers/apple_embedded/os_apple_embedded.h"
 #import "drivers/apple_embedded/tts_apple_embedded.h"
+#include "servers/display/accessibility_server.h"
 #include "servers/display/native_menu.h"
 
 #import <GameController/GameController.h>
@@ -176,10 +177,17 @@ DisplayServerAppleEmbedded::DisplayServerAppleEmbedded(const String &p_rendering
 
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 
+	GDTView *godot_view = GDTAppDelegateService.viewController.godotView;
+	if (godot_view) {
+		AccessibilityServer::get_singleton()->window_create(DisplayServerEnums::MAIN_WINDOW_ID, (__bridge void *)godot_view);
+	}
+
 	r_error = OK;
 }
 
 DisplayServerAppleEmbedded::~DisplayServerAppleEmbedded() {
+	AccessibilityServer::get_singleton()->window_destroy(DisplayServerEnums::MAIN_WINDOW_ID);
+
 	if (native_menu) {
 		memdelete(native_menu);
 		native_menu = nullptr;
@@ -383,9 +391,16 @@ bool DisplayServerAppleEmbedded::has_feature(DisplayServerEnums::Feature p_featu
 		case DisplayServerEnums::FEATURE_VIRTUAL_KEYBOARD:
 		case DisplayServerEnums::FEATURE_TEXT_TO_SPEECH:
 			return true;
+		case DisplayServerEnums::FEATURE_ACCESSIBILITY_SCREEN_READER: {
+			return AccessibilityServer::get_singleton()->is_supported();
+		} break;
 		default:
 			return false;
 	}
+}
+
+int DisplayServerAppleEmbedded::accessibility_screen_reader_active() const {
+	return UIAccessibilityIsVoiceOverRunning() ? 1 : 0;
 }
 
 void DisplayServerAppleEmbedded::initialize_tts() const {

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -49,6 +49,7 @@
 #endif
 #include "main/main.h"
 #include "servers/camera/camera_server.h"
+#include "servers/display/accessibility_server.h"
 
 #import <AVFoundation/AVFAudio.h>
 #import <AudioToolbox/AudioServices.h>
@@ -779,6 +780,8 @@ void OS_AppleEmbedded::on_focus_out() {
 			DisplayServerAppleEmbedded::get_singleton()->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
 		}
 
+		AccessibilityServer::get_singleton()->set_window_focused(DisplayServer::MAIN_WINDOW_ID, false);
+
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 		}
@@ -796,6 +799,8 @@ void OS_AppleEmbedded::on_focus_in() {
 		if (DisplayServerAppleEmbedded::get_singleton()) {
 			DisplayServerAppleEmbedded::get_singleton()->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_IN);
 		}
+
+		AccessibilityServer::get_singleton()->set_window_focused(DisplayServer::MAIN_WINDOW_ID, true);
 
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1845,6 +1845,24 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 		return ERR_CANT_OPEN;
 	}
 
+	constexpr int ZIP_FNAME_MAX = 16384;
+
+	{
+		int scan_ret = unzGoToFirstFile(src_pkg_zip);
+		while (scan_ret == UNZ_OK) {
+			unz_file_info scan_info;
+			char scan_fname[ZIP_FNAME_MAX];
+			if (unzGetCurrentFileInfo(src_pkg_zip, &scan_info, scan_fname, ZIP_FNAME_MAX, nullptr, 0, nullptr, 0) != UNZ_OK) {
+				break;
+			}
+			if (String::utf8(scan_fname).begins_with("AccessKit.xcframework/")) {
+				config_data.has_accesskit = true;
+				break;
+			}
+			scan_ret = unzGoToNextFile(src_pkg_zip);
+		}
+	}
+
 	err = _export_apple_embedded_plugins(p_preset, config_data, binary_dir, module_libs, assets, p_debug);
 	if (err != OK) {
 		// TODO: Improve error reporting by using `add_message` throughout all methods called via `_export_apple_embedded_plugins`.

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -144,6 +144,7 @@ protected:
 		String modules_buildphase;
 		String modules_buildgrp;
 		Vector<String> capabilities;
+		bool has_accesskit = false;
 	};
 
 	struct CodeSigningDetails {

--- a/misc/dist/apple_embedded_xcode/godot_apple_embedded.xcodeproj/project.pbxproj
+++ b/misc/dist/apple_embedded_xcode/godot_apple_embedded.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */; };
 		D07CD44E1C5D589C00B7FB28 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D07CD44D1C5D589C00B7FB28 /* Images.xcassets */; };
         $moltenvk_buildfile
+        $accesskit_buildfile
 		D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE4418AEBDA2004A7AAE /* InfoPlist.strings */; };
 		D0BCFE7818AEBFEB004A7AAE /* $binary.pck in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE7718AEBFEB004A7AAE /* $binary.pck */; };
 		F965960D2BC2C3A800579C7E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F965960C2BC2C3A800579C7E /* PrivacyInfo.xcprivacy */; };
@@ -43,6 +44,7 @@
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "$binary.entitlements"; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
         $moltenvk_fileref
+        $accesskit_fileref
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "$binary.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE4318AEBDA2004A7AAE /* $binary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "$binary-Info.plist"; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			buildActionMask = 2147483647;
 			files = (
                 $moltenvk_buildphase
+                $accesskit_buildphase
 				DEADBEEF2F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildphase
 				$additional_pbx_frameworks_build
@@ -95,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
                 $moltenvk_buildgrp
+                $accesskit_buildgrp
 				DEADBEEF1F582BE20003B888 /* $binary.xcframework */,
 				$modules_buildgrp
 				$additional_pbx_frameworks_refs

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -23,6 +23,20 @@ def can_build():
 def get_opts():
     from SCons.Variables import BoolVariable
 
+    # Dependencies folder. Mirrors the layout used by macOS / Windows.
+    deps_folder = os.getenv("LOCALAPPDATA")
+    if deps_folder:
+        deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
+    else:
+        try:
+            import inspect
+
+            caller_frame = inspect.stack()[1]
+            caller_script_dir = os.path.dirname(os.path.abspath(caller_frame[1]))
+            deps_folder = os.path.join(caller_script_dir, "bin", "build_deps")
+        except Exception:
+            deps_folder = ""
+
     return [
         ("vulkan_sdk_path", "Path to the Vulkan SDK", ""),
         ("SWIFT_FRONTEND", "Path to the swift-frontend binary", ""),
@@ -32,6 +46,12 @@ def get_opts():
         (("apple_target_triple", "ios_triple"), "Triple for the corresponding target Apple platform toolchain", ""),
         BoolVariable(("simulator", "ios_simulator"), "Build for Simulator", False),
         BoolVariable("generate_bundle", "Generate an APP bundle after building iOS/macOS binaries", False),
+        # Screen reader support.
+        (
+            "accesskit_sdk_path",
+            "Path to the AccessKit C SDK",
+            os.path.join(deps_folder, "accesskit"),
+        ),
     ]
 
 
@@ -152,6 +172,27 @@ def configure(env: "SConsEnvironment"):
 
     env.Prepend(CPPPATH=["#platform/ios"])
     env.Append(CPPDEFINES=["IOS_ENABLED", "APPLE_EMBEDDED_ENABLED", "UNIX_ENABLED", "COREAUDIO_ENABLED"])
+
+    # AccessKit (screen reader support).
+    if env["accesskit"]:
+        if env["simulator"]:
+            ak_lib = os.path.join(
+                env["accesskit_sdk_path"], "lib", "ios-simulator", "arm64", "static", "libaccesskit.a"
+            )
+        else:
+            ak_lib = os.path.join(env["accesskit_sdk_path"], "lib", "ios", "arm64", "static", "libaccesskit.a")
+        if os.path.isfile(ak_lib):
+            env.Prepend(CPPPATH=[os.path.join(env["accesskit_sdk_path"], "include")])
+            env.Append(CPPDEFINES=["ACCESSKIT_ENABLED"])
+        else:
+            print_warning(
+                "The screen reader support driver requires dependencies to be installed.\n"
+                f"You can install them by running `python3 {os.path.join('misc', 'scripts', 'install_accesskit.py')}`.\n"
+                "See the documentation for more information:\n"
+                "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_ios.html\n"
+                "Alternatively, disable this driver by compiling with `accesskit=no` explicitly."
+            )
+            env["accesskit"] = False
 
     if env["metal"] and env["simulator"]:
         print_warning("iOS Simulator does not support the Metal rendering driver")

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -422,6 +422,20 @@ String EditorExportPlatformIOS::_process_config_file_line(const Ref<EditorExport
 		String value = "9039D3BD24C093AC0020482C /* MoltenVK.xcframework */,";
 		strnew += p_line.replace("$moltenvk_buildgrp", value) + "\n";
 
+		// AccessKit Framework
+	} else if (p_line.contains("$accesskit_buildfile")) {
+		String value = p_config.has_accesskit ? "34E718094B1805BD1139E86C /* AccessKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A06DCD3FADF513A489D6CE0C /* AccessKit.xcframework */; };" : "";
+		strnew += p_line.replace("$accesskit_buildfile", value) + "\n";
+	} else if (p_line.contains("$accesskit_fileref")) {
+		String value = p_config.has_accesskit ? "A06DCD3FADF513A489D6CE0C /* AccessKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AccessKit; path = AccessKit.xcframework; sourceTree = \"<group>\"; };" : "";
+		strnew += p_line.replace("$accesskit_fileref", value) + "\n";
+	} else if (p_line.contains("$accesskit_buildphase")) {
+		String value = p_config.has_accesskit ? "34E718094B1805BD1139E86C /* AccessKit.xcframework in Frameworks */," : "";
+		strnew += p_line.replace("$accesskit_buildphase", value) + "\n";
+	} else if (p_line.contains("$accesskit_buildgrp")) {
+		String value = p_config.has_accesskit ? "A06DCD3FADF513A489D6CE0C /* AccessKit.xcframework */," : "";
+		strnew += p_line.replace("$accesskit_buildgrp", value) + "\n";
+
 		// Launch Storyboard
 	} else if (p_line.contains("$plist_launch_screen_name")) {
 		String value = "<key>UILaunchStoryboardName</key>\n<string>Launch Screen</string>";

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -298,6 +298,11 @@ def generate_bundle_apple_embedded(platform, framework_dir, framework_dir_sim, u
             )
             shutil.copy(mvk_path + "/Info.plist", app_dir + "/MoltenVK.xcframework/Info.plist")
 
+    if env["accesskit"]:
+        ak_xcf = os.path.join(env["accesskit_sdk_path"], "lib", "ios", "AccessKit.xcframework")
+        if os.path.isdir(ak_xcf):
+            shutil.copytree(ak_xcf, app_dir + "/AccessKit.xcframework")
+
     # ZIP Xcode project bundle.
     zip_dir = env.Dir("#bin/" + (app_prefix + extra_suffix).replace(".", "_")).abspath
     shutil.make_archive(zip_dir, "zip", root_dir=app_dir)


### PR DESCRIPTION
> [!NOTE]
> AI-assisted contribution disclosure:
Claude Code was used to help generate an initial boilerplate draft based on the existing macOS AccessKit implementation and to explore unfamiliar APIs. The generated code was not accepted as-is and required significant manual debugging, modification, integration work, and testing.
The implementation was built, exported, and tested manually on physical iOS hardware with VoiceOver enabled. Additional fixes and follow-up changes were made during review and integration.
This PR should be considered AI-assisted, not AI-authored.

## What problem(s) does this PR solve?

iOS is currently the only major Godot platform without screen reader support. macOS, Windows, and Linux already integrate the AccessKit-based `AccessibilityServerAccessKit` driver, but iOS has no implementation, so VoiceOver cannot read `Control` elements or their `accessibility_name` / `description` / `role` properties in apps exported from Godot.

This PR adds the missing iOS glue so VoiceOver works out of the box, using the same driver and the upstream `accesskit_ios_subclassing_adapter`.

- Closes #

## Additional information

### What changed

- **`drivers/accesskit/accessibility_server_accesskit.{h,cpp}`** - Adds an `APPLE_EMBEDDED_ENABLED` branch alongside the existing macOS / Windows / Linux paths in `window_create` / `window_destroy` / `update_if_active`, using AccessKit's 3-callback iOS variant.
- **`platform/apple_embedded/display_server_apple_embedded.{h,mm}`** - Registers `godotView` as the host `UIView` with `AccessibilityServer::window_create`, advertises `FEATURE_ACCESSIBILITY_SCREEN_READER`, and surfaces VoiceOver state via `accessibility_screen_reader_active()` backed by `UIAccessibilityIsVoiceOverRunning`.
- **`platform/ios/detect.py`** - Adds an `accesskit_sdk_path` SCons option mirroring the macOS pattern, links the appropriate device / simulator static slice, and defines `ACCESSKIT_ENABLED` when found.
- **`drivers/SCsub`** - Includes the AccessKit driver sources in the iOS build.

### Scope decisions

- **visionOS deliberately not enabled.** The `APPLE_EMBEDDED_ENABLED` guard would cover it, but visionOS is kept out of `drivers/SCsub` and `platform/visionos/detect.py` to limit this PR's scope. Happy to follow up in a separate PR.
- **No new script-exposed API.** No `doc/classes/` changes are required - the feature surfaces through the existing `AccessibilityServer` API and `Control.accessibility_*` properties already documented for the other platforms.

### Dependency status

This PR depends on **AccessKit C 0.22.1** (released 2026-05-24, [AccessKit/accesskit-c#94](https://github.com/AccessKit/accesskit-c/pull/94)), which introduces the iOS adapters.

A matching **godot-accesskit-c-static** release with iOS binaries (`lib/ios/{arm64,simulator_arm64}/static/libaccesskit.a`) is still pending. Until that lands, the PR can be built by compiling `accesskit-c` 0.22.1 locally and pointing `accesskit_sdk_path=...` at the resulting tree. **Suggest holding merge until the static-bindings release is cut.**

### Test plan

Manual VoiceOver testing - no automated tests added. The change is platform glue with no host-testable surface, matching how the macOS / Windows / Linux AccessKit integrations were merged.

Tested with VoiceOver enabled on:
- [x] iOS device (arm64) - `Control` nodes are reachable via swipe navigation; `accessibility_name`, `description`, and `role` are announced
- [x] Confirmed no regression with VoiceOver disabled

Reviewers wanting to reproduce: build `accesskit-c` 0.22.1 with the iOS targets, then:

```bash
scons platform=ios target=template_debug arch=arm64 accesskit_sdk_path=/path/to/accesskit-c
```
