### PR TITLE
Use `Vector2` for `LabelSettings` Stacked Shadows offset

### DIFF
--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -178,7 +178,7 @@
 			The color of the shadow at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
 		</member>
-		<member name="stacked_shadow_{index}/offset" type="Vector2" setter="" getter="" default="Vector2i(1, 1)">
+		<member name="stacked_shadow_{index}/offset" type="Vector2" setter="" getter="" default="Vector2(1, 1)">
 			The offset of the shadow at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
 		</member>

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -45,7 +45,7 @@ public:
 		Color color;
 	};
 	struct StackedShadowData {
-		Vector2i offset = Vector2i(1, 1);
+		Vector2 offset = Vector2(1, 1);
 		Color color;
 		int32_t outline_size = 0;
 	};


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Closes #119699

Fixes `StackedShadowData::offset` being stored as `Vector2i` instead of `Vector2`, causing sub-pixel/fractional offset values to be silently truncated when set via the public API which correctly exposes the field as `Vector2`.

## Additional information

`StackedShadowData::offset` was declared as `Vector2i` in `label_settings.h`, but the getter/setter pair (`set_stacked_shadow_offset` / `get_stacked_shadow_offset`) both use `Vector2`. This mismatch meant any fractional component of the offset (e.g. `Vector2(0.5, 1.3)`) was silently lost on assignment due to implicit truncation, while the Inspector continued displaying a `Vector2` field — making the bug very difficult to notice.

The fix replaces the two `Vector2i` occurrences in `StackedShadowData` with `Vector2`, aligning the internal storage type with the public API. Existing saved resources are unaffected since whole-number offsets convert identically.