### PR TITLE
Interpolate pan in `AudioEffectPanner` to avoid clicks

### DIFF
--- a/servers/audio/effects/audio_effect_panner.cpp
+++ b/servers/audio/effects/audio_effect_panner.cpp
@@ -33,19 +33,27 @@
 #include "core/object/class_db.h"
 
 void AudioEffectPannerInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	float lvol = CLAMP(1.0 - base->pan, 0, 1);
-	float rvol = CLAMP(1.0 + base->pan, 0, 1);
+	//interpolate pan to avoid clicks if this changes
+	float pan = base->pan;
+	float p = mix_pan;
+	float pan_inc = (pan - mix_pan) / float(p_frame_count);
 
 	for (int i = 0; i < p_frame_count; i++) {
+		float lvol = CLAMP(1.0 - p, 0, 1);
+		float rvol = CLAMP(1.0 + p, 0, 1);
 		p_dst_frames[i].left = p_src_frames[i].left * lvol + p_src_frames[i].right * (1.0 - rvol);
 		p_dst_frames[i].right = p_src_frames[i].right * rvol + p_src_frames[i].left * (1.0 - lvol);
+		p += pan_inc;
 	}
+	//set pan for next mix
+	mix_pan = pan;
 }
 
 Ref<AudioEffectInstance> AudioEffectPanner::instantiate() {
 	Ref<AudioEffectPannerInstance> ins;
 	ins.instantiate();
 	ins->base = Ref<AudioEffectPanner>(this);
+	ins->mix_pan = pan;
 	return ins;
 }
 

--- a/servers/audio/effects/audio_effect_panner.cpp
+++ b/servers/audio/effects/audio_effect_panner.cpp
@@ -33,19 +33,27 @@
 #include "core/object/class_db.h"
 
 void AudioEffectPannerInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	float lvol = CLAMP(1.0 - base->pan, 0, 1);
-	float rvol = CLAMP(1.0 + base->pan, 0, 1);
+	// Interpolate pan to avoid clicks on fast changes.
+	float pan = base->pan;
+	float p = mix_pan;
+	float pan_inc = (pan - mix_pan) / float(p_frame_count);
 
 	for (int i = 0; i < p_frame_count; i++) {
+		float lvol = CLAMP(1.0 - p, 0, 1);
+		float rvol = CLAMP(1.0 + p, 0, 1);
 		p_dst_frames[i].left = p_src_frames[i].left * lvol + p_src_frames[i].right * (1.0 - rvol);
 		p_dst_frames[i].right = p_src_frames[i].right * rvol + p_src_frames[i].left * (1.0 - lvol);
+		p += pan_inc;
 	}
+	// Set pan for next mix.
+	mix_pan = pan;
 }
 
 Ref<AudioEffectInstance> AudioEffectPanner::instantiate() {
 	Ref<AudioEffectPannerInstance> ins;
 	ins.instantiate();
 	ins->base = Ref<AudioEffectPanner>(this);
+	ins->mix_pan = pan;
 	return ins;
 }
 

--- a/servers/audio/effects/audio_effect_panner.h
+++ b/servers/audio/effects/audio_effect_panner.h
@@ -39,6 +39,8 @@ class AudioEffectPannerInstance : public AudioEffectInstance {
 	friend class AudioEffectPanner;
 	Ref<AudioEffectPanner> base;
 
+	float mix_pan = 0;
+
 public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #106587.

Mirrors the per-buffer interpolation already used in AudioEffectAmplify, so changing the panner's pan value on an active bus no longer produces crackle from value discontinuities at buffer boundaries.


## Additional information

Credit to @Arazalera for diagnosing the issue and proposing the fix.

Note that I am still new to audio stuff and I am trying to learn so I can contribute better to this area, I hope this be will the start of more contributions (as time permits).

----

_Disclaimer: AI tooling was used in the review of this change. Any code not physically typed out by myself has been carefully reviewed to the best of my ability._