### PR TITLE
Add touch support to `TextEdit`

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1399,6 +1399,9 @@
 			If [code]true[/code], text can be selected.
 			If [code]false[/code], text can not be selected by the user or by the [method select] or [method select_all] methods.
 		</member>
+		<member name="selection_handle_enabled" type="bool" setter="set_selection_handle_enabled" getter="is_selection_handle_enabled" default="true">
+			If [code]true[/code], enables the handles used for text selection. These handles are only visible on touchscreen and can be dragged to adjust the selected text range.
+		</member>
 		<member name="shortcut_keys_enabled" type="bool" setter="set_shortcut_keys_enabled" getter="is_shortcut_keys_enabled" default="true">
 			If [code]true[/code], shortcut keys for context menu items are enabled, even if the context menu is disabled.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1911,7 +1911,7 @@ void CodeTextEditor::_zoom_out() {
 }
 
 void CodeTextEditor::_zoom_to(float p_zoom_factor) {
-	if (zoom_factor == p_zoom_factor) {
+	if (Math::is_equal_approx(zoom_factor, p_zoom_factor)) {
 		return;
 	}
 

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -146,7 +146,7 @@ void AndroidInputHandler::_cancel_all_touch() {
 	touch.clear();
 }
 
-void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled, bool p_double_tap) {
+void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled) {
 	if (touch.size()) {
 		//end all if exist
 		for (int i = 0; i < touch.size(); i++) {
@@ -156,7 +156,7 @@ void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled, bool
 			ev->set_pressed(p_pressed);
 			ev->set_canceled(p_canceled);
 			ev->set_position(touch[i].pos);
-			ev->set_double_tap(p_double_tap);
+			ev->set_double_tap(touch[i].double_tap);
 			Input::get_singleton()->parse_input_event(ev);
 		}
 	}
@@ -167,7 +167,7 @@ void AndroidInputHandler::_release_all_touch() {
 	touch.clear();
 }
 
-void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points, bool p_double_tap) {
+void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points) {
 	switch (p_event) {
 		case AMOTION_EVENT_ACTION_DOWN: { //gesture begin
 			// Release any remaining touches or mouse event
@@ -180,10 +180,11 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 				touch.write[i].pos = p_points[i].pos;
 				touch.write[i].pressure = p_points[i].pressure;
 				touch.write[i].tilt = p_points[i].tilt;
+				touch.write[i].double_tap = p_points[i].double_tap;
 			}
 
 			//send touch
-			_parse_all_touch(true, false, p_double_tap);
+			_parse_all_touch(true, false);
 
 		} break;
 		case AMOTION_EVENT_ACTION_MOVE: { //motion

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -43,6 +43,7 @@ public:
 		Point2 pos;
 		float pressure = 0;
 		Vector2 tilt;
+		bool double_tap = false;
 	};
 
 	struct MouseEventInfo {
@@ -90,7 +91,7 @@ private:
 
 	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
 
-	void _parse_all_touch(bool p_pressed, bool p_canceled = false, bool p_double_tap = false);
+	void _parse_all_touch(bool p_pressed, bool p_canceled = false);
 
 	void _release_all_touch();
 
@@ -98,7 +99,7 @@ private:
 
 public:
 	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt);
-	void process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points, bool p_double_tap);
+	void process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
 	void process_magnify(Point2 p_pos, float p_factor);
 	void process_pan(Point2 p_pos, Vector2 p_delta);
 	void process_joy_event(JoypadEvent p_event);

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -30,13 +30,10 @@
 
 package org.godotengine.godot.input
 
-import android.os.Build
 import android.view.GestureDetector.SimpleOnGestureListener
-import android.view.InputDevice
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.ScaleGestureDetector.OnScaleGestureListener
-import org.godotengine.godot.GodotLib
 
 /**
  * Handles regular and scale gesture input related events for the [GodotView] view.
@@ -51,11 +48,18 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	/**
-	 * Enable pan and scale gestures
+	 * Enable panning gestures.
 	 */
-	var panningAndScalingEnabled = false
+	var panningEnabled = false
+
+	/**
+	 * Enable scaling gestures.
+	 */
+	var scalingEnabled = false
 
 	var scrollDeadzoneDisabled = false
+
+	var longPressEnabled = false
 
 	/**
 	 * Enable haptic feedback on long-press right-click
@@ -181,8 +185,12 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	override fun onDoubleTapEvent(event: MotionEvent): Boolean {
 		if (event.actionMasked == MotionEvent.ACTION_UP) {
 			nextDownIsDoubleTap = false
-			inputHandler.handleMotionEvent(event)
-		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && !panningAndScalingEnabled) {
+
+			// Long press is restored to its previous value.
+			inputHandler.gestureDetector.setIsLongpressEnabled(longPressEnabled)
+
+			inputHandler.handleMotionEvent(event, event.actionMasked, true)
+		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && !(scalingEnabled && inputHandler.scaleGestureDetector.isQuickScaleEnabled)) {
 			inputHandler.handleMotionEvent(event)
 		}
 
@@ -190,6 +198,9 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	override fun onDoubleTap(event: MotionEvent): Boolean {
+		// Long press is disabled as it interferes with double tap events.
+		inputHandler.gestureDetector.setIsLongpressEnabled(false)
+
 		nextDownIsDoubleTap = true
 		return true
 	}
@@ -214,7 +225,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 
 		val x = terminusEvent.x
 		val y = terminusEvent.y
-		if (terminusEvent.pointerCount >= 2 && panningAndScalingEnabled && !pointerCaptureInProgress && !dragInProgress) {
+		if (terminusEvent.pointerCount >= 2 && panningEnabled && !pointerCaptureInProgress && !dragInProgress) {
 			inputHandler.handlePanEvent(x, y, distanceX / 5f, distanceY / 5f)
 		} else if (!scaleInProgress) {
 			dragInProgress = true
@@ -226,7 +237,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	override fun onScale(detector: ScaleGestureDetector): Boolean {
-		if (!panningAndScalingEnabled || pointerCaptureInProgress || dragInProgress) {
+		if (!scalingEnabled || pointerCaptureInProgress || dragInProgress) {
 			return false
 		}
 
@@ -237,7 +248,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
-		if (!panningAndScalingEnabled || pointerCaptureInProgress || dragInProgress) {
+		if (!scalingEnabled || pointerCaptureInProgress || dragInProgress) {
 			return false
 		}
 		scaleInProgress = true

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -88,8 +88,8 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	private final Godot godot;
 	private final InputManager mInputManager;
 	private final WindowManager windowManager;
-	private final GestureDetector gestureDetector;
-	private final ScaleGestureDetector scaleGestureDetector;
+	final GestureDetector gestureDetector;
+	final ScaleGestureDetector scaleGestureDetector;
 	private final GodotGestureHandler godotGestureHandler;
 
 	/**
@@ -112,9 +112,12 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 
 		this.godotGestureHandler = new GodotGestureHandler(this);
 		this.gestureDetector = new GestureDetector(context, godotGestureHandler);
-		this.gestureDetector.setIsLongpressEnabled(false);
+		enableLongPress(false);
+
 		this.scaleGestureDetector = new ScaleGestureDetector(context, godotGestureHandler);
 		this.scaleGestureDetector.setStylusScaleEnabled(true);
+		this.scaleGestureDetector.setQuickScaleEnabled(false);
+
 		Configuration config = context.getResources().getConfiguration();
 		hasHardwareKeyboardConfig = config.keyboard != Configuration.KEYBOARD_NOKEYS &&
 				config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO;
@@ -125,6 +128,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	 */
 	public void enableLongPress(boolean enable) {
 		this.gestureDetector.setIsLongpressEnabled(enable);
+		this.godotGestureHandler.setLongPressEnabled(enable);
 	}
 
 	/**
@@ -157,7 +161,8 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	 * Note: This may interfere with multi-touch handling / support.
 	 */
 	public void enablePanningAndScalingGestures(boolean enable) {
-		this.godotGestureHandler.setPanningAndScalingEnabled(enable);
+		this.godotGestureHandler.setPanningEnabled(enable);
+		this.godotGestureHandler.setScalingEnabled(enable);
 	}
 
 	/**

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -362,10 +362,11 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JN
 		tp.pos = Point2(p[1], p[2]);
 		tp.pressure = p[3];
 		tp.tilt = Vector2(p[4], p[5]);
+		tp.double_tap = p_double_tap;
 		points.push_back(tp);
 	}
 
-	input_handler->process_touch_event(ev, pointer, points, p_double_tap);
+	input_handler->process_touch_event(ev, pointer, points);
 }
 
 // Called on the UI thread

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -466,9 +466,65 @@ void CodeEdit::_draw_guidelines() {
 }
 
 void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
+	int event_device_id = p_gui_input->get_device();
+	Ref<InputEventScreenTouch> touch = p_gui_input;
+	if (touch.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
+		if (code_completion_active) {
+			Vector2 touch_pos = touch->get_position();
+			if (code_completion_rect.has_point(touch_pos) || code_completion_scroll_rect.has_point(touch_pos)) {
+				if (touch->is_pressed()) {
+					is_code_completion_drag_started = true;
+					if (code_completion_force_item_center == -1) {
+						code_completion_force_item_center = code_completion_current_selected;
+					}
+
+					code_completion_current_selected = CLAMP(code_completion_line_ofs + (touch_pos.y - code_completion_rect.position.y) / get_line_height(), 0, code_completion_options.size() - 1);
+					code_completion_pan_offset = 0.0f;
+					if (touch->is_double_tap()) {
+						confirm_code_completion();
+					}
+					queue_redraw();
+					queue_accessibility_update();
+				} else {
+					// Finger lifted up inside the boundaries.
+					is_code_completion_drag_started = false;
+				}
+				accept_event();
+				return;
+			}
+
+			// If touch lands completely outside the completion popup.
+			if (touch->is_pressed()) {
+				cancel_code_completion();
+				set_code_hint("");
+			} else {
+				is_code_completion_drag_started = false;
+				accept_event();
+				return;
+			}
+		} else {
+			if (touch->is_pressed()) {
+				set_code_hint("");
+			}
+		}
+	}
+
+	real_t delta = 0.0;
+	bool is_valid_scroll_event = false;
+
 	Ref<InputEventPanGesture> pan_gesture = p_gui_input;
 	if (pan_gesture.is_valid() && code_completion_active && code_completion_rect.has_point(pan_gesture->get_position())) {
-		const real_t delta = pan_gesture->get_delta().y;
+		delta = pan_gesture->get_delta().y;
+		is_valid_scroll_event = true;
+	}
+
+	Ref<InputEventScreenDrag> drag = p_gui_input;
+	if (drag.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION && code_completion_active && is_code_completion_drag_started) {
+		delta = -(drag->get_relative().y / (real_t)get_line_height());
+		is_valid_scroll_event = true;
+	}
+
+	if (is_valid_scroll_event) {
 		code_completion_pan_offset += delta;
 		if (code_completion_pan_offset <= -1.0) {
 			if (code_completion_current_selected > 0) {
@@ -490,7 +546,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	Ref<InputEventMouseButton> mb = p_gui_input;
-	if (mb.is_valid()) {
+	if (mb.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
 		// Ignore mouse clicks in IME input mode, let TextEdit handle it.
 		if (has_ime_text()) {
 			TextEdit::gui_input(p_gui_input);
@@ -621,7 +677,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	Ref<InputEventMouseMotion> mm = p_gui_input;
-	if (mm.is_valid()) {
+	if (mm.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
 		Vector2i mpos = mm->get_position();
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -209,6 +209,7 @@ private:
 	bool code_completion_enabled = false;
 	bool code_completion_forced = false;
 
+	Vector2 completion_touch_drag_accum;
 	bool code_completion_active = false;
 	bool is_code_completion_scroll_hovered = false;
 	bool is_code_completion_scroll_pressed = false;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -891,7 +891,70 @@ void TextEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (scrolling && get_v_scroll() != target_v_scroll) {
+			if (touch_dragging_starting || touch_dragging_in_progress || touch_dragging_deaccel) {
+				if (touch_dragging_deaccel) {
+					// Deceleration handling loop; finger-up after flick.
+					Vector2 pos = Vector2(h_scroll->get_value(), v_scroll->get_value());
+
+					float line_height = MAX(1, get_line_height());
+					Vector2 frame_movement = drag_speed * get_process_delta_time();
+
+					pos.x += frame_movement.x;
+					pos.y += frame_movement.y / line_height;
+
+					bool turnoff_h = false;
+					bool turnoff_v = false;
+
+					if (pos.x < 0) {
+						pos.x = 0;
+						turnoff_h = true;
+					}
+					if (pos.x > (h_scroll->get_max() - h_scroll->get_page())) {
+						pos.x = h_scroll->get_max() - h_scroll->get_page();
+						turnoff_h = true;
+					}
+
+					if (pos.y < 0) {
+						pos.y = 0;
+						turnoff_v = true;
+					}
+					if (pos.y > (v_scroll->get_max() - v_scroll->get_page())) {
+						pos.y = v_scroll->get_max() - v_scroll->get_page();
+						turnoff_v = true;
+					}
+
+					h_scroll->scroll_to(pos.x);
+					v_scroll->scroll_to(pos.y);
+
+					float sgn_x = drag_speed.x < 0 ? -1 : 1;
+					float val_x = Math::abs(drag_speed.x);
+					val_x -= 1000.0f * get_process_delta_time();
+					if (val_x < 0) {
+						turnoff_h = true;
+					}
+
+					float sgn_y = drag_speed.y < 0 ? -1 : 1;
+					float val_y = Math::abs(drag_speed.y);
+					val_y -= 1000.0f * get_process_delta_time();
+					if (val_y < 0) {
+						turnoff_v = true;
+					}
+
+					drag_speed = Vector2(sgn_x * val_x, sgn_y * val_y);
+
+					if (turnoff_h && turnoff_v) {
+						_cancel_inertial_scroll();
+					}
+				} else {
+					// Active touch scrolling; finger-down.
+					if (time_since_motion == 0.0 || time_since_motion > 0.1) {
+						Vector2 diff = drag_accum - last_drag_accum;
+						last_drag_accum = drag_accum;
+						drag_speed = diff / get_process_delta_time();
+					}
+					time_since_motion += get_process_delta_time();
+				}
+			} else if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
 				double dist = std::abs(target_y);
 				// To ensure minimap is responsive override the speed setting.
@@ -1955,6 +2018,25 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 
+			// Selection handles.
+			if (show_selection_handle && selection_handle_enabled) {
+				for (int c = 0; c < get_caret_count(); c++) {
+					if (!has_selection(c)) {
+						continue;
+					}
+
+					Vector<Point2i> handles_pos = _get_selection_handles_pos(c);
+					Point2i start_pos = handles_pos[0];
+					Point2i end_pos = handles_pos[1];
+					if (start_pos.x != -1) {
+						_draw_selection_handle(start_pos);
+					}
+					if (end_pos.x != -1) {
+						_draw_selection_handle(end_pos);
+					}
+				}
+			}
+
 			if (has_focus()) {
 				_update_ime_window_position();
 			}
@@ -2056,6 +2138,54 @@ void TextEdit::_notification(int p_what) {
 			}
 		} break;
 	}
+}
+
+void TextEdit::_draw_selection_handle(Vector2 p_pos) const {
+	Color handle_color = theme_cache.caret_color;
+	int line_height = get_line_height();
+
+	int handle_line_width = theme_cache.caret_width * MAX(1, theme_cache.base_scale);
+	RS::get_singleton()->canvas_item_add_line(text_ci, p_pos, p_pos + Vector2(0, line_height), handle_color, handle_line_width);
+
+	Vector2 circle_center = p_pos + Vector2(0, line_height + selection_handle_radius);
+	RS::get_singleton()->canvas_item_add_circle(text_ci, circle_center, selection_handle_radius, handle_color);
+}
+
+/*
+ * Returns true if p_column is at index 0 or if it is the first character of a wrapped line segment.
+ */
+bool TextEdit::_is_first_column(int p_line, int p_column) const {
+	bool is_first_column = p_column == 0;
+	if (!is_first_column && is_line_wrapped(p_line)) {
+		int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
+		int wrap_index_last_column = get_line_wrap_index_at_column(p_line, p_column - 1);
+		is_first_column = wrap_index != wrap_index_last_column;
+	}
+	return is_first_column;
+}
+
+Vector<Point2i> TextEdit::_get_selection_handles_pos(int p_caret) const {
+	int selection_from_line = get_selection_from_line(p_caret);
+	int selection_from_column = get_selection_from_column(p_caret);
+	int selection_to_line = get_selection_to_line(p_caret);
+	int selection_to_column = get_selection_to_column(p_caret);
+	Rect2i start_rect = get_rect_at_line_column(selection_from_line, selection_from_column);
+	Rect2i end_rect = get_rect_at_line_column(selection_to_line, selection_to_column);
+
+	Point2i start_pos = start_rect.position;
+	if (start_pos.x != -1 && !_is_first_column(selection_from_line, selection_from_column)) {
+		start_pos.x += start_rect.size.x;
+	}
+
+	Point2i end_pos = end_rect.position;
+	if (end_pos.x != -1 && !_is_first_column(selection_to_line, selection_to_column)) {
+		end_pos.x += end_rect.size.x;
+	}
+
+	Vector<Point2i> result;
+	result.push_back(start_pos);
+	result.push_back(end_pos);
+	return result;
 }
 
 void TextEdit::unhandled_key_input(const Ref<InputEvent> &p_event) {
@@ -2257,9 +2387,12 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	double prev_v_scroll = v_scroll->get_value();
 	double prev_h_scroll = h_scroll->get_value();
 
+	int event_device_id = p_gui_input->get_device();
 	Ref<InputEventMouseButton> mb = p_gui_input;
 
-	if (mb.is_valid()) {
+	if (mb.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
+		show_selection_handle = false; // Hiding selection handle because mouse is used.
+
 		Vector2i mpos = mb->get_position();
 		if (is_layout_rtl()) {
 			mpos.x = get_size().x - mpos.x;
@@ -2507,16 +2640,271 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_CLIPBOARD_PRIMARY)) {
 					DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 				}
+
+				if (editable) {
+					_show_virtual_keyboard();
+				}
+			}
+		}
+	}
+
+	Ref<InputEventScreenTouch> touch = p_gui_input;
+	if (touch.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
+		show_selection_handle = true;
+
+		// Prioritizing selection handle input
+		if (touch->is_pressed() && selection_handle_enabled) {
+			for (int c = 0; c < get_caret_count(); c++) {
+				if (!has_selection(c)) {
+					continue;
+				}
+
+				Vector<Point2i> handles_pos = _get_selection_handles_pos(c);
+				Point2i start_pos = handles_pos[0];
+				Point2i end_pos = handles_pos[1];
+
+				int line_height = get_line_height();
+
+				float start_dist = touch->get_position().distance_to(start_pos + Vector2(0, line_height + selection_handle_radius));
+				bool start_touched = start_pos.x != -1 && start_dist < selection_handle_radius * 2;
+				float end_dist = touch->get_position().distance_to(end_pos + Vector2(0, line_height + selection_handle_radius));
+				bool end_touched = end_pos.x != -1 && end_dist < selection_handle_radius * 2;
+
+				if (!start_touched && !end_touched) {
+					continue;
+				}
+
+				if (start_touched && end_touched) {
+					start_touched = start_dist < end_dist;
+					end_touched = !start_touched;
+				}
+
+				if (start_touched) {
+					selection_handle_drag_type = is_caret_after_selection_origin(c) ? SELECTION_HANDLE_START : SELECTION_HANDLE_END;
+					selection_handle_drag_offset = touch->get_position() - Vector2(start_pos) - Vector2(0, line_height / 2);
+				} else {
+					selection_handle_drag_type = is_caret_after_selection_origin(c) ? SELECTION_HANDLE_END : SELECTION_HANDLE_START;
+					selection_handle_drag_offset = touch->get_position() - Vector2(end_pos) - Vector2(0, line_height / 2);
+				}
+				dragging_caret_index = c;
+				_cancel_inertial_scroll();
+				accept_event();
+				return; // Return early to block default touch logic
+			}
+		}
+
+		if (touch->is_released() && selection_handle_drag_type != SELECTION_HANDLE_NONE) {
+			selection_handle_drag_type = SELECTION_HANDLE_NONE;
+			dragging_caret_index = -1;
+			accept_event();
+			return;
+		}
+
+		if (touch->is_pressed() && !touch->is_double_tap()) {
+			if (draw_minimap) {
+				_update_minimap_click();
+				if (dragging_minimap) {
+					return;
+				}
 			}
 
-			if (editable) {
-				_show_virtual_keyboard();
+			if (touch_dragging_deaccel) {
+				_cancel_inertial_scroll();
 			}
+
+			touch_dragging_starting = true;
+			touch_dragging_in_progress = false;
+
+			drag_speed = Vector2();
+			drag_accum = Vector2();
+			last_drag_accum = Vector2();
+			drag_from = Vector2(prev_h_scroll, prev_v_scroll);
+			touch_dragging_deaccel = false;
+			time_since_motion = 0.0;
+
+			set_process_internal(true);
+		}
+
+		if ((touch->is_pressed() && touch->is_double_tap()) || (touch->is_released() && !touch->is_double_tap() && !touch_dragging_in_progress && !pan_gesture_performed)) {
+			// Otherwise, if we receive a double touch press event, or a single touch release event with no touch dragging having occurred,
+			// we process as a regular tap, similar to how mouse click are handled above omitting logic not relevant to touch taps.
+			// Notice that a key difference from the mouse click handling logic and double tap events is that for single tap, we apply the logic below on release instead of on press.
+			// This is because we're unsure whether single tap press event will end as a single tap press->release event, or turn into a drag (press->drag->release) event.
+			Vector2i touch_pos = touch->get_position();
+			if (is_layout_rtl()) {
+				touch_pos.x = get_size().x - touch_pos.x;
+			}
+			_reset_caret_blink_timer();
+
+			apply_ime();
+
+			Point2i pos = get_line_column_at_pos(touch_pos);
+			int line = pos.y;
+			int col = pos.x;
+
+			// Gutters.
+			Vector2i current_hovered_gutter = _get_hovered_gutter(touch_pos);
+			if (current_hovered_gutter != Vector2i(-1, -1)) {
+				emit_signal(SNAME("gutter_clicked"), current_hovered_gutter.y, current_hovered_gutter.x);
+				return;
+			}
+			int left_margin = get_line_start_margin();
+			if (touch_pos.x < left_margin + gutters_width + gutter_padding) {
+				return;
+			}
+
+			// Minimap.
+			if (draw_minimap) {
+				if (touch->is_double_tap()) {
+					_update_minimap_click();
+					if (dragging_minimap) {
+						return;
+					}
+				} else if (dragging_minimap) {
+					// touch is released, cleanup minimap logic.
+					dragging_minimap = false;
+					can_drag_minimap = false;
+					minimap_clicked = false;
+					return;
+				}
+			}
+
+			// Update caret.
+			if (!touch->is_double_tap()) {
+				// A regular click clears all other carets.
+				int caret = 0;
+				remove_secondary_carets();
+				deselect();
+
+				_push_current_op();
+				set_caret_line(line, false, true, -1, caret);
+				set_caret_column(col, false, caret);
+
+				adjust_viewport_to_caret();
+			} else {
+				// Start double-click select word mode.
+				set_selection_mode(SelectionMode::SELECTION_MODE_WORD);
+				_update_selection_mode_word(true);
+			}
+
+			// Click inline objects.
+			if (inline_object_click_handler.is_valid()) {
+				int xmargin_beg = left_margin + gutters_width + gutter_padding;
+				int wrap_i = get_line_wrap_index_at_column(pos.y, pos.x);
+				const float wrap_indent = _get_wrap_indent_offset(pos.y, wrap_i, is_layout_rtl());
+
+				Ref<TextParagraph> ldata = text.get_line_data(line);
+				for (const Variant &inline_key : ldata->get_line_objects(wrap_i)) {
+					if (!is_inline_info_valid(inline_key)) {
+						continue;
+					}
+					Dictionary info = inline_key.duplicate();
+					info["line"] = line;
+					Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, inline_key);
+					obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
+
+					if (touch_pos.x > obj_rect.position.x && touch_pos.x < obj_rect.get_end().x) {
+						Rect2 col_rect = get_rect_at_line_column(line, col);
+						col_rect.position += get_screen_position() + Vector2(col_rect.size.x, 0);
+						col_rect.size = obj_rect.size;
+						set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_NONE);
+						inline_object_click_handler.call(info, col_rect);
+						break;
+					}
+				}
+			}
+
+			queue_accessibility_update();
+			queue_redraw();
+		}
+
+		if (touch->is_released()) {
+			if (!touch_dragging_in_progress) {
+				// If touch dragging did not occur, we perform some tidy up similar to what's done for the mouse click logic.
+				if (has_ime_text()) {
+					// Ignore mouse up in IME input mode.
+				} else {
+					dragging_selection = false;
+					set_selection_mode(SelectionMode::SELECTION_MODE_NONE);
+					click_select_held->stop();
+					if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_CLIPBOARD_PRIMARY)) {
+						DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
+					}
+
+					// Avoid showing the virtual keyboard when released on the minimap, or pan gesture performed.
+					if (editable && !dragging_minimap && !pan_gesture_performed) {
+						_show_virtual_keyboard();
+					}
+					dragging_minimap = false;
+					can_drag_minimap = false;
+					pan_gesture_performed = false;
+				}
+			}
+
+			if (touch_dragging_starting || touch_dragging_in_progress) {
+				if (touch->is_canceled() || drag_speed == Vector2()) {
+					_cancel_inertial_scroll();
+				} else {
+					touch_dragging_deaccel = true;
+				}
+			}
+
+			touch_dragging_starting = false;
+			touch_dragging_in_progress = false;
+		}
+	}
+
+	Ref<InputEventScreenDrag> drag = p_gui_input;
+	if (drag.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
+		show_selection_handle = true; // Showing selection handle because native touch input is used.
+
+		if (selection_handle_drag_type != SELECTION_HANDLE_NONE) {
+			Vector2 corrected_text_pos = drag->get_position() - selection_handle_drag_offset;
+			Point2i pos = get_line_column_at_pos(corrected_text_pos);
+			int c = dragging_caret_index;
+
+			if (selection_handle_drag_type == SELECTION_HANDLE_END) {
+				select(get_selection_origin_line(c), get_selection_origin_column(c), pos.y, pos.x, c);
+			} else {
+				select(pos.y, pos.x, get_caret_line(c), get_caret_column(c), c);
+			}
+
+			accept_event();
+			return;
+		}
+
+		// If we've started dragging and aren't actively processing deceleration momentum
+		if (touch_dragging_starting && !touch_dragging_deaccel) {
+			touch_dragging_in_progress = true;
+			Vector2 motion = drag->get_relative();
+
+			drag_accum -= motion;
+
+			// Convert the vertical accumulation from raw pixels to lines
+			float line_height = MAX(1, get_line_height());
+			float vertical_line_offset = drag_accum.y / line_height;
+
+			Vector2 diff = drag_from + Vector2(drag_accum.x, vertical_line_offset);
+			h_scroll->scroll_to(diff.x);
+			v_scroll->scroll_to(diff.y);
+
+			time_since_motion = 0.0;
+			accept_event();
+		} else {
+			// Likely follow up from a double tap touch event; we apply similar logic as the mouse motion logic.
+			_on_drag_or_mouse_motion_event(drag->get_position(), true);
 		}
 	}
 
 	const Ref<InputEventPanGesture> pan_gesture = p_gui_input;
 	if (pan_gesture.is_valid()) {
+		// A pan gesture starts with two fingers, so we mark both a drag and a pan as in progress.
+		// When the first finger is lifted, it triggers a touch release event that clears touch_dragging_in_progress,
+		// it performs same like the end of a single-finger drag.
+		// pan_gesture_performed remains set until the second touch release event, allowing us
+		// to detect that the interaction was part of a pan gesture and avoid showing the virtual keyboard.
+		touch_dragging_in_progress = true;
+		pan_gesture_performed = true;
 		const real_t delta = pan_gesture->get_delta().y;
 		if (delta < 0) {
 			_scroll_up(-delta, false);
@@ -2534,62 +2922,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 	Ref<InputEventMouseMotion> mm = p_gui_input;
 
-	if (mm.is_valid()) {
-		Vector2i mpos = mm->get_position();
-		if (is_layout_rtl()) {
-			mpos.x = get_size().x - mpos.x;
-		}
-
-		if (mm->get_button_mask().has_flag(MouseButtonMask::LEFT) && get_viewport()->gui_get_drag_data() == Variant()) {
-			// Update if not in drag and drop.
-			_reset_caret_blink_timer();
-
-			if (draw_minimap && !dragging_selection) {
-				_update_minimap_drag();
-			}
-
-			if (!dragging_minimap && !has_ime_text()) {
-				switch (selecting_mode) {
-					case SelectionMode::SELECTION_MODE_POINTER: {
-						_update_selection_mode_pointer();
-					} break;
-					case SelectionMode::SELECTION_MODE_WORD: {
-						_update_selection_mode_word();
-					} break;
-					case SelectionMode::SELECTION_MODE_LINE: {
-						_update_selection_mode_line();
-					} break;
-					default: {
-						break;
-					}
-				}
-			}
-		}
-
-		// Update hovered gutter.
-		Vector2i current_hovered_gutter = _get_hovered_gutter(mpos);
-		if (current_hovered_gutter != hovered_gutter) {
-			hovered_gutter = current_hovered_gutter;
-			queue_redraw();
-		}
-
-		if (drag_action && can_drop_data(mpos, get_viewport()->gui_get_drag_data())) {
-			apply_ime();
-			// Update drag and drop caret.
-			drag_caret_force_displayed = true;
-			Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
-
-			if (drag_caret_index == -1) {
-				// Force create a new caret for drag and drop.
-				carets.push_back(Caret());
-				drag_caret_index = carets.size() - 1;
-			}
-
-			drag_caret_force_displayed = true;
-			set_caret_line(pos.y, false, true, -1, drag_caret_index);
-			set_caret_column(pos.x, true, drag_caret_index);
-			dragging_selection = true;
-		}
+	if (mm.is_valid() && event_device_id != InputEvent::DEVICE_ID_EMULATION) {
+		_on_drag_or_mouse_motion_event(mm->get_position(), mm->get_button_mask().has_flag(MouseButtonMask::LEFT));
 	}
 
 	if (draw_minimap && !dragging_selection) {
@@ -2882,6 +3216,72 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 	}
+}
+
+void TextEdit::_on_drag_or_mouse_motion_event(Vector2i p_event_position, bool p_is_left_click_or_drag) {
+	if (is_layout_rtl()) {
+		p_event_position.x = get_size().x - p_event_position.x;
+	}
+
+	if (p_is_left_click_or_drag && get_viewport()->gui_get_drag_data() == Variant()) {
+		// Update if not in drag and drop.
+		_reset_caret_blink_timer();
+
+		if (draw_minimap && !dragging_selection) {
+			_update_minimap_drag();
+		}
+
+		if (!dragging_minimap && !has_ime_text()) {
+			switch (selecting_mode) {
+				case SelectionMode::SELECTION_MODE_POINTER: {
+					_update_selection_mode_pointer();
+				} break;
+				case SelectionMode::SELECTION_MODE_WORD: {
+					_update_selection_mode_word();
+				} break;
+				case SelectionMode::SELECTION_MODE_LINE: {
+					_update_selection_mode_line();
+				} break;
+				default: {
+					break;
+				}
+			}
+		}
+	}
+
+	// Update hovered gutter.
+	Vector2i current_hovered_gutter = _get_hovered_gutter(p_event_position);
+	if (current_hovered_gutter != hovered_gutter) {
+		hovered_gutter = current_hovered_gutter;
+		queue_redraw();
+	}
+
+	if (drag_action && can_drop_data(p_event_position, get_viewport()->gui_get_drag_data())) {
+		apply_ime();
+		// Update drag and drop caret.
+		drag_caret_force_displayed = true;
+		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
+
+		if (drag_caret_index == -1) {
+			// Force create a new caret for drag and drop.
+			carets.push_back(Caret());
+			drag_caret_index = carets.size() - 1;
+		}
+
+		drag_caret_force_displayed = true;
+		set_caret_line(pos.y, false, true, -1, drag_caret_index);
+		set_caret_column(pos.x, true, drag_caret_index);
+		dragging_selection = true;
+	}
+}
+
+void TextEdit::_cancel_inertial_scroll() {
+	set_process_internal(false);
+	touch_dragging_deaccel = false;
+	drag_speed = Vector2();
+	drag_accum = Vector2();
+	last_drag_accum = Vector2();
+	drag_from = Vector2();
 }
 
 /* Input actions. */
@@ -3410,6 +3810,10 @@ void TextEdit::_update_theme_item_cache() {
 	if (text.get_line_height() + theme_cache.line_spacing < 1) {
 		WARN_PRINT("Line height is too small, please increase font_size and/or line_spacing");
 	}
+
+	// The value was chosen after trying a few different radii.
+	// 10.0 provided the best balance between being easy to grab without making the touch area feel too large.
+	selection_handle_radius = 10.0 * theme_cache.base_scale;
 }
 
 void TextEdit::_update_caches(bool p_invalidate_all) {
@@ -6378,6 +6782,14 @@ void TextEdit::delete_selection(int p_caret) {
 	end_complex_operation();
 }
 
+void TextEdit::set_selection_handle_enabled(bool p_enabled) {
+	selection_handle_enabled = p_enabled;
+}
+
+bool TextEdit::is_selection_handle_enabled() const {
+	return selection_handle_enabled;
+}
+
 /* Line wrapping. */
 void TextEdit::set_line_wrapping_mode(LineWrappingMode p_wrapping_mode) {
 	if (line_wrapping_mode != p_wrapping_mode) {
@@ -7463,6 +7875,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("deselect", "caret_index"), &TextEdit::deselect, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("delete_selection", "caret_index"), &TextEdit::delete_selection, DEFVAL(-1));
 
+	ClassDB::bind_method(D_METHOD("set_selection_handle_enabled", "enable"), &TextEdit::set_selection_handle_enabled);
+	ClassDB::bind_method(D_METHOD("is_selection_handle_enabled"), &TextEdit::is_selection_handle_enabled);
+
 	/* Line wrapping. */
 	BIND_ENUM_CONSTANT(LINE_WRAPPING_NONE);
 	BIND_ENUM_CONSTANT(LINE_WRAPPING_BOUNDARY);
@@ -7625,6 +8040,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Arbitrary:1,Word:2,Word (Smart):3"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_wrapped_lines"), "set_indent_wrapped_lines", "is_indent_wrapped_lines");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tab_input_mode"), "set_tab_input_mode", "get_tab_input_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selection_handle_enabled"), "set_selection_handle_enabled", "is_selection_handle_enabled");
 
 	ADD_GROUP("Virtual Keyboard", "virtual_keyboard_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -510,6 +510,36 @@ private:
 	uint64_t last_dblclk = 0;
 	Vector2 last_dblclk_pos;
 
+	bool touch_dragging_starting = false;
+	bool touch_dragging_in_progress = false;
+	bool touch_dragging_deaccel = false;
+	Vector2 drag_accum;
+	Vector2 drag_from;
+	Vector2 drag_speed;
+	Vector2 last_drag_accum;
+	double time_since_motion = 0.0;
+	bool pan_gesture_performed = false;
+
+	enum SelectionHandleDragType {
+		SELECTION_HANDLE_NONE,
+		SELECTION_HANDLE_START,
+		SELECTION_HANDLE_END,
+	};
+
+	SelectionHandleDragType selection_handle_drag_type = SELECTION_HANDLE_NONE;
+	float selection_handle_radius;
+	int dragging_caret_index = -1;
+	Vector2 selection_handle_drag_offset;
+	bool show_selection_handle = false;
+	bool selection_handle_enabled = true;
+	Vector<Point2i> _get_selection_handles_pos(int p_cursor) const;
+	bool _is_first_column(int p_line, int p_column) const;
+	void _draw_selection_handle(Vector2 p_pos) const;
+
+	void _cancel_inertial_scroll();
+
+	void _on_drag_or_mouse_motion_event(Vector2i p_event_position, bool p_is_left_click_or_drag);
+
 	void _selection_changed(int p_caret = -1);
 	void _click_selection_held();
 
@@ -1039,6 +1069,9 @@ public:
 
 	void deselect(int p_caret = -1);
 	void delete_selection(int p_caret = -1);
+
+	void set_selection_handle_enabled(bool p_enabled);
+	bool is_selection_handle_enabled() const;
 
 	/* Line wrapping. */
 	void set_line_wrapping_mode(LineWrappingMode p_wrapping_mode);


### PR DESCRIPTION
This PR adds native touch support to `TextEdit` and `CodeEdit`.

- Tap (press -> release): positions the cursor and opens the virtual keyboard.
- Drag (press -> drag -> release): scrolls the text content, including inertial scrolling support.
- Text selection:
    - Double-tap selects a word.
    - Double-tap, hold, and drag selects the portion you're hovering over.
    - Basic selection handle support has also been added and additional improvements like a context panel would be done in a follow-up.
- Added drag-scrolling support to the code completion popup. Previously, it could not be scrolled using touch input. See https://github.com/godotengine/godot/pull/119706#issuecomment-4691322370

https://github.com/user-attachments/assets/66779249-6759-432f-8ed2-860c380b795c

