### PR TITLE
Fix inconsistent node filtering in animation editor

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -882,7 +882,7 @@ bool AnimationBezierTrackEdit::_is_track_displayed(int p_track_index) {
 			if (!node) {
 				return false; // No node, no filter.
 			}
-			if (!EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
+			if (!editor->filtered_nodes.has(node)) {
 				return false; // Skip track due to not selected.
 			}
 		}
@@ -1012,36 +1012,6 @@ void AnimationBezierTrackEdit::set_root(Node *p_root) {
 
 void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 	is_filtered = p_filtered;
-	if (animation.is_null()) {
-		return;
-	}
-	String base_path = String(animation->track_get_path(selected_track));
-	if (is_filtered) {
-		if (root && root->has_node(base_path)) {
-			Node *node = root->get_node(base_path);
-			if (!node || !EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
-				for (int i = 0; i < animation->get_track_count(); ++i) {
-					if (animation->track_get_type(i) != Animation::TrackType::TYPE_BEZIER) {
-						continue;
-					}
-
-					base_path = String(animation->track_get_path(i));
-					if (root && root->has_node(base_path)) {
-						node = root->get_node(base_path);
-						if (!node) {
-							continue; // No node, no filter.
-						}
-						if (!EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
-							continue; // Skip track due to not selected.
-						}
-
-						set_animation_and_track(animation, i, read_only);
-						break;
-					}
-				}
-			}
-		}
-	}
 	queue_redraw();
 }
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -5253,13 +5253,12 @@ void AnimationTrackEditor::_update_tracks() {
 
 		if (use_filter) {
 			NodePath path = animation->track_get_path(i);
-
 			if (root) {
 				Node *node = root->get_node_or_null(path);
 				if (!node) {
 					continue; // No node, no filter.
 				}
-				if (!EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
+				if (!filtered_nodes.has(node)) {
 					continue; // Skip track due to not selected.
 				}
 			}
@@ -7922,8 +7921,13 @@ void AnimationTrackEditor::_scene_changed() {
 }
 
 void AnimationTrackEditor::_selection_changed() {
+	const TypedArray<Node> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_nodes();
+	if (selected_nodes.size() > 0) {
+		filtered_nodes = selected_nodes;
+	}
 	if (selected_filter->is_pressed()) {
 		_update_tracks(); // Needs updating.
+		bezier_edit->queue_redraw();
 	} else {
 		_redraw_tracks();
 		_redraw_groups();

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -852,6 +852,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Button *view_group = nullptr;
 	Button *selected_filter = nullptr;
 	Button *alphabetic_sorting = nullptr;
+	TypedArray<Node> filtered_nodes;
 
 	void _auto_fit();
 	void _auto_fit_bezier();


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently when enabling node filtering in the animation editor, selecting a keyframe (or any other resource) makes all tracks hidden (filtered out), rendering the filtering feature almost useless.

This fix retains the last selected nodes, so when the node selection gets cleared the most recently selected nodes are used for the filtering. Closes #101031.

Also fixes node filtering not being updated on selection change in the Bezier editor. (I did not find an issue for this).

## Additional information

### Current state

https://github.com/user-attachments/assets/725efaa3-aaa6-4a5d-bf13-093eb0fef969

### PR

https://github.com/user-attachments/assets/426364a0-8751-45a1-9c31-06bfdcad2356

Supersedes #101946