### PR TITLE
[macOS] Add architecture selector to the export options.

### DIFF
--- a/core/io/file_access_packed_byte_array.cpp
+++ b/core/io/file_access_packed_byte_array.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  lipo.h                                                                */
+/*  file_access_packed_byte_array.cpp                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,51 +28,74 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "file_access_packed_byte_array.h"
 
-// Universal / Universal 2 fat binary file creator and extractor.
+Error FileAccessPackedBayteArray::open_custom(const PackedByteArray &p_data) {
+	data = p_data;
+	pos = 0;
+	return OK;
+}
 
-#include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
+void FileAccessPackedBayteArray::seek(uint64_t p_position) {
+	ERR_FAIL_COND(p_position > (uint64_t)data.size());
+	pos = p_position;
+}
 
-class LipO : public RefCounted {
-	GDSOFTCLASS(LipO, RefCounted);
+void FileAccessPackedBayteArray::seek_end(int64_t p_position) {
+	ERR_FAIL_COND((int64_t)data.size() + p_position < 0);
+	seek(data.size() + p_position);
+}
 
-	struct FatArch {
-		uint32_t cputype;
-		uint32_t cpusubtype;
-		uint64_t offset;
-		uint64_t size;
-		uint32_t align;
-	};
+uint64_t FileAccessPackedBayteArray::get_position() const {
+	return pos;
+}
 
-	Ref<FileAccess> fa;
-	Vector<FatArch> archs;
+uint64_t FileAccessPackedBayteArray::get_length() const {
+	return data.size();
+}
 
-	static inline size_t PAD(size_t s, size_t a) {
-		return (a - s % a);
+bool FileAccessPackedBayteArray::eof_reached() const {
+	return pos >= (uint64_t)data.size();
+}
+
+uint64_t FileAccessPackedBayteArray::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+	ERR_FAIL_NULL_V(p_dst, -1);
+
+	uint64_t left = data.size() - pos;
+	uint64_t read = MIN(p_length, left);
+
+	if (read < p_length) {
+		WARN_PRINT("Reading less data than requested");
 	}
 
-	static bool _create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes);
+	memcpy(p_dst, &data[pos], read);
+	pos += read;
 
-public:
-	static bool is_lipo(const String &p_path);
-	static bool is_lipo(const PackedByteArray &p_buffer);
-	static bool is_lipo(const Ref<FileAccess> &p_fa);
+	return read;
+}
 
-	static bool create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
-	static bool create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
+Error FileAccessPackedBayteArray::get_error() const {
+	return pos >= (uint64_t)data.size() ? ERR_FILE_EOF : OK;
+}
 
-	bool open_file(const String &p_path);
-	bool open_buffer(const PackedByteArray &p_buffer);
-	bool open_file(const Ref<FileAccess> &p_fa);
+Error FileAccessPackedBayteArray::resize(int64_t p_length) {
+	return data.resize(p_length);
+}
 
-	int get_arch_count() const;
-	uint32_t get_arch_cputype(int p_index) const;
-	uint32_t get_arch_cpusubtype(int p_index) const;
-	bool extract_arch(int p_index, const String &p_path);
+bool FileAccessPackedBayteArray::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	if (!p_length) {
+		return true;
+	}
 
-	void close();
+	ERR_FAIL_NULL_V(p_src, false);
 
-	~LipO();
-};
+	uint64_t left = data.size() - pos;
+	uint64_t write = MIN(p_length, left);
+
+	memcpy(data.ptrw() + pos, p_src, write);
+	pos += write;
+
+	ERR_FAIL_COND_V_MSG(write < p_length, false, "Writing less data than requested.");
+
+	return true;
+}

--- a/core/io/file_access_packed_byte_array.cpp
+++ b/core/io/file_access_packed_byte_array.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  lipo.h                                                                */
+/*  file_access_packed_byte_array.cpp                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,51 +28,74 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "file_access_packed_byte_array.h"
 
-// Universal / Universal 2 fat binary file creator and extractor.
+Error FileAccessPackedByteArray::open_custom(const PackedByteArray &p_data) {
+	data = p_data;
+	pos = 0;
+	return OK;
+}
 
-#include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
+void FileAccessPackedByteArray::seek(uint64_t p_position) {
+	ERR_FAIL_COND(p_position > (uint64_t)data.size());
+	pos = p_position;
+}
 
-class LipO : public RefCounted {
-	GDSOFTCLASS(LipO, RefCounted);
+void FileAccessPackedByteArray::seek_end(int64_t p_position) {
+	ERR_FAIL_COND((int64_t)data.size() + p_position < 0);
+	seek(data.size() + p_position);
+}
 
-	struct FatArch {
-		uint32_t cputype;
-		uint32_t cpusubtype;
-		uint64_t offset;
-		uint64_t size;
-		uint32_t align;
-	};
+uint64_t FileAccessPackedByteArray::get_position() const {
+	return pos;
+}
 
-	Ref<FileAccess> fa;
-	Vector<FatArch> archs;
+uint64_t FileAccessPackedByteArray::get_length() const {
+	return data.size();
+}
 
-	static inline size_t PAD(size_t s, size_t a) {
-		return (a - s % a);
+bool FileAccessPackedByteArray::eof_reached() const {
+	return pos >= (uint64_t)data.size();
+}
+
+uint64_t FileAccessPackedByteArray::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+	ERR_FAIL_NULL_V(p_dst, -1);
+
+	uint64_t left = data.size() - pos;
+	uint64_t read = MIN(p_length, left);
+
+	if (read < p_length) {
+		WARN_PRINT("Reading less data than requested");
 	}
 
-	static bool _create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes);
+	memcpy(p_dst, &data[pos], read);
+	pos += read;
 
-public:
-	static bool is_lipo(const String &p_path);
-	static bool is_lipo(const PackedByteArray &p_buffer);
-	static bool is_lipo(const Ref<FileAccess> &p_fa);
+	return read;
+}
 
-	static bool create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
-	static bool create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
+Error FileAccessPackedByteArray::get_error() const {
+	return pos >= (uint64_t)data.size() ? ERR_FILE_EOF : OK;
+}
 
-	bool open_file(const String &p_path);
-	bool open_buffer(const PackedByteArray &p_buffer);
-	bool open_file(const Ref<FileAccess> &p_fa);
+Error FileAccessPackedByteArray::resize(int64_t p_length) {
+	return data.resize(p_length);
+}
 
-	int get_arch_count() const;
-	uint32_t get_arch_cputype(int p_index) const;
-	uint32_t get_arch_cpusubtype(int p_index) const;
-	bool extract_arch(int p_index, const String &p_path);
+bool FileAccessPackedByteArray::store_buffer(const uint8_t *p_src, uint64_t p_length) {
+	if (!p_length) {
+		return true;
+	}
 
-	void close();
+	ERR_FAIL_NULL_V(p_src, false);
 
-	~LipO();
-};
+	uint64_t left = data.size() - pos;
+	uint64_t write = MIN(p_length, left);
+
+	memcpy(data.ptrw() + pos, p_src, write);
+	pos += write;
+
+	ERR_FAIL_COND_V_MSG(write < p_length, false, "Writing less data than requested.");
+
+	return true;
+}

--- a/core/io/file_access_packed_byte_array.h
+++ b/core/io/file_access_packed_byte_array.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  lipo.h                                                                */
+/*  file_access_packed_byte_array.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,49 +30,49 @@
 
 #pragma once
 
-// Universal / Universal 2 fat binary file creator and extractor.
-
 #include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
 
-class LipO : public RefCounted {
-	GDSOFTCLASS(LipO, RefCounted);
+class FileAccessPackedBayteArray : public FileAccess {
+	GDSOFTCLASS(FileAccessPackedBayteArray, FileAccess);
 
-	struct FatArch {
-		uint32_t cputype;
-		uint32_t cpusubtype;
-		uint64_t offset;
-		uint64_t size;
-		uint32_t align;
-	};
+	PackedByteArray data;
+	mutable uint64_t pos = 0;
 
-	Ref<FileAccess> fa;
-	Vector<FatArch> archs;
-
-	static inline size_t PAD(size_t s, size_t a) {
-		return (a - s % a);
-	}
-
-	static bool _create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes);
+	static Ref<FileAccess> create();
 
 public:
-	static bool is_lipo(const String &p_path);
-	static bool is_lipo(const PackedByteArray &p_buffer);
-	static bool is_lipo(const Ref<FileAccess> &p_fa);
+	virtual Error open_custom(const PackedByteArray &p_data);
+	virtual Error open_internal(const String &p_path, int p_mode_flags) override { return ERR_UNAVAILABLE; }
+	virtual bool is_open() const override { return true; }
 
-	static bool create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
-	static bool create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
+	virtual void seek(uint64_t p_position) override;
+	virtual void seek_end(int64_t p_position) override;
+	virtual uint64_t get_position() const override;
+	virtual uint64_t get_length() const override;
 
-	bool open_file(const String &p_path);
-	bool open_buffer(const PackedByteArray &p_buffer);
-	bool open_file(const Ref<FileAccess> &p_fa);
+	virtual bool eof_reached() const override;
 
-	int get_arch_count() const;
-	uint32_t get_arch_cputype(int p_index) const;
-	uint32_t get_arch_cpusubtype(int p_index) const;
-	bool extract_arch(int p_index, const String &p_path);
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	void close();
+	virtual Error get_error() const override;
 
-	~LipO();
+	virtual Error resize(int64_t p_length) override;
+	virtual void flush() override {}
+	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
+
+	virtual bool file_exists(const String &p_name) override { return false; }
+
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
+	virtual int64_t _get_size(const String &p_file) override { return -1; }
+
+	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }
+
+	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
+	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
+	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
+	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+
+	virtual void close() override {}
 };

--- a/core/io/file_access_packed_byte_array.h
+++ b/core/io/file_access_packed_byte_array.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  lipo.h                                                                */
+/*  file_access_packed_byte_array.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,49 +30,49 @@
 
 #pragma once
 
-// Universal / Universal 2 fat binary file creator and extractor.
-
 #include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
 
-class LipO : public RefCounted {
-	GDSOFTCLASS(LipO, RefCounted);
+class FileAccessPackedByteArray : public FileAccess {
+	GDSOFTCLASS(FileAccessPackedByteArray, FileAccess);
 
-	struct FatArch {
-		uint32_t cputype;
-		uint32_t cpusubtype;
-		uint64_t offset;
-		uint64_t size;
-		uint32_t align;
-	};
+	PackedByteArray data;
+	mutable uint64_t pos = 0;
 
-	Ref<FileAccess> fa;
-	Vector<FatArch> archs;
-
-	static inline size_t PAD(size_t s, size_t a) {
-		return (a - s % a);
-	}
-
-	static bool _create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes);
+	static Ref<FileAccess> create();
 
 public:
-	static bool is_lipo(const String &p_path);
-	static bool is_lipo(const PackedByteArray &p_buffer);
-	static bool is_lipo(const Ref<FileAccess> &p_fa);
+	virtual Error open_custom(const PackedByteArray &p_data);
+	virtual Error open_internal(const String &p_path, int p_mode_flags) override { return ERR_UNAVAILABLE; }
+	virtual bool is_open() const override { return true; }
 
-	static bool create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
-	static bool create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes = Vector<Vector2i>());
+	virtual void seek(uint64_t p_position) override;
+	virtual void seek_end(int64_t p_position) override;
+	virtual uint64_t get_position() const override;
+	virtual uint64_t get_length() const override;
 
-	bool open_file(const String &p_path);
-	bool open_buffer(const PackedByteArray &p_buffer);
-	bool open_file(const Ref<FileAccess> &p_fa);
+	virtual bool eof_reached() const override;
 
-	int get_arch_count() const;
-	uint32_t get_arch_cputype(int p_index) const;
-	uint32_t get_arch_cpusubtype(int p_index) const;
-	bool extract_arch(int p_index, const String &p_path);
+	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
-	void close();
+	virtual Error get_error() const override;
 
-	~LipO();
+	virtual Error resize(int64_t p_length) override;
+	virtual void flush() override {}
+	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
+
+	virtual bool file_exists(const String &p_name) override { return false; }
+
+	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
+	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
+	virtual int64_t _get_size(const String &p_file) override { return -1; }
+
+	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
+	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }
+
+	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
+	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
+	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
+	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+
+	virtual void close() override {}
 };

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -1493,8 +1493,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	}
 	if (files_to_sign.size() > 1) {
 		print_verbose("CodeSign: Rebuilding fat executable...");
-		LipO lip;
-		if (!lip.create_file(main_exe, files_to_sign)) {
+		if (!LipO::create_file(main_exe, files_to_sign)) {
 			CLEANUP();
 			r_error_msg = TTR("Failed to create fat binary.");
 			ERR_FAIL_V_MSG(FAILED, "CodeSign: Failed to create fat binary.");

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -1492,8 +1492,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	}
 	if (files_to_sign.size() > 1) {
 		print_verbose("CodeSign: Rebuilding fat executable...");
-		LipO lip;
-		if (!lip.create_file(main_exe, files_to_sign)) {
+		if (!LipO::create_file(main_exe, files_to_sign)) {
 			CLEANUP();
 			r_error_msg = TTR("Failed to create fat binary.");
 			ERR_FAIL_V_MSG(FAILED, "CodeSign: Failed to create fat binary.");

--- a/editor/export/lipo.cpp
+++ b/editor/export/lipo.cpp
@@ -30,133 +30,77 @@
 
 #include "lipo.h"
 
+#include "core/io/file_access_packed_byte_array.h"
 #include "editor/export/macho.h"
 
 bool LipO::is_lipo(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fb->get_32();
+	return is_lipo(fb);
+}
+
+bool LipO::is_lipo(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return is_lipo(fb);
+}
+
+bool LipO::is_lipo(const Ref<FileAccess> &p_fa) {
+	ERR_FAIL_COND_V(p_fa.is_null(), false);
+	uint32_t magic = p_fa->get_32();
 	return (magic == 0xbebafeca || magic == 0xcafebabe || magic == 0xbfbafeca || magic == 0xcafebabf);
 }
 
-bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files) {
-	close();
-
-	fa = FileAccess::open(p_output_path, FileAccess::WRITE);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_output_path));
-
-	uint64_t max_size = 0;
-	for (int i = 0; i < p_files.size(); i++) {
-		{
-			MachO mh;
-			if (!mh.open_file(p_files[i])) {
-				ERR_FAIL_V_MSG(false, vformat("LipO: Invalid MachO file: \"%s\".", p_files[i]));
-			}
-
-			FatArch arch;
-			arch.cputype = mh.get_cputype();
-			arch.cpusubtype = mh.get_cpusubtype();
-			arch.offset = 0;
-			arch.size = mh.get_size();
-			arch.align = mh.get_align();
-			max_size += arch.size;
-
-			archs.push_back(arch);
-		}
-
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
+bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes) {
+	Vector<Ref<FileAccess>> files;
+	for (const String &file : p_files) {
+		Ref<FileAccess> fb = FileAccess::open(file, FileAccess::READ);
+		ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", file));
+		files.push_back(fb);
 	}
-
-	// Write header.
-	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
-	if (is_64) {
-		fa->store_32(0xbfbafeca);
-	} else {
-		fa->store_32(0xbebafeca);
-	}
-	fa->store_32(BSWAP32(archs.size()));
-	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
-	for (int i = 0; i < archs.size(); i++) {
-		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
-		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
-		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-		}
-		offset = archs[i].offset + archs[i].size;
-	}
-
-	// Write files and padding.
-	for (int i = 0; i < archs.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
-		uint64_t cur = fa->get_position();
-		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
-		}
-		int pages = archs[i].size / 4096;
-		int remain = archs[i].size % 4096;
-		unsigned char step[4096];
-		for (int j = 0; j < pages; j++) {
-			uint64_t br = fb->get_buffer(step, 4096);
-			if (br > 0) {
-				fa->store_buffer(step, br);
-			}
-		}
-		uint64_t br = fb->get_buffer(step, remain);
-		if (br > 0) {
-			fa->store_buffer(step, br);
-		}
-	}
-	return true;
+	return _create_file(p_output_path, files, p_cputypes);
 }
 
-bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes) {
-	close();
+bool LipO::create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes) {
+	Vector<Ref<FileAccess>> files;
+	for (const PackedByteArray &file : p_file_buffers) {
+		Ref<FileAccessPackedBayteArray> fb;
+		fb.instantiate();
+		fb->open_custom(file);
 
-	fa = FileAccess::open(p_output_path, FileAccess::WRITE);
+		files.push_back(fb);
+	}
+	return _create_file(p_output_path, files, p_cputypes);
+}
+
+bool LipO::_create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes) {
+	Vector<FatArch> archs;
+	Ref<FileAccess> fa = FileAccess::open(p_output_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_output_path));
-	ERR_FAIL_COND_V(p_files.size() != p_cputypes.size(), false);
 
 	uint64_t max_size = 0;
 	for (int i = 0; i < p_files.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
-
 		{
 			FatArch arch;
 			MachO mh;
-			if (MachO::is_macho(p_files[i]) && mh.open_file(p_files[i])) {
+			if (mh.open_file(p_files[i])) {
 				arch.cputype = mh.get_cputype();
 				arch.cpusubtype = mh.get_cpusubtype();
 				arch.offset = 0;
 				arch.size = mh.get_size();
 				arch.align = mh.get_align();
-				ERR_FAIL_V_MSG(arch.cputype != (uint32_t)p_cputypes[i].x || arch.cpusubtype != (uint32_t)p_cputypes[i].y, vformat("Mismatching MachO architecture: \"%s\".", p_files[i]));
+				if (p_files.size() == p_cputypes.size()) {
+					ERR_FAIL_V_MSG(arch.cputype != (uint32_t)p_cputypes[i].x || arch.cpusubtype != (uint32_t)p_cputypes[i].y, vformat("Mismatching MachO architecture: \"%s\".", p_files[i]));
+				}
 			} else {
+				if (p_files.size() != p_cputypes.size()) {
+					ERR_FAIL_V(false);
+				}
 				arch.cputype = (uint32_t)p_cputypes[i].x;
 				arch.cpusubtype = (uint32_t)p_cputypes[i].y;
 				arch.offset = 0;
-				arch.size = fb->get_length();
+				arch.size = p_files[i]->get_length();
 				arch.align = 0x03;
 			}
 			max_size += arch.size;
@@ -195,11 +139,6 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 
 	// Write files and padding.
 	for (int i = 0; i < archs.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
 			fa->store_8(0);
@@ -208,12 +147,12 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		int remain = archs[i].size % 4096;
 		unsigned char step[4096];
 		for (int j = 0; j < pages; j++) {
-			uint64_t br = fb->get_buffer(step, 4096);
+			uint64_t br = p_files[i]->get_buffer(step, 4096);
 			if (br > 0) {
 				fa->store_buffer(step, br);
 			}
 		}
-		uint64_t br = fb->get_buffer(step, remain);
+		uint64_t br = p_files[i]->get_buffer(step, remain);
 		if (br > 0) {
 			fa->store_buffer(step, br);
 		}
@@ -222,10 +161,24 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 }
 
 bool LipO::open_file(const String &p_path) {
-	close();
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
 
-	fa = FileAccess::open(p_path, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
+	return open_file(fb);
+}
+
+bool LipO::open_buffer(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+
+	return open_file(fb);
+}
+
+bool LipO::open_file(const Ref<FileAccess> &p_fb) {
+	close();
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	fa = p_fb;
 
 	uint32_t magic = fa->get_32();
 	if (magic == 0xbebafeca) {
@@ -284,7 +237,7 @@ bool LipO::open_file(const String &p_path) {
 		}
 	} else {
 		close();
-		ERR_FAIL_V_MSG(false, vformat("LipO: Invalid fat binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("LipO: Invalid fat binary: \"%s\".", fa->get_path()));
 	}
 	return true;
 }
@@ -333,6 +286,7 @@ bool LipO::extract_arch(int p_index, const String &p_path) {
 
 void LipO::close() {
 	archs.clear();
+	fa = nullptr;
 }
 
 LipO::~LipO() {

--- a/editor/export/lipo.cpp
+++ b/editor/export/lipo.cpp
@@ -30,133 +30,77 @@
 
 #include "lipo.h"
 
+#include "core/io/file_access_packed_byte_array.h"
 #include "editor/export/macho.h"
 
 bool LipO::is_lipo(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fb->get_32();
+	return is_lipo(fb);
+}
+
+bool LipO::is_lipo(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return is_lipo(fb);
+}
+
+bool LipO::is_lipo(const Ref<FileAccess> &p_fa) {
+	ERR_FAIL_COND_V(p_fa.is_null(), false);
+	uint32_t magic = p_fa->get_32();
 	return (magic == 0xbebafeca || magic == 0xcafebabe || magic == 0xbfbafeca || magic == 0xcafebabf);
 }
 
-bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files) {
-	close();
-
-	fa = FileAccess::open(p_output_path, FileAccess::WRITE);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_output_path));
-
-	uint64_t max_size = 0;
-	for (int i = 0; i < p_files.size(); i++) {
-		{
-			MachO mh;
-			if (!mh.open_file(p_files[i])) {
-				ERR_FAIL_V_MSG(false, vformat("LipO: Invalid MachO file: \"%s\".", p_files[i]));
-			}
-
-			FatArch arch;
-			arch.cputype = mh.get_cputype();
-			arch.cpusubtype = mh.get_cpusubtype();
-			arch.offset = 0;
-			arch.size = mh.get_size();
-			arch.align = mh.get_align();
-			max_size += arch.size;
-
-			archs.push_back(arch);
-		}
-
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
+bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes) {
+	Vector<Ref<FileAccess>> files;
+	for (const String &file : p_files) {
+		Ref<FileAccess> fb = FileAccess::open(file, FileAccess::READ);
+		ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", file));
+		files.push_back(fb);
 	}
-
-	// Write header.
-	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
-	if (is_64) {
-		fa->store_32(0xbfbafeca);
-	} else {
-		fa->store_32(0xbebafeca);
-	}
-	fa->store_32(BSWAP32(archs.size()));
-	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
-	for (int i = 0; i < archs.size(); i++) {
-		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
-		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
-		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-		}
-		offset = archs[i].offset + archs[i].size;
-	}
-
-	// Write files and padding.
-	for (int i = 0; i < archs.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
-		uint64_t cur = fa->get_position();
-		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
-		}
-		int pages = archs[i].size / 4096;
-		int remain = archs[i].size % 4096;
-		unsigned char step[4096];
-		for (int j = 0; j < pages; j++) {
-			uint64_t br = fb->get_buffer(step, 4096);
-			if (br > 0) {
-				fa->store_buffer(step, br);
-			}
-		}
-		uint64_t br = fb->get_buffer(step, remain);
-		if (br > 0) {
-			fa->store_buffer(step, br);
-		}
-	}
-	return true;
+	return _create_file(p_output_path, files, p_cputypes);
 }
 
-bool LipO::create_file(const String &p_output_path, const Vector<String> &p_files, const Vector<Vector2i> &p_cputypes) {
-	close();
+bool LipO::create_file(const String &p_output_path, const Vector<PackedByteArray> &p_file_buffers, const Vector<Vector2i> &p_cputypes) {
+	Vector<Ref<FileAccess>> files;
+	for (const PackedByteArray &file : p_file_buffers) {
+		Ref<FileAccessPackedByteArray> fb;
+		fb.instantiate();
+		fb->open_custom(file);
 
-	fa = FileAccess::open(p_output_path, FileAccess::WRITE);
+		files.push_back(fb);
+	}
+	return _create_file(p_output_path, files, p_cputypes);
+}
+
+bool LipO::_create_file(const String &p_output_path, const Vector<Ref<FileAccess>> &p_files, const Vector<Vector2i> &p_cputypes) {
+	Vector<FatArch> archs;
+	Ref<FileAccess> fa = FileAccess::open(p_output_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_output_path));
-	ERR_FAIL_COND_V(p_files.size() != p_cputypes.size(), false);
 
 	uint64_t max_size = 0;
 	for (int i = 0; i < p_files.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
-
 		{
 			FatArch arch;
 			MachO mh;
-			if (MachO::is_macho(p_files[i]) && mh.open_file(p_files[i])) {
+			if (mh.open_file(p_files[i])) {
 				arch.cputype = mh.get_cputype();
 				arch.cpusubtype = mh.get_cpusubtype();
 				arch.offset = 0;
 				arch.size = mh.get_size();
 				arch.align = mh.get_align();
-				ERR_FAIL_V_MSG(arch.cputype != (uint32_t)p_cputypes[i].x || arch.cpusubtype != (uint32_t)p_cputypes[i].y, vformat("Mismatching MachO architecture: \"%s\".", p_files[i]));
+				if (p_files.size() == p_cputypes.size()) {
+					ERR_FAIL_V_MSG(arch.cputype != (uint32_t)p_cputypes[i].x || arch.cpusubtype != (uint32_t)p_cputypes[i].y, vformat("Mismatching MachO architecture: \"%s\".", p_files[i]));
+				}
 			} else {
+				if (p_files.size() != p_cputypes.size()) {
+					ERR_FAIL_V(false);
+				}
 				arch.cputype = (uint32_t)p_cputypes[i].x;
 				arch.cpusubtype = (uint32_t)p_cputypes[i].y;
 				arch.offset = 0;
-				arch.size = fb->get_length();
+				arch.size = p_files[i]->get_length();
 				arch.align = 0x03;
 			}
 			max_size += arch.size;
@@ -195,11 +139,6 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 
 	// Write files and padding.
 	for (int i = 0; i < archs.size(); i++) {
-		Ref<FileAccess> fb = FileAccess::open(p_files[i], FileAccess::READ);
-		if (fb.is_null()) {
-			close();
-			ERR_FAIL_V_MSG(false, vformat("LipO: Can't open file: \"%s\".", p_files[i]));
-		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
 			fa->store_8(0);
@@ -208,12 +147,12 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		int remain = archs[i].size % 4096;
 		unsigned char step[4096];
 		for (int j = 0; j < pages; j++) {
-			uint64_t br = fb->get_buffer(step, 4096);
+			uint64_t br = p_files[i]->get_buffer(step, 4096);
 			if (br > 0) {
 				fa->store_buffer(step, br);
 			}
 		}
-		uint64_t br = fb->get_buffer(step, remain);
+		uint64_t br = p_files[i]->get_buffer(step, remain);
 		if (br > 0) {
 			fa->store_buffer(step, br);
 		}
@@ -222,10 +161,24 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 }
 
 bool LipO::open_file(const String &p_path) {
-	close();
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
 
-	fa = FileAccess::open(p_path, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
+	return open_file(fb);
+}
+
+bool LipO::open_buffer(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+
+	return open_file(fb);
+}
+
+bool LipO::open_file(const Ref<FileAccess> &p_fb) {
+	close();
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	fa = p_fb;
 
 	uint32_t magic = fa->get_32();
 	if (magic == 0xbebafeca) {
@@ -284,7 +237,7 @@ bool LipO::open_file(const String &p_path) {
 		}
 	} else {
 		close();
-		ERR_FAIL_V_MSG(false, vformat("LipO: Invalid fat binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("LipO: Invalid fat binary: \"%s\".", fa->get_path()));
 	}
 	return true;
 }
@@ -333,6 +286,7 @@ bool LipO::extract_arch(int p_index, const String &p_path) {
 
 void LipO::close() {
 	archs.clear();
+	fa = nullptr;
 }
 
 LipO::~LipO() {

--- a/editor/export/macho.cpp
+++ b/editor/export/macho.cpp
@@ -31,6 +31,7 @@
 #include "macho.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/io/file_access_packed_byte_array.h"
 
 uint32_t MachO::seg_align(uint64_t p_vmaddr, uint32_t p_min, uint32_t p_max) {
 	uint32_t salign = p_max;
@@ -103,33 +104,117 @@ bool MachO::alloc_signature(uint64_t p_size) {
 bool MachO::is_macho(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fb->get_32();
+	return is_macho(fb);
+}
+
+bool MachO::is_macho(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return is_macho(fb);
+}
+
+bool MachO::is_macho(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	uint32_t magic = p_fb->get_32();
 	return (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf);
 }
 
 uint32_t MachO::get_filetype(const String &p_path) {
-	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fa->get_32();
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
+	return get_filetype(fb);
+}
+
+uint32_t MachO::get_filetype(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return get_filetype(fb);
+}
+
+uint32_t MachO::get_filetype(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), 0);
+	uint32_t magic = p_fb->get_32();
 	MachHeader mach_header;
 
 	// Read MachO header.
-	if (magic == 0xcefaedfe || magic == 0xfeedface) {
-		// Thin 32-bit binary.
-		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
-	} else if (magic == 0xcffaedfe || magic == 0xfeedfacf) {
-		// Thin 64-bit binary.
-		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
-		fa->get_32(); // Skip extra reserved field.
+	if (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf) {
+		p_fb->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
 	} else {
-		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_fb->get_path()));
 	}
 	return mach_header.filetype;
 }
 
+uint32_t MachO::get_cputype(const String &p_path) {
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
+	return get_cputype(fb);
+}
+
+uint32_t MachO::get_cputype(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return get_cputype(fb);
+}
+
+uint32_t MachO::get_cputype(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), 0);
+	uint32_t magic = p_fb->get_32();
+	MachHeader mach_header;
+
+	// Read MachO header.
+	if (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf) {
+		p_fb->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
+	} else {
+		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_fb->get_path()));
+	}
+	return mach_header.cputype;
+}
+
+String MachO::arch_name(uint32_t p_arch) {
+	if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_X86)) {
+		return "x86_64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_ARM)) {
+		return "arm64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_PPC)) {
+		return "ppc64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_RISCV)) {
+		return "rv64";
+	} else if (p_arch == CPU_TYPE_X86) {
+		return "x86_32";
+	} else if (p_arch == CPU_TYPE_ARM) {
+		return "arm32";
+	} else if (p_arch == CPU_TYPE_PPC) {
+		return "ppc32";
+	} else if (p_arch == CPU_TYPE_RISCV) {
+		return "rv32";
+	} else {
+		return "unknown";
+	}
+}
+
 bool MachO::open_file(const String &p_path) {
-	fa = FileAccess::open(p_path, FileAccess::READ_WRITE);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
+
+	return open_file(fb);
+}
+
+bool MachO::open_buffer(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedBayteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+
+	return open_file(fb);
+}
+
+bool MachO::open_file(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	fa = p_fb;
+
 	uint32_t magic = fa->get_32();
 	MachHeader mach_header;
 
@@ -143,7 +228,7 @@ bool MachO::open_file(const String &p_path) {
 		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
 		fa->get_32(); // Skip extra reserved field.
 	} else {
-		ERR_FAIL_V_MSG(false, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("MachO: File is not a valid MachO binary: \"%s\".", fa->get_path()));
 	}
 
 	if (swap) {
@@ -243,7 +328,7 @@ bool MachO::open_file(const String &p_path) {
 	}
 
 	if (exe_limit == 0 || lc_limit == 0) {
-		ERR_FAIL_V_MSG(false, vformat("MachO: No load commands or executable code found: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("MachO: No load commands or executable code found: \"%s\".", fa->get_path()));
 	}
 
 	return true;

--- a/editor/export/macho.cpp
+++ b/editor/export/macho.cpp
@@ -31,6 +31,7 @@
 #include "macho.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/io/file_access_packed_byte_array.h"
 
 uint32_t MachO::seg_align(uint64_t p_vmaddr, uint32_t p_min, uint32_t p_max) {
 	uint32_t salign = p_max;
@@ -103,33 +104,117 @@ bool MachO::alloc_signature(uint64_t p_size) {
 bool MachO::is_macho(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fb->get_32();
+	return is_macho(fb);
+}
+
+bool MachO::is_macho(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return is_macho(fb);
+}
+
+bool MachO::is_macho(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	uint32_t magic = p_fb->get_32();
 	return (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf);
 }
 
 uint32_t MachO::get_filetype(const String &p_path) {
-	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fa->get_32();
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
+	return get_filetype(fb);
+}
+
+uint32_t MachO::get_filetype(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return get_filetype(fb);
+}
+
+uint32_t MachO::get_filetype(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), 0);
+	uint32_t magic = p_fb->get_32();
 	MachHeader mach_header;
 
 	// Read MachO header.
-	if (magic == 0xcefaedfe || magic == 0xfeedface) {
-		// Thin 32-bit binary.
-		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
-	} else if (magic == 0xcffaedfe || magic == 0xfeedfacf) {
-		// Thin 64-bit binary.
-		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
-		fa->get_32(); // Skip extra reserved field.
+	if (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf) {
+		p_fb->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
 	} else {
-		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_fb->get_path()));
 	}
 	return mach_header.filetype;
 }
 
+uint32_t MachO::get_cputype(const String &p_path) {
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), 0, vformat("MachO: Can't open file: \"%s\".", p_path));
+	return get_cputype(fb);
+}
+
+uint32_t MachO::get_cputype(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+	return get_cputype(fb);
+}
+
+uint32_t MachO::get_cputype(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), 0);
+	uint32_t magic = p_fb->get_32();
+	MachHeader mach_header;
+
+	// Read MachO header.
+	if (magic == 0xcefaedfe || magic == 0xfeedface || magic == 0xcffaedfe || magic == 0xfeedfacf) {
+		p_fb->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
+	} else {
+		ERR_FAIL_V_MSG(0, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_fb->get_path()));
+	}
+	return mach_header.cputype;
+}
+
+String MachO::arch_name(uint32_t p_arch) {
+	if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_X86)) {
+		return "x86_64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_ARM)) {
+		return "arm64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_PPC)) {
+		return "ppc64";
+	} else if (p_arch == (CPU_TYPE_64BIT | CPU_TYPE_RISCV)) {
+		return "rv64";
+	} else if (p_arch == CPU_TYPE_X86) {
+		return "x86_32";
+	} else if (p_arch == CPU_TYPE_ARM) {
+		return "arm32";
+	} else if (p_arch == CPU_TYPE_PPC) {
+		return "ppc32";
+	} else if (p_arch == CPU_TYPE_RISCV) {
+		return "rv32";
+	} else {
+		return "unknown";
+	}
+}
+
 bool MachO::open_file(const String &p_path) {
-	fa = FileAccess::open(p_path, FileAccess::READ_WRITE);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
+	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("MachO: Can't open file: \"%s\".", p_path));
+
+	return open_file(fb);
+}
+
+bool MachO::open_buffer(const PackedByteArray &p_buffer) {
+	Ref<FileAccessPackedByteArray> fb;
+	fb.instantiate();
+	fb->open_custom(p_buffer);
+
+	return open_file(fb);
+}
+
+bool MachO::open_file(const Ref<FileAccess> &p_fb) {
+	ERR_FAIL_COND_V(p_fb.is_null(), false);
+	fa = p_fb;
+
 	uint32_t magic = fa->get_32();
 	MachHeader mach_header;
 
@@ -143,7 +228,7 @@ bool MachO::open_file(const String &p_path) {
 		fa->get_buffer((uint8_t *)&mach_header, sizeof(MachHeader));
 		fa->get_32(); // Skip extra reserved field.
 	} else {
-		ERR_FAIL_V_MSG(false, vformat("MachO: File is not a valid MachO binary: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("MachO: File is not a valid MachO binary: \"%s\".", fa->get_path()));
 	}
 
 	if (swap) {
@@ -243,7 +328,7 @@ bool MachO::open_file(const String &p_path) {
 	}
 
 	if (exe_limit == 0 || lc_limit == 0) {
-		ERR_FAIL_V_MSG(false, vformat("MachO: No load commands or executable code found: \"%s\".", p_path));
+		ERR_FAIL_V_MSG(false, vformat("MachO: No load commands or executable code found: \"%s\".", fa->get_path()));
 	}
 
 	return true;

--- a/editor/export/macho.h
+++ b/editor/export/macho.h
@@ -117,6 +117,14 @@ public:
 		PLATFORM_VISIONOSSIMULATOR = 12,
 	};
 
+	enum CPUType {
+		CPU_TYPE_64BIT = 0x01000000,
+		CPU_TYPE_X86 = 0x00000007,
+		CPU_TYPE_ARM = 0x0000000C,
+		CPU_TYPE_PPC = 0x00000012,
+		CPU_TYPE_RISCV = 0x00000018,
+	};
+
 	struct LoadCommandHeader {
 		uint32_t cmd;
 		uint32_t cmdsize;
@@ -199,9 +207,22 @@ private:
 
 public:
 	static bool is_macho(const String &p_path);
+	static bool is_macho(const PackedByteArray &p_buffer);
+	static bool is_macho(const Ref<FileAccess> &p_fb);
+
 	static uint32_t get_filetype(const String &p_path);
+	static uint32_t get_filetype(const PackedByteArray &p_buffer);
+	static uint32_t get_filetype(const Ref<FileAccess> &p_fb);
+
+	static uint32_t get_cputype(const String &p_path);
+	static uint32_t get_cputype(const PackedByteArray &p_buffer);
+	static uint32_t get_cputype(const Ref<FileAccess> &p_fb);
+
+	static String arch_name(uint32_t p_arch);
 
 	bool open_file(const String &p_path);
+	bool open_buffer(const PackedByteArray &p_buffer);
+	bool open_file(const Ref<FileAccess> &p_fb);
 
 	uint64_t get_exe_base();
 	uint64_t get_exe_limit();

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -52,15 +52,11 @@ $usage_descriptions
 	<string>public.app-category.$app_category</string>
 	<key>LSArchitecturePriority</key>
 	<array>
-		<string>arm64</string>
-		<string>x86_64</string>
+$arch_priority
 	</array>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
-		<key>arm64</key>
-		<string>$min_version_arm64</string>
-		<key>x86_64</key>
-		<string>$min_version_x86_64</string>
+$min_version_info
 	</dict>
 	<key>NSHighResolutionCapable</key>
 $highres

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -52,15 +52,13 @@ $usage_descriptions
 	<string>public.app-category.$app_category</string>
 	<key>LSArchitecturePriority</key>
 	<array>
-		<string>arm64</string>
-		<string>x86_64</string>
+$arch_priority
 	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>$min_version_common</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
-		<key>arm64</key>
-		<string>$min_version_arm64</string>
-		<key>x86_64</key>
-		<string>$min_version_x86_64</string>
+$min_version_info
 	</dict>
 	<key>NSHighResolutionCapable</key>
 $highres

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -124,8 +124,7 @@ bool godot_icall_Internal_IsMacOSAppBundleInstalled(const godot_string *p_bundle
 bool godot_icall_Internal_LipOCreateFile(const godot_string *p_output_path, const godot_packed_array *p_files) {
 	String output_path = *reinterpret_cast<const String *>(p_output_path);
 	PackedStringArray files = *reinterpret_cast<const PackedStringArray *>(p_files);
-	LipO lip;
-	return lip.create_file(output_path, files);
+	return LipO::create_file(output_path, files);
 }
 
 bool godot_icall_Internal_GodotIs32Bits() {

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -123,8 +123,7 @@ bool godot_icall_Internal_IsMacOSAppBundleInstalled(const godot_string *p_bundle
 bool godot_icall_Internal_LipOCreateFile(const godot_string *p_output_path, const godot_packed_array *p_files) {
 	String output_path = *reinterpret_cast<const String *>(p_output_path);
 	PackedStringArray files = *reinterpret_cast<const PackedStringArray *>(p_files);
-	LipO lip;
-	return lip.create_file(output_path, files);
+	return LipO::create_file(output_path, files);
 }
 
 bool godot_icall_Internal_GodotIs32Bits() {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -475,7 +475,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "export/distribution_type", PROPERTY_HINT_ENUM, "Testing,Distribution"), 1, true));
 #endif
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "universal,x86_64,arm64", PROPERTY_USAGE_STORAGE), "universal"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "universal,arm64,x86_64"), "universal"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
@@ -844,6 +844,7 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 
 void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary, bool p_lg_icon_exported, const String &p_lg_icon) {
 	String str = String::utf8((const char *)plist.ptr(), plist.size());
+	String arch = p_preset->get("binary_format/architecture");
 	String strnew;
 	Vector<String> lines = str.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
@@ -864,10 +865,28 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			strnew += lines[i].replace("$app_category", cat.to_lower()) + "\n";
 		} else if (lines[i].contains("$copyright")) {
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright").operator String().xml_escape(true)) + "\n";
+		} else if (lines[i].contains("$arch_priority")) {
+			String arch_pr;
+			if (arch == "universal" || arch == "arm64") {
+				arch_pr += "\t\t<string>arm64</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				arch_pr += "\t\t<string>x86_64</string>\n";
+			}
+			strnew += lines[i].replace("$arch_priority", arch_pr);
+		} else if (lines[i].contains("$min_version_info")) {
+			String min_version_info;
+			if (arch == "universal" || arch == "arm64") {
+				min_version_info += "\t\t<key>arm64</key>\n\t\t<string>" + p_preset->get("application/min_macos_version_arm64").operator String() + "</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				min_version_info += "\t\t<key>x86_64</key>\n\t\t<string>" + p_preset->get("application/min_macos_version_x86_64").operator String() + "</string>\n";
+			}
+			strnew += lines[i].replace("$min_version_info", min_version_info);
 		} else if (lines[i].contains("$min_version_arm64")) {
-			strnew += lines[i].replace("$min_version_arm64", p_preset->get("application/min_macos_version_arm64")) + "\n";
+			strnew += lines[i].replace("$min_version_arm64", p_preset->get("application/min_macos_version_arm64")) + "\n"; // Old template.
 		} else if (lines[i].contains("$min_version_x86_64")) {
-			strnew += lines[i].replace("$min_version_x86_64", p_preset->get("application/min_macos_version_x86_64")) + "\n";
+			strnew += lines[i].replace("$min_version_x86_64", p_preset->get("application/min_macos_version_x86_64")) + "\n"; // Old template.
 		} else if (lines[i].contains("$min_version")) {
 			strnew += lines[i].replace("$min_version", p_preset->get("application/min_macos_version_x86_64")) + "\n"; // Old template, use x86-64 version for both.
 		} else if (lines[i].contains("$highres")) {
@@ -1380,6 +1399,143 @@ void EditorExportPlatformMacOS::_code_sign_directory(const Ref<EditorExportPrese
 	}
 }
 
+// Changes dir for the current scope, returning back to the original dir
+// when scope exits
+class DirChanger {
+	Ref<DirAccess> da;
+	String original_dir;
+
+public:
+	DirChanger(const Ref<DirAccess> &p_da, const String &p_dir) :
+			da(p_da),
+			original_dir(p_da->get_current_dir()) {
+		p_da->change_dir(p_dir);
+	}
+
+	~DirChanger() {
+		da->change_dir(original_dir);
+	}
+};
+
+Error EditorExportPlatformMacOS::_copy_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, const String &p_to, int p_chmod_flags) {
+	String architecture = p_preset->get("binary_format/architecture");
+
+	if (architecture != "universal" && LipO::is_lipo(p_from)) {
+		LipO lip;
+		lip.open_file(p_from);
+		int arch_idx = -1;
+		for (int i = 0; i < lip.get_arch_count(); i++) {
+			if (architecture == "arm64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) {
+				arch_idx = i;
+				break;
+			}
+			if (architecture == "x86_64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86)) {
+				arch_idx = i;
+				break;
+			}
+		}
+		if (arch_idx == -1) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not find binary for architecture \"%s\" in universal binary \"%s\"."), architecture, p_from));
+			return ERR_CANT_CREATE;
+		}
+		if (lip.extract_arch(arch_idx, p_to)) {
+			print_verbose(vformat("Extracted binary for architecture \"%s\" from universal binary \"%s\" to \"%s\".", architecture, p_from, p_to));
+			if (p_chmod_flags != -1) {
+				FileAccess::set_unix_permissions(p_to, p_chmod_flags);
+			}
+			return OK;
+		} else {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), p_from));
+			return ERR_CANT_CREATE;
+		}
+	} else {
+		if (architecture != "universal" && MachO::is_macho(p_from)) {
+			if ((architecture == "arm64" && MachO::get_cputype(p_from) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) || (architecture == "x86_64" && MachO::get_cputype(p_from) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86))) {
+				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Mismatching binary \"%s\" architecture: found \"%s\", expected \"%s\""), p_from, MachO::arch_name(MachO::get_cputype(p_from)), architecture));
+			}
+		}
+		return p_dir_access->copy(p_from, p_to, p_chmod_flags);
+	}
+}
+
+Error EditorExportPlatformMacOS::_copy_dir_and_validate_arch_impl(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links) {
+	List<String> dirs;
+
+	String curdir = p_dir_access->get_current_dir();
+	p_dir_access->list_dir_begin();
+	String n = p_dir_access->get_next();
+	while (!n.is_empty()) {
+		if (n != "." && n != "..") {
+			if (p_copy_links && p_dir_access->is_link(p_dir_access->get_current_dir().path_join(n))) {
+				Error err = p_target_da->create_link(p_dir_access->read_link(p_dir_access->get_current_dir().path_join(n)), p_to + n);
+				if (err) {
+					ERR_PRINT(vformat("Failed to copy symlink \"%s\".", n));
+				}
+			} else if (p_dir_access->current_is_dir()) {
+				dirs.push_back(n);
+			} else {
+				const String &rel_path = n;
+				if (!n.is_relative_path()) {
+					p_dir_access->list_dir_end();
+					ERR_FAIL_V_MSG(ERR_BUG, vformat("BUG: \"%s\" is not a relative path.", n));
+				}
+
+				Error err = _copy_and_validate_arch(p_preset, p_dir_access, p_dir_access->get_current_dir().path_join(n), p_to + rel_path, p_chmod_flags);
+				if (err) {
+					p_dir_access->list_dir_end();
+					ERR_FAIL_V_MSG(err, vformat("Failed to copy file \"%s\".", n));
+				}
+			}
+		}
+
+		n = p_dir_access->get_next();
+	}
+
+	p_dir_access->list_dir_end();
+
+	for (const String &rel_path : dirs) {
+		String target_dir = p_to + rel_path;
+		if (!p_target_da->dir_exists(target_dir)) {
+			Error err = p_target_da->make_dir(target_dir);
+			ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create directory '%s'.", target_dir));
+		}
+
+		Error err = p_dir_access->change_dir(rel_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot change current directory to '%s'.", rel_path));
+
+		err = _copy_dir_and_validate_arch_impl(p_preset, p_dir_access, p_target_da, p_to + rel_path + "/", p_chmod_flags, p_copy_links);
+		if (err) {
+			p_dir_access->change_dir("..");
+			ERR_FAIL_V_MSG(err, "Failed to copy recursively.");
+		}
+		err = p_dir_access->change_dir("..");
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to go back.");
+	}
+
+	return OK;
+}
+
+Error EditorExportPlatformMacOS::_copy_dir_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, String p_to, int p_chmod_flags, bool p_copy_links) {
+	ERR_FAIL_COND_V_MSG(!p_dir_access->dir_exists(p_from), ERR_FILE_NOT_FOUND, "Source directory doesn't exist.");
+
+	Ref<DirAccess> target_da = DirAccess::create_for_path(p_to);
+	ERR_FAIL_COND_V_MSG(target_da.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", p_to));
+
+	if (!target_da->dir_exists(p_to)) {
+		Error err = target_da->make_dir_recursive(p_to);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create directory '%s'.", p_to));
+	}
+
+	if (!p_to.ends_with("/")) {
+		p_to = p_to + "/";
+	}
+
+	DirChanger dir_changer(p_dir_access, p_from);
+	Error err = _copy_dir_and_validate_arch_impl(p_preset, p_dir_access, target_da, p_to, p_chmod_flags, p_copy_links);
+
+	return err;
+}
+
 Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access, const String &p_src_path,
 		const String &p_in_app_path, bool p_sign_enabled,
 		const Ref<EditorExportPreset> &p_preset, const String &p_ent_path,
@@ -1417,7 +1573,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 
 		err = dir_access->make_dir_recursive(p_in_app_path);
 		if (err == OK) {
-			err = dir_access->copy_dir(p_src_path, p_in_app_path, -1, true);
+			err = _copy_dir_and_validate_arch(p_preset, dir_access, p_src_path, p_in_app_path, -1, true);
 		}
 		if (err == OK && plist_missing) {
 			add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("\"%s\": Info.plist missing or invalid, new Info.plist generated."), p_src_path.get_file()));
@@ -1431,32 +1587,44 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 				}
 			}
 
-			String info_plist_format = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-									   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
-									   "<plist version=\"1.0\">\n"
-									   "  <dict>\n"
-									   "    <key>CFBundleExecutable</key>\n"
-									   "    <string>$name</string>\n"
-									   "    <key>CFBundleIdentifier</key>\n"
-									   "    <string>$id.framework.$cl_name</string>\n"
-									   "    <key>CFBundleInfoDictionaryVersion</key>\n"
-									   "    <string>6.0</string>\n"
-									   "    <key>CFBundleName</key>\n"
-									   "    <string>$name</string>\n"
-									   "    <key>CFBundlePackageType</key>\n"
-									   "    <string>FMWK</string>\n"
-									   "    <key>CFBundleShortVersionString</key>\n"
-									   "    <string>1.0.0</string>\n"
-									   "    <key>CFBundleSupportedPlatforms</key>\n"
-									   "    <array>\n"
-									   "      <string>MacOSX</string>\n"
-									   "    </array>\n"
-									   "    <key>CFBundleVersion</key>\n"
-									   "    <string>1.0.0</string>\n"
-									   "    <key>LSMinimumSystemVersion</key>\n"
-									   "    <string>10.12</string>\n"
-									   "  </dict>\n"
-									   "</plist>";
+			String arch = p_preset->get("binary_format/architecture");
+			String min_version_info;
+			if (arch == "universal" || arch == "arm64") {
+				min_version_info += "      <key>arm64</key>\n      <string>" + p_preset->get("application/min_macos_version_arm64").operator String() + "</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				min_version_info += "     <key>x86_64</key>\n      <string>" + p_preset->get("application/min_macos_version_x86_64").operator String() + "</string>\n";
+			}
+
+			String info_plist_format = vformat("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+											   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+											   "<plist version=\"1.0\">\n"
+											   "  <dict>\n"
+											   "    <key>CFBundleExecutable</key>\n"
+											   "    <string>$name</string>\n"
+											   "    <key>CFBundleIdentifier</key>\n"
+											   "    <string>$id.framework.$cl_name</string>\n"
+											   "    <key>CFBundleInfoDictionaryVersion</key>\n"
+											   "    <string>6.0</string>\n"
+											   "    <key>CFBundleName</key>\n"
+											   "    <string>$name</string>\n"
+											   "    <key>CFBundlePackageType</key>\n"
+											   "    <string>FMWK</string>\n"
+											   "    <key>CFBundleShortVersionString</key>\n"
+											   "    <string>1.0.0</string>\n"
+											   "    <key>CFBundleSupportedPlatforms</key>\n"
+											   "    <array>\n"
+											   "      <string>MacOSX</string>\n"
+											   "    </array>\n"
+											   "    <key>CFBundleVersion</key>\n"
+											   "    <string>1.0.0</string>\n"
+											   "    <key>LSMinimumSystemVersionByArchitecture</key>\n"
+											   "    <dict>\n"
+											   "%s"
+											   "    </dict>\n"
+											   "  </dict>\n"
+											   "</plist>",
+					min_version_info);
 
 			String info_plist = info_plist_format.replace("$id", lib_id).replace("$name", lib_name).replace("$cl_name", lib_clean_name);
 
@@ -1468,7 +1636,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 		}
 	} else {
 		print_verbose("export dylib: " + p_src_path + " -> " + p_in_app_path);
-		err = dir_access->copy(p_src_path, p_in_app_path);
+		err = _copy_and_validate_arch(p_preset, dir_access, p_src_path, p_in_app_path);
 	}
 	if (err == OK && p_sign_enabled) {
 		if (dir_access->dir_exists(p_src_path) && p_src_path.get_extension().is_empty()) {
@@ -1668,6 +1836,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	String architecture = p_preset->get("binary_format/architecture");
 	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + "." + architecture;
+	String binary_to_use_uni = "godot_macos_" + String(p_debug ? "debug" : "release") + ".universal";
 
 	String pkg_name;
 	if (String(get_project_setting(p_preset, "application/config/name")) != "") {
@@ -1901,6 +2070,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		include_angle_libs = true;
 	}
 
+	HashMap<String, Vector<PackedByteArray>> universal_binaries;
 	while (ret == UNZ_OK && err == OK) {
 		// Get filename.
 		unz_file_info info;
@@ -1911,6 +2081,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		String file = String::utf8(fname);
+		String ofile = file;
 
 		Vector<uint8_t> data;
 		data.resize(info.uncompressed_size);
@@ -1980,7 +2151,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (file.begins_with("Contents/MacOS/godot_")) {
-			if (file != "Contents/MacOS/" + binary_to_use) {
+			if (file != "Contents/MacOS/" + binary_to_use && file != "Contents/MacOS/" + binary_to_use_uni) {
 				ret = unzGoToNextFile(src_pkg_zip);
 				continue; // skip
 			}
@@ -2027,11 +2198,28 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 				}
 			}
 			if (err == OK) {
-				Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
-				if (f.is_valid()) {
-					f->store_buffer(data.ptr(), data.size());
-					f.unref();
-					if (is_executable(file)) {
+				if (architecture == "universal" && MachO::is_macho(data)) {
+					universal_binaries[file].push_back(data);
+				} else if (architecture != "universal" && LipO::is_lipo(data)) {
+					LipO lip;
+					lip.open_buffer(data);
+					int arch_idx = -1;
+					for (int i = 0; i < lip.get_arch_count(); i++) {
+						if (architecture == "arm64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) {
+							arch_idx = i;
+							break;
+						}
+						if (architecture == "x86_64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86)) {
+							arch_idx = i;
+							break;
+						}
+					}
+					if (arch_idx == -1) {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not find binary for architecture \"%s\" in universal binary \"%s\"."), architecture, ofile));
+						err = ERR_CANT_CREATE;
+					}
+					if (lip.extract_arch(arch_idx, file)) {
+						print_verbose(vformat("Extracted binary for architecture \"%s\" from universal binary \"%s\" to \"%s\".", architecture, ofile, file));
 						// chmod with 0755 if the file is executable.
 						FileAccess::set_unix_permissions(file, 0755);
 #ifndef UNIX_ENABLED
@@ -2039,10 +2227,33 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 							add_message(EXPORT_MESSAGE_INFO, TTR("Export"), vformat(TTR("Unable to set Unix permissions for executable \"%s\". Use \"chmod +x\" to set it after transferring the exported .app to macOS or Linux."), "Contents/MacOS/" + file.get_file()));
 						}
 #endif
+					} else {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
+						err = ERR_CANT_CREATE;
 					}
 				} else {
-					add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
-					err = ERR_CANT_CREATE;
+					if (architecture != "universal" && MachO::is_macho(data)) {
+						if ((architecture == "arm64" && MachO::get_cputype(data) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) || (architecture == "x86_64" && MachO::get_cputype(data) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86))) {
+							add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Mismatching binary \"%s\" architecture: found \"%s\", expected \"%s\""), ofile, MachO::arch_name(MachO::get_cputype(data)), architecture));
+						}
+					}
+					Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
+					if (f.is_valid()) {
+						f->store_buffer(data.ptr(), data.size());
+						f.unref();
+						if (is_executable(file)) {
+							// chmod with 0755 if the file is executable.
+							FileAccess::set_unix_permissions(file, 0755);
+#ifndef UNIX_ENABLED
+							if (export_format == "app") {
+								add_message(EXPORT_MESSAGE_INFO, TTR("Export"), vformat(TTR("Unable to set Unix permissions for executable \"%s\". Use \"chmod +x\" to set it after transferring the exported .app to macOS or Linux."), "Contents/MacOS/" + file.get_file()));
+							}
+#endif
+						}
+					} else {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
+						err = ERR_CANT_CREATE;
+					}
 				}
 			}
 		}
@@ -2052,6 +2263,14 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	// We're done with our source zip.
 	unzClose(src_pkg_zip);
+
+	for (const KeyValue<String, Vector<PackedByteArray>> &E : universal_binaries) {
+		if (!LipO::create_file(E.key, E.value)) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Unable to create universal bninary \"%s\""), E.key));
+			err = ERR_CANT_CREATE;
+		}
+	}
+	universal_binaries.clear();
 
 	if (!found_binary) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Requested template binary \"%s\" not found. It might be missing from your template archive."), binary_to_use));

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -475,7 +475,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "export/distribution_type", PROPERTY_HINT_ENUM, "Testing,Distribution"), 1, true));
 #endif
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "universal,x86_64,arm64", PROPERTY_USAGE_STORAGE), "universal"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "universal,arm64,x86_64"), "universal"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
@@ -844,6 +844,7 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 
 void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary, bool p_lg_icon_exported, const String &p_lg_icon) {
 	String str = String::utf8((const char *)plist.ptr(), plist.size());
+	String arch = p_preset->get("binary_format/architecture");
 	String strnew;
 	Vector<String> lines = str.split("\n");
 	for (int i = 0; i < lines.size(); i++) {
@@ -864,10 +865,40 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			strnew += lines[i].replace("$app_category", cat.to_lower()) + "\n";
 		} else if (lines[i].contains("$copyright")) {
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright").operator String().xml_escape(true)) + "\n";
+		} else if (lines[i].contains("$arch_priority")) {
+			String arch_pr;
+			if (arch == "universal" || arch == "arm64") {
+				arch_pr += "\t\t<string>arm64</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				arch_pr += "\t\t<string>x86_64</string>\n";
+			}
+			strnew += lines[i].replace("$arch_priority", arch_pr);
+		} else if (lines[i].contains("$min_version_common")) {
+			double v_min = 0.0;
+			if (arch == "universal") {
+				double v_arm64 = p_preset->get("application/min_macos_version_arm64");
+				double v_x86_64 = p_preset->get("application/min_macos_version_x86_64");
+				v_min = MIN(v_arm64, v_x86_64);
+			} else if (arch == "arm64") {
+				v_min = p_preset->get("application/min_macos_version_arm64");
+			} else if (arch == "x86_64") {
+				v_min = p_preset->get("application/min_macos_version_x86_64");
+			}
+			strnew += lines[i].replace("$min_version_common", rtos(v_min)) + "\n";
+		} else if (lines[i].contains("$min_version_info")) {
+			String min_version_info;
+			if (arch == "universal" || arch == "arm64") {
+				min_version_info += "\t\t<key>arm64</key>\n\t\t<string>" + p_preset->get("application/min_macos_version_arm64").operator String() + "</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				min_version_info += "\t\t<key>x86_64</key>\n\t\t<string>" + p_preset->get("application/min_macos_version_x86_64").operator String() + "</string>\n";
+			}
+			strnew += lines[i].replace("$min_version_info", min_version_info);
 		} else if (lines[i].contains("$min_version_arm64")) {
-			strnew += lines[i].replace("$min_version_arm64", p_preset->get("application/min_macos_version_arm64")) + "\n";
+			strnew += lines[i].replace("$min_version_arm64", p_preset->get("application/min_macos_version_arm64")) + "\n"; // Old template.
 		} else if (lines[i].contains("$min_version_x86_64")) {
-			strnew += lines[i].replace("$min_version_x86_64", p_preset->get("application/min_macos_version_x86_64")) + "\n";
+			strnew += lines[i].replace("$min_version_x86_64", p_preset->get("application/min_macos_version_x86_64")) + "\n"; // Old template.
 		} else if (lines[i].contains("$min_version")) {
 			strnew += lines[i].replace("$min_version", p_preset->get("application/min_macos_version_x86_64")) + "\n"; // Old template, use x86-64 version for both.
 		} else if (lines[i].contains("$highres")) {
@@ -1380,6 +1411,142 @@ void EditorExportPlatformMacOS::_code_sign_directory(const Ref<EditorExportPrese
 	}
 }
 
+// Changes dir for the current scope, returning back to the original dir
+// when scope exits
+class DirChanger {
+	Ref<DirAccess> da;
+	String original_dir;
+
+public:
+	DirChanger(const Ref<DirAccess> &p_da, const String &p_dir) :
+			da(p_da),
+			original_dir(p_da->get_current_dir()) {
+		p_da->change_dir(p_dir);
+	}
+
+	~DirChanger() {
+		da->change_dir(original_dir);
+	}
+};
+
+Error EditorExportPlatformMacOS::_copy_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, const String &p_to, int p_chmod_flags) {
+	String architecture = p_preset->get("binary_format/architecture");
+
+	if (architecture != "universal" && LipO::is_lipo(p_from)) {
+		LipO lip;
+		lip.open_file(p_from);
+		int arch_idx = -1;
+		for (int i = 0; i < lip.get_arch_count(); i++) {
+			if (architecture == "arm64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) {
+				arch_idx = i;
+				break;
+			}
+			if (architecture == "x86_64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86)) {
+				arch_idx = i;
+				break;
+			}
+		}
+		if (arch_idx == -1) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not find binary for architecture \"%s\" in universal binary \"%s\"."), architecture, p_from));
+			return ERR_CANT_CREATE;
+		}
+		if (lip.extract_arch(arch_idx, p_to)) {
+			print_verbose(vformat("Extracted binary for architecture \"%s\" from universal binary \"%s\" to \"%s\".", architecture, p_from, p_to));
+			if (p_chmod_flags != -1) {
+				FileAccess::set_unix_permissions(p_to, p_chmod_flags);
+			}
+			return OK;
+		} else {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), p_from));
+			return ERR_CANT_CREATE;
+		}
+	} else {
+		if (architecture != "universal" && MachO::is_macho(p_from)) {
+			if ((architecture == "arm64" && MachO::get_cputype(p_from) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) || (architecture == "x86_64" && MachO::get_cputype(p_from) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86))) {
+				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Mismatching binary \"%s\" architecture: found \"%s\", expected \"%s\""), p_from, MachO::arch_name(MachO::get_cputype(p_from)), architecture));
+			}
+		}
+		return p_dir_access->copy(p_from, p_to, p_chmod_flags);
+	}
+}
+
+Error EditorExportPlatformMacOS::_copy_dir_and_validate_arch_impl(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links) {
+	List<String> dirs;
+
+	p_dir_access->list_dir_begin();
+	String n = p_dir_access->get_next();
+	while (!n.is_empty()) {
+		if (n != "." && n != "..") {
+			if (p_copy_links && p_dir_access->is_link(p_dir_access->get_current_dir().path_join(n))) {
+				Error err = p_target_da->create_link(p_dir_access->read_link(p_dir_access->get_current_dir().path_join(n)), p_to + n);
+				if (err) {
+					ERR_PRINT(vformat("Failed to copy symlink \"%s\".", n));
+				}
+			} else if (p_dir_access->current_is_dir()) {
+				dirs.push_back(n);
+			} else {
+				const String &rel_path = n;
+				if (!n.is_relative_path()) {
+					p_dir_access->list_dir_end();
+					ERR_FAIL_V_MSG(ERR_BUG, vformat("BUG: \"%s\" is not a relative path.", n));
+				}
+
+				Error err = _copy_and_validate_arch(p_preset, p_dir_access, p_dir_access->get_current_dir().path_join(n), p_to + rel_path, p_chmod_flags);
+				if (err) {
+					p_dir_access->list_dir_end();
+					ERR_FAIL_V_MSG(err, vformat("Failed to copy file \"%s\".", n));
+				}
+			}
+		}
+
+		n = p_dir_access->get_next();
+	}
+
+	p_dir_access->list_dir_end();
+
+	for (const String &rel_path : dirs) {
+		String target_dir = p_to + rel_path;
+		if (!p_target_da->dir_exists(target_dir)) {
+			Error err = p_target_da->make_dir(target_dir);
+			ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create directory '%s'.", target_dir));
+		}
+
+		Error err = p_dir_access->change_dir(rel_path);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot change current directory to '%s'.", rel_path));
+
+		err = _copy_dir_and_validate_arch_impl(p_preset, p_dir_access, p_target_da, p_to + rel_path + "/", p_chmod_flags, p_copy_links);
+		if (err) {
+			p_dir_access->change_dir("..");
+			ERR_FAIL_V_MSG(err, "Failed to copy recursively.");
+		}
+		err = p_dir_access->change_dir("..");
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to go back.");
+	}
+
+	return OK;
+}
+
+Error EditorExportPlatformMacOS::_copy_dir_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, String p_to, int p_chmod_flags, bool p_copy_links) {
+	ERR_FAIL_COND_V_MSG(!p_dir_access->dir_exists(p_from), ERR_FILE_NOT_FOUND, "Source directory doesn't exist.");
+
+	Ref<DirAccess> target_da = DirAccess::create_for_path(p_to);
+	ERR_FAIL_COND_V_MSG(target_da.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", p_to));
+
+	if (!target_da->dir_exists(p_to)) {
+		Error err = target_da->make_dir_recursive(p_to);
+		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create directory '%s'.", p_to));
+	}
+
+	if (!p_to.ends_with("/")) {
+		p_to = p_to + "/";
+	}
+
+	DirChanger dir_changer(p_dir_access, p_from);
+	Error err = _copy_dir_and_validate_arch_impl(p_preset, p_dir_access, target_da, p_to, p_chmod_flags, p_copy_links);
+
+	return err;
+}
+
 Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access, const String &p_src_path,
 		const String &p_in_app_path, bool p_sign_enabled,
 		const Ref<EditorExportPreset> &p_preset, const String &p_ent_path,
@@ -1417,7 +1584,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 
 		err = dir_access->make_dir_recursive(p_in_app_path);
 		if (err == OK) {
-			err = dir_access->copy_dir(p_src_path, p_in_app_path, -1, true);
+			err = _copy_dir_and_validate_arch(p_preset, dir_access, p_src_path, p_in_app_path, -1, true);
 		}
 		if (err == OK && plist_missing) {
 			add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("\"%s\": Info.plist missing or invalid, new Info.plist generated."), p_src_path.get_file()));
@@ -1431,32 +1598,44 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 				}
 			}
 
-			String info_plist_format = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-									   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
-									   "<plist version=\"1.0\">\n"
-									   "  <dict>\n"
-									   "    <key>CFBundleExecutable</key>\n"
-									   "    <string>$name</string>\n"
-									   "    <key>CFBundleIdentifier</key>\n"
-									   "    <string>$id.framework.$cl_name</string>\n"
-									   "    <key>CFBundleInfoDictionaryVersion</key>\n"
-									   "    <string>6.0</string>\n"
-									   "    <key>CFBundleName</key>\n"
-									   "    <string>$name</string>\n"
-									   "    <key>CFBundlePackageType</key>\n"
-									   "    <string>FMWK</string>\n"
-									   "    <key>CFBundleShortVersionString</key>\n"
-									   "    <string>1.0.0</string>\n"
-									   "    <key>CFBundleSupportedPlatforms</key>\n"
-									   "    <array>\n"
-									   "      <string>MacOSX</string>\n"
-									   "    </array>\n"
-									   "    <key>CFBundleVersion</key>\n"
-									   "    <string>1.0.0</string>\n"
-									   "    <key>LSMinimumSystemVersion</key>\n"
-									   "    <string>10.12</string>\n"
-									   "  </dict>\n"
-									   "</plist>";
+			String arch = p_preset->get("binary_format/architecture");
+			String min_version_info;
+			if (arch == "universal" || arch == "arm64") {
+				min_version_info += "      <key>arm64</key>\n      <string>" + p_preset->get("application/min_macos_version_arm64").operator String() + "</string>\n";
+			}
+			if (arch == "universal" || arch == "x86_64") {
+				min_version_info += "     <key>x86_64</key>\n      <string>" + p_preset->get("application/min_macos_version_x86_64").operator String() + "</string>\n";
+			}
+
+			String info_plist_format = vformat("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+											   "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+											   "<plist version=\"1.0\">\n"
+											   "  <dict>\n"
+											   "    <key>CFBundleExecutable</key>\n"
+											   "    <string>$name</string>\n"
+											   "    <key>CFBundleIdentifier</key>\n"
+											   "    <string>$id.framework.$cl_name</string>\n"
+											   "    <key>CFBundleInfoDictionaryVersion</key>\n"
+											   "    <string>6.0</string>\n"
+											   "    <key>CFBundleName</key>\n"
+											   "    <string>$name</string>\n"
+											   "    <key>CFBundlePackageType</key>\n"
+											   "    <string>FMWK</string>\n"
+											   "    <key>CFBundleShortVersionString</key>\n"
+											   "    <string>1.0.0</string>\n"
+											   "    <key>CFBundleSupportedPlatforms</key>\n"
+											   "    <array>\n"
+											   "      <string>MacOSX</string>\n"
+											   "    </array>\n"
+											   "    <key>CFBundleVersion</key>\n"
+											   "    <string>1.0.0</string>\n"
+											   "    <key>LSMinimumSystemVersionByArchitecture</key>\n"
+											   "    <dict>\n"
+											   "%s"
+											   "    </dict>\n"
+											   "  </dict>\n"
+											   "</plist>",
+					min_version_info);
 
 			String info_plist = info_plist_format.replace("$id", lib_id).replace("$name", lib_name).replace("$cl_name", lib_clean_name);
 
@@ -1468,7 +1647,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 		}
 	} else {
 		print_verbose("export dylib: " + p_src_path + " -> " + p_in_app_path);
-		err = dir_access->copy(p_src_path, p_in_app_path);
+		err = _copy_and_validate_arch(p_preset, dir_access, p_src_path, p_in_app_path);
 	}
 	if (err == OK && p_sign_enabled) {
 		if (dir_access->dir_exists(p_src_path) && p_src_path.get_extension().is_empty()) {
@@ -1668,6 +1847,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	String architecture = p_preset->get("binary_format/architecture");
 	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + "." + architecture;
+	String binary_to_use_uni = "godot_macos_" + String(p_debug ? "debug" : "release") + ".universal";
 
 	String pkg_name;
 	if (String(get_project_setting(p_preset, "application/config/name")) != "") {
@@ -1901,6 +2081,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		include_angle_libs = true;
 	}
 
+	HashMap<String, Vector<PackedByteArray>> universal_binaries;
 	while (ret == UNZ_OK && err == OK) {
 		// Get filename.
 		unz_file_info info;
@@ -1911,6 +2092,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		String file = String::utf8(fname);
+		String ofile = file;
 
 		Vector<uint8_t> data;
 		data.resize(info.uncompressed_size);
@@ -1980,7 +2162,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (file.begins_with("Contents/MacOS/godot_")) {
-			if (file != "Contents/MacOS/" + binary_to_use) {
+			if (file != "Contents/MacOS/" + binary_to_use && file != "Contents/MacOS/" + binary_to_use_uni) {
 				ret = unzGoToNextFile(src_pkg_zip);
 				continue; // skip
 			}
@@ -2027,11 +2209,28 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 				}
 			}
 			if (err == OK) {
-				Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
-				if (f.is_valid()) {
-					f->store_buffer(data.ptr(), data.size());
-					f.unref();
-					if (is_executable(file)) {
+				if (architecture == "universal" && MachO::is_macho(data)) {
+					universal_binaries[file].push_back(data);
+				} else if (architecture != "universal" && LipO::is_lipo(data)) {
+					LipO lip;
+					lip.open_buffer(data);
+					int arch_idx = -1;
+					for (int i = 0; i < lip.get_arch_count(); i++) {
+						if (architecture == "arm64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) {
+							arch_idx = i;
+							break;
+						}
+						if (architecture == "x86_64" && lip.get_arch_cputype(i) == (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86)) {
+							arch_idx = i;
+							break;
+						}
+					}
+					if (arch_idx == -1) {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not find binary for architecture \"%s\" in universal binary \"%s\"."), architecture, ofile));
+						err = ERR_CANT_CREATE;
+					}
+					if (lip.extract_arch(arch_idx, file)) {
+						print_verbose(vformat("Extracted binary for architecture \"%s\" from universal binary \"%s\" to \"%s\".", architecture, ofile, file));
 						// chmod with 0755 if the file is executable.
 						FileAccess::set_unix_permissions(file, 0755);
 #ifndef UNIX_ENABLED
@@ -2039,10 +2238,33 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 							add_message(EXPORT_MESSAGE_INFO, TTR("Export"), vformat(TTR("Unable to set Unix permissions for executable \"%s\". Use \"chmod +x\" to set it after transferring the exported .app to macOS or Linux."), "Contents/MacOS/" + file.get_file()));
 						}
 #endif
+					} else {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
+						err = ERR_CANT_CREATE;
 					}
 				} else {
-					add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
-					err = ERR_CANT_CREATE;
+					if (architecture != "universal" && MachO::is_macho(data)) {
+						if ((architecture == "arm64" && MachO::get_cputype(data) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_ARM)) || (architecture == "x86_64" && MachO::get_cputype(data) != (MachO::CPU_TYPE_64BIT | MachO::CPU_TYPE_X86))) {
+							add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Mismatching binary \"%s\" architecture: found \"%s\", expected \"%s\""), ofile, MachO::arch_name(MachO::get_cputype(data)), architecture));
+						}
+					}
+					Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
+					if (f.is_valid()) {
+						f->store_buffer(data.ptr(), data.size());
+						f.unref();
+						if (is_executable(file)) {
+							// chmod with 0755 if the file is executable.
+							FileAccess::set_unix_permissions(file, 0755);
+#ifndef UNIX_ENABLED
+							if (export_format == "app") {
+								add_message(EXPORT_MESSAGE_INFO, TTR("Export"), vformat(TTR("Unable to set Unix permissions for executable \"%s\". Use \"chmod +x\" to set it after transferring the exported .app to macOS or Linux."), "Contents/MacOS/" + file.get_file()));
+							}
+#endif
+						}
+					} else {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
+						err = ERR_CANT_CREATE;
+					}
 				}
 			}
 		}
@@ -2052,6 +2274,14 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	// We're done with our source zip.
 	unzClose(src_pkg_zip);
+
+	for (const KeyValue<String, Vector<PackedByteArray>> &E : universal_binaries) {
+		if (!LipO::create_file(E.key, E.value)) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Unable to create universal bninary \"%s\""), E.key));
+			err = ERR_CANT_CREATE;
+		}
+	}
+	universal_binaries.clear();
 
 	if (!found_binary) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Requested template binary \"%s\" not found. It might be missing from your template archive."), binary_to_use));

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -86,6 +86,9 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 
 	Error _export_liquid_glass_icon(const Ref<EditorExportPreset> &p_preset, const String &p_app_path, const String &p_icon_path);
 	Error _notarize(const Ref<EditorExportPreset> &p_preset, const String &p_path);
+	Error _copy_dir_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, String p_to, int p_chmod_flags, bool p_copy_links);
+	Error _copy_dir_and_validate_arch_impl(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links);
+	Error _copy_and_validate_arch(const Ref<EditorExportPreset> &p_preset, const Ref<DirAccess> &p_dir_access, const String &p_from, const String &p_to, int p_chmod_flags = -1);
 	void _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, bool p_warn = true, bool p_set_id = false);
 	void _code_sign_directory(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, const String &p_helper_ent_path, bool p_should_error_on_non_code = true);
 	Error _copy_and_sign_files(Ref<DirAccess> &dir_access, const String &p_src_path, const String &p_in_app_path,


### PR DESCRIPTION
- Exposes `binary_format/architecture` in the export options (default to "universal").
- Validates (for single arch template) and extracts requested architecture from universal template binaries during export.
- Validates (for single arch template) and extracts requested architecture from GDExtension binaries.

Fixes https://github.com/godotengine/godot/issues/121170 