### PR TITLE
Correct path splitting logic in String::parse_url()

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -111,6 +111,12 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 	if (pos != -1) {
 		r_path = base.substr(pos);
 		base = base.substr(0, pos);
+	} else {
+		pos = base.find_char('?');
+		if (pos != -1) {
+			r_path = "/" + base.substr(pos);
+			base = base.substr(0, pos);
+		}
 	}
 	// Host
 	pos = base.find_char('@');

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -2223,6 +2223,10 @@ TEST_CASE("[String][URL] Parse URL") {
 	CHECK_URL("https://me:secret@godotengine.org", "https://", "godotengine.org", 0, "", "", Error::OK);
 	CHECK_URL("https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]/ipv6", "https://", "fedc:ba98:7654:3210:fedc:ba98:7654:3210", 0, "/ipv6", "", Error::OK);
 
+	// Query without explicit path slash (issue #119695).
+	CHECK_URL("https://httpbin.org?token=abc", "https://", "httpbin.org", 0, "/?token=abc", "", Error::OK);
+	CHECK_URL("https://httpbin.org/?token=abc", "https://", "httpbin.org", 0, "/?token=abc", "", Error::OK);
+
 	// Scheme vs Fragment.
 	CHECK_URL("google.com/#goto=http://redirect_url/", "", "google.com", 0, "/", "goto=http://redirect_url/", Error::OK);
 


### PR DESCRIPTION

### What problem does this PR solve?

  - Closes #119695

 Fixed String::parse_url() incorrectly parsing URLs like https://httpbin.org?token=abc, where the query string was treated as part of the host because no / path was present, causing HTTPRequest and WebSocketPeer to glitch.

  ##  Additional information

  The fix checks for ? as a fallback when no / is found, and prepends / to form a valid path (e.g. /?token=abc), which is the
  correct HTTP request target for a query-only URL.

  Two test cases added to tests/core/string/test_string.cpp:
  - https://httpbin.org?token=abc — the broken case, now fixed
  - https://httpbin.org/?token=abc — regression guard for the existing slash form