### PR TITLE
Don't use system color as godot base color when Follow System Theme is active

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -374,11 +374,6 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/icon_saturation", config.icon_saturation);
 		}
 
-		if (follow_system_theme && system_base_color != Color(0, 0, 0, 0)) {
-			config.base_color = system_base_color;
-			config.preset = "Custom";
-		}
-
 		if (use_system_accent_color && system_accent_color != Color(0, 0, 0, 0)) {
 			config.accent_color = system_accent_color;
 			config.preset = "Custom";


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/109005

## Additional information

System base color can have unpredictable values based on OS and shouldn't be used directly as godot base color. Instead only its luminance should be used to choose between pre-configured light/dark themes in godot, as it's done in most other apps that implement this feature.

More context [here](https://github.com/godotengine/godot/issues/109005#issuecomment-4528865145).