### PR TITLE
Update LabelSettings.xml | Fix StackedShadowData::offset type mismatch (Vector2i → Vector2)

### DIFF
--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -178,7 +178,7 @@
 			The color of the shadow at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
 		</member>
-		<member name="stacked_shadow_{index}/offset" type="Vector2" setter="" getter="" default="Vector2i(1, 1)">
+		<member name="stacked_shadow_{index}/offset" type="Vector2" setter="" getter="" default="Vector2(1, 1)">
 			The offset of the shadow at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
 		</member>


### PR DESCRIPTION
Also fixes the corresponding documentation in `doc/classes/LabelSettings.xml` 
where `stacked_shadow_{index}/offset` incorrectly listed its default value as 
`Vector2i(1, 1)` instead of `Vector2(1, 1)`, matching the declared type.