### PR TITLE
Change disabled "Paste" options to hidden

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3958,20 +3958,26 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		BEGIN_SECTION()
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCut")), ED_GET_SHORTCUT("scene_tree/cut_node"), TOOL_CUT);
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("scene_tree/copy_node"), TOOL_COPY);
+
 		if (!node_clipboard.is_empty()) {
+			bool is_paste_icon_added = false; // Only add an icon to the first "paste" option.
+
 			if (selection.size() == 1) {
 				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
-				menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
-				if (selection.front()->get() == edited_scene) {
-					menu->set_item_disabled(-1, true);
+				is_paste_icon_added = true;
+
+				if (selection.front()->get() != edited_scene) {
+					menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
 				}
 			}
+
 			if (selection.size() >= 1) {
-				if (can_rename || can_replace) {
+				if ((selection.front()->get() != edited_scene) && (can_rename || can_replace)) {
 					menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/paste_node_as_replacement"), TOOL_PASTE_AS_REPLACEMENT);
-				}
-				if (selection.front()->get() == edited_scene) {
-					menu->set_item_disabled(-1, true);
+					if (!is_paste_icon_added) {
+						menu->set_item_icon(-1, get_editor_theme_icon(SNAME("ActionPaste")));
+						is_paste_icon_added = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/119697
Closes https://github.com/godotengine/godot/issues/119674

Changes:
- Disabled "Paste" options are now hidden.
- The first "Paste" option now always has an icon.
  - This happens when "Paste", "Paste as Sibling" are unavailable, and "Paste as Replacement" is available.

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="379" height="489" alt="Image" src="https://github.com/user-attachments/assets/95e50236-80e8-46f4-a017-e99c9f9c6e05" /> | <img width="380" height="489" alt="Image 2026-05-24_16-09-06" src="https://github.com/user-attachments/assets/fcb70e5e-9fb9-444b-8a8c-3159d3e73196" /> |
| <img width="380" height="488" alt="Image" src="https://github.com/user-attachments/assets/d9314e10-99e0-4c2b-9774-ee47f02affbd" /> | <img width="381" height="489" alt="Image 2026-05-24_16-09-24" src="https://github.com/user-attachments/assets/c2b14180-77bb-436a-856f-88a960c44d42" /> |
| <img width="379" height="490" alt="Image" src="https://github.com/user-attachments/assets/35438d24-0263-4c23-b482-21f401a11a50" /> | <img width="379" height="490" alt="Image 2026-05-24_16-09-42" src="https://github.com/user-attachments/assets/8208c64f-4c13-40b1-9cab-d7e2accddac2" /> |
| <img width="379" height="489" alt="Image" src="https://github.com/user-attachments/assets/c69d4a7c-db8d-4f44-8ba6-318a3ee846b0" /> | <img width="380" height="489" alt="Image 2026-05-24_16-10-01" src="https://github.com/user-attachments/assets/cfc73f62-2325-4478-968b-6eab074e839a" /> |
