### PR TITLE
Fix editor scene tabs not updating properly on theme change

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -60,6 +60,7 @@ void EditorSceneTabs::_notification(int p_what) {
 			scene_tabs->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 			scene_list->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
+			_update_tab_titles();
 
 			scene_tab_add->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));


### PR DESCRIPTION
Fixes this when changing themes:

<img width="254" height="51" alt="image" src="https://github.com/user-attachments/assets/68cdbde5-95ba-4467-9b1e-a57392728a37" />

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119731*