### PR TITLE
Fix Project Manager shows outdated path when changing casing

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1009,12 +1009,13 @@ void ProjectList::load_project_list() {
 		String parent = path.get_base_dir();
 		String basename = path.get_file();
 
-		if (da->change_dir(parent) != OK) {
-			continue;
-		}
 		if (da->is_case_sensitive(parent)) {
 			continue;
 		}
+		if (da->change_dir(parent) != OK) {
+			continue;
+		}
+
 		da->list_dir_begin();
 		String n = da->get_next();
 		while (!n.is_empty()) {

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1003,6 +1003,8 @@ void ProjectList::find_projects_multiple(const PackedStringArray &p_paths) {
 void ProjectList::load_project_list() {
 	_config.load(_config_path);
 	Vector<String> sections = _config.get_sections();
+	Vector<String> old_paths;
+	Vector<String> new_paths;
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	for (const String &path : sections) {
@@ -1020,14 +1022,22 @@ void ProjectList::load_project_list() {
 		String n = da->get_next();
 		while (!n.is_empty()) {
 			if (da->current_is_dir() && n.to_lower() == basename.to_lower() && n != basename) {
-				_config.erase_section(path);
-				_config.set_value(parent.path_join(n), "favorite", false);
-				_config.save(_config_path);
-				break;
+				old_paths.append(path);
+				new_paths.append(parent.path_join(n));
 			}
 			n = da->get_next();
 		}
 		da->list_dir_end();
+	}
+
+	for (int i = 0; i < old_paths.size(); i++) {
+		bool favorite = _config.get_value(old_paths[i], "favorite", false);
+		_config.erase_section(old_paths[i]);
+		_config.set_value(new_paths[i], "favorite", favorite);
+	}
+
+	if (!old_paths.is_empty()) {
+		_config.save(_config_path);
 	}
 
 	for (const String &path : sections) {

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1004,6 +1004,29 @@ void ProjectList::load_project_list() {
 	_config.load(_config_path);
 	Vector<String> sections = _config.get_sections();
 
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	for (const String &path : sections) {
+		String parent = path.get_base_dir();
+		String basename = path.get_file();
+
+		if (da->change_dir(parent) != OK) {
+			continue;
+		}
+
+		da->list_dir_begin();
+		String n = da->get_next();
+		while (!n.is_empty()) {
+			if (da->current_is_dir() && n.to_lower() == basename.to_lower() && n != basename) {
+				_config.erase_section(path);
+				_config.set_value(parent.path_join(n), "favorite", false);
+				_config.save(_config_path);
+				break;
+			}
+			n = da->get_next();
+		}
+		da->list_dir_end();
+	}
+
 	for (const String &path : sections) {
 		bool favorite = _config.get_value(path, "favorite", false);
 		_projects.push_back(load_project_data(path, favorite));

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1012,7 +1012,9 @@ void ProjectList::load_project_list() {
 		if (da->change_dir(parent) != OK) {
 			continue;
 		}
-
+		if (da->is_case_sensitive(parent)) {
+			continue;
+		}
 		da->list_dir_begin();
 		String n = da->get_next();
 		while (!n.is_empty()) {


### PR DESCRIPTION
It will update the original path when restart the godot and click the original project

Demo:

https://github.com/user-attachments/assets/d55af954-9b87-4710-90b4-528e6286fbab


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

This may not be the ideal solution, but it resolves the issue. Related to #119671.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
AI usage

Used ChatGPT for guidance on Git/GitHub workflow and PR preparation.

* *Bugsquad edit, fixes: #119671*