### PR TITLE
Fix scene tab text color on theme change

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -65,6 +65,8 @@ void EditorSceneTabs::_notification(int p_what) {
 			scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
 
 			scene_tab_add_ph->set_custom_minimum_size(scene_tab_add->get_minimum_size());
+
+			_update_tab_titles();
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119731

## Additional information

Regression from https://github.com/godotengine/godot/pull/118139 (it added color overrides to those tabs but didn't set them on theme change)
