### PR TITLE
[Linux/Windows] Improve SSE4.2 detection.

### DIFF
--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -13,6 +13,14 @@ common_linuxbsd = [
     "freedesktop_at_spi_monitor.cpp",
 ]
 
+if env["arch"] == "x86_64" and env["library_type"] == "executable":
+    env_cpp_check = env.Clone()
+    env_cpp_check.add_source_files(common_linuxbsd, ["cpu_feature_validation.c"])
+    if "-msse4.2" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-msse4.2")
+    if "-mpopcnt" in env_cpp_check["CCFLAGS"]:
+        env_cpp_check["CCFLAGS"].remove("-mpopcnt")
+
 if env["library_type"] == "executable":
     common_linuxbsd += ["godot_linuxbsd.cpp"]
 else:

--- a/platform/linuxbsd/cpu_feature_validation.c
+++ b/platform/linuxbsd/cpu_feature_validation.c
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include <windows.h>
-#ifdef _MSC_VER
-#include <intrin.h> // For builtin __cpuid.
-#else
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 void __cpuid(int *r_cpuinfo, int p_info) {
 	// Note: Some compilers have a buggy `__cpuid` intrinsic, using inline assembly (based on LLVM-20 implementation) instead.
 	__asm__ __volatile__(
@@ -41,33 +41,26 @@ void __cpuid(int *r_cpuinfo, int p_info) {
 			: "=a"(r_cpuinfo[0]), "=r"(r_cpuinfo[1]), "=c"(r_cpuinfo[2]), "=d"(r_cpuinfo[3])
 			: "0"(p_info));
 }
-#endif
 
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-extern int WINAPI mainCRTStartup();
-#else
-extern int WINAPI WinMainCRTStartup();
-#endif
-
-#if defined(__GNUC__) || defined(__clang__)
-extern int WINAPI ShimMainCRTStartup() __attribute__((used));
-#endif
-
-extern int WINAPI ShimMainCRTStartup() {
-	BOOL cpuid_supported = FALSE;
+__attribute__((constructor)) void cpu_validation_shim() {
+	bool cpuid_supported = false;
 
 	int cpuinfo[4];
 	__cpuid(cpuinfo, 0x01);
 	cpuid_supported = (cpuinfo[2] & (1 << 20)) && (cpuinfo[2] & (1 << 23)); // SSE4.2 + POPCNT
 
-	if (cpuid_supported) {
-#ifdef WINDOWS_SUBSYSTEM_CONSOLE
-		return mainCRTStartup();
-#else
-		return WinMainCRTStartup();
-#endif
-	} else {
-		MessageBoxW(NULL, L"A CPU with SSE4.2 instruction set support is required.", L"Godot Engine", MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
-		return -1;
+	if (!cpuid_supported) {
+		printf("A CPU with SSE4.2 instruction set support is required.\n");
+		int ret = system("zenity --warning --title \"Godot Engine\" --text \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
+		if (ret != 0) {
+			ret = system("kdialog --title \"Godot Engine\" --sorry \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
+		}
+		if (ret != 0) {
+			ret = system("Xdialog --title \"Godot Engine\" --msgbox \"A CPU with SSE4.2 instruction set support is required.\" 0 0 2> /dev/null");
+		}
+		if (ret != 0) {
+			ret = system("xmessage -center -title \"Godot Engine\" \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
+		}
+		abort();
 	}
 }

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -43,18 +43,6 @@
 #include <sys/resource.h>
 #endif
 
-#if defined(__x86_64) || defined(__x86_64__)
-void __cpuid(int *r_cpuinfo, int p_info) {
-	// Note: Some compilers have a buggy `__cpuid` intrinsic, using inline assembly (based on LLVM-20 implementation) instead.
-	__asm__ __volatile__(
-			"xchgq %%rbx, %q1;"
-			"cpuid;"
-			"xchgq %%rbx, %q1;"
-			: "=a"(r_cpuinfo[0]), "=r"(r_cpuinfo[1]), "=c"(r_cpuinfo[2]), "=d"(r_cpuinfo[3])
-			: "0"(p_info));
-}
-#endif
-
 // For export templates, add a section; the exporter will patch it to enclose
 // the data appended to the executable (bundled PCK).
 #if !defined(TOOLS_ENABLED) && defined(__GNUC__)
@@ -68,27 +56,6 @@ extern "C" const char *pck_section_dummy_call() {
 #endif
 
 int main(int argc, char *argv[]) {
-#if defined(__x86_64) || defined(__x86_64__)
-	int cpuinfo[4];
-	__cpuid(cpuinfo, 0x01);
-
-	if (!(cpuinfo[2] & (1 << 20))) {
-		printf("A CPU with SSE4.2 instruction set support is required.\n");
-
-		int ret = system("zenity --warning --title \"Godot Engine\" --text \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		if (ret != 0) {
-			ret = system("kdialog --title \"Godot Engine\" --sorry \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		}
-		if (ret != 0) {
-			ret = system("Xdialog --title \"Godot Engine\" --msgbox \"A CPU with SSE4.2 instruction set support is required.\" 0 0 2> /dev/null");
-		}
-		if (ret != 0) {
-			ret = system("xmessage -center -title \"Godot Engine\" \"A CPU with SSE4.2 instruction set support is required.\" 2> /dev/null");
-		}
-		abort();
-	}
-#endif
-
 #if defined(ASAN_ENABLED)
 	// Note: Set stack size to be at least 30 MB (vs 8 MB default) to avoid overflow, address sanitizer can increase stack usage up to 3 times.
 	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -54,6 +54,8 @@ if env["arch"] == "x86_64" and env["library_type"] == "executable":
     else:
         if "-msse4.2" in env_cpp_check["CCFLAGS"]:
             env_cpp_check["CCFLAGS"].remove("-msse4.2")
+        if "-mpopcnt" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-mpopcnt")
         env.Append(LINKFLAGS=["-Wl,--entry=ShimMainCRTStartup"])
 
 


### PR DESCRIPTION
Extracted part of https://github.com/godotengine/godot/pull/119676

- Removes redundant `IsProcessorFeaturePresent` check from Windows.
- Moves Linux code to a separate compilation unit with disabled SSE4.2.
- Changes Linux code to from `main` to `__attribute__((constructor))` to be called as early as possible.
- Changes detection code to check both SSE4.2 and POPCNT flags (should not make any difference on real hardware, but it is a separate extension).