### PR TITLE
Fix PopupMenu counting separators for search bar

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1091,7 +1091,17 @@ void PopupMenu::_draw_items() {
 
 void PopupMenu::_update_search_bar_visibility() {
 	if (search_bar) {
-		search_bar->set_visible(search_bar_enabled && items.size() >= search_bar_min_item_count);
+		if (search_bar_enabled) {
+			int item_count = 0;
+			for (const Item &item : items) {
+				if (!item.separator) {
+					item_count++;
+				}
+			}
+			search_bar->set_visible(item_count >= search_bar_min_item_count);
+		} else {
+			search_bar->hide();
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

PopupMenu's `search_bar_min_item_count` also counts separators, which is wrong.

## Additional information

Especially noticeable in shader picker.
<img width="303" height="338" alt="image" src="https://github.com/user-attachments/assets/f29c71d0-f7c6-47e5-a70c-0bcec9ecba64" />

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
