### PR TITLE
Add note in `SceneTree.paused` explaining that the game remains paused on scene changes

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -287,6 +287,7 @@
 			If [code]true[/code], the scene tree is considered paused. This causes the following behavior:
 			- 2D and 3D physics will be stopped, as well as collision detection and related signals.
 			- Depending on each node's [member Node.process_mode], their [method Node._process], [method Node._physics_process] and [method Node._input] callback methods may not called anymore.
+			[b]Note:[/b] The state remains across scene changes with [method SceneTree.change_scene_to_file], [method SceneTree.change_scene_to_node], or [method SceneTree.change_scene_to_packed]. If the game is paused, the game will remain paused when the new scene loads.
 		</member>
 		<member name="physics_interpolation" type="bool" setter="set_physics_interpolation_enabled" getter="is_physics_interpolation_enabled" default="false">
 			If [code]true[/code], the renderer will interpolate the transforms of objects (both physics and non-physics) between the last two transforms, so that smooth motion is seen even when physics ticks do not coincide with rendered frames.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Add a clarification on paused that explains that the game remains paused on scene changes.

## Additional information

Yesterday I was making a main menu, the main menu code is exactly the same as the pause menu, the main menu worked as main menu AND in the pause menu, but the main menu broke when coming from the game when the player quit into the main menu. No button could be interacted and the music in the main menu broke.

I spent some time debugging to see if the code paths added the signals and they did.

The only thing that gave away the actual issue was that the music player had it's stream paused. And I realized that the pause menu paused the game, but the scene changed didn't unpause the game at all, and the main menu had it's game paused.

Unpausing the game before changing the scene solved the issue.