### PR TITLE
Fix t-pose appearing in certain state machine configurations

### DIFF
--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -173,7 +173,7 @@
 		</member>
 		<member name="defer_end" type="bool" setter="set_defer_end" getter="is_end_deferred" default="false">
 			If [code]true[/code], exiting a state machine through an immediate transition will blend the parent with the state machine's last animation instead of with the RESET animation.
-			    	Keep in mind that when this option is active, [signal AnimationNodeStateMachinePlayback.state_finished] will never be emitted for the last node.
+			[b]Note:[/b] When this option is active, [signal AnimationNodeStateMachinePlayback.state_finished] will never be emitted for the last node.
 		</member>
 		<member name="reset_ends" type="bool" setter="set_reset_ends" getter="are_ends_reset" default="false">
 			If [code]true[/code], treat the cross-fade to the start and end nodes as a blend with the RESET animation.

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -171,13 +171,13 @@
 		<member name="allow_transition_to_self" type="bool" setter="set_allow_transition_to_self" getter="is_allow_transition_to_self" default="false">
 			If [code]true[/code], allows teleport to the self state with [method AnimationNodeStateMachinePlayback.travel]. When the reset option is enabled in [method AnimationNodeStateMachinePlayback.travel], the animation is restarted. If [code]false[/code], nothing happens on the teleportation to the self state.
 		</member>
+		<member name="defer_end" type="bool" setter="set_defer_end" getter="is_end_deferred" default="false">
+			If [code]true[/code], exiting a state machine through an immediate transition will blend the parent with the state machine's last animation instead of with the RESET animation.
+			    	Keep in mind that when this option is active, [signal AnimationNodeStateMachinePlayback.state_finished] will never be emitted for the last node.
+		</member>
 		<member name="reset_ends" type="bool" setter="set_reset_ends" getter="are_ends_reset" default="false">
 			If [code]true[/code], treat the cross-fade to the start and end nodes as a blend with the RESET animation.
 			In most cases, when additional cross-fades are performed in the parent [AnimationNode] of the state machine, setting this property to [code]false[/code] and matching the cross-fade time of the parent [AnimationNode] and the state machine's start node and end node gives good results.
-		</member>
-		<member name="defer_end" type="bool" setter="set_defer_end" getter="is_end_deferred" default="false">
-		    If [code]true[/code], prevent transitioning to the end node of this state machine through an Immediate transition. The state machine will still be treated as having ended to any parents, the difference being that by not actually moving to the End node, the parent will always blend with a valid animation from the state machine instead of the RESET animation.
-			Keep in mind that when this option is active, [signal AnimationNodeStateMachinePlayback.state_finished] will never be emitted for the last node.
 		</member>
 		<member name="state_machine_type" type="int" setter="set_state_machine_type" getter="get_state_machine_type" enum="AnimationNodeStateMachine.StateMachineType" default="0">
 			This property can define the process of transitions for different use cases. See also [enum AnimationNodeStateMachine.StateMachineType].

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -175,6 +175,10 @@
 			If [code]true[/code], treat the cross-fade to the start and end nodes as a blend with the RESET animation.
 			In most cases, when additional cross-fades are performed in the parent [AnimationNode] of the state machine, setting this property to [code]false[/code] and matching the cross-fade time of the parent [AnimationNode] and the state machine's start node and end node gives good results.
 		</member>
+		<member name="defer_end" type="bool" setter="set_defer_end" getter="is_end_deferred" default="false">
+		    If [code]true[/code], prevent transitioning to the end node of this state machine through an Immediate transition. The state machine will still be treated as having ended to any parents, the difference being that by not actually moving to the End node, the parent will always blend with a valid animation from the state machine instead of the RESET animation.
+			Keep in mind that when this option is active, [signal AnimationNodeStateMachinePlayback.state_finished] will never be emitted for the last node.
+		</member>
 		<member name="state_machine_type" type="int" setter="set_state_machine_type" getter="get_state_machine_type" enum="AnimationNodeStateMachine.StateMachineType" default="0">
 			This property can define the process of transitions for different use cases. See also [enum AnimationNodeStateMachine.StateMachineType].
 		</member>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -198,6 +198,7 @@ AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
 
 void AnimationNodeStateMachinePlayback::_set_current(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
 	current = p_state;
+	pending_end = false;
 	if (current == StringName()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
 		group_end_transition = Ref<AnimationNodeStateMachineTransition>();
@@ -916,6 +917,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		if (fading_from != StringName()) {
 			return Animation::is_greater_approx(current_nti.get_remain(), fadeing_from_nti.get_remain()) ? current_nti : fadeing_from_nti;
 		}
+		current_nti.pending_end = pending_end;
 		return current_nti;
 	}
 
@@ -1042,9 +1044,25 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationNode::P
 		return false;
 	}
 
-	if (current != SceneStringName(Start) && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
+	if (current == SceneStringName(Start)) {
+		return true;
+	}
+
+	if (p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
 		return Animation::is_less_or_equal_approx(current_nti.get_remain(p_next.break_loop_at_end), p_next.xfade);
 	}
+
+	if (!p_state_machine->is_end_deferred()) {
+		return true;
+	}
+
+	if (p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE) {
+		if (p_next.node == SceneStringName(End)) {
+			pending_end = true;
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -1350,6 +1368,14 @@ void AnimationNodeStateMachine::set_reset_ends(bool p_enable) {
 
 bool AnimationNodeStateMachine::are_ends_reset() const {
 	return reset_ends;
+}
+
+void AnimationNodeStateMachine::set_defer_end(bool p_enable) {
+	defer_end = p_enable;
+}
+
+bool AnimationNodeStateMachine::is_end_deferred() const {
+	return defer_end;
 }
 
 bool AnimationNodeStateMachine::can_edit_node(const StringName &p_name) const {
@@ -1857,9 +1883,13 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_reset_ends", "enable"), &AnimationNodeStateMachine::set_reset_ends);
 	ClassDB::bind_method(D_METHOD("are_ends_reset"), &AnimationNodeStateMachine::are_ends_reset);
 
+	ClassDB::bind_method(D_METHOD("set_defer_end", "enable"), &AnimationNodeStateMachine::set_defer_end);
+	ClassDB::bind_method(D_METHOD("is_end_deferred"), &AnimationNodeStateMachine::is_end_deferred);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "state_machine_type", PROPERTY_HINT_ENUM, "Root,Nested,Grouped"), "set_state_machine_type", "get_state_machine_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_transition_to_self"), "set_allow_transition_to_self", "is_allow_transition_to_self");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_ends"), "set_reset_ends", "are_ends_reset");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "defer_end"), "set_defer_end", "is_end_deferred");
 
 	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_ROOT);
 	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_NESTED);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -129,6 +129,7 @@ private:
 	HashMap<StringName, State> states;
 	bool allow_transition_to_self = false;
 	bool reset_ends = false;
+	bool defer_end = false;
 
 	struct Transition {
 		StringName from;
@@ -206,6 +207,9 @@ public:
 
 	void set_reset_ends(bool p_enable);
 	bool are_ends_reset() const;
+
+	void set_defer_end(bool p_enable);
+	bool is_end_deferred() const;
 
 	bool can_edit_node(const StringName &p_name) const;
 
@@ -288,6 +292,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool teleport_request = false;
 
 	bool is_grouped = false;
+	bool pending_end = false;
 
 	void _clear_fading(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
 	void _signal_state_change(AnimationTree *p_animation_tree, const StringName &p_state, bool p_started);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -80,11 +80,15 @@ public:
 		Animation::LoopMode loop_mode = Animation::LOOP_NONE;
 		bool will_end = false; // For breaking loop, it is true when just looped.
 		bool is_infinity = false; // For unpredictable state machine's end.
+		bool pending_end = false;
 
 		bool is_looping() {
 			return loop_mode != Animation::LOOP_NONE;
 		}
 		double get_remain(bool p_break_loop = false) {
+			if (pending_end) {
+				return 0;
+			}
 			if ((is_looping() && !p_break_loop) || is_infinity) {
 				return HUGE_LENGTH;
 			}


### PR DESCRIPTION
## What this PR tries to solve

When using inner state machines (trying to avoid the word "nested" here since it can also refer to the type of state machine) in certain configurations, an undesired t-pose (RESET animation) can appear. This has been documented in at least [this issue](https://github.com/godotengine/godot/issues/98617).

More specifically, it can be reproduced with the following simple setup:

1. Create an AnimationTree
2. Let the root be a state machine
3. Add a looping animation, and create a transition to it
4. Add an inner state machine
5. For the inner state machine, set it up so that it has one non-looping animation node and transitions between Start, the animation node, and End, with Advance Mode set to "Auto" and Switch Mode set to "Immediate". 

<img width="809" height="93" alt="Screenshot_20260525_183112" src="https://github.com/user-attachments/assets/0ac32552-0e9d-4e33-82e8-4e385bdda52b" />

6. In the outer state machine, add a transition from the animation node to the inner state machine, making sure that Advance Mode is "Enabled" and Switch Mode is "Immediate"
7. Add a transition back from the inner state machine to the animation node, making sure that Advance Mode is "Auto" and Switch Mode is "At End"

<img width="261" height="243" alt="Screenshot_20260525_183055" src="https://github.com/user-attachments/assets/4c917149-58ac-48a9-ace5-79f5660092c3" />

8. Make sure "Play Mode" is set to "Travel", and press Play on the inner state machine to travel there

What happens currently is that the character will display the t-pose (RESET animation) for 1 frame. The problem can be amplified by setting an xfade time on the transition from the inner state machine to the animation node, for example to 1 second. When repeating the last step, we can clearly see how the character immediately teleports to the RESET animation, and then fades back to the animation.

See this small video for a better understanding of the problem:

[Screencast_20260525_091930.webm](https://github.com/user-attachments/assets/3fb7c74f-07c9-40bd-9a0a-3088241f35c3)

Now, this is a very artificial problem, as no one would likely set up their animation tree like this. Something that is way more sane though, is doing this in combination with advance expressions. This is what both me and https://github.com/godotengine/godot/issues/98617 tried to do. Essentially, what we want to do is having an inner state machine such as the one in the example, which is entered based on a condition. We then want the state machine to only exit once a certain condition has been reached.

A great example can be taken from the mentioned issue, where the OP has different character states, and they want to handle them inside an inner state machine. The expression for the transition *into* the inner state machine would look something like `!stance.is_empty()`. Inside the inner state machine, different animations can then be selected based on which stance is selected specifically, for example one condition could read `stance == "chrouch"`. This would lead to a looped crouch animation, which would have an exit transition with the condition `stance != "chrouch"`, which would exit the inner state machine.

However, trying to do this will trigger the scenario we could see in the simpler, artificial scenario, resulting in a t-pose on exiting the inner state machine, see the following video:

[Screencast_20260525_092202.webm](https://github.com/user-attachments/assets/87f95458-3bc9-4591-aad2-9930a2668d9a)

One can partially work around it by setting "Deterministic" to false for the AnimationTree instance, which will get rid of the blending with the t-pose, but will also result in the xfade setting not being respected, as no crossfade will be performed when exiting the inner state machine.

## My understanding of the problem

Having looked through the code and played around with the editor, I believe I understand why this happens. I would not classify it as a "bug" per se, more so an undesired behavior. I do not think that anyone in any scenario *wants* the current behavior.

Since we are using an immediate transition, we will transition to the next node immediately when the condition is fulfilled. This happens to be the End node, which does not have any animation data associated with it. This is also what instructs the parent to transition to the next node, as it will cause `NodeTimeInfo::get_remain()` to return 0 for the inner state machine. For the "At End" case, I believe it works because the last animation is played to the end, effectively resulting in the state machine exiting *before* the End node is reached, since `NodeTimeInfo::get_remain()` will return 0 already before changing the current node.

## The proposed solution

This PR tries to mimic the behavior of "At End" transitions in an inner state machine by treating a transition from a `SWITCH_MODE_IMMEDIATE` node to the End node a bit special. Instead of changing the current node, we will prevent the transition and set a flag, `pending_end` to true. This will set `pending_end` on `current_nti` to true, causing `NodeTimeInfo::get_remain()` to return 0 despite the entire animation not having played.

Doing this is enough to get the parent to start its transition while preserving the animation data from the last node, instead of getting the t-pose from the RESET animation, see these videos:

[Screencast_20260525_092004.webm](https://github.com/user-attachments/assets/0f4034ed-c6e7-49fd-82dc-21aa453de9e6)

[Screencast_20260525_092235.webm](https://github.com/user-attachments/assets/7d1178f0-c209-451f-8cc4-98d34b45f1be)

I believe this is the most isolated fix that can be done to solve this problem.

Despite this likely being a sane default, I decided to put this behind a property, "Defer End", since it could technically change behavior that some people rely on.

No AI was used whatsoever.

closes: #98617