### PR TITLE
macOS: Fix mouse warp for embedded game window

### DIFF
--- a/platform/macos/display_server_macos_embedded.mm
+++ b/platform/macos/display_server_macos_embedded.mm
@@ -285,7 +285,7 @@ void DisplayServerMacOSEmbedded::warp_mouse(const Point2i &p_position) {
 	Input::get_singleton()->set_mouse_position(p_position);
 	// Convert from game pixels to points for the editor.
 	float inv_scale = 1.0f / screen_get_max_scale();
-	EngineDebugger::get_singleton()->send_message("game_view:warp_mouse", { Point2i(inv_scale * p_position) });
+	EngineDebugger::get_singleton()->send_message("game_view:warp_mouse", { Point2i(Vector2(p_position) * inv_scale) });
 }
 
 Point2i DisplayServerMacOSEmbedded::mouse_get_position() const {

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -126,7 +126,7 @@ bool GameViewDebuggerMacOS::_msg_warp_mouse(const Array &p_args) {
 	// Position arrives in points; convert to editor pixels.
 	Vector2i pos = p_args[0];
 	float scale = DisplayServer::get_singleton()->screen_get_max_scale();
-	embedded_process->get_layer_host()->warp_mouse(Vector2i(scale * pos));
+	embedded_process->get_layer_host()->warp_mouse(Vector2i(Vector2(pos) * scale));
 	return true;
 }
 


### PR DESCRIPTION
# Summary

Closes #118941

Regression introduced in #117891, which added a points/pixels scale conversion to the warp-mouse message round-trip:

```cpp
// display_server_macos_embedded.mm — send side
Point2i(inv_scale * p_position)

// embedded_game_view_plugin.mm — receive side
Vector2i(scale * pos)
```

`Vector2i` has no `operator*(float)` member; only `operator*(int32_t)`. The free function `operator*(float, const Vector2i &)` forwards to the member, so the float scalar is silently truncated to `int32_t`. With a Retina scale of `2.0`, `inv_scale = 0.5f` truncates to `0` and the sent position becomes `(0, 0)`. The editor multiplies by `2`, still `(0, 0)`, and the cursor warps to the top-left corner.

I'd argue that is a bit of a foot-gun.

## 🤖 AI disclosure

I used AI to investigate and propose a fix, which I have validated.