### PR TITLE
Fix RichTextLabel tab_size 0 causing 1px indent on lists and indents

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3638,7 +3638,9 @@ int RichTextLabel::_find_margin(Item *p_item, const Ref<Font> &p_base_font, int 
 			if (font_size_it && font_size_it->font_size > 0) {
 				font_size = font_size_it->font_size;
 			}
-			margin += MAX(1, tab_size * (font->get_char_size(' ', font_size).width + font->get_spacing(TextServer::SPACING_SPACE)));
+			if (tab_size > 0) {
+				margin += MAX(1, tab_size * (font->get_char_size(' ', font_size).width + font->get_spacing(TextServer::SPACING_SPACE)));
+			}
 
 		} else if (item->type == ITEM_LIST) {
 			Ref<Font> font = p_base_font;
@@ -3657,7 +3659,9 @@ int RichTextLabel::_find_margin(Item *p_item, const Ref<Font> &p_base_font, int 
 			if (font_size_it && font_size_it->font_size > 0) {
 				font_size = font_size_it->font_size;
 			}
-			margin += MAX(1, tab_size * (font->get_char_size(' ', font_size).width + font->get_spacing(TextServer::SPACING_SPACE)));
+			if (tab_size > 0) {
+				margin += MAX(1, tab_size * (font->get_char_size(' ', font_size).width + font->get_spacing(TextServer::SPACING_SPACE)));
+			}
 		}
 
 		item = item->parent;


### PR DESCRIPTION
Setting tab_size to 0 on a RichTextLabel with [ul] or [indent] still indents by 1 pixel instead of 0.

The issue is in _find_margin where MAX(1, tab_size * (...)) clamps the result to a minimum of 1, even when tab_size is 0 and the user expects no indentation at all.

Fixed by guarding the margin addition with tab_size > 0, which is already how inline tab alignment handles it.