### PR TITLE
Allow shortcuts bound to numpad keys to work in text editor

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -706,7 +706,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 	// Allow unicode handling if:
 	// No modifiers are pressed (except Shift and CapsLock)
-	bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
+	bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed() || (k->get_keycode() >= Key::KP_MULTIPLY && k->get_keycode() <= Key::KP_9));
 
 	/* AUTO-COMPLETE */
 	if (code_completion_enabled && k->is_action("ui_text_completion_query", true)) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1053,7 +1053,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	// Allow unicode handling if:
 	// * No Modifiers are pressed (except shift)
-	bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
+	bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed() || (k->get_keycode() >= Key::KP_MULTIPLY && k->get_keycode() <= Key::KP_9));
 
 	if (allow_unicode_handling && editable && k->get_unicode() >= 32) {
 		// Handle Unicode if no modifiers are active.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2622,7 +2622,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		// Allow unicode handling if:
 		// * No modifiers are pressed (except Shift and CapsLock)
-		bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
+		bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed() || (k->get_keycode() >= Key::KP_MULTIPLY && k->get_keycode() <= Key::KP_9));
 
 		// Check and handle all built-in shortcuts.
 


### PR DESCRIPTION
Co-authored by: bruvzg <7645683+bruvzg@users.noreply.github.com>

## What problem(s) does this PR solve?

- Closes #119727

## Additional information

When a user binds numpad keys to the debugger functions, this PR makes the numpad buttons actually serve as the debug functionality, rather than typing the number/symbol associated.

Code was entirely written by @bruvzg in https://github.com/godotengine/godot/issues/119727, I tested it locally