### PR TITLE
Fix Parallax2D positioning with Camera2D zoom

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -63,7 +63,7 @@ void Camera2D::_update_scroll() {
 		viewport->set_canvas_transform(xform);
 
 		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5) : Point2());
-		Point2 adj_screen_pos = camera_screen_center - (screen_size * 0.5);
+		Point2 adj_screen_pos = camera_screen_center - (screen_size * 0.5 / zoom);
 
 		// TODO: Remove xform and screen_offset when ParallaxBackground/ParallaxLayer is removed.
 		get_tree()->call_group(group_name, SNAME("_camera_moved"), xform, screen_offset, adj_screen_pos);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes incorrect Parallax2D positioning when Camera2D zoom is not `(1, 1)`.

## Additional information

Fixes incorrect `Parallax2D` positioning when used with a zoomed `Camera2D`.

When `Camera2D.zoom != Vector2(1, 1)`, `Parallax2D` nodes using `repeat_size`
can be positioned outside the visible area.

Root cause:
`Camera2D` computes `adj_screen_pos` using the full viewport size, which
does not match the actual visible world region when zoom is applied.

Fix:
Divide the viewport half-size by the camera zoom before computing
`adj_screen_pos`, so the offset matches the visible world area.

Tested manually with:
- `zoom = (1, 1)`
- `zoom = (2, 2)`
- `zoom = (3, 3)`

AI disclosure:
AI was used to help refine the wording and structure of this PR description.
The bug investigation, code change, and testing were performed manually.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119776*