### PR TITLE
iOS: Fix ignored orientation changes in embedded mode

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -665,11 +665,25 @@ void DisplayServerAppleEmbedded::screen_set_orientation(DisplayServerEnums::Scre
 	ERR_FAIL_INDEX(p_screen, screen_count);
 
 	screen_orientation = p_orientation;
-	if (@available(iOS 16.0, *)) {
-		[GDTAppDelegateService.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
+#ifdef IOS_ENABLED
+	// Under the SwiftUI app lifecycle, GDTViewController is wrapped by a UIHostingController
+	// that is the window's root VC. iOS queries the root VC for orientation preferences, so we
+	// must install the selectors on the hosting class before requesting an orientation update.
+	GDTViewController *vc = GDTAppDelegateService.viewController;
+	if (!vc) {
+		return;
 	}
-#if !defined(VISIONOS_ENABLED)
-	else {
+	[vc propagateUIPreferencesToRootViewController];
+
+	UIViewController *rootViewController = vc.view.window.rootViewController ?: vc;
+	if (@available(iOS 16.0, *)) {
+		[rootViewController setNeedsUpdateOfSupportedInterfaceOrientations];
+		UIWindowScene *windowScene = rootViewController.view.window.windowScene;
+		if (windowScene) {
+			UIWindowSceneGeometryPreferencesIOS *preferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:[rootViewController supportedInterfaceOrientations]];
+			[windowScene requestGeometryUpdateWithPreferences:preferences errorHandler:nil];
+		}
+	} else {
 		[UIViewController attemptRotationToDeviceOrientation];
 	}
 #endif

--- a/drivers/apple_embedded/godot_view_controller.h
+++ b/drivers/apple_embedded/godot_view_controller.h
@@ -40,4 +40,8 @@
 @property(nonatomic, readonly, strong) GDTView *godotView;
 @property(nonatomic, readonly, strong) GDTKeyboardInputView *keyboardView;
 
+#ifdef IOS_ENABLED
+- (void)propagateUIPreferencesToRootViewController;
+#endif
+
 @end

--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -254,6 +254,8 @@
 		@selector(preferredScreenEdgesDeferringSystemGestures),
 		@selector(prefersHomeIndicatorAutoHidden),
 		@selector(prefersStatusBarHidden),
+		@selector(shouldAutorotate),
+		@selector(supportedInterfaceOrientations),
 	};
 
 	for (SEL sel : selectors) {


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #118350

## Additional information

Fix orientation updates for embedded iOS builds.

Under the SwiftUI app lifecycle, the Godot view controller may be wrapped by a hosting controller that acts as the window's root view controller. Propagate orientation-related UIKit preferences to the root controller before requesting an update.

This also fixes orientation settings not being applied correctly on iOS.