### PR TITLE
Fix Vector4 properties' proportions in VisualShader

### DIFF
--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -327,8 +327,8 @@ void VisualShaderGraphPlugin::set_input_port_default_value(VisualShader::Type p_
 			Vector3 v = p_value;
 			button->set_text(String::num(v.x, 3) + "," + String::num(v.y, 3) + "," + String::num(v.z, 3));
 		} break;
-		case Variant::VECTOR4: {
-			Vector4 v = p_value;
+		case Variant::QUATERNION: {
+			Quaternion v = p_value;
 			button->set_text(String::num(v.x, 3) + "," + String::num(v.y, 3) + "," + String::num(v.z, 3) + "," + String::num(v.w, 3));
 		} break;
 		default: {
@@ -3414,7 +3414,7 @@ void VisualShaderEditor::_edit_port_default_input(Object *p_button, int p_node, 
 		case Variant::BASIS:
 			popup_pref_size.width = 320;
 			break;
-		case Variant::VECTOR4:
+		case Variant::QUATERNION:
 		case Variant::PLANE:
 		case Variant::TRANSFORM2D:
 		case Variant::TRANSFORM3D:


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes the button's text being missing.
Fixes the `EditorProperty` for Vector4s being too small to actually see.

These two fixes were very similar, and are both ~one line each so I decided to put them together in this PR.
Both of the fixes include changing type detection to `Variant::QUATERNION` instead of `Variant::VECTOR4`, as `vec4` uses `Quaternion` in visual shader internals, probably due to `Vector4` not existing before 4.0.

## Additional information

Before:

<img width="265" height="332" alt="image" src="https://github.com/user-attachments/assets/1b273e6e-2339-4321-b08f-8e3aa1851e76" />

After:
<img width="510" height="220" alt="image" src="https://github.com/user-attachments/assets/0aedd108-ab68-4f13-b146-4ef4c988012c" />


