### PR TITLE
Fix C# caught exceptions not reaching custom loggers

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -100,6 +100,12 @@ namespace Godot.NativeInterop
             }
         }
 
+        private static void PushErrorToLoggers(string message)
+        {
+            using godot_string nMessage = Marshaling.ConvertStringToNative(message);
+            NativeFuncs.godotsharp_internal_os_print_error(nMessage, godot_error_handler_type.ERR_HANDLER_ERROR);
+        }
+
         public static void LogException(Exception e)
         {
             try
@@ -107,6 +113,7 @@ namespace Godot.NativeInterop
                 if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
                 {
                     SendToScriptDebugger(e);
+                    PushErrorToLoggers(e.ToString());
                 }
                 else
                 {
@@ -126,10 +133,12 @@ namespace Godot.NativeInterop
                 if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
                 {
                     SendToScriptDebugger(e);
+                    PushErrorToLoggers("Unhandled exception\n" + e);
                 }
-
-                // In this case, print it as well in addition to sending it to the script debugger
-                GD.PushError("Unhandled exception\n" + e);
+                else
+                {
+                    GD.PushError("Unhandled exception\n" + e);
+                }
             }
             catch (Exception unexpected)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -603,6 +603,8 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_err_print_error(in godot_string p_function, in godot_string p_file, int p_line, in godot_string p_error, in godot_string p_message = default, godot_bool p_editor_notify = godot_bool.False, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
 
+        internal static partial void godotsharp_internal_os_print_error(in godot_string p_message, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
+
         // Object
 
         public static partial void godotsharp_object_to_string(IntPtr ptr, out godot_string r_str);

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1489,6 +1489,13 @@ void godotsharp_err_print_error(const godot_string *p_function, const godot_stri
 			p_editor_notify, p_type);
 }
 
+void godotsharp_internal_os_print_error(const godot_string *p_message, ErrorHandlerType p_type) {
+	OS::get_singleton()->print_error(
+			"", "", 0,
+			reinterpret_cast<const String *>(p_message)->utf8().get_data(),
+			"", false, (Logger::ErrorType)p_type);
+}
+
 void godotsharp_var_to_str(const godot_variant *p_var, godot_string *r_ret) {
 	const Variant &var = *reinterpret_cast<const Variant *>(p_var);
 	String &vars = *memnew_placement(r_ret, String);
@@ -1845,6 +1852,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_var_to_bytes,
 	(void *)godotsharp_var_to_str,
 	(void *)godotsharp_err_print_error,
+	(void *)godotsharp_internal_os_print_error,
 	(void *)godotsharp_object_to_string,
 	(void *)godotsharp_string_size,
 	(void *)godotsharp_packed_byte_array_size,


### PR DESCRIPTION
## Summary

- `ExceptionUtils.LogException` now always calls `GD.PushError` after optionally sending to the script debugger, matching `LogUnhandledException`.
- Fixes caught C# exceptions not appearing in `OS.add_logger()` custom loggers, file logging, or the standard `OS.print_error` pipeline during editor play when the script debugger is active.

## Problem

When the script debugger is active (typical editor run), caught C# exceptions were sent only via `godotsharp_internal_script_debugger_send_error` → `RemoteDebugger::send_error`. They never went through `GD.PushError` → `_err_print_error` → `OS::print_error`, so custom loggers and project file logging did not see them. The editor debugger UI still showed them.

Previously, `GD.PushError` ran only in the `else` branch (debugger inactive).

## Solution

Always call `GD.PushError(e.ToString())` after `SendToScriptDebugger`, same pattern as `LogUnhandledException`.


Closes: https://github.com/godotengine/godot/issues/115283
Closes: https://github.com/godotengine/godot/issues/54389
