### PR TITLE
Fix flickering lighting on mesh-instances with non-uniform scale

### DIFF
--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -75,7 +75,7 @@ void RenderGeometryInstanceBase::set_transform(const Transform3D &p_transform, c
 
 	float max_scale = MAX(model_scale_vec.x, MAX(model_scale_vec.y, model_scale_vec.z));
 	float min_scale = MIN(model_scale_vec.x, MIN(model_scale_vec.y, model_scale_vec.z));
-	non_uniform_scale = max_scale >= 0.0 && (min_scale / max_scale) < 0.9;
+	non_uniform_scale = max_scale >= 0.0 && (min_scale / max_scale) < 0.999;
 
 	lod_model_scale = max_scale;
 }


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #106150

## Additional information

- The flickering happens because sometimes the matrix for non-uniform scale is applied to the normals while othertimes it's the matrix for uniform scale. This is caused by a flickering `non_uniform_scale` flag which in turn is caused by floating point imprecisions.
- The flickering occures when `min_scale / max_scale` is around the epsilon, which was 0.9 before the fix.
- I tightend the epsilon to 0.999 which should still leave room for floating point inaccuracies. The flag will now alternate when `min_scale / max_scale` is around 0.999. However, at this point the matrices for uniform and non-uniform scale are similiar enough that no visual flicker should be apparent.
- Note: This change will cause more geometry instances to be considered as non-uniformly scaled. This could have a minor impact on performance in scenes with many slightly non-uniformly scaled instances.


_Bugsquad edit: Fixes https://github.com/godotengine/godot/issues/101377_