### PR TITLE
Add getter methods for title bar controls in FoldableContainer

### DIFF
--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -31,6 +31,20 @@
 				Folds the container and emits [signal folding_changed].
 			</description>
 		</method>
+		<method name="get_title_bar_control" qualifiers="const">
+			<return type="Control" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the title bar [Control] at the given [param index], or [code]null[/code] if the index is out of bounds.
+				Use [method get_title_bar_control_count] to get the total number of title bar controls.
+			</description>
+		</method>
+		<method name="get_title_bar_control_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of controls added to the title bar via [method add_title_bar_control].
+			</description>
+		</method>
 		<method name="remove_title_bar_control">
 			<return type="void" />
 			<param index="0" name="control" type="Control" />

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -245,6 +245,15 @@ void FoldableContainer::remove_title_bar_control(Control *p_control) {
 	remove_child(p_control);
 }
 
+Control *FoldableContainer::get_title_bar_control(int64_t p_index) const {
+	ERR_FAIL_INDEX_V(p_index, title_controls.size(), nullptr);
+	return title_controls[p_index];
+}
+
+int FoldableContainer::get_title_bar_control_count() const {
+	return title_controls.size();
+}
+
 void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -582,6 +591,8 @@ void FoldableContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title_position", "title_position"), &FoldableContainer::set_title_position);
 	ClassDB::bind_method(D_METHOD("get_title_position"), &FoldableContainer::get_title_position);
 	ClassDB::bind_method(D_METHOD("add_title_bar_control", "control"), &FoldableContainer::add_title_bar_control);
+	ClassDB::bind_method(D_METHOD("get_title_bar_control", "index"), &FoldableContainer::get_title_bar_control);
+	ClassDB::bind_method(D_METHOD("get_title_bar_control_count"), &FoldableContainer::get_title_bar_control_count);
 	ClassDB::bind_method(D_METHOD("remove_title_bar_control", "control"), &FoldableContainer::remove_title_bar_control);
 
 	ADD_SIGNAL(MethodInfo("folding_changed", PropertyInfo(Variant::BOOL, "is_folded")));

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -136,6 +136,8 @@ public:
 
 	void add_title_bar_control(Control *p_control);
 	void remove_title_bar_control(Control *p_control);
+	Control *get_title_bar_control(int64_t p_index) const;
+	int get_title_bar_control_count() const;
 
 	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;


### PR DESCRIPTION
Adds two new methods to FoldableContainer:
- `get_title_bar_control_count() -> int` — returns the number of controls added to the title bar.
- `get_title_bar_control(index: int) -> Control` — returns the control at the given index.

Previously there was no way to query which controls had already been added to the title bar, making it impossible to avoid duplicates when calling `add_title_bar_control()` from external code, since title bar controls are added as internal children and are not accessible via regular child iteration.