### PR TITLE
Support for lazy allocating samplers

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -38,6 +38,7 @@
 #include "servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h"
 #include "servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h"
 #include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
+#include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/storage/variant_converters.h"
 
 using namespace RendererRD;
@@ -1434,30 +1435,34 @@ template void MaterialStorage::Samplers::append_uniforms(LocalVector<RD::Uniform
 template void MaterialStorage::Samplers::append_uniforms(Vector<RD::Uniform> &p_uniforms, int p_first_index) const;
 
 template <typename Collection>
-void MaterialStorage::Samplers::append_uniforms(Collection &p_uniforms, int p_first_index) const {
-	// Binding ids are aligned with samplers_inc.glsl.
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 0, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 1, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 2, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 3, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 4, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 5, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC][RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 6, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 7, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 8, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 9, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 10, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-	p_uniforms.push_back(RD::Uniform(RD::UNIFORM_TYPE_SAMPLER, p_first_index + 11, rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC][RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED]));
-}
+void MaterialStorage::Samplers::append_uniforms(
+		Collection &p_uniforms,
+		int p_first_index) const {
+	static const RSE::CanvasItemTextureFilter filters[] = {
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST,
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR,
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS,
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS,
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC,
+		RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC,
+	};
 
-bool MaterialStorage::Samplers::is_valid() const {
-	return rids[1][1].is_valid();
-}
+	static const RSE::CanvasItemTextureRepeat repeats[] = {
+		RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED,
+		RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED,
+	};
 
-bool MaterialStorage::Samplers::is_null() const {
-	return rids[1][1].is_null();
-}
+	int binding_index = p_first_index;
 
+	for (RSE::CanvasItemTextureRepeat repeat : repeats) {
+		for (RSE::CanvasItemTextureFilter filter : filters) {
+			p_uniforms.push_back(RD::Uniform(
+					RD::UNIFORM_TYPE_SAMPLER,
+					binding_index++,
+					get_sampler(filter, repeat)));
+		}
+	}
+}
 ///////////////////////////////////////////////////////////////////////////
 // MaterialStorage
 
@@ -2663,93 +2668,71 @@ MaterialStorage::Samplers MaterialStorage::samplers_rd_allocate(float p_mipmap_b
 	samplers.anisotropic_filtering_level = (int)anisotropic_filtering_level;
 	samplers.use_nearest_mipmap_filter = GLOBAL_GET_CACHED(bool, "rendering/textures/default_filters/use_nearest_mipmap_filter");
 
-	RD::SamplerFilter mip_filter = samplers.use_nearest_mipmap_filter ? RD::SAMPLER_FILTER_NEAREST : RD::SAMPLER_FILTER_LINEAR;
-	float anisotropy_max = float(1 << samplers.anisotropic_filtering_level);
-
 	for (int i = 1; i < RSE::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
 		for (int j = 1; j < RSE::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
-			RD::SamplerState sampler_state;
-			switch (i) {
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.max_lod = 0;
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.max_lod = 0;
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.mip_filter = mip_filter;
-					sampler_state.lod_bias = samplers.mipmap_bias;
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.mip_filter = mip_filter;
-					sampler_state.lod_bias = samplers.mipmap_bias;
+			RD::SamplerState sampler_state = default_sampler_state_for(&samplers, (RSE::CanvasItemTextureFilter)i, (RSE::CanvasItemTextureRepeat)j);
 
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
-					sampler_state.mip_filter = mip_filter;
-					sampler_state.lod_bias = samplers.mipmap_bias;
-					sampler_state.use_anisotropy = true;
-					sampler_state.anisotropy_max = anisotropy_max;
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
-					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
-					sampler_state.mip_filter = mip_filter;
-					sampler_state.lod_bias = samplers.mipmap_bias;
-					sampler_state.use_anisotropy = true;
-					sampler_state.anisotropy_max = anisotropy_max;
-
-				} break;
-				default: {
-				}
-			}
-			switch (j) {
-				case RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED: {
-					sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
-					sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
-					sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
-
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
-					sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_REPEAT;
-					sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_REPEAT;
-					sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_REPEAT;
-				} break;
-				case RSE::CANVAS_ITEM_TEXTURE_REPEAT_MIRROR: {
-					sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
-					sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
-					sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
-				} break;
-				default: {
-				}
-			}
-
-			samplers.rids[i][j] = RD::get_singleton()->sampler_create(sampler_state);
+			_sampler_acquire(sampler_state);
+			samplers.states.push_back(sampler_state);
 		}
 	}
 
 	return samplers;
 }
 
-void MaterialStorage::samplers_rd_free(Samplers &p_samplers) const {
-	for (int i = 1; i < RSE::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
-		for (int j = 1; j < RSE::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
-			if (p_samplers.rids[i][j].is_valid()) {
-				RD::get_singleton()->free_rid(p_samplers.rids[i][j]);
-				p_samplers.rids[i][j] = RID();
-			}
-		}
+RID MaterialStorage::_sampler_acquire(const RD::SamplerState &p_state) const {
+	MutexLock lock(sampler_cache_mutex);
+
+	SamplerEntry *entry = sampler_cache.getptr(p_state);
+
+	if (entry) {
+		entry->refcount++;
+		return entry->rid;
 	}
+
+	RID rid = RD::get_singleton()->sampler_create(p_state);
+
+	SamplerEntry new_entry;
+	new_entry.rid = rid;
+	new_entry.refcount = 1;
+
+	sampler_cache.insert(p_state, new_entry);
+
+	return rid;
+}
+
+RID MaterialStorage::_get_sampler(const RD::SamplerState &p_state) const {
+	MutexLock lock(sampler_cache_mutex);
+
+	const SamplerEntry *entry = sampler_cache.getptr(p_state);
+
+	ERR_FAIL_NULL_V(entry, RID());
+
+	return entry->rid;
+}
+
+void MaterialStorage::_sampler_release(const RD::SamplerState &p_state) const {
+	MutexLock lock(sampler_cache_mutex);
+
+	SamplerEntry *entry = sampler_cache.getptr(p_state);
+	ERR_FAIL_NULL(entry);
+
+	ERR_FAIL_COND(entry->refcount == 0);
+
+	entry->refcount--;
+
+	if (entry->refcount == 0) {
+		RD::get_singleton()->free_rid(entry->rid);
+		sampler_cache.erase(p_state);
+	}
+}
+
+void MaterialStorage::samplers_rd_free(Samplers &p_samplers) const {
+	for (const RD::SamplerState &state : p_samplers.states) {
+		_sampler_release(state);
+	}
+
+	p_samplers.states.clear();
 }
 
 void MaterialStorage::material_set_data_request_function(ShaderType p_shader_type, MaterialStorage::MaterialDataRequestFunction p_function) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -121,20 +121,24 @@ public:
 		Vector<RID> texture_cache;
 	};
 
+	struct SamplerEntry {
+		RID rid;
+		uint32_t refcount = 0;
+	};
+
 	struct Samplers {
-		RID rids[RSE::CANVAS_ITEM_TEXTURE_FILTER_MAX][RSE::CANVAS_ITEM_TEXTURE_REPEAT_MAX];
+		LocalVector<RD::SamplerState> states;
 		float mipmap_bias = 0.0f;
 		bool use_nearest_mipmap_filter = false;
 		int anisotropic_filtering_level = 2;
 
 		_FORCE_INLINE_ RID get_sampler(RSE::CanvasItemTextureFilter p_filter, RSE::CanvasItemTextureRepeat p_repeat) const {
-			return rids[p_filter][p_repeat];
+			RD::SamplerState sampler_state = default_sampler_state_for(this, p_filter, p_repeat);
+			return MaterialStorage::get_singleton()->_get_sampler(sampler_state);
 		}
 
 		template <typename Collection>
 		void append_uniforms(Collection &p_uniforms, int p_first_index) const;
-		bool is_valid() const;
-		bool is_null() const;
 	};
 
 	/* Texture Blit Shader */
@@ -190,6 +194,9 @@ private:
 	/* Samplers */
 
 	Samplers default_samplers;
+
+	mutable Mutex sampler_cache_mutex;
+	mutable HashMap<RD::SamplerState, SamplerEntry> sampler_cache;
 
 	/* Buffers */
 
@@ -419,7 +426,86 @@ public:
 	/* Samplers */
 
 	Samplers samplers_rd_allocate(float p_mipmap_bias = 0.0f, RSE::ViewportAnisotropicFiltering anisotropic_filtering_level = RSE::ViewportAnisotropicFiltering::VIEWPORT_ANISOTROPY_4X) const;
+	RID _sampler_acquire(const RD::SamplerState &p_state) const;
+	RID _get_sampler(const RD::SamplerState &p_state) const;
+	void _sampler_release(const RD::SamplerState &p_state) const;
 	void samplers_rd_free(Samplers &p_samplers) const;
+
+	_FORCE_INLINE_ static RD::SamplerState default_sampler_state_for(const MaterialStorage::Samplers *samplers,
+			RSE::CanvasItemTextureFilter p_filter,
+			RSE::CanvasItemTextureRepeat p_repeat) {
+		RD::SamplerFilter mip_filter = samplers->use_nearest_mipmap_filter ? RD::SAMPLER_FILTER_NEAREST : RD::SAMPLER_FILTER_LINEAR;
+		float anisotropy_max = float(1 << samplers->anisotropic_filtering_level);
+
+		RD::SamplerState sampler_state = {};
+
+		switch (p_filter) {
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.max_lod = 0;
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.max_lod = 0;
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.mip_filter = mip_filter;
+				sampler_state.lod_bias = samplers->mipmap_bias;
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.mip_filter = mip_filter;
+				sampler_state.lod_bias = samplers->mipmap_bias;
+
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_NEAREST;
+				sampler_state.mip_filter = mip_filter;
+				sampler_state.lod_bias = samplers->mipmap_bias;
+				sampler_state.use_anisotropy = true;
+				sampler_state.anisotropy_max = anisotropy_max;
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
+				sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
+				sampler_state.mip_filter = mip_filter;
+				sampler_state.lod_bias = samplers->mipmap_bias;
+				sampler_state.use_anisotropy = true;
+				sampler_state.anisotropy_max = anisotropy_max;
+
+			} break;
+			default: {
+			}
+		}
+		switch (p_repeat) {
+			case RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED: {
+				sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
+				sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
+				sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
+
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
+				sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_REPEAT;
+				sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_REPEAT;
+				sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_REPEAT;
+			} break;
+			case RSE::CANVAS_ITEM_TEXTURE_REPEAT_MIRROR: {
+				sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
+				sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
+				sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_MIRRORED_REPEAT;
+			} break;
+			default: {
+			}
+		}
+
+		return sampler_state;
+	}
 
 	_FORCE_INLINE_ RID sampler_rd_get_default(RSE::CanvasItemTextureFilter p_filter, RSE::CanvasItemTextureRepeat p_repeat) {
 		return default_samplers.get_sampler(p_filter, p_repeat);

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -539,6 +539,24 @@ public:
 		float max_lod = 1e20; // Something very large should do.
 		SamplerBorderColor border_color = SAMPLER_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
 		bool unnormalized_uvw = false;
+
+		_FORCE_INLINE_ bool operator==(const SamplerState &p_other) const {
+			return mag_filter == p_other.mag_filter &&
+					min_filter == p_other.min_filter &&
+					mip_filter == p_other.mip_filter &&
+					repeat_u == p_other.repeat_u &&
+					repeat_v == p_other.repeat_v &&
+					repeat_w == p_other.repeat_w &&
+					lod_bias == p_other.lod_bias &&
+					use_anisotropy == p_other.use_anisotropy &&
+					anisotropy_max == p_other.anisotropy_max &&
+					enable_compare == p_other.enable_compare &&
+					compare_op == p_other.compare_op &&
+					min_lod == p_other.min_lod &&
+					max_lod == p_other.max_lod &&
+					border_color == p_other.border_color &&
+					unnormalized_uvw == p_other.unnormalized_uvw;
+		}
 	};
 
 	/**********************/
@@ -1161,4 +1179,29 @@ public:
 		BitField<ShaderStage> stages_bits = {};
 		BitField<ShaderStage> push_constant_stages = {};
 	};
+};
+
+template <>
+struct HashMapHasherDefaultImpl<RenderingDeviceCommons::SamplerState> {
+	static _FORCE_INLINE_ uint32_t hash(const RenderingDeviceCommons::SamplerState &p_state) {
+		uint32_t h = HASH_MURMUR3_SEED;
+
+		h = hash_murmur3_one_32(p_state.mag_filter, h);
+		h = hash_murmur3_one_32(p_state.min_filter, h);
+		h = hash_murmur3_one_32(p_state.mip_filter, h);
+		h = hash_murmur3_one_32(p_state.repeat_u, h);
+		h = hash_murmur3_one_32(p_state.repeat_v, h);
+		h = hash_murmur3_one_32(p_state.repeat_w, h);
+		h = hash_murmur3_one_float(p_state.lod_bias, h);
+		h = hash_murmur3_one_32(p_state.use_anisotropy, h);
+		h = hash_murmur3_one_float(p_state.anisotropy_max, h);
+		h = hash_murmur3_one_32(p_state.enable_compare, h);
+		h = hash_murmur3_one_32(p_state.compare_op, h);
+		h = hash_murmur3_one_float(p_state.min_lod, h);
+		h = hash_murmur3_one_float(p_state.max_lod, h);
+		h = hash_murmur3_one_32(p_state.border_color, h);
+		h = hash_murmur3_one_32(p_state.unnormalized_uvw, h);
+
+		return hash_fmix32(h);
+	}
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?
Currently, Godot exposes a fixed, preallocated list of possible Sampler permutations to Materials. This means that several parameters, like per-axis wrap modes or anistropy, can not be configured per material. This PR seeks to begin to add support for that with a few key changes to material storage, without breaking the current system.

- `RD::SamplerState` is now hashable
- Samplers are now globally cached and ref-counted in material storage. Existing permutations will be reused when the `RD::SamplerState` hash matches. Permutations will be deleted once their reference count falls to zero.
-  Ownership is retained by the `Samplers` object, which contains a list of `RD::SamplerState` permutations it has increased the reference count for.
- `samplers_rd_allocate` will continue to allocate the existing standard permutations for `Samplers` objects by default. In future this should be made specific to the `default_samplers` object, although that's a potentially breaking change.
- `default_sampler_state_for` serves as a bridge to always provide the exact `RD::SamplerState` expected from a `Samplers` + `RSE::CanvasItemTextureFilter` + `RSE::CanvasItemTextureRepeat`

## Open Questions

- Continuing utility of the `Samplers` object, should it be removed entirely?
- Should `Samplers::get_sampler` be expected to create permutations if they don't currently exist?
- The `RSE::CanvasItemTextureFilter` + `RSE::CanvasItemTextureRepeat` pattern is common throughout the renderer for a number of standard shaders. Should `default_sampler_state_for` be formalised and made more readily accessible?

## Additional information

Retooled from #100777.
