### PR TITLE
Seek past skipped shader variant payloads to avoid reading incorrect data

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -645,6 +645,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		int variant_id = group_to_variant_map[p_group][i];
 		uint32_t variant_size = f->get_32();
 		if (!variants_enabled[variant_id]) {
+			f->seek(f->get_position() + variant_size);
 			continue;
 		}
 		if (variant_size == 0) {


### PR DESCRIPTION
When a shader variant is disabled, the old code was not advancing the file cursor past the payload of the disabled variant payload. This caused it to read the size of the next variant out of the payload of the previous disabled variant. This was observable because I would see the `ERROR: Condition "br != variant_size" is true` message sometimes when switching back and forth between XR and no XR.

Fixes #119673.