### PR TITLE
Add initialization of typed Arrays/Dictionaries using ternary operators

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2109,16 +2109,11 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 	if (p_assignable->initializer != nullptr) {
 		reduce_expression(p_assignable->initializer);
 
-		if (p_assignable->initializer->type == GDScriptParser::Node::ARRAY) {
-			GDScriptParser::ArrayNode *array = static_cast<GDScriptParser::ArrayNode *>(p_assignable->initializer);
-			if (has_specified_type && specified_type.has_container_element_type(0)) {
-				update_array_literal_element_type(array, specified_type.get_container_element_type(0));
-			}
-		} else if (p_assignable->initializer->type == GDScriptParser::Node::DICTIONARY) {
-			GDScriptParser::DictionaryNode *dictionary = static_cast<GDScriptParser::DictionaryNode *>(p_assignable->initializer);
-			if (has_specified_type && specified_type.has_container_element_types()) {
-				update_dictionary_literal_element_type(dictionary, specified_type.get_container_element_type_or_variant(0), specified_type.get_container_element_type_or_variant(1));
-			}
+		if (has_specified_type && specified_type.has_container_element_type(0)) {
+			update_array_expression_element_type(p_assignable->initializer, specified_type.get_container_element_type(0));
+		}
+		if (has_specified_type && specified_type.has_container_element_types()) {
+			update_dictionary_expression_element_type(p_assignable->initializer, specified_type.get_container_element_type_or_variant(0), specified_type.get_container_element_type_or_variant(1));
 		}
 
 		if (is_constant && !p_assignable->initializer->is_constant) {
@@ -2361,11 +2356,8 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 					p_for->use_conversion_assign = true;
 				}
 				if (p_for->list) {
-					if (p_for->list->type == GDScriptParser::Node::ARRAY) {
-						update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_for->list), specified_type);
-					} else if (p_for->list->type == GDScriptParser::Node::DICTIONARY) {
-						update_dictionary_literal_element_type(static_cast<GDScriptParser::DictionaryNode *>(p_for->list), specified_type, GDScriptParser::DataType::get_variant_type());
-					}
+					update_array_expression_element_type(p_for->list, specified_type);
+					update_dictionary_expression_element_type(p_for->list, specified_type, GDScriptParser::DataType::get_variant_type());
 				}
 			}
 			p_for->variable->set_datatype(specified_type);
@@ -2567,10 +2559,11 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			result.builtin_type = Variant::NIL;
 			result.is_constant = true;
 		} else {
-			if (p_return->return_value->type == GDScriptParser::Node::ARRAY && has_expected_type && expected_type.has_container_element_type(0)) {
-				update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_return->return_value), expected_type.get_container_element_type(0));
-			} else if (p_return->return_value->type == GDScriptParser::Node::DICTIONARY && has_expected_type && expected_type.has_container_element_types()) {
-				update_dictionary_literal_element_type(static_cast<GDScriptParser::DictionaryNode *>(p_return->return_value),
+			if (has_expected_type && expected_type.has_container_element_type(0)) {
+				update_array_expression_element_type(p_return->return_value, expected_type.get_container_element_type(0));
+			}
+			if (has_expected_type && expected_type.has_container_element_types()) {
+				update_dictionary_expression_element_type(p_return->return_value,
 						expected_type.get_container_element_type_or_variant(0), expected_type.get_container_element_type_or_variant(1));
 			}
 			if (has_expected_type && expected_type.is_hard_type() && p_return->return_value->is_constant) {
@@ -2868,6 +2861,41 @@ void GDScriptAnalyzer::update_dictionary_literal_element_type(GDScriptParser::Di
 	p_dictionary->set_datatype(dictionary_type);
 }
 
+void GDScriptAnalyzer::update_array_expression_element_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_element_type) {
+	if (p_expression == nullptr) {
+		return;
+	}
+	if (p_expression->type == GDScriptParser::Node::ARRAY) {
+		update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_expression), p_element_type);
+	} else if (p_expression->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+		GDScriptParser::TernaryOpNode *ternary = static_cast<GDScriptParser::TernaryOpNode *>(p_expression);
+		update_array_expression_element_type(ternary->true_expr, p_element_type);
+		update_array_expression_element_type(ternary->false_expr, p_element_type);
+		GDScriptParser::DataType type = ternary->get_datatype();
+		type.set_container_element_type(0, p_element_type);
+		type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+		ternary->set_datatype(type);
+	}
+}
+
+void GDScriptAnalyzer::update_dictionary_expression_element_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_key_element_type, const GDScriptParser::DataType &p_value_element_type) {
+	if (p_expression == nullptr) {
+		return;
+	}
+	if (p_expression->type == GDScriptParser::Node::DICTIONARY) {
+		update_dictionary_literal_element_type(static_cast<GDScriptParser::DictionaryNode *>(p_expression), p_key_element_type, p_value_element_type);
+	} else if (p_expression->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+		GDScriptParser::TernaryOpNode *ternary = static_cast<GDScriptParser::TernaryOpNode *>(p_expression);
+		update_dictionary_expression_element_type(ternary->true_expr, p_key_element_type, p_value_element_type);
+		update_dictionary_expression_element_type(ternary->false_expr, p_key_element_type, p_value_element_type);
+		GDScriptParser::DataType type = ternary->get_datatype();
+		type.set_container_element_type(0, p_key_element_type);
+		type.set_container_element_type(1, p_value_element_type);
+		type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+		ternary->set_datatype(type);
+	}
+}
+
 void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assignment) {
 	reduce_expression(p_assignment->assigned_value);
 
@@ -2962,10 +2990,11 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 	}
 
 	// Check if assigned value is an array/dictionary literal, so we can make it a typed container too if appropriate.
-	if (p_assignment->assigned_value->type == GDScriptParser::Node::ARRAY && assignee_type.is_hard_type() && assignee_type.has_container_element_type(0)) {
-		update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_assignment->assigned_value), assignee_type.get_container_element_type(0));
-	} else if (p_assignment->assigned_value->type == GDScriptParser::Node::DICTIONARY && assignee_type.is_hard_type() && assignee_type.has_container_element_types()) {
-		update_dictionary_literal_element_type(static_cast<GDScriptParser::DictionaryNode *>(p_assignment->assigned_value),
+	if (assignee_type.is_hard_type() && assignee_type.has_container_element_type(0)) {
+		update_array_expression_element_type(p_assignment->assigned_value, assignee_type.get_container_element_type(0));
+	}
+	if (assignee_type.is_hard_type() && assignee_type.has_container_element_types()) {
+		update_dictionary_expression_element_type(p_assignment->assigned_value,
 				assignee_type.get_container_element_type_or_variant(0), assignee_type.get_container_element_type_or_variant(1));
 	}
 
@@ -3251,14 +3280,15 @@ const char *check_for_renamed_identifier(String identifier, GDScriptParser::Node
 
 void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_await, bool p_is_root) {
 	bool all_is_constant = true;
-	HashMap<int, GDScriptParser::ArrayNode *> arrays; // For array literal to potentially type when passing.
-	HashMap<int, GDScriptParser::DictionaryNode *> dictionaries; // Same, but for dictionaries.
+	HashMap<int, GDScriptParser::ExpressionNode *> arrays;
+	HashMap<int, GDScriptParser::ExpressionNode *> dictionaries;
 	for (int i = 0; i < p_call->arguments.size(); i++) {
 		reduce_expression(p_call->arguments[i]);
-		if (p_call->arguments[i]->type == GDScriptParser::Node::ARRAY) {
-			arrays[i] = static_cast<GDScriptParser::ArrayNode *>(p_call->arguments[i]);
-		} else if (p_call->arguments[i]->type == GDScriptParser::Node::DICTIONARY) {
-			dictionaries[i] = static_cast<GDScriptParser::DictionaryNode *>(p_call->arguments[i]);
+		if (p_call->arguments[i]->type == GDScriptParser::Node::ARRAY || p_call->arguments[i]->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+			arrays[i] = p_call->arguments[i];
+		}
+		if (p_call->arguments[i]->type == GDScriptParser::Node::DICTIONARY || p_call->arguments[i]->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+			dictionaries[i] = p_call->arguments[i];
 		}
 		all_is_constant = all_is_constant && p_call->arguments[i]->is_constant;
 	}
@@ -3645,18 +3675,18 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 
 		// If the function requires typed arrays we must make literals be typed.
-		for (const KeyValue<int, GDScriptParser::ArrayNode *> &E : arrays) {
+		for (const KeyValue<int, GDScriptParser::ExpressionNode *> &E : arrays) {
 			int index = E.key;
 			if (index < par_types.size() && par_types.get(index).is_hard_type() && par_types.get(index).has_container_element_type(0)) {
-				update_array_literal_element_type(E.value, par_types.get(index).get_container_element_type(0));
+				update_array_expression_element_type(E.value, par_types.get(index).get_container_element_type(0));
 			}
 		}
-		for (const KeyValue<int, GDScriptParser::DictionaryNode *> &E : dictionaries) {
+		for (const KeyValue<int, GDScriptParser::ExpressionNode *> &E : dictionaries) {
 			int index = E.key;
 			if (index < par_types.size() && par_types.get(index).is_hard_type() && par_types.get(index).has_container_element_types()) {
 				GDScriptParser::DataType key = par_types.get(index).get_container_element_type_or_variant(0);
 				GDScriptParser::DataType value = par_types.get(index).get_container_element_type_or_variant(1);
-				update_dictionary_literal_element_type(E.value, key, value);
+				update_dictionary_expression_element_type(E.value, key, value);
 			}
 		}
 		validate_call_arg(par_types, default_arg_count, method_flags.has_flag(METHOD_FLAG_VARARG), p_call);
@@ -3805,12 +3835,12 @@ void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {
 		}
 	}
 
-	if (p_cast->operand->type == GDScriptParser::Node::ARRAY && cast_type.has_container_element_type(0)) {
-		update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_cast->operand), cast_type.get_container_element_type(0));
+	if (cast_type.has_container_element_type(0)) {
+		update_array_expression_element_type(p_cast->operand, cast_type.get_container_element_type(0));
 	}
 
-	if (p_cast->operand->type == GDScriptParser::Node::DICTIONARY && cast_type.has_container_element_types()) {
-		update_dictionary_literal_element_type(static_cast<GDScriptParser::DictionaryNode *>(p_cast->operand),
+	if (cast_type.has_container_element_types()) {
+		update_dictionary_expression_element_type(p_cast->operand,
 				cast_type.get_container_element_type_or_variant(0), cast_type.get_container_element_type_or_variant(1));
 	}
 

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -145,7 +145,9 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType get_operation_type(Variant::Operator p_operation, const GDScriptParser::DataType &p_a, bool &r_valid, const GDScriptParser::Node *p_source);
 	void update_const_expression_builtin_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_type, const char *p_usage, bool p_is_cast = false);
 	void update_array_literal_element_type(GDScriptParser::ArrayNode *p_array, const GDScriptParser::DataType &p_element_type);
+	void update_array_expression_element_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_element_type);
 	void update_dictionary_literal_element_type(GDScriptParser::DictionaryNode *p_dictionary, const GDScriptParser::DataType &p_key_element_type, const GDScriptParser::DataType &p_value_element_type);
+	void update_dictionary_expression_element_type(GDScriptParser::ExpressionNode *p_expression, const GDScriptParser::DataType &p_key_element_type, const GDScriptParser::DataType &p_value_element_type);
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false, const GDScriptParser::Node *p_source_node = nullptr);
 	bool is_type_compatible_strict_collections(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source);
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin = nullptr);

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_assignment.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_assignment.gd
@@ -1,0 +1,9 @@
+func test() -> void:
+	var condition: bool = true
+	var data: Array[int] = []
+	data = [0,1] if condition else [8,9]
+
+	Utils.check(data.get_typed_builtin() == TYPE_INT)
+	Utils.check(data[0] == 0)
+	Utils.check(data[1] == 1)
+	print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_assignment.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_assignment.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_false.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_false.gd
@@ -1,0 +1,7 @@
+func test() -> void:
+	var condition: bool = false
+	var data: Array[int] = [0,1] if condition else [8,9]
+	Utils.check(data.get_typed_builtin() == TYPE_INT)
+	Utils.check(data[0] == 8)
+	Utils.check(data[1] == 9)
+	print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_false.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_false.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_true.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_true.gd
@@ -1,0 +1,7 @@
+func test() -> void:
+	var condition: bool = true
+	var data: Array[int] = [0,1] if condition else [8,9]
+	Utils.check(data.get_typed_builtin() == TYPE_INT)
+	Utils.check(data[0] == 0)
+	Utils.check(data[1] == 1)
+	print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_true.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_array_ternary_initializer_true.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_false.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_false.gd
@@ -1,0 +1,16 @@
+func test() -> void:
+	var condition: bool = false
+
+	var data: Dictionary[String, int] = {
+		old = 0,
+		new = 1,
+	} if condition else {
+		old = 8,
+		new = 9,
+	}
+
+	Utils.check(data.get_typed_key_builtin() == TYPE_STRING)
+	Utils.check(data.get_typed_value_builtin() == TYPE_INT)
+	Utils.check(data["old"] == 8)
+	Utils.check(data["new"] == 9)
+	print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_false.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_false.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_true.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_true.gd
@@ -1,0 +1,16 @@
+func test() -> void:
+	var condition: bool = true
+
+	var data: Dictionary[String, int] = {
+		old = 0,
+		new = 1,
+	} if condition else {
+		old = 8,
+		new = 9,
+	}
+
+	Utils.check(data.get_typed_key_builtin() == TYPE_STRING)
+	Utils.check(data.get_typed_value_builtin() == TYPE_INT)
+	Utils.check(data["old"] == 0)
+	Utils.check(data["new"] == 1)
+	print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_true.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_dictionary_ternary_initializer_true.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Allows a typed Array/Dictionary var to be defined using a ternary operator. Variable assignment using ternary expressions was already functional when assigning to existing variables or initializing untyped Array/Dictionary variables, this just adds support for initializing typed variables. 

Fixes https://github.com/godotengine/godot/issues/110628. 

Added unit tests as well.