### PR TITLE
Fix backspace being unable to delete pre-existing text in any input field when using a soft keyboard on Android.

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotEditText.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotEditText.java
@@ -239,6 +239,14 @@ public class GodotEditText extends EditText {
 			return mRenderView.getInputHandler().onKeyDown(keyCode, keyEvent);
 		}
 
+		// If EditText is empty, super.onKeyDown won't modify the Editable,
+		// so beforeTextChanged won't fire and Godot never receives the DEL event.
+		// Forward it directly in that case.
+		if (keyCode == KeyEvent.KEYCODE_DEL && length() == 0) {
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_DEL, 0, 0, true, false);
+			return true;
+		}
+
 		// pass event to godot in special cases
 		if (needHandlingInGodot(keyCode, keyEvent) && mRenderView.getInputHandler().onKeyDown(keyCode, keyEvent)) {
 			return true;
@@ -259,6 +267,12 @@ public class GodotEditText extends EditText {
 		// If this is a BACK key and we don't have focus anymore, forward to render view
 		if (keyCode == KeyEvent.KEYCODE_BACK && !hasFocus()) {
 			return mRenderView.getInputHandler().onKeyUp(keyCode, keyEvent);
+		}
+
+		// Paired release event for the KEYCODE_DEL press forwarded in onKeyDown.
+		if (keyCode == KeyEvent.KEYCODE_DEL && length() == 0) {
+			mRenderView.getInputHandler().handleKeyEvent(KeyEvent.KEYCODE_DEL, 0, 0, false, false);
+			return true;
 		}
 
 		if (needHandlingInGodot(keyCode, keyEvent) && mRenderView.getInputHandler().onKeyUp(keyCode, keyEvent)) {


### PR DESCRIPTION
When a virtual keyboard is shown, GodotEditText is seeded with only
the text before the cursor (mOriginText). The TextWatcher in
GodotTextInputWrapper relies on this content changing to detect
backspace presses and forward KEYCODE_DEL to the engine.

Once the user backspaces through all the seeded content, the EditText
becomes empty. Any further backspace press (sent via sendKeyEvent by
the soft keyboard) calls super.onKeyDown(KEYCODE_DEL) on an empty
EditText, which changes nothing, so beforeTextChanged() never fires
and the engine receives no DEL event.

Result:
- Characters typed in the current session are deletable
- Pre-existing text before the cursor can't be deleted
- Workaround: re-tap the field (triggers showKeyboard() again,
  reseeding the EditText)

Confirmed with Unexpected Keyboard (uses sendKeyEvent for backspace),
Hacker's Keyboard, and Samsung Keyboard.

### The fix
Forward KEYCODE_DEL directly to the engine inside onKeyDown() when
the EditText is empty. This is safe because:
- beforeTextChanged() cannot fire on an empty EditText, so there is
  no risk of double DEL events.
- If the cursor is already at position 0, the engine ignores the
  event gracefully, same as any other editor.

### Testing
Open any TextEdit or LineEdit node on Android, try to move the cursor forward using the soft keyboard arrows or by sliding on the keyboard to the right on Samsung Keyboard. Type some text, then backspace past what you typed and into the original content. Should
now delete continuously without requiring a re-tap.

Fixes for Android #72969

Related: #68338