### PR TITLE
Add error messages for disabled ETC2/ASTC texture compression on Web and Apple Embedded export

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2291,6 +2291,7 @@ bool EditorExportPlatformAppleEmbedded::has_valid_project_configuration(const Re
 	}
 
 	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
+		err += TTR("Cannot export for embedded Apple devices if ETC2/ASTC texture format is disabled. Enable it in the Project Settings (Rendering > Textures > VRAM Compression > Import ETC2 ASTC).") + "\n";
 		valid = false;
 	}
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -470,6 +470,7 @@ bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorEx
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
+			err += TTR("Cannot export for Web if ETC2/ASTC texture format is disabled. Enable it in the Project Settings (Rendering > Textures > VRAM Compression > Import ETC2 ASTC).") + "\n";
 			valid = false;
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119803

Fixes silent ETC2/ASTC texture compression validation errors on Web and Apple Embedded export platforms. When `ResourceImporterTextureSettings::should_import_etc2_astc()` returns `false`, these platforms set `valid = false` in their `has_valid_project_configuration()` methods without appending any explanatory error message, producing blank/cryptic validation errors in the export dialog.

**Note:** This is the remaining gap after the Android fix (PR #117341, FarizzDev, merged Apr 2026, milestone 4.7) and macOS fix (PR #86769, StagnationPoint, merged Jan 2024, milestone 4.3). This PR brings the two remaining platforms into consistency with macOS and Android.

## Changes

### Two commits, one per platform:

| Commit | File | Change |
|--------|------|--------|
| 1 | `platform/web/export/export_plugin.cpp` | Add `TTR()` error message before `valid = false` |
| 2 | `editor/export/editor_export_platform_apple_embedded.cpp` | Add `TTR()` error message before `valid = false` |

Each commit adds a single line following this pattern (matching the existing macOS and Android implementations):

```cpp
err += TTR("Cannot export for <Platform> if ETC2/ASTC texture format is disabled. "
           "Enable it in the Project Settings (Rendering > Textures > VRAM Compression > "
           "Import ETC2 ASTC).") + "\n";
valid = false;
```

### What does NOT change

- No API changes
- No behavior changes (the `valid = false` is still set; the export is still blocked)
- Only the error message is added, providing users with a clear explanation of why the export is blocked and how to fix it

## Testing

- **Verification**: Build Godot with patches applied. Disable ETC2/ASTC in Project Settings. Open Export dialog. Confirm the error message appears instead of a blank validation error.
- **Verified on**: Web and Apple Embedded export presets
- **Reference comparison**: macOS and Android export presets confirm the same pattern works correctly (PR #86769, PR #117341)
- **No regressions**: Adding an error string before `valid = false` cannot affect exports that already pass validation

## Additional information

**Rationale for separate commits:** Each commit addresses a different platform and file, making cherry-picking and backporting straightforward.

**Related prior work:**
- Issue #119803 — tracks the remaining gap (Web + Apple Embedded)
- PR #86769 (StagnationPoint, Jan 2024) — macOS fix (same pattern, milestone 4.3)
- PR #117341 (FarizzDev, Apr 2026) — Android fix (same pattern, milestone 4.7)

**Code owners affected:**
- `platform/web/` — `@godotengine/web`
- `editor/export/` — `@godotengine/editor`
- `drivers/apple_embedded/` — `@godotengine/ios`

**AI disclosure:** This contribution was authored with assistance from an AI coding agent (OpenCode+DeepSeek-v4-Flash), which helped with root cause analysis and patch drafting. All code changes were requested, reviewed and tested by the author.
