### PR TITLE
Allow metadata names of Object type to support Unicode identifiers.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1033,7 +1033,7 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (E) {
 		E->value = p_value;
 	} else {
-		ERR_FAIL_COND_MSG(!p_name.string().is_valid_ascii_identifier(), vformat("Invalid metadata identifier: '%s'.", p_name));
+		ERR_FAIL_COND_MSG(!p_name.string().is_valid_unicode_identifier(), vformat("Invalid metadata identifier: '%s'.", p_name));
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 
 		const String &sname = p_name;

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -645,7 +645,7 @@
 			<param index="1" name="default" type="Variant" default="null" />
 			<description>
 				Returns the object's metadata value for the given entry [param name]. If the entry does not exist, returns [param default]. If [param default] is [code]null[/code], an error is also generated.
-				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_identifier] method.
+				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_unicode_identifier] method.
 				[b]Note:[/b] Metadata that has a name starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 			</description>
 		</method>
@@ -731,7 +731,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns [code]true[/code] if a metadata entry is found with the given [param name]. See also [method get_meta], [method set_meta] and [method remove_meta].
-				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_identifier] method.
+				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_unicode_identifier] method.
 				[b]Note:[/b] Metadata that has a name starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 			</description>
 		</method>
@@ -860,7 +860,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Removes the given entry [param name] from the object's metadata. See also [method has_meta], [method get_meta] and [method set_meta].
-				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_identifier] method.
+				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_unicode_identifier] method.
 				[b]Note:[/b] Metadata that has a name starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 			</description>
 		</method>
@@ -967,7 +967,7 @@
 			<description>
 				Adds or changes the entry [param name] inside the object's metadata. The metadata [param value] can be any [Variant], although some types cannot be serialized correctly.
 				If [param value] is [code]null[/code], the entry is removed. This is the equivalent of using [method remove_meta]. See also [method has_meta] and [method get_meta].
-				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_identifier] method.
+				[b]Note:[/b] A metadata's name must be a valid identifier as per [method StringName.is_valid_unicode_identifier] method.
 				[b]Note:[/b] Metadata that has a name starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 			</description>
 		</method>

--- a/editor/inspector/add_metadata_dialog.cpp
+++ b/editor/inspector/add_metadata_dialog.cpp
@@ -106,7 +106,7 @@ void AddMetadataDialog::_check_meta_name() {
 
 	if (meta_name.is_empty()) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
-	} else if (!meta_name.is_valid_ascii_identifier()) {
+	} else if (!meta_name.is_valid_unicode_identifier()) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
 	} else if (_existing_metas.find(meta_name)) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Allow metadata names of Object type to support Unicode identifiers.

## Additional information
Since Godot 4.0, the game engine allows developers to use non-ASCII encoding for naming script identifiers. However, the metadata property of object types still uses the old method `StringName.is_valid_identifier` to determine the legality of metadata names. This results in developers being unable to use non-ASCII characters to add metadata, for example, they cannot use Chinese, Japanese, Korean, Russian, and other characters to name metadata identifiers. But just by slightly modifying the code, metadata can use Unicode characters for naming identifiers and can be accessed and modified normally. It's unclear whether this issue was forgotten by the community, which is why metadata hasn't been updated in time?

The following screenshots are the results after modifying the source code of the game engine.

<img width="586" height="353" alt="截图 2026-05-27 15-53-53" src="https://github.com/user-attachments/assets/0a3f41f1-5375-4d63-b321-d705e1a60097" />
<img width="586" height="353" alt="截图 2026-05-27 15-54-33" src="https://github.com/user-attachments/assets/9b6fafcf-b886-43ca-828e-5412cda59b67" />
<img width="1366" height="768" alt="截图 2026-05-27 15-56-25" src="https://github.com/user-attachments/assets/a04f32ff-3f50-4ea3-953b-8766d67aa5f4" />



<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
