### PR TITLE
GDScript: Fix null-mutex crash in GDScript and GDScriptInstance destructors on shutdown

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1485,6 +1485,11 @@ void GDScript::clear() {
 }
 
 void GDScript::cancel_pending_functions(bool warn) {
+	if (!GDScriptLanguage::get_singleton()) {
+		// GDScriptLanguage has been destroyed during Main::cleanup().
+		// All pending functions have been cleared by GDScriptLanguage::finish().
+		return;
+	}
 	MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
 
 	while (SelfList<GDScriptFunctionState> *E = pending_func_states.first()) {
@@ -1522,10 +1527,14 @@ GDScript::~GDScript() {
 
 	cancel_pending_functions(false);
 
-	{
-		MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
+	if (GDScriptLanguage::get_singleton()) {
+		GDScriptLanguage::get_singleton()->mutex.lock();
+	}
 
-		script_list.remove_from_list();
+	script_list.remove_from_list();
+
+	if (GDScriptLanguage::get_singleton()) {
+		GDScriptLanguage::get_singleton()->mutex.unlock();
 	}
 }
 
@@ -2064,7 +2073,14 @@ void GDScriptInstance::reload_members() {
 }
 
 GDScriptInstance::~GDScriptInstance() {
-	MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
+	// GDScriptLanguage may have been destroyed during Main::cleanup() before
+	// this destructor runs. If so, the mutex is no longer needed since all
+	// script data has been cleared by GDScriptLanguage::finish().
+	// Use manual lock/unlock (not MutexLock RAII) to keep the mutex held
+	// for the entire destructor body regardless of null-singleton guard.
+	if (GDScriptLanguage::get_singleton()) {
+		GDScriptLanguage::get_singleton()->mutex.lock();
+	}
 
 	while (SelfList<GDScriptFunctionState> *E = pending_func_states.first()) {
 		// Order matters since clearing the stack may already cause
@@ -2080,6 +2096,10 @@ GDScriptInstance::~GDScriptInstance() {
 
 	if (script.is_valid()) {
 		script->instances.remove(&script_instance_list);
+	}
+
+	if (GDScriptLanguage::get_singleton()) {
+		GDScriptLanguage::get_singleton()->mutex.unlock();
 	}
 }
 


### PR DESCRIPTION

## What changed

Three null-singleton guards in `modules/gdscript/gdscript.cpp`:

1. **`GDScriptInstance::~GDScriptInstance()`** — Use manual `lock()`/`unlock()` instead of scoped `MutexLock`, so the mutex is held for the entire destructor body even with the null-singleton check. Addresses review feedback from @bruvzg on the previous version (PR #119800).

2. **`GDScript::cancel_pending_functions()`** — Early return when `GDScriptLanguage::get_singleton()` is null. All pending functions have been cleared by `GDScriptLanguage::finish()`.

3. **`GDScript::~GDScript()`** — Null-singleton guard for the `script_list.remove_from_list()` mutex block.

## Why this is safe

After `GDScriptLanguage::finish()` has been called (which happens before the singleton is destroyed), no GDScript code executes. The mutex is not needed during single-threaded shutdown when all script data structures have already been cleared.

## Testing

- Reproduction project from #119279 validated before patch: all methods exit with code 134 (SIGABRT)
- After fix: all methods exit cleanly with code 0
- Validated on both 4.6.3-stable and master

## Previous iteration

This is a corrected version of PR #119800 which was closed. The previous version used `MutexLock` inside an `if` block, which created a scope-narrowing issue (the lock was released at the end of the `if` block before the destructor body ran). This version uses manual lock/unlock as suggested by @bruvzg.

## AI disclosure

This contribution was authored with assistance from an AI coding agent (OpenCode+DeepSeek-v4-Flash), which helped with the root cause analysis, reproduction, and patch drafting. All code changes were reviewed and tested by the author.