### PR TITLE
Break out of Tween infinite loops in release builds

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -376,9 +376,6 @@ bool Tween::step(double p_delta) {
 	bool step_active = false;
 	total_time += rem_delta;
 
-	// Infinite-loop guard variables, used in both debug and release builds.
-	// In release builds the guard silently breaks the step instead of throwing,
-	// preventing freezes when a Tween chain accidentally produces zero-duration loops.
 	double initial_delta = rem_delta;
 	bool potential_infinite = false;
 
@@ -411,11 +408,6 @@ bool Tween::step(double p_delta) {
 					emit_signal(SNAME("loop_finished"), loops_done);
 					current_step = 0;
 					_start_tweeners();
-					// Detect infinite loop (looped without consuming any time).
-					// In debug builds we surface a hard error so the developer can fix it;
-					// in release builds we break the step silently so the running game
-					// does not freeze (observed on mobile profilers as Tween::step
-					// dominating frame time when an infinite Tween becomes zero-duration).
 					if (loops <= 0 && Math::is_equal_approx(rem_delta, initial_delta)) {
 						if (!potential_infinite) {
 							potential_infinite = true;

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -376,10 +376,11 @@ bool Tween::step(double p_delta) {
 	bool step_active = false;
 	total_time += rem_delta;
 
-#ifdef DEBUG_ENABLED
+	// Infinite-loop guard variables, used in both debug and release builds.
+	// In release builds the guard silently breaks the step instead of throwing,
+	// preventing freezes when a Tween chain accidentally produces zero-duration loops.
 	double initial_delta = rem_delta;
 	bool potential_infinite = false;
-#endif
 
 	while (running && rem_delta > 0) {
 		double step_delta = rem_delta;
@@ -410,17 +411,24 @@ bool Tween::step(double p_delta) {
 					emit_signal(SNAME("loop_finished"), loops_done);
 					current_step = 0;
 					_start_tweeners();
-#ifdef DEBUG_ENABLED
+					// Detect infinite loop (looped without consuming any time).
+					// In debug builds we surface a hard error so the developer can fix it;
+					// in release builds we break the step silently so the running game
+					// does not freeze (observed on mobile profilers as Tween::step
+					// dominating frame time when an infinite Tween becomes zero-duration).
 					if (loops <= 0 && Math::is_equal_approx(rem_delta, initial_delta)) {
 						if (!potential_infinite) {
 							potential_infinite = true;
 						} else {
 							// Looped twice without using any time, this is 100% certain infinite loop.
 							in_step = false;
+#ifdef DEBUG_ENABLED
 							ERR_FAIL_V_MSG(false, "Infinite loop detected. Check set_loops() description for more info.");
+#else
+							return false;
+#endif
 						}
 					}
-#endif
 				}
 			} else {
 				_start_tweeners();

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -416,9 +416,8 @@ bool Tween::step(double p_delta) {
 							in_step = false;
 #ifdef DEBUG_ENABLED
 							ERR_FAIL_V_MSG(false, "Infinite loop detected. Check set_loops() description for more info.");
-#else
-							return false;
 #endif
+							return false;
 						}
 					}
 				}


### PR DESCRIPTION
The infinite-loop guard in `Tween::step` (the `initial_delta` / `potential_infinite` book-keeping plus the `Math::is_equal_approx(rem_delta, initial_delta)` check) is wrapped in `#ifdef DEBUG_ENABLED`. In release builds the guard is compiled out, so a Tween with `set_loops(-1)` whose tweener returns `temp_delta = 0` makes the inner `while (running && rem_delta > 0)` loop spin forever and freezes the main thread.

This moves the two guard variables out of the debug-only block. Debug builds still hit the existing `ERR_FAIL_V_MSG`; release builds break the step with `return false`. The detection logic itself is unchanged.

No associated bug report yet — happy to open a minimal repro issue (a `set_loops(-1)` tween whose tweener returns zero delta) if that helps triage. The freeze was originally diagnosed on an Android export via simpleperf.

Disclosure: I used an LLM to help draft the commit message and the original PR description. The code change itself (moving the two `#ifdef` boundaries, +12 / -4) is mine.