### PR TITLE
Fix `PopupMenu`s keeping old size when `GraphNode` scale is changed.

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -149,7 +149,7 @@ EditorDockDragHint::EditorDockDragHint() {
 	dock_drop_highlight->set_border_width_all(Math::round(2 * EDSCALE));
 }
 
-void DockTabContainer::_pre_popup() {
+void DockTabContainer::_pre_popup(const Size2i &p_size) {
 	dock_context_popup->set_dock(get_dock(get_current_tab()));
 }
 
@@ -167,7 +167,7 @@ void DockTabContainer::_tab_rmb_clicked(int p_tab_idx) {
 
 void DockTabContainer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		connect("pre_popup_pressed", callable_mp(this, &DockTabContainer::_pre_popup));
+		connect("pre_popup_pressed", callable_mp(this, &DockTabContainer::_pre_popup).bind(Size2i()));
 		connect("child_order_changed", callable_mp(this, &DockTabContainer::update_visibility));
 	}
 }

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -73,7 +73,7 @@ class DockTabContainer : public TabContainer {
 
 	EditorDockDragHint *drag_hint = nullptr;
 
-	void _pre_popup();
+	void _pre_popup(const Size2i &p_size);
 	void _tab_rmb_clicked(int p_tab_idx);
 
 protected:

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3674,7 +3674,7 @@ bool PopupMenu::get_shrink_width() const {
 	return shrink_width;
 }
 
-void PopupMenu::_pre_popup() {
+void PopupMenu::_pre_popup(const Size2i &p_size) {
 	real_t popup_scale = 1.0;
 	bool scale_with_parent = true;
 	Node *parent_node = get_parent();
@@ -3716,6 +3716,9 @@ void PopupMenu::_pre_popup() {
 
 	set_content_scale_factor(popup_scale);
 	if (is_wrapping_controls()) {
+		if (scale_with_parent) {
+			set_size(p_size);
+		}
 		Size2 minsize = get_contents_minimum_size() * popup_scale;
 		Size2 maxsize = get_max_size();
 		if (maxsize.height > 0) {

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -265,7 +265,7 @@ class PopupMenu : public Popup {
 	bool shrink_width = true;
 
 protected:
-	virtual void _pre_popup() override;
+	virtual void _pre_popup(const Size2i &p_size) override;
 	virtual Rect2i _popup_adjust_rect() const override;
 
 	virtual void add_child_notify(Node *p_child) override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2125,7 +2125,7 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 	if (popup_rect != Rect2()) {
 		set_size(popup_rect.size);
 	}
-	_pre_popup();
+	_pre_popup(popup_rect.size);
 	if (popup_rect != Rect2i()) {
 		popup_rect.size = get_size();
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
@@ -2164,7 +2164,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	if (popup_rect != Rect2()) {
 		set_size(popup_rect.size);
 	}
-	_pre_popup();
+	_pre_popup(popup_rect.size);
 	if (popup_rect != Rect2i()) {
 		popup_rect.size = get_size();
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
@@ -2201,7 +2201,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 	if (popup_rect != Rect2()) {
 		set_size(popup_rect.size);
 	}
-	_pre_popup();
+	_pre_popup(popup_rect.size);
 	if (popup_rect != Rect2i()) {
 		popup_rect.size = get_size();
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
@@ -2217,7 +2217,7 @@ void Window::popup(const Rect2i &p_screen_rect) {
 	if (screen_rect != Rect2i()) {
 		set_size(screen_rect.size);
 	}
-	_pre_popup();
+	_pre_popup(screen_rect.size);
 	if (screen_rect != Rect2i()) {
 		screen_rect.size = get_size();
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -266,7 +266,7 @@ private:
 
 protected:
 	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i());
-	virtual void _pre_popup() {} // Called after "about_to_popup", but before window is shown.
+	virtual void _pre_popup(const Size2i &p_size) {} // Called after "about_to_popup", but before window is shown.
 	virtual Rect2i _popup_adjust_rect() const { return Rect2i(); }
 	virtual void _post_popup() {}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116835