### PR TITLE
WebRTC: Add clear_buffer method to WebRTCDataChannel

### DIFF
--- a/modules/webrtc/doc_classes/WebRTCDataChannel.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannel.xml
@@ -7,6 +7,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="clear_buffer">
+			<return type="void" />
+			<description>
+				Clears the packet buffer of this data channel.
+			</description>
+		</method>
 		<method name="close">
 			<return type="void" />
 			<description>

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -7,6 +7,11 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_clear_buffer" qualifiers="virtual required">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="_close" qualifiers="virtual required">
 			<return type="void" />
 			<description>

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -35,6 +35,7 @@
 
 void WebRTCDataChannel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("poll"), &WebRTCDataChannel::poll);
+	ClassDB::bind_method(D_METHOD("clear_buffer"), &WebRTCDataChannel::clear_buffer);
 	ClassDB::bind_method(D_METHOD("close"), &WebRTCDataChannel::close);
 
 	ClassDB::bind_method(D_METHOD("was_string_packet"), &WebRTCDataChannel::was_string_packet);

--- a/modules/webrtc/webrtc_data_channel.h
+++ b/modules/webrtc/webrtc_data_channel.h
@@ -70,6 +70,7 @@ public:
 	virtual int get_buffered_amount() const = 0;
 
 	virtual Error poll() = 0;
+	virtual void clear_buffer() = 0;
 	virtual void close() = 0;
 
 	WebRTCDataChannel();

--- a/modules/webrtc/webrtc_data_channel_extension.cpp
+++ b/modules/webrtc/webrtc_data_channel_extension.cpp
@@ -41,6 +41,7 @@ void WebRTCDataChannelExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_max_packet_size);
 
 	GDVIRTUAL_BIND(_poll);
+	GDVIRTUAL_BIND(_clear_buffer);
 	GDVIRTUAL_BIND(_close);
 
 	GDVIRTUAL_BIND(_set_write_mode, "write_mode");

--- a/modules/webrtc/webrtc_data_channel_extension.h
+++ b/modules/webrtc/webrtc_data_channel_extension.h
@@ -44,6 +44,7 @@ protected:
 
 public:
 	EXBIND0R(Error, poll);
+	EXBIND0(clear_buffer);
 	EXBIND0(close);
 
 	EXBIND1(set_write_mode, WriteMode);

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -83,6 +83,12 @@ void WebRTCDataChannelJS::_on_message(void *p_obj, const uint8_t *p_data, int p_
 	peer->queue_count++;
 }
 
+void WebRTCDataChannelJS::clear_buffer() {
+	in_buffer.clear();
+	queue_count = 0;
+	_was_string = false;
+}
+
 void WebRTCDataChannelJS::close() {
 	in_buffer.resize(0);
 	queue_count = 0;

--- a/modules/webrtc/webrtc_data_channel_js.h
+++ b/modules/webrtc/webrtc_data_channel_js.h
@@ -74,6 +74,7 @@ public:
 	virtual int get_buffered_amount() const override;
 
 	virtual Error poll() override;
+	virtual void clear_buffer() override;
 	virtual void close() override;
 
 	/** Inherited from PacketPeer: **/


### PR DESCRIPTION
Allows for manual clearing of the data channel packet buffer by calling `data_channel.clear_buffer()`, preventing unnecessary processing of irrelevant packets.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- In web exports, requestAnimationFrame stops being called when the tab goes out of focus (GH-37031). Instead of dumping "stale" packets in order, users can opt to clear the buffer to reconcile the receiver state immediately.
- Prevents buffer overflow error spam.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
