### PR TITLE
Add Frame Duration to VideoStreamPlayer

### DIFF
--- a/doc/classes/VideoStreamPlayback.xml
+++ b/doc/classes/VideoStreamPlayback.xml
@@ -15,6 +15,12 @@
 				Returns the number of audio channels.
 			</description>
 		</method>
+		<method name="_get_frame_duration" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Returns the duration of a single video frame for the current video, in seconds.
+			</description>
+		</method>
 		<method name="_get_length" qualifiers="virtual const">
 			<return type="float" />
 			<description>

--- a/doc/classes/VideoStreamPlayback.xml
+++ b/doc/classes/VideoStreamPlayback.xml
@@ -18,7 +18,7 @@
 		<method name="_get_frame_duration" qualifiers="virtual const">
 			<return type="float" />
 			<description>
-				Returns the duration of a single video frame for the current video, in seconds.
+				Override to return the duration of a single video frame for the current video, in seconds.
 			</description>
 		</method>
 		<method name="_get_length" qualifiers="virtual const">

--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -15,7 +15,7 @@
 		<method name="get_stream_frame_duration" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the duration of a single video frame from the current stream, in seconds.
+				Returns the duration of a single video frame for the current stream, in seconds.
 			</description>
 		</method>
 		<method name="get_stream_length" qualifiers="const">

--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -15,10 +15,9 @@
 		<method name="get_stream_frame_duration" qualifiers="const">
 			<return type="float" />
 			<description>
-				The frame duration of the current stream, in seconds.
+				Returns the duration of a single video frame from the current stream, in seconds.
 			</description>
 		</method>
-
 		<method name="get_stream_length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -12,6 +12,13 @@
 		<link title="Playing videos">$DOCS_URL/tutorials/animation/playing_videos.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_stream_frame_duration" qualifiers="const">
+			<return type="float" />
+			<description>
+				The frame duration of the current stream, in seconds.
+			</description>
+		</method>
+
 		<method name="get_stream_length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -640,6 +640,10 @@ bool VideoStreamPlaybackTheora::is_paused() const {
 	return paused;
 }
 
+double VideoStreamPlaybackTheora::get_frame_duration() const {
+	return frame_duration;
+}
+
 double VideoStreamPlaybackTheora::get_length() const {
 	return stream_length;
 }

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -134,6 +134,7 @@ public:
 	virtual void set_paused(bool p_paused) override;
 	virtual bool is_paused() const override;
 
+	virtual double get_frame_duration() const override;
 	virtual double get_length() const override;
 
 	virtual double get_playback_position() const override;

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -453,6 +453,14 @@ String VideoStreamPlayer::get_stream_name() const {
 	return stream->get_name();
 }
 
+
+double VideoStreamPlayer::get_stream_frame_duration() const {
+	if (playback.is_null()) {
+		return 0;
+	}
+	return playback->get_frame_duration();
+}
+
 double VideoStreamPlayer::get_stream_length() const {
 	if (playback.is_null()) {
 		return 0;
@@ -553,6 +561,7 @@ void VideoStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_audio_track"), &VideoStreamPlayer::get_audio_track);
 
 	ClassDB::bind_method(D_METHOD("get_stream_name"), &VideoStreamPlayer::get_stream_name);
+	ClassDB::bind_method(D_METHOD("get_stream_frame_duration"), &VideoStreamPlayer::get_stream_frame_duration);
 	ClassDB::bind_method(D_METHOD("get_stream_length"), &VideoStreamPlayer::get_stream_length);
 
 	ClassDB::bind_method(D_METHOD("set_stream_position", "position"), &VideoStreamPlayer::set_stream_position);

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -453,7 +453,6 @@ String VideoStreamPlayer::get_stream_name() const {
 	return stream->get_name();
 }
 
-
 double VideoStreamPlayer::get_stream_frame_duration() const {
 	if (playback.is_null()) {
 		return 0;

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -105,6 +105,7 @@ public:
 	float get_speed_scale() const;
 
 	String get_stream_name() const;
+	double get_stream_frame_duration() const;
 	double get_stream_length() const;
 	double get_stream_position() const;
 	void set_stream_position(double p_position);

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -41,6 +41,7 @@ void VideoStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_is_playing);
 	GDVIRTUAL_BIND(_set_paused, "paused");
 	GDVIRTUAL_BIND(_is_paused);
+	GDVIRTUAL_BIND(_get_frame_duration);
 	GDVIRTUAL_BIND(_get_length);
 	GDVIRTUAL_BIND(_get_playback_position);
 	GDVIRTUAL_BIND(_seek, "time");
@@ -85,6 +86,14 @@ bool VideoStreamPlayback::is_paused() const {
 	return false;
 }
 
+double VideoStreamPlayback::get_frame_duration() const {
+	double ret;
+	if (GDVIRTUAL_CALL(_get_frame_duration, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
 double VideoStreamPlayback::get_length() const {
 	double ret;
 	if (GDVIRTUAL_CALL(_get_length, ret)) {
@@ -92,6 +101,7 @@ double VideoStreamPlayback::get_length() const {
 	}
 	return 0;
 }
+
 
 double VideoStreamPlayback::get_playback_position() const {
 	double ret;

--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -102,7 +102,6 @@ double VideoStreamPlayback::get_length() const {
 	return 0;
 }
 
-
 double VideoStreamPlayback::get_playback_position() const {
 	double ret;
 	if (GDVIRTUAL_CALL(_get_playback_position, ret)) {

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -49,6 +49,7 @@ protected:
 	GDVIRTUAL0RC(bool, _is_playing);
 	GDVIRTUAL1(_set_paused, bool);
 	GDVIRTUAL0RC(bool, _is_paused);
+	GDVIRTUAL0RC(double, _get_frame_duration);
 	GDVIRTUAL0RC(double, _get_length);
 	GDVIRTUAL0RC(double, _get_playback_position);
 	GDVIRTUAL1(_seek, double);
@@ -71,6 +72,8 @@ public:
 
 	virtual void set_paused(bool p_paused);
 	virtual bool is_paused() const;
+
+	virtual double get_frame_duration() const;
 
 	virtual double get_length() const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Adds the capability to get the frame duration so it's possible to calculate the video frames per second.
- It helps to automate video processing and Full-Motion Video games (FMV) creation.

## Additional information

- This PR just exposes the existing, but not used, "frame_duration" property from the "VideoStreamPlaybackTheora" class.
- Adds "get_stream_frame_duration" method to "VideoStreamPlayer" so you can get FPS with "1/get_stream_frame_duration()".

Usage demo (Live on Twitch 😺):
<video src="https://github.com/user-attachments/assets/f1875943-c7b8-40ed-bbfb-e0e877352831">
</video>

