### PR TITLE
Clarify CanvasItem modulate docs

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -666,13 +666,13 @@
 			The material applied to this [CanvasItem].
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)" keywords="color, colour">
-			The color applied to this [CanvasItem]. This property does affect child [CanvasItem]s, unlike [member self_modulate] which only affects the node itself.
+			The color multiplied with this [CanvasItem]'s rendered color. This property is inherited by child [CanvasItem]s, unlike [member self_modulate], which only affects the node itself.
 		</member>
 		<member name="oversampling_with_scale" type="int" setter="set_oversampling_with_scale" getter="get_oversampling_with_scale" enum="CanvasItem.OversamplingWithScale" default="0">
 			If enabled, oversampling for this [CanvasItem] is automatically adjusted with scale.
 		</member>
 		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" default="Color(1, 1, 1, 1)">
-			The color applied to this [CanvasItem]. This property does [b]not[/b] affect child [CanvasItem]s, unlike [member modulate] which affects both the node itself and its children.
+			The color multiplied with this [CanvasItem]'s rendered color. This property does [b]not[/b] affect child [CanvasItem]s, unlike [member modulate], which affects both the node itself and its children.
 			[b]Note:[/b] Internal children are also not affected by this property (see the [code]include_internal[/code] parameter in [method Node.add_child]). For built-in nodes this includes sliders in [ColorPicker], and the tab bar in [TabContainer].
 		</member>
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled" default="false">


### PR DESCRIPTION
Clarifies that `CanvasItem.modulate` and `CanvasItem.self_modulate` are multiplied with the rendered color, rather than only being generally "applied".

Closes #117992.

Validation:
- `xmllint --noout doc/classes/CanvasItem.xml`
- `git diff --check`

Disclosure: AI tools were used to inspect issue context and review wording. The final documentation change and validation were manually checked.