### PR TITLE
Add missing range to `zstd_supercompression_level` setting

### DIFF
--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -44,7 +44,7 @@ void initialize_basis_universal_module(ModuleInitializationLevel p_level) {
 #ifdef TOOLS_ENABLED
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/basis_universal/rdo_dict_size", PROPERTY_HINT_RANGE, "64,65536,1"), 1024);
 	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "rendering/textures/basis_universal/zstd_supercompression"), true);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/basis_universal/zstd_supercompression_level"), 6);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/basis_universal/zstd_supercompression_level", PROPERTY_HINT_RANGE, "1,22,1"), 6);
 
 	Image::basis_universal_packer = basis_universal_packer;
 #endif


### PR DESCRIPTION
The documentation says the value can range from 1 to 22, but in code, the field is unlocked for pretty much any integer.

Probably missed from #105080.