### PR TITLE
Localization support for SpinBox's prefix and suffix

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -238,6 +238,8 @@ PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlug
 	// Scene Node's properties containing strings that will be fetched for translation.
 	lookup_properties.insert("text");
 	lookup_properties.insert("*_text");
+	lookup_properties.insert("prefix");
+	lookup_properties.insert("suffix");
 	lookup_properties.insert("popup/*/text");
 	lookup_properties.insert("title");
 	lookup_properties.insert("filters");

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -109,11 +109,11 @@ void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	last_text_value = value;
 
 	if (!line_edit->is_editing()) {
-		if (!prefix.is_empty()) {
-			value = prefix + " " + value;
+		if (!prefix_translated.is_empty()) {
+			value = prefix_translated + " " + value;
 		}
-		if (!suffix.is_empty()) {
-			value += " " + suffix;
+		if (!suffix_translated.is_empty()) {
+			value += " " + suffix_translated;
 		}
 	}
 
@@ -153,7 +153,7 @@ void SpinBox::_text_submitted(const String &p_string) {
 	text = text.replace_char(';', ',');
 	text = TranslationServer::get_singleton()->parse_number(text, lang);
 	// Ignore the prefix and suffix in the expression.
-	text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
+	text = text.trim_prefix(prefix_translated + " ").trim_suffix(" " + suffix_translated);
 
 	Error err = expr->parse(text);
 
@@ -161,7 +161,7 @@ void SpinBox::_text_submitted(const String &p_string) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = p_string;
 		text = TranslationServer::get_singleton()->parse_number(text, lang);
-		text = text.trim_prefix(prefix + " ").trim_suffix(" " + suffix);
+		text = text.trim_prefix(prefix_translated + " ").trim_suffix(" " + suffix_translated);
 
 		err = expr->parse(text);
 		if (err != OK) {
@@ -533,6 +533,9 @@ void SpinBox::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
+			prefix_translated = atr(prefix);
+			suffix_translated = atr(suffix);
+			_update_text();
 			queue_redraw();
 		} break;
 
@@ -564,6 +567,7 @@ void SpinBox::set_suffix(const String &p_suffix) {
 	}
 
 	suffix = p_suffix;
+	suffix_translated = atr(suffix);
 	_update_text();
 }
 
@@ -577,6 +581,7 @@ void SpinBox::set_prefix(const String &p_prefix) {
 	}
 
 	prefix = p_prefix;
+	prefix_translated = atr(prefix);
 	_update_text();
 }
 

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -76,7 +76,9 @@ class SpinBox : public Range {
 	void _text_changed(const String &p_string);
 
 	String prefix;
+	String prefix_translated;
 	String suffix;
+	String suffix_translated;
 	String last_text_value;
 	double custom_arrow_step = 0.0;
 	bool custom_arrow_round = false;


### PR DESCRIPTION
## Summary of Changes

This adds supports for localization with Godot's built-in system of `SpinBox`'s `prefix` and `suffix`.

## Motivation

I was learning how Godot's localization system works by applying it to [my current project](https://gitlab.com/leroymilo/open-love-hue) when I noticed that the prefixes of my `SpinBox` controls would not appear in the .pot template file generated.
After searching about this in the issues an proposals, I decided to look how complicated it would be to implement it in order to make a proposal: https://github.com/godotengine/godot-proposals/issues/14923
The workaround would require adding translation keys manually to the .pot template, localize prefix and suffix on scene ready, and handle NOTIFICATION_TRANSLATION_CHANGED to update them.

## Technical Overview

The change is very simple, but this is my first PR so please pardon me if this is too detailed. It adds:
- "prefix" and "suffix" to the properties searched by the translation parser plugin (might be overkill since they only exist for `SpinBox`, but I don't know enough to see another way)
- `prefix_translated` and `suffix_translated` to the `SpinBox` class
- handling of translation in setters
- text editing and submitting with translated prefix and suffix
- handling of NOTIFICATION_TRANSLATION_CHANGED

## Testing

Built with no errors, succesfully tested in the mentioned project: translation keys are added to the .pot template, and translations are applied, as well as updated on locale changed.

## Discussion
 
I looked at the implementation of `LineEdit.placeholder_text` to see what needs to be done for a localizable field, so I might have missed something that I'm not aware of, but I'm pretty confident that the current changes to `SpinBox` have no issue.
I'm a bit less confident about adding stuff to the translation plugin's `lookup_properties`, although I couldn't think of anything else "prefix" and "suffix" refer to.
I wasn't able to setup my IDE for code completion and style checks since I'm using VSCodium with clangd (no MS C/C++ extension...), but I would be surprised a change this small breaks style guidelines.

In the end, I strongly believe that these changes are much simpler than a potential workaround with manual .pot editing and additional gdscript overhead.