### PR TITLE
Change type validation error messages to be more readable

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -235,7 +235,7 @@ void Array::assign(const Array &p_array) {
 		for (int i = 0; i < size; i++) {
 			const Variant &element = source[i];
 			if (element.get_type() != Variant::NIL && (element.get_type() != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
 			}
 		}
 		_p->array = p_array._p->array;
@@ -258,11 +258,11 @@ void Array::assign(const Array &p_array) {
 				continue;
 			}
 			if (!Variant::can_convert_strict(value->get_type(), typed.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
 			}
 			Callable::CallError ce;
 			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
 		}
 	} else if (Variant::can_convert_strict(source_typed.type, typed.type)) {
 		// from primitives to different convertible primitives
@@ -270,10 +270,10 @@ void Array::assign(const Array &p_array) {
 			const Variant *value = source + i;
 			Callable::CallError ce;
 			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
 	}
 
 	_p->array = array;
@@ -408,7 +408,7 @@ int Array::find_custom(const Callable &p_callable, int p_from) const {
 			ERR_FAIL_V_MSG(ret, vformat("Error calling method from 'find_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
 		}
 
-		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, ret, "Error on method from 'find_custom': Return type of callable must be boolean.");
+		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, ret, "Error calling method from 'find_custom': Return type of callable must be boolean.");
 		if (res.operator bool()) {
 			return i;
 		}
@@ -468,7 +468,7 @@ int Array::rfind_custom(const Callable &p_callable, int p_from) const {
 			ERR_FAIL_V_MSG(-1, vformat("Error calling method from 'rfind_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
 		}
 
-		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, -1, "Error on method from 'rfind_custom': Return type of callable must be boolean.");
+		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, -1, "Error calling method from 'rfind_custom': Return type of callable must be boolean.");
 		if (res.operator bool()) {
 			return i;
 		}
@@ -496,7 +496,7 @@ int Array::count(const Variant &p_value) const {
 
 bool Array::has(const Variant &p_value) const {
 	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "use 'has'"), false);
+	ERR_FAIL_COND_V(!_p->typed.validate(value, "use 'has' with"), false);
 
 	return find(value) != -1;
 }
@@ -755,13 +755,13 @@ void Array::shuffle() {
 
 int Array::bsearch(const Variant &p_value, bool p_before) const {
 	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search"), -1);
+	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search using"), -1);
 	return _p->array.span().bisect<_ArrayVariantSort>(value, p_before);
 }
 
 int Array::bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before) const {
 	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "custom binary search"), -1);
+	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search with a custom comparator using"), -1);
 
 	return _p->array.bsearch_custom<CallableComparator>(value, p_before, p_callable);
 }

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -70,7 +70,7 @@ private:
 			}
 
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of type '%s'.", String(p_operation), Variant::get_type_name(inout_variant.get_type()), where, Variant::get_type_name(type)));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(inout_variant.get_type()), where, Variant::get_type_name(type)));
 			} else {
 				return false;
 			}
@@ -112,7 +112,13 @@ private:
 		const StringName &obj_class = object->get_class_name();
 		if (obj_class != class_name && !object->is_class(class_name)) {
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), obj_class, where, String(class_name)));
+				String object_class_name = object->get_class();
+				if (const Ref<Script> other_script = object->get_script(); other_script.is_valid()) {
+					if (const StringName &script_global_name = other_script->get_global_name(); !script_global_name.is_empty()) {
+						object_class_name = script_global_name;
+					}
+				}
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object of type '%s' into a %s of incompatible type '%s'.", String(p_operation), object_class_name, where, String(class_name)));
 			} else {
 				return false;
 			}
@@ -127,14 +133,14 @@ private:
 		// Check base script..
 		if (other_script.is_null()) {
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s of incompatible type '%s'.", String(p_operation), String(where), String(script->get_class_name())));
 			} else {
 				return false;
 			}
 		}
 		if (!other_script->inherits_script(script)) {
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s of incompatible type '%s'.", String(p_operation), String(where), String(script->get_class_name())));
 			} else {
 				return false;
 			}

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array.out
@@ -3,7 +3,7 @@ GDTEST_RUNTIME_ERROR
 >> SCRIPT ERROR at runtime/errors/typed_array.gd:10 on subtest_assign_basic_to_typed(): Trying to assign an array of type "Array" to a variable of type "Array[int]".
 >> SCRIPT ERROR at runtime/errors/typed_array.gd:15 on subtest_assign_basic_to_differently_typed(): Trying to assign an array of type "Array[float]" to a variable of type "Array[int]".
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to set an object into a TypedArray, that does not inherit from 'GDScript'.
+>>   Attempted to set an object into a TypedArray of incompatible type 'GDScript'.
 >> ERROR: Condition "!_p->typed.validate(value, "set")" is true.
 end subtest_assign_wrong_to_typed
 >> SCRIPT ERROR at runtime/errors/typed_array.gd:24 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_array.gd)'. The array of argument 1 (Array) does not have the same element type as the expected typed array argument.

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary.out
@@ -2,16 +2,16 @@ GDTEST_RUNTIME_ERROR
 ~~ WARNING at line 45: (UNSAFE_CALL_ARGUMENT) The argument 1 of the function "expect_typed()" requires the subtype "Dictionary[int, int]" but the supertype "Variant" was provided.
 >> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:16 on subtest_assign_basic_to_typed(): Trying to assign a dictionary of type "Dictionary" to a variable of type "Dictionary[int, int]".
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to set a variable of type 'String' into a TypedDictionary.Key of type 'int'.
+>>   Attempted to set a variable of type 'String' into a TypedDictionary.Key of incompatible type 'int'.
 >> ERROR: Condition "!_p->typed_key.validate(key, "set")" is true. Returning: false
 >> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:21 on subtest_assign_basic_to_differently_typed_key(): Invalid assignment of property or key 'key' with value of type 'int' on a base object of type 'Dictionary[int, int]'.
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to set a variable of type 'String' into a TypedDictionary.Value of type 'int'.
+>>   Attempted to set a variable of type 'String' into a TypedDictionary.Value of incompatible type 'int'.
 >> ERROR: Condition "!_p->typed_value.validate(value, "set")" is true. Returning: false
 >> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:26 on subtest_assign_basic_to_differently_typed_value(): Invalid assignment of property or key '0' with value of type 'String' on a base object of type 'Dictionary[int, int]'.
 >> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:31 on subtest_assign_differently_typed(): Trying to assign a dictionary of type "Dictionary[float, float]" to a variable of type "Dictionary[int, int]".
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to set an object into a TypedDictionary.Key, that does not inherit from 'GDScript'.
+>>   Attempted to set an object into a TypedDictionary.Key of incompatible type 'GDScript'.
 >> ERROR: Condition "!_p->typed_key.validate(key, "set")" is true. Returning: false
 end subtest_assign_wrong_to_typed
 >> SCRIPT ERROR at runtime/errors/typed_dictionary.gd:40 on subtest_pass_basic_to_typed(): Invalid type in function 'expect_typed' in base 'RefCounted (typed_dictionary.gd)'. The dictionary of argument 1 (Dictionary) does not have the same element type as the expected typed dictionary argument.


### PR DESCRIPTION
## What problem(s) does this PR solve?

A lot of type validation error messages generated by TypedArray are confusing and have inconsistent style and grammar. The main focus here was bsearch_custom, which generates this totally gramatically correct sentence `Attempted to custom binary search an object into a TypedArray, that does not inherit from 'GDScript'.`, but I've also tweaked the template slightly to be maybe easier to read generally. I unified the language between `Object`s and other `Variant`s to the more general 'incompatible type', as I think it highlights what is causing the error more clearly. A few other error messages just read poorly, like the one for `has`.

## Additional information

note: Ivorforce said it was okay to open this PR without an associated issue or proposal on Discord
<img width="447" height="52" alt="image" src="https://github.com/user-attachments/assets/6027057e-e55d-4504-ad9c-0fa048d45f56" />


Before and after:
<img width="2379" height="255" alt="image" src="https://github.com/user-attachments/assets/0c47576d-3f97-4b28-b698-c8382764c3c1" />

Test script:
```gdscript
extends Control

func _ready() -> void:
	var arr: Array[Node3D]
	var r := arr.bsearch_custom(self, func(a, b): return false)
	arr.push_back(self)
	arr.bsearch(self)
	arr.assign([self])
	arr.push_back(5)
	arr.has(self)
	var d: Dictionary[int, Node2D]
	d.set(func(): pass, Node2D.new())
	d.set(5, self)
```

```diff
-Attempted to custom binary search an object of type 'Control' into a TypedArray, which does not inherit from 'Node3D'.
+Attempted to binary search with a custom comparator using an object of type 'Control' into a TypedArray of incompatible type 'Node3D'.
-Attempted to push_back an object of type 'Control' into a TypedArray, which does not inherit from 'Node3D'.
+Attempted to push_back an object of type 'Control' into a TypedArray of incompatible type 'Node3D'.
-Attempted to binary search an object of type 'Control' into a TypedArray, which does not inherit from 'Node3D'.
+Attempted to binary search using an object of type 'Control' into a TypedArray of incompatible type 'Node3D'.
-Attempted to assign an object of type 'Control' into a TypedArray, which does not inherit from 'Node3D'.
+Attempted to assign an object of type 'Control' into a TypedArray of incompatible type 'Node3D'.
-Unable to convert array index 0 from "Object" to "Object".
+Unable to convert array index 0 from 'Object' to 'Object'.
-Attempted to push_back a variable of type 'int' into a TypedArray of type 'Object'.
+Attempted to push_back a variable of type 'int' into a TypedArray of incompatible type 'Object'.
-Attempted to use 'has' an object of type 'Control' into a TypedArray, which does not inherit from 'Node3D'.
+Attempted to use 'has' with an object of type 'Control' into a TypedArray of incompatible type 'Node3D'.
-Attempted to set a variable of type 'Callable' into a TypedDictionary.Key of type 'int'.
+Attempted to set a variable of type 'Callable' into a TypedDictionary.Key of incompatible type 'int'.
-Attempted to set an object of type 'Control' into a TypedDictionary.Value, which does not inherit from 'Node2D'.
+Attempted to set an object of type 'Control' into a TypedDictionary.Value of incompatible type 'Node2D'.
```