### PR TITLE
Remove the godot::String and godot::StringName from godot.natvis

### DIFF
--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -242,28 +242,10 @@
 		<StringView Condition="_cowdata._ptr != 0">_cowdata._ptr,s32</StringView>
 	</Type>
 
-	<Type Name="godot::String">
-		<DisplayString>{*reinterpret_cast&lt;void**&gt;(opaque),s32}</DisplayString>
-		<Expand>
-			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
-			<Item Name="string">*reinterpret_cast&lt;void**&gt;(opaque),s32</Item>
-		</Expand>
-	</Type>
-
 	<Type Name="StringName">
 		<DisplayString Condition="_data">{_data->name,s32}</DisplayString>
 		<DisplayString Condition="!_data">[empty]</DisplayString>
 		<StringView Condition="_data">_data->name,s32</StringView>
-	</Type>
-
-	<!-- can't cast the opaque to ::StringName because Natvis does not support global namespace specifier? -->
-	<Type Name="godot::StringName">
-		<Intrinsic Name="get_data_ptr" Expression="(*reinterpret_cast&lt;const char32_t***&gt;(opaque))[1]" />
-		<DisplayString Condition="get_data_ptr()">{get_data_ptr(),s32}</DisplayString>
-		<Expand>
-			<Item Name="opaque_ptr">*reinterpret_cast&lt;void**&gt;(opaque)</Item>
-			<Item Name="cname">get_data_ptr(),s32</Item>
-		</Expand>
 	</Type>
 
 	<Type Name="Object::SignalData">


### PR DESCRIPTION
Those visualizers are going to be in godot-cpp (https://github.com/godotengine/godot-cpp/pull/1977)

## What problem(s) does this PR solve?

- Removes confusion and duplication.

I myself worked on adding godot:StringName in https://github.com/godotengine/godot/pull/116955
Later in discussion https://chat.godotengine.org/channel/gdextension?msg=mCgwe4cCkP3b43TjY
we realized there is no point in keeping godot-cpp type in the godot.natvis in the godotengine repo. All the types in godot-cpp are not the same - godot-cpp wraps the original godotengine types.