### PR TITLE
Fix GDScript type confusion in virtual machine

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -467,10 +467,10 @@ void GDScriptByteCodeGenerator::write_type_adjust(const Address &p_target, Varia
 			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_TRANSFORM2D);
 			break;
 		case Variant::VECTOR4:
-			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_VECTOR3);
+			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_VECTOR4);
 			break;
 		case Variant::VECTOR4I:
-			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_VECTOR3I);
+			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_VECTOR4I);
 			break;
 		case Variant::PLANE:
 			append_opcode(GDScriptFunction::OPCODE_TYPE_ADJUST_PLANE);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3151,7 +3151,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				Vector2i *bounds = VariantInternal::get_vector2i(container);
 
-				VariantInternal::initialize(counter, Variant::FLOAT);
+				VariantInternal::initialize(counter, Variant::INT);
 				*VariantInternal::get_int(counter) = bounds->x;
 
 				if (bounds->x < bounds->y) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes 2 type confusions in the gdscript VM

1. `OPCODE_ITERATE_BEGIN_VECTOR2I` initializes its counter as Variant::FLOAT but reads it as Variant::INT
2. `GDScriptByteCodeGenerator::write_type_adjust` emits the VECTOR3 opcodes for VECTOR4

Interestingly enough this does not seem to cause any issues (currently). I found these while debugging a separate issue.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/121194*