### PR TITLE
Add offset to 3D viewport navigation controls

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -6991,10 +6991,10 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	position_control->set_navigation_mode(View3DController::NAV_MODE_MOVE);
 	position_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
 	position_control->set_h_size_flags(SIZE_SHRINK_END);
-	position_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
-	position_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
-	position_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_BEGIN, navigation_control_size * EDSCALE);
-	position_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	position_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 10 * EDSCALE);
+	position_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -(navigation_control_size + 10) * EDSCALE);
+	position_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_BEGIN, (navigation_control_size + 10) * EDSCALE);
+	position_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
 	position_control->set_viewport(this);
 	surface->add_child(position_control);
 
@@ -7002,10 +7002,10 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	look_control->set_navigation_mode(View3DController::NAV_MODE_LOOK);
 	look_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
 	look_control->set_h_size_flags(SIZE_SHRINK_END);
-	look_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -navigation_control_size * EDSCALE);
-	look_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
-	look_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-	look_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+	look_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -(navigation_control_size + 10) * EDSCALE);
+	look_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -(navigation_control_size + 10) * EDSCALE);
+	look_control->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -10 * EDSCALE);
+	look_control->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
 	look_control->set_viewport(this);
 	surface->add_child(look_control);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, the touch navigation control joysticks in the 3D viewport are flush with the viewport edges with no offset, while other viewport overlays like the Perspective button and the rotation axis ball already have a `10 * EDSCALE` offset from the edges. This PR applies the same consistent offset to both navigation control joysticks.

## Additional information

Before:
<img width="2152" height="1080" alt="Screenshot_20260528-175404_Godot Engine 4" src="https://github.com/user-attachments/assets/38fb9fee-9ee9-4891-b466-5bbf66852b9c" />

After:
<img width="2152" height="1080" alt="Screenshot_20260528-175345_Godot Engine 4 (debug)" src="https://github.com/user-attachments/assets/8d487adc-688e-4472-9897-603c589696e1" />