### PR TITLE
Linux camera: Support planar YUV420 and honor V4L2 bytesperline in all decoders

### DIFF
--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -198,6 +198,62 @@ void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
 	camera_feed->set_rgb_image(image);
 }
 
+Yuv420BufferDecoder::Yuv420BufferDecoder(CameraFeed *p_camera_feed, bool p_v_plane_first) :
+		BufferDecoder(p_camera_feed) {
+	v_plane_first = p_v_plane_first;
+	const size_t chroma_size = (size_t)(width / 2) * (height / 2);
+	y_buffer.resize((size_t)width * height);
+	cbcr_buffer.resize(chroma_size * 2);
+	y_image.instantiate();
+	cbcr_image.instantiate();
+}
+
+void Yuv420BufferDecoder::decode(StreamingBuffer p_buffer) {
+	const int chroma_width = width / 2;
+	const int chroma_height = height / 2;
+
+	// Y plane uses the driver-reported pitch (bytesperline); chroma planes
+	// follow the V4L2 convention of half-stride. Fall back to tightly packed
+	// when no pitch is provided (legacy producers, contiguous buffers).
+	const int y_stride = p_buffer.pitch > 0 ? p_buffer.pitch : width;
+	const int chroma_stride = y_stride / 2;
+
+	const size_t y_plane_size = (size_t)y_stride * height;
+	const size_t chroma_plane_size = (size_t)chroma_stride * chroma_height;
+	const size_t expected_size = y_plane_size + chroma_plane_size * 2;
+
+	if (p_buffer.length < expected_size) {
+		return;
+	}
+
+	const uint8_t *src = (const uint8_t *)p_buffer.start;
+	const uint8_t *plane2 = src + y_plane_size;
+	const uint8_t *plane3 = plane2 + chroma_plane_size;
+	const uint8_t *cb_plane = v_plane_first ? plane3 : plane2;
+	const uint8_t *cr_plane = v_plane_first ? plane2 : plane3;
+
+	// Copy Y plane row by row to strip stride padding.
+	uint8_t *y_dst = y_buffer.ptrw();
+	for (int y = 0; y < height; y++) {
+		memcpy(y_dst + (size_t)y * width, src + (size_t)y * y_stride, width);
+	}
+
+	// Interleave Cb and Cr into RG8 (R=Cb, G=Cr) row by row.
+	uint8_t *cbcr_dst = cbcr_buffer.ptrw();
+	for (int y = 0; y < chroma_height; y++) {
+		const uint8_t *cb_row = cb_plane + (size_t)y * chroma_stride;
+		const uint8_t *cr_row = cr_plane + (size_t)y * chroma_stride;
+		for (int x = 0; x < chroma_width; x++) {
+			*cbcr_dst++ = cb_row[x];
+			*cbcr_dst++ = cr_row[x];
+		}
+	}
+
+	y_image->set_data(width, height, false, Image::FORMAT_L8, y_buffer);
+	cbcr_image->set_data(chroma_width, chroma_height, false, Image::FORMAT_RG8, cbcr_buffer);
+	camera_feed->set_ycbcr_images(y_image, cbcr_image);
+}
+
 JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
 }

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -77,21 +77,28 @@ void SeparateYuyvBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *y_dst = (uint8_t *)y_image_data.ptrw();
 	uint8_t *uv_dst = (uint8_t *)cbcr_image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
-	uint8_t *u_src = src + component_indexes[2];
-	uint8_t *v_src = src + component_indexes[3];
+	// YUYV-family is packed 4:2:2 (2 bytes per pixel). Honor driver-reported
+	// pitch in case bytesperline is padded for row alignment.
+	const int row_stride = p_buffer.pitch > 0 ? p_buffer.pitch : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		*y_dst++ = *y0_src;
-		*y_dst++ = *y1_src;
-		*uv_dst++ = *u_src;
-		*uv_dst++ = *v_src;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row = src + (size_t)y * row_stride;
+		uint8_t *y0_src = row + component_indexes[0];
+		uint8_t *y1_src = row + component_indexes[1];
+		uint8_t *u_src = row + component_indexes[2];
+		uint8_t *v_src = row + component_indexes[3];
 
-		y0_src += 4;
-		y1_src += 4;
-		u_src += 4;
-		v_src += 4;
+		for (int x = 0; x < width; x += 2) {
+			*y_dst++ = *y0_src;
+			*y_dst++ = *y1_src;
+			*uv_dst++ = *u_src;
+			*uv_dst++ = *v_src;
+
+			y0_src += 4;
+			y1_src += 4;
+			u_src += 4;
+			v_src += 4;
+		}
 	}
 
 	if (y_image.is_valid()) {
@@ -116,15 +123,20 @@ YuyvToGrayscaleBufferDecoder::YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_
 void YuyvToGrayscaleBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
+	const int row_stride = p_buffer.pitch > 0 ? p_buffer.pitch : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		*dst++ = *y0_src;
-		*dst++ = *y1_src;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row = src + (size_t)y * row_stride;
+		uint8_t *y0_src = row + component_indexes[0];
+		uint8_t *y1_src = row + component_indexes[1];
 
-		y0_src += 4;
-		y1_src += 4;
+		for (int x = 0; x < width; x += 2) {
+			*dst++ = *y0_src;
+			*dst++ = *y1_src;
+
+			y0_src += 4;
+			y1_src += 4;
+		}
 	}
 
 	if (image.is_valid()) {
@@ -143,31 +155,36 @@ YuyvToRgbBufferDecoder::YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed) :
 
 void YuyvToRgbBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
-	uint8_t *u_src = src + component_indexes[2];
-	uint8_t *v_src = src + component_indexes[3];
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
+	const int row_stride = p_buffer.pitch > 0 ? p_buffer.pitch : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		int u = *u_src;
-		int v = *v_src;
-		int u1 = (((u - 128) << 7) + (u - 128)) >> 6;
-		int rg = (((u - 128) << 1) + (u - 128) + ((v - 128) << 2) + ((v - 128) << 1)) >> 3;
-		int v1 = (((v - 128) << 1) + (v - 128)) >> 1;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row = src + (size_t)y * row_stride;
+		uint8_t *y0_src = row + component_indexes[0];
+		uint8_t *y1_src = row + component_indexes[1];
+		uint8_t *u_src = row + component_indexes[2];
+		uint8_t *v_src = row + component_indexes[3];
 
-		*dst++ = CLAMP(*y0_src + v1, 0, 255);
-		*dst++ = CLAMP(*y0_src - rg, 0, 255);
-		*dst++ = CLAMP(*y0_src + u1, 0, 255);
+		for (int x = 0; x < width; x += 2) {
+			int u = *u_src;
+			int v = *v_src;
+			int u1 = (((u - 128) << 7) + (u - 128)) >> 6;
+			int rg = (((u - 128) << 1) + (u - 128) + ((v - 128) << 2) + ((v - 128) << 1)) >> 3;
+			int v1 = (((v - 128) << 1) + (v - 128)) >> 1;
 
-		*dst++ = CLAMP(*y1_src + v1, 0, 255);
-		*dst++ = CLAMP(*y1_src - rg, 0, 255);
-		*dst++ = CLAMP(*y1_src + u1, 0, 255);
+			*dst++ = CLAMP(*y0_src + v1, 0, 255);
+			*dst++ = CLAMP(*y0_src - rg, 0, 255);
+			*dst++ = CLAMP(*y0_src + u1, 0, 255);
 
-		y0_src += 4;
-		y1_src += 4;
-		u_src += 4;
-		v_src += 4;
+			*dst++ = CLAMP(*y1_src + v1, 0, 255);
+			*dst++ = CLAMP(*y1_src - rg, 0, 255);
+			*dst++ = CLAMP(*y1_src + u1, 0, 255);
+
+			y0_src += 4;
+			y1_src += 4;
+			u_src += 4;
+			v_src += 4;
+		}
 	}
 
 	if (image.is_valid()) {
@@ -187,7 +204,20 @@ CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba) :
 
 void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
+	uint8_t *src = (uint8_t *)p_buffer.start;
+	const int bpp = rgba ? 4 : 2;
+	const int row_bytes = width * bpp;
+	const int row_stride = p_buffer.pitch > 0 ? p_buffer.pitch : row_bytes;
+
+	if (row_stride == row_bytes) {
+		// No padding: single contiguous copy.
+		memcpy(dst, src, (size_t)row_bytes * height);
+	} else {
+		// Strip row padding.
+		for (int y = 0; y < height; y++) {
+			memcpy(dst + (size_t)y * row_bytes, src + (size_t)y * row_stride, row_bytes);
+		}
+	}
 
 	if (image.is_valid()) {
 		image->set_data(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);

--- a/modules/camera/buffer_decoder.h
+++ b/modules/camera/buffer_decoder.h
@@ -38,6 +38,7 @@ class CameraFeed;
 struct StreamingBuffer {
 	void *start = nullptr;
 	size_t length = 0;
+	int32_t pitch = 0; // Y plane row stride in bytes (0 = assume tightly packed: pitch == width).
 };
 
 class BufferDecoder {
@@ -100,6 +101,22 @@ private:
 
 public:
 	CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba);
+	virtual void decode(StreamingBuffer p_buffer) override;
+};
+
+// Decoder for V4L2_PIX_FMT_YUV420 (YU12 / I420) and V4L2_PIX_FMT_YVU420 (YV12).
+// Planar 4:2:0: Y plane (w*h) followed by Cb and Cr planes (w/2 * h/2 each).
+// V4L2_PIX_FMT_YVU420 swaps the order to Y, V, U.
+class Yuv420BufferDecoder : public BufferDecoder {
+private:
+	bool v_plane_first = false; // True for V4L2_PIX_FMT_YVU420 (Y, V, U order).
+	Vector<uint8_t> y_buffer;
+	Vector<uint8_t> cbcr_buffer; // Interleaved CbCr (RG8 format: R=Cb, G=Cr).
+	Ref<Image> y_image;
+	Ref<Image> cbcr_image;
+
+public:
+	Yuv420BufferDecoder(CameraFeed *p_camera_feed, bool p_v_plane_first);
 	virtual void decode(StreamingBuffer p_buffer) override;
 };
 

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -197,7 +197,9 @@ void CameraFeedLinux::_read_frame() {
 		return;
 	}
 
-	buffer_decoder->decode(buffers[buffer.index]);
+	StreamingBuffer streaming_buffer = buffers[buffer.index];
+	streaming_buffer.pitch = buffer_pitch;
+	buffer_decoder->decode(streaming_buffer);
 
 	if (ioctl(file_descriptor, VIDIOC_QBUF, &buffer) == -1) {
 		print_error(vformat("ioctl(VIDIOC_QBUF) error: %d.", errno));
@@ -245,6 +247,10 @@ BufferDecoder *CameraFeedLinux::_create_buffer_decoder() {
 		case V4L2_PIX_FMT_MJPEG:
 		case V4L2_PIX_FMT_JPEG:
 			return memnew(JpegBufferDecoder(this));
+		case V4L2_PIX_FMT_YUV420:
+			return memnew(Yuv420BufferDecoder(this, false));
+		case V4L2_PIX_FMT_YVU420:
+			return memnew(Yuv420BufferDecoder(this, true));
 		case V4L2_PIX_FMT_YUYV:
 		case V4L2_PIX_FMT_YYUV:
 		case V4L2_PIX_FMT_YVYU:
@@ -324,6 +330,10 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 		close(file_descriptor);
 		ERR_FAIL_V_MSG(false, vformat("Cannot set format, error: %d.", errno));
 	}
+
+	// Driver fills bytesperline (Y plane stride) on successful S_FMT. May exceed
+	// width when the driver pads rows for alignment; decoders must honor it.
+	buffer_pitch = (int32_t)format.fmt.pix.bytesperline;
 
 	if (feed_format.frame_numerator > 0) {
 		struct v4l2_streamparm param;

--- a/modules/camera/camera_feed_linux.h
+++ b/modules/camera/camera_feed_linux.h
@@ -49,6 +49,7 @@ private:
 	int file_descriptor = -1;
 	StreamingBuffer *buffers = nullptr;
 	unsigned int buffer_count = 0;
+	int32_t buffer_pitch = 0; // Y plane row stride reported by V4L2 (bytesperline).
 	BufferDecoder *buffer_decoder = nullptr;
 
 	static void update_buffer_thread_func(void *p_func);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119851

## Additional information

1. Add a decoder for `V4L2_PIX_FMT_YUV420` (YU12 / I420) and `V4L2_PIX_FMT_YVU420` (YV12) so planar 4:2:0 sources like DroidCam decode correctly instead of falling through to the RGBA copy decoder. Like the existing YUYV decoders, it splits into Y / CbCr images and lets the GPU shader do the YUV->RGB conversion.
2. Apply the row-pitch (`bytesperline`) handling that the YUV420 decoder needs to the other (YUYV and copy) decoders as well, so padded rows are handled consistently.

DroidCam (planar YUV 4:2:0, 1920x1080) now renders correctly:

<img width="1280" height="718" alt="fixed-droidcam" src="https://github.com/user-attachments/assets/9a25dbd4-e73d-4006-a8c1-c056d8ef2fc7" />

### AI usage disclosure

Claude Code was used to analyze the V4L2 buffer handling, implement the YUV420 decoder and the pitch handling, assess the impact of the missing pitch handling across the other decoders, and draft the issue and this PR description.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
