### PR TITLE
🤖 Add Curve2D circle and rectangle builders

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -27,6 +27,21 @@
 				Removes all points from the curve.
 			</description>
 		</method>
+		<method name="create_circle" qualifiers="static">
+			<return type="Curve2D" />
+			<param index="0" name="radius" type="float" />
+			<param index="1" name="center" type="Vector2" default="Vector2(0, 0)" />
+			<description>
+				Creates a new closed curve approximating a circle with four cubic Bézier segments. The circle is centered at [param center] and has the specified [param radius]. The [param radius] must be greater than [code]0[/code].
+			</description>
+		</method>
+		<method name="create_rectangle" qualifiers="static">
+			<return type="Curve2D" />
+			<param index="0" name="rect" type="Rect2" />
+			<description>
+				Creates a new closed curve following the edges of [param rect]. If [param rect] has a negative size, the rectangle is normalized with [method Rect2.abs]. The rectangle must have non-zero width and height.
+			</description>
+		</method>
 		<method name="get_baked_length" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -48,6 +48,8 @@ void Path2DEditor::_notification(int p_what) {
 			curve_edit->set_button_icon(get_editor_theme_icon(SNAME("CurveEdit")));
 			curve_edit_curve->set_button_icon(get_editor_theme_icon(SNAME("CurveCurve")));
 			curve_create->set_button_icon(get_editor_theme_icon(SNAME("CurveCreate")));
+			curve_create_circle->set_button_icon(get_editor_theme_icon(SNAME("CircleShape2D")));
+			curve_create_rectangle->set_button_icon(get_editor_theme_icon(SNAME("RectangleShape2D")));
 			curve_del->set_button_icon(get_editor_theme_icon(SNAME("CurveDelete")));
 			curve_close->set_button_icon(get_editor_theme_icon(SNAME("CurveClose")));
 			curve_clear_points->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
@@ -798,6 +800,41 @@ void Path2DEditor::_create_curve() {
 	undo_redo->commit_action();
 }
 
+void Path2DEditor::_create_primitive_curve(int p_option) {
+	ERR_FAIL_NULL(node);
+	ERR_FAIL_COND(node->get_curve().is_null());
+
+	Ref<Curve2D> new_curve;
+	String action_name;
+
+	switch (PrimitiveOption(p_option)) {
+		case PRIMITIVE_OPTION_CIRCLE: {
+			new_curve = Curve2D::create_circle(64.0);
+			action_name = TTR("Create Circle Curve");
+		} break;
+		case PRIMITIVE_OPTION_RECTANGLE: {
+			new_curve = Curve2D::create_rectangle(Rect2(-64.0, -64.0, 128.0, 128.0));
+			action_name = TTR("Create Rectangle Curve");
+		} break;
+		default: {
+			ERR_FAIL_MSG("Invalid primitive curve option.");
+		} break;
+	}
+
+	ERR_FAIL_COND(new_curve.is_null());
+
+	PackedVector2Array new_points = new_curve->get_points();
+	PackedVector2Array previous_points = node->get_curve()->get_points().duplicate();
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(action_name, UndoRedo::MERGE_DISABLE, node);
+	undo_redo->add_do_method(this, "_restore_curve_points", node, new_points);
+	undo_redo->add_undo_method(this, "_restore_curve_points", node, previous_points);
+	undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+	undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+	undo_redo->commit_action();
+}
+
 void Path2DEditor::_confirm_clear_points() {
 	if (!node || node->get_curve().is_null()) {
 		return;
@@ -840,7 +877,7 @@ void Path2DEditor::_restore_curve_points(Path2D *p_path2d, const PackedVector2Ar
 	}
 
 	if (node == p_path2d) {
-		_mode_selected(MODE_EDIT);
+		_mode_selected(p_points.is_empty() ? MODE_CREATE : MODE_EDIT);
 	}
 }
 
@@ -874,6 +911,22 @@ Path2DEditor::Path2DEditor() {
 	curve_create->set_accessibility_name(TTRC("Add Point (in empty space)"));
 	curve_create->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CREATE));
 	toolbar->add_child(curve_create);
+
+	curve_create_circle = memnew(Button);
+	curve_create_circle->set_theme_type_variation(SceneStringName(FlatButton));
+	curve_create_circle->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	curve_create_circle->set_tooltip_text(TTR("Create Circle Curve"));
+	curve_create_circle->set_accessibility_name(TTRC("Create Circle Curve"));
+	curve_create_circle->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_create_primitive_curve).bind(PRIMITIVE_OPTION_CIRCLE));
+	toolbar->add_child(curve_create_circle);
+
+	curve_create_rectangle = memnew(Button);
+	curve_create_rectangle->set_theme_type_variation(SceneStringName(FlatButton));
+	curve_create_rectangle->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	curve_create_rectangle->set_tooltip_text(TTR("Create Rectangle Curve"));
+	curve_create_rectangle->set_accessibility_name(TTRC("Create Rectangle Curve"));
+	curve_create_rectangle->connect(SceneStringName(pressed), callable_mp(this, &Path2DEditor::_create_primitive_curve).bind(PRIMITIVE_OPTION_RECTANGLE));
+	toolbar->add_child(curve_create_rectangle);
 
 	curve_del = memnew(Button);
 	curve_del->set_theme_type_variation(SceneStringName(FlatButton));

--- a/editor/scene/2d/path_2d_editor_plugin.h
+++ b/editor/scene/2d/path_2d_editor_plugin.h
@@ -61,6 +61,8 @@ class Path2DEditor : public HBoxContainer {
 	Button *curve_clear_points = nullptr;
 	Button *curve_close = nullptr;
 	Button *curve_create = nullptr;
+	Button *curve_create_circle = nullptr;
+	Button *curve_create_rectangle = nullptr;
 	Button *curve_del = nullptr;
 	Button *curve_edit = nullptr;
 	Button *curve_edit_curve = nullptr;
@@ -76,6 +78,11 @@ class Path2DEditor : public HBoxContainer {
 	enum HandleOption {
 		HANDLE_OPTION_ANGLE,
 		HANDLE_OPTION_LENGTH,
+	};
+
+	enum PrimitiveOption {
+		PRIMITIVE_OPTION_CIRCLE,
+		PRIMITIVE_OPTION_RECTANGLE,
 	};
 
 	enum Action {
@@ -108,6 +115,7 @@ class Path2DEditor : public HBoxContainer {
 	void _update_toolbar();
 
 	void _create_curve();
+	void _create_primitive_curve(int p_option);
 	void _confirm_clear_points();
 	void _clear_curve_points(Path2D *p_path2d);
 	void _restore_curve_points(Path2D *p_path2d, const PackedVector2Array &p_points);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -763,6 +763,41 @@ void Curve2D::clear_points() {
 	}
 }
 
+Ref<Curve2D> Curve2D::create_circle(real_t p_radius, const Vector2 &p_center) {
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_radius), Ref<Curve2D>(), "Radius is non-finite.");
+	ERR_FAIL_COND_V_MSG(p_radius <= 0.0, Ref<Curve2D>(), "Radius must be greater than 0.");
+	ERR_FAIL_COND_V_MSG(!p_center.is_finite(), Ref<Curve2D>(), "Center is non-finite.");
+
+	const real_t control_offset = p_radius * (4.0 * (Math::SQRT2 - 1.0) / 3.0);
+
+	Ref<Curve2D> curve;
+	curve.instantiate();
+	curve->add_point(p_center + Vector2(p_radius, 0.0), Vector2(), Vector2(0.0, control_offset));
+	curve->add_point(p_center + Vector2(0.0, p_radius), Vector2(control_offset, 0.0), Vector2(-control_offset, 0.0));
+	curve->add_point(p_center + Vector2(-p_radius, 0.0), Vector2(0.0, control_offset), Vector2(0.0, -control_offset));
+	curve->add_point(p_center + Vector2(0.0, -p_radius), Vector2(-control_offset, 0.0), Vector2(control_offset, 0.0));
+	curve->add_point(p_center + Vector2(p_radius, 0.0), Vector2(0.0, -control_offset), Vector2());
+
+	return curve;
+}
+
+Ref<Curve2D> Curve2D::create_rectangle(const Rect2 &p_rect) {
+	ERR_FAIL_COND_V_MSG(!p_rect.is_finite(), Ref<Curve2D>(), "Rectangle is non-finite.");
+
+	const Rect2 rect = p_rect.abs();
+	ERR_FAIL_COND_V_MSG(rect.size.x <= 0.0 || rect.size.y <= 0.0, Ref<Curve2D>(), "Rectangle size must be greater than 0.");
+
+	Ref<Curve2D> curve;
+	curve.instantiate();
+	curve->add_point(rect.position);
+	curve->add_point(rect.position + Vector2(rect.size.x, 0.0));
+	curve->add_point(rect.position + rect.size);
+	curve->add_point(rect.position + Vector2(0.0, rect.size.y));
+	curve->add_point(rect.position);
+
+	return curve;
+}
+
 Vector2 Curve2D::sample(int p_index, const real_t p_offset) const {
 	int pc = points.size();
 	ERR_FAIL_COND_V(pc == 0, Vector2());
@@ -1316,6 +1351,8 @@ void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_out", "idx"), &Curve2D::get_point_out);
 	ClassDB::bind_method(D_METHOD("remove_point", "idx"), &Curve2D::remove_point);
 	ClassDB::bind_method(D_METHOD("clear_points"), &Curve2D::clear_points);
+	ClassDB::bind_static_method("Curve2D", D_METHOD("create_circle", "radius", "center"), &Curve2D::create_circle, DEFVAL(Vector2()));
+	ClassDB::bind_static_method("Curve2D", D_METHOD("create_rectangle", "rect"), &Curve2D::create_rectangle);
 	ClassDB::bind_method(D_METHOD("sample", "idx", "t"), &Curve2D::sample);
 	ClassDB::bind_method(D_METHOD("samplef", "fofs"), &Curve2D::samplef);
 	//ClassDB::bind_method(D_METHOD("bake","subdivs"),&Curve2D::bake,DEFVAL(10));

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "core/math/rect2.h"
 #include "core/templates/rb_map.h"
 #include "scene/property_list_helper.h"
 
@@ -249,6 +250,9 @@ public:
 	Vector2 get_point_out(int p_index) const;
 	void remove_point(int p_index);
 	void clear_points();
+
+	static Ref<Curve2D> create_circle(real_t p_radius, const Vector2 &p_center = Vector2());
+	static Ref<Curve2D> create_rectangle(const Rect2 &p_rect);
 
 	Vector2 sample(int p_index, real_t p_offset) const;
 	Vector2 samplef(real_t p_findex) const;

--- a/tests/scene/test_curve_2d.cpp
+++ b/tests/scene/test_curve_2d.cpp
@@ -93,6 +93,67 @@ TEST_CASE("[Curve2D] Point management") {
 	}
 }
 
+TEST_CASE("[Curve2D] Primitive curve creation") {
+	SUBCASE("Circle") {
+		const Vector2 center = Vector2(4, -3);
+		const real_t radius = 10.0;
+		const real_t control_offset = radius * (4.0 * (Math::SQRT2 - 1.0) / 3.0);
+		Ref<Curve2D> curve = Curve2D::create_circle(radius, center);
+
+		REQUIRE(curve.is_valid());
+		CHECK(curve->get_point_count() == 5);
+
+		CHECK(curve->get_point_position(0).is_equal_approx(Vector2(14, -3)));
+		CHECK(curve->get_point_in(0).is_zero_approx());
+		CHECK(curve->get_point_out(0).is_equal_approx(Vector2(0, control_offset)));
+
+		CHECK(curve->get_point_position(1).is_equal_approx(Vector2(4, 7)));
+		CHECK(curve->get_point_in(1).is_equal_approx(Vector2(control_offset, 0)));
+		CHECK(curve->get_point_out(1).is_equal_approx(Vector2(-control_offset, 0)));
+
+		CHECK(curve->get_point_position(2).is_equal_approx(Vector2(-6, -3)));
+		CHECK(curve->get_point_in(2).is_equal_approx(Vector2(0, control_offset)));
+		CHECK(curve->get_point_out(2).is_equal_approx(Vector2(0, -control_offset)));
+
+		CHECK(curve->get_point_position(3).is_equal_approx(Vector2(4, -13)));
+		CHECK(curve->get_point_in(3).is_equal_approx(Vector2(-control_offset, 0)));
+		CHECK(curve->get_point_out(3).is_equal_approx(Vector2(control_offset, 0)));
+
+		CHECK(curve->get_point_position(4).is_equal_approx(Vector2(14, -3)));
+		CHECK(curve->get_point_in(4).is_equal_approx(Vector2(0, -control_offset)));
+		CHECK(curve->get_point_out(4).is_zero_approx());
+	}
+
+	SUBCASE("Rectangle") {
+		Ref<Curve2D> curve = Curve2D::create_rectangle(Rect2(Vector2(10, 20), Vector2(-30, -40)));
+
+		REQUIRE(curve.is_valid());
+		CHECK(curve->get_point_count() == 5);
+
+		CHECK(curve->get_point_position(0).is_equal_approx(Vector2(-20, -20)));
+		CHECK(curve->get_point_position(1).is_equal_approx(Vector2(10, -20)));
+		CHECK(curve->get_point_position(2).is_equal_approx(Vector2(10, 20)));
+		CHECK(curve->get_point_position(3).is_equal_approx(Vector2(-20, 20)));
+		CHECK(curve->get_point_position(4).is_equal_approx(Vector2(-20, -20)));
+
+		for (int i = 0; i < curve->get_point_count(); i++) {
+			CHECK(curve->get_point_in(i).is_zero_approx());
+			CHECK(curve->get_point_out(i).is_zero_approx());
+		}
+
+		CHECK(Math::is_equal_approx(curve->get_baked_length(), real_t(140.0)));
+	}
+
+	SUBCASE("Invalid input") {
+		ERR_PRINT_OFF;
+		CHECK(Curve2D::create_circle(0.0).is_null());
+		CHECK(Curve2D::create_circle(-1.0).is_null());
+		CHECK(Curve2D::create_rectangle(Rect2(Vector2(), Vector2(0, 1))).is_null());
+		CHECK(Curve2D::create_rectangle(Rect2(Vector2(), Vector2(1, 0))).is_null());
+		ERR_PRINT_ON;
+	}
+}
+
 TEST_CASE("[Curve2D] Baked") {
 	Ref<Curve2D> curve = memnew(Curve2D);
 


### PR DESCRIPTION
> [!INFO] *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of cookesan, to add reusable Curve2D circle and rectangle path builders and expose them in the Path2D editor.

## What problem(s) does this PR solve?

Path2D is useful with PathFollow2D, but creating common closed paths such as circles and rectangles currently requires manually placing Bezier points or writing the same setup code in each project.

This adds:

- `Curve2D.create_circle(radius, center = Vector2())`
- `Curve2D.create_rectangle(rect)`
- Path2D editor toolbar buttons for creating a default circle or rectangle curve with undo/redo support

## Additional information

`create_circle()` uses the standard four-segment cubic Bezier circle approximation. `create_rectangle()` normalizes negative `Rect2` sizes with `Rect2.abs()` and rejects zero-size rectangles.

The scope is intentionally limited to reusable Curve2D path construction and Path2D authoring. It does not add a general 2D shape node or drawing primitive system.

Validation performed:

- `python3 misc/scripts/file_format.py scene/resources/curve.h scene/resources/curve.cpp editor/scene/2d/path_2d_editor_plugin.h editor/scene/2d/path_2d_editor_plugin.cpp tests/scene/test_curve_2d.cpp doc/classes/Curve2D.xml`
- `python3 misc/scripts/copyright_headers.py scene/resources/curve.h scene/resources/curve.cpp editor/scene/2d/path_2d_editor_plugin.h editor/scene/2d/path_2d_editor_plugin.cpp tests/scene/test_curve_2d.cpp`
- `python3 misc/scripts/header_guards.py scene/resources/curve.h editor/scene/2d/path_2d_editor_plugin.h`
- `python3 misc/scripts/validate_includes.py scene/resources/curve.cpp editor/scene/2d/path_2d_editor_plugin.cpp tests/scene/test_curve_2d.cpp`
- `pipx run --spec xmlschema python misc/scripts/validate_xml.py doc/classes/Curve2D.xml`
- `bin/godot.macos.editor.dev.arm64 --doctool --headless`
- `./misc/scripts/validate_extension_api.sh bin/godot.macos.editor.dev.arm64`
- `pipx run --spec "scons>=4.8,<5" scons platform=macos target=editor tests=yes dev_build=yes vulkan=no angle=no accesskit=no -j4`
- `bin/godot.macos.editor.dev.arm64 --headless --test --test-case="*[Curve2D]*"`
- `bin/godot.macos.editor.dev.arm64 --headless --test --test-case="*[Path2D]*"`
- `bin/godot.macos.editor.dev.arm64 --headless --test --test-case="*[PathFollow2D]*"`