### PR TITLE
Add max_global_polyphony setting to AudioStreamPlayer and option to bypass it

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1754,6 +1754,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type", PROPERTY_HINT_ENUM, "Stream,Sample"), 0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/default_playback_type.web", PROPERTY_HINT_ENUM, "Stream,Sample"), 1);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/max_global_polyphony", PROPERTY_HINT_RANGE, "0,65535,1"), 1000);
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/3d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -97,6 +97,12 @@
 				Returns the [AudioSamplePlayback] associated with this [AudioStreamPlayback] for playing back the audio sample of this stream.
 			</description>
 		</method>
+		<method name="is_bypassing_global_polyphony" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the stream is set to bypass global polyphony (see [member AudioStreamPlayer.bypass_global_polyphony]).
+			</description>
+		</method>
 		<method name="is_playing" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -66,13 +66,13 @@
 			The target bus name. All sounds from this node will be playing on this bus.
 			[b]Note:[/b] At runtime, if no bus with the given name exists, all sounds will fall back on [code]"Master"[/code]. See also [method AudioServer.get_bus_name].
 		</member>
-		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
-			The maximum number of sounds this node can play at the same time. Calling [method play] after this value is reached will cut off the oldest sounds.
-			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
-		</member>
 		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
 			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
 			Use this for sounds like music, ambience, or announcements that should not be interrupted.
+		</member>
+		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
+			The maximum number of sounds this node can play at the same time. Calling [method play] after this value is reached will cut off the oldest sounds.
+			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
 		</member>
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
 			The mix target channels. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -68,6 +68,11 @@
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Calling [method play] after this value is reached will cut off the oldest sounds.
+			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
+		</member>
+		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
+			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
+			Use this for sounds like music, ambience, or announcements that should not be interrupted.
 		</member>
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
 			The mix target channels. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -66,16 +66,16 @@
 			Bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
+			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
+			Use this for sounds like music, ambience, or announcements that should not be interrupted.
+		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="2000.0">
 			Maximum distance from which audio is still hearable.
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
-		</member>
-		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
-			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
-			Use this for sounds like music, ambience, or announcements that should not be interrupted.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/2d_panning_strength] with this factor. Higher values will pan audio from left to right more dramatically than lower values.

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -71,6 +71,11 @@
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
+			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
+		</member>
+		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
+			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
+			Use this for sounds like music, ambience, or announcements that should not be interrupted.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/2d_panning_strength] with this factor. Higher values will pan audio from left to right more dramatically than lower values.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -93,6 +93,11 @@
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
+			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
+		</member>
+		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
+			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
+			Use this for sounds like music, ambience, or announcements that should not be interrupted.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/3d_panning_strength] by this factor. If the product is [code]0.0[/code] then stereo panning is disabled and the volume is the same for all channels. If the product is [code]1.0[/code] then one of the channels will be muted when the sound is located exactly to the left (or right) of the listener.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -72,6 +72,10 @@
 			The bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
+			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
+			Use this for sounds like music, ambience, or announcements that should not be interrupted.
+		</member>
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="AudioStreamPlayer3D.DopplerTracking" default="0">
 			Decides in which step the Doppler effect should be calculated.
 			[b]Note:[/b] If [member doppler_tracking] is not [constant DOPPLER_TRACKING_DISABLED] but the current [Camera3D]/[AudioListener3D] has doppler tracking disabled, the Doppler effect will be heard but will not take the movement of the current listener into account. If accurate Doppler effect is desired, doppler tracking should be enabled on both the [AudioStreamPlayer3D] and the current [Camera3D]/[AudioListener3D].
@@ -94,10 +98,6 @@
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 			Unlike [member ProjectSettings.audio/general/max_global_polyphony], this limit considers only sounds played by this node.
-		</member>
-		<member name="bypass_global_polyphony" type="bool" setter="set_bypass_global_polyphony" getter="is_bypassing_global_polyphony" default="false">
-			If [code]true[/code], sounds played from this node won't count towards the global polyphony limit, as defined in [member ProjectSettings.audio/general/max_global_polyphony], and will not be cut off from that limit being reached.
-			Use this for sounds like music, ambience, or announcements that should not be interrupted.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/3d_panning_strength] by this factor. If the product is [code]0.0[/code] then stereo panning is disabled and the volume is the same for all channels. If the product is [code]1.0[/code] then one of the channels will be muted when the sound is located exactly to the left (or right) of the listener.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -469,6 +469,11 @@
 		<member name="audio/driver/output_latency.web" type="int" setter="" getter="" default="50">
 			Safer override for [member audio/driver/output_latency] in the Web platform, to avoid audio issues especially on mobile devices.
 		</member>
+		<member name="audio/general/max_global_polyphony" type="int" setter="" getter="" default="1000">
+			The maximum number of sounds that can play globally at the same time. If playing a new sound would cause this limit to be exceeded, the oldest sound will be cut off.
+			Unlike [member AudioStreamPlayer.max_polyphony], this limit considers every sound from every node at once.
+			For playing sounds that should never be cut off, use [member AudioStreamPlayer.bypass_global_polyphony].
+		</member>
 		<member name="audio/general/2d_panning_strength" type="float" setter="" getter="" default="0.5">
 			The base strength of the panning effect for all [AudioStreamPlayer2D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer2D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones. When using speakers, you may find lower values to sound better as speakers have a lower stereo separation compared to headphones.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -469,11 +469,6 @@
 		<member name="audio/driver/output_latency.web" type="int" setter="" getter="" default="50">
 			Safer override for [member audio/driver/output_latency] in the Web platform, to avoid audio issues especially on mobile devices.
 		</member>
-		<member name="audio/general/max_global_polyphony" type="int" setter="" getter="" default="1000">
-			The maximum number of sounds that can play globally at the same time. If playing a new sound would cause this limit to be exceeded, the oldest sound will be cut off.
-			Unlike [member AudioStreamPlayer.max_polyphony], this limit considers every sound from every node at once.
-			For playing sounds that should never be cut off, use [member AudioStreamPlayer.bypass_global_polyphony].
-		</member>
 		<member name="audio/general/2d_panning_strength" type="float" setter="" getter="" default="0.5">
 			The base strength of the panning effect for all [AudioStreamPlayer2D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer2D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones. When using speakers, you may find lower values to sound better as speakers have a lower stereo separation compared to headphones.
@@ -497,6 +492,11 @@
 		</member>
 		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0" keywords="ambient, play, record, solo">
 			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
+		</member>
+		<member name="audio/general/max_global_polyphony" type="int" setter="" getter="" default="1000">
+			The maximum number of sounds that can play globally at the same time. If playing a new sound would cause this limit to be exceeded, the oldest sound will be cut off.
+			Unlike [member AudioStreamPlayer.max_polyphony], this limit considers every sound from every node at once.
+			For playing sounds that should never be cut off, use [member AudioStreamPlayer.bypass_global_polyphony].
 		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled on startup, otherwise it is enabled the first time any TTS method is used. See also [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -351,6 +351,14 @@ int AudioStreamPlayer2D::get_max_polyphony() const {
 	return internal->max_polyphony;
 }
 
+void AudioStreamPlayer2D::set_bypass_global_polyphony(bool p_bypass) {
+	internal->set_bypass_global_polyphony(p_bypass);
+}
+
+bool AudioStreamPlayer2D::is_bypassing_global_polyphony() const {
+	return internal->bypass_global_polyphony;
+}
+
 void AudioStreamPlayer2D::set_panning_strength(float p_panning_strength) {
 	ERR_FAIL_COND_MSG(p_panning_strength < 0, "Panning strength must be a positive number.");
 	panning_strength = p_panning_strength;
@@ -392,6 +400,9 @@ void AudioStreamPlayer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer2D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer2D::get_pitch_scale);
+
+	ClassDB::bind_method(D_METHOD("set_bypass_global_polyphony", "bypass"), &AudioStreamPlayer2D::set_bypass_global_polyphony);
+	ClassDB::bind_method(D_METHOD("is_bypassing_global_polyphony"), &AudioStreamPlayer2D::is_bypassing_global_polyphony);
 
 	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer2D::play, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer2D::seek);
@@ -442,6 +453,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "1,4096,1,or_greater,exp,suffix:px"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_attenuation", "get_attenuation");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bypass_global_polyphony"), "set_bypass_global_polyphony", "is_bypassing_global_polyphony");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "panning_strength", PROPERTY_HINT_RANGE, "0,3,0.01,or_greater"), "set_panning_strength", "get_panning_strength");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "area_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_area_mask", "get_area_mask");

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -130,6 +130,9 @@ public:
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;
 
+	void set_bypass_global_polyphony(bool p_bypass);
+	bool is_bypassing_global_polyphony() const;
+
 	void set_panning_strength(float p_panning_strength);
 	float get_panning_strength() const;
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -828,6 +828,14 @@ int AudioStreamPlayer3D::get_max_polyphony() const {
 	return internal->max_polyphony;
 }
 
+void AudioStreamPlayer3D::set_bypass_global_polyphony(bool p_bypass) {
+	internal->set_bypass_global_polyphony(p_bypass);
+}
+
+bool AudioStreamPlayer3D::is_bypassing_global_polyphony() const {
+	return internal->bypass_global_polyphony;
+}
+
 void AudioStreamPlayer3D::set_panning_strength(float p_panning_strength) {
 	ERR_FAIL_COND_MSG(p_panning_strength < 0, "Panning strength must be a positive number.");
 	panning_strength = p_panning_strength;
@@ -875,6 +883,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer3D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer3D::get_pitch_scale);
+
+	ClassDB::bind_method(D_METHOD("set_bypass_global_polyphony", "bypass"), &AudioStreamPlayer3D::set_bypass_global_polyphony);
+	ClassDB::bind_method(D_METHOD("is_bypassing_global_polyphony"), &AudioStreamPlayer3D::is_bypassing_global_polyphony);
 
 	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer3D::play, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer3D::seek);
@@ -945,6 +956,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,or_greater,suffix:m"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bypass_global_polyphony"), "set_bypass_global_polyphony", "is_bypassing_global_polyphony");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "panning_strength", PROPERTY_HINT_RANGE, "0,3,0.01,or_greater"), "set_panning_strength", "get_panning_strength");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "area_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_area_mask", "get_area_mask");

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -173,6 +173,9 @@ public:
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;
 
+	void set_bypass_global_polyphony(bool p_bypass);
+	bool is_bypassing_global_polyphony() const;
+
 	void set_autoplay(bool p_enable);
 	bool is_autoplay_enabled() const;
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -106,6 +106,14 @@ int AudioStreamPlayer::get_max_polyphony() const {
 	return internal->max_polyphony;
 }
 
+void AudioStreamPlayer::set_bypass_global_polyphony(bool p_bypass) {
+	internal->set_bypass_global_polyphony(p_bypass);
+}
+
+bool AudioStreamPlayer::is_bypassing_global_polyphony() const {
+	return internal->bypass_global_polyphony;
+}
+
 void AudioStreamPlayer::play(float p_from_pos) {
 	Ref<AudioStreamPlayback> stream_playback = internal->play_basic();
 	if (stream_playback.is_null()) {
@@ -250,6 +258,9 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
+	ClassDB::bind_method(D_METHOD("set_bypass_global_polyphony", "bypass"), &AudioStreamPlayer::set_bypass_global_polyphony);
+	ClassDB::bind_method(D_METHOD("is_bypassing_global_polyphony"), &AudioStreamPlayer::is_bypassing_global_polyphony);
+
 	ClassDB::bind_method(D_METHOD("play", "from_position"), &AudioStreamPlayer::play, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("seek", "to_position"), &AudioStreamPlayer::seek);
 	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayer::stop);
@@ -289,6 +300,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_target", PROPERTY_HINT_ENUM, "Stereo,Surround,Center"), "set_mix_target", "get_mix_target");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bypass_global_polyphony"), "set_bypass_global_polyphony", "is_bypassing_global_polyphony");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -88,6 +88,9 @@ public:
 	void set_max_polyphony(int p_max_polyphony);
 	int get_max_polyphony() const;
 
+	void set_bypass_global_polyphony(bool p_bypass);
+	bool is_bypassing_global_polyphony() const;
+
 	void play(float p_from_pos = 0.0);
 	void seek(float p_seconds);
 	void stop();

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -149,6 +149,8 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 	stream_playback = stream->instantiate_playback();
 	ERR_FAIL_COND_V_MSG(stream_playback.is_null(), stream_playback, "Failed to instantiate playback.");
 
+	stream_playback->set_bypass_global_polyphony(bypass_global_polyphony);
+
 	for (const KeyValue<StringName, ParameterData> &K : playback_parameters) {
 		stream_playback->set_parameter(K.value.path, K.value.value);
 	}
@@ -326,6 +328,10 @@ void AudioStreamPlayerInternal::set_max_polyphony(int p_max_polyphony) {
 	if (p_max_polyphony > 0) {
 		max_polyphony = p_max_polyphony;
 	}
+}
+
+void AudioStreamPlayerInternal::set_bypass_global_polyphony(bool p_bypass) {
+	bypass_global_polyphony = p_bypass;
 }
 
 bool AudioStreamPlayerInternal::has_stream_playback() {

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -74,6 +74,7 @@ public:
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
+	bool bypass_global_polyphony = false;
 	StringName bus;
 	int max_polyphony = 1;
 
@@ -89,6 +90,7 @@ public:
 	void set_stream(Ref<AudioStream> p_stream);
 	void set_pitch_scale(float p_pitch_scale);
 	void set_max_polyphony(int p_max_polyphony);
+	void set_bypass_global_polyphony(bool p_bypass);
 
 	StringName get_bus() const;
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -733,6 +733,9 @@ void AudioServer::_delete_stream_playback(Ref<AudioStreamPlayback> p_playback) {
 
 void AudioServer::_delete_stream_playback_list_node(AudioStreamPlaybackListNode *p_playback_node) {
 	// Remove the playback from the list, registering a destructor to be run on the main thread.
+	if (!p_playback_node->stream_playback->is_bypassing_global_polyphony()) {
+		playback_count--;
+	}
 	playback_list.erase(p_playback_node, [](AudioStreamPlaybackListNode *p) {
 		delete p->prev_bus_details;
 		delete p->bus_details.load();
@@ -1284,6 +1287,29 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 	playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
 
 	playback_list.insert(playback_node);
+	if (!p_playback->is_bypassing_global_polyphony()) {
+		playback_count++;
+	}
+
+	ensure_playback_limit();
+}
+
+void AudioServer::ensure_playback_limit() {
+	while (playback_count > get_max_global_polyphony()) {
+		AudioStreamPlaybackListNode *last = nullptr;
+		for (AudioStreamPlaybackListNode *node : playback_list) {
+			if (node->stream_playback->is_bypassing_global_polyphony()) {
+				continue;
+			}
+			last = node;
+		}
+
+		if (!last) {
+			return;
+		}
+
+		stop_playback_stream(last->stream_playback);
+	}
 }
 
 void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
@@ -1960,6 +1986,10 @@ AudioServer::PlaybackType AudioServer::get_default_playback_type() const {
 			return PlaybackType::PLAYBACK_TYPE_STREAM;
 		} break;
 	}
+}
+
+int AudioServer::get_max_global_polyphony() const {
+	return GLOBAL_GET_CACHED(int, "audio/general/max_global_polyphony");
 }
 
 bool AudioServer::is_stream_registered_as_sample(const Ref<AudioStream> &p_stream) {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -222,6 +222,8 @@ private:
 	int channel_count = 0;
 	int to_mix = 0;
 
+	int playback_count = 0;
+
 	float playback_speed_scale = 1.0f;
 
 	bool tag_used_audio_streams = false;
@@ -435,6 +437,7 @@ public:
 	// Expose all parameters.
 	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
+	void ensure_playback_limit();
 
 	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes);
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes);
@@ -507,6 +510,7 @@ public:
 #endif
 
 	PlaybackType get_default_playback_type() const;
+	int get_max_global_polyphony() const;
 
 	bool is_stream_registered_as_sample(const Ref<AudioStream> &p_stream);
 	void register_stream_as_sample(const Ref<AudioStream> &p_stream);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -116,6 +116,14 @@ Variant AudioStreamPlayback::get_parameter(const StringName &p_name) const {
 	return ret;
 }
 
+void AudioStreamPlayback::set_bypass_global_polyphony(bool p_bypass) {
+	bypass_global_polyphony = p_bypass;
+}
+
+bool AudioStreamPlayback::is_bypassing_global_polyphony() const {
+	return bypass_global_polyphony;
+}
+
 Ref<AudioSamplePlayback> AudioStreamPlayback::get_sample_playback() const {
 	return nullptr;
 }
@@ -141,6 +149,10 @@ void AudioStreamPlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_loop_count"), &AudioStreamPlayback::get_loop_count);
 	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayback::get_playback_position);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayback::is_playing);
+	ClassDB::bind_method(D_METHOD("set_bypass_global_polyphony", "bypass"), &AudioStreamPlayback::set_bypass_global_polyphony);
+	ClassDB::bind_method(D_METHOD("is_bypassing_global_polyphony"), &AudioStreamPlayback::is_bypassing_global_polyphony);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bypass_global_polyphony"), "set_bypass_global_polyphony", "is_bypassing_global_polyphony");
 }
 
 AudioStreamPlayback::AudioStreamPlayback() {}

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -149,10 +149,7 @@ void AudioStreamPlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_loop_count"), &AudioStreamPlayback::get_loop_count);
 	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayback::get_playback_position);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayback::is_playing);
-	ClassDB::bind_method(D_METHOD("set_bypass_global_polyphony", "bypass"), &AudioStreamPlayback::set_bypass_global_polyphony);
 	ClassDB::bind_method(D_METHOD("is_bypassing_global_polyphony"), &AudioStreamPlayback::is_bypassing_global_polyphony);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bypass_global_polyphony"), "set_bypass_global_polyphony", "is_bypassing_global_polyphony");
 }
 
 AudioStreamPlayback::AudioStreamPlayback() {}

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -77,6 +77,9 @@ public:
 class AudioStreamPlayback : public RefCounted {
 	GDCLASS(AudioStreamPlayback, RefCounted);
 
+private:
+	bool bypass_global_polyphony = false;
+
 protected:
 	static void _bind_methods();
 	PackedVector2Array _mix_audio_bind(float p_rate_scale, int p_frames);
@@ -112,6 +115,9 @@ public:
 	virtual bool get_is_sample() const { return false; }
 	virtual Ref<AudioSamplePlayback> get_sample_playback() const;
 	virtual void set_sample_playback(const Ref<AudioSamplePlayback> &p_playback) {}
+
+	void set_bypass_global_polyphony(bool p_bypass);
+	bool is_bypassing_global_polyphony() const;
 
 	AudioStreamPlayback();
 	~AudioStreamPlayback();


### PR DESCRIPTION
Closes godotengine/godot-proposals#13892

Introduces a global limit to concurrently playing sounds, on top of the per-node limit that already exists. It can be configured via ProjectSettings.audio/general/max_global_polyphony. It also introduces a per-node bypass option, `AudioStreamPlayer.bypass_global_polyphony`, for sounds like music and ambient SFX that should not be interrupted.

When `AudioServer::start_playback_stream()` is called and the number of currently active playbacks meets or exceeds max_global_polyphony, the server first iterates its active playback list and then finds and stops the oldest playback. However, playbacks with the bypass flag set are never evicted and do not count toward the voice limit.

https://github.com/user-attachments/assets/d2e9ff71-9bda-46de-826a-1d6f8f224e02


