### PR TITLE
Make `AudioStreamPreviewGenerator` use `WorkerThreadPool`

### DIFF
--- a/editor/audio/audio_stream_preview.cpp
+++ b/editor/audio/audio_stream_preview.cpp
@@ -212,8 +212,7 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 	preview->preview->length = len_s;
 
 	if (preview->playback.is_valid()) {
-		preview->thread = memnew(Thread);
-		preview->thread->start(_preview_thread, preview);
+		preview->task_id = WorkerThreadPool::get_singleton()->add_native_task(&AudioStreamPreviewGenerator::_preview_thread, preview, true, "AudioStreamPreviewGenerator");
 	}
 
 	return preview->preview;
@@ -233,12 +232,12 @@ void AudioStreamPreviewGenerator::_notification(int p_what) {
 			List<ObjectID> to_erase;
 			for (KeyValue<ObjectID, Preview> &E : previews) {
 				if (!E.value.generating.is_set()) {
-					if (E.value.thread) {
-						E.value.thread->wait_to_finish();
-						memdelete(E.value.thread);
-						E.value.thread = nullptr;
-					}
-					if (!ObjectDB::get_instance(E.key)) { //no longer in use, get rid of preview
+					if (E.value.task_id != WorkerThreadPool::INVALID_TASK_ID) {
+						if (WorkerThreadPool::get_singleton()->is_task_completed(E.value.task_id)) {
+							WorkerThreadPool::get_singleton()->wait_for_task_completion(E.value.task_id);
+							E.value.task_id = WorkerThreadPool::INVALID_TASK_ID;
+						}
+					} else if (!ObjectDB::get_instance(E.key)) { //no longer in use, get rid of preview
 						to_erase.push_back(E.key);
 					}
 				}
@@ -255,4 +254,13 @@ void AudioStreamPreviewGenerator::_notification(int p_what) {
 AudioStreamPreviewGenerator::AudioStreamPreviewGenerator() {
 	singleton = this;
 	set_process(true);
+}
+
+AudioStreamPreviewGenerator::~AudioStreamPreviewGenerator() {
+	for (KeyValue<ObjectID, Preview> &E : previews) {
+		if (E.value.task_id != WorkerThreadPool::INVALID_TASK_ID) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.value.task_id);
+		}
+	}
+	previews.clear();
 }

--- a/editor/audio/audio_stream_preview.h
+++ b/editor/audio/audio_stream_preview.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/os/thread.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/templates/safe_refcount.h"
 #include "scene/main/node.h"
 #include "servers/audio/audio_stream.h"
@@ -64,7 +64,7 @@ class AudioStreamPreviewGenerator : public Node {
 		Ref<AudioStreamPlayback> playback;
 		SafeFlag generating;
 		ObjectID id;
-		Thread *thread = nullptr;
+		WorkerThreadPool::TaskID task_id = WorkerThreadPool::INVALID_TASK_ID;
 
 		// Needed for the bookkeeping of the Map
 		void operator=(const Preview &p_rhs) {
@@ -73,7 +73,7 @@ class AudioStreamPreviewGenerator : public Node {
 			playback = p_rhs.playback;
 			generating.set_to(generating.is_set());
 			id = p_rhs.id;
-			thread = p_rhs.thread;
+			task_id = p_rhs.task_id;
 		}
 		Preview(const Preview &p_rhs) {
 			preview = p_rhs.preview;
@@ -81,7 +81,7 @@ class AudioStreamPreviewGenerator : public Node {
 			playback = p_rhs.playback;
 			generating.set_to(generating.is_set());
 			id = p_rhs.id;
-			thread = p_rhs.thread;
+			task_id = p_rhs.task_id;
 		}
 		Preview() {}
 	};
@@ -102,4 +102,5 @@ public:
 	Ref<AudioStreamPreview> generate_preview(const Ref<AudioStream> &p_stream);
 
 	AudioStreamPreviewGenerator();
+	~AudioStreamPreviewGenerator();
 };


### PR DESCRIPTION
Makes `AudioStreamPreviewGenerator` use `WorkerThreadPool` tasks instead of spawning new Threads.

The `Thread` spawn was causing editor performance issues on platforms that have a high thread creation cost.

Having the preview generate on a thread did not help performance when the creating of the thread was causing all the issues. E.g. on Windows importing a folder with a lot of audio files made the editor feel stuck from spawning so many new threads.