### PR TITLE
Ensure renaming an Autoload removes the old name from code suggestions

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -185,11 +185,11 @@ void EditorAutoloadSettings::_autoload_edited() {
 
 		undo_redo->add_do_property(ProjectSettings::get_singleton(), name, scr_path);
 		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, order);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", selected_autoload);
+		undo_redo->add_do_property(ProjectSettings::get_singleton(), selected_autoload, Variant());
 
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), selected_autoload, scr_path);
 		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_autoload, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, Variant());
 
 		undo_redo->add_do_method(this, CoreStringName(call_deferred), "update_autoload");
 		undo_redo->add_undo_method(this, CoreStringName(call_deferred), "update_autoload");


### PR DESCRIPTION
## What problem(s) does this PR solve?

Correctly removes old name of edited Autoloads from code suggestion.

- Closes #119772.

## Additional information

Changes two lines responsible for deleting the old name from project settings to work like it does in `autoload_remove` in the same file, setting it with a null value instead of using `clear` which doesn't affect the list of `autoloads`.

Example from `autoload_remove`
```cpp
undo_redo->create_action(TTR("Remove Autoload"));

undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
```