### PR TITLE
Change default physics bias to 0.2 (from 0.8)

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8349,6 +8349,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	settings["display/window/stretch/aspect"] = "expand";
 	settings["display/window/stretch/mode"] = "canvas_items";
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
+	settings["physics/2d/solver/default_contact_bias"] = 0.2;
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	return settings;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- A Baumgarte bias setting of 0.8 is higher than recommended in literature. (0.2 - 0.3 recommended)
- Fixes excess bounciness and instability. 
- Makes Godot Physics acceptable in my game (it was volatile with a large body count)
- Collision bias and constraint bias defaults were vastly different, making it hard to create a stable fix for joints.
- This default setting is a roadblock to demonstrating further physics solver and stability fixes and improvements.

## Additional information

- Most modern external engines don't use Baumgarte bias but calculate it from softness settings, so they likely ignore this change anyway. Rapier add on remains unchanged, but I haven't tested any other add ons.
- I have tested with the Godot-demo-projects box stacking and pyramid tests (which are unchanged) and my own game and tests (which sees a big behaviour improvement).
- This change could be registered by users who rely on contact impulse reporting and are used to more erratic impulses.

I think the problem might have slipped in by accident, and if so, it seems like a no brainer to fix. If it causes some other problem, then I imagine there is some other issue to be looked at.