### PR TITLE
Enable `touch_dragger` in `ExportTemplateManager` on touchscreen devices

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -1307,6 +1307,12 @@ void ExportTemplateManager::_notification(int p_what) {
 			EditorNode::get_bottom_panel()->get_progress_indicator()->connect("clicked", callable_mp(this, &ExportTemplateManager::popup_manager));
 		} break;
 
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				center_split->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
+			}
+		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (template_data.is_empty()) {
 				break;
@@ -1601,8 +1607,9 @@ ExportTemplateManager::ExportTemplateManager() {
 	side_vb->add_child(version_list);
 	version_list->connect(SceneStringName(item_selected), callable_mp(this, &ExportTemplateManager::_version_selected).unbind(1));
 
-	VSplitContainer *center_split = memnew(VSplitContainer);
+	center_split = memnew(VSplitContainer);
 	center_split->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	center_split->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
 	main_split->add_child(center_split);
 
 	VBoxContainer *available_templates_container = memnew(VBoxContainer);

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -43,6 +43,7 @@ class OptionButton;
 class Texture2D;
 class Tree;
 class TreeItem;
+class VSplitContainer;
 
 class TemplateDownloader : public HTTPRequest {
 	GDCLASS(TemplateDownloader, HTTPRequest);
@@ -190,6 +191,7 @@ class ExportTemplateManager : public AcceptDialog {
 	HashMap<String, int> checked_cache;
 	HashMap<String, bool> folding_cache;
 
+	VSplitContainer *center_split = nullptr;
 	OptionButton *mirrors_list = nullptr;
 	Button *open_mirror = nullptr;
 	ItemList *version_list = nullptr;


### PR DESCRIPTION
Enables `touch_dragger` for `center_split` in `ExportTemplateManager`. This improves usability on mobile devices. Previously, the available templates panel was too narrow and difficult to interact with on mobile screens. With `touch_dragger` enabled, users can easily resize the split view and expand the area as needed.