### PR TITLE
Editor: Fix Incorrect Implementation in  "Editor: Fix Tag Overrun Behavior"

### DIFF
--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -41,7 +41,7 @@ void ProjectTag::_notification(int p_what) {
 	// HACK: Can't be set in constructor because `get_size()` would return empty.
 	// This logic should be migrated once `Button` utilizes internal labels.
 	if (p_what == NOTIFICATION_READY) {
-		button->set_custom_minimum_size(get_size());
+		button->set_custom_minimum_size(button->get_size());
 		button->set_text_overrun_behavior(TextServer::OverrunBehavior::OVERRUN_TRIM_ELLIPSIS);
 	}
 }


### PR DESCRIPTION
This exists because it seems StarryWorm won't be able to alleviate the need for this just yet, as stated here #119345 (direct quote below)
> This behaves poorly inside of `Container` nodes. As such, this does not fix the hack introduced in #119088 (unfortunately)