### PR TITLE
Add author disclosure to PR template (incentivizing AI usage disclosure)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,6 @@ Please target the `master` branch. We will take care of backporting relevant fix
 
 Before submitting, please read our checklist for contributors:
 https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-
-Use of AI must be disclosed and should include a description of how it was used.
 -->
 
 ## What problem(s) does this PR solve?
@@ -15,4 +13,10 @@ Use of AI must be disclosed and should include a description of how it was used.
 
 <!--
 Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
+-->
+
+## Author disclosure
+
+<!--
+If you did not write any part of this PR yourself, disclose that here. If you used AI for this PR, disclose what you used AI for specifically.
 -->


### PR DESCRIPTION
## What problem(s) does this PR solve?

The current PR template asks for disclosing AI, but is so lenient about it that at least half of the obviously-AI PRs from the last month or so don’t even bother mentioning it.

It is important for reviewers to know when AI is used or not, and if it was used: to what extent. Not being sure comes to the detriment of first time reviewers as half the time of a reviewer is spent on investigating the PR and author to determine AI usage. This is increasingly demotivating to reviewers. PRs that do not disclose the use of generative AI waste reviewer time with code that makes no sense. Code added by an agent that doesn’t care, can’t take responsibility for it, or can’t continue to maintain it, should not be added to the codebase. It is important for the health of Godot that human made contributions can be reviewed with the attention they deserve. AI use disclose, or non-use disclosure, is part of the solution. This PR makes it more explicit.

## Additional information

Please do suggest any improvements you can think of.

## Author disclosure

No generative AI was used to make this PR.