### PR TITLE
Add "empty list" check to `[br]` tag handler in `make_rst.py`

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2312,7 +2312,7 @@ def format_text_block(
                 # Make a new paragraph instead of a linebreak, rst is not so linebreak friendly
                 tag_text = "\n\n"
                 # Strip potential leading spaces
-                while post_text[0] == " ":
+                while post_text and post_text[0] == " ":
                     post_text = post_text[1:]
 
             elif tag_state.name == "center":

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2312,8 +2312,8 @@ def format_text_block(
                 # Make a new paragraph instead of a linebreak, rst is not so linebreak friendly
                 tag_text = "\n\n"
                 # Strip potential leading spaces
-                while post_text and post_text[0] == " ":
-                    post_text = post_text[1:]
+                if post_text.startswith(" "):
+                    post_text = post_text.lstrip()
 
             elif tag_state.name == "center":
                 if tag_state.closing:


### PR DESCRIPTION
## What problem(s) does this PR solve?

Suspected bug in XML to RST Conversion. The code breaks at `line 2315` of `make_rst.py` with an **index out of bounds error**. The the bug most likely occurs when a `[br]` tag is immediately followed by a newline.

There is no check for when the `post_text` array becomes empty and hence breaks the code.

I have tested it on my own XML files successfully and did not encounter any errors.

## Additional information

I also noticed a mistake in the Godot documentation for creating your own doc-website using RST (over [here](https://docs.godotengine.org/en/stable/tutorials/scripting/cpp/gdextension_docs_system.html#publishing-documentation-online)).

The docs instruct us to download `version.py` and `make_rst.py` but not the local dependency `misc.utility.color` written at `line 17` of `make_rst.py`.

I am making my own XML-to-RST converter which is simply a variant of this repo stripped down specifically for RST Conversion as a quick fix. You can find it at [MUmarShahbaz/Godot-XML-to-RST](https://github.com/MUmarShahbaz/Godot-XML-to-RST) if you want to reference it in the docs as a temporary (or permanent) fix.