### PR TITLE
Fix flickering on resize caused by auto-exposure

### DIFF
--- a/servers/rendering/renderer_rd/effects/luminance.cpp
+++ b/servers/rendering/renderer_rd/effects/luminance.cpp
@@ -79,6 +79,12 @@ Luminance::~Luminance() {
 	}
 }
 
+Luminance::LuminanceBuffers::~LuminanceBuffers() {
+	if (last_luminance.is_valid()) {
+		RD::get_singleton()->free_rid(last_luminance);
+	}
+}
+
 void Luminance::LuminanceBuffers::set_prefer_raster_effects(bool p_prefer_raster_effects) {
 	prefer_raster_effects = p_prefer_raster_effects;
 }
@@ -106,7 +112,7 @@ void Luminance::LuminanceBuffers::configure(RenderSceneBuffersRD *p_render_buffe
 		}
 
 		if (final) {
-			tf.usage_bits |= RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+			tf.usage_bits |= RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 		}
 
 		RID texture = RD::get_singleton()->texture_create(tf, RD::TextureView());
@@ -114,7 +120,11 @@ void Luminance::LuminanceBuffers::configure(RenderSceneBuffersRD *p_render_buffe
 
 		if (final) {
 			current = RD::get_singleton()->texture_create(tf, RD::TextureView());
-			RD::get_singleton()->texture_clear(current, Color(0.0, 0.0, 0.0), 0u, 1u, 0u, 1u);
+			if (last_luminance.is_valid()) {
+				RD::get_singleton()->texture_copy(last_luminance, current, Vector3(), Vector3(), Vector3(1, 1, 1), 0u, 0u, 0u, 0u);
+			} else {
+				RD::get_singleton()->texture_clear(current, DEFAULT_LUMINANCE, 0u, 1u, 0u, 1u);
+			}
 			break;
 		}
 	}
@@ -126,8 +136,12 @@ void Luminance::LuminanceBuffers::free_data() {
 	}
 	reduce.clear();
 
+	if (last_luminance.is_valid()) {
+		RD::get_singleton()->free_rid(last_luminance);
+	}
+
 	if (current.is_valid()) {
-		RD::get_singleton()->free_rid(current);
+		last_luminance = current;
 		current = RID();
 	}
 }

--- a/servers/rendering/renderer_rd/effects/luminance.h
+++ b/servers/rendering/renderer_rd/effects/luminance.h
@@ -91,16 +91,20 @@ public:
 		GDCLASS(LuminanceBuffers, RenderBufferCustomDataRD);
 
 	private:
+		static constexpr Color DEFAULT_LUMINANCE = Color(0.754, 0.754, 0.754);
 		bool prefer_raster_effects;
 
 	public:
 		Vector<RID> reduce;
 		RID current;
+		RID last_luminance;
 
 		virtual void configure(RenderSceneBuffersRD *p_render_buffers) override;
 		virtual void free_data() override;
 
 		void set_prefer_raster_effects(bool p_prefer_raster_effects);
+
+		~LuminanceBuffers();
 	};
 
 	Ref<LuminanceBuffers> get_luminance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers);


### PR DESCRIPTION
- Cache current luminance value before freeing buffer and use that as the initial clear color when re-configuring
- Stops bright flashing when resizing in the editor and in game

## What problem(s) does this PR solve?

- Closes #104761

## Additional information

I'm not certain about the method of obtaining the current value from the buffer, if there is a better way let me know. I'm not a fan of including `marshalls.h` for what is effectively a reinterpret cast of 4 bytes, but I suppose it's better to use official APIs instead of hacking in a direct cast.

The default clear for current is equivalent to the GRAY color. Using a default color other than black is better anyway because that is the main cause of over-exposure during resizing. If something happens and it loses the current value, it will still flick to a new exposure but the brighter default will prevent it from blinding people for a second.
