### PR TITLE
For Rider: Sync dotnet setting "dotnet/editor/editor_path_optional" 

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -53,6 +53,7 @@ namespace GodotTools.Ides.Rider
                 Globals.EditorDef(EditorPathSettingName, editorPath);
                 return;
             }
+            if (SyncWithGDScriptExternalEditorIfValid(editor, editorSettings, "text_editor/external/exec_path")) return;
 
             var paths = RiderPathLocator.GetAllRiderPaths().Where(info => IsMatch(editor, info.Path)).ToArray();
             if (paths.Length == 0)
@@ -63,6 +64,19 @@ namespace GodotTools.Ides.Rider
             string newPath = paths.Last().Path;
             Globals.EditorDef(EditorPathSettingName, newPath);
             editorSettings.SetSetting(EditorPathSettingName, newPath);
+        }
+
+        private static bool SyncWithGDScriptExternalEditorIfValid(ExternalEditorId editor, EditorSettings editorSettings, string settingName)
+        {
+            var editorPath = (string)editorSettings.GetSetting(settingName);
+            if (File.Exists(editorPath) && IsMatch(editor, editorPath))
+            {
+                editorSettings.SetSetting(EditorPathSettingName, editorPath);
+                Globals.EditorDef(EditorPathSettingName, editorPath);
+                return true;
+            }
+
+            return false;
         }
 
         private static bool IsMatch(ExternalEditorId editorId, string path)


### PR DESCRIPTION
from "text_editor/external/exec_path" in a cases, when no own value is set.

We already have GodotEditor addon https://godotengine.org/asset-library/asset/4576, which is good in finding Rider on all OS. When Rider is set as as external editor for gdscript, and dotnet external editor is being switched to Rider too, then the value from GDScript external editor would be used, if no own value exists.

## What problem(s) does this PR solve?

Partially adresses https://github.com/godotengine/godot-proposals/issues/14905
