### PR TITLE
Fix "Open Documentation" ignoring non-top-level nodes

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1311,8 +1311,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 		} break;
 		case TOOL_OPEN_DOCUMENTATION: {
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			for (const Node *node : selection) {
+			for (const Node *node : editor_selection->get_full_selected_node_list()) {
 				String class_name;
 				Ref<Script> script_base = node->get_script();
 				while (script_base.is_valid()) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/119907

Note: Split from https://github.com/godotengine/godot/pull/119617. Can be merged separately.

Changes:
- "Open Documentation" now applies to all nodes in the selection, instead of non-top-level nodes only.

Video:

https://github.com/user-attachments/assets/7ad292f0-4288-4e30-83bb-1cee9c5f2da4
