### PR TITLE
Fix "Move Up/Down" editing foreign nodes

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -885,14 +885,14 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			if (!_validate_no_foreign_selected(editor_selection->get_top_selected_node_list())) {
+			List<Node *> selection = editor_selection->get_full_selected_node_list();
+			if (!_validate_no_foreign_selected(selection)) {
 				break;
 			}
 
 			bool MOVING_DOWN = (p_tool == TOOL_MOVE_DOWN);
 			bool MOVING_UP = !MOVING_DOWN;
 
-			List<Node *> selection = editor_selection->get_full_selected_node_list();
 			selection.sort_custom<Node::Comparator>(); // sort by index
 			if (MOVING_DOWN) {
 				selection.reverse();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/119906

Note: Split from https://github.com/godotengine/godot/pull/119617. Can be merged separately.

Changes:
- "Move Up/Down" now checks if any selected child node is foreign.

Video:

https://github.com/user-attachments/assets/f8b53260-917c-45fc-8879-e0ec0274e5b0



