### PR TITLE
Add PhysicsDirectSpaceState3D.intersect_ray_into for allocation-free raycasts

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -75,6 +75,24 @@
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
 		</method>
+		<method name="intersect_ray_into">
+			<return type="bool" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
+			<param index="1" name="result" type="PhysicsRayQueryResult3D" />
+			<description>
+				Allocation-free variant of [method intersect_ray]. Performs the same intersection query but writes the hit data into the caller-provided [param result] holder instead of allocating a new [Dictionary] per call. Returns [code]true[/code] when the ray hit something, [code]false[/code] otherwise; on a miss, [param result] is cleared.
+				This is the preferred entry point for hot-path raycasts (hitscan weapons, line-of-sight checks, foot IK probes), where the per-call [Dictionary] allocation and key-string interning of [method intersect_ray] becomes a measurable source of garbage on busy frames. The legacy [method intersect_ray] is unchanged.
+				[codeblock]
+				var query := PhysicsRayQueryParameters3D.create(from, to)
+				var result := PhysicsRayQueryResult3D.new()  # allocate once, reuse every frame
+				var space := get_world_3d().direct_space_state
+				if space.intersect_ray_into(query, result):
+				    position = result.get_position()
+				    normal = result.get_normal()
+				[/codeblock]
+				[b]Note:[/b] [param result] is overwritten on every call. Reading fields from a previous query after a new [method intersect_ray_into] call returns stale or unrelated data.
+			</description>
+		</method>
 		<method name="intersect_shape">
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />

--- a/doc/classes/PhysicsRayQueryResult3D.xml
+++ b/doc/classes/PhysicsRayQueryResult3D.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsRayQueryResult3D" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Holds the result of a [method PhysicsDirectSpaceState3D.intersect_ray_into] query.
+	</brief_description>
+	<description>
+		Reusable result holder for the allocation-free raycast API [method PhysicsDirectSpaceState3D.intersect_ray_into]. The caller creates one instance and passes it to every query, avoiding the per-call [Dictionary] allocation that the legacy [method PhysicsDirectSpaceState3D.intersect_ray] performs.
+		Fields are populated by the engine on a successful hit and cleared when the ray misses. Read [method has_hit] first; the other getters are only meaningful when it returns [code]true[/code].
+		[codeblock]
+		var query := PhysicsRayQueryParameters3D.create(from, to)
+		var result := PhysicsRayQueryResult3D.new()  # allocate once, reuse for every cast
+		var space := get_world_3d().direct_space_state
+		if space.intersect_ray_into(query, result):
+		    print("hit at ", result.get_position(), " normal ", result.get_normal())
+		[/codeblock]
+	</description>
+	<tutorials>
+		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>
+	</tutorials>
+	<methods>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<description>
+				Returns the colliding object, or [code]null[/code] when no hit was recorded.
+			</description>
+		</method>
+		<method name="get_collider_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the unique instance ID of the colliding object. See [method Object.get_instance_id]. Returns [code]0[/code] when no hit was recorded.
+			</description>
+		</method>
+		<method name="get_face_index" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the face index at the intersection point.
+				[b]Note:[/b] Returns a valid index only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise [code]-1[/code] is returned.
+			</description>
+		</method>
+		<method name="get_normal" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray started inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] was [code]true[/code]. Equivalent to the [code]normal[/code] key of the [Dictionary] returned by [method PhysicsDirectSpaceState3D.intersect_ray].
+			</description>
+		</method>
+		<method name="get_position" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the intersection point in global coordinates. Equivalent to the [code]position[/code] key of the [Dictionary] returned by [method PhysicsDirectSpaceState3D.intersect_ray].
+			</description>
+		</method>
+		<method name="get_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the intersecting object's [RID].
+			</description>
+		</method>
+		<method name="get_shape" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the shape index of the colliding shape on the intersecting object. See [CollisionObject3D].
+			</description>
+		</method>
+		<method name="has_hit" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the most recent [method PhysicsDirectSpaceState3D.intersect_ray_into] call that filled this result reported a hit. When [code]false[/code], the other getters return zero / default values and should not be relied on.
+				[method PhysicsDirectSpaceState3D.intersect_ray_into] also returns this same value, so checking the call's return value is usually sufficient.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -383,6 +383,16 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	return d;
 }
 
+bool PhysicsDirectSpaceState3D::_intersect_ray_into(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, RequiredParam<PhysicsRayQueryResult3D> rp_result) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, false);
+	EXTRACT_PARAM_OR_FAIL_V(p_result, rp_result, false);
+
+	RayResult result;
+	bool hit = intersect_ray(p_ray_query->get_parameters(), result);
+	p_result->_set_result(result, hit);
+	return hit;
+}
+
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results) {
 	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
 
@@ -488,10 +498,50 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
+	ClassDB::bind_method(D_METHOD("intersect_ray_into", "parameters", "result"), &PhysicsDirectSpaceState3D::_intersect_ray_into);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("get_rest_info", "parameters"), &PhysicsDirectSpaceState3D::_get_rest_info);
+}
+
+///////////////////////////////
+
+void PhysicsRayQueryResult3D::_set_result(const PhysicsDirectSpaceState3D::RayResult &p_result, bool p_hit) {
+	hit = p_hit;
+	if (p_hit) {
+		position = p_result.position;
+		normal = p_result.normal;
+		face_index = p_result.face_index;
+		collider_id = p_result.collider_id;
+		collider = p_result.collider;
+		shape = p_result.shape;
+		rid = p_result.rid;
+	} else {
+		_clear();
+	}
+}
+
+void PhysicsRayQueryResult3D::_clear() {
+	hit = false;
+	position = Vector3();
+	normal = Vector3();
+	face_index = -1;
+	collider_id = ObjectID();
+	collider = nullptr;
+	shape = 0;
+	rid = RID();
+}
+
+void PhysicsRayQueryResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("has_hit"), &PhysicsRayQueryResult3D::has_hit);
+	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsRayQueryResult3D::get_position);
+	ClassDB::bind_method(D_METHOD("get_normal"), &PhysicsRayQueryResult3D::get_normal);
+	ClassDB::bind_method(D_METHOD("get_face_index"), &PhysicsRayQueryResult3D::get_face_index);
+	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsRayQueryResult3D::get_collider_id);
+	ClassDB::bind_method(D_METHOD("get_collider"), &PhysicsRayQueryResult3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsRayQueryResult3D::get_shape);
+	ClassDB::bind_method(D_METHOD("get_rid"), &PhysicsRayQueryResult3D::get_rid);
 }
 
 ///////////////////////////////

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -122,11 +122,14 @@ class PhysicsRayQueryParameters3D;
 class PhysicsPointQueryParameters3D;
 class PhysicsShapeQueryParameters3D;
 
+class PhysicsRayQueryResult3D;
+
 class PhysicsDirectSpaceState3D : public Object {
 	GDCLASS(PhysicsDirectSpaceState3D, Object);
 
 private:
 	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query);
+	bool _intersect_ray_into(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, RequiredParam<PhysicsRayQueryResult3D> rp_result);
 	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
@@ -830,6 +833,40 @@ public:
 
 	PhysicsServer3D();
 	~PhysicsServer3D();
+};
+
+// Pooled, reusable result holder for intersect_ray_into — avoids the Dictionary
+// allocation + 7x Variant boxing the legacy intersect_ray return-by-Dictionary
+// path performs on every successful raycast. Caller allocates once, reuses
+// across queries.
+class PhysicsRayQueryResult3D : public RefCounted {
+	GDCLASS(PhysicsRayQueryResult3D, RefCounted);
+
+	bool hit = false;
+	Vector3 position;
+	Vector3 normal;
+	int face_index = -1;
+	ObjectID collider_id;
+	Object *collider = nullptr;
+	int shape = 0;
+	RID rid;
+
+protected:
+	static void _bind_methods();
+
+public:
+	// Engine-internal — populated by PhysicsDirectSpaceState3D::_intersect_ray_into.
+	void _set_result(const PhysicsDirectSpaceState3D::RayResult &p_result, bool p_hit);
+	void _clear();
+
+	bool has_hit() const { return hit; }
+	Vector3 get_position() const { return position; }
+	Vector3 get_normal() const { return normal; }
+	int get_face_index() const { return face_index; }
+	ObjectID get_collider_id() const { return collider_id; }
+	Object *get_collider() const { return collider; }
+	int get_shape() const { return shape; }
+	RID get_rid() const { return rid; }
 };
 
 class PhysicsRayQueryParameters3D : public RefCounted {

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -346,6 +346,7 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count");
 
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
+	GDREGISTER_CLASS(PhysicsRayQueryResult3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsTestMotionParameters3D);


### PR DESCRIPTION
### Summary

Adds an allocation-free variant of `PhysicsDirectSpaceState3D.intersect_ray()`:

```cpp
bool intersect_ray_into(Ref<PhysicsRayQueryParameters3D> parameters,
                        Ref<PhysicsRayQueryResult3D>     result);
```

with a new `RefCounted` result holder `PhysicsRayQueryResult3D`. The caller pre-allocates the holder once and reuses it across every raycast, avoiding the `Dictionary` + per-key `Variant` boxing the existing `intersect_ray()` performs on every call.

Purely additive — the existing `intersect_ray()` is **unchanged**. No backwards-compat impact on projects, GDScript, GDExtension, or the C# bindings. The new class follows the same shape as `PhysicsTestMotionResult3D` (RefCounted, methods-only, populated by the engine).

```gdscript
var query := PhysicsRayQueryParameters3D.create(from, to)
var result := PhysicsRayQueryResult3D.new()  # allocate once, reuse every frame
var space := get_world_3d().direct_space_state
if space.intersect_ray_into(query, result):
    position = result.get_position()
    normal = result.get_normal()
```

### Why this is worth adding

`intersect_ray()` is in the hot path of many runtime systems where the per-call `Dictionary` allocation becomes a measurable cost:

- **Hitscan weapons** in FPS games (1+ ray per shot, multiple for spread / penetration)
- **Camera collision** (per-frame, per actor)
- **Line-of-sight visibility checks** (fog-of-war, AI sensing)
- **Foot IK probes** (one per foot per frame)
- **Audio occlusion** (one per audible source)
- **Grenade trajectory preview** (per simulation step)

Each call currently allocates:
1. C++ side: one `Dictionary` + 7× `Variant` boxes (`position`, `normal`, `face_index`, `collider_id`, `collider`, `shape`, `rid`) + per-key `StringName` interning.
2. For C# users: a managed `Godot.Collections.Dictionary` wrapper per call, plus **every `result["position"]` read crosses the binding twice** — once to fetch the `Variant`, once to unbox.

For projects where these add up (FPS games, busy AI scenes, twin-stick shooters with hitscan), this becomes a visible item in the GC histogram and a measurable contributor to the frame-time tail. The new path writes straight into the result holder's typed fields and field reads go through the regular PtrCall path used by every other engine getter — no Variant round-trip on either side.

### What changed

| File | Lines | Purpose |
|------|-------|---------|
| `servers/physics_3d/physics_server_3d.h` | +37 | Forward decl + `PhysicsRayQueryResult3D` class + `_intersect_ray_into` declaration |
| `servers/physics_3d/physics_server_3d.cpp` | +50 | `_intersect_ray_into` impl + `PhysicsRayQueryResult3D::_set_result/_clear/_bind_methods` |
| `servers/register_server_types.cpp` | +1 | `GDREGISTER_CLASS(PhysicsRayQueryResult3D)` |
| `doc/classes/PhysicsDirectSpaceState3D.xml` | +18 | New `intersect_ray_into` method doc with GDScript example |
| `doc/classes/PhysicsRayQueryResult3D.xml` | +72 (new) | Full class doc, all 8 getters, usage example |

Total: 178 lines of code + docs. No deletions, no renames.

### API surface

`PhysicsRayQueryResult3D` (new, RefCounted) — methods only, all `const`. Mirrors `PhysicsTestMotionResult3D` style.

| Method | Returns | Notes |
|--------|---------|-------|
| `has_hit()` | `bool` | Same value the call returns |
| `get_position()` | `Vector3` | Intersection point, global coords |
| `get_normal()` | `Vector3` | Surface normal |
| `get_face_index()` | `int` | `-1` unless `ConcavePolygonShape3D` |
| `get_collider()` | `Object` | Colliding node, or `null` on miss |
| `get_collider_id()` | `int` | Instance ID |
| `get_shape()` | `int` | Shape index on the collider |
| `get_rid()` | `RID` | Physics RID of the intersecting object |

On miss the holder is cleared (`has_hit() == false`, other getters return zeroed defaults).

### Bindings & scripting languages

- **GDScript** — works out of the box. `PhysicsRayQueryResult3D.new()` and the getters above.
- **C# / Mono** — auto-generated `Godot.PhysicsRayQueryResult3D` wrapper via the same `GDREGISTER_CLASS` path that handles `PhysicsTestMotionResult3D`. All getters become `GetXxx()` methods. Reads use the existing PtrCall path that powers every other engine getter (no Variant round-trip).
- **GDExtension** — registered via `GDREGISTER_CLASS`, so language bindings (rust-godot, godot-cpp, etc.) pick it up automatically.

### Backwards compatibility

Zero impact on existing projects:

- `intersect_ray()` signature, behavior, and Dictionary key shape — **unchanged**.
- The new class doesn't shadow or replace anything.
- No serialised resource or scene-file format changes.

Existing call sites get no benefit unless they actively opt into the new method. Migration is a small per-call-site change (declare a result field, pass it as the second arg, read typed fields instead of dictionary lookups).

### Performance methodology

The patch was developed against a 16-player competitive FPS project running on the Mono build. Measured impact comes from two places:

1. **Engine-side**: `Dictionary` + 7× `Variant` heap allocation per successful `intersect_ray()`. Eliminated for the new entry point by writing directly into the holder's fields.
2. **C# binding**: `Godot.Collections.Dictionary` managed wrapper + per-property cross-binding `Variant` unboxing. Replaced by the standard PtrCall getters that every other engine class uses.

The reduction is proportional to raycast frequency. On a 60-second listen-server bot match (8 bots, dust2-scale map, full-auto fire) the project-side migration cut the per-second `intersect_ray`-attributable allocations to a small constant.

I'll be happy to add an engine-only microbenchmark to `tests/` if reviewers want a number in-tree before merge — let me know the preferred shape.

### Open questions for reviewers

1. **Naming**: `intersect_ray_into(query, result)` follows the C++ "out parameter" convention. Alternatives considered: `intersect_ray_to`, `intersect_ray_filled`, `cast_ray`. Happy to rename.
2. **Default-init values on miss**: `_clear()` sets `face_index = -1` (matches `RayResult::face_index` default and the existing `intersect_ray` semantics) and other fields to zero defaults. Open to leaving them untouched if reviewers prefer; just need to document either choice clearly.
3. **Member exposure**: I exposed getters only (no `<members>` block, no `ADD_PROPERTY`). Matches `PhysicsTestMotionResult3D`. If reviewers want property-style access from scripts, I can add `ADD_PROPERTY` with empty setters (read-only), though that mixes a bit awkwardly with the editor's property inspector for a holder that should never be edited from there.

### Follow-up work (intentionally not in this PR)

To keep the PR small and reviewable, the following are explicitly **not** included here. Happy to do them as separate PRs if there's appetite:

- **2D equivalent**: `PhysicsRayQueryResult2D` + `PhysicsDirectSpaceState2D.intersect_ray_into`. Same pattern, mechanically applied to the 2D server.
- **Same pattern for the other space-state queries that allocate `Dictionary` / `Array` results**: `intersect_shape`, `intersect_point`, `get_rest_info`, `cast_motion`. These have multi-result shapes that need slightly more design (caller-provided typed array? max-results cap on the holder?), better as a follow-up.

### Testing

- Manual: bot-match scenario above, 60-second sessions before/after with the same query params. Verified equivalent hit results between `intersect_ray` and `intersect_ray_into` (collider, position, normal, face_index match within float-precision).
- Edge cases verified by inspection:
  - Miss case: `has_hit() == false`, all getters return zero/`null`.
  - Repeated calls reusing the same result holder: previous fields cleanly overwritten via `_set_result` / `_clear`.
  - GDScript and C# both pick up the new class in autocomplete + docs.

---

_This is my first upstream Godot contribution — happy to adjust the patch, naming, doc wording, or anything else the reviewers prefer. If a `godot-proposals` issue is expected first for this kind of additive API, let me know and I'll open one and link it back._
