### PR TITLE
Fix remote scene tree expanding selected nodes on reveal

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -287,7 +287,10 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 				if (should_scroll) {
 					// Temporarily set to `false`, to allow caching the unfolds.
 					updating_scene_tree = false;
-					item->uncollapse_tree();
+					// Expand ancestors to make the item visible.
+					if (TreeItem *parent_item = item->get_parent()) {
+						parent_item->uncollapse_tree();
+					}
 					updating_scene_tree = true;
 					scroll_item = item;
 				}


### PR DESCRIPTION
When a node is selected in the remote scene tree, expand only its ancestors and not the node itself. This applies when it's selected in the tree directly or picked from the game viewport, since both go through the same code path.

Before:

https://github.com/user-attachments/assets/6e17b77f-4c9f-47b5-ad78-5968feb507cd

After:

https://github.com/user-attachments/assets/25b861cf-2b03-4ca1-ad6b-524539320596

## What problem(s) does this PR solve?

Previously, selecting a node in the remote scene tree would cause that node to be expanded, revealing its children.
This differs from the local scene tree, where selecting a node does not expand the node. I'm assuming this is not the intended behavior.

## Additional information

🤖 I used Claude Code to help identify the root cause along with manual tracing using GDB.