### PR TITLE
Wayland: Fix crash with zero-geometry windows

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -871,7 +871,9 @@ void DisplayServerWayland::show_window(DisplayServerEnums::WindowID p_window_id)
 
 		wd.root_id = root_id;
 
-		if (!window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, p_window_id)) {
+		bool is_toplevel = !window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, p_window_id);
+
+		if (is_toplevel) {
 			// NOTE: DO **NOT** KEEP THE POSITION SET FOR TOPLEVELS. Wayland does not
 			// track them and we're gonna get our events transformed in unexpected ways.
 			wd.rect.position = Point2i();
@@ -881,7 +883,6 @@ void DisplayServerWayland::show_window(DisplayServerEnums::WindowID p_window_id)
 			wayland_thread.window_set_min_size(p_window_id, wd.min_size);
 			wayland_thread.window_set_max_size(p_window_id, wd.max_size);
 			wayland_thread.window_set_app_id(p_window_id, _get_app_id_from_context(context));
-			wayland_thread.window_set_borderless(p_window_id, window_get_flag(DisplayServerEnums::WINDOW_FLAG_BORDERLESS, p_window_id));
 
 			// Since it can't have a position. Let's tell the window node the news by
 			// sending the actual rect to it.
@@ -909,6 +910,11 @@ void DisplayServerWayland::show_window(DisplayServerEnums::WindowID p_window_id)
 			_send_window_event(DisplayServerEnums::WINDOW_EVENT_FORCE_CLOSE, p_window_id);
 
 			return;
+		}
+
+		if (is_toplevel) {
+			// Need to do this after window_wait_ready above to avoid zero-geometry error with libdecor.
+			wayland_thread.window_set_borderless(p_window_id, window_get_flag(DisplayServerEnums::WINDOW_FLAG_BORDERLESS, p_window_id));
 		}
 
 		// NOTE: The XDG shell protocol is built in a way that causes the window to


### PR DESCRIPTION
Setting a window to borderless when using libdecor before the window is configured causes libdecor to commit a zero-geometry window. This is a Wayland protocol violation and causes a crash.

Fix by setting the window to borderless after the window is configured. This is harmless on non-libdecor flows.

AI Disclaimer: Code and commit message is written entirely by me. Earlier iterations included additional safeguards suggested by AI. They were simple but ultimately not related to the fix, so I removed them.

- Fixes #119923