### PR TITLE
Fix inconsistent max size checks for drawable textures

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1208,7 +1208,7 @@ void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int
 
 	// GUARDRAIL: Bad Widths/Heights
 	ERR_FAIL_COND_MSG(p_width <= 0 || p_height <= 0, "Drawable Texture Width or Height cannot be less than 1.");
-	ERR_FAIL_COND_MSG(p_width >= 16384 || p_height >= 16384, "Drawable Texture Width or Height cannot be greater than 16383.");
+	ERR_FAIL_COND_MSG(p_width > 16384 || p_height > 16384, "Drawable Texture Width or Height cannot be greater than 16384.");
 
 	Image::Format format;
 	switch (p_format) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1287,11 +1287,11 @@ void TextureStorage::texture_proxy_initialize(RID p_texture, RID p_base) {
 }
 
 void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int p_height, RSE::TextureDrawableFormat p_format, const Color &p_color, bool p_with_mipmaps) {
-	// Near identical to  Texture_2D_initialize, Generates an empty white image based on parameters
+	// Near identical to Texture_2D_initialize, Generates an empty white image based on parameters
 
 	// GUARDRAIL: Bad Widths/Heights
 	ERR_FAIL_COND_MSG(p_width <= 0 || p_height <= 0, "Drawable Texture Width or Height cannot be less than 1.");
-	ERR_FAIL_COND_MSG(p_width >= 16384 || p_height >= 16384, "Drawable Texture Width or Height cannot be greater than 16383.");
+	ERR_FAIL_COND_MSG(p_width > 16384 || p_height > 16384, "Drawable Texture Width or Height cannot be greater than 16384.");
 
 	Image::Format format;
 	switch (p_format) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Sets the maximum size in `texture_storage.cpp` of `DrawableTexture2D` to 16384 x 16384, to match the general Texture2D size limit and the limit set in `drawable_texture_2d.cpp`
- Closes #119928