### PR TITLE
GDScript: Remove unused code in `GDScriptFunctionState`

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -285,27 +285,6 @@ Variant GDScriptFunctionState::_signal_callback(const Variant **p_args, int p_ar
 	return resume(arg);
 }
 
-bool GDScriptFunctionState::is_valid(bool p_extended_check) const {
-	if (function == nullptr) {
-		return false;
-	}
-
-	if (p_extended_check) {
-		MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
-
-		// Script gone?
-		if (!scripts_list.in_list()) {
-			return false;
-		}
-		// Class instance gone? (if not static function)
-		if (state.instance && !instances_list.in_list()) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	ERR_FAIL_NULL_V(function, Variant());
 	{
@@ -362,8 +341,6 @@ void GDScriptFunctionState::_clear_connections() {
 }
 
 void GDScriptFunctionState::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("resume", "arg"), &GDScriptFunctionState::resume, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("is_valid", "extended_check"), &GDScriptFunctionState::is_valid, DEFVAL(false));
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "_signal_callback", &GDScriptFunctionState::_signal_callback, MethodInfo("_signal_callback"));
 
 	ADD_SIGNAL(MethodInfo("completed", PropertyInfo(Variant::NIL, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
@@ -375,10 +352,8 @@ GDScriptFunctionState::GDScriptFunctionState() :
 }
 
 GDScriptFunctionState::~GDScriptFunctionState() {
-	{
-		MutexLock lock(GDScriptLanguage::singleton->mutex);
-		scripts_list.remove_from_list();
-		instances_list.remove_from_list();
-		_clear_stack();
-	}
+	MutexLock lock(GDScriptLanguage::singleton->mutex);
+	scripts_list.remove_from_list();
+	instances_list.remove_from_list();
+	_clear_stack();
 }

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -501,21 +501,22 @@ public:
 
 class GDScriptFunctionState : public RefCounted {
 	GDCLASS(GDScriptFunctionState, RefCounted);
+
 	friend class GDScriptFunction;
+
 	GDScriptFunction *function = nullptr;
 	GDScriptFunction::CallState state;
-	Variant _signal_callback(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	SelfList<GDScriptFunctionState> scripts_list;
 	SelfList<GDScriptFunctionState> instances_list;
+
+	Variant _signal_callback(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	Variant resume(const Variant &p_arg);
 
 protected:
 	static void _bind_methods();
 
 public:
-	bool is_valid(bool p_extended_check = false) const;
-	Variant resume(const Variant &p_arg = Variant());
-
 #ifdef DEBUG_ENABLED
 	// Returns a human-readable representation of the function.
 	String get_readable_function() {


### PR DESCRIPTION
## What problem(s) does this PR solve?

The `resume()` and `is_valid()` methods are leftovers from 3.x, when `GDScriptFunctionState` was exposed. Since that's no longer the case, we can remove them from `_bind_methods()` and remove `is_valid()` entirely.

## Additional information

_None._
