### PR TITLE
Clear editor `get_image` cache when image is externally changed.

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1007,6 +1007,13 @@ void TextureStorage::texture_free(RID p_texture) {
 		memdelete(t->canvas_texture);
 	}
 
+#ifdef TOOLS_ENABLED
+	if (t->image_cache_2d.is_valid()) {
+		t->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+		t->image_cache_2d.unref();
+	}
+#endif
+
 	bool must_free_data = false;
 	if (t->is_proxy) {
 		if (t->proxy_to.is_valid()) {
@@ -1288,7 +1295,10 @@ void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image,
 	GLES3::Utilities::get_singleton()->texture_resize_data(tex->tex_id, tex->total_data_size);
 
 #ifdef TOOLS_ENABLED
-	tex->image_cache_2d.unref();
+	if (tex->image_cache_2d.is_valid()) {
+		tex->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+		tex->image_cache_2d.unref();
+	}
 #endif
 }
 
@@ -1634,6 +1644,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() && !texture->is_render_target) {
 		texture->image_cache_2d = image;
+		texture->image_cache_2d->connect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed).bind(p_texture));
 	}
 #endif
 

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -33,6 +33,7 @@
 #ifdef GLES3_ENABLED
 
 #include "core/io/image.h"
+#include "core/object/callable_mp.h"
 #include "core/templates/rb_map.h"
 #include "core/templates/rid_owner.h"
 #include "drivers/gles3/shaders/canvas_sdf.glsl.gen.h"
@@ -429,6 +430,16 @@ private:
 	RID_Owner<CanvasTexture, true> canvas_texture_owner;
 
 	/* Texture API */
+#ifdef TOOLS_ENABLED
+	static void _image_cache_2d_changed(const RID &p_tex) {
+		Texture *tex = get_singleton()->texture_owner.get_or_null(p_tex);
+		if (tex) {
+			tex->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+			tex->image_cache_2d.unref();
+		}
+	}
+#endif
+
 	// Textures can be created from threads, so this RID_Owner is thread safe.
 	mutable RID_Owner<Texture, true> texture_owner;
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -943,6 +943,13 @@ void TextureStorage::texture_free(RID p_texture) {
 
 	t->cleanup();
 
+#ifdef TOOLS_ENABLED
+	if (t->image_cache_2d.is_valid()) {
+		t->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+		t->image_cache_2d.unref();
+	}
+#endif
+
 	if (t->is_proxy && t->proxy_to.is_valid()) {
 		Texture *proxy_to = texture_owner.get_or_null(t->proxy_to);
 		if (proxy_to) {
@@ -1601,7 +1608,10 @@ void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image
 	}
 
 #ifdef TOOLS_ENABLED
-	tex->image_cache_2d.unref();
+	if (tex->image_cache_2d.is_valid()) {
+		tex->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+		tex->image_cache_2d.unref();
+	}
 #endif
 	TextureToRDFormat f;
 	Ref<Image> validated = _validate_texture_format(p_image, f);
@@ -1904,6 +1914,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() && !tex->is_render_target) {
 		tex->image_cache_2d = image;
+		tex->image_cache_2d->connect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed).bind(p_texture));
 	}
 #endif
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/callable_mp.h"
 #include "core/templates/paged_array.h"
 #include "core/templates/rid_owner.h"
 #include "servers/rendering/renderer_rd/shaders/canvas_sdf.glsl.gen.h"
@@ -204,6 +205,16 @@ private:
 
 		void cleanup();
 	};
+
+#ifdef TOOLS_ENABLED
+	static void _image_cache_2d_changed(const RID &p_tex) {
+		Texture *tex = get_singleton()->texture_owner.get_or_null(p_tex);
+		if (tex) {
+			tex->image_cache_2d->disconnect_changed(callable_mp_static(&TextureStorage::_image_cache_2d_changed));
+			tex->image_cache_2d.unref();
+		}
+	}
+#endif
 
 	// Textures can be created from threads, so this RID_Owner is thread safe.
 	mutable RID_Owner<Texture, true> texture_owner;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/119922