### PR TITLE
GDScript: Don't register unexposed classes as constants

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2145,7 +2145,7 @@ void GDScriptLanguage::remove_named_global_constant(const StringName &p_name) {
 }
 
 void GDScriptLanguage::init() {
-	//populate global constants
+	// Populate core constants.
 	int gcc = CoreConstants::get_global_constant_count();
 	for (int i = 0; i < gcc; i++) {
 		_add_global(StringName(CoreConstants::get_global_constant_name(i)), CoreConstants::get_global_constant_value(i));
@@ -2156,19 +2156,19 @@ void GDScriptLanguage::init() {
 	_add_global(StringName("INF"), Math::INF);
 	_add_global(StringName("NAN"), Math::NaN);
 
-	//populate native classes
+	// Populate native classes.
 
 	LocalVector<StringName> class_list;
 	ClassDB::get_class_list(class_list);
 	for (const StringName &class_name : class_list) {
-		if (globals.has(class_name)) {
+		if (globals.has(class_name) || !GDScriptAnalyzer::class_exists(class_name)) {
 			continue;
 		}
 		Ref<GDScriptNativeClass> nc = memnew(GDScriptNativeClass(class_name));
 		_add_global(class_name, nc);
 	}
 
-	//populate singletons
+	// Populate singletons (overriding the native class registered under the same name).
 
 	List<Engine::Singleton> singletons;
 	Engine::get_singleton()->get_singletons(&singletons);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4632,15 +4632,11 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (GDScriptLanguage::get_singleton()->has_any_global_constant(name)) {
-		// We checked for `ClassDB` classes above. Any `ClassDB` class that reaches this point is not exposed and should not be accessible.
-		// TODO: Remove this check once `globals` does only contain publicly available things.
-		if (!ClassDB::class_exists(name)) {
-			Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
-			p_identifier->set_datatype(type_from_variant(constant, p_identifier));
-			p_identifier->is_constant = true;
-			p_identifier->reduced_value = constant;
-			return;
-		}
+		Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
+		p_identifier->set_datatype(type_from_variant(constant, p_identifier));
+		p_identifier->is_constant = true;
+		p_identifier->reduced_value = constant;
+		return;
 	}
 
 	if (CoreConstants::is_global_enum(name)) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/119935

## Additional information

In terms of risk: `GDScriptFunctionState` is the only builtin class that's registered using `GDREGISTER_INTERNAL_CLASS`. So this should only effect this class and maybe some extension classes. Since `GDScriptFunctionState` was not present in `globals` prior to https://github.com/godotengine/godot/pull/119352 I don't see much risk.