### PR TITLE
Fix spelling of "GDExtension" in the Export Template Manager

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -458,7 +458,7 @@ void ExportTemplateManager::_initialize_template_data() {
 	{
 		TemplateInfo info;
 		info.name = TTR("Web with Extensions");
-		info.description = TTRC("Web build with support for GDExtextensions. Only useful if you use GDExtensions, otherwise it only increases build size.");
+		info.description = TTRC("Web build with support for GDExtensions. Only useful if you use GDExtensions, otherwise it only increases build size.");
 		info.file_list = { "web_dlink_debug.zip", "web_dlink_release.zip" };
 		template_data[TemplateID::WEB_EXTENSIONS] = info;
 	}


### PR DESCRIPTION
Fixed a minor spelling mistake in `editor/export/export_template_manager.cpp`.

<img width="173" height="123" alt="image" src="https://github.com/user-attachments/assets/7b1d09cf-5e78-4ccf-92f1-54c4661d005a" />