### PR TITLE
GDScript: Use `GDSOFTCLASS` for some internal classes

### DIFF
--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -38,7 +38,7 @@
 #include "editor/translations/editor_translation_parser.h"
 
 class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
-	GDCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
+	GDSOFTCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
 	const HashMap<int, GDScriptTokenizer::CommentData> *comment_data = nullptr;
 

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -33,7 +33,7 @@
 #include "editor/plugins/editor_plugin.h"
 
 class GDScriptLanguageServer : public EditorPlugin {
-	GDCLASS(GDScriptLanguageServer, EditorPlugin);
+	GDSOFTCLASS(GDScriptLanguageServer, EditorPlugin);
 
 	Thread thread;
 	bool thread_running = false;

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -80,8 +80,8 @@ GDScriptCache *gdscript_cache = nullptr;
 
 Ref<GDScriptEditorTranslationParserPlugin> gdscript_translation_parser_plugin;
 
-class EditorExportGDScript : public EditorExportPlugin {
-	GDCLASS(EditorExportGDScript, EditorExportPlugin);
+class GDScriptExportPlugin : public EditorExportPlugin {
+	GDSOFTCLASS(GDScriptExportPlugin, EditorExportPlugin);
 
 	static constexpr EditorExportPreset::ScriptExportMode DEFAULT_SCRIPT_MODE = EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
 	EditorExportPreset::ScriptExportMode script_mode = DEFAULT_SCRIPT_MODE;
@@ -121,7 +121,7 @@ public:
 };
 
 static void _editor_init() {
-	Ref<EditorExportGDScript> gd_export;
+	Ref<GDScriptExportPlugin> gd_export;
 	gd_export.instantiate();
 	EditorExport::get_singleton()->add_export_plugin(gd_export);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

The `GDCLASS` macro adds a class to `ClassDB` (even without using `GDREGISTER_CLASS`, this behavior likely arose with the introduction of `GDType`). The following classes are internal, well-isolated, and do not interact with `ClassDB` in any way (they do not define `_bind_methods()`):

* `GDScriptEditorTranslationParserPlugin`;
* `GDScriptLanguageServer`;
* `GDScriptExportPlugin` (former `EditorExportGDScript`).

So, it is safe to use `GDSOFTCLASS` instead of `GDCLASS` for them. The risk is minimal, the only side effect I know of is that these classes will disappear from `ClassDB.get_class_list()`.

This PR also renames the `EditorExportGDScript` class to `GDScriptExportPlugin` for consistency with other classes in the module (most use the `GDScript` prefix rather than the suffix) and other `EditorExportPlugin` descendants:

```c++
class DedicatedServerExportPlugin : public EditorExportPlugin
class GDExtensionExportPlugin : public EditorExportPlugin
class ShaderBakerExportPlugin : public EditorExportPlugin
class OpenXRExportPlugin : public EditorExportPlugin
```

## Additional information

_None._
