### PR TITLE
Expose Window.clamp_to_embedder property

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -60,6 +60,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="clamp_to_embedder" type="bool" setter="set_clamp_to_embedder" getter="is_clamped_to_embedder" overrides="Window" default="true" />
 		<member name="dialog_autowrap" type="bool" setter="set_autowrap" getter="has_autowrap" default="false">
 			Sets autowrapping for the text in the dialog.
 		</member>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -644,6 +644,10 @@
 		<member name="borderless" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the window will have no borders.
 		</member>
+		<member name="clamp_to_embedder" type="bool" setter="set_clamp_to_embedder" getter="is_clamped_to_embedder" default="false">
+			If [code]true[/code], the [Window] position will be clamped so it cannot be dragged outside of the parent viewport.
+			[b]Note:[/b] This property only works with embedded windows.
+		</member>
 		<member name="content_scale_aspect" type="int" setter="set_content_scale_aspect" getter="get_content_scale_aspect" enum="Window.ContentScaleAspect" default="0">
 			Specifies how the content's aspect behaves when the [Window] is resized. The base aspect is determined by [member content_scale_size].
 		</member>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3422,6 +3422,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclusive", "exclusive"), &Window::set_exclusive);
 	ClassDB::bind_method(D_METHOD("is_exclusive"), &Window::is_exclusive);
 
+	ClassDB::bind_method(D_METHOD("set_clamp_to_embedder", "clamp_to_embedder"), &Window::set_clamp_to_embedder);
+	ClassDB::bind_method(D_METHOD("is_clamped_to_embedder"), &Window::is_clamped_to_embedder);
+
 	ClassDB::bind_method(D_METHOD("set_unparent_when_invisible", "unparent"), &Window::set_unparent_when_invisible);
 
 	ClassDB::bind_method(D_METHOD("can_draw"), &Window::can_draw);
@@ -3570,6 +3573,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transient"), "set_transient", "is_transient");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transient_to_focused"), "set_transient_to_focused", "is_transient_to_focused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclusive"), "set_exclusive", "is_exclusive");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clamp_to_embedder"), "set_clamp_to_embedder", "is_clamped_to_embedder");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "unresizable"), "set_flag", "get_flag", FLAG_RESIZE_DISABLED);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "borderless"), "set_flag", "get_flag", FLAG_BORDERLESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "always_on_top"), "set_flag", "get_flag", FLAG_ALWAYS_ON_TOP);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes godotengine/godot-proposals#11938

## Additional information

Makes Window.clamp_to_embedder property visible in the Inspector and accessible from GDScript.

<details>
<summary>Screenshots</summary>

<img width="353" height="787" alt="Inspector" src="https://github.com/user-attachments/assets/43750891-94fc-4d24-ab2c-1e42a1f136fb" />
<img width="812" height="168" alt="Documentation" src="https://github.com/user-attachments/assets/5248b91c-a874-4a7d-909b-7ae1f917c91b" />

</details>