### PR TITLE
CI: Only free runner disk space when sanitized

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -60,6 +60,7 @@ jobs:
               linker=mold
             bin: ./bin/godot.linuxbsd.editor.dev.double.x86_64.san
             proj-test: true
+            free-space: true
 
           - name: Editor with clang sanitizers (target=editor, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
@@ -73,6 +74,7 @@ jobs:
             bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
             # Test our oldest supported SCons/Python versions on one arbitrary editor build.
             legacy-scons: true
+            free-space: true
 
           - name: Editor with ThreadSanitizer (target=editor, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
@@ -83,6 +85,7 @@ jobs:
               use_llvm=yes
               linker=lld
             bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
+            free-space: true
 
           - name: Template w/ Mono, release (target=template_release)
             cache-name: linux-template-mono
@@ -129,6 +132,7 @@ jobs:
           fi
 
       - name: Free disk space on runner
+        if: matrix.free-space
         run: |
           echo "Disk usage before:" && df -h
           sudo rm -rf /usr/local/lib/android


### PR DESCRIPTION
Sometimes our Linux runners will lag during the "Free disk space on runner" step, with runtimes ranging from ~20 seconds to nearly 3 minutes. The entire reason this step needs to exist to begin with is because of how bloated our sanitizers builds can become. I don't know why it didn't occur to me sooner, but we should've been restricting this to *only* those builds, allowing all other Linux builds to execute significantly faster