### PR TITLE
Add information about easy `rand_weighted()` pitfall

### DIFF
--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -23,7 +23,7 @@
 			<description>
 				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
 				For example, if [code skip-lint][0.5, 1, 1, 2][/code] is passed as a parameter, then the method is twice as likely to return [code]3[/code] (the index of the value [code]2[/code]) and twice as unlikely to return [code]0[/code] (the index of the value [code]0.5[/code]) compared to the indices [code]1[/code] and [code]2[/code].
-				Prints an error and returns [code]-1[/code] if the array is empty. A negative value weight may cause unexpected results. If the negative number's absolute value is greater than the sum of the remaining weights, the method will always return ``0``.
+				Prints an error and returns [code]-1[/code] if the array is empty. Passing a negative weight results in undefined behavior.
 				[codeblocks]
 				[gdscript]
 				var rng = RandomNumberGenerator.new()

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -23,7 +23,7 @@
 			<description>
 				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
 				For example, if [code skip-lint][0.5, 1, 1, 2][/code] is passed as a parameter, then the method is twice as likely to return [code]3[/code] (the index of the value [code]2[/code]) and twice as unlikely to return [code]0[/code] (the index of the value [code]0.5[/code]) compared to the indices [code]1[/code] and [code]2[/code].
-				Prints an error and returns [code]-1[/code] if the array is empty.
+				Prints an error and returns [code]-1[/code] if the array is empty. A negative value weight may cause unexpected results. If the negative number's absolute value is greater than the sum of the remaining weights, the method will always return ``0``.
 				[codeblocks]
 				[gdscript]
 				var rng = RandomNumberGenerator.new()

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -21,7 +21,7 @@
 			<return type="int" />
 			<param index="0" name="weights" type="PackedFloat32Array" />
 			<description>
-				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
+				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a non-negative floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
 				For example, if [code skip-lint][0.5, 1, 1, 2][/code] is passed as a parameter, then the method is twice as likely to return [code]3[/code] (the index of the value [code]2[/code]) and twice as unlikely to return [code]0[/code] (the index of the value [code]0.5[/code]) compared to the indices [code]1[/code] and [code]2[/code].
 				Prints an error and returns [code]-1[/code] if the array is empty. Passing a negative weight results in undefined behavior.
 				[codeblocks]


### PR DESCRIPTION
This part of the `rand_weighted()` method under the hood causes negative number weights to produce likely-unexpected results.

```cpp
for (int64_t i = 0; i < weights_size; ++i) {
	weights_sum += weights[i];
}
```

Added a brief mention of this fact under the `rand_weighted()` method.

To reproduce what I'm talking about, this code will only ever print the number 1 because the `-6.0` weight is added to the weights_sum canceling out all other values. 

```gdscript
func _ready() -> void:
	var my_array: Array[int] = [1, 2, 3, 4]
	var my_weights: Array[float] = [1.0, 2.0, 3.0, -6.0]
	var rng: RandomNumberGenerator = RandomNumberGenerator.new()
	for i: int in 1000:
		print(my_array[rng.rand_weighted(my_weights)])

```

I'm doubtful this is a bug, but it's definitely an easy pitfall.


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Explains a behavior that isn't currently documented, but easy to run into if you commonly manipulate weights for things like random loot generation with a luck stat.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
