### PR TITLE
Fix EditorSpinSlider not showing tooltips

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -44,9 +44,15 @@
 #include "scene/theme/theme_db.h"
 
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
-	String value = get_text_value() + suffix;
+	const String base_tooltip = Range::get_tooltip(p_pos);
+
+	const String value = get_text_value() + suffix;
 	if (!read_only && grabber->is_visible()) {
 		String tooltip = value;
+		if (!base_tooltip.is_empty()) {
+			tooltip += "\n" + TTR(base_tooltip);
+		}
+
 		Key key = OS::prefer_meta_over_ctrl() ? Key::META : Key::CTRL;
 		if (!editing_integer) {
 			tooltip += "\n\n" + vformat(TTR("Hold %s to round to integers."), find_keycode_name(key));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

EditorSpinSlider overrides `get_tooltip()` for a custom tooltip, so any text in `hint_tooltip` is discarded. This PR makes it display the tooltip text below value.
<img width="340" height="183" alt="image" src="https://github.com/user-attachments/assets/adfe6763-c652-4429-b0ca-67a2cc1c7c0c" />


## Additional information

Found it when reviewing #116392, the screenshot is from that PR.