### PR TITLE
Editor: Add support for marking properties as favorite per scene

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -204,6 +204,13 @@
 				Emit it if you want to key a property with a single value.
 			</description>
 		</signal>
+		<signal name="property_local_favorited">
+			<param index="0" name="property" type="StringName" />
+			<param index="1" name="favorited" type="bool" />
+			<description>
+				Emit it if you want to mark a property as favorited for the current scene, making it appear at the top of the inspector for that scene.
+			</description>
+		</signal>
 		<signal name="property_overridden">
 			<description>
 				Emitted when a setting override for the current project is requested.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9233,6 +9233,7 @@ EditorNode::EditorNode() {
 	filesystem_dock->connect("instantiate", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_editor_layout));
 	get_project_settings()->connect_filesystem_dock_signals(filesystem_dock);
+	editor_settings_dialog->connect_filesystem_dock_signals(filesystem_dock);
 	editor_dock_manager->add_dock(filesystem_dock);
 
 	memnew(InspectorDock(editor_data));

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -640,6 +640,20 @@ void EditorProperty::_notification(int p_what) {
 				revert_rect = Rect2();
 			}
 
+			if (locally_favorited) {
+				const Ref<Texture2D> &favorite_local_icon = theme_cache.favorite_local_icon;
+				int margin_w = theme_cache.horizontal_separation;
+				int total_icon_w = margin_w + favorite_local_icon->get_width();
+				int y = (size.height - favorite_local_icon->get_height()) / 2;
+				if (rtl) {
+					draw_texture(favorite_local_icon, Vector2(size.width - ofs - favorite_local_icon->get_width(), y), color);
+				} else {
+					draw_texture(favorite_local_icon, Vector2(ofs, y), color);
+				}
+				ofs += total_icon_w;
+				text_limit -= total_icon_w;
+			}
+
 			if (!pin_hidden && pinned) {
 				const Ref<Texture2D> &pinned_icon = theme_cache.pin_icon;
 				int margin_w = theme_cache.horizontal_separation;
@@ -1430,6 +1444,18 @@ bool EditorProperty::is_favoritable() const {
 	return can_favorite;
 }
 
+void EditorProperty::set_local_favoritable(bool p_favoritable) {
+	can_local_favorite = p_favoritable;
+}
+
+bool EditorProperty::is_local_favoritable() const {
+	return can_local_favorite;
+}
+
+void EditorProperty::set_local_favorite_enabled(bool p_enabled) {
+	local_favorite_enabled = p_enabled;
+}
+
 void EditorProperty::set_object_and_property(Object *p_object, const StringName &p_property) {
 	object = p_object;
 	property = p_property;
@@ -1551,6 +1577,10 @@ void EditorProperty::menu_option(int p_option) {
 			emit_signal(SNAME("property_favorited"), property, !favorited);
 			queue_redraw();
 		} break;
+		case MENU_FAVORITE_LOCAL_PROPERTY: {
+			emit_signal(SNAME("property_local_favorited"), property, !locally_favorited);
+			queue_redraw();
+		} break;
 		case MENU_PIN_VALUE: {
 			emit_signal(SNAME("property_pinned"), property, !pinned);
 			queue_redraw();
@@ -1654,6 +1684,7 @@ void EditorProperty::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("property_checked", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "checked")));
 	ADD_SIGNAL(MethodInfo("property_overridden"));
 	ADD_SIGNAL(MethodInfo("property_favorited", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "favorited")));
+	ADD_SIGNAL(MethodInfo("property_local_favorited", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "favorited")));
 	ADD_SIGNAL(MethodInfo("property_pinned", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "pinned")));
 	ADD_SIGNAL(MethodInfo("property_can_revert_changed", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "can_revert")));
 	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::STRING, "path"), PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, Resource::get_class_static())));
@@ -1702,7 +1733,7 @@ void EditorProperty::_update_popup() {
 	menu->add_icon_shortcut(theme_cache.copy_node_path_icon, ED_GET_SHORTCUT("property_editor/copy_property_path"), MENU_COPY_PROPERTY_PATH);
 	menu->set_item_disabled(-1, internal || property_path.is_empty());
 
-	if (can_favorite || !pin_hidden) {
+	if (can_favorite || can_local_favorite || !pin_hidden) {
 		menu->add_separator();
 	}
 
@@ -1714,6 +1745,22 @@ void EditorProperty::_update_popup() {
 			// TRANSLATORS: This is a menu item to add a property to the favorites.
 			menu->add_icon_item(theme_cache.favorite_icon, TTR("Favorite Property"), MENU_FAVORITE_PROPERTY);
 			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_PROPERTY), TTR("Make this property be placed at the top for all objects of this class."));
+		}
+	}
+
+	if (can_local_favorite) {
+		if (!local_favorite_enabled) {
+			// TRANSLATORS: Disabled menu item. In parenthesis is a notice that the user must save the scene before local favorites are available.
+			menu->add_icon_item(theme_cache.favorite_icon, TTR("Favorite Local Property (Save Scene First)"), MENU_FAVORITE_LOCAL_PROPERTY);
+			menu->set_item_disabled(menu->get_item_index(MENU_FAVORITE_LOCAL_PROPERTY), true);
+			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_LOCAL_PROPERTY), TTR("Local favorites require the current scene to be saved first."));
+		} else if (locally_favorited) {
+			menu->add_icon_item(theme_cache.unfavorite_icon, TTR("Unfavorite Local Property"), MENU_FAVORITE_LOCAL_PROPERTY);
+			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_LOCAL_PROPERTY), TTR("Make this property be put back at its original place in this scene."));
+		} else {
+			// TRANSLATORS: This is a menu item to add a property to the local favorites for the current scene.
+			menu->add_icon_item(theme_cache.favorite_icon, TTR("Favorite Local Property"), MENU_FAVORITE_LOCAL_PROPERTY);
+			menu->set_item_tooltip(menu->get_item_index(MENU_FAVORITE_LOCAL_PROPERTY), TTR("Make this property be placed at the top for objects of this class in this scene."));
 		}
 	}
 
@@ -1826,6 +1873,8 @@ static Ref<Script> _get_category_script(const PropertyInfo &p_info) {
 }
 
 void EditorInspectorCategory::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("unfavorite_global"));
+	ADD_SIGNAL(MethodInfo("unfavorite_local"));
 	ADD_SIGNAL(MethodInfo("unfavorite_all"));
 }
 
@@ -1943,6 +1992,12 @@ void EditorInspectorCategory::set_as_favorite() {
 	_update_icon();
 }
 
+void EditorInspectorCategory::set_favorite_counts(int p_global_count, int p_local_count, int p_combined_count) {
+	global_favorite_count = p_global_count;
+	local_favorite_count = p_local_count;
+	combined_favorite_count = p_combined_count;
+}
+
 void EditorInspectorCategory::set_property_info(const PropertyInfo &p_info) {
 	info = p_info;
 
@@ -2016,6 +2071,14 @@ void EditorInspectorCategory::_handle_menu_option(int p_option) {
 			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
 		} break;
 
+		case MENU_UNFAVORITE_GLOBAL: {
+			emit_signal(SNAME("unfavorite_global"));
+		} break;
+
+		case MENU_UNFAVORITE_LOCAL: {
+			emit_signal(SNAME("unfavorite_local"));
+		} break;
+
 		case MENU_UNFAVORITE_ALL: {
 			emit_signal(SNAME("unfavorite_all"));
 		} break;
@@ -2025,10 +2088,26 @@ void EditorInspectorCategory::_handle_menu_option(int p_option) {
 void EditorInspectorCategory::_popup_context_menu(const Point2i &p_position) {
 	if (menu == nullptr) {
 		menu = memnew(PopupMenu);
+		menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorInspectorCategory::_handle_menu_option));
+		add_child(menu);
+	}
 
-		if (is_favorite) {
-			menu->add_item(TTRC("Unfavorite All"), MENU_UNFAVORITE_ALL);
-		} else {
+	if (is_favorite) {
+		menu->clear();
+		if (global_favorite_count > 0) {
+			// TRANSLATORS: Category menu item. %d is the number of global favorites to be removed.
+			menu->add_icon_item(theme_cache.icon_unfavorite, vformat(TTR("Unfavorite Global (%d)"), global_favorite_count), MENU_UNFAVORITE_GLOBAL);
+		}
+		if (local_favorite_count > 0) {
+			// TRANSLATORS: Category menu item. %d is the number of local favorites (current scene only) to be removed.
+			menu->add_icon_item(theme_cache.icon_unfavorite, vformat(TTR("Unfavorite Local (%d)"), local_favorite_count), MENU_UNFAVORITE_LOCAL);
+		}
+		if (global_favorite_count > 0 && local_favorite_count > 0) {
+			// TRANSLATORS: Category menu item. %d is the combined number of global and local favorites to be removed.
+			menu->add_icon_item(theme_cache.icon_unfavorite, vformat(TTR("Unfavorite All (%d)"), combined_favorite_count), MENU_UNFAVORITE_ALL);
+		}
+	} else {
+		if (!menu_items_built) {
 			menu->add_icon_item(theme_cache.icon_copy, TTRC("Copy Category Values"), MENU_COPY_VALUE);
 			menu->add_icon_item(theme_cache.icon_paste, TTRC("Paste Category Values"), MENU_PASTE_VALUE);
 
@@ -2036,23 +2115,16 @@ void EditorInspectorCategory::_popup_context_menu(const Point2i &p_position) {
 				menu->add_item(TTRC("Open Documentation"), MENU_OPEN_DOCS);
 				menu->set_item_disabled(-1, !EditorHelp::get_doc_data()->class_list.has(doc_class_name));
 			}
+			menu_items_built = true;
 		}
-
-		menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorInspectorCategory::_handle_menu_option));
-		add_child(menu);
-	}
-
-	if (!is_favorite) {
 		menu->set_item_disabled(MENU_PASTE_VALUE, EditorInspector::get_property_clipboard_type() != EditorInspector::PropertyClipboard::Type::CATEGORY);
-	}
 
-	if (menu_icon_dirty) {
-		if (is_favorite) {
-			menu->set_item_icon(menu->get_item_index(MENU_UNFAVORITE_ALL), theme_cache.icon_unfavorite);
-		} else if (!doc_class_name.is_empty()) {
-			menu->set_item_icon(menu->get_item_index(MENU_OPEN_DOCS), theme_cache.icon_help);
+		if (menu_icon_dirty) {
+			if (!doc_class_name.is_empty()) {
+				menu->set_item_icon(menu->get_item_index(MENU_OPEN_DOCS), theme_cache.icon_help);
+			}
+			menu_icon_dirty = false;
 		}
-		menu_icon_dirty = false;
 	}
 
 	menu->set_position(p_position);
@@ -3944,6 +4016,7 @@ void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_ca
 	p_cache.paste_icon = p_control->get_editor_theme_icon(SNAME("ActionPaste"));
 	p_cache.unfavorite_icon = p_control->get_editor_theme_icon(SNAME("Unfavorite"));
 	p_cache.favorite_icon = p_control->get_editor_theme_icon(SNAME("Favorites"));
+	p_cache.favorite_local_icon = p_control->get_editor_theme_icon(SNAME("Favorites"));
 	p_cache.override_icon = p_control->get_editor_theme_icon(SNAME("Override"));
 	p_cache.remove_icon = p_control->get_editor_theme_icon(SNAME("Remove"));
 	p_cache.help_icon = p_control->get_editor_theme_icon(SNAME("Help"));
@@ -4037,25 +4110,43 @@ String EditorInspector::get_selected_path() const {
 	return property_selected;
 }
 
-void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> p_plugin) {
+void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, bool p_disable_favorite, Ref<EditorInspectorPlugin> p_plugin) {
 	for (const EditorInspectorPlugin::AddedEditor &F : p_plugin->added_editors) {
 		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
 
-		if (ep && !F.properties.is_empty() && current_favorites.has(F.properties[0])) {
+		const bool is_locally_favorited = ep && !F.properties.is_empty() && current_local_favorites.has(F.properties[0]);
+		const bool is_globally_favorited = ep && !F.properties.is_empty() && current_favorites.has(F.properties[0]);
+
+		if (is_locally_favorited) {
+			ep->locally_favorited = true;
+		}
+
+		if (is_globally_favorited) {
 			ep->favorited = true;
-			favorites_vbox->add_child(F.property_editor);
+		}
+
+		if (is_locally_favorited) {
+			local_favorites_vbox->add_child(F.property_editor);
+		} else if (is_globally_favorited) {
+			global_favorites_vbox->add_child(F.property_editor);
 		} else {
 			p_current_vbox->add_child(F.property_editor);
 		}
 
 		if (ep) {
 			ep->object = object;
+			// Exclude multi-property plugin editors since favoriting one of their names would be ambiguous
+			const bool single_property = F.properties.size() == 1;
+			ep->set_favoritable(can_favorite && !p_disable_favorite && !ep->is_deletable() && single_property);
+			ep->set_local_favoritable(ep->is_favoritable());
+			ep->set_local_favorite_enabled(!current_scene_path.is_empty());
 			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed).bind(false));
 			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
 			ep->connect("property_deleted", callable_mp(this, &EditorInspector::_property_deleted), CONNECT_DEFERRED);
 			ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
 			ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
 			ep->connect("property_favorited", callable_mp(this, &EditorInspector::_set_property_favorited), CONNECT_DEFERRED);
+			ep->connect("property_local_favorited", callable_mp(this, &EditorInspector::_set_property_local_favorited), CONNECT_DEFERRED);
 			ep->connect("property_pinned", callable_mp(this, &EditorInspector::_property_pinned));
 			ep->connect("selected", callable_mp(this, &EditorInspector::_property_selected));
 			ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
@@ -4250,7 +4341,8 @@ void EditorInspector::update_tree() {
 
 	HashMap<VBoxContainer *, HashMap<String, VBoxContainer *>> vbox_per_path;
 	HashMap<String, EditorInspectorArray *> editor_inspector_array_per_prefix;
-	HashMap<String, HashMap<String, LocalVector<EditorProperty *>>> favorites_to_add;
+	HashMap<String, HashMap<String, LocalVector<EditorProperty *>>> local_favorites_to_add;
+	HashMap<String, HashMap<String, LocalVector<EditorProperty *>>> global_favorites_to_add;
 	HashMap<String, EditorInspectorSection *> togglable_editor_inspector_sections;
 
 	const Color sscolor = theme_cache.prop_subsection;
@@ -4259,7 +4351,7 @@ void EditorInspector::update_tree() {
 	if (!valid_plugins.is_empty()) {
 		for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
 			ped->parse_begin(object);
-			_parse_added_editors(begin_vbox, nullptr, ped);
+			_parse_added_editors(begin_vbox, nullptr, false, ped);
 		}
 
 		// Show if any of the editors were added to the beginning.
@@ -4395,7 +4487,7 @@ void EditorInspector::update_tree() {
 			// Add editors at the start of a category.
 			for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
 				ped->parse_category(object, p.name);
-				_parse_added_editors(main_vbox, nullptr, ped);
+				_parse_added_editors(main_vbox, nullptr, disable_favorite, ped);
 			}
 
 			continue;
@@ -4624,7 +4716,7 @@ void EditorInspector::update_tree() {
 				// Add editors at the start of a group.
 				for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
 					ped->parse_group(object, path);
-					_parse_added_editors(section->get_vbox(), section, ped);
+					_parse_added_editors(section->get_vbox(), section, disable_favorite, ped);
 				}
 
 				vbox_per_path[root_vbox][acc_path] = section->get_vbox();
@@ -4947,15 +5039,31 @@ void EditorInspector::update_tree() {
 				ep->set_draw_warning(draw_warning);
 				ep->set_use_folding(use_folding);
 				ep->set_favoritable(can_favorite && !disable_favorite && !ep->is_deletable());
+				ep->set_local_favoritable(ep->is_favoritable());
+				ep->set_local_favorite_enabled(!current_scene_path.is_empty());
 				ep->set_checkable(checkable);
 				ep->set_checked(checked);
 				ep->set_keying(keying);
 				ep->set_read_only(property_read_only || all_read_only);
 			}
 
-			if (ep && ep->is_favoritable() && current_favorites.has(p.name)) {
+			const bool is_locally_favorited = ep && ep->is_favoritable() && current_local_favorites.has(p.name);
+			const bool is_globally_favorited = ep && ep->is_favoritable() && current_favorites.has(p.name);
+
+			if (is_locally_favorited) {
+				ep->locally_favorited = true;
+			}
+
+			if (is_globally_favorited) {
 				ep->favorited = true;
-				favorites_to_add[group][subgroup].push_back(ep);
+			}
+
+			if (is_locally_favorited || is_globally_favorited) {
+				if (is_locally_favorited) {
+					local_favorites_to_add[group][subgroup].push_back(ep);
+				} else {
+					global_favorites_to_add[group][subgroup].push_back(ep);
+				}
 
 				if (group_togglable_property) {
 					togglable_editor_inspector_sections[group] = group_togglable_property;
@@ -4990,6 +5098,7 @@ void EditorInspector::update_tree() {
 				ep->connect("property_deleted", callable_mp(this, &EditorInspector::_property_deleted), CONNECT_DEFERRED);
 				ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
 				ep->connect("property_favorited", callable_mp(this, &EditorInspector::_set_property_favorited), CONNECT_DEFERRED);
+				ep->connect("property_local_favorited", callable_mp(this, &EditorInspector::_set_property_local_favorited), CONNECT_DEFERRED);
 				ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
 				ep->connect("property_pinned", callable_mp(this, &EditorInspector::_property_pinned));
 				ep->connect("selected", callable_mp(this, &EditorInspector::_property_selected));
@@ -5017,59 +5126,20 @@ void EditorInspector::update_tree() {
 		}
 	}
 
-	if (!current_favorites.is_empty()) {
+	if (!current_local_favorites.is_empty() || !current_favorites.is_empty()) {
 		favorites_section->show();
 
 		// Organize the favorited properties in their sections, to keep context and differentiate from others with the same name.
 		bool is_localized = property_name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED;
-		for (const KeyValue<String, HashMap<String, LocalVector<EditorProperty *>>> &KV : favorites_to_add) {
-			String section_name = KV.key;
-			String label;
-			String tooltip;
-			VBoxContainer *parent_vbox = favorites_vbox;
-			if (!section_name.is_empty()) {
-				favorites_groups_vbox->show();
-
-				if (is_localized) {
-					label = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
-					tooltip = section_name;
-				} else {
-					label = section_name;
-					tooltip = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
-				}
-
-				EditorInspectorSection *section = memnew(EditorInspectorSection);
-				get_root_inspector()->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(section, &EditorInspectorSection::reset_timer).unbind(1));
-				favorites_groups_vbox->add_child(section);
-				parent_vbox = section->get_vbox();
-
-				section->setup("", section_name, object, sscolor, false);
-				section->set_tooltip_text(tooltip);
-
-				if (togglable_editor_inspector_sections.has(section_name)) {
-					EditorInspectorSection *corresponding_section = togglable_editor_inspector_sections.get(section_name);
-
-					bool valid = false;
-					Variant value_checked = object->get(corresponding_section->related_enable_property, &valid);
-					if (valid) {
-						section->section = corresponding_section->section;
-						section->set_checkable(corresponding_section->related_enable_property, corresponding_section->checkbox_only, value_checked.operator bool());
-						section->set_keying(keying);
-						if (use_doc_hints) {
-							section->set_tooltip_text(corresponding_section->get_tooltip_text());
-						}
-
-						section->connect("section_toggled_by_user", callable_mp(this, &EditorInspector::_section_toggled_by_user));
-						section->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
-						sections.push_back(section);
-					}
-				}
-			}
-
-			for (const KeyValue<String, LocalVector<EditorProperty *>> &KV2 : KV.value) {
-				section_name = KV2.key;
-				VBoxContainer *vbox = parent_vbox;
+		auto add_favorites = [&](const HashMap<String, HashMap<String, LocalVector<EditorProperty *>>> &p_favorites_to_add, VBoxContainer *p_target_vbox, VBoxContainer *p_target_groups_vbox) {
+			for (const KeyValue<String, HashMap<String, LocalVector<EditorProperty *>>> &KV : p_favorites_to_add) {
+				String section_name = KV.key;
+				String label;
+				String tooltip;
+				VBoxContainer *parent_vbox = p_target_vbox;
 				if (!section_name.is_empty()) {
+					p_target_groups_vbox->show();
+
 					if (is_localized) {
 						label = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 						tooltip = section_name;
@@ -5080,13 +5150,14 @@ void EditorInspector::update_tree() {
 
 					EditorInspectorSection *section = memnew(EditorInspectorSection);
 					get_root_inspector()->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(section, &EditorInspectorSection::reset_timer).unbind(1));
-					vbox->add_child(section);
-					vbox = section->get_vbox();
+					p_target_groups_vbox->add_child(section);
+					parent_vbox = section->get_vbox();
+
 					section->setup("", section_name, object, sscolor, false);
 					section->set_tooltip_text(tooltip);
 
-					if (togglable_editor_inspector_sections.has(KV.key + "/" + section_name)) {
-						EditorInspectorSection *corresponding_section = togglable_editor_inspector_sections.get(KV.key + "/" + section_name);
+					if (togglable_editor_inspector_sections.has(section_name)) {
+						EditorInspectorSection *corresponding_section = togglable_editor_inspector_sections.get(section_name);
 
 						bool valid = false;
 						Variant value_checked = object->get(corresponding_section->related_enable_property, &valid);
@@ -5105,38 +5176,81 @@ void EditorInspector::update_tree() {
 					}
 				}
 
-				for (EditorProperty *ep : KV2.value) {
-					vbox->add_child(ep);
-
-					Node *section_search = vbox->get_parent();
-					while (section_search) {
-						EditorInspectorSection *section = Object::cast_to<EditorInspectorSection>(section_search);
-						if (section) {
-							ep->connect("property_can_revert_changed", callable_mp(section, &EditorInspectorSection::property_can_revert_changed));
+				for (const KeyValue<String, LocalVector<EditorProperty *>> &KV2 : KV.value) {
+					section_name = KV2.key;
+					VBoxContainer *vbox = parent_vbox;
+					if (!section_name.is_empty()) {
+						if (is_localized) {
+							label = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
+							tooltip = section_name;
+						} else {
+							label = section_name;
+							tooltip = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 						}
-						section_search = section_search->get_parent();
-						if (Object::cast_to<EditorInspector>(section_search)) {
-							// Skip sub-resource inspectors.
-							break;
+
+						EditorInspectorSection *section = memnew(EditorInspectorSection);
+						get_root_inspector()->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(section, &EditorInspectorSection::reset_timer).unbind(1));
+						vbox->add_child(section);
+						vbox = section->get_vbox();
+						section->setup("", section_name, object, sscolor, false);
+						section->set_tooltip_text(tooltip);
+
+						if (togglable_editor_inspector_sections.has(KV.key + "/" + section_name)) {
+							EditorInspectorSection *corresponding_section = togglable_editor_inspector_sections.get(KV.key + "/" + section_name);
+
+							bool valid = false;
+							Variant value_checked = object->get(corresponding_section->related_enable_property, &valid);
+							if (valid) {
+								section->section = corresponding_section->section;
+								section->set_checkable(corresponding_section->related_enable_property, corresponding_section->checkbox_only, value_checked.operator bool());
+								section->set_keying(keying);
+								if (use_doc_hints) {
+									section->set_tooltip_text(corresponding_section->get_tooltip_text());
+								}
+
+								section->connect("section_toggled_by_user", callable_mp(this, &EditorInspector::_section_toggled_by_user));
+								section->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
+								sections.push_back(section);
+							}
 						}
 					}
 
-					// Now that it's inside the tree, do the setup.
-					ep->update_property();
-					ep->_update_flags();
-					ep->update_editor_property_status();
-					ep->update_cache();
+					for (EditorProperty *ep : KV2.value) {
+						vbox->add_child(ep);
 
-					if (current_selected && ep->property == current_selected) {
-						ep->select(current_focusable);
+						Node *section_search = vbox->get_parent();
+						while (section_search) {
+							EditorInspectorSection *section = Object::cast_to<EditorInspectorSection>(section_search);
+							if (section) {
+								ep->connect("property_can_revert_changed", callable_mp(section, &EditorInspectorSection::property_can_revert_changed));
+							}
+							section_search = section_search->get_parent();
+							if (Object::cast_to<EditorInspector>(section_search)) {
+								// Skip sub-resource inspectors.
+								break;
+							}
+						}
+
+						// Now that it's inside the tree, do the setup.
+						ep->update_property();
+						ep->_update_flags();
+						ep->update_editor_property_status();
+						ep->update_cache();
+
+						if (current_selected && ep->property == current_selected) {
+							ep->select(current_focusable);
+						}
 					}
 				}
-			}
 
-			if (favorites_vbox->get_child_count() > 0) {
-				favorites_vbox->show();
+				if (p_target_vbox->get_child_count() > 0) {
+					p_target_vbox->show();
+				}
 			}
-		}
+		};
+
+		add_favorites(local_favorites_to_add, local_favorites_vbox, local_favorites_groups_vbox);
+		add_favorites(global_favorites_to_add, global_favorites_vbox, global_favorites_groups_vbox);
 
 		// Show a separator if there's no category to clearly divide the properties.
 		favorites_separator->hide();
@@ -5176,7 +5290,7 @@ void EditorInspector::update_tree() {
 	// Get the lists of to add at the end.
 	for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
 		ped->parse_end(object);
-		_parse_added_editors(main_vbox, nullptr, ped);
+		_parse_added_editors(main_vbox, nullptr, false, ped);
 	}
 
 	if (is_main_editor_inspector()) {
@@ -5218,13 +5332,21 @@ void EditorInspector::_clear(bool p_hide_plugins) {
 	}
 
 	favorites_section->hide();
-	favorites_vbox->hide();
-	while (favorites_vbox->get_child_count()) {
-		memdelete(favorites_vbox->get_child(0));
+	local_favorites_vbox->hide();
+	while (local_favorites_vbox->get_child_count()) {
+		memdelete(local_favorites_vbox->get_child(0));
 	}
-	favorites_groups_vbox->hide();
-	while (favorites_groups_vbox->get_child_count()) {
-		memdelete(favorites_groups_vbox->get_child(0));
+	local_favorites_groups_vbox->hide();
+	while (local_favorites_groups_vbox->get_child_count()) {
+		memdelete(local_favorites_groups_vbox->get_child(0));
+	}
+	global_favorites_vbox->hide();
+	while (global_favorites_vbox->get_child_count()) {
+		memdelete(global_favorites_vbox->get_child(0));
+	}
+	global_favorites_groups_vbox->hide();
+	while (global_favorites_groups_vbox->get_child_count()) {
+		memdelete(global_favorites_groups_vbox->get_child(0));
 	}
 
 	while (main_vbox->get_child_count()) {
@@ -5806,6 +5928,43 @@ void EditorInspector::_object_id_selected(const String &p_path, ObjectID p_id) {
 	emit_signal(SNAME("object_id_selected"), p_id);
 }
 
+String EditorInspector::_get_current_scene_path_for_favorites() const {
+	EditorNode *editor_node = EditorNode::get_singleton();
+	if (!editor_node) {
+		return String();
+	}
+
+	Node *edited_scene = editor_node->get_edited_scene();
+	if (!edited_scene) {
+		return String();
+	}
+
+	Node *node = Object::cast_to<Node>(object);
+	if (const MultiNodeEdit *mne = Object::cast_to<MultiNodeEdit>(object)) {
+		if (mne->get_node_count() > 0) {
+			node = edited_scene->get_node_or_null(mne->get_node(0));
+		}
+	}
+	if (node) {
+		if (node == edited_scene || edited_scene->is_ancestor_of(node)) {
+			return edited_scene->get_scene_file_path();
+		}
+		return String();
+	}
+
+	const Resource *resource = Object::cast_to<Resource>(object);
+	if (!resource) {
+		return String();
+	}
+
+	const String resource_path = resource->get_path();
+	if (resource_path.contains("::")) {
+		return resource_path.get_slice("::", 0);
+	}
+
+	return edited_scene->get_scene_file_path();
+}
+
 void EditorInspector::_resource_selected(const String &p_path, Ref<Resource> p_resource) {
 	emit_signal(SNAME("resource_selected"), p_resource, p_path);
 }
@@ -5816,13 +5975,27 @@ void EditorInspector::_node_removed(Node *p_node) {
 	}
 }
 
+void EditorInspector::_scene_saved(const String &) {
+	if (object) {
+		callable_mp(this, &EditorInspector::_update_current_favorites).call_deferred();
+		callable_mp(this, &EditorInspector::update_tree).call_deferred();
+	}
+}
+
 void EditorInspector::_update_current_favorites() {
 	current_favorites.clear();
+	current_local_favorites.clear();
+	current_scene_path = String();
 	if (!can_favorite) {
 		return;
 	}
+	current_scene_path = _get_current_scene_path_for_favorites();
 
 	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
+	HashMap<String, PackedStringArray> local_favorites;
+	if (!current_scene_path.is_empty()) {
+		local_favorites = EditorSettings::get_singleton()->get_local_favorite_properties(current_scene_path);
+	}
 
 	// Fetch script properties.
 	Ref<Script> scr = object->get_script();
@@ -5838,7 +6011,7 @@ void EditorInspector::_update_current_favorites() {
 
 		for (PropertyInfo &p : plist) {
 			if (p.usage & PROPERTY_USAGE_CATEGORY) {
-				path = favorites.has(p.hint_string) ? p.hint_string : String();
+				path = (favorites.has(p.hint_string) || local_favorites.has(p.hint_string)) ? p.hint_string : String();
 			} else if (p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE && !path.is_empty()) {
 				props[path].push_back(p.name);
 			}
@@ -5848,6 +6021,21 @@ void EditorInspector::_update_current_favorites() {
 		bool invalid_props = false;
 		for (const KeyValue<String, LocalVector<String>> &KV : props) {
 			path = KV.key;
+			for (int i = 0; i < local_favorites[path].size(); i++) {
+				String prop = local_favorites[path][i];
+				if (KV.value.has(prop)) {
+					current_local_favorites.append(prop);
+				} else {
+					invalid_props = true;
+					local_favorites[path].erase(prop);
+					i--;
+				}
+			}
+
+			if (local_favorites[path].is_empty()) {
+				local_favorites.erase(path);
+			}
+
 			for (int i = 0; i < favorites[path].size(); i++) {
 				String prop = favorites[path][i];
 				if (KV.value.has(prop)) {
@@ -5866,22 +6054,32 @@ void EditorInspector::_update_current_favorites() {
 
 		if (invalid_props) {
 			EditorSettings::get_singleton()->set_favorite_properties(favorites);
+			if (!current_scene_path.is_empty()) {
+				EditorSettings::get_singleton()->set_local_favorite_properties(current_scene_path, local_favorites);
+			}
 		}
 	}
 
 	// Fetch built-in properties.
 	const MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(object);
 	StringName class_name = multi_node_edit ? multi_node_edit->get_edited_class_name() : object->get_class_name();
+	for (const KeyValue<String, PackedStringArray> &KV : local_favorites) {
+		if (ClassDB::is_parent_class(class_name, KV.key)) {
+			current_local_favorites.append_array(KV.value);
+		}
+	}
 	for (const KeyValue<String, PackedStringArray> &KV : favorites) {
 		if (ClassDB::is_parent_class(class_name, KV.key)) {
 			current_favorites.append_array(KV.value);
 		}
 	}
+
+	_sync_favorite_counts_to_category();
 }
 
-void EditorInspector::_set_property_favorited(const String &p_path, bool p_favorited) {
+StringName EditorInspector::_get_favorite_property_class_name(const String &p_path) const {
 	if (!object) {
-		return;
+		return StringName();
 	}
 
 	const MultiNodeEdit *mne = Object::cast_to<MultiNodeEdit>(object);
@@ -5941,7 +6139,16 @@ void EditorInspector::_set_property_favorited(const String &p_path, bool p_favor
 			}
 		}
 
-		ERR_FAIL_COND_MSG(class_name.is_empty(), "Can't favorite invalid property. If said property was from a script and recently renamed, try saving it first.");
+		ERR_FAIL_COND_V_MSG(class_name.is_empty(), StringName(), "Can't favorite invalid property. If said property was from a script and recently renamed, try saving it first.");
+	}
+
+	return class_name;
+}
+
+void EditorInspector::_set_property_favorited(const String &p_path, bool p_favorited) {
+	StringName class_name = _get_favorite_property_class_name(p_path);
+	if (class_name.is_empty()) {
+		return;
 	}
 
 	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
@@ -5961,37 +6168,109 @@ void EditorInspector::_set_property_favorited(const String &p_path, bool p_favor
 	}
 	EditorSettings::get_singleton()->set_favorite_properties(favorites);
 
+	_sync_favorite_counts_to_category();
 	update_tree();
 }
 
-void EditorInspector::_clear_current_favorites() {
-	current_favorites.clear();
+void EditorInspector::_set_property_local_favorited(const String &p_path, bool p_favorited) {
+	const String scene_path = _get_current_scene_path_for_favorites();
+	if (scene_path.is_empty()) {
+		return;
+	}
 
-	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
+	StringName class_name = _get_favorite_property_class_name(p_path);
+	if (class_name.is_empty()) {
+		return;
+	}
 
+	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_local_favorite_properties(scene_path);
+	if (p_favorited) {
+		if (!current_local_favorites.has(p_path)) {
+			current_local_favorites.append(p_path);
+		}
+		if (!favorites[class_name].has(p_path)) {
+			favorites[class_name].append(p_path);
+		}
+	} else {
+		current_local_favorites.erase(p_path);
+
+		if (favorites.has(class_name) && favorites[class_name].has(p_path)) {
+			if (favorites[class_name].size() > 1) {
+				favorites[class_name].erase(p_path);
+			} else {
+				favorites.erase(class_name);
+			}
+		}
+	}
+	EditorSettings::get_singleton()->set_local_favorite_properties(scene_path, favorites);
+
+	_sync_favorite_counts_to_category();
+	update_tree();
+}
+
+void EditorInspector::_sync_favorite_counts_to_category() {
+	int combined = current_favorites.size() + current_local_favorites.size();
+	for (int i = 0; i < current_local_favorites.size(); i++) {
+		if (current_favorites.has(current_local_favorites[i])) {
+			combined--;
+		}
+	}
+	favorites_category->set_favorite_counts(current_favorites.size(), current_local_favorites.size(), combined);
+}
+
+void EditorInspector::_erase_favorites_for_current_object(HashMap<String, PackedStringArray> &p_favorites) {
 	Ref<Script> scr = object->get_script();
 	if (scr.is_valid()) {
 		List<PropertyInfo> plist;
 		scr->get_script_property_list(&plist);
 
 		for (PropertyInfo &p : plist) {
-			if (p.usage & PROPERTY_USAGE_CATEGORY && favorites.has(p.hint_string)) {
-				favorites.erase(p.hint_string);
+			if (p.usage & PROPERTY_USAGE_CATEGORY && p_favorites.has(p.hint_string)) {
+				p_favorites.erase(p.hint_string);
 			}
 		}
 	}
 
 	StringName class_name = object->get_class_name();
 	while (class_name) {
-		if (favorites.has(class_name)) {
-			favorites.erase(class_name);
+		if (p_favorites.has(class_name)) {
+			p_favorites.erase(class_name);
 		}
 
 		class_name = ClassDB::get_parent_class(class_name);
 	}
+}
 
+void EditorInspector::_clear_current_favorites() {
+	current_favorites.clear();
+
+	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
+	_erase_favorites_for_current_object(favorites);
 	EditorSettings::get_singleton()->set_favorite_properties(favorites);
+
+	_sync_favorite_counts_to_category();
 	update_tree();
+}
+
+void EditorInspector::_clear_current_local_favorites() {
+	current_local_favorites.clear();
+	_sync_favorite_counts_to_category();
+
+	const String scene_path = _get_current_scene_path_for_favorites();
+	if (scene_path.is_empty()) {
+		return;
+	}
+
+	HashMap<String, PackedStringArray> local_favorites = EditorSettings::get_singleton()->get_local_favorite_properties(scene_path);
+	_erase_favorites_for_current_object(local_favorites);
+	EditorSettings::get_singleton()->set_local_favorite_properties(scene_path, local_favorites);
+
+	update_tree();
+}
+
+void EditorInspector::_clear_current_favorites_all() {
+	_clear_current_favorites();
+	_clear_current_local_favorites();
 }
 
 void EditorInspector::_notification(int p_what) {
@@ -6019,12 +6298,18 @@ void EditorInspector::_notification(int p_what) {
 				EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
 			}
 			set_process(is_visible_in_tree());
+			if (!is_sub_inspector() && EditorNode::get_singleton()) {
+				EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &EditorInspector::_scene_saved));
+			}
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
+			if (!is_sub_inspector() && EditorNode::get_singleton() && EditorNode::get_singleton()->is_connected("scene_saved", callable_mp(this, &EditorInspector::_scene_saved))) {
+				EditorNode::get_singleton()->disconnect("scene_saved", callable_mp(this, &EditorInspector::_scene_saved));
+			}
 			if (!is_sub_inspector() && is_inside_tree()) {
 				get_tree()->disconnect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
 			}
@@ -6257,19 +6542,30 @@ EditorInspector::EditorInspector() {
 	base_vbox->add_child(favorites_section);
 	favorites_section->hide();
 
-	EditorInspectorCategory *favorites_category = memnew(EditorInspectorCategory);
+	favorites_category = memnew(EditorInspectorCategory);
 	favorites_category->set_as_favorite();
-	favorites_category->connect("unfavorite_all", callable_mp(this, &EditorInspector::_clear_current_favorites));
+	favorites_category->connect("unfavorite_global", callable_mp(this, &EditorInspector::_clear_current_favorites));
+	favorites_category->connect("unfavorite_local", callable_mp(this, &EditorInspector::_clear_current_local_favorites));
+	favorites_category->connect("unfavorite_all", callable_mp(this, &EditorInspector::_clear_current_favorites_all));
 	favorites_section->add_child(favorites_category);
 
-	favorites_vbox = memnew(VBoxContainer);
-	favorites_vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
-	favorites_section->add_child(favorites_vbox);
-	favorites_vbox->hide();
-	favorites_groups_vbox = memnew(VBoxContainer);
-	favorites_groups_vbox->set_theme_type_variation(SNAME("EditorInspectorContainer"));
-	favorites_section->add_child(favorites_groups_vbox);
-	favorites_groups_vbox->hide();
+	// Local favorites render above global. Within each tier, ungrouped properties appear above grouped ones.
+	local_favorites_vbox = memnew(VBoxContainer);
+	local_favorites_vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
+	favorites_section->add_child(local_favorites_vbox);
+	local_favorites_vbox->hide();
+	local_favorites_groups_vbox = memnew(VBoxContainer);
+	local_favorites_groups_vbox->set_theme_type_variation(SNAME("EditorInspectorContainer"));
+	favorites_section->add_child(local_favorites_groups_vbox);
+	local_favorites_groups_vbox->hide();
+	global_favorites_vbox = memnew(VBoxContainer);
+	global_favorites_vbox->set_theme_type_variation(SNAME("EditorPropertyContainer"));
+	favorites_section->add_child(global_favorites_vbox);
+	global_favorites_vbox->hide();
+	global_favorites_groups_vbox = memnew(VBoxContainer);
+	global_favorites_groups_vbox->set_theme_type_variation(SNAME("EditorInspectorContainer"));
+	favorites_section->add_child(global_favorites_groups_vbox);
+	global_favorites_groups_vbox->hide();
 
 	favorites_separator = memnew(HSeparator);
 	favorites_section->add_child(favorites_separator);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -94,6 +94,7 @@ protected:
 		Ref<Texture2D> paste_icon;
 		Ref<Texture2D> unfavorite_icon;
 		Ref<Texture2D> favorite_icon;
+		Ref<Texture2D> favorite_local_icon;
 		Ref<Texture2D> override_icon;
 		Ref<Texture2D> remove_icon;
 		Ref<Texture2D> help_icon;
@@ -123,6 +124,7 @@ public:
 		MENU_COPY_PROPERTY_PATH,
 		MENU_OVERRIDE_FOR_PROJECT,
 		MENU_FAVORITE_PROPERTY,
+		MENU_FAVORITE_LOCAL_PROPERTY,
 		MENU_PIN_VALUE,
 		MENU_DELETE,
 		MENU_REVERT_VALUE,
@@ -183,6 +185,9 @@ private:
 
 	bool can_favorite = false;
 	bool favorited = false;
+	bool can_local_favorite = false;
+	bool local_favorite_enabled = false;
+	bool locally_favorited = false;
 
 	bool use_folding = false;
 	bool draw_top_bg = true;
@@ -323,6 +328,9 @@ public:
 
 	void set_favoritable(bool p_favoritable);
 	bool is_favoritable() const;
+	void set_local_favoritable(bool p_favoritable);
+	bool is_local_favoritable() const;
+	void set_local_favorite_enabled(bool p_enabled);
 
 	void set_object_and_property(Object *p_object, const StringName &p_property);
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
@@ -387,6 +395,8 @@ class EditorInspectorCategory : public Control {
 		MENU_COPY_VALUE,
 		MENU_PASTE_VALUE,
 		MENU_OPEN_DOCS,
+		MENU_UNFAVORITE_GLOBAL,
+		MENU_UNFAVORITE_LOCAL,
 		MENU_UNFAVORITE_ALL,
 	};
 
@@ -417,6 +427,10 @@ class EditorInspectorCategory : public Control {
 	PopupMenu *menu = nullptr;
 	bool is_favorite = false;
 	bool menu_icon_dirty = true;
+	bool menu_items_built = false;
+	int global_favorite_count = 0;
+	int local_favorite_count = 0;
+	int combined_favorite_count = 0;
 
 	LocalVector<EditorProperty *> category_properties;
 
@@ -435,6 +449,7 @@ protected:
 
 public:
 	void set_as_favorite();
+	void set_favorite_counts(int p_global_count, int p_local_count, int p_combined_count);
 	void set_property_info(const PropertyInfo &p_info);
 	void set_doc_class_name(const String &p_name);
 
@@ -762,9 +777,14 @@ private:
 
 	bool can_favorite = false;
 	PackedStringArray current_favorites;
+	PackedStringArray current_local_favorites;
+	String current_scene_path;
 	VBoxContainer *favorites_section = nullptr;
-	VBoxContainer *favorites_vbox = nullptr;
-	VBoxContainer *favorites_groups_vbox = nullptr;
+	EditorInspectorCategory *favorites_category = nullptr;
+	VBoxContainer *local_favorites_vbox = nullptr;
+	VBoxContainer *local_favorites_groups_vbox = nullptr;
+	VBoxContainer *global_favorites_vbox = nullptr;
+	VBoxContainer *global_favorites_groups_vbox = nullptr;
 	HSeparator *favorites_separator = nullptr;
 
 	EditorInspector *root_inspector = nullptr;
@@ -846,10 +866,18 @@ private:
 	void _property_selected(const String &p_path, int p_focusable);
 	void _object_id_selected(const String &p_path, ObjectID p_id);
 
+	String _get_current_scene_path_for_favorites() const;
 	void _update_current_favorites();
+	StringName _get_favorite_property_class_name(const String &p_path) const;
 	void _set_property_favorited(const String &p_path, bool p_favorited);
+	void _set_property_local_favorited(const String &p_path, bool p_favorited);
+	void _sync_favorite_counts_to_category();
+	void _erase_favorites_for_current_object(HashMap<String, PackedStringArray> &p_favorites);
 	void _clear_current_favorites();
+	void _clear_current_local_favorites();
+	void _clear_current_favorites_all();
 
+	void _scene_saved(const String &p_path);
 	void _node_removed(Node *p_node);
 
 	HashMap<StringName, int> per_array_page;
@@ -860,7 +888,7 @@ private:
 
 	void _keying_changed();
 
-	void _parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> p_plugin);
+	void _parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, bool p_disable_favorite, Ref<EditorInspectorPlugin> p_plugin);
 
 	void _vscroll_changed(double);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1781,6 +1781,72 @@ void EditorSettings::set_favorite_properties(const HashMap<String, PackedStringA
 	cf->save(favorite_properties_file);
 }
 
+void EditorSettings::_save_local_favorite_properties_to_disk() const {
+	String favorite_properties_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorite_properties_local");
+
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	for (const KeyValue<String, HashMap<String, PackedStringArray>> &scene_kv : local_favorite_properties) {
+		Dictionary scene_properties;
+		for (const KeyValue<String, PackedStringArray> &class_kv : scene_kv.value) {
+			scene_properties[class_kv.key] = class_kv.value;
+		}
+		cf->set_value(scene_kv.key, "properties", scene_properties);
+	}
+	cf->save(favorite_properties_file);
+}
+
+void EditorSettings::set_local_favorite_properties(const String &p_scene_path, const HashMap<String, PackedStringArray> &p_favorite_properties) {
+	if (p_favorite_properties.is_empty()) {
+		local_favorite_properties.erase(p_scene_path);
+	} else {
+		local_favorite_properties.insert(p_scene_path, p_favorite_properties);
+	}
+
+	_save_local_favorite_properties_to_disk();
+}
+
+void EditorSettings::update_local_favorites_on_file_move(const String &p_old_file, const String &p_new_file) {
+	if (p_old_file == p_new_file) {
+		return;
+	}
+	HashMap<String, HashMap<String, PackedStringArray>>::Iterator it = local_favorite_properties.find(p_old_file);
+	if (!it) {
+		return;
+	}
+	local_favorite_properties.insert(p_new_file, it->value);
+	local_favorite_properties.erase(p_old_file);
+	_save_local_favorite_properties_to_disk();
+}
+
+void EditorSettings::update_local_favorites_on_folder_move(const String &p_old_folder, const String &p_new_folder) {
+	String old_path = p_old_folder.ends_with("/") ? p_old_folder : p_old_folder + "/";
+	String new_path = p_new_folder.ends_with("/") ? p_new_folder : p_new_folder + "/";
+
+	if (old_path == new_path) {
+		return;
+	}
+
+	Vector<String> keys_to_rewrite;
+	for (const KeyValue<String, HashMap<String, PackedStringArray>> &kv : local_favorite_properties) {
+		if (kv.key.begins_with(old_path)) {
+			keys_to_rewrite.push_back(kv.key);
+		}
+	}
+
+	if (keys_to_rewrite.is_empty()) {
+		return;
+	}
+
+	for (const String &old_key : keys_to_rewrite) {
+		String new_key = new_path + old_key.substr(old_path.length());
+		local_favorite_properties.insert(new_key, local_favorite_properties[old_key]);
+		local_favorite_properties.erase(old_key);
+	}
+
+	_save_local_favorite_properties_to_disk();
+}
+
 Vector<String> EditorSettings::get_favorites() const {
 	return favorites;
 }
@@ -1803,6 +1869,40 @@ Vector<String> EditorSettings::get_favorite_folders() const {
 
 HashMap<String, PackedStringArray> EditorSettings::get_favorite_properties() const {
 	return HashMap<String, PackedStringArray>(favorite_properties);
+}
+
+HashMap<String, PackedStringArray> EditorSettings::get_local_favorite_properties(const String &p_scene_path) const {
+	const HashMap<String, HashMap<String, PackedStringArray>>::ConstIterator favorites_it = local_favorite_properties.find(p_scene_path);
+	if (!favorites_it) {
+		return HashMap<String, PackedStringArray>();
+	}
+
+	return HashMap<String, PackedStringArray>(favorites_it->value);
+}
+
+void EditorSettings::clear_local_favorite_properties_for_scene(const String &p_scene_path) {
+	set_local_favorite_properties(p_scene_path, HashMap<String, PackedStringArray>());
+}
+
+void EditorSettings::clear_local_favorite_properties_for_folder(const String &p_folder) {
+	String path = p_folder.ends_with("/") ? p_folder : p_folder + "/";
+
+	Vector<String> keys_to_remove;
+	for (const KeyValue<String, HashMap<String, PackedStringArray>> &kv : local_favorite_properties) {
+		if (kv.key.begins_with(path)) {
+			keys_to_remove.push_back(kv.key);
+		}
+	}
+
+	if (keys_to_remove.is_empty()) {
+		return;
+	}
+
+	for (const String &key : keys_to_remove) {
+		local_favorite_properties.erase(key);
+	}
+
+	_save_local_favorite_properties_to_disk();
 }
 
 void EditorSettings::set_recent_dirs(const Vector<String> &p_recent_dirs, bool p_update_file_dialog) {
@@ -1835,14 +1935,17 @@ Vector<String> EditorSettings::get_recent_dirs() const {
 void EditorSettings::load_favorites_and_recent_dirs() {
 	String favorites_file;
 	String favorite_properties_file;
+	String favorite_properties_local_file;
 	String recent_dirs_file;
 	if (Engine::get_singleton()->is_project_manager_hint()) {
 		favorites_file = EditorPaths::get_singleton()->get_config_dir().path_join("favorite_dirs");
 		favorite_properties_file = EditorPaths::get_singleton()->get_config_dir().path_join("favorite_properties");
+		favorite_properties_local_file = EditorPaths::get_singleton()->get_config_dir().path_join("favorite_properties_local");
 		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().path_join("recent_dirs");
 	} else {
 		favorites_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorites");
 		favorite_properties_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorite_properties");
+		favorite_properties_local_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorite_properties_local");
 		recent_dirs_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("recent_dirs");
 	}
 
@@ -1873,6 +1976,47 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 						favorite_properties[E].push_back(property);
 					}
 				}
+			}
+		}
+	}
+
+	/// Inspector Local Favorites
+
+	cf.instantiate();
+	if (cf->load(favorite_properties_local_file) == OK) {
+		Vector<String> secs = cf->get_sections();
+
+		for (const String &E : secs) {
+			if (!ResourceLoader::exists(E)) {
+				continue;
+			}
+
+			Dictionary scene_dict = cf->get_value(E, "properties", Dictionary());
+			if (scene_dict.is_empty()) {
+				continue;
+			}
+
+			HashMap<String, PackedStringArray> scene_favorites;
+			Array keys = scene_dict.keys();
+			for (int i = 0; i < keys.size(); i++) {
+				String class_name = keys[i];
+				if (!EditorNode::get_editor_data().is_type_recognized(class_name) && !ResourceLoader::exists(class_name, "Script")) {
+					continue;
+				}
+
+				PackedStringArray properties = PackedStringArray(scene_dict[class_name]);
+				if (properties.is_empty()) {
+					continue;
+				}
+				for (const String &property : properties) {
+					if (!scene_favorites[class_name].has(property)) {
+						scene_favorites[class_name].push_back(property);
+					}
+				}
+			}
+
+			if (!scene_favorites.is_empty()) {
+				local_favorite_properties.insert(E, scene_favorites);
 			}
 		}
 	}

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -104,6 +104,7 @@ private:
 
 	Vector<String> favorites;
 	HashMap<String, PackedStringArray> favorite_properties;
+	HashMap<String, HashMap<String, PackedStringArray>> local_favorite_properties;
 	Vector<String> recent_dirs;
 
 	bool save_changed_setting = true;
@@ -120,6 +121,7 @@ private:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
 	void _set_initialized();
+	void _save_local_favorite_properties_to_disk() const;
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
 	void _load_default_visual_shader_editor_theme();
 	static String _guess_exec_args_for_extenal_editor(const String &p_value);
@@ -188,6 +190,12 @@ public:
 	Vector<String> get_favorite_folders() const;
 	void set_favorite_properties(const HashMap<String, PackedStringArray> &p_favorite_properties);
 	HashMap<String, PackedStringArray> get_favorite_properties() const;
+	void set_local_favorite_properties(const String &p_scene_path, const HashMap<String, PackedStringArray> &p_favorite_properties);
+	HashMap<String, PackedStringArray> get_local_favorite_properties(const String &p_scene_path) const;
+	void clear_local_favorite_properties_for_scene(const String &p_scene_path);
+	void clear_local_favorite_properties_for_folder(const String &p_folder);
+	void update_local_favorites_on_file_move(const String &p_old_file, const String &p_new_file);
+	void update_local_favorites_on_folder_move(const String &p_old_folder, const String &p_new_folder);
 	void set_recent_dirs(const Vector<String> &p_recent_dirs, bool p_update_file_dialog = true);
 	void set_recent_dirs_bind(const Vector<String> &p_recent_dirs);
 	Vector<String> get_recent_dirs() const;

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -37,6 +37,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/docks/filesystem_dock.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -951,6 +952,14 @@ void EditorSettingsDialog::_editor_restart_request() {
 
 void EditorSettingsDialog::_editor_restart_close() {
 	restart_container->hide();
+}
+
+void EditorSettingsDialog::connect_filesystem_dock_signals(FileSystemDock *p_fs_dock) {
+	p_fs_dock->connect("files_moved", callable_mp(EditorSettings::get_singleton(), &EditorSettings::update_local_favorites_on_file_move));
+	p_fs_dock->connect("folder_moved", callable_mp(EditorSettings::get_singleton(), &EditorSettings::update_local_favorites_on_folder_move));
+	// Clearing on file_removed/folder_removed results in favorites being lost if the user saves a still-open scene back to the disk after deleting it.
+	p_fs_dock->connect("file_removed", callable_mp(EditorSettings::get_singleton(), &EditorSettings::clear_local_favorite_properties_for_scene));
+	p_fs_dock->connect("folder_removed", callable_mp(EditorSettings::get_singleton(), &EditorSettings::clear_local_favorite_properties_for_folder));
 }
 
 void EditorSettingsDialog::_bind_methods() {

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -35,6 +35,7 @@
 
 class CheckButton;
 class EditorEventSearchBar;
+class FileSystemDock;
 class EventListenerLineEdit;
 class InputEventConfigurationDialog;
 class PanelContainer;
@@ -133,6 +134,7 @@ public:
 	static void update_3d_navigation_preset();
 	void set_current_section(const String &p_section);
 	void set_advanced_mode_enabled(bool p_enabled);
+	void connect_filesystem_dock_signals(FileSystemDock *p_fs_dock);
 
 	EditorSettingsDialog();
 };


### PR DESCRIPTION
Created a new system to allow properties to be set as favorite on a specific scene. The system stores the favorites in .godot/favorite_properties_local, and is mostly based on the previously existing favorite system. The properties are keyed by scene path and class name.

<img width="552" height="240" alt="image" src="https://github.com/user-attachments/assets/6666ed86-0b9b-4e7b-8ec6-030408352832" />

The inspector now allows two new actions, "Favorite Local Property" and "Unfavorite Local Property". These actions are visible but disabled on unsaved scenes. If the scene is unsaved, the "Favorite Local Property" button requests that the user saves the scene first. The inspector is also able to Unfavorite All/Global/Local, with each button either removing all favorites, only the project wide favorites or only the local favorites, respectively.  If a property is both a local and a global favorite, pressing Unfavorite Local or Unfavorite Global will only remove the respective category from the property, while Unfavorite All will remove both.

<img width="553" height="313" alt="image" src="https://github.com/user-attachments/assets/0616f6c8-e1a6-4168-9482-2378e8ad25d4" />

The local favorites are also updated when a scene is either moved, renamed or removed, in order to keep the list accurate, and works with node properties, external resource properties and single-property plugins.

## What problem(s) does this PR solve?

- Closes godotengine/godot-proposals#14573

## Additional information

The feature was tested manually. We tried analyzing the favorites across multiple scenes, renaming/moving scenes around and checking persistence after shutdown. We also created a small single property plugin, which was able to be favorited, and swapped it to a multiple property favorite, which was then unable to be favorited. We also tested the feature with a Right-To-Left language, and the new icons seemed to behave correctly.

One edge case the reviewer may want to pay attention to, is that when a scene is deleted in godot, it goes back to being an unsaved scene, instead of being outright deleted. However, creating a scene, adding local favorites, deleting it (so that it becomes unsaved again) and re-saving after causes the local favorites to be erased from the scene. We ended up leaving this as is, since the feature isn't supposed to work with unsaved scenes (as the properties are scene dependent) and the re-saved scene is technically a new scene, different from the previous ones.