### PR TITLE
Document that ResourceLoader.load_threaded_get consumes its threaded request

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -114,6 +114,7 @@
 			<description>
 				Returns the resource loaded by [method load_threaded_request].
 				If this is called before the loading thread is done (i.e. [method load_threaded_get_status] is not [constant THREAD_LOAD_LOADED]), the calling thread will be blocked until the resource has finished loading. However, it's recommended to use [method load_threaded_get_status] to known when the load has actually completed.
+				[b]Note:[/b] Each successful call collects the result of a request started with [method load_threaded_request] for [param path], consuming that request. Once a path's pending requests have all been collected, calling this method again for the same path returns null until a new request is started with [method load_threaded_request]. The loaded resource is still added to the resource cache, so after collecting it once you can retrieve it again with [method load] for as long as a reference to it remains alive.
 			</description>
 		</method>
 		<method name="load_threaded_get_status">


### PR DESCRIPTION
Addresses godotengine/godot-docs#8047.

ResourceLoader's threaded loading methods don't explain why a second load_threaded_get() call on the same path returns null. Users on the issue hit this and couldn't tell from the docs whether it was a bug.

From core/io/resource_loader.cpp, load_threaded_get consumes the request started by load_threaded_request: each call collects one pending request, and once a path's requests are all collected the next call returns null until a new request is started. The loaded resource still goes into the normal resource cache, so it can be retrieved again with load() while a reference to it stays alive.

This adds a Note to load_threaded_get in doc/classes/ResourceLoader.xml documenting that behavior.