### PR TITLE
GDScript: Fix static class call resolving to native method

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -645,6 +645,9 @@
 		<member name="debug/gdscript/warnings/static_called_on_instance" type="int" setter="" getter="" default="1">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when calling a static method from an instance of a class instead of from the class directly.
 		</member>
+		<member name="debug/gdscript/warnings/static_method_shadows_script_method" type="int" setter="" getter="" default="2">
+			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when defining a static method that shadows a non-static method from the script's native class hierarchy.
+		</member>
 		<member name="debug/gdscript/warnings/unassigned_variable" type="int" setter="" getter="" default="1">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when using a variable that wasn't previously assigned.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1978,6 +1978,15 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			}
 #endif // DEBUG_ENABLED
 		}
+
+#ifdef DEBUG_ENABLED
+		if (!p_is_lambda && p_function->is_static && !String(function_name).begins_with("@")) {
+			MethodBind *script_method = ClassDB::get_method(GDScript::get_class_static(), function_name);
+			if (script_method != nullptr && !script_method->is_static()) {
+				parser->push_warning(p_function, GDScriptWarning::STATIC_METHOD_SHADOWS_SCRIPT_METHOD, function_name, script_method->get_instance_class());
+			}
+		}
+#endif // DEBUG_ENABLED
 #endif // TOOLS_ENABLED
 	}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -690,13 +690,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								if (r_error) {
 									return GDScriptCodeGenerator::Address();
 								}
-								const GDScriptParser::DataType &base_type = subscript->base->get_datatype();
-								bool is_script_class_metatype = base_type.is_meta_type &&
-										(base_type.kind == GDScriptParser::DataType::CLASS || base_type.kind == GDScriptParser::DataType::SCRIPT);
 								if (is_awaited) {
 									gen->write_call_async(result, base, call->function_name, arguments);
-								} else if (is_script_class_metatype) {
-									gen->write_call(result, base, call->function_name, arguments);
 								} else if (base.type.kind != GDScriptDataType::VARIANT && base.type.kind != GDScriptDataType::BUILTIN) {
 									// Native method, use faster path.
 									StringName class_name;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -690,8 +690,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								if (r_error) {
 									return GDScriptCodeGenerator::Address();
 								}
+								const GDScriptParser::DataType &base_type = subscript->base->get_datatype();
+								bool is_script_class_metatype = base_type.is_meta_type &&
+										(base_type.kind == GDScriptParser::DataType::CLASS || base_type.kind == GDScriptParser::DataType::SCRIPT);
 								if (is_awaited) {
 									gen->write_call_async(result, base, call->function_name, arguments);
+								} else if (is_script_class_metatype) {
+									gen->write_call(result, base, call->function_name, arguments);
 								} else if (base.type.kind != GDScriptDataType::VARIANT && base.type.kind != GDScriptDataType::BUILTIN) {
 									// Native method, use faster path.
 									StringName class_name;

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -166,6 +166,9 @@ String GDScriptWarning::get_message() const {
 		case NATIVE_METHOD_OVERRIDE:
 			CHECK_SYMBOLS(2);
 			return vformat(R"*(The method "%s()" overrides a method from native class "%s". This won't be called by the engine and may not work as expected.)*", symbols[0], symbols[1]);
+		case STATIC_METHOD_SHADOWS_SCRIPT_METHOD:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The static method "%s()" shadows a non-static method from native class "%s". This may not work as expected when calling the method through the script class.)*", symbols[0], symbols[1]);
 		case GET_NODE_DEFAULT_WITHOUT_ONREADY:
 			CHECK_SYMBOLS(1);
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
@@ -247,6 +250,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("CONFUSABLE_TEMPORARY_MODIFICATION"),
 		PNAME("INFERENCE_ON_VARIANT"),
 		PNAME("NATIVE_METHOD_OVERRIDE"),
+		PNAME("STATIC_METHOD_SHADOWS_SCRIPT_METHOD"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
 #ifndef DISABLE_DEPRECATED

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -90,6 +90,7 @@ public:
 		CONFUSABLE_TEMPORARY_MODIFICATION, // Modifying a temporary value in a complex assignment chain or calling a non-`const` method.
 		INFERENCE_ON_VARIANT, // The declaration uses type inference but the value is typed as Variant.
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
+		STATIC_METHOD_SHADOWS_SCRIPT_METHOD, // The script static method shadows a non-static method of the script resource, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
 #ifndef DISABLE_DEPRECATED
@@ -149,6 +150,7 @@ public:
 		WARN, // CONFUSABLE_TEMPORARY_MODIFICATION
 		ERROR, // INFERENCE_ON_VARIANT // Most likely done by accident, usually inference is trying for a particular type.
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
+		ERROR, // STATIC_METHOD_SHADOWS_SCRIPT_METHOD // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119911

## Additional information

`UserConfig.reload()` is being optimized into `GDScript.reload()` because the compiler treats the script class reference as the underlying `GDScript` resource and takes the native MethodBind path. The correct behavior is to skip the native MethodBind path for script class.




