### PR TITLE
Make script editor member overview navigate to and fold/unfold methods.

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1423,26 +1423,6 @@ void CodeTextEditor::goto_line_centered(int p_line, int p_column) {
 	center_viewport_to_caret();
 }
 
-void CodeTextEditor::goto_line_centered_toggle_fold(int p_line, int p_column) {
-	bool already_on_line = (text_editor->get_caret_line(0) == p_line);
-	text_editor->remove_secondary_carets();
-	text_editor->deselect();
-	if (already_on_line) {
-		if (text_editor->is_line_folded(p_line)) {
-			text_editor->unfold_line(p_line);
-		} else {
-			text_editor->fold_line(p_line);
-		}
-	} else {
-		text_editor->unfold_line(CLAMP(p_line, 0, text_editor->get_line_count() - 1));
-	}
-	text_editor->set_caret_line(p_line, false);
-	text_editor->set_caret_column(p_column, false);
-	text_editor->set_code_hint("");
-	text_editor->cancel_code_completion();
-	center_viewport_to_caret();
-}
-
 void CodeTextEditor::set_executing_line(int p_line) {
 	text_editor->set_line_as_executing(p_line, true);
 }

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1423,6 +1423,26 @@ void CodeTextEditor::goto_line_centered(int p_line, int p_column) {
 	center_viewport_to_caret();
 }
 
+void CodeTextEditor::goto_line_centered_toggle_fold(int p_line, int p_column) {
+	bool already_on_line = (text_editor->get_caret_line(0) == p_line);
+	text_editor->remove_secondary_carets();
+	text_editor->deselect();
+	if (already_on_line) {
+		if (text_editor->is_line_folded(p_line)) {
+			text_editor->unfold_line(p_line);
+		} else {
+			text_editor->fold_line(p_line);
+		}
+	} else {
+		text_editor->unfold_line(CLAMP(p_line, 0, text_editor->get_line_count() - 1));
+	}
+	text_editor->set_caret_line(p_line, false);
+	text_editor->set_caret_column(p_column, false);
+	text_editor->set_code_hint("");
+	text_editor->cancel_code_completion();
+	center_viewport_to_caret();
+}
+
 void CodeTextEditor::set_executing_line(int p_line) {
 	text_editor->set_line_as_executing(p_line, true);
 }

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -264,7 +264,6 @@ public:
 	void goto_line(int p_line, int p_column = 0);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	void goto_line_centered(int p_line, int p_column = 0);
-	void goto_line_centered_toggle_fold(int p_line, int p_column = 0);
 	void set_executing_line(int p_line);
 	void clear_executing_line();
 

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -264,6 +264,7 @@ public:
 	void goto_line(int p_line, int p_column = 0);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	void goto_line_centered(int p_line, int p_column = 0);
+	void goto_line_centered_toggle_fold(int p_line, int p_column = 0);
 	void set_executing_line(int p_line);
 	void clear_executing_line();
 

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -211,15 +211,7 @@ public:
 	virtual void goto_line(int p_line, int p_column = 0) { code_editor->goto_line(p_line, p_column); }
 	virtual void goto_line_selection(int p_line, int p_begin, int p_end) { code_editor->goto_line_selection(p_line, p_begin, p_end); }
 	virtual void goto_line_centered(int p_line, int p_column = 0) { code_editor->goto_line_centered(p_line, p_column); }
-	virtual int get_caret_line(int p_caret = 0) const { return code_editor->get_text_editor()->get_caret_line(p_caret); }
-	virtual void toggle_fold_line(int p_line) {
-		CodeEdit *te = code_editor->get_text_editor();
-		if (te->is_line_folded(p_line)) {
-			te->unfold_line(p_line);
-		} else {
-			te->fold_line(p_line);
-		}
-	}
+	virtual void goto_line_centered_toggle_fold(int p_line, int p_column = 0) { code_editor->goto_line_centered_toggle_fold(p_line, p_column); }
 	virtual void set_executing_line(int p_line) { code_editor->set_executing_line(p_line); }
 	virtual void clear_executing_line() { code_editor->clear_executing_line(); }
 

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -211,15 +211,6 @@ public:
 	virtual void goto_line(int p_line, int p_column = 0) { code_editor->goto_line(p_line, p_column); }
 	virtual void goto_line_selection(int p_line, int p_begin, int p_end) { code_editor->goto_line_selection(p_line, p_begin, p_end); }
 	virtual void goto_line_centered(int p_line, int p_column = 0) { code_editor->goto_line_centered(p_line, p_column); }
-	virtual int get_caret_line(int p_caret = 0) const { return code_editor->get_text_editor()->get_caret_line(p_caret); }
-	virtual void toggle_fold_line(int p_line) {
-		CodeEdit *te = code_editor->get_text_editor();
-		if (te->is_line_folded(p_line)) {
-			te->unfold_line(p_line);
-		} else {
-			te->fold_line(p_line);
-		}
-	}
 	virtual void set_executing_line(int p_line) { code_editor->set_executing_line(p_line); }
 	virtual void clear_executing_line() { code_editor->clear_executing_line(); }
 

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -211,6 +211,15 @@ public:
 	virtual void goto_line(int p_line, int p_column = 0) { code_editor->goto_line(p_line, p_column); }
 	virtual void goto_line_selection(int p_line, int p_begin, int p_end) { code_editor->goto_line_selection(p_line, p_begin, p_end); }
 	virtual void goto_line_centered(int p_line, int p_column = 0) { code_editor->goto_line_centered(p_line, p_column); }
+	virtual int get_caret_line(int p_caret = 0) const { return code_editor->get_text_editor()->get_caret_line(p_caret); }
+	virtual void toggle_fold_line(int p_line) {
+		CodeEdit *te = code_editor->get_text_editor();
+		if (te->is_line_folded(p_line)) {
+			te->unfold_line(p_line);
+		} else {
+			te->fold_line(p_line);
+		}
+	}
 	virtual void set_executing_line(int p_line) { code_editor->set_executing_line(p_line); }
 	virtual void clear_executing_line() { code_editor->clear_executing_line(); }
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1649,11 +1649,7 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	int line = members_overview->get_item_metadata(p_idx);
 	ScriptEditorBase *current = _get_current_editor();
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(current)) {
-		if (teb->get_caret_line(0) == line) {
-			teb->toggle_fold_line(line);
-		} else {
-			teb->goto_line_centered(line);
-		}
+		teb->goto_line_centered_toggle_fold(line);
 	}
 }
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1649,7 +1649,11 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	int line = members_overview->get_item_metadata(p_idx);
 	ScriptEditorBase *current = _get_current_editor();
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(current)) {
-		teb->goto_line_centered(line);
+		if (teb->get_caret_line(0) == line) {
+			teb->toggle_fold_line(line);
+		} else {
+			teb->goto_line_centered(line);
+		}
 	}
 }
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1649,7 +1649,11 @@ void ScriptEditor::_members_overview_selected(int p_idx) {
 	int line = members_overview->get_item_metadata(p_idx);
 	ScriptEditorBase *current = _get_current_editor();
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(current)) {
-		teb->goto_line_centered_toggle_fold(line);
+		if (teb->get_caret_line(0) == line) {
+			teb->toggle_fold_line(line);
+		} else {
+			teb->goto_line_centered(line);
+		}
 	}
 }
 


### PR DESCRIPTION
### Issue solved

Clicking more than once on the member overview would do nothing after the initial 'seek' action. Now it will fold/unfold the function if the caret did not move.

### Changes

**script_editor_base.h**
  -  get_caret_line casts the pre-existing function from code_editor->get_text_editor() without changing its shape.
  - toggle_fold_line, uses existing function is_line_folded as the conditional to pick fold/unfold actions.

**script_editor_plugin.cpp->_members_overview_selected**
  -   If the current line equals the target line, then call the new function toggle_fold_line else call goto_line_centered as usual.

### Motivation

I was refactoring my code and needed to quickly move between pairs of functions. I wrote a GDScript tool to test the concept. It worked great, and was very simple to implement in C++.

It seemed a good idea to keep all the functions _members_overview_selected calls next to each other. Even though the Shader Editor doesn't have the member overview right now, the new functions should be compatible if that does become a feature.

### Testing

Tested by opening a project with a long script and clicking the member overview list items (Windows 11).

- SOEL86