### PR TITLE
Fix scene tab menu not updating tab bar.

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -503,7 +503,7 @@ EditorSceneTabs::EditorSceneTabs() {
 	scene_list->get_popup()->set_search_bar_enabled(true);
 	scene_list->get_popup()->set_search_bar_min_item_count(10);
 	scene_list->get_popup()->connect("about_to_popup", callable_mp(this, &EditorSceneTabs::_update_scene_list));
-	scene_list->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
+	scene_list->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorSceneTabs::set_current_tab));
 	tabbar_container->add_child(scene_list);
 
 	// On-hover tab preview.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/119947

## Additional information

Likely regression from https://github.com/godotengine/godot/pull/116905, similar to https://github.com/godotengine/godot/issues/119470 (and fixed in the same way).