### PR TITLE
Use `GDSOFTCLASS` for internal `IP` implementations

### DIFF
--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -35,7 +35,7 @@
 #include "core/io/ip.h"
 
 class IPUnix : public IP {
-	GDCLASS(IPUnix, IP);
+	GDSOFTCLASS(IPUnix, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/drivers/windows/ip_windows.h
+++ b/drivers/windows/ip_windows.h
@@ -35,7 +35,7 @@
 #include "core/io/ip.h"
 
 class IPWindows : public IP {
-	GDCLASS(IPWindows, IP);
+	GDSOFTCLASS(IPWindows, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/platform/web/ip_web.h
+++ b/platform/web/ip_web.h
@@ -33,7 +33,7 @@
 #include "core/io/ip.h"
 
 class IPWeb : public IP {
-	GDCLASS(IPWeb, IP);
+	GDSOFTCLASS(IPWeb, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override {}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

While working on GDS I recently noticed that certain internal classes show up in the ClassDB, that do not require any ClassDB features. This PR converts the registration of `IP` implementations to `GDSOFTCLASS` to keep them out of the `ClassDB`.

## Additional information

Those classes do not bind any methods or signals. So there is no reason to have them in the ClassDB.
