### PR TITLE
Fix `CanvasItemEditor::center_at` rounding

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5612,7 +5612,7 @@ void CanvasItemEditor::focus_selection() {
 
 void CanvasItemEditor::center_at(const Point2 &p_pos) {
 	Vector2 offset = viewport->get_size() / 2 - EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform().xform(p_pos);
-	view_offset -= (offset / zoom).round();
+	view_offset = (view_offset - offset / zoom).round();
 	update_viewport();
 }
 


### PR DESCRIPTION
Fixes #119961.

Makes the rounding be applied to the final calculated `view_offset` instead of to the `offset` by which the `view_offset` was being modified.

Simplified example showcasing the change:

- Before:

viewport_center|view_offset|offset|view_offset - offset.round()
-|-|-|-
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(595.0, 410.0)
(595.5, 410.0)|(595.0, 410.0)|(-0.5, 0.0)|(596.0, 410.0)
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(595.0, 410.0)
(595.5, 410.0)|(595.0, 410.0)|(-0.5, 0.0)|(596.0, 410.0)

- After:

viewport_center|view_offset|offset|(view_offset - offset).round()
-|-|-|-
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(596.0, 410.0)
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(596.0, 410.0)
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(596.0, 410.0)
(595.5, 410.0)|(596.0, 410.0)|(0.5, 0.0)|(596.0, 410.0)

I'm not sure if rounding is needed at all there, but didn't removed it to avoid potential regressions.