### PR TITLE
[macOS] Fix build with enabled ANGLE and disabled Vulkan/Metal.

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -293,6 +293,7 @@ def configure(env: "SConsEnvironment"):
                 env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
                 env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
                 env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
+                extra_frameworks.add("Metal")
             else:
                 print_warning(
                     "The ANGLE rendering driver requires dependencies to be installed.\n"


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes build with `metal=no vulkna=no angle=yes`.

## Additional information

ANGLE uses OpenGL over Metal and therefore needs base Metal framework linked. It's not common or useful configuration, but can happen in x86-64 CI build if MoltenVK download fails.