### PR TITLE
Properly update shader text syntax highlighting (for disabled regions)

### DIFF
--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -1273,6 +1273,7 @@ void ShaderTextEditor::_validate_script() {
 			syntax_highlighter->add_disabled_branch_region(Point2i(region.from_line, region.to_line));
 		}
 	}
+	syntax_highlighter->emit_changed();
 
 	set_error("");
 	set_error_count(0);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7029,12 +7029,16 @@ void TextEdit::set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighte
 		return;
 	}
 
+	if (syntax_highlighter.is_valid()) {
+		syntax_highlighter->disconnect_changed(callable_mp(this, &TextEdit::_syntax_highlighter_changed));
+	}
+
 	syntax_highlighter = p_syntax_highlighter;
 	if (syntax_highlighter.is_valid()) {
 		syntax_highlighter->set_text_edit(this);
+		syntax_highlighter->connect_changed(callable_mp(this, &TextEdit::_syntax_highlighter_changed));
 	}
-	_clear_syntax_highlighting_cache();
-	queue_redraw();
+	_syntax_highlighter_changed();
 }
 
 Ref<SyntaxHighlighter> TextEdit::get_syntax_highlighter() const {
@@ -9107,6 +9111,11 @@ Vector<Pair<int64_t, Color>> TextEdit::_get_line_syntax_highlighting(int p_line)
 
 void TextEdit::_clear_syntax_highlighting_cache() {
 	syntax_highlighting_cache.clear();
+}
+
+void TextEdit::_syntax_highlighter_changed() {
+	_clear_syntax_highlighting_cache();
+	queue_redraw();
 }
 
 /* Deprecated. */

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -603,6 +603,7 @@ private:
 
 	Vector<Pair<int64_t, Color>> _get_line_syntax_highlighting(int p_line);
 	void _clear_syntax_highlighting_cache();
+	void _syntax_highlighter_changed();
 
 	/* Visual. */
 	struct ThemeCache {


### PR DESCRIPTION
Before:

<img width="602" height="384" alt="bug" src="https://github.com/user-attachments/assets/2f7e42cc-3945-4784-9b4e-eebbdbc1a3ab" />

After:

<img width="602" height="384" alt="fix" src="https://github.com/user-attachments/assets/3f357598-4166-4914-a539-31d96cde768b" />

Test shader:

```gdshader
shader_type canvas_item;

#define one 1
#if one == 0
const int x = 0; 
#endif
```