### PR TITLE
Put area light cluster iterations behind a spec constant.

### DIFF
--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -415,6 +415,11 @@ public:
 		render_element_count++;
 	}
 
+	_FORCE_INLINE_ uint32_t get_cluster_count_by_type(ElementType p_element_type) const {
+		DEV_ASSERT(p_element_type < ELEMENT_TYPE_MAX);
+		return cluster_count_by_type[p_element_type];
+	}
+
 	void bake_cluster();
 	void debug(ElementType p_element);
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2181,6 +2181,10 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	}
 	_pre_opaque_render(p_render_data, using_ssao, using_ssil, using_ssr, using_sdfgi || using_voxelgi, normal_roughness_views, rb_data.is_valid() && rb_data->has_voxelgi() ? rb_data->get_voxelgi() : RID());
 
+	if (current_cluster_builder) {
+		base_specialization.cluster_has_area_light = current_cluster_builder->get_cluster_count_by_type(ClusterBuilderRD::ELEMENT_TYPE_AREA_LIGHT) != 0;
+	}
+
 	RENDER_TIMESTAMP("Render Opaque Pass");
 
 	RD::get_singleton()->draw_command_begin_label("Render Opaque Pass");

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -127,6 +127,7 @@ public:
 				uint32_t multimesh_has_color : 1;
 				uint32_t multimesh_has_custom_data : 1;
 				uint32_t fog_use_legacy_blending : 1;
+				uint32_t cluster_has_area_light : 1;
 			};
 		};
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2817,7 +2817,7 @@ void fragment_shader(in SceneData scene_data) {
 		}
 	}
 
-	{ // area lights
+	if (sc_cluster_has_area_light()) { // area lights
 
 		uint cluster_area_offset = cluster_offset + implementation_data.cluster_type_size * 2;
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -142,6 +142,10 @@ bool sc_fog_use_legacy_blending() {
 	return ((sc_packed_1() >> 4) & 1U) != 0;
 }
 
+bool sc_cluster_has_area_light() {
+	return ((sc_packed_1() >> 5) & 1U) != 0;
+}
+
 float sc_luminance_multiplier() {
 	// Not used in clustered renderer but we share some code with the mobile renderer that requires this.
 	return 1.0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119963 (probably)

## Additional information

Area lights have a massive VGPR footprint, the amount of registers go from 85~ to 150~ and the shader becomes twice as long. This PR makes area light code not get compiled in unless there is one visible in the frustum.

Mobile does not need this since area light count is already a specialization constant there.
Compatibility does not need it either as it enables `DISABLE_LIGHT_AREA` spec constant if there are no area lights.