### PR TITLE
Don't use CreateCommandList1 on D3D12.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2577,18 +2577,9 @@ RDD::CommandBufferID RenderingDeviceDriverD3D12::command_buffer_create(CommandPo
 
 	ComPtr<ID3D12GraphicsCommandList> cmd_list;
 	{
-		ComPtr<ID3D12Device4> device_4;
-		device->QueryInterface(device_4.GetAddressOf());
-		HRESULT res = E_FAIL;
-		if (device_4) {
-			res = device_4->CreateCommandList1(0, list_type, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(cmd_list.GetAddressOf()));
-		} else {
-			res = device->CreateCommandList(0, list_type, cmd_allocator.Get(), nullptr, IID_PPV_ARGS(cmd_list.GetAddressOf()));
-		}
+		HRESULT res = device->CreateCommandList(0, list_type, cmd_allocator.Get(), nullptr, IID_PPV_ARGS(cmd_list.GetAddressOf()));
 		ERR_FAIL_COND_V_MSG(!SUCCEEDED(res), CommandBufferID(), "CreateCommandList failed with error " + vformat("0x%08ux", (uint64_t)res) + ".");
-		if (!device_4) {
-			cmd_list->Close();
-		}
+		cmd_list->Close();
 	}
 
 	CPUDescriptorHeapPool::Allocation uav_alloc;


### PR DESCRIPTION
The current implementation of the usage of CreateCommandList1 on the D3D12 driver introduces a failure point for devices that might report the Device4 API as supported, but fail to create the command list when called. While this is not expected behavior, I've found it to happen on some devices.

~~Apart from that, it seems the command allocator is created regardless of whether this API is used, which it doesn't require, and probably leads to two command allocators being created per command buffer: one that goes unused and one internally by the driver.~~ Upon further review, it seems this is only necessary because it has to create the command list in an open state. It still requires the command allocator to begin the command list.

I couldn't find much benefit or difference to using the newer API here instead of the safer option.