### PR TITLE
Pulseaudio: Do not crash when getting latency when disconnected

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -373,6 +373,10 @@ Error AudioDriverPulseAudio::init() {
 float AudioDriverPulseAudio::get_latency() {
 	lock();
 
+	if (pa_str == nullptr) {
+		return 0;
+	}
+
 	pa_usec_t pa_lat = 0;
 	if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
 		int negative = 0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

When pulseaudio is disconnected, we pass a null pointer to a pulseaudio function which asserts that the pointer is not null. The whole game crashes.  Fix this,