### PR TITLE
Pulseaudio: Do not report the same message twice in a row

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -397,6 +397,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	unsigned int write_ofs = 0;
 	size_t avail_bytes = 0;
 	uint64_t default_device_msec = OS::get_singleton()->get_ticks_msec();
+	int last_reported_errno = PA_OK;
 
 	while (!ad->exit_thread.is_set()) {
 		size_t read_bytes = 0;
@@ -506,7 +507,11 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 					pa_operation_unref(pa_op);
 				} else {
-					ERR_PRINT("pa_context_get_server_info error: " + String(pa_strerror(pa_context_errno(ad->pa_ctx))));
+					int pa_errno = pa_context_errno(ad->pa_ctx);
+					if (pa_errno != last_reported_errno) {
+						last_reported_errno = pa_errno;
+						ERR_PRINT("pa_context_get_server_info error: " + String(pa_strerror(pa_errno)));
+					}
 				}
 
 				if (old_default_device != ad->default_output_device) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Partial fix for #54584.  Don't repeatedly print the same error message.  This addresses the spam problem, but does NOT reconnect.  The full fix is #119298.  

Note that this fix is in a different spot than the one in #119298 -- that one is when we try to reconnect, which would supersede this one.  It's OK to do either or both.