### PR TITLE
Move "Batch Rename" closer to "Rename" and fix undercounting

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4039,7 +4039,11 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			BEGIN_SECTION()
 			if (can_rename) {
 				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
+				if (full_selection.size() > 1) {
+					menu->add_shortcut(ED_GET_SHORTCUT("scene_tree/batch_rename"), TOOL_BATCH_RENAME);
+				}
 			}
+
 			if (can_replace) {
 				menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Reload")), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_CHANGE_TYPE);
 			}
@@ -4129,12 +4133,6 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		END_SECTION()
 	}
 
-	if (profile_allow_editing && selection.size() > 1) {
-		//this is not a commonly used action, it makes no sense for it to be where it was nor always present.
-		BEGIN_SECTION()
-		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/batch_rename"), TOOL_BATCH_RENAME);
-		END_SECTION()
-	}
 	BEGIN_SECTION()
 	// Group "open_in_editor" with "show_in_file_system", if it is available.
 	if (is_tool_scene_open_inherited_available) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14626

Related PRs:
- https://github.com/godotengine/godot/pull/118577
- https://github.com/godotengine/godot/pull/119617

Changes:
- "Batch Rename" now shows up under "Rename" in the scene tree context menu.
  - Removes the redundant icon of "Batch Rename", similar to the "Paste" options.
- "Batch Rename" now correctly counts the number of selected nodes.
  - See https://github.com/godotengine/godot/pull/119617
- ~"Batch Rename" now appears even with only one node selected.~

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="380" height="489" alt="Image 2026-06-02_12-58-16" src="https://github.com/user-attachments/assets/c1877793-5927-44f1-9423-ef8a533683e6" /> | <img width="380" height="491" alt="Image 2026-06-02_13-20-07" src="https://github.com/user-attachments/assets/5af78214-efaa-46e7-80ac-db866fbc46c1" /> |
| <img width="380" height="488" alt="Image 2026-06-02_12-58-30" src="https://github.com/user-attachments/assets/bc302a91-2386-485d-b213-f53a1c6ddb90" /> | <img width="379" height="489" alt="Image 2026-06-02_13-20-20" src="https://github.com/user-attachments/assets/a7b3898d-c8e3-4c34-9092-ae2267fcd31a" /> |
| <img width="380" height="489" alt="Image 2026-06-02_12-58-50" src="https://github.com/user-attachments/assets/4f4ec798-04d0-4d8c-8e61-0238cd6aaee6" /> | <img width="379" height="489" alt="Image 2026-06-02_13-20-33" src="https://github.com/user-attachments/assets/50d20213-e337-4cc7-b4f8-2a9c5df04ba2" /> |
