### PR TITLE
Fix AnimationNode's branching by custom timeline usage

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -207,7 +207,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_pro
 	// 3. Progress for Animation.
 	double prev_playback_time = prev_time;
 	double cur_playback_time = cur_time;
-	if (stretch_time_scale) {
+	if (use_custom_timeline && stretch_time_scale) {
 		double mlt = anim_size / timeline_length;
 		prev_playback_time *= mlt;
 		cur_playback_time *= mlt;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119979
- Follow up https://github.com/godotengine/godot/pull/119871

Since the default value for `stretch_time_scale` is `true`, the code would check it even when `use_custom_timeline` was disabled, causing it to use an uninitialized `timeline_length` in the speed calculation. Fixed the check. cc @chocola-mint 

Since the default value for `timeline_length` is 1.0 seconds, issues arise with animations that do not exactly 1.0 second duration. I didn’t notice this in #119871 test because the test used animations with 1.0 seconds duration. If we’re creating tests, we should include animations that do not 1.0 seconds duration.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
