### PR TITLE
NodePath Navigation in Script Editor ("Go to Node")

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -42,6 +42,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc/editor_help.h"
 #include "editor/docks/filesystem_dock.h"
+#include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -54,6 +55,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
@@ -866,7 +868,7 @@ void ScriptTextEditor::_validate_script() {
 		if (errors.size() > 0) {
 			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
 			const String message = errors.front()->get().message.replace("[", "[lb]");
-			const Point2i display_pos = code_editor->get_pos_for_display(code_editor->get_error_pos());
+			const Point2i display_pos = code_editor->get_error_pos() + Point2i(1, 1);
 			const String error_text = vformat(TTR("Error at ([hint=Line %d, column %d]%d, %d[/hint]):"), display_pos.x, display_pos.y, display_pos.x, display_pos.y) + " " + message;
 			code_editor->set_error(error_text);
 		}
@@ -1188,6 +1190,12 @@ void ScriptTextEditor::_on_caret_moved() {
 }
 
 void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_column) {
+	CodeEdit *text_edit = code_editor->get_text_editor();
+	String nodepath = text_edit->get_nodepath_at_pos(p_row, p_column);
+	if (!nodepath.is_empty() && _navigate_nodepath(p_row, p_column)) {
+		return;
+	}
+
 	Ref<Script> script = edited_res;
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
@@ -1293,7 +1301,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		// Check for Autoload scenes.
 		const ProjectSettings::AutoloadInfo &info = ProjectSettings::get_singleton()->get_autoload(p_symbol);
 		if (info.is_singleton) {
-			EditorNode::get_singleton()->open_scene(info.path);
+			EditorNode::get_singleton()->load_scene(info.path);
 		}
 	} else if (p_symbol.is_relative_path()) {
 		// Every symbol other than absolute path is relative path so keep this condition at last.
@@ -1308,7 +1316,28 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	CodeEdit *text_edit = code_editor->get_text_editor();
 
 	Ref<Script> script = edited_res;
-	Node *base = get_tree()->get_edited_scene_root();
+	Node *scene_root = get_tree()->get_edited_scene_root();
+	if (scene_root) {
+		NodePath np(p_symbol);
+		if (!np.is_empty()) {
+			if (np.is_absolute()) {
+				if (scene_root->get_node_or_null(np)) {
+					text_edit->set_symbol_lookup_word_as_valid(true);
+					return;
+				}
+			} else {
+				Vector<Node *> script_nodes = _find_all_node_for_script(scene_root, scene_root, script);
+				for (Node *owner : script_nodes) {
+					if (owner->get_node_or_null(np)) {
+						text_edit->set_symbol_lookup_word_as_valid(true);
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	Node *base = scene_root;
 	if (base) {
 		base = _find_node_for_script(base, base, script);
 	}
@@ -1328,6 +1357,101 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 		}
 	} else {
 		text_edit->set_symbol_lookup_word_as_valid(false);
+	}
+}
+
+bool ScriptTextEditor::_navigate_nodepath(int p_row, int p_column) {
+	CodeEdit *text_edit = code_editor->get_text_editor();
+	String nodepath = text_edit->get_nodepath_at_pos(p_row, p_column);
+	if (nodepath.is_empty()) {
+		return false;
+	}
+
+	Node *scene_root = get_tree()->get_edited_scene_root();
+	if (!scene_root) {
+		return false;
+	}
+
+	Ref<Script> script = edited_res;
+	Vector<Node *> script_nodes = _find_all_node_for_script(scene_root, scene_root, script);
+	if (script_nodes.is_empty()) {
+		EditorToaster::get_singleton()->popup_str(
+				vformat(TTR("NodePath '%s': script is not attached to any node in the current scene."), nodepath),
+				EditorToaster::SEVERITY_WARNING);
+		return true;
+	}
+
+	NodePath np(nodepath);
+	if (np.is_absolute()) {
+		Node *target = scene_root->get_node_or_null(np);
+		if (target) {
+			_navigate_to_scene_node(target);
+			return true;
+		}
+
+		EditorToaster::get_singleton()->popup_str(
+				vformat(TTR("NodePath '%s' could not be resolved in the current scene."), nodepath),
+				EditorToaster::SEVERITY_WARNING);
+		return true;
+	}
+
+	Vector<Node *> resolved;
+	HashSet<Node *> unique_nodes;
+	for (Node *owner : script_nodes) {
+		Node *target = owner->get_node_or_null(np);
+		if (target && !unique_nodes.has(target)) {
+			unique_nodes.insert(target);
+			resolved.push_back(target);
+		}
+	}
+
+	if (resolved.is_empty()) {
+		EditorToaster::get_singleton()->popup_str(
+				vformat(TTR("NodePath '%s' could not be resolved in the current scene."), nodepath),
+				EditorToaster::SEVERITY_WARNING);
+		return true;
+	}
+
+	if (resolved.size() == 1) {
+		_navigate_to_scene_node(resolved[0]);
+		return true;
+	}
+
+	_pending_nodepath_nodes.clear();
+	nodepath_select_list->clear();
+	for (Node *node : resolved) {
+		NodePath scene_path = scene_root->get_path_to(node);
+		int item = nodepath_select_list->add_item(vformat(TTR("%s (%s)"), String(scene_path), node->get_class()));
+		nodepath_select_list->set_item_tooltip(item, vformat(TTR("Type: %s"), node->get_class()));
+		_pending_nodepath_nodes.push_back(node);
+	}
+
+	nodepath_select_dialog->set_title(vformat(TTR("Select target for NodePath: %s"), nodepath));
+	nodepath_select_label->set_text(vformat(TTR("%d matches for NodePath '%s'. Select the target node:"), resolved.size(), nodepath));
+	nodepath_select_list->select(0);
+	nodepath_select_list->grab_focus();
+	nodepath_select_dialog->popup_centered(Size2(420, 320) * EDSCALE);
+	return true;
+}
+
+void ScriptTextEditor::_navigate_to_scene_node(Node *p_node) {
+	SceneTreeDock::get_singleton()->set_selected(p_node, true);
+}
+
+void ScriptTextEditor::_nodepath_select_confirmed() {
+	PackedInt32Array selected = nodepath_select_list->get_selected_items();
+	if (selected.is_empty()) {
+		return;
+	}
+
+	int idx = selected[0];
+	if (idx < 0 || idx >= _pending_nodepath_nodes.size()) {
+		return;
+	}
+
+	Node *node = _pending_nodepath_nodes[idx];
+	if (node) {
+		_navigate_to_scene_node(node);
 	}
 }
 
@@ -2705,6 +2829,27 @@ void ScriptTextEditor::_enable_code_editor() {
 	add_child(quick_open);
 
 	add_child(connection_info_dialog);
+
+	nodepath_select_dialog = memnew(AcceptDialog);
+	nodepath_select_dialog->set_ok_button_text(TTR("Navigate"));
+	nodepath_select_label = memnew(Label);
+	nodepath_select_label->set_text(TTR("Multiple nodes found. Select the target node:"));
+	nodepath_select_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	nodepath_select_list = memnew(ItemList);
+	nodepath_select_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	nodepath_select_list->set_select_mode(ItemList::SELECT_SINGLE);
+	nodepath_select_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	nodepath_select_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+
+	VBoxContainer *np_vbc = memnew(VBoxContainer);
+	np_vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	np_vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	np_vbc->add_child(nodepath_select_label);
+	np_vbc->add_child(nodepath_select_list);
+	nodepath_select_dialog->add_child(np_vbc);
+
+	nodepath_select_dialog->connect("confirmed", callable_mp(this, &ScriptTextEditor::_nodepath_select_confirmed));
+	add_child(nodepath_select_dialog);
 }
 
 ScriptTextEditor::ScriptTextEditor() {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -39,6 +39,8 @@
 #include "scene/gui/tree.h"
 
 class RichTextLabel;
+class ItemList;
+class Node;
 
 class ConnectionInfoDialog : public AcceptDialog {
 	GDCLASS(ConnectionInfoDialog, AcceptDialog);
@@ -81,6 +83,10 @@ class ScriptTextEditor : public CodeEditorBase {
 
 	ScriptEditorQuickOpen *quick_open = nullptr;
 	ConnectionInfoDialog *connection_info_dialog = nullptr;
+	AcceptDialog *nodepath_select_dialog = nullptr;
+	Label *nodepath_select_label = nullptr;
+	ItemList *nodepath_select_list = nullptr;
+	Vector<Node *> _pending_nodepath_nodes;
 
 	int connection_gutter = -1;
 	void _gutter_clicked(int p_line, int p_gutter);
@@ -194,6 +200,10 @@ protected:
 	void _validate_symbol(const String &p_symbol);
 
 	void _show_symbol_tooltip(const String &p_symbol, int p_row, int p_column, bool p_shortcut = false);
+
+	bool _navigate_nodepath(int p_row, int p_column);
+	void _navigate_to_scene_node(Node *p_node);
+	void _nodepath_select_confirmed();
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2713,6 +2713,71 @@ String CodeEdit::get_text_with_cursor_char(int p_line, int p_column) const {
 	return result.as_string();
 }
 
+String CodeEdit::get_nodepath_at_pos(int p_line, int p_column) const {
+	if (p_line < 0 || p_column < 0) {
+		return String();
+	}
+	const String &line = get_line(p_line);
+	if (line.is_empty() || p_column < 0 || p_column > line.length()) {
+		return String();
+	}
+
+	// NodePath after $:
+	int left = p_column;
+	bool quoted = false;
+	while (left > 0 && (is_ascii_identifier_char(line[left - 1]) || line[left - 1] == '/' || line[left - 1] == '.' || line[left - 1] == '"')) {
+		left--;
+	}
+
+	if (left > 0 && line[left - 1] == '$') {
+		if (left < line.length() && line[left] == '"') {
+			quoted = true;
+			left++;
+		}
+
+		int right = p_column;
+		while (right < line.length() && (is_ascii_identifier_char(line[right]) || line[right] == '/' || line[right] == '.')) {
+			right++;
+		}
+		if (quoted && right < line.length() && line[right] == '"') {
+			quoted = false;
+		}
+		if (right > left && !quoted) {
+			return line.substr(left, right - left);
+		}
+	}
+
+	// NodePath from get_node("..."):
+	left = p_column;
+	while (left > 0 && (is_ascii_identifier_char(line[left - 1]) || line[left - 1] == '/' || line[left - 1] == '.')) {
+		left--;
+	}
+
+	int start = left;
+	if (start > 0 && line[start - 1] == '"') {
+		start--;
+	} else {
+		return String();
+	}
+	if (start > 0 && line[start - 1] == '^') {
+		start--;
+	}
+
+	static const String get_node_prefix = "get_node(";
+	const int prefix_len = get_node_prefix.length();
+	if (start >= prefix_len && line.substr(start - prefix_len, prefix_len) == get_node_prefix) {
+		int right = p_column;
+		while (right < line.length() && (is_ascii_identifier_char(line[right]) || line[right] == '/' || line[right] == '.')) {
+			right++;
+		}
+		if (right > left) {
+			return line.substr(left, right - left);
+		}
+	}
+
+	return String();
+}
+
 String CodeEdit::get_lookup_word(int p_line, int p_column) const {
 	if (p_line < 0 || p_column < 0) {
 		return String();
@@ -2729,6 +2794,12 @@ String CodeEdit::get_lookup_word(int p_line, int p_column) const {
 			return get_line(start_line).substr(start_column, end_column - start_column - 1);
 		}
 	}
+
+	String nodepath = get_nodepath_at_pos(p_line, p_column);
+	if (!nodepath.is_empty()) {
+		return nodepath;
+	}
+
 	return get_word(p_line, p_column);
 }
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -518,6 +518,7 @@ public:
 	String get_text_for_symbol_lookup() const;
 	String get_text_with_cursor_char(int p_line, int p_column) const;
 	String get_lookup_word(int p_line, int p_column) const;
+	String get_nodepath_at_pos(int p_line, int p_column) const;
 
 	void set_symbol_lookup_word_as_valid(bool p_valid);
 

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -5714,6 +5714,171 @@ func _ready():
 	memdelete(code_edit);
 }
 
+TEST_CASE("[SceneTree][CodeEdit] nodepath dollar extraction") {
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+	code_edit->grab_focus();
+
+	SUBCASE("[SceneTree][CodeEdit] simple name, cursor on first char") {
+		code_edit->set_text("var x = $Node");
+		CHECK(code_edit->get_nodepath_at_pos(0, 9) == "Node");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] simple name, cursor in middle") {
+		code_edit->set_text("var x = $Node");
+		CHECK(code_edit->get_nodepath_at_pos(0, 11) == "Node");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] simple name, cursor on last char") {
+		code_edit->set_text("var x = $Node");
+		CHECK(code_edit->get_nodepath_at_pos(0, 12) == "Node");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on first segment") {
+		code_edit->set_text("var x = $Node/Child");
+		// var x = $Node/Child
+		//          ^col 9
+		CHECK(code_edit->get_nodepath_at_pos(0, 9) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on slash") {
+		code_edit->set_text("var x = $Node/Child");
+		// Cursor on '/' at col 13
+		CHECK(code_edit->get_nodepath_at_pos(0, 13) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on second segment") {
+		code_edit->set_text("var x = $Node/Child");
+		// Cursor on 'C' of 'Child' at col 15
+		CHECK(code_edit->get_nodepath_at_pos(0, 15) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] three-segment path") {
+		code_edit->set_text("var x = $UI/HUD/HealthBar");
+		// var x = $UI/HUD/HealthBar
+		CHECK(code_edit->get_nodepath_at_pos(0, 18) == "UI/HUD/HealthBar");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] unique node name with percent returns empty") {
+		code_edit->set_text("var x = $%UniqueNode");
+		// '%' is not a scanned character; the '$' prefix is not found, so nothing is returned.
+		CHECK(code_edit->get_nodepath_at_pos(0, 12).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] cursor at the '$' itself returns empty") {
+		code_edit->set_text("var x = $Node");
+		// Cursor on '$' at col 8 — not inside the path
+		CHECK(code_edit->get_nodepath_at_pos(0, 8).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] cursor before '$' returns empty") {
+		code_edit->set_text("var x = $Node");
+		// Cursor on space before '$' at col 7
+		CHECK(code_edit->get_nodepath_at_pos(0, 5).is_empty());
+	}
+
+	memdelete(code_edit);
+}
+
+TEST_CASE("[SceneTree][CodeEdit] nodepath get_node extraction") {
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+	code_edit->grab_focus();
+
+	SUBCASE("[SceneTree][CodeEdit] simple name, cursor inside string") {
+		code_edit->set_text("get_node(\"Node\")");
+		// get_node("Node")
+		//           ^col 10
+		CHECK(code_edit->get_nodepath_at_pos(0, 10) == "Node");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on first segment") {
+		code_edit->set_text("get_node(\"Node/Child\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 10) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on slash") {
+		code_edit->set_text("get_node(\"Node/Child\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 14) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] two-segment path, cursor on second segment") {
+		code_edit->set_text("get_node(\"Node/Child\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 17) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] three-segment path") {
+		code_edit->set_text("get_node(\"UI/HUD/HealthBar\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 15) == "UI/HUD/HealthBar");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] NodePath literal with caret prefix") {
+		code_edit->set_text("get_node(^\"Node/Child\")");
+		// get_node(^"Node/Child")
+		CHECK(code_edit->get_nodepath_at_pos(0, 12) == "Node/Child");
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] single-quoted string not supported") {
+		// Only double-quoted strings are recognized; single quotes return empty.
+		CHECK(code_edit->get_nodepath_at_pos(0, 11).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] cursor outside string returns empty") {
+		// Cursor on 'g' of get_node, not inside the string
+		code_edit->set_text("get_node(\"Node/Child\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 2).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] cursor after closing paren returns empty") {
+		// Cursor after ')'
+		code_edit->set_text("get_node(\"Node\")");
+		CHECK(code_edit->get_nodepath_at_pos(0, 16).is_empty());
+	}
+
+	memdelete(code_edit);
+}
+
+TEST_CASE("[SceneTree][CodeEdit] nodepath edge cases") {
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+	code_edit->grab_focus();
+
+	SUBCASE("[SceneTree][CodeEdit] empty line returns empty") {
+		code_edit->set_text("");
+		CHECK(code_edit->get_nodepath_at_pos(0, 0).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] out-of-bounds column returns empty") {
+		code_edit->set_text("$Node");
+		CHECK(code_edit->get_nodepath_at_pos(0, 100).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] negative column returns empty") {
+		code_edit->set_text("$Node");
+		CHECK(code_edit->get_nodepath_at_pos(0, -1).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] regular identifier (not a NodePath) returns empty") {
+		// Regular method call — no '$' or get_node context
+		code_edit->set_text("set_visible(true)");
+		CHECK(code_edit->get_nodepath_at_pos(0, 4).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] string not in get_node returns empty") {
+		// Just a string assignment, not get_node
+		code_edit->set_text("var s = \"Node/Child\"");
+		CHECK(code_edit->get_nodepath_at_pos(0, 12).is_empty());
+	}
+
+	SUBCASE("[SceneTree][CodeEdit] dollar at line start with no path returns empty") {
+		// "$" alone
+		code_edit->set_text("$");
+		CHECK(code_edit->get_nodepath_at_pos(0, 1).is_empty());
+	}
+
+	memdelete(code_edit);
+}
+
 } // namespace TestCodeEdit
 
 #endif // ADVANCED_GUI_DISABLED


### PR DESCRIPTION
## Feature Preview


https://github.com/user-attachments/assets/8fb43170-a709-49f2-8a98-75c3e7e11fee


## Motivation

In large projects, NodePaths are used to reference nodes across scenes and scripts. However, navigating from these references to the actual node in the Scene Tree currently requires manual searching.
This PR introduces direct navigation support for NodePaths in the Script Editor, allowing users to jump from code references directly to the corresponding node in the Scene Tree. This brings an IDE-like experience (similar to *Go to Definition*) into the editor, improving navigation efficiency in medium to large-scale projects.

This feature was previously discussed in:
https://github.com/godotengine/godot-proposals/issues/14224

## Implementation Overview

The feature is implemented in two main layers:

### 1. NodePath Detection (CodeEdit)

This layer extracts NodePath expressions from the script text at the current cursor position.

It performs a line-based analysis to identify supported NodePath usages:

- `$Node/Child` shorthand syntax
- `get_node("Node/Child")` calls

Matched expressions are forwarded to the navigation system for resolution.

### 2. Navigation & Resolution (ScriptTextEditor)

This layer is responsible for resolving NodePath expressions and performing the corresponding navigation within the editor.

NodePaths extracted from the script are resolved against the current scene context, producing one or more candidate nodes in the SceneTree. These results are then used to determine how navigation is performed.

**Resolution result handling:**

- **Single match:** The target node is selected and focused in the Scene Tree
- **Multiple matches:** A selection popup is presented to disambiguate between valid targets
- **No matches:** A warning is shown