### PR TITLE
JoltPhysics: Change ConeTwistJoint3D to use cone shaped limits

### DIFF
--- a/modules/jolt_physics/joints/jolt_cone_twist_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_cone_twist_joint_3d.cpp
@@ -78,7 +78,6 @@ JPH::Constraint *JoltConeTwistJoint3D::_build_swing_twist(JPH::Body *p_jolt_body
 	constraint_settings.mPosition2 = to_jolt_r(p_shifted_ref_b.origin);
 	constraint_settings.mTwistAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_X));
 	constraint_settings.mPlaneAxis2 = to_jolt(p_shifted_ref_b.basis.get_column(Vector3::AXIS_Z));
-	constraint_settings.mSwingType = JPH::ESwingType::Pyramid;
 
 	if (p_jolt_body_a == nullptr) {
 		return constraint_settings.Create(JPH::Body::sFixedToWorld, *p_jolt_body_b);


### PR DESCRIPTION
For some reason (lost in time) we chose to make the limits pyramid shaped. GodotPhysics3D uses cone shaped limits instead. This change matches that behavior.

Closes #119926