### PR TITLE
Merge the two `Object` mutexes to save on RAM (1/4 down) and allocation time (~20% down).

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -72,10 +72,10 @@ struct ObjectSignalLock {
 	Mutex *mutex2 = nullptr;
 
 	ObjectSignalLock(const Object *p_obj1, const Object *p_obj2 = nullptr) {
-		mutex1 = p_obj1->signal_mutex;
+		mutex1 = &p_obj1->_control_mutex;
 
 		if (p_obj2 != nullptr) {
-			mutex2 = p_obj2->signal_mutex;
+			mutex2 = &p_obj2->_control_mutex;
 
 			if (mutex2 < mutex1) {
 				// We must always lock two locks in the same order.
@@ -222,9 +222,6 @@ void Object::_initialize() {
 }
 
 void Object::_postinitialize() {
-	if (_uses_signal_mutex()) {
-		signal_mutex = memnew(Mutex);
-	}
 	notification(NOTIFICATION_POSTINITIALIZE);
 }
 
@@ -872,6 +869,21 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 	}
 
 	return ret;
+}
+
+bool Object::_instance_binding_reference(bool p_reference) {
+	bool can_die = true;
+	if (_instance_bindings) {
+		MutexLock instance_binding_lock(_control_mutex);
+		for (uint32_t i = 0; i < _instance_binding_count; i++) {
+			if (_instance_bindings[i].reference_callback) {
+				if (!_instance_bindings[i].reference_callback(_instance_bindings[i].token, _instance_bindings[i].binding, p_reference)) {
+					can_die = false;
+				}
+			}
+		}
+	}
+	return can_die;
 }
 
 void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const {
@@ -1662,10 +1674,6 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 	return true;
 }
 
-bool Object::_uses_signal_mutex() const {
-	return true;
-}
-
 String Object::_get_locale() const {
 	TranslationServer *ts = TranslationServer::get_singleton();
 	const StringName domain_name = get_translation_domain();
@@ -2162,7 +2170,7 @@ void Object::set_instance_binding(void *p_token, void *p_binding, const GDExtens
 
 void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
 	void *binding = nullptr;
-	MutexLock instance_binding_lock(_instance_binding_mutex);
+	MutexLock instance_binding_lock(_control_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (_instance_bindings[i].token == p_token) {
 			binding = _instance_bindings[i].binding;
@@ -2198,7 +2206,7 @@ void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindi
 
 bool Object::has_instance_binding(void *p_token) {
 	bool found = false;
-	MutexLock instance_binding_lock(_instance_binding_mutex);
+	MutexLock instance_binding_lock(_control_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (_instance_bindings[i].token == p_token) {
 			found = true;
@@ -2211,7 +2219,7 @@ bool Object::has_instance_binding(void *p_token) {
 
 void Object::free_instance_binding(void *p_token) {
 	bool found = false;
-	MutexLock instance_binding_lock(_instance_binding_mutex);
+	MutexLock instance_binding_lock(_control_mutex);
 	for (uint32_t i = 0; i < _instance_binding_count; i++) {
 		if (!found && _instance_bindings[i].token == p_token) {
 			if (_instance_bindings[i].free_callback) {
@@ -2246,7 +2254,7 @@ void Object::clear_internal_extension() {
 	_gdtype_ptr = &_get_typev();
 
 	// Clear the instance bindings.
-	_instance_binding_mutex.lock();
+	_control_mutex.lock();
 	if (_instance_bindings) {
 		if (_instance_bindings[0].free_callback) {
 			_instance_bindings[0].free_callback(_instance_bindings[0].token, this, _instance_bindings[0].binding);
@@ -2256,7 +2264,7 @@ void Object::clear_internal_extension() {
 		_instance_bindings[0].free_callback = nullptr;
 		_instance_bindings[0].reference_callback = nullptr;
 	}
-	_instance_binding_mutex.unlock();
+	_control_mutex.unlock();
 
 	// Clear the virtual methods.
 	while (virtual_method_list) {
@@ -2361,8 +2369,6 @@ Object::~Object() {
 		}
 		memfree(_instance_bindings);
 	}
-
-	memdelete(signal_mutex);
 }
 
 bool predelete_handler(Object *p_object) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -411,6 +411,9 @@ private:
 	friend bool predelete_handler(Object *);
 	friend void postinitialize_handler(Object *);
 
+	// Used for thread-safe behavior, such as instance bindings and signals.
+	mutable Mutex _control_mutex;
+
 	ObjectGDExtension *_extension = nullptr;
 	GDExtensionClassInstancePtr _extension_instance = nullptr;
 
@@ -425,7 +428,6 @@ private:
 		HashMap<Callable, Slot> slot_map;
 		bool removable = false;
 	};
-	mutable Mutex *signal_mutex = nullptr;
 	HashMap<StringName, SignalData> signal_map;
 	List<Connection> connections;
 #ifdef DEBUG_ENABLED
@@ -493,7 +495,6 @@ private:
 
 	friend class RefCounted;
 
-	BinaryMutex _instance_binding_mutex;
 	struct InstanceBinding {
 		void *binding = nullptr;
 		void *token = nullptr;
@@ -508,20 +509,7 @@ private:
 protected:
 	StringName _translation_domain;
 
-	_FORCE_INLINE_ bool _instance_binding_reference(bool p_reference) {
-		bool can_die = true;
-		if (_instance_bindings) {
-			MutexLock instance_binding_lock(_instance_binding_mutex);
-			for (uint32_t i = 0; i < _instance_binding_count; i++) {
-				if (_instance_bindings[i].reference_callback) {
-					if (!_instance_bindings[i].reference_callback(_instance_bindings[i].token, _instance_bindings[i].binding, p_reference)) {
-						can_die = false;
-					}
-				}
-			}
-		}
-		return can_die;
-	}
+	bool _instance_binding_reference(bool p_reference);
 
 	// Used in gdvirtual.gen.h
 	void _gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const;
@@ -604,8 +592,6 @@ protected:
 	void _define_ancestry(AncestralClass p_class) { _ancestry |= (uint32_t)p_class; }
 	// Prefer using derives_from.
 	bool _has_ancestry(AncestralClass p_class) const { return _ancestry & (uint32_t)p_class; }
-
-	virtual bool _uses_signal_mutex() const;
 
 	// Internal helper to get the current locale, taking into account the translation domain.
 	String _get_locale() const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -423,8 +423,6 @@ protected:
 	}
 
 protected:
-	virtual bool _uses_signal_mutex() const override { return false; } // Node uses thread guards instead.
-
 	virtual void input(const Ref<InputEvent> &p_event);
 	virtual void shortcut_input(const Ref<InputEvent> &p_key_event);
 	virtual void unhandled_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Reduces non-`Node` `Object` size by ~88 bytes, which is around 1/4 of their total size (assuming empty).

## Additional information

There's no real need to have two separate mutexes. Access to both is rare, and mutexes are huge.

Performance should be the same as before, or better. `Object` instantiation should be measurably faster (no additional allocation).

**Note:** Mostly untested right now (except for a quick compile and unit test/editor run).
The main risk I see is if I misinterpreted the `signal` code and this change introduces some deadlock potential.

- Somewhat related to https://github.com/godotengine/godot/pull/117511.