### PR TITLE
[RTL] Fix last line height with some fallback fonts.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -715,8 +715,10 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	String txt;
 	String txt_sub;
 	Item *it_to = (p_line + 1 < (int)p_frame->lines.size()) ? p_frame->lines[p_line + 1].from : nullptr;
+	Item *it_prev = l.from ? l.from : current;
 	int remaining_characters = visible_characters - l.char_offset;
 	for (Item *it = l.from; it && it != it_to; it = _get_next_item(it)) {
+		it_prev = it;
 		switch (it->type) {
 			case ITEM_DROPCAP: {
 				// Add dropcap.
@@ -748,6 +750,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				txt += "\n";
 				l.char_count++;
 				remaining_characters--;
+				it_prev = nullptr;
 			} break;
 			case ITEM_TEXT: {
 				ItemText *t = static_cast<ItemText *>(it);
@@ -873,6 +876,28 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 			default:
 				break;
 		}
+	}
+
+	// Add zero-width space to the end if line did not end with /n to ensure uniform height.
+	if (it_prev) {
+		Ref<Font> font = p_base_font;
+		int font_size = p_base_font_size;
+
+		ItemFont *font_it = _find_font(it_prev);
+		if (font_it) {
+			if (font_it->font.is_valid()) {
+				font = font_it->font;
+			}
+			if (font_it->font_size > 0) {
+				font_size = font_it->font_size;
+			}
+		}
+		ItemFontSize *font_size_it = _find_font_size(it_prev);
+		if (font_size_it && font_size_it->font_size > 0) {
+			font_size = font_size_it->font_size;
+		}
+		l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it_prev->rid);
+		txt += "\n";
 	}
 
 	// Apply BiDi override.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes https://github.com/godotengine/godot/issues/119986

## Additional information

To ensure paragraphs with non-visual characters only have correct height (see https://github.com/godotengine/godot/pull/108959), a zero width space is added to the end of each paragraph when shaping, in case of RTL it was only done paragraphs with `ITEM_NEWLINE`. This PR adds it to the last line which does not include `ITEM_NEWLINE` as well.

> Not reproducible 4.6.stable

It is reproducible in 4.6.3, 4.6 and 4.5 (have not tested other versions, but likely a regression in 4.4), the screenshot in the issue seems to use different fallback font for some reason.