### PR TITLE
Prevent crash when detaching freed debugger

### DIFF
--- a/editor/debugger/editor_debugger_plugin.cpp
+++ b/editor/debugger/editor_debugger_plugin.cpp
@@ -109,7 +109,7 @@ void EditorDebuggerSession::set_breakpoint(const String &p_path, int p_line, boo
 }
 
 void EditorDebuggerSession::detach_debugger() {
-	if (!debugger) {
+	if (!debugger || !ObjectDB::get_instance(debugger_id)) {
 		return;
 	}
 	debugger->disconnect("started", callable_mp(this, &EditorDebuggerSession::_started));
@@ -125,6 +125,7 @@ void EditorDebuggerSession::detach_debugger() {
 EditorDebuggerSession::EditorDebuggerSession(ScriptEditorDebugger *p_debugger) {
 	ERR_FAIL_NULL(p_debugger);
 	debugger = p_debugger;
+	debugger_id = p_debugger->get_instance_id();
 	debugger->connect("started", callable_mp(this, &EditorDebuggerSession::_started));
 	debugger->connect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
 	debugger->connect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));

--- a/editor/debugger/editor_debugger_plugin.h
+++ b/editor/debugger/editor_debugger_plugin.h
@@ -43,6 +43,7 @@ private:
 	HashSet<Control *> tabs;
 
 	ScriptEditorDebugger *debugger = nullptr;
+	ObjectID debugger_id;
 
 	void _breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump);
 	void _started();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #118518

## Additional information

My assessment was not entirely accurate. The actual cause of the crash is that EditorDebuggerNode was doing the cleanup after debuggers were already freed, so the invalid pointer was in EditorDebuggerSession holding reference to the freed debugger. This unfortunate order is determined by scene tree, so I just opted to add an ObjectID for the debugger as an extra safeguard.

The issue still can be prevented by properly deregistering the plugins.