### PR TITLE
Clean Up `x` position calcuation of the `AudioStream` filename in the Inspector

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1764,7 +1764,7 @@ void EditorAudioStreamPicker::_preview_draw() {
 
 	float text_width = size.width - 4 * EDSCALE - icon->get_width();
 	if (text_width > 0) {
-		stream_preview_rect->draw_string(font, Point2i(EDSCALE * 4 + icon->get_width(), rect.position.y + font->get_ascent(font_size) + (rect.size.height - font->get_height(font_size)) / 2), text, HORIZONTAL_ALIGNMENT_CENTER, text_width, font_size, get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
+		stream_preview_rect->draw_string(font, Point2i(size.width - text_width, rect.position.y + font->get_ascent(font_size) + (rect.size.height - font->get_height(font_size)) / 2), text, HORIZONTAL_ALIGNMENT_CENTER, text_width, font_size, get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
 	}
 }
 


### PR DESCRIPTION
## What problem does this solve

Forgot to include this in https://github.com/godotengine/godot/pull/119497 😐

It cleans up the first parameter of `Point2i` in `EditorAudioStreamPicker::_preview_draw()` using the local variable created in the PR above. Someone could call it a micro-optimization, but I think that the compiler did this already, and the effect would be one multiplication operation and function call less, which is basically zero.

## Additional info

Replaces
`EDSCALE * 4 + icon->get_width()`
with
`size.width - text_width`