### PR TITLE
OpenGL: Fix vertex shader compilation error with `EYE_OFFSET`

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -681,6 +681,7 @@ void vertex_shader(vec4 vertex_angle_attrib_input,
 #ifndef USE_MULTIVIEW
 	mat4 projection_matrix = scene_data_input.projection_matrix;
 	mat4 inv_projection_matrix = scene_data_input.inv_projection_matrix;
+	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 #endif //!USE_MULTIVIEW
 
 #ifdef USE_INSTANCING


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, if you use `EYE_OFFSET` in the `vertex()` function of a .gdshader on OpenGL, you'll get this error:

```
06-03 11:14:29.278  8841  8877 E godot   : ERROR: SceneShaderGLES3: Vertex shader compilation failed:
06-03 11:14:29.278  8841  8877 E godot   : ERROR: 0:804: 'eye_offset' : undeclared identifier
06-03 11:14:29.278  8841  8877 E godot   : ERROR: 0:804: 'xy' :  field selection requires structure, vector, or matrix on left hand side
06-03 11:14:29.278  8841  8877 E godot   : ERROR: 2 compilation errors.  No code generated.
```

In XR, the shader will still work - this error is from compiling the non-multiview variant where `eye_offset` isn't defined, but it will be there in the multiview variant

The issue is that we should always make sure that `eye_offset` is defined, which is already handled for the fragment shader on OpenGL, and for both the vertex and fragment shaders in the Mobile and Forward+ renderers.

It was just omitted for the vertex shader in OpenGL, which is what this PR fixes :-)