### PR TITLE
Wrap project titles

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -174,6 +174,12 @@ void ProjectListItemControl::_notification(int p_what) {
 
 			draw_line(Point2(0, get_size().y + 1), Point2(get_size().x, get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("ProjectList")));
 		} break;
+
+		case NOTIFICATION_READY: {
+			const Callable callback = callable_mp(this, &ProjectListItemControl::update_title_size);
+			get_window()->connect(SNAME("size_changed"), callback);
+			callback.call_deferred();
+		} break;
 	}
 }
 
@@ -421,6 +427,10 @@ void ProjectListItemControl::set_is_grayed(bool p_grayed) {
 	}
 }
 
+void ProjectListItemControl::update_title_size() {
+	project_title->set_custom_minimum_size(Vector2(get_size().x * 0.5, 0));
+}
+
 void ProjectListItemControl::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("favorite_pressed"));
 	ADD_SIGNAL(MethodInfo("explore_pressed"));
@@ -472,6 +482,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		project_title->set_focus_mode(FOCUS_ACCESSIBILITY);
 		project_title->set_name("ProjectName");
 		project_title->set_h_size_flags(Control::SIZE_FILL);
+		project_title->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 		title_hb->add_child(project_title);
 
 		tag_container = memnew(HFlowContainer);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -111,6 +111,8 @@ public:
 	void set_is_missing(bool p_missing);
 	void set_is_grayed(bool p_grayed);
 
+	void update_title_size();
+
 	ProjectListItemControl();
 };
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119468

## Additional information

This PR just enables autowrap on titles + sets minimum width of titles to half of the available space. The project items might get rather high as the result, but it only happens with very long titles (which are unusual).

<img width="1154" height="839" alt="image" src="https://github.com/user-attachments/assets/2ea34cdb-5162-4f82-9d3f-1bb61ace6366" />

Since this solution is rather simple, it does not necessarily supersede #119580