### PR TITLE
Prevent stale updates to parent maximum size cache

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1738,10 +1738,14 @@ void Control::update_maximum_size() {
 	data.maximum_size_valid = false;
 
 	Size2 parent_max = data.propagate_maximum_size ? get_inner_combined_maximum_size().min(get_combined_maximum_size()) : Size2(-1, -1);
+	parent_max = parent_max.maxf(-1.0f);
 
 	for (Node *child : iterate_children()) {
 		Control *child_control = Object::cast_to<Control>(child);
 		if (child_control && !child_control->is_set_as_top_level() && child_control->data.maximum_size_valid) {
+			if (child_control->data.parent_maximum_size_cache == parent_max) {
+				continue;
+			}
 			child_control->data.parent_maximum_size_cache = parent_max;
 			child_control->update_maximum_size();
 		}
@@ -1862,10 +1866,11 @@ Size2 Control::get_inner_combined_maximum_size() const {
 }
 
 void Control::set_parent_maximum_size_cache(const Size2 &p_parent_max) {
-	if (data.parent_maximum_size_cache == p_parent_max) {
+	const Size2 normalized = p_parent_max.maxf(-1.0f);
+	if (data.parent_maximum_size_cache == normalized) {
 		return;
 	}
-	data.parent_maximum_size_cache = p_parent_max;
+	data.parent_maximum_size_cache = normalized;
 	update_maximum_size();
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119889 

## Additional information

Whilst trying to debug the above issue, I put in update checks to avoid spamming my console with useless messages (I had some print statements in the loop to tell me what changed), as I suspected it to be an update order issue. Adding the early return statement in the loop somehow fixed the issue.

The fix in `Control::set_parent_maximum_size_cache` is technically unrelated to the bug, but I found the oversight while debugging and fixed it (also as part of trying not to be spammed). Removes unnecessary updates so I left it in. 

Checked for regression against previous update order issues. 