### PR TITLE
Add session number and count as command line arguments when running multiple instances

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -163,6 +163,13 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	for (int i = 0; i < instance_count; i++) {
 		List<String> instance_args(args);
 		RunInstancesDialog::get_singleton()->get_argument_list_for_instance(i, instance_args);
+
+		instance_args.push_back("--session-number");
+		instance_args.push_back(itos(i + 1));
+
+		instance_args.push_back("--session-count");
+		instance_args.push_back(itos(instance_count));
+
 		RunInstancesDialog::get_singleton()->apply_custom_features(i);
 		if (instance_starting_callback) {
 			instance_starting_callback(i, instance_args);

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -378,6 +378,11 @@ RunInstancesDialog::RunInstancesDialog() {
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	main_vb->add_child(mc);
 
+	Label *session_info_label = memnew(Label);
+	session_info_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	session_info_label->set_text(TTR("The `--session-number` <id> and `--session-count` <id> arguments are automatically passed, and can be read from scripts to customize the behavior of each instance."));
+	main_vb->add_child(session_info_label);
+
 	instance_tree = memnew(Tree);
 	instance_tree->set_h_scroll_enabled(false);
 	instance_tree->set_theme_type_variation("TreeTable");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1497,6 +1497,25 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
+		} else if (arg == "--session-number") {
+			if (N) {
+				main_args.push_back(arg);
+				main_args.push_back(N->get());
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing session number argument, aborting.\n");
+				goto error;
+			}
+		} else if (arg == "--session-count") {
+			if (N) {
+				main_args.push_back(arg);
+				main_args.push_back(N->get());
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing session count argument, aborting.\n");
+				goto error;
+			}
+
 		} else if (arg == "--headless") { // enable headless mode (no audio, no rendering).
 
 			audio_driver = NULL_AUDIO_DRIVER;


### PR DESCRIPTION
Closes [3577](https://github.com/godotengine/godot-proposals/issues/3357) and [14916](https://github.com/godotengine/godot-proposals/issues/14916) (sort of).

Currently I am just adding them as command line arguments as @Calinou suggested in my proposal, but might be better to add them as actual functions. If you have other suggestions and where to put them lmk.

This is nice to have by default so users don't have to hardcode the session number and count into args themselves, especially if you want to switch between 2-3-4 instances. We will also need this per-requisite if we end up doing automatic window resizing and positioning based on instance numbers/count, as suggested in [14916](https://github.com/godotengine/godot-proposals/issues/14916).