### PR TITLE
Fix download scripts and build in the MSYS2 environment.

### DIFF
--- a/misc/scripts/install_accesskit.py
+++ b/misc/scripts/install_accesskit.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
 deps_folder = os.getenv("LOCALAPPDATA")
-if deps_folder:
+if deps_folder and not os.getenv("MSYSTEM"):
     deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
 else:
     deps_folder = os.path.join("bin", "build_deps")

--- a/misc/scripts/install_angle.py
+++ b/misc/scripts/install_angle.py
@@ -13,7 +13,7 @@ from misc.utility.color import Ansi, color_print
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
 deps_folder = os.getenv("LOCALAPPDATA")
-if deps_folder:
+if deps_folder and not os.getenv("MSYSTEM"):
     deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
 else:
     deps_folder = os.path.join("bin", "build_deps")

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -25,7 +25,7 @@ args = parser.parse_args()
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
 deps_folder = os.getenv("LOCALAPPDATA")
-if deps_folder:
+if deps_folder and not os.getenv("MSYSTEM"):
     deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
 else:
     deps_folder = os.path.join("bin", "build_deps")

--- a/misc/scripts/install_winrt.py
+++ b/misc/scripts/install_winrt.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../
 # Base Godot dependencies path
 # If cross-compiling (no LOCALAPPDATA), we install in `bin`
 deps_folder = os.getenv("LOCALAPPDATA")
-if deps_folder:
+if deps_folder and not os.getenv("MSYSTEM"):
     deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
 else:
     deps_folder = os.path.join("bin", "build_deps")

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -205,7 +205,7 @@ def get_opts():
 
     # Dependencies folder.
     deps_folder = os.getenv("LOCALAPPDATA")
-    if deps_folder:
+    if deps_folder and not os.getenv("MSYSTEM"):
         deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
     else:
         # Cross-compiling, the deps install script puts things in `bin`.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes build errors in MSYS2 environment.

## Additional information

MSYS2 environment has `LOCALAPPDATA` set, but mix of POSIX and Windows paths can result in a wrong location used to download and search for dependencies. This PR forces both to use `bin` folder (like it is done on other platforms) if MSYS2 is detected.