### PR TITLE
Fix incorrect TTRN usage in the editor

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -755,6 +755,9 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 #define TTRGET(m_value) (m_value)
 #endif
 
+// Use for simple plural messages, i.e. with no counter in the message.
+#define TPL(m_count, m_singular, m_plural) ((m_count == 1) ? (m_singular) : (m_plural))
+
 // Use this to mark property names for editor translation.
 // Often for dynamic properties defined in _get_property_list().
 // Property names defined directly inside EDITOR_DEF, GLOBAL_DEF, and ADD_PROPERTY macros don't need this.

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -362,7 +362,7 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action_for_history(TTRN("Instantiate Scene", "Instantiate Scenes", instances.size()), editor_data->get_current_edited_scene_history_id());
+	undo_redo->create_action_for_history(TPL(instances.size(), TTR("Instantiate Scene"), TTR("Instantiate Scenes")), editor_data->get_current_edited_scene_history_id());
 	undo_redo->add_do_method(editor_selection, "clear");
 
 	for (int i = 0; i < instances.size(); i++) {
@@ -435,7 +435,7 @@ void SceneTreeDock::_perform_create_audio_stream_players(const Vector<String> &p
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action_for_history(TTRN("Create AudioStreamPlayer", "Create AudioStreamPlayers", nodes.size()), editor_data->get_current_edited_scene_history_id());
+	undo_redo->create_action_for_history(TPL(nodes.size(), TTR("Create AudioStreamPlayer"), TTR("Create AudioStreamPlayers")), editor_data->get_current_edited_scene_history_id());
 	undo_redo->add_do_method(editor_selection, "clear");
 
 	for (int i = 0; i < nodes.size(); i++) {

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -460,7 +460,7 @@ void DependencyEditorOwners::_list_rmb_clicked(int p_item, const Vector2 &p_pos,
 		}
 
 		if (only_scenes_selected) {
-			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTRN("Open Scene", "Open Scenes", selected_items.size()), FILE_MENU_OPEN);
+			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TPL(TTRC("Open Scene"), TTRC("Open Scenes"), selected_items.size()), FILE_MENU_OPEN);
 		} else if (selected_items.size() == 1) {
 			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open"), FILE_MENU_OPEN);
 		} else {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6064,7 +6064,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 		}
 	}
 
-	String title = TTRN("Can't drop the file...", "Can't drop the files...", files.size());
+	String title = TPL(files.size(), TTR("Can't drop the file..."), TTR("Can't drop the files..."));
 	if (is_cyclical_dep) {
 		_show_tooltip(title, vformat(TTR("Circular dependency found at %s."), error_file));
 		return false;
@@ -6081,17 +6081,9 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 	preview_node->hide();
 
 	String desc = "[ul]" +
-			TTRN("[b]Default:[/b] Add as sibling of selected node (except when root is selected).",
-					"[b]Default:[/b] Add as siblings of selected node (except when root is selected).",
-					files.size()) +
-			"\n" +
-			TTRN("[b]Hold Shift:[/b] Add as child of selected node.",
-					"[b]Hold Shift:[/b] Add as children of selected node.",
-					files.size()) +
-			"\n" +
-			TTRN("[b]Hold Alt:[/b] Add as child of root node.",
-					"[b]Hold Alt:[/b] Add as children of root node.",
-					files.size());
+			TPL(files.size(), TTR("[b]Default:[/b] Add as sibling of selected node (except when root is selected)."), TTR("[b]Default:[/b] Add as siblings of selected node (except when root is selected).")) + "\n" +
+			TPL(files.size(), TTR("[b]Hold Shift:[/b] Add as child of selected node."), TTR("[b]Hold Shift:[/b] Add as children of selected node.")) + "\n" +
+			TPL(files.size(), TTR("[b]Hold Alt:[/b] Add as child of root node."), TTR("[b]Hold Alt:[/b] Add as children of root node."));
 
 	if (files.size() > 1) {
 		title = TTR("Dropping multiple files...");

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -6592,7 +6592,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 		}
 	}
 
-	String title = TTRN("Can't drop the file...", "Can't drop the files...", files.size());
+	String title = TPL(files.size(), TTR("Can't drop the file..."), TTR("Can't drop the files..."));
 	if (!error_message.is_empty()) {
 		_show_tooltip(title, error_message);
 		canvas_item_editor->update_viewport();
@@ -6626,17 +6626,9 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 	canvas_item_editor->update_viewport();
 
 	String desc = "[ul]" +
-			TTRN("[b]Default:[/b] Add as sibling of selected node (except when root is selected).",
-					"[b]Default:[/b] Add as siblings of selected node (except when root is selected).",
-					files.size()) +
-			"\n" +
-			TTRN("[b]Hold Shift:[/b] Add as child of selected node.",
-					"[b]Hold Shift:[/b] Add as children of selected node.",
-					files.size()) +
-			"\n" +
-			TTRN("[b]Hold Alt:[/b] Add as child of root node.",
-					"[b]Hold Alt:[/b] Add as children of root node.",
-					files.size());
+			TPL(files.size(), TTR("[b]Default:[/b] Add as sibling of selected node (except when root is selected)."), TTR("[b]Default:[/b] Add as siblings of selected node (except when root is selected).")) + "\n" +
+			TPL(files.size(), TTR("[b]Hold Shift:[/b] Add as child of selected node."), TTR("[b]Hold Shift:[/b] Add as children of selected node.")) + "\n" +
+			TPL(files.size(), TTR("[b]Hold Alt:[/b] Add as child of root node."), TTR("[b]Hold Alt:[/b] Add as children of root node."));
 
 	if (files.size() > 1) {
 		title = TTR("Dropping multiple files...");

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -540,7 +540,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			}
 		}
 		if (num_groups >= 1) {
-			msg_temp += TTRN("Node is in this group:", "Node is in the following groups:", num_groups) + "\n";
+			msg_temp += TPL(num_groups, TTR("Node is in this group:"), TTR("Node is in the following groups:")) + "\n";
 
 			List<GroupInfo> groups;
 			p_node->get_groups(&groups);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1964,15 +1964,15 @@ void ScriptTextEditor::_set_drop_info_text(const Dictionary &p_info) const {
 
 	if (type == "files" || type == "files_and_dirs" || type == "resource") {
 		Array files = p_info.get("files", Array());
-		text = TTRN("Drop file path.", "Drop file paths.", files.size()) +
-				"\n" + vformat(TTRN("Hold %s: Add const preload by %s.", "Hold %s: Add const preloads by %s.", files.size()), c, default_drop_option) +
-				"\n" + vformat(TTRN("Hold %s+Shift: Add const preload by %s.", "Hold %s+Shift: Add const preloads by %s.", files.size()), c, alternate_drop_option) +
-				"\n" + TTRN("Hold Alt: Add @export var pointing to the resource.", "Hold Alt: Add @export vars pointing to the resources.", files.size());
+		text = TPL(files.size(), TTR("Drop file path."), TTR("Drop file paths.")) +
+				"\n" + vformat(TPL(files.size(), TTR("Hold %s: Add const preload by %s."), TTR("Hold %s: Add const preloads by %s.")), c, default_drop_option) +
+				"\n" + vformat(TPL(files.size(), TTR("Hold %s+Shift: Add const preload by %s."), TTR("Hold %s+Shift: Add const preloads by %s.")), c, alternate_drop_option) +
+				"\n" + TPL(files.size(), TTR("Hold Alt: Add @export var pointing to the resource."), TTR("Hold Alt: Add @export vars pointing to the resources."));
 	} else if (type == "nodes") {
 		Array nodes = p_info["nodes"];
-		text = TTRN("Drop node path.", "Drop node paths.", nodes.size()) +
-				"\n" + vformat(TTRN("Hold %s: Add @onready var pointing to the node path.", "Hold %s: Add @onready vars pointing to the node paths.", nodes.size()), c) +
-				"\n" + TTRN("Hold Alt: Add @export var pointing to the node.", "Hold Alt: Add @export vars pointing to the nodes.", nodes.size());
+		text = TPL(nodes.size(), TTR("Drop node path."), TTR("Drop node paths.")) +
+				"\n" + vformat(TPL(nodes.size(), TTR("Hold %s: Add @onready var pointing to the node path."), TTR("Hold %s: Add @onready vars pointing to the node paths.")), c) +
+				"\n" + TPL(nodes.size(), TTR("Hold Alt: Add @export var pointing to the node."), TTR("Hold Alt: Add @export vars pointing to the nodes."));
 	} else if (type == "obj_property") {
 		text = TTR("Drop property path.");
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

TTRN should be used only for dynamic strings that include counter, as they are affected by plural rules. For simple plural/singular messages these rules don't apply, so using TTRN is wrong.