### PR TITLE
🤖 Clarify TileSetAtlasSource runtime texture docs

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -52,7 +52,8 @@
 		<method name="get_runtime_texture" qualifiers="const">
 			<return type="Texture2D" />
 			<description>
-				If [member use_texture_padding] is [code]false[/code], returns [member texture]. Otherwise, returns an internal [ImageTexture] created that includes the padding.
+				If [member use_texture_padding] is [code]false[/code], returns [member texture]. Otherwise, returns an internal [CanvasTexture] created with one pixel of padding around each tile.
+				The padded texture is generated asynchronously after the [TileSetAtlasSource] resource is modified. Until the update runs, this method may return [code]null[/code] or the previous padded texture.
 			</description>
 		</method>
 		<method name="get_runtime_tile_texture_region" qualifiers="const">


### PR DESCRIPTION
Fixes #119896

> [!INFO] *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of YUHAO-corn, to update the class reference for `TileSetAtlasSource.get_runtime_texture()` based on the behavior discussed in the linked issue.

This updates the class reference for `TileSetAtlasSource.get_runtime_texture()`:

- changes the padded runtime texture type from `ImageTexture` to `CanvasTexture`;
- notes that the padded texture update is asynchronous, so the method may return `null` or the previous padded texture before the update runs.

Validation:

```text
xmllint --noout --schema doc/class.xsd doc/classes/TileSetAtlasSource.xml
```