### PR TITLE
Try recovering the `project.godot` file from memory if it's missing when running the project

### DIFF
--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -269,11 +269,12 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 	if (!resource_path.is_empty()) {
 		String project_file_path = resource_path.path_join("project.godot");
 		if (!FileAccess::exists(project_file_path)) {
-			// TODO: Try to recover the "project.godot" file using ProjectSettings::get_singleton()->save()
-			EditorNode::get_singleton()->show_warning(
-					TTRC("Failed to run the project because the project.godot file is missing."),
-					TTRC("Error!"));
-			return;
+			if (ProjectSettings::get_singleton()->save() != OK) {
+				EditorNode::get_singleton()->show_warning(
+						TTRC("Failed to run the project because the project.godot file is missing."),
+						TTRC("Error!"));
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow up for https://github.com/godotengine/godot/pull/119508.
- TODO in `editor/run/editor_run_bar.cpp`:
https://github.com/godotengine/godot/blob/f964fa714f503bd063b96f6194eb3e45355c1084/editor/run/editor_run_bar.cpp#L271-L276

Before showing the error that the project failed to run, it calls `ProjectSettings::get_singleton()->save()` which recreates the `project.godot` file and allows to continue the execution of the scene. If that failed, it shows the error and returns.