### PR TITLE
Allow dropping raw files as UID

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1965,6 +1965,7 @@ void ScriptTextEditor::_set_drop_info_text(const Dictionary &p_info) const {
 	if (type == "files" || type == "files_and_dirs" || type == "resource") {
 		Array files = p_info.get("files", Array());
 		text = TTRN("Drop file path.", "Drop file paths.", files.size()) +
+				"\n" + TTR("Hold Shift: Drop file UID(s).") +
 				"\n" + vformat(TTRN("Hold %s: Add const preload by %s.", "Hold %s: Add const preloads by %s.", files.size()), c, default_drop_option) +
 				"\n" + vformat(TTRN("Hold %s+Shift: Add const preload by %s.", "Hold %s+Shift: Add const preloads by %s.", files.size()), c, alternate_drop_option) +
 				"\n" + TTRN("Hold Alt: Add @export var pointing to the resource.", "Hold Alt: Add @export vars pointing to the resources.", files.size());
@@ -2154,7 +2155,14 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 					parts.append(_get_dropped_resource_as_exported_member(resource, obj_ids));
 				}
 			} else {
-				parts.append(_quote_drop_data(path));
+				String drop_path = path;
+				if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
+					ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(path);
+					if (id != ResourceUID::INVALID_ID) {
+						drop_path = ResourceUID::get_singleton()->id_to_text(id);
+					}
+				}
+				parts.append(_quote_drop_data(drop_path));
 			}
 		}
 		String join_string;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Right now you can drop Resources as a preloaded path or UID, or drop as path, but there is no option to drop a resource as a UID (without preload). I need it from time to time, it's easy to add and would be convenient.

This PR adds it. You can hold Shift without anything else and it will auto-convert paths to UID where applicable.

## Additional information

https://github.com/user-attachments/assets/2f52a018-207c-4673-af57-2be4dac16bad

