### PR TITLE
Add Toki Pona to language script list

### DIFF
--- a/core/string/locales.h
+++ b/core/string/locales.h
@@ -1538,6 +1538,7 @@ static const char *language_script_list[][2] = {
 	{ "tn", "Latn" },
 	{ "to", "Latn" },
 	{ "tog", "Latn" },
+	{ "tok", "Latn" },
 	{ "tpi", "Latn" },
 	{ "tr", "Latn Arab" },
 	{ "tru", "Latn Syrc" },


### PR DESCRIPTION
As per #102787 "**Add Toki Pona (tok) to language/locale list.**", this one-liner adds toki pona to language_script_list with the `"Latn"` code, as per [unicode.org/.../languages_and_scripts](https://www.unicode.org/cldr/charts/48/supplemental/languages_and_scripts.html#tok)

Beforehand, this language did not show up in the `application/config/name_localized`'s "Select a Locale" window, for example. After this change was tested, toki pona is now available to choose!

(Shoutout to @EGAMatsu for initiating)