### PR TITLE
feat: Add Web export support for .NET (C#) version

### DIFF
--- a/modules/mono/SdkPackageVersions.props
+++ b/modules/mono/SdkPackageVersions.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Godot package versions for .NET SDK -->
+    <PackageVersion_GodotSharp>4.6.0</PackageVersion_GodotSharp>
+    <PackageVersion_GodotSharpEditor>4.6.0</PackageVersion_GodotSharpEditor>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -1,3 +1,8 @@
+import os
+import os.path
+import shutil
+
+
 def is_desktop(platform):
     return platform in ["windows", "macos", "linuxbsd"]
 
@@ -11,12 +16,137 @@ def module_supports_tools_on(platform):
 
 
 def configure(env, env_mono):
-    # is_android = env["platform"] == "android"
-    # is_web = env["platform"] == "web"
-    # is_ios = env["platform"] == "ios"
-    # is_ios_sim = is_ios and env["arch"] in ["x86_32", "x86_64"]
-
     if env.editor_build:
         if not module_supports_tools_on(env["platform"]):
             raise RuntimeError("This module does not currently support building for this platform for editor builds.")
         env_mono.Append(CPPDEFINES=["GD_MONO_HOT_RELOAD"])
+
+    if env["platform"] == "web":
+        rid = get_rid(env["platform"], env["arch"])
+
+        this_script_dir = os.path.dirname(os.path.realpath(__file__))
+        module_dir = os.path.abspath(os.path.join(this_script_dir, os.pardir))
+        get_runtime_pack_project_path = os.path.join(module_dir, "runtime", "GetRuntimePack")
+
+        mono_runtime_copy_path = os.path.join(get_runtime_pack_project_path, "bin", "mono_runtime")
+        try:
+            shutil.rmtree(mono_runtime_copy_path)
+        except FileNotFoundError:
+            # It's fine if this directory doesn't exist.
+            pass
+
+        import subprocess
+        exit_code = subprocess.call(
+            [
+                "dotnet", "build",
+                get_runtime_pack_project_path,
+                "-r", "browser-wasm",
+                "-c", "Release",
+            ]
+        )
+        if exit_code != 0:
+            raise RuntimeError("Couldn't retrieve Mono runtime pack for '" + rid + "'.")
+
+        with open(os.path.join(get_runtime_pack_project_path, "bin", rid, "runtime-pack-dir.txt")) as f:
+            mono_runtime_path = os.path.join(f.readline().strip(), "runtimes", rid, "native")
+            shutil.copytree(mono_runtime_path, mono_runtime_copy_path)
+            mono_runtime_path = mono_runtime_copy_path
+
+        # The default Mono runtime uses WASM exceptions.
+        env.Append(CCFLAGS=["-fwasm-exceptions"])
+        env.Append(LINKFLAGS=["-fwasm-exceptions"])
+
+        env_mono.Prepend(CPPPATH=os.path.join(mono_runtime_path, "include", "mono-2.0"))
+
+        env_mono.Append(LIBPATH=[mono_runtime_path])
+
+        # Mono libraries.
+        add_mono_library(env, "libmonosgen-2.0.a", mono_runtime_path)
+        add_mono_library(env, "libmono-wasm-eh-wasm.a", mono_runtime_path)
+        add_mono_library(env, "libmono-ee-interp.a", mono_runtime_path)
+        add_mono_library(env, "libSystem.Native.a", mono_runtime_path)
+        add_mono_library(env, "libSystem.Globalization.Native.a", mono_runtime_path)
+        add_mono_library(env, "libSystem.IO.Compression.Native.a", mono_runtime_path)
+        add_mono_library(env, "wasm-bundled-timezones.a", mono_runtime_path)
+        add_mono_library(env, "libmono-wasm-simd.a", mono_runtime_path)
+        add_mono_library(env, "libmono-icall-table.a", mono_runtime_path)
+        add_mono_library(env, "libicuuc.a", mono_runtime_path)
+        add_mono_library(env, "libicudata.a", mono_runtime_path)
+        add_mono_library(env, "libicui18n.a", mono_runtime_path)
+        add_mono_library(env, "libz.a", mono_runtime_path)
+
+        # Mono components.
+        add_mono_component(env, "debugger", mono_runtime_path)
+        add_mono_component(env, "diagnostics_tracing", mono_runtime_path)
+        add_mono_component(env, "hot_reload", mono_runtime_path)
+        add_mono_component(env, "marshal-ilgen", mono_runtime_path)
+
+        # WASM additional sources.
+        env_thirdparty = env_mono.Clone()
+        env_thirdparty.disable_warnings()
+        env_thirdparty.Append(CPPDEFINES=["GEN_PINVOKE"])
+        if env["dlink_enabled"]:
+            env_thirdparty.Append(CPPDEFINES=["WASM_SUPPORTS_DLOPEN"])
+        env_thirdparty.Prepend(CPPPATH=os.path.join(mono_runtime_path, "include", "wasm"))
+        get_runtime_pack_project_includes = os.path.join(get_runtime_pack_project_path, "obj", "Release", "net9.0", rid, "wasm", "for-publish")
+        env_thirdparty.Prepend(CPPPATH=os.path.join(get_runtime_pack_project_includes))
+        env_thirdparty.add_source_files(
+            env.modules_sources,
+            [
+                os.path.join(mono_runtime_path, "src", "runtime.c"),
+                os.path.join(mono_runtime_path, "src", "driver.c"),
+                os.path.join(mono_runtime_path, "src", "corebindings.c"),
+                os.path.join(mono_runtime_path, "src", "pinvoke.c"),
+            ],
+        )
+
+        env.AddJSLibraries([os.path.join(mono_runtime_path, "src", "es6", "dotnet.es6.lib.js")])
+
+
+"""
+Get the .NET runtime identifier for the given Godot platform and architecture names.
+"""
+def get_rid(platform: str, arch: str):
+    # Web runtime identifier is always browser-wasm.
+    if platform == "web":
+        return "browser-wasm"
+
+    # Platform renames.
+    if platform == "macos":
+        platform = "osx"
+    elif platform == "linuxbsd":
+        platform = "linux"
+
+    # Arch renames.
+    if arch == "x86_32":
+        arch = "x86"
+    elif arch == "x86_64":
+        arch = "x64"
+    elif arch == "arm32":
+        arch = "arm"
+
+    return platform + "-" + arch
+
+
+"""
+Link mono components statically (use the stubs to load them dynamically at runtime).
+See: https://github.com/dotnet/runtime/blob/main/docs/design/mono/components.md
+"""
+def add_mono_component(env, name: str, mono_runtime_path: str, is_stub: bool = False):
+    stub_suffix = "-stub" if is_stub else ""
+    component_filename = "libmono-component-" + name + stub_suffix + "-static.a"
+    add_mono_library(env, component_filename, mono_runtime_path)
+
+
+"""
+Link mono library archive (.a) statically.
+"""
+def add_mono_library(env, filename: str, mono_runtime_path: str):
+    assert(filename.endswith(".a"))
+    env.Append(
+        LINKFLAGS=[
+            "-Wl,-whole-archive",
+            os.path.join(mono_runtime_path, filename),
+            "-Wl,-no-whole-archive",
+        ]
+    )

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -88,7 +88,7 @@ def configure(env, env_mono):
         if env["dlink_enabled"]:
             env_thirdparty.Append(CPPDEFINES=["WASM_SUPPORTS_DLOPEN"])
         env_thirdparty.Prepend(CPPPATH=os.path.join(mono_runtime_path, "include", "wasm"))
-        get_runtime_pack_project_includes = os.path.join(get_runtime_pack_project_path, "obj", "Release", "net9.0", rid, "wasm", "for-publish")
+        get_runtime_pack_project_includes = os.path.join(get_runtime_pack_project_path, "obj", "Release", "net9.0", rid, "wasm", "for-build")
         env_thirdparty.Prepend(CPPPATH=os.path.join(get_runtime_pack_project_includes))
         env_thirdparty.add_source_files(
             env.modules_sources,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Browser.targets
@@ -1,0 +1,29 @@
+<Project>
+  <PropertyGroup>
+    <UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' and '$(PublishAot)' != 'true' ">true</UseMonoRuntime>
+
+    <!-- Default to relinking in ExportDebug and ExportRelease configurations. -->
+    <WasmBuildNative Condition=" '$(WasmBuildNative)' == '' and '$(Configuration)' == 'ExportDebug' ">true</WasmBuildNative>
+    <WasmBuildNative Condition=" '$(WasmBuildNative)' == '' and '$(Configuration)' == 'ExportRelease' ">true</WasmBuildNative>
+  </PropertyGroup>
+
+  <!-- Configuration for the Mono WASM runtime.
+       Must match the features enabled on GetRuntimePack.csproj.
+       WasmEnableThreads defaults to false; users building with thread support
+       should set WasmEnableThreads=true in their project. -->
+  <PropertyGroup>
+    <WasmEnableThreads Condition=" '$(WasmEnableThreads)' == '' ">false</WasmEnableThreads>
+    <WasmEnableExceptionHandling Condition=" '$(WasmEnableExceptionHandling)' == '' ">true</WasmEnableExceptionHandling>
+    <WasmEnableSIMD Condition=" '$(WasmEnableSIMD)' == '' ">true</WasmEnableSIMD>
+  </PropertyGroup>
+
+  <!-- Godot doesn't load globalization data so we must enable invariant mode. -->
+  <PropertyGroup>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -179,7 +179,7 @@ namespace GodotTools.Export
             if (!TryDeterminePlatformFromOSName(osName, out string? platform))
                 throw new NotSupportedException("Target platform not supported.");
 
-            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS }
+            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.Web }
                     .Contains(platform))
             {
                 throw new NotImplementedException("Target platform not yet implemented.");
@@ -192,9 +192,14 @@ namespace GodotTools.Export
                 IncludeDebugSymbols = (bool)GetOption("dotnet/include_debug_symbols"),
                 RidOS = DetermineRuntimeIdentifierOS(platform, useAndroidLinuxBionic),
                 Archs = [],
-                UseTempDir = platform != OS.Platforms.iOS, // xcode project links directly to files in the publish dir, so use one that sticks around.
+                UseTempDir = platform != OS.Platforms.iOS,
                 BundleOutputs = true,
             };
+
+            if (features.Contains("wasm32"))
+            {
+                publishConfig.Archs.Add("wasm32");
+            }
 
             if (features.Contains("x86_64"))
             {
@@ -242,7 +247,7 @@ namespace GodotTools.Export
 
             List<string> outputPaths = new();
 
-            bool embedBuildResults = ((bool)GetOption("dotnet/embed_build_outputs") || platform == OS.Platforms.Android) && platform != OS.Platforms.MacOS;
+            bool embedBuildResults = ((bool)GetOption("dotnet/embed_build_outputs") || platform == OS.Platforms.Android || platform == OS.Platforms.Web) && platform != OS.Platforms.MacOS;
 
             var exportedJars = new HashSet<string>();
 

--- a/modules/mono/runtime/GetRuntimePack/GetRuntimePack.csproj
+++ b/modules/mono/runtime/GetRuntimePack/GetRuntimePack.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <!--
+      This project only exists to resolve and fetch the WASM Mono runtime pack.
+      We don't want it to build as a regular app.
+    -->
+    <UseMonoRuntime>true</UseMonoRuntime>
+    <SelfContained>true</SelfContained>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Threading: default to false -->
+    <WasmEnableThreads Condition=" '$(WasmEnableThreads)' == '' ">false</WasmEnableThreads>
+    <WasmEnableExceptionHandling>true</WasmEnableExceptionHandling>
+    <WasmEnableSIMD>true</WasmEnableSIMD>
+    <!-- Don't try to publish for the host platform, we only need the target -->
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+  <!-- Directly locate the Mono WASM runtime pack in the dotnet packs directory -->
+  <Target Name="WriteRuntimePackDir" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <MonoRuntimePackDir Condition="Exists('$(DotNetRoot)packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\$(NETCoreSdkVersion)')">$(DotNetRoot)packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\$(NETCoreSdkVersion)</MonoRuntimePackDir>
+      <MonoRuntimePackDir Condition=" '$(MonoRuntimePackDir)' == '' And Exists('C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\9.0.16') ">C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\9.0.16</MonoRuntimePackDir>
+    </PropertyGroup>
+    <Error Condition=" '$(MonoRuntimePackDir)' == '' " Text="Could not find Mono browser-wasm runtime pack. Looked in $(DotNetRoot)packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\$(NETCoreSdkVersion) and C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Runtime.Mono.browser-wasm\9.0.16" />
+    <Message Importance="High" Text="Mono runtime pack found at: $(MonoRuntimePackDir)"/>
+    <MakeDir Directories="bin\$(RuntimeIdentifier)" />
+    <WriteLinesToFile Overwrite="true" File="bin\$(RuntimeIdentifier)\runtime-pack-dir.txt" Lines="$(MonoRuntimePackDir)" />
+  </Target>
+</Project>

--- a/modules/mono/runtime/GetRuntimePack/ManagedCallbacks.cs
+++ b/modules/mono/runtime/GetRuntimePack/ManagedCallbacks.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Runtime.InteropServices;
+using Godot.NativeInterop;
+
+namespace Godot.NativeInterop
+{
+    public enum godot_bool : byte { }
+
+    public ref struct godot_ref { }
+
+    public ref struct godot_variant_call_error { }
+
+    public ref struct godot_csharp_type_info { }
+
+    public ref struct godot_variant { }
+
+    public ref struct godot_string { }
+
+    public ref struct godot_string_name { }
+
+    public ref struct godot_array { }
+
+    public ref struct godot_dictionary { }
+}
+
+namespace Godot
+{
+    public class SignalAwaiter
+    {
+        [UnmanagedCallersOnly]
+        internal static unsafe void SignalCallback(IntPtr awaiterGCHandlePtr, godot_variant** args, int argCount, godot_bool* outAwaiterIsNull) { }
+    }
+
+    internal static class DelegateUtils
+    {
+        [UnmanagedCallersOnly]
+        internal static godot_bool DelegateEquals(IntPtr delegateGCHandleA, IntPtr delegateGCHandleB)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static int DelegateHash(IntPtr delegateGCHandle)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe int GetArgumentCount(IntPtr delegateGCHandle, godot_bool* outIsValid)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void InvokeWithVariantArgs(IntPtr delegateGCHandle, void* trampoline, godot_variant** args, int argc, godot_variant* outRet) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool TrySerializeDelegateWithGCHandle(IntPtr delegateGCHandle,
+            godot_array* nSerializedData)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool TryDeserializeDelegateWithGCHandle(godot_array* nSerializedData,
+            IntPtr* delegateGCHandle)
+        {
+            throw null!;
+        }
+    }
+
+    internal static class DebuggingUtils
+    {
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetCurrentStackInfo(void* destVector) { }
+    }
+
+    internal static class DisposablesTracker
+    {
+        [UnmanagedCallersOnly]
+        internal static void OnGodotShuttingDown() { }
+    }
+
+    public static class GD
+    {
+        [UnmanagedCallersOnly]
+        internal static void OnCoreApiAssemblyLoaded(godot_bool isDebug) { }
+    }
+}
+
+namespace Godot.Bridge
+{
+    public static class ScriptManagerBridge
+    {
+        [UnmanagedCallersOnly]
+        internal static void FrameCallback() { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName, IntPtr godotObject)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool CreateManagedForGodotObjectScriptInstance(IntPtr scriptPtr, IntPtr godotObject, godot_variant** args, int argCount)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetScriptNativeName(IntPtr scriptPtr, godot_string_name* outRes) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetGlobalClassName(godot_string* scriptPath, godot_string* outBaseType, godot_string* outIconPath, godot_string* outClassName) { }
+
+        [UnmanagedCallersOnly]
+        internal static void SetGodotObjectPtr(IntPtr gcHandlePtr, IntPtr newPtr) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void RaiseEventSignal(IntPtr ownerGCHandlePtr, godot_string_name* eventSignalName, godot_variant** args, int argCount, godot_bool* outOwnerIsNull) { }
+
+        [UnmanagedCallersOnly]
+        internal static godot_bool ScriptIsOrInherits(IntPtr scriptPtr, IntPtr scriptPtrMaybeBase)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool AddScriptBridge(IntPtr scriptPtr, godot_string* scriptPath)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetOrCreateScriptBridgeForPath(godot_string* scriptPath, godot_ref* outScript) { }
+
+        [UnmanagedCallersOnly]
+        internal static void RemoveScriptBridge(IntPtr scriptPtr) { }
+
+        [UnmanagedCallersOnly]
+        internal static godot_bool TryReloadRegisteredScriptWithClass(IntPtr scriptPtr)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void UpdateScriptClassInfo(IntPtr scriptPtr, godot_csharp_type_info* outTypeInfo, godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest, godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetPropertyInfoList(IntPtr scriptPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool CallStatic(IntPtr scriptPtr, godot_string_name* method, godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetPropertyDefaultValues(IntPtr scriptPtr, delegate* unmanaged<IntPtr, void*, int, void> addDefValFunc) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool SwapGCHandleForType(IntPtr oldGCHandlePtr, IntPtr* outNewGCHandlePtr, godot_bool createWeak)
+        {
+            throw null!;
+        }
+    }
+
+    internal static class CSharpInstanceBridge
+    {
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool Call(IntPtr godotObjectGCHandle, godot_string_name* method, godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool Set(IntPtr godotObjectGCHandle, godot_string_name* name, godot_variant* value)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool Get(IntPtr godotObjectGCHandle, godot_string_name* name, godot_variant* outRet)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static void CallDispose(IntPtr godotObjectGCHandle, godot_bool okIfNull) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void CallToString(IntPtr godotObjectGCHandle, godot_string* outRes, godot_bool* outValid) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool HasMethodUnknownParams(IntPtr godotObjectGCHandle, godot_string_name* method)
+        {
+            throw null!;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void SerializeState(IntPtr godotObjectGCHandle, godot_dictionary* propertiesState, godot_dictionary* signalEventsState) { }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void DeserializeState(IntPtr godotObjectGCHandle, godot_dictionary* propertiesState, godot_dictionary* signalEventsState) { }
+    }
+
+    internal static class GCHandleBridge
+    {
+        [UnmanagedCallersOnly]
+        internal static void FreeGCHandle(IntPtr gcHandlePtr) { }
+
+        [UnmanagedCallersOnly]
+        internal static godot_bool GCHandleIsTargetCollectible(IntPtr gcHandlePtr)
+        {
+            throw null!;
+        }
+    }
+}

--- a/modules/mono/runtime/GetRuntimePack/Program.cs
+++ b/modules/mono/runtime/GetRuntimePack/Program.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+internal class Program
+{
+    internal static void Main()
+    {
+        throw new UnreachableException();
+    }
+}

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -89,6 +89,7 @@ def get_flags():
         # run-time performance.
         # Note that this overrides the "auto" behavior for target/dev_build.
         "optimize": "size",
+        "supported": ["mono"],
     }
 
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -420,11 +420,9 @@ Ref<Texture2D> EditorExportPlatformWeb::get_logo() const {
 
 bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
 #ifdef MODULE_MONO_ENABLED
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
-	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	return false;
-#else
+	// Web export is still a work in progress, keep a message as a warning.
+	err += TTR("Exporting to Web when using C#/.NET is experimental.") + "\n";
+#endif
 
 	String err;
 	bool valid = false;
@@ -456,7 +454,6 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
-#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {


### PR DESCRIPTION
Adds WebAssembly export support for the Mono/.NET build of Godot Engine, enabling Web export for C# Godot projects.

## Changes

- **Platform detection**: Added `"mono"` to web platform's supported modules
- **Web export plugin**: Added `#ifdef MODULE_MONO_ENABLED` warning for experimental status
- **ExportPlugin.cs**: Added `OS.Platforms.Web` to the supported platform list
- **Browser.props/targets**: New MSBuild files for browser-wasm AOT compilation
- **GetRuntimePack**: Added browser-wasm RID support
- **mono_configure.py**: Use dotnet build + direct runtime pack resolution for browser-wasm

Fixes #70796