### PR TITLE
Update D3D12 download script to use current release.

### DIFF
--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -33,7 +33,7 @@ else:
 # Mesa NIR
 # Sync with `drivers/d3d12/SCsub` when updating Mesa.
 # Check for latest version: https://github.com/godotengine/godot-nir-static/releases/latest
-mesa_version = "25.3.1-2"
+mesa_version = "25.3.1-3"
 # WinPixEventRuntime
 # Check for latest version: https://www.nuget.org/api/v2/package/WinPixEventRuntime (check downloaded filename)
 pix_version = "1.0.240308001"


### PR DESCRIPTION
## What problem(s) does this PR solve?

See https://github.com/godotengine/godot-nir-static/issues/32

## Additional information

Official builds seems to be fine, so this is primarily for compatibility with older compilers and consistency.