### PR TITLE
GDScript: Exclude `globals` internal classes in the analyzer

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4632,11 +4632,15 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (GDScriptLanguage::get_singleton()->has_any_global_constant(name)) {
-		Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
-		p_identifier->set_datatype(type_from_variant(constant, p_identifier));
-		p_identifier->is_constant = true;
-		p_identifier->reduced_value = constant;
-		return;
+		// We checked for `ClassDB` classes above. Any `ClassDB` class that reaches this point is not exposed and should not be accessible.
+		// TODO: Remove this check once `globals` does only contain publicly available things.
+		if (!ClassDB::class_exists(name)) {
+			Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
+			p_identifier->set_datatype(type_from_variant(constant, p_identifier));
+			p_identifier->is_constant = true;
+			p_identifier->reduced_value = constant;
+			return;
+		}
 	}
 
 	if (CoreConstants::is_global_enum(name)) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/invalid_identifier.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/invalid_identifier.gd
@@ -1,0 +1,3 @@
+func test():
+	print(GDScriptFunctionState)
+	print(GDScriptNativeClass)

--- a/modules/gdscript/tests/scripts/analyzer/errors/invalid_identifier.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/invalid_identifier.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 2: Identifier "GDScriptFunctionState" not declared in the current scope.
+>> ERROR at line 3: Identifier "GDScriptNativeClass" not declared in the current scope.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/119935
- Less risky alternative to https://github.com/godotengine/godot/pull/119936 (does not supersede however, we should merge the other PR in early 4.8 IMHO)

## Additional information

Instead of excluding those classes from `globals`, we protect the specific usage of `globals` in the analyzer, thus reducing risk for other usages of `globals`.

CC @dalexeev 
