### PR TITLE
Track buffer/memory usage using safe numerics.

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -268,9 +268,7 @@ Error RenderingDevice::_acceleration_structure_scratch_buffer_create(Acceleratio
 		p_acceleration_structure->scratch_buffer = driver->buffer_create(scratch_size, RDD::BUFFER_USAGE_STORAGE_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 		ERR_FAIL_COND_V(!p_acceleration_structure->scratch_buffer, ERR_CANT_CREATE);
 
-		_THREAD_SAFE_LOCK_
-		buffer_memory += scratch_size;
-		_THREAD_SAFE_UNLOCK_
+		buffer_memory.add(scratch_size);
 	}
 
 	return OK;
@@ -511,9 +509,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
 
-		_THREAD_SAFE_LOCK_
-		buffer_memory += instance_buffer_size;
-		_THREAD_SAFE_UNLOCK_
+		buffer_memory.add(instance_buffer_size);
 
 		AccelerationStructure::InstanceBuffer instance_buffer;
 		instance_buffer.driver_id = instance_buffer_driver_id;
@@ -578,9 +574,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 RDD::BufferID RenderingDevice::_hit_sbt_buffer_create(uint32_t p_buffer_size) {
 	RDD::BufferID buffer = driver->buffer_create(p_buffer_size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	if (buffer) {
-		_THREAD_SAFE_LOCK_
-		buffer_memory += p_buffer_size;
-		_THREAD_SAFE_UNLOCK_
+		buffer_memory.add(p_buffer_size);
 	}
 
 	return buffer;
@@ -1490,9 +1484,7 @@ RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, Span<uint8_t> 
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += buffer.size;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(buffer.size);
 
 	RID id = storage_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -1530,9 +1522,7 @@ RID RenderingDevice::texture_buffer_create(uint32_t p_size_elements, DataFormat 
 		_buffer_initialize(&texture_buffer, p_data);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += size_bytes;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(size_bytes);
 
 	RID id = texture_buffer_owner.make_rid(texture_buffer);
 #ifdef DEV_ENABLED
@@ -1743,7 +1733,7 @@ RID RenderingDevice::texture_create(const TextureFormat &p_format, const Texture
 		_texture_make_mutable(&texture, RID());
 	}
 
-	texture_memory += driver->texture_get_allocation_size(texture.driver_id);
+	texture_memory.add(driver->texture_get_allocation_size(texture.driver_id));
 
 	RID id = texture_owner.make_rid(texture);
 #ifdef DEV_ENABLED
@@ -1817,7 +1807,7 @@ RID RenderingDevice::texture_create_shared(const TextureView &p_view, RID p_with
 
 		texture.shared_fallback->texture = driver->texture_create(alias_format, tv);
 		texture.shared_fallback->raw_reinterpretation = raw_reintepretation;
-		texture_memory += driver->texture_get_allocation_size(texture.shared_fallback->texture);
+		texture_memory.add(driver->texture_get_allocation_size(texture.shared_fallback->texture));
 
 		RDG::ResourceTracker *tracker = RDG::resource_tracker_create();
 		tracker->texture_driver_id = texture.shared_fallback->texture;
@@ -1997,7 +1987,7 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 
 		texture.shared_fallback->texture = driver->texture_create(slice_format, tv);
 		texture.shared_fallback->raw_reinterpretation = raw_reintepretation;
-		texture_memory += driver->texture_get_allocation_size(texture.shared_fallback->texture);
+		texture_memory.add(driver->texture_get_allocation_size(texture.shared_fallback->texture));
 
 		RDG::ResourceTracker *tracker = RDG::resource_tracker_create();
 		tracker->texture_driver_id = texture.shared_fallback->texture;
@@ -2430,12 +2420,12 @@ void RenderingDevice::_texture_free_shared_fallback(Texture *p_texture) {
 		}
 
 		if (p_texture->shared_fallback->texture.id != 0) {
-			texture_memory -= driver->texture_get_allocation_size(p_texture->shared_fallback->texture);
+			texture_memory.sub(driver->texture_get_allocation_size(p_texture->shared_fallback->texture));
 			driver->texture_free(p_texture->shared_fallback->texture);
 		}
 
 		if (p_texture->shared_fallback->buffer.id != 0) {
-			buffer_memory -= driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer);
+			buffer_memory.sub(driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer));
 			driver->buffer_free(p_texture->shared_fallback->buffer);
 		}
 
@@ -2570,7 +2560,7 @@ void RenderingDevice::_texture_create_reinterpret_buffer(Texture *p_texture) {
 	uint32_t row_pitch = STEPIFY(p_texture->width * pixel_bytes, row_pitch_step);
 	uint64_t buffer_size = STEPIFY(pixel_bytes * row_pitch * p_texture->height * p_texture->depth, transfer_alignment);
 	p_texture->shared_fallback->buffer = driver->buffer_create(buffer_size, RDD::BUFFER_USAGE_TRANSFER_FROM_BIT | RDD::BUFFER_USAGE_TRANSFER_TO_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
-	buffer_memory += driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer);
+	buffer_memory.add(driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer));
 
 	RDG::ResourceTracker *tracker = RDG::resource_tracker_create();
 	tracker->buffer_driver_id = p_texture->shared_fallback->buffer;
@@ -3856,9 +3846,7 @@ RID RenderingDevice::vertex_buffer_create(uint32_t p_size_bytes, Span<uint8_t> p
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += buffer.size;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(buffer.size);
 
 	RID id = vertex_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -4073,9 +4061,7 @@ RID RenderingDevice::index_buffer_create(uint32_t p_index_count, IndexBufferForm
 		_buffer_initialize(&index_buffer, p_data);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += index_buffer.size;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(index_buffer.size);
 
 	RID id = index_buffer_owner.make_rid(index_buffer);
 #ifdef DEV_ENABLED
@@ -4327,9 +4313,7 @@ RID RenderingDevice::uniform_buffer_create(uint32_t p_size_bytes, Span<uint8_t> 
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += buffer.size;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(buffer.size);
 
 	RID id = uniform_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -5126,9 +5110,7 @@ Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPip
 		ERR_FAIL_V(err);
 	}
 
-	_THREAD_SAFE_LOCK_
-	buffer_memory += r_sbt_buffer.size;
-	_THREAD_SAFE_UNLOCK_
+	buffer_memory.add(r_sbt_buffer.size);
 
 	return OK;
 }
@@ -7917,7 +7899,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 		RaytracingPipeline *pipeline = &frames[p_frame].raytracing_pipelines_to_dispose_of.front()->get();
 
 		driver->buffer_free(pipeline->sbt_buffer.driver_id);
-		buffer_memory -= pipeline->sbt_buffer.size;
+		buffer_memory.sub(pipeline->sbt_buffer.size);
 
 		driver->raytracing_pipeline_free(pipeline->driver_id);
 
@@ -7931,11 +7913,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 		driver->acceleration_structure_free(acceleration_structure.driver_id);
 
 		if (acceleration_structure.scratch_buffer) {
-			size_t scratch_size = driver->buffer_get_allocation_size(acceleration_structure.scratch_buffer);
-			_THREAD_SAFE_LOCK_
-			buffer_memory -= scratch_size;
-			_THREAD_SAFE_UNLOCK_
-
+			buffer_memory.sub(driver->buffer_get_allocation_size(acceleration_structure.scratch_buffer));
 			driver->buffer_free(acceleration_structure.scratch_buffer);
 		}
 
@@ -7946,9 +7924,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 				driver->buffer_free(instance_buffer.driver_id);
 			}
 
-			_THREAD_SAFE_LOCK_
-			buffer_memory -= instance_buffer_size * acceleration_structure.instance_buffers.size();
-			_THREAD_SAFE_UNLOCK_
+			buffer_memory.sub(instance_buffer_size * acceleration_structure.instance_buffers.size());
 		}
 
 		frames[p_frame].acceleration_structures_to_dispose_of.pop_front();
@@ -7997,7 +7973,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 		_texture_free_shared_fallback(texture);
 
-		texture_memory -= driver->texture_get_allocation_size(texture->driver_id);
+		texture_memory.sub(driver->texture_get_allocation_size(texture->driver_id));
 		driver->texture_free(texture->driver_id);
 
 		frames[p_frame].textures_to_dispose_of.pop_front();
@@ -8007,7 +7983,7 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 	while (frames[p_frame].buffers_to_dispose_of.front()) {
 		Buffer &buffer = frames[p_frame].buffers_to_dispose_of.front()->get();
 		driver->buffer_free(buffer.driver_id);
-		buffer_memory -= buffer.size;
+		buffer_memory.sub(buffer.size);
 
 		frames[p_frame].buffers_to_dispose_of.pop_front();
 	}
@@ -8024,10 +8000,10 @@ uint32_t RenderingDevice::get_frame_delay() const {
 uint64_t RenderingDevice::get_memory_usage(MemoryType p_type) const {
 	switch (p_type) {
 		case MEMORY_BUFFERS: {
-			return buffer_memory;
+			return buffer_memory.get();
 		}
 		case MEMORY_TEXTURES: {
-			return texture_memory;
+			return texture_memory.get();
 		}
 		case MEMORY_TOTAL: {
 			return driver->get_total_memory_used();

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1864,8 +1864,8 @@ public:
 private:
 	void _free_pending_resources(int p_frame);
 
-	uint64_t texture_memory = 0;
-	uint64_t buffer_memory = 0;
+	SafeNumeric<uint64_t> texture_memory;
+	SafeNumeric<uint64_t> buffer_memory;
 
 protected:
 	void execute_chained_cmds(bool p_present_swap_chain,


### PR DESCRIPTION
## What problem(s) does this PR solve?

Avoids using the global RD mutex just for incrementing/decrementing these variables. By result, it also fixes places where mutexes were not used and the values were actually thread unsafe.

## Additional information

N/A