### PR TITLE
Fix sky distortion when using an orthogonal camera

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -251,6 +251,7 @@
 		</member>
 		<member name="sky_custom_fov" type="float" setter="set_sky_custom_fov" getter="get_sky_custom_fov" default="0.0">
 			If set to a value greater than [code]0.0[/code], overrides the field of view to use for sky rendering. If set to [code]0.0[/code], the same FOV as the current [Camera3D] is used for sky rendering.
+			[b]Note:[/b] When using an orthogonal camera, a custom FOV of [code]0.1[/code] degrees is used by default to avoid distortion. Depending on the sky contents, this can lead to rapid background color changes when the orthogonal camera rotates. Setting a higher custom FOV can help mitigate this issue.
 		</member>
 		<member name="sky_rotation" type="Vector3" setter="set_sky_rotation" getter="get_sky_rotation" default="Vector3(0, 0, 0)">
 			The rotation to use for sky rendering.

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1180,13 +1180,16 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 
 	float custom_fov = RendererSceneRenderRD::get_singleton()->environment_get_sky_custom_fov(p_render_data->environment);
 
-	if (custom_fov && sky_scene_state.view_count == 1) {
-		// With custom fov we don't support stereo...
+	if ((custom_fov || projection.is_orthogonal()) && sky_scene_state.view_count == 1) {
+		// Use a very low FOV when using orthogonal projection.
+		// This is more technically correct compared to drawing a stretched out sky.
+
+		// With custom FOV we don't support stereo...
 		float near_plane = projection.get_z_near();
 		float far_plane = projection.get_z_far();
 		float aspect = projection.get_aspect();
 
-		projection.set_perspective(custom_fov, aspect, near_plane, far_plane);
+		projection.set_perspective(MAX(0.1, custom_fov), aspect, near_plane, far_plane);
 	}
 
 	sky_scene_state.cam_projection = correction * projection;


### PR DESCRIPTION
A very low custom FOV is now used by default when using an orthogonal camera. This FOV can still be increased by adjusting the Sky Custom FOV property in Environment.

The new behavior is closer to how Blender behaves.

- This closes https://github.com/godotengine/godot/issues/23077.

## Preview

### Before

https://github.com/user-attachments/assets/169833b4-8a7d-48d8-8c8c-d8b783b152d9

### After

https://github.com/user-attachments/assets/7bdb226e-a6b1-41c7-a8b2-4d4fc3544ef9