### PR TITLE
Remove unnessecary `get_singleton()` calls to improve code readiblity and performance (for `/editor/*`)

### DIFF
--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -1049,7 +1049,8 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_PROCESS: {
-			AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+			AnimationTreeEditor *tree_editor = AnimationTreeEditor::get_singleton();
+			AnimationTree *tree = tree_editor->get_animation_tree();
 			if (!tree) {
 				return; // Node has been changed.
 			}
@@ -1062,7 +1063,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 			blend_tree->get_node_connections(&conns);
 			for (const AnimationNodeBlendTree::NodeConnection &E : conns) {
 				float activity = 0;
-				StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
+				StringName path = tree_editor->get_base_path() + E.input_node;
 				if (!tree->is_state_invalid()) {
 					activity = tree->get_connection_activity(path, E.input_index);
 				}
@@ -1075,9 +1076,9 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 					if (tree->has_animation(an->get_animation())) {
 						Ref<Animation> anim = tree->get_animation(an->get_animation());
 						if (anim.is_valid()) {
-							//StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + E.input_node;
-							StringName length_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E.key) + "/current_length";
-							StringName time_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E.key) + "/current_position";
+							//StringName path = tree_editor->get_base_path() + E.input_node;
+							StringName length_path = tree_editor->get_base_path() + String(E.key) + "/current_length";
+							StringName time_path = tree_editor->get_base_path() + String(E.key) + "/current_position";
 							E.value->set_max(tree->get(length_path));
 							E.value->set_value(tree->get(time_path));
 						}

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1730,21 +1730,23 @@ void AnimationPlayerEditor::_allocate_onion_layers() {
 	onion.captures.resize(captures);
 	onion.captures_valid.resize(captures);
 
+	RS *rs = RS::get_singleton();
+
 	for (int i = 0; i < captures; i++) {
 		bool is_present = onion.differences_only && i == captures - 1;
 
 		// Each capture is a viewport with a canvas item attached that renders a full-size rect with the contents of the main viewport.
-		onion.captures[i] = RS::get_singleton()->viewport_create();
+		onion.captures[i] = rs->viewport_create();
 
-		RS::get_singleton()->viewport_set_size(onion.captures[i], capture_size.width, capture_size.height);
-		RS::get_singleton()->viewport_set_update_mode(onion.captures[i], RSE::VIEWPORT_UPDATE_ALWAYS);
-		RS::get_singleton()->viewport_set_transparent_background(onion.captures[i], !is_present);
-		RS::get_singleton()->viewport_attach_canvas(onion.captures[i], onion.capture.canvas);
+		rs->viewport_set_size(onion.captures[i], capture_size.width, capture_size.height);
+		rs->viewport_set_update_mode(onion.captures[i], RSE::VIEWPORT_UPDATE_ALWAYS);
+		rs->viewport_set_transparent_background(onion.captures[i], !is_present);
+		rs->viewport_attach_canvas(onion.captures[i], onion.capture.canvas);
 	}
 
 	// Reset the capture canvas item to the current root viewport texture (defensive).
-	RS::get_singleton()->canvas_item_clear(onion.capture.canvas_item);
-	RS::get_singleton()->canvas_item_add_texture_rect(onion.capture.canvas_item, Rect2(Point2(), Point2(capture_size.x, -capture_size.y)), get_tree()->get_root()->get_texture()->get_rid());
+	rs->canvas_item_clear(onion.capture.canvas_item);
+	rs->canvas_item_add_texture_rect(onion.capture.canvas_item, Rect2(Point2(), Point2(capture_size.x, -capture_size.y)), get_tree()->get_root()->get_texture()->get_rid());
 
 	onion.capture_size = capture_size;
 }
@@ -1834,21 +1836,23 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 		CanvasItemEditor::get_singleton()->set_state(new_state);
 	}
 
+	RS *rs = RS::get_singleton();
+
 	// Tweak the root viewport to ensure it's rendered before our target.
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
 	onion.temp.screen_rect = Rect2(Vector2(), DisplayServer::get_singleton()->window_get_size(DisplayServerEnums::MAIN_WINDOW_ID));
-	RS::get_singleton()->viewport_attach_to_screen(root_vp, Rect2(), DisplayServerEnums::INVALID_WINDOW_ID);
-	RS::get_singleton()->viewport_set_update_mode(root_vp, RSE::VIEWPORT_UPDATE_ALWAYS);
+	rs->viewport_attach_to_screen(root_vp, Rect2(), DisplayServerEnums::INVALID_WINDOW_ID);
+	rs->viewport_set_update_mode(root_vp, RSE::VIEWPORT_UPDATE_ALWAYS);
 
 	RID present_rid;
 	if (onion.differences_only) {
 		// Capture present scene as it is.
-		RS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, RID());
+		rs->canvas_item_set_material(onion.capture.canvas_item, RID());
 		present_rid = onion.captures[onion.captures.size() - 1];
-		RS::get_singleton()->viewport_set_active(present_rid, true);
-		RS::get_singleton()->viewport_set_parent_viewport(root_vp, present_rid);
-		RS::get_singleton()->draw(false);
-		RS::get_singleton()->viewport_set_active(present_rid, false);
+		rs->viewport_set_active(present_rid, true);
+		rs->viewport_set_parent_viewport(root_vp, present_rid);
+		rs->draw(false);
+		rs->viewport_set_active(present_rid, false);
 	}
 
 	// Backup current animation state.
@@ -1857,7 +1861,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 
 	// Render every past/future step with the capture shader.
 
-	RS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
+	rs->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
 	onion.capture.material->set_shader_parameter("bkg_color", GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
 	onion.capture.material->set_shader_parameter("differences_only", onion.differences_only);
 	onion.capture.material->set_shader_parameter("present", onion.differences_only ? RS::get_singleton()->viewport_get_texture(present_rid) : RID());
@@ -1906,10 +1910,11 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_step_capture(int p_step_offs
 	DEV_ASSERT(onion.captures_valid[p_capture_idx]);
 
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
-	RS::get_singleton()->viewport_set_active(onion.captures[p_capture_idx], true);
-	RS::get_singleton()->viewport_set_parent_viewport(root_vp, onion.captures[p_capture_idx]);
-	RS::get_singleton()->draw(false);
-	RS::get_singleton()->viewport_set_active(onion.captures[p_capture_idx], false);
+	RS *rs = RS::get_singleton();
+	rs->viewport_set_active(onion.captures[p_capture_idx], true);
+	rs->viewport_set_parent_viewport(root_vp, onion.captures[p_capture_idx]);
+	rs->draw(false);
+	rs->viewport_set_active(onion.captures[p_capture_idx], false);
 
 	int last_step_offset = onion.future ? onion.steps : 0;
 	if (p_step_offset < last_step_offset) {
@@ -1922,9 +1927,10 @@ void AnimationPlayerEditor::_prepare_onion_layers_2_step_capture(int p_step_offs
 void AnimationPlayerEditor::_prepare_onion_layers_2_epilog() {
 	// Restore root viewport.
 	RID root_vp = get_tree()->get_root()->get_viewport_rid();
-	RS::get_singleton()->viewport_set_parent_viewport(root_vp, RID());
-	RS::get_singleton()->viewport_attach_to_screen(root_vp, onion.temp.screen_rect, DisplayServerEnums::MAIN_WINDOW_ID);
-	RS::get_singleton()->viewport_set_update_mode(root_vp, RSE::VIEWPORT_UPDATE_WHEN_VISIBLE);
+	RS *rs = RS::get_singleton();
+	rs->viewport_set_parent_viewport(root_vp, RID());
+	rs->viewport_attach_to_screen(root_vp, onion.temp.screen_rect, DisplayServerEnums::MAIN_WINDOW_ID);
+	rs->viewport_set_update_mode(root_vp, RSE::VIEWPORT_UPDATE_WHEN_VISIBLE);
 
 	// Restore animation state.
 	// Here we're combine the power of seeking back to the original position and
@@ -2137,19 +2143,20 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	tool_anim->set_flat(false);
 	tool_anim->set_tooltip_text(TTRC("Animation Tools"));
 	tool_anim->set_text(TTRC("Animation"));
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/new_animation", TTRC("New...")), TOOL_NEW_ANIM);
-	tool_anim->get_popup()->add_separator();
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/animation_libraries", TTRC("Manage Animations...")), TOOL_ANIM_LIBRARY);
-	tool_anim->get_popup()->add_separator();
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/duplicate_animation", TTRC("Duplicate...")), TOOL_DUPLICATE_ANIM);
-	tool_anim->get_popup()->add_separator();
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/rename_animation", TTRC("Rename...")), TOOL_RENAME_ANIM);
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/edit_transitions", TTRC("Edit Transitions...")), TOOL_EDIT_TRANSITIONS);
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/open_animation_in_inspector", TTRC("Open in Inspector")), TOOL_EDIT_RESOURCE);
-	tool_anim->get_popup()->add_separator();
-	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/remove_animation", TTRC("Remove")), TOOL_REMOVE_ANIM);
+	PopupMenu *tool_anim_popup = tool_anim->get_popup();
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/new_animation", TTRC("New...")), TOOL_NEW_ANIM);
+	tool_anim_popup->add_separator();
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/animation_libraries", TTRC("Manage Animations...")), TOOL_ANIM_LIBRARY);
+	tool_anim_popup->add_separator();
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/duplicate_animation", TTRC("Duplicate...")), TOOL_DUPLICATE_ANIM);
+	tool_anim_popup->add_separator();
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/rename_animation", TTRC("Rename...")), TOOL_RENAME_ANIM);
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/edit_transitions", TTRC("Edit Transitions...")), TOOL_EDIT_TRANSITIONS);
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/open_animation_in_inspector", TTRC("Open in Inspector")), TOOL_EDIT_RESOURCE);
+	tool_anim_popup->add_separator();
+	tool_anim_popup->add_shortcut(ED_SHORTCUT("animation_player_editor/remove_animation", TTRC("Remove")), TOOL_REMOVE_ANIM);
 	tool_anim->set_disabled(true);
-	tool_anim->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_animation_tool_menu));
+	tool_anim_popup->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_animation_tool_menu));
 	hb->add_child(tool_anim);
 
 	animation = memnew(OptionButton);
@@ -2184,22 +2191,23 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	onion_skinning->set_flat(false);
 	onion_skinning->set_theme_type_variation("FlatMenuButton");
 	onion_skinning->set_tooltip_text(TTRC("Onion Skinning Options"));
-	onion_skinning->get_popup()->add_separator(TTRC("Directions"));
+	PopupMenu *onion_skinning_popup = onion_skinning->get_popup();
+	onion_skinning_popup->add_separator(TTRC("Directions"));
 	// TRANSLATORS: Opposite of "Future", refers to a direction in animation onion skinning.
-	onion_skinning->get_popup()->add_check_item(TTRC("Past"), ONION_SKINNING_PAST);
-	onion_skinning->get_popup()->set_item_checked(-1, true);
+	onion_skinning_popup->add_check_item(TTRC("Past"), ONION_SKINNING_PAST);
+	onion_skinning_popup->set_item_checked(-1, true);
 	// TRANSLATORS: Opposite of "Past", refers to a direction in animation onion skinning.
-	onion_skinning->get_popup()->add_check_item(TTRC("Future"), ONION_SKINNING_FUTURE);
-	onion_skinning->get_popup()->add_separator(TTRC("Depth"));
-	onion_skinning->get_popup()->add_radio_check_item(TTRC("1 step"), ONION_SKINNING_1_STEP);
-	onion_skinning->get_popup()->set_item_checked(-1, true);
-	onion_skinning->get_popup()->add_radio_check_item(TTRC("2 steps"), ONION_SKINNING_2_STEPS);
-	onion_skinning->get_popup()->add_radio_check_item(TTRC("3 steps"), ONION_SKINNING_3_STEPS);
-	onion_skinning->get_popup()->add_separator();
-	onion_skinning->get_popup()->add_check_item(TTRC("Differences Only"), ONION_SKINNING_DIFFERENCES_ONLY);
-	onion_skinning->get_popup()->add_check_item(TTRC("Force White Modulate"), ONION_SKINNING_FORCE_WHITE_MODULATE);
-	onion_skinning->get_popup()->add_check_item(TTRC("Include Gizmos (3D)"), ONION_SKINNING_INCLUDE_GIZMOS);
-	onion_skinning->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu));
+	onion_skinning_popup->add_check_item(TTRC("Future"), ONION_SKINNING_FUTURE);
+	onion_skinning_popup->add_separator(TTRC("Depth"));
+	onion_skinning_popup->add_radio_check_item(TTRC("1 step"), ONION_SKINNING_1_STEP);
+	onion_skinning_popup->set_item_checked(-1, true);
+	onion_skinning_popup->add_radio_check_item(TTRC("2 steps"), ONION_SKINNING_2_STEPS);
+	onion_skinning_popup->add_radio_check_item(TTRC("3 steps"), ONION_SKINNING_3_STEPS);
+	onion_skinning_popup->add_separator();
+	onion_skinning_popup->add_check_item(TTRC("Differences Only"), ONION_SKINNING_DIFFERENCES_ONLY);
+	onion_skinning_popup->add_check_item(TTRC("Force White Modulate"), ONION_SKINNING_FORCE_WHITE_MODULATE);
+	onion_skinning_popup->add_check_item(TTRC("Include Gizmos (3D)"), ONION_SKINNING_INCLUDE_GIZMOS);
+	onion_skinning_popup->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu));
 	hb->add_child(onion_skinning);
 
 	hb->add_child(memnew(VSeparator));
@@ -2295,9 +2303,10 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 
 	track_editor->connect(SceneStringName(visibility_changed), callable_mp(this, &AnimationPlayerEditor::_editor_visibility_changed));
 
-	onion.capture.canvas = RS::get_singleton()->canvas_create();
-	onion.capture.canvas_item = RS::get_singleton()->canvas_item_create();
-	RS::get_singleton()->canvas_item_set_parent(onion.capture.canvas_item, onion.capture.canvas);
+	RS *rs = RS::get_singleton();
+	onion.capture.canvas = rs->canvas_create();
+	onion.capture.canvas_item = rs->canvas_item_create();
+	rs->canvas_item_set_parent(onion.capture.canvas_item, onion.capture.canvas);
 
 	onion.capture.material.instantiate();
 
@@ -2330,7 +2339,7 @@ void fragment() {
 	COLOR = vec4(capture_samp.rgb * dir_color.rgb, bkg_mask * diff_mask);
 }
 )");
-	RS::get_singleton()->material_set_shader(onion.capture.material->get_rid(), onion.capture.shader->get_rid());
+	rs->material_set_shader(onion.capture.material->get_rid(), onion.capture.shader->get_rid());
 
 	ED_SHORTCUT("animation_editor/stop_animation", TTRC("Pause/Stop Animation"), Key::S, true);
 	ED_SHORTCUT("animation_editor/play_animation", TTRC("Play Animation"), Key::D, true);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -216,6 +216,8 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		return;
 	}
 
+	EditorNode *editor_node = EditorNode::get_singleton();
+
 	String node_directory;
 	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(_get_root_playback_path(node_directory));
 	if (playback.is_null()) {
@@ -299,7 +301,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				_update_connected_nodes(selected_node);
 
 				Ref<AnimationNode> anode = state_machine->get_node(selected_node);
-				EditorNode::get_singleton()->push_item(anode.ptr(), "", true);
+				editor_node->push_item(anode.ptr(), "", true);
 				state_machine_draw->queue_redraw();
 				dragging_selected_attempt = true;
 				dragging_selected = false;
@@ -357,7 +359,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 		// If no state or transition was selected, select host StateMachine node.
 		if (selected_node.is_empty() && selected_transition_index == -1) {
-			EditorNode::get_singleton()->push_item(state_machine.ptr(), "", true);
+			editor_node->push_item(state_machine.ptr(), "", true);
 		}
 
 		state_machine_draw->queue_redraw();
@@ -417,7 +419,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			Ref<AnimationNodeEndState> end_node = node;
 
 			if (state_machine->has_transition(connecting_from, connecting_to_node) && state_machine->can_edit_node(connecting_to_node) && anodesm.is_null()) {
-				EditorNode::get_singleton()->show_warning(TTR("Transition exists!"));
+				editor_node->show_warning(TTR("Transition exists!"));
 				connecting = false;
 			} else {
 				_add_transition();
@@ -475,13 +477,13 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			if (new_from == old_from && new_to == old_to) {
 				// No change.
 			} else if (new_from == new_to) {
-				EditorNode::get_singleton()->show_warning(TTR("Cannot transition to self!"));
+				editor_node->show_warning(TTR("Cannot transition to self!"));
 			} else if (new_to == SceneStringName(Start)) {
-				EditorNode::get_singleton()->show_warning(TTR("Cannot transition to \"Start\"!"));
+				editor_node->show_warning(TTR("Cannot transition to \"Start\"!"));
 			} else if (new_from == SceneStringName(End)) {
-				EditorNode::get_singleton()->show_warning(TTR("Cannot transition from \"End\"!"));
+				editor_node->show_warning(TTR("Cannot transition from \"End\"!"));
 			} else if (state_machine->has_transition(new_from, new_to)) {
-				EditorNode::get_singleton()->show_warning(vformat(TTR("Transition from \"%s\" to \"%s\" already exists!"), new_from, new_to));
+				editor_node->show_warning(vformat(TTR("Transition from \"%s\" to \"%s\" already exists!"), new_from, new_to));
 			} else {
 				_reconnect_transition();
 			}
@@ -548,7 +550,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 		if (clicked_node != StringName()) {
 			Ref<AnimationNode> anode = state_machine->get_node(clicked_node);
-			EditorNode::get_singleton()->push_item(anode.ptr(), "", true);
+			editor_node->push_item(anode.ptr(), "", true);
 			dragging_selected_attempt = true;
 			dragging_selected = false;
 			drag_from = mb->get_position();

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -4839,12 +4839,13 @@ bool AnimationTrackEditor::is_global_library_read_only() const {
 }
 
 Ref<Animation> AnimationTrackEditor::_create_and_get_reset_animation() {
-	AnimationPlayer *player = AnimationPlayerEditor::get_singleton()->get_player();
+	AnimationPlayerEditor *player_editor = AnimationPlayerEditor::get_singleton();
+	AnimationPlayer *player = player_editor->get_player();
 	if (player->has_animation(SceneStringName(RESET))) {
 		return player->get_animation(SceneStringName(RESET));
 	} else {
 		Ref<AnimationLibrary> al;
-		AnimationMixer *mixer = AnimationPlayerEditor::get_singleton()->fetch_mixer_for_library();
+		AnimationMixer *mixer = player_editor->fetch_mixer_for_library();
 		if (mixer) {
 			if (!mixer->has_animation_library("")) {
 				al.instantiate();
@@ -4858,9 +4859,9 @@ Ref<Animation> AnimationTrackEditor::_create_and_get_reset_animation() {
 		reset_anim->set_length(ANIM_MIN_LENGTH);
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->add_do_method(al.ptr(), "add_animation", SceneStringName(RESET), reset_anim);
-		undo_redo->add_do_method(AnimationPlayerEditor::get_singleton(), "_animation_player_changed", player);
+		undo_redo->add_do_method(player_editor, "_animation_player_changed", player);
 		undo_redo->add_undo_method(al.ptr(), "remove_animation", SceneStringName(RESET));
-		undo_redo->add_undo_method(AnimationPlayerEditor::get_singleton(), "_animation_player_changed", player);
+		undo_redo->add_undo_method(player_editor, "_animation_player_changed", player);
 		return reset_anim;
 	}
 }

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -324,29 +324,31 @@ void EditorAudioBus::update_bus() {
 
 	updating_bus = true;
 
+	AudioServer *as = AudioServer::get_singleton();
+
 	int index = get_index();
 
-	float db_value = AudioServer::get_singleton()->get_bus_volume_db(index);
+	float db_value = as->get_bus_volume_db(index);
 	slider->set_value(_scaled_db_to_normalized_volume(db_value));
-	track_name->set_text(AudioServer::get_singleton()->get_bus_name(index));
+	track_name->set_text(as->get_bus_name(index));
 	if (is_master) {
 		track_name->set_editable(false);
 	}
 
-	solo->set_pressed(AudioServer::get_singleton()->is_bus_solo(index));
-	mute->set_pressed(AudioServer::get_singleton()->is_bus_mute(index));
-	bypass->set_pressed(AudioServer::get_singleton()->is_bus_bypassing_effects(index));
+	solo->set_pressed(as->is_bus_solo(index));
+	mute->set_pressed(as->is_bus_mute(index));
+	bypass->set_pressed(as->is_bus_bypassing_effects(index));
 	// effects..
 	effects->clear();
 
 	TreeItem *root = effects->create_item();
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_effect_count(index); i++) {
-		Ref<AudioEffect> afx = AudioServer::get_singleton()->get_bus_effect(index, i);
+	for (int i = 0; i < as->get_bus_effect_count(index); i++) {
+		Ref<AudioEffect> afx = as->get_bus_effect(index, i);
 
 		TreeItem *fx = effects->create_item(root);
 		fx->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 		fx->set_editable(0, true);
-		fx->set_checked(0, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
+		fx->set_checked(0, as->is_bus_effect_enabled(index, i));
 		fx->set_text(0, afx->get_name());
 		fx->set_metadata(0, i);
 	}
@@ -369,7 +371,9 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	updating_bus = true;
 	track_name->release_focus();
 
-	if (p_new_name == AudioServer::get_singleton()->get_bus_name(get_index())) {
+	AudioServer *as = AudioServer::get_singleton();
+
+	if (p_new_name == as->get_bus_name(get_index())) {
 		updating_bus = false;
 		return;
 	}
@@ -379,8 +383,8 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 
 	while (true) {
 		bool name_free = true;
-		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-			if (AudioServer::get_singleton()->get_bus_name(i) == attempt) {
+		for (int i = 0; i < as->get_bus_count(); i++) {
+			if (as->get_bus_name(i) == attempt) {
 				name_free = false;
 				break;
 			}
@@ -396,17 +400,17 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 
-	StringName current = AudioServer::get_singleton()->get_bus_name(get_index());
+	StringName current = as->get_bus_name(get_index());
 
 	ur->create_action(TTR("Rename Audio Bus"));
 
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
+	ur->add_do_method(as, "set_bus_name", get_index(), attempt);
+	ur->add_undo_method(as, "set_bus_name", get_index(), current);
 
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-		if (AudioServer::get_singleton()->get_bus_send(i) == current) {
-			ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", i, attempt);
-			ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", i, current);
+	for (int i = 0; i < as->get_bus_count(); i++) {
+		if (as->get_bus_send(i) == current) {
+			ur->add_do_method(as, "set_bus_send", i, attempt);
+			ur->add_undo_method(as, "set_bus_send", i, current);
 		}
 	}
 
@@ -436,10 +440,11 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 		slider->set_value(_scaled_db_to_normalized_volume(Math::round(p_db)));
 	}
 
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Change Audio Bus Volume"), UndoRedo::MERGE_ENDS);
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), p_db);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", get_index(), AudioServer::get_singleton()->get_bus_volume_db(get_index()));
+	ur->add_do_method(as, "set_bus_volume_db", get_index(), p_db);
+	ur->add_undo_method(as, "set_bus_volume_db", get_index(), as->get_bus_volume_db(get_index()));
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
@@ -824,27 +829,28 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		paste_at = -1;
 	}
 
-	bool enabled = AudioServer::get_singleton()->is_bus_effect_enabled(bus, effect);
+	AudioServer *as = AudioServer::get_singleton();
+	bool enabled = as->is_bus_effect_enabled(bus, effect);
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Move Bus Effect"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", bus, effect);
-	ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(bus, effect), paste_at);
+	ur->add_do_method(as, "remove_bus_effect", bus, effect);
+	ur->add_do_method(as, "add_bus_effect", get_index(), as->get_bus_effect(bus, effect), paste_at);
 
 	if (paste_at == -1) {
-		paste_at = AudioServer::get_singleton()->get_bus_effect_count(get_index());
+		paste_at = as->get_bus_effect_count(get_index());
 		if (bus == get_index()) {
 			paste_at--;
 		}
 	}
 	if (!enabled) {
-		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), paste_at, false);
+		ur->add_do_method(as, "set_bus_effect_enabled", get_index(), paste_at, false);
 	}
 
-	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), paste_at);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", bus, AudioServer::get_singleton()->get_bus_effect(bus, effect), effect);
+	ur->add_undo_method(as, "remove_bus_effect", get_index(), paste_at);
+	ur->add_undo_method(as, "add_bus_effect", bus, as->get_bus_effect(bus, effect), effect);
 	if (!enabled) {
-		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", bus, effect, false);
+		ur->add_undo_method(as, "set_bus_effect_enabled", bus, effect, false);
 	}
 
 	ur->add_do_method(buses, "_update_bus", get_index());
@@ -868,11 +874,12 @@ void EditorAudioBus::_delete_effect_pressed(int p_option) {
 
 	int index = item->get_metadata(0);
 
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Delete Bus Effect"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), index);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", get_index(), AudioServer::get_singleton()->get_bus_effect(get_index(), index), index);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), index, AudioServer::get_singleton()->is_bus_effect_enabled(get_index(), index));
+	ur->add_do_method(as, "remove_bus_effect", get_index(), index);
+	ur->add_undo_method(as, "add_bus_effect", get_index(), as->get_bus_effect(get_index(), index), index);
+	ur->add_undo_method(as, "set_bus_effect_enabled", get_index(), index, as->is_bus_effect_enabled(get_index(), index));
 	ur->add_do_method(buses, "_update_bus", get_index());
 	ur->add_undo_method(buses, "_update_bus", get_index());
 	ur->commit_action();
@@ -1323,11 +1330,11 @@ void EditorAudioBuses::_notification(int p_what) {
 }
 
 void EditorAudioBuses::_add_bus() {
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-
 	ur->create_action(TTR("Add Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count() + 1);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count());
+	ur->add_do_method(as, "set_bus_count", as->get_bus_count() + 1);
+	ur->add_undo_method(as, "set_bus_count", as->get_bus_count());
 	ur->commit_action();
 }
 
@@ -1353,41 +1360,42 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 		return;
 	}
 
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-
 	ur->create_action(TTR("Delete Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "remove_bus", index);
-	ur->add_undo_method(AudioServer::get_singleton(), "add_bus", index);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", index, AudioServer::get_singleton()->get_bus_name(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_send", index, AudioServer::get_singleton()->get_bus_send(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_solo", index, AudioServer::get_singleton()->is_bus_solo(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_mute", index, AudioServer::get_singleton()->is_bus_mute(index));
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_bypass_effects", index, AudioServer::get_singleton()->is_bus_bypassing_effects(index));
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_effect_count(index); i++) {
-		ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", index, AudioServer::get_singleton()->get_bus_effect(index, i));
-		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", index, i, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
+	ur->add_do_method(as, "remove_bus", index);
+	ur->add_undo_method(as, "add_bus", index);
+	ur->add_undo_method(as, "set_bus_name", index, as->get_bus_name(index));
+	ur->add_undo_method(as, "set_bus_volume_db", index, as->get_bus_volume_db(index));
+	ur->add_undo_method(as, "set_bus_send", index, as->get_bus_send(index));
+	ur->add_undo_method(as, "set_bus_solo", index, as->is_bus_solo(index));
+	ur->add_undo_method(as, "set_bus_mute", index, as->is_bus_mute(index));
+	ur->add_undo_method(as, "set_bus_bypass_effects", index, as->is_bus_bypassing_effects(index));
+	for (int i = 0; i < as->get_bus_effect_count(index); i++) {
+		ur->add_undo_method(as, "add_bus_effect", index, as->get_bus_effect(index, i));
+		ur->add_undo_method(as, "set_bus_effect_enabled", index, i, as->is_bus_effect_enabled(index, i));
 	}
 	ur->commit_action();
 }
 
 void EditorAudioBuses::_duplicate_bus(int p_which) {
 	int add_at_pos = p_which + 1;
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Duplicate Audio Bus"));
-	ur->add_do_method(AudioServer::get_singleton(), "add_bus", add_at_pos);
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", add_at_pos, AudioServer::get_singleton()->get_bus_name(p_which) + " Copy");
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", add_at_pos, AudioServer::get_singleton()->get_bus_volume_db(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_send", add_at_pos, AudioServer::get_singleton()->get_bus_send(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_solo", add_at_pos, AudioServer::get_singleton()->is_bus_solo(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_mute", add_at_pos, AudioServer::get_singleton()->is_bus_mute(p_which));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_bypass_effects", add_at_pos, AudioServer::get_singleton()->is_bus_bypassing_effects(p_which));
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_effect_count(p_which); i++) {
-		ur->add_do_method(AudioServer::get_singleton(), "add_bus_effect", add_at_pos, AudioServer::get_singleton()->get_bus_effect(p_which, i));
-		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", add_at_pos, i, AudioServer::get_singleton()->is_bus_effect_enabled(p_which, i));
+	ur->add_do_method(as, "add_bus", add_at_pos);
+	ur->add_do_method(as, "set_bus_name", add_at_pos, as->get_bus_name(p_which) + " Copy");
+	ur->add_do_method(as, "set_bus_volume_db", add_at_pos, as->get_bus_volume_db(p_which));
+	ur->add_do_method(as, "set_bus_send", add_at_pos, as->get_bus_send(p_which));
+	ur->add_do_method(as, "set_bus_solo", add_at_pos, as->is_bus_solo(p_which));
+	ur->add_do_method(as, "set_bus_mute", add_at_pos, as->is_bus_mute(p_which));
+	ur->add_do_method(as, "set_bus_bypass_effects", add_at_pos, as->is_bus_bypassing_effects(p_which));
+	for (int i = 0; i < as->get_bus_effect_count(p_which); i++) {
+		ur->add_do_method(as, "add_bus_effect", add_at_pos, as->get_bus_effect(p_which, i));
+		ur->add_do_method(as, "set_bus_effect_enabled", add_at_pos, i, as->is_bus_effect_enabled(p_which, i));
 	}
 	ur->add_do_method(this, "_update_bus", add_at_pos);
-	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus", add_at_pos);
+	ur->add_undo_method(as, "remove_bus", add_at_pos);
 	ur->commit_action();
 }
 
@@ -1395,10 +1403,11 @@ void EditorAudioBuses::_reset_bus_volume(Object *p_which) {
 	EditorAudioBus *bus = Object::cast_to<EditorAudioBus>(p_which);
 	int index = bus->get_index();
 
+	AudioServer *as = AudioServer::get_singleton();
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Reset Bus Volume"));
-	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
-	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
+	ur->add_do_method(as, "set_bus_volume_db", index, 0.f);
+	ur->add_undo_method(as, "set_bus_volume_db", index, as->get_bus_volume_db(index));
 	ur->add_do_method(this, "_update_bus", index);
 	ur->add_undo_method(this, "_update_bus", index);
 	ur->commit_action();

--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -227,16 +227,17 @@ void DebuggerEditorPlugin::_notification(int p_what) {
 }
 
 void DebuggerEditorPlugin::_update_debug_options() {
-	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", true);
-	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
-	bool check_debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
-	bool check_debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);
-	bool check_debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
-	bool check_debug_avoidance = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_avoidance", false);
-	bool check_debug_canvas_redraw = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
-	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", true);
-	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", true);
-	bool check_server_keep_open = EditorSettings::get_singleton()->get_project_metadata("debug_options", "server_keep_open", false);
+	EditorSettings *es = EditorSettings::get_singleton();
+	bool check_deploy_remote = es->get_project_metadata("debug_options", "run_deploy_remote_debug", true);
+	bool check_file_server = es->get_project_metadata("debug_options", "run_file_server", false);
+	bool check_debug_collisions = es->get_project_metadata("debug_options", "run_debug_collisions", false);
+	bool check_debug_paths = es->get_project_metadata("debug_options", "run_debug_paths", false);
+	bool check_debug_navigation = es->get_project_metadata("debug_options", "run_debug_navigation", false);
+	bool check_debug_avoidance = es->get_project_metadata("debug_options", "run_debug_avoidance", false);
+	bool check_debug_canvas_redraw = es->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
+	bool check_live_debug = es->get_project_metadata("debug_options", "run_live_debug", true);
+	bool check_reload_scripts = es->get_project_metadata("debug_options", "run_reload_scripts", true);
+	bool check_server_keep_open = es->get_project_metadata("debug_options", "server_keep_open", false);
 
 	if (check_deploy_remote) {
 		_menu_option(RUN_DEPLOY_REMOTE_DEBUG);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -3343,12 +3343,13 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 }
 
 void FileSystemDock::_update_folder_colors_setting() {
-	if (!ProjectSettings::get_singleton()->has_setting("file_customization/folder_colors")) {
-		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", assigned_folder_colors);
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (!ps->has_setting("file_customization/folder_colors")) {
+		ps->set_setting("file_customization/folder_colors", assigned_folder_colors);
 	} else if (assigned_folder_colors.is_empty()) {
-		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", Variant());
+		ps->set_setting("file_customization/folder_colors", Variant());
 	}
-	ProjectSettings::get_singleton()->save();
+	ps->save();
 }
 
 void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu) {

--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -459,15 +459,16 @@ void GroupsEditor::_menu_id_pressed(int p_id) {
 			String description = ti->get_meta("__description");
 			String property_name = GLOBAL_GROUP_PREFIX + group_name;
 
+			ProjectSettings *project_settings = ProjectSettings::get_singleton();
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			if (is_local) {
 				undo_redo->create_action(TTR("Convert to Global Group"));
 
-				undo_redo->add_do_property(ProjectSettings::get_singleton(), property_name, "");
-				undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_name, Variant());
+				undo_redo->add_do_property(project_settings, property_name, "");
+				undo_redo->add_undo_property(project_settings, property_name, Variant());
 
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+				undo_redo->add_do_method(project_settings, "save");
+				undo_redo->add_undo_method(project_settings, "save");
 
 				undo_redo->add_undo_method(this, "_add_scene_group", group_name);
 
@@ -478,11 +479,11 @@ void GroupsEditor::_menu_id_pressed(int p_id) {
 			} else {
 				undo_redo->create_action(TTR("Convert to Scene Group"));
 
-				undo_redo->add_do_property(ProjectSettings::get_singleton(), property_name, Variant());
-				undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_name, description);
+				undo_redo->add_do_property(project_settings, property_name, Variant());
+				undo_redo->add_undo_property(project_settings, property_name, description);
 
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+				undo_redo->add_do_method(project_settings, "save");
+				undo_redo->add_undo_method(project_settings, "save");
 
 				undo_redo->add_do_method(this, "_add_scene_group", group_name);
 
@@ -549,11 +550,13 @@ void GroupsEditor::_confirm_add() {
 	} else {
 		String property_name = GLOBAL_GROUP_PREFIX + name;
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_name, description);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_name, Variant());
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+		undo_redo->add_do_property(project_settings, property_name, description);
+		undo_redo->add_undo_property(project_settings, property_name, Variant());
+
+		undo_redo->add_do_method(project_settings, "save");
+		undo_redo->add_undo_method(project_settings, "save");
 
 		undo_redo->add_do_method(this, "_update_groups");
 		undo_redo->add_undo_method(this, "_update_groups");
@@ -595,19 +598,22 @@ void GroupsEditor::_confirm_rename() {
 
 		String description = ti->get_meta("__description");
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, description);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, description);
+		undo_redo->add_do_property(project_settings, property_new_name, description);
+		undo_redo->add_undo_property(project_settings, property_new_name, Variant());
+
+		undo_redo->add_do_property(project_settings, property_old_name, Variant());
+		undo_redo->add_undo_property(project_settings, property_old_name, description);
 
 		if (rename_check_box->is_pressed()) {
-			undo_redo->add_do_method(ProjectSettingsEditor::get_singleton()->get_group_settings(), "rename_references", old_name, new_name);
-			undo_redo->add_undo_method(ProjectSettingsEditor::get_singleton()->get_group_settings(), "rename_references", new_name, old_name);
+			GroupSettingsEditor *group_settings = ProjectSettingsEditor::get_singleton()->get_group_settings();
+			undo_redo->add_do_method(group_settings, "rename_references", old_name, new_name);
+			undo_redo->add_undo_method(group_settings, "rename_references", new_name, old_name);
 		}
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+		undo_redo->add_do_method(project_settings, "save");
+		undo_redo->add_undo_method(project_settings, "save");
 
 		undo_redo->add_do_method(this, "_update_groups");
 		undo_redo->add_undo_method(this, "_update_groups");
@@ -640,15 +646,17 @@ void GroupsEditor::_confirm_delete() {
 		String property_name = GLOBAL_GROUP_PREFIX + name;
 		String description = ti->get_meta("__description");
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), property_name, Variant());
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_name, description);
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+		undo_redo->add_do_property(project_settings, property_name, Variant());
+		undo_redo->add_undo_property(project_settings, property_name, description);
 
 		if (remove_check_box->is_pressed()) {
 			undo_redo->add_do_method(ProjectSettingsEditor::get_singleton()->get_group_settings(), "remove_references", name);
 		}
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "save");
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "save");
+		undo_redo->add_do_method(project_settings, "save");
+		undo_redo->add_undo_method(project_settings, "save");
 
 		undo_redo->add_do_method(this, "_update_groups");
 		undo_redo->add_undo_method(this, "_update_groups");

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2664,16 +2664,17 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 		EditorNode::setup_built_in_resource(p_script, edited_scene->get_scene_file_path());
 	}
 
+	InspectorDock *inspector_dock = InspectorDock::get_singleton();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Attach Script"), UndoRedo::MERGE_DISABLE, selected.front()->get());
 	for (Node *E : selected) {
 		Ref<Script> existing = E->get_script();
-		undo_redo->add_do_method(InspectorDock::get_singleton(), "store_script_properties", E);
-		undo_redo->add_undo_method(InspectorDock::get_singleton(), "store_script_properties", E);
+		undo_redo->add_do_method(inspector_dock, "store_script_properties", E);
+		undo_redo->add_undo_method(inspector_dock, "store_script_properties", E);
 		undo_redo->add_do_method(E, "set_script", p_script);
 		undo_redo->add_undo_method(E, "set_script", existing);
-		undo_redo->add_do_method(InspectorDock::get_singleton(), "apply_script_properties", E);
-		undo_redo->add_undo_method(InspectorDock::get_singleton(), "apply_script_properties", E);
+		undo_redo->add_do_method(inspector_dock, "apply_script_properties", E);
+		undo_redo->add_undo_method(inspector_dock, "apply_script_properties", E);
 		undo_redo->add_do_method(this, "_queue_update_script_button");
 		undo_redo->add_undo_method(this, "_queue_update_script_button");
 	}
@@ -3776,13 +3777,14 @@ void SceneTreeDock::_script_dropped(const String &p_file, NodePath p_to) {
 			}
 		}
 
+		InspectorDock *inspector_dock = InspectorDock::get_singleton();
 		undo_redo->create_action(TTR("Attach Script"), UndoRedo::MERGE_DISABLE, n);
-		undo_redo->add_do_method(InspectorDock::get_singleton(), "store_script_properties", n);
-		undo_redo->add_undo_method(InspectorDock::get_singleton(), "store_script_properties", n);
+		undo_redo->add_do_method(inspector_dock, "store_script_properties", n);
+		undo_redo->add_undo_method(inspector_dock, "store_script_properties", n);
 		undo_redo->add_do_method(n, "set_script", scr);
 		undo_redo->add_undo_method(n, "set_script", n->get_script());
-		undo_redo->add_do_method(InspectorDock::get_singleton(), "apply_script_properties", n);
-		undo_redo->add_undo_method(InspectorDock::get_singleton(), "apply_script_properties", n);
+		undo_redo->add_do_method(inspector_dock, "apply_script_properties", n);
+		undo_redo->add_undo_method(inspector_dock, "apply_script_properties", n);
 		undo_redo->add_do_method(this, "_queue_update_script_button");
 		undo_redo->add_undo_method(this, "_queue_update_script_button");
 		undo_redo->commit_action();

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -151,25 +151,27 @@ TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const TypedArray<Mesh
 Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size) {
 	int size = p_preview_size;
 
-	RID scenario = RS::get_singleton()->scenario_create();
+	RS *rs = RS::get_singleton();
 
-	RID viewport = RS::get_singleton()->viewport_create();
-	RS::get_singleton()->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_ALWAYS);
-	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, size, size);
-	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
-	RS::get_singleton()->viewport_set_active(viewport, true);
-	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
+	RID scenario = rs->scenario_create();
 
-	RID camera = RS::get_singleton()->camera_create();
-	RS::get_singleton()->viewport_attach_camera(viewport, camera);
+	RID viewport = rs->viewport_create();
+	rs->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_ALWAYS);
+	rs->viewport_set_scenario(viewport, scenario);
+	rs->viewport_set_size(viewport, size, size);
+	rs->viewport_set_transparent_background(viewport, true);
+	rs->viewport_set_active(viewport, true);
+	RID viewport_texture = rs->viewport_get_texture(viewport);
 
-	RID light = RS::get_singleton()->directional_light_create();
-	RID light_instance = RS::get_singleton()->instance_create2(light, scenario);
+	RID camera = rs->camera_create();
+	rs->viewport_attach_camera(viewport, camera);
 
-	RID light2 = RS::get_singleton()->directional_light_create();
-	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
-	RID light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
+	RID light = rs->directional_light_create();
+	RID light_instance = rs->instance_create2(light, scenario);
+
+	RID light2 = rs->directional_light_create();
+	rs->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	RID light_instance2 = rs->instance_create2(light2, scenario);
 
 	EditorProgress ep("mlib", TTR("Creating Mesh Previews"), p_meshes.size());
 
@@ -187,8 +189,8 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 			mesh_xform = (*p_transforms)[i];
 		}
 
-		RID inst = RS::get_singleton()->instance_create2(mesh->get_rid(), scenario);
-		RS::get_singleton()->instance_set_transform(inst, mesh_xform);
+		RID inst = rs->instance_create2(mesh->get_rid(), scenario);
+		rs->instance_set_transform(inst, mesh_xform);
 
 		AABB aabb = mesh->get_aabb();
 		Vector3 ofs = aabb.get_center();
@@ -207,32 +209,32 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		xform.invert();
 		xform = mesh_xform * xform;
 
-		RS::get_singleton()->camera_set_transform(camera, xform * Transform3D(Basis(), Vector3(0, 0, 3)));
-		RS::get_singleton()->camera_set_orthogonal(camera, m * 2, 0.01, 1000.0);
+		rs->camera_set_transform(camera, xform * Transform3D(Basis(), Vector3(0, 0, 3)));
+		rs->camera_set_orthogonal(camera, m * 2, 0.01, 1000.0);
 
-		RS::get_singleton()->instance_set_transform(light_instance, xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
-		RS::get_singleton()->instance_set_transform(light_instance2, xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
+		rs->instance_set_transform(light_instance, xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
+		rs->instance_set_transform(light_instance2, xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
 
 		ep.step(TTR("Thumbnail..."), i);
 		DisplayServer::get_singleton()->process_events();
 		Main::iteration();
 		Main::iteration();
-		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
+		Ref<Image> img = rs->texture_2d_get(viewport_texture);
 		ERR_CONTINUE(img.is_null() || img->is_empty());
 		Ref<ImageTexture> it = ImageTexture::create_from_image(img);
 
-		RS::get_singleton()->free_rid(inst);
+		rs->free_rid(inst);
 
 		textures.push_back(it);
 	}
 
-	RS::get_singleton()->free_rid(viewport);
-	RS::get_singleton()->free_rid(light);
-	RS::get_singleton()->free_rid(light_instance);
-	RS::get_singleton()->free_rid(light2);
-	RS::get_singleton()->free_rid(light_instance2);
-	RS::get_singleton()->free_rid(camera);
-	RS::get_singleton()->free_rid(scenario);
+	rs->free_rid(viewport);
+	rs->free_rid(light);
+	rs->free_rid(light_instance);
+	rs->free_rid(light2);
+	rs->free_rid(light_instance2);
+	rs->free_rid(camera);
+	rs->free_rid(scenario);
 
 	return textures;
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -495,45 +495,47 @@ void EditorNode::_update_from_settings() {
 		scene_root->propagate_notification(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
 	}
 
+	RS *rs = RS::get_singleton();
+
 	RSE::DOFBokehShape dof_shape = RSE::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
-	RS::get_singleton()->camera_attributes_set_dof_blur_bokeh_shape(dof_shape);
+	rs->camera_attributes_set_dof_blur_bokeh_shape(dof_shape);
 	RSE::DOFBlurQuality dof_quality = RSE::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));
 	bool dof_jitter = GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_use_jitter");
-	RS::get_singleton()->camera_attributes_set_dof_blur_quality(dof_quality, dof_jitter);
-	RS::get_singleton()->environment_set_ssao_quality(RSE::EnvironmentSSAOQuality(int(GLOBAL_GET("rendering/environment/ssao/quality"))), GLOBAL_GET("rendering/environment/ssao/half_size"), GLOBAL_GET("rendering/environment/ssao/adaptive_target"), GLOBAL_GET("rendering/environment/ssao/blur_passes"), GLOBAL_GET("rendering/environment/ssao/fadeout_from"), GLOBAL_GET("rendering/environment/ssao/fadeout_to"));
-	RS::get_singleton()->screen_space_roughness_limiter_set_active(GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit"));
+	rs->camera_attributes_set_dof_blur_quality(dof_quality, dof_jitter);
+	rs->environment_set_ssao_quality(RSE::EnvironmentSSAOQuality(int(GLOBAL_GET("rendering/environment/ssao/quality"))), GLOBAL_GET("rendering/environment/ssao/half_size"), GLOBAL_GET("rendering/environment/ssao/adaptive_target"), GLOBAL_GET("rendering/environment/ssao/blur_passes"), GLOBAL_GET("rendering/environment/ssao/fadeout_from"), GLOBAL_GET("rendering/environment/ssao/fadeout_to"));
+	rs->screen_space_roughness_limiter_set_active(GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/enabled"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/amount"), GLOBAL_GET("rendering/anti_aliasing/screen_space_roughness_limiter/limit"));
 	bool glow_bicubic = int(GLOBAL_GET("rendering/environment/glow/upscale_mode")) > 0;
-	RS::get_singleton()->environment_set_ssil_quality(RSE::EnvironmentSSILQuality(int(GLOBAL_GET("rendering/environment/ssil/quality"))), GLOBAL_GET("rendering/environment/ssil/half_size"), GLOBAL_GET("rendering/environment/ssil/adaptive_target"), GLOBAL_GET("rendering/environment/ssil/blur_passes"), GLOBAL_GET("rendering/environment/ssil/fadeout_from"), GLOBAL_GET("rendering/environment/ssil/fadeout_to"));
-	RS::get_singleton()->environment_glow_set_use_bicubic_upscale(glow_bicubic);
-	RS::get_singleton()->environment_set_ssr_half_size(GLOBAL_GET("rendering/environment/screen_space_reflection/half_size"));
+	rs->environment_set_ssil_quality(RSE::EnvironmentSSILQuality(int(GLOBAL_GET("rendering/environment/ssil/quality"))), GLOBAL_GET("rendering/environment/ssil/half_size"), GLOBAL_GET("rendering/environment/ssil/adaptive_target"), GLOBAL_GET("rendering/environment/ssil/blur_passes"), GLOBAL_GET("rendering/environment/ssil/fadeout_from"), GLOBAL_GET("rendering/environment/ssil/fadeout_to"));
+	rs->environment_glow_set_use_bicubic_upscale(glow_bicubic);
+	rs->environment_set_ssr_half_size(GLOBAL_GET("rendering/environment/screen_space_reflection/half_size"));
 	RSE::SubSurfaceScatteringQuality sss_quality = RSE::SubSurfaceScatteringQuality(int(GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_quality")));
-	RS::get_singleton()->sub_surface_scattering_set_quality(sss_quality);
+	rs->sub_surface_scattering_set_quality(sss_quality);
 	float sss_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_scale");
 	float sss_depth_scale = GLOBAL_GET("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale");
-	RS::get_singleton()->sub_surface_scattering_set_scale(sss_scale, sss_depth_scale);
+	rs->sub_surface_scattering_set_scale(sss_scale, sss_depth_scale);
 
 	uint32_t directional_shadow_size = GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/size");
 	uint32_t directional_shadow_16_bits = GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/16_bits");
-	RS::get_singleton()->directional_shadow_atlas_set_size(directional_shadow_size, directional_shadow_16_bits);
+	rs->directional_shadow_atlas_set_size(directional_shadow_size, directional_shadow_16_bits);
 
 	RSE::ShadowQuality shadows_quality = RSE::ShadowQuality(int(GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality")));
-	RS::get_singleton()->positional_soft_shadow_filter_set_quality(shadows_quality);
+	rs->positional_soft_shadow_filter_set_quality(shadows_quality);
 	RSE::ShadowQuality directional_shadow_quality = RSE::ShadowQuality(int(GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality")));
-	RS::get_singleton()->directional_soft_shadow_filter_set_quality(directional_shadow_quality);
+	rs->directional_soft_shadow_filter_set_quality(directional_shadow_quality);
 	float probe_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
-	RS::get_singleton()->lightmap_set_probe_capture_update_speed(probe_update_speed);
+	rs->lightmap_set_probe_capture_update_speed(probe_update_speed);
 	RSE::EnvironmentSDFGIFramesToConverge frames_to_converge = RSE::EnvironmentSDFGIFramesToConverge(int(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")));
-	RS::get_singleton()->environment_set_sdfgi_frames_to_converge(frames_to_converge);
+	rs->environment_set_sdfgi_frames_to_converge(frames_to_converge);
 	RSE::EnvironmentSDFGIRayCount ray_count = RSE::EnvironmentSDFGIRayCount(int(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")));
-	RS::get_singleton()->environment_set_sdfgi_ray_count(ray_count);
+	rs->environment_set_sdfgi_ray_count(ray_count);
 	RSE::VoxelGIQuality voxel_gi_quality = RSE::VoxelGIQuality(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")));
-	RS::get_singleton()->voxel_gi_set_quality(voxel_gi_quality);
-	RS::get_singleton()->environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
-	RS::get_singleton()->environment_set_volumetric_fog_filter_active(bool(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter")));
-	RS::get_singleton()->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/2d/shadow_atlas/size"));
+	rs->voxel_gi_set_quality(voxel_gi_quality);
+	rs->environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
+	rs->environment_set_volumetric_fog_filter_active(bool(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter")));
+	rs->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/2d/shadow_atlas/size"));
 
 	bool use_half_res_gi = GLOBAL_GET("rendering/global_illumination/gi/use_half_resolution");
-	RS::get_singleton()->gi_set_use_half_resolution(use_half_res_gi);
+	rs->gi_set_use_half_resolution(use_half_res_gi);
 
 	bool snap_2d_transforms = GLOBAL_GET("rendering/2d/snap/snap_2d_transforms_to_pixel");
 	scene_root->set_snap_2d_transforms_to_pixel(snap_2d_transforms);
@@ -568,10 +570,10 @@ void EditorNode::_update_from_settings() {
 	float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
 	scene_root->set_mesh_lod_threshold(mesh_lod_threshold);
 
-	RS::get_singleton()->decals_set_filter(RSE::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
-	RS::get_singleton()->light_projectors_set_filter(RSE::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
-	RS::get_singleton()->lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
-	RS::get_singleton()->material_set_use_debanding(GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding"));
+	rs->decals_set_filter(RSE::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
+	rs->light_projectors_set_filter(RSE::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
+	rs->lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
+	rs->material_set_use_debanding(GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding"));
 
 	SceneTree *tree = get_tree();
 	tree->set_debug_collisions_color(GLOBAL_GET("debug/shapes/collision/shape_color"));
@@ -600,25 +602,27 @@ void EditorNode::_update_from_settings() {
 	_update_translations();
 
 #ifdef DEBUG_ENABLED
-	NavigationServer2D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/2d/edge_connection_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_disabled_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_disabled_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_connections"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
+	NavigationServer2D *nav_server_2d = NavigationServer2D::get_singleton();
+	nav_server_2d->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/2d/edge_connection_color"));
+	nav_server_2d->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_color"));
+	nav_server_2d->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_color"));
+	nav_server_2d->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_disabled_color"));
+	nav_server_2d->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_disabled_color"));
+	nav_server_2d->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_connections"));
+	nav_server_2d->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
+	nav_server_2d->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
 
-	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_disabled_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_disabled_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections_xray"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+	NavigationServer3D *nav_server_3d = NavigationServer3D::get_singleton();
+	nav_server_3d->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
+	nav_server_3d->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
+	nav_server_3d->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
+	nav_server_3d->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_disabled_color"));
+	nav_server_3d->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_disabled_color"));
+	nav_server_3d->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections"));
+	nav_server_3d->set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections_xray"));
+	nav_server_3d->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
+	nav_server_3d->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
+	nav_server_3d->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
 #endif // DEBUG_ENABLED
 }
 
@@ -956,10 +960,11 @@ void EditorNode::_notification(int p_what) {
 
 			_begin_first_scan();
 
-			last_dark_mode_state = DisplayServer::get_singleton()->is_dark_mode();
-			last_system_accent_color = DisplayServer::get_singleton()->get_accent_color();
-			last_system_base_color = DisplayServer::get_singleton()->get_base_color();
-			DisplayServer::get_singleton()->set_system_theme_change_callback(callable_mp(this, &EditorNode::_check_system_theme_changed));
+			DisplayServer *display_server = DisplayServer::get_singleton();
+			last_dark_mode_state = display_server->is_dark_mode();
+			last_system_accent_color = display_server->get_accent_color();
+			last_system_base_color = display_server->get_base_color();
+			display_server->set_system_theme_change_callback(callable_mp(this, &EditorNode::_check_system_theme_changed));
 
 			get_viewport()->connect("size_changed", callable_mp(this, &EditorNode::_viewport_resized));
 
@@ -1088,16 +1093,17 @@ void EditorNode::_notification(int p_what) {
 			}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/input/tablet_driver")) {
+				DisplayServer *display_server = DisplayServer::get_singleton();
 				String tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
 				int tablet_driver_idx = EDITOR_GET("interface/editor/input/tablet_driver");
 				if (tablet_driver_idx != -1) {
-					tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(tablet_driver_idx);
+					tablet_driver = display_server->tablet_get_driver_name(tablet_driver_idx);
 				}
 				if (tablet_driver.is_empty()) {
-					tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
+					tablet_driver = display_server->tablet_get_driver_name(0);
 				}
-				DisplayServer::get_singleton()->tablet_set_current_driver(tablet_driver);
-				print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
+				display_server->tablet_set_current_driver(tablet_driver);
+				print_verbose("Using \"" + display_server->tablet_get_current_driver() + "\" pen tablet driver...");
 			}
 
 			if (EDITOR_GET("interface/editor/behavior/import_resources_when_unfocused")) {
@@ -8404,10 +8410,11 @@ EditorNode::EditorNode() {
 	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
 	add_child(epnp);
 
-	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
-	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
-	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
-	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->connect("version_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
+	undo_redo->connect("version_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
+	undo_redo->connect("history_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
+	undo_redo->connect("history_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorNode::_update_from_settings));
 	GDExtensionManager::get_singleton()->connect("extensions_reloaded", callable_mp(this, &EditorNode::_gdextensions_reloaded));
 
@@ -8441,8 +8448,9 @@ EditorNode::EditorNode() {
 		bool agile_input_event_flushing = EDITOR_GET("input/buffering/agile_event_flushing");
 		bool use_accumulated_input = EDITOR_GET("input/buffering/use_accumulated_input");
 
-		Input::get_singleton()->set_agile_input_event_flushing(agile_input_event_flushing);
-		Input::get_singleton()->set_use_accumulated_input(use_accumulated_input);
+		Input *input_singleton = Input::get_singleton();
+		input_singleton->set_agile_input_event_flushing(agile_input_event_flushing);
+		input_singleton->set_use_accumulated_input(use_accumulated_input);
 	}
 
 	{
@@ -8508,82 +8516,84 @@ EditorNode::EditorNode() {
 	});
 
 	{
+		ResourceFormatImporter *resource_format_importer = ResourceFormatImporter::get_singleton();
+
 		// Register importers at the beginning, so dialogs are created with the right extensions.
 		Ref<ResourceImporterTexture> import_texture = memnew(ResourceImporterTexture(true));
-		ResourceFormatImporter::get_singleton()->add_importer(import_texture);
+		resource_format_importer->add_importer(import_texture);
 
 		Ref<ResourceImporterLayeredTexture> import_cubemap;
 		import_cubemap.instantiate();
 		import_cubemap->set_mode(ResourceImporterLayeredTexture::MODE_CUBEMAP);
-		ResourceFormatImporter::get_singleton()->add_importer(import_cubemap);
+		resource_format_importer->add_importer(import_cubemap);
 
 		Ref<ResourceImporterLayeredTexture> import_array;
 		import_array.instantiate();
 		import_array->set_mode(ResourceImporterLayeredTexture::MODE_2D_ARRAY);
-		ResourceFormatImporter::get_singleton()->add_importer(import_array);
+		resource_format_importer->add_importer(import_array);
 
 		Ref<ResourceImporterLayeredTexture> import_cubemap_array;
 		import_cubemap_array.instantiate();
 		import_cubemap_array->set_mode(ResourceImporterLayeredTexture::MODE_CUBEMAP_ARRAY);
-		ResourceFormatImporter::get_singleton()->add_importer(import_cubemap_array);
+		resource_format_importer->add_importer(import_cubemap_array);
 
 		Ref<ResourceImporterLayeredTexture> import_3d = memnew(ResourceImporterLayeredTexture(true));
 		import_3d->set_mode(ResourceImporterLayeredTexture::MODE_3D);
-		ResourceFormatImporter::get_singleton()->add_importer(import_3d);
+		resource_format_importer->add_importer(import_3d);
 
 		Ref<ResourceImporterImage> import_image;
 		import_image.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_image);
+		resource_format_importer->add_importer(import_image);
 
 		Ref<ResourceImporterSVG> import_svg;
 		import_svg.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_svg);
+		resource_format_importer->add_importer(import_svg);
 
 		Ref<ResourceImporterTextureAtlas> import_texture_atlas;
 		import_texture_atlas.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_texture_atlas);
+		resource_format_importer->add_importer(import_texture_atlas);
 
 		Ref<ResourceImporterDynamicFont> import_font_data_dynamic;
 		import_font_data_dynamic.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_font_data_dynamic);
+		resource_format_importer->add_importer(import_font_data_dynamic);
 
 		Ref<ResourceImporterBMFont> import_font_data_bmfont;
 		import_font_data_bmfont.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_font_data_bmfont);
+		resource_format_importer->add_importer(import_font_data_bmfont);
 
 		Ref<ResourceImporterImageFont> import_font_data_image;
 		import_font_data_image.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_font_data_image);
+		resource_format_importer->add_importer(import_font_data_image);
 
 		Ref<ResourceImporterCSVTranslation> import_csv_translation;
 		import_csv_translation.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_csv_translation);
+		resource_format_importer->add_importer(import_csv_translation);
 
 		Ref<ResourceImporterWAV> import_wav;
 		import_wav.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_wav);
+		resource_format_importer->add_importer(import_wav);
 
 		Ref<ResourceImporterOBJ> import_obj;
 		import_obj.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_obj);
+		resource_format_importer->add_importer(import_obj);
 
 		Ref<ResourceImporterShaderFile> import_shader_file;
 		import_shader_file.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
+		resource_format_importer->add_importer(import_shader_file);
 
 		Ref<ResourceImporterScene> import_model_as_scene;
 		import_model_as_scene.instantiate("PackedScene");
-		ResourceFormatImporter::get_singleton()->add_importer(import_model_as_scene);
+		resource_format_importer->add_importer(import_model_as_scene);
 
 		Ref<ResourceImporterScene> import_model_as_animation;
 		import_model_as_animation.instantiate("AnimationLibrary");
-		ResourceFormatImporter::get_singleton()->add_importer(import_model_as_animation);
+		resource_format_importer->add_importer(import_model_as_animation);
 
 		Ref<ResourceImporterScene> import_scene_as_mesh_library = memnew(ResourceImporterScene("MeshLibrary"));
-		ResourceFormatImporter::get_singleton()->add_importer(import_scene_as_mesh_library);
+		resource_format_importer->add_importer(import_scene_as_mesh_library);
 
 		Ref<ResourceImporterScene> import_scene_as_single_mesh = memnew(ResourceImporterScene("ArrayMesh"));
-		ResourceFormatImporter::get_singleton()->add_importer(import_scene_as_single_mesh);
+		resource_format_importer->add_importer(import_scene_as_single_mesh);
 
 		{
 			Ref<EditorSceneFormatImporterCollada> import_collada;
@@ -8601,7 +8611,7 @@ EditorNode::EditorNode() {
 
 		Ref<ResourceImporterBitMap> import_bitmap;
 		import_bitmap.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_bitmap);
+		resource_format_importer->add_importer(import_bitmap);
 	}
 
 	{
@@ -9562,11 +9572,12 @@ EditorNode::EditorNode() {
 	execute_output_dialog->add_child(execute_outputs);
 	execute_output_dialog->set_title("");
 
-	EditorFileSystem::get_singleton()->connect("sources_changed", callable_mp(this, &EditorNode::_sources_changed));
-	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorNode::_fs_changed));
-	EditorFileSystem::get_singleton()->connect("resources_reimporting", callable_mp(this, &EditorNode::_resources_reimporting));
-	EditorFileSystem::get_singleton()->connect("resources_reimported", callable_mp(this, &EditorNode::_resources_reimported));
-	EditorFileSystem::get_singleton()->connect("resources_reload", callable_mp(this, &EditorNode::_resources_changed));
+	EditorFileSystem *editor_file_system = EditorFileSystem::get_singleton();
+	editor_file_system->connect("sources_changed", callable_mp(this, &EditorNode::_sources_changed));
+	editor_file_system->connect("filesystem_changed", callable_mp(this, &EditorNode::_fs_changed));
+	editor_file_system->connect("resources_reimporting", callable_mp(this, &EditorNode::_resources_reimporting));
+	editor_file_system->connect("resources_reimported", callable_mp(this, &EditorNode::_resources_reimported));
+	editor_file_system->connect("resources_reload", callable_mp(this, &EditorNode::_resources_changed));
 
 	_build_icon_type_cache();
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2614,15 +2614,17 @@ Error EditorExportPlatform::ssh_run_on_remote(const String &p_host, const String
 	String out;
 	int exit_code = -1;
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		OS::get_singleton()->print("Executing: %s", ssh_path.utf8().get_data());
+	OS *os = OS::get_singleton();
+
+	if (os->is_stdout_verbose()) {
+		os->print("Executing: %s", ssh_path.utf8().get_data());
 		for (const String &arg : args) {
-			OS::get_singleton()->print(" %s", arg.utf8().get_data());
+			os->print(" %s", arg.utf8().get_data());
 		}
-		OS::get_singleton()->print("\n");
+		os->print("\n");
 	}
 
-	Error err = OS::get_singleton()->execute(ssh_path, args, &out, &exit_code, true);
+	Error err = os->execute(ssh_path, args, &out, &exit_code, true);
 	if (out.is_empty()) {
 		print_verbose(vformat("Exit code: %d", exit_code));
 	} else {
@@ -2668,15 +2670,17 @@ Error EditorExportPlatform::ssh_run_on_remote_no_wait(const String &p_host, cons
 	args.push_back(p_host);
 	args.push_back(p_cmd_args);
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		OS::get_singleton()->print("Executing: %s", ssh_path.utf8().get_data());
+	OS *os = OS::get_singleton();
+
+	if (os->is_stdout_verbose()) {
+		os->print("Executing: %s", ssh_path.utf8().get_data());
 		for (const String &arg : args) {
-			OS::get_singleton()->print(" %s", arg.utf8().get_data());
+			os->print(" %s", arg.utf8().get_data());
 		}
-		OS::get_singleton()->print("\n");
+		os->print("\n");
 	}
 
-	return OS::get_singleton()->create_process(ssh_path, args, r_pid);
+	return os->create_process(ssh_path, args, r_pid);
 }
 
 Error EditorExportPlatform::ssh_push_to_remote(const String &p_host, const String &p_port, const Vector<String> &p_scp_args, const String &p_src_file, const String &p_dst_file) const {
@@ -2704,15 +2708,17 @@ Error EditorExportPlatform::ssh_push_to_remote(const String &p_host, const Strin
 	String out;
 	int exit_code = -1;
 
-	if (OS::get_singleton()->is_stdout_verbose()) {
-		OS::get_singleton()->print("Executing: %s", scp_path.utf8().get_data());
+	OS *os = OS::get_singleton();
+
+	if (os->is_stdout_verbose()) {
+		os->print("Executing: %s", scp_path.utf8().get_data());
 		for (const String &arg : args) {
-			OS::get_singleton()->print(" %s", arg.utf8().get_data());
+			os->print(" %s", arg.utf8().get_data());
 		}
-		OS::get_singleton()->print("\n");
+		os->print("\n");
 	}
 
-	Error err = OS::get_singleton()->execute(scp_path, args, &out, &exit_code, true);
+	Error err = os->execute(scp_path, args, &out, &exit_code, true);
 	if (err != OK) {
 		return err;
 	} else if (exit_code != 0) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -124,10 +124,11 @@ void ProjectExportDialog::_notification(int p_what) {
 			delete_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Remove")));
 			patch_add_btn->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 
-			script_key_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
-			export_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
-			export_error2->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
-			export_warning->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor)));
+			Ref<Theme> editor_theme = EditorNode::get_singleton()->get_editor_theme();
+			script_key_error->add_theme_color_override(SceneStringName(font_color), editor_theme->get_color(SNAME("error_color"), EditorStringName(Editor)));
+			export_error->add_theme_color_override(SceneStringName(font_color), editor_theme->get_color(SNAME("error_color"), EditorStringName(Editor)));
+			export_error2->add_theme_color_override(SceneStringName(font_color), editor_theme->get_color(SNAME("error_color"), EditorStringName(Editor)));
+			export_warning->add_theme_color_override(SceneStringName(font_color), editor_theme->get_color(SNAME("warning_color"), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -146,10 +147,10 @@ void ProjectExportDialog::_notification(int p_what) {
 }
 
 void ProjectExportDialog::popup_export() {
+	EditorExport *editor_export = EditorExport::get_singleton();
 	add_preset->get_popup()->clear();
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_platform_count(); i++) {
-		Ref<EditorExportPlatform> plat = EditorExport::get_singleton()->get_export_platform(i);
-
+	for (int i = 0; i < editor_export->get_export_platform_count(); i++) {
+		Ref<EditorExportPlatform> plat = editor_export->get_export_platform(i);
 		add_preset->get_popup()->add_icon_item(plat->get_logo(), plat->get_name());
 	}
 
@@ -168,16 +169,19 @@ void ProjectExportDialog::popup_export() {
 }
 
 void ProjectExportDialog::_add_preset(int p_platform) {
-	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_platform(p_platform)->create_preset();
+	EditorExport *editor_export = EditorExport::get_singleton();
+	Ref<EditorExportPlatform> editor_export_platform = editor_export->get_export_platform(p_platform);
+
+	Ref<EditorExportPreset> preset = editor_export_platform->create_preset();
 	ERR_FAIL_COND(preset.is_null());
 
-	String preset_name = EditorExport::get_singleton()->get_export_platform(p_platform)->get_name();
+	String preset_name = editor_export_platform->get_name();
 	int attempt = 1;
 	while (true) {
 		bool valid = true;
 
-		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-			Ref<EditorExportPreset> p = EditorExport::get_singleton()->get_export_preset(i);
+		for (int i = 0; i < editor_export->get_export_preset_count(); i++) {
+			Ref<EditorExportPreset> p = editor_export->get_export_preset(i);
 			if (p->get_name() == preset_name) {
 				valid = false;
 				break;
@@ -189,16 +193,16 @@ void ProjectExportDialog::_add_preset(int p_platform) {
 		}
 
 		attempt++;
-		preset_name = EditorExport::get_singleton()->get_export_platform(p_platform)->get_name() + " " + itos(attempt);
+		preset_name = editor_export_platform->get_name() + " " + itos(attempt);
 	}
 
 	preset->set_name(preset_name);
-	if (EditorExport::get_singleton()->get_runnable_preset_for_platform(preset->get_platform()).is_null()) {
-		EditorExport::get_singleton()->set_runnable_preset(preset);
+	if (editor_export->get_runnable_preset_for_platform(preset->get_platform()).is_null()) {
+		editor_export->set_runnable_preset(preset);
 	}
-	EditorExport::get_singleton()->add_export_preset(preset);
+	editor_export->add_export_preset(preset);
 	_update_presets();
-	_edit_preset(EditorExport::get_singleton()->get_export_preset_count() - 1);
+	_edit_preset(editor_export->get_export_preset_count() - 1);
 }
 
 void ProjectExportDialog::_force_update_current_preset_parameters() {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -918,14 +918,15 @@ bool EditorFileSystem::_update_scan_actions() {
 				fs_changed = true;
 
 				const String new_file_path = ia.dir->get_file_path(idx);
+				ResourceUID *resource_uid_singleton = ResourceUID::get_singleton();
 				const ResourceUID::ID existing_id = ResourceLoader::get_resource_uid(new_file_path);
 				if (existing_id != ResourceUID::INVALID_ID) {
-					const bool id_known = ResourceUID::get_singleton()->has_id(existing_id);
-					const String old_path = id_known ? ResourceUID::get_singleton()->get_id_path(existing_id) : String();
+					const bool id_known = resource_uid_singleton->has_id(existing_id);
+					const String old_path = id_known ? resource_uid_singleton->get_id_path(existing_id) : String();
 
 					if (id_known && old_path != new_file_path && FileAccess::exists(old_path)) {
-						const ResourceUID::ID new_id = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
-						ResourceUID::get_singleton()->add_id(new_id, new_file_path);
+						const ResourceUID::ID new_id = resource_uid_singleton->create_id_for_path(new_file_path);
+						resource_uid_singleton->add_id(new_id, new_file_path);
 						ResourceSaver::set_uid(new_file_path, new_id);
 						WARN_PRINT(vformat("Duplicate UID detected for Resource at \"%s\".\nOld Resource path: \"%s\". The new file UID was changed automatically.", new_file_path, old_path));
 						ia.new_file->uid = new_id;
@@ -934,9 +935,9 @@ bool EditorFileSystem::_update_scan_actions() {
 						ResourceSaver::set_uid(new_file_path, existing_id);
 
 						if (id_known) {
-							ResourceUID::get_singleton()->set_id(existing_id, new_file_path);
+							resource_uid_singleton->set_id(existing_id, new_file_path);
 						} else {
-							ResourceUID::get_singleton()->add_id(existing_id, new_file_path);
+							resource_uid_singleton->add_id(existing_id, new_file_path);
 						}
 
 						ia.new_file->uid = existing_id;
@@ -944,8 +945,8 @@ bool EditorFileSystem::_update_scan_actions() {
 				} else if (ResourceLoader::should_create_uid_file(new_file_path)) {
 					Ref<FileAccess> f = FileAccess::open(new_file_path + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
-						ia.new_file->uid = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
-						f->store_line(ResourceUID::get_singleton()->id_to_text(ia.new_file->uid));
+						ia.new_file->uid = resource_uid_singleton->create_id_for_path(new_file_path);
+						f->store_line(resource_uid_singleton->id_to_text(ia.new_file->uid));
 					}
 				}
 
@@ -2398,6 +2399,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 }
 
 void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
+	ResourceUID *resource_uid = ResourceUID::get_singleton();
 	bool updated = false;
 	bool update_files_icon_cache = false;
 	Vector<EditorFileSystemDirectory::FileInfo *> files_to_update_icon_path;
@@ -2417,8 +2419,8 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			_delete_internal_files(file);
 			if (cpos != -1) { // Might've never been part of the editor file system (*.* files deleted in Open dialog).
 				if (fs->files[cpos]->uid != ResourceUID::INVALID_ID) {
-					if (ResourceUID::get_singleton()->has_id(fs->files[cpos]->uid)) {
-						ResourceUID::get_singleton()->remove_id(fs->files[cpos]->uid);
+					if (resource_uid->has_id(fs->files[cpos]->uid)) {
+						resource_uid->remove_id(fs->files[cpos]->uid);
 					}
 				}
 				if (ClassDB::is_parent_class(fs->files[cpos]->type, SNAME("Script"))) {
@@ -2494,20 +2496,20 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
 
 			if (uid != ResourceUID::INVALID_ID) {
-				if (ResourceUID::get_singleton()->has_id(uid)) {
-					ResourceUID::get_singleton()->set_id(uid, file);
+				if (resource_uid->has_id(uid)) {
+					resource_uid->set_id(uid, file);
 				} else {
-					ResourceUID::get_singleton()->add_id(uid, file);
+					resource_uid->add_id(uid, file);
 				}
 
-				ResourceUID::get_singleton()->update_cache();
+				resource_uid->update_cache();
 			} else {
 				if (ResourceLoader::should_create_uid_file(file)) {
 					Ref<FileAccess> f = FileAccess::open(file + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
-						const ResourceUID::ID id = ResourceUID::get_singleton()->create_id_for_path(file);
-						ResourceUID::get_singleton()->add_id(id, file);
-						f->store_line(ResourceUID::get_singleton()->id_to_text(id));
+						const ResourceUID::ID id = resource_uid->create_id_for_path(file);
+						resource_uid->add_id(id, file);
+						f->store_line(resource_uid->id_to_text(id));
 						fi->uid = id;
 					}
 				}

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -129,10 +129,12 @@ EditorPaths::EditorPaths() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
+	OS *os = OS::get_singleton();
+
 	project_data_dir = ProjectSettings::get_singleton()->get_project_data_path();
 
 	// Self-contained mode if a `._sc_` or `_sc_` file is present in executable dir.
-	String exe_path = OS::get_singleton()->get_executable_path().get_base_dir();
+	String exe_path = os->get_executable_path().get_base_dir();
 	Ref<DirAccess> d = DirAccess::create_for_path(exe_path);
 	if (d->file_exists(exe_path + "/._sc_")) {
 		self_contained = true;
@@ -144,7 +146,7 @@ EditorPaths::EditorPaths() {
 
 	// On macOS, look outside .app bundle, since .app bundle is read-only.
 	// Note: This will not work if Gatekeeper path randomization is active.
-	if (OS::get_singleton()->has_feature("macos") && exe_path.ends_with("MacOS") && exe_path.path_join("..").simplify_path().ends_with("Contents")) {
+	if (os->has_feature("macos") && exe_path.ends_with("MacOS") && exe_path.path_join("..").simplify_path().ends_with("Contents")) {
 		exe_path = exe_path.path_join("../../..").simplify_path();
 		d = DirAccess::create_for_path(exe_path);
 		if (d->file_exists(exe_path + "/._sc_")) {
@@ -171,19 +173,19 @@ EditorPaths::EditorPaths() {
 		temp_dir = data_dir.path_join("temp");
 	} else {
 		// Typically XDG_DATA_HOME or %APPDATA%.
-		data_path = OS::get_singleton()->get_data_path();
-		data_dir = data_path.path_join(OS::get_singleton()->get_godot_dir_name());
+		data_path = os->get_data_path();
+		data_dir = data_path.path_join(os->get_godot_dir_name());
 		// Can be different from data_path e.g. on Linux or macOS.
-		config_path = OS::get_singleton()->get_config_path();
-		config_dir = config_path.path_join(OS::get_singleton()->get_godot_dir_name());
+		config_path = os->get_config_path();
+		config_dir = config_path.path_join(os->get_godot_dir_name());
 		// Can be different from above paths, otherwise a subfolder of data_dir.
-		cache_path = OS::get_singleton()->get_cache_path();
+		cache_path = os->get_cache_path();
 		if (cache_path == data_path) {
 			cache_dir = data_dir.path_join("cache");
 		} else {
-			cache_dir = cache_path.path_join(OS::get_singleton()->get_godot_dir_name());
+			cache_dir = cache_path.path_join(os->get_godot_dir_name());
 		}
-		temp_dir = OS::get_singleton()->get_temp_path();
+		temp_dir = os->get_temp_path();
 	}
 
 	paths_valid = (!data_path.is_empty() && !config_path.is_empty() && !cache_path.is_empty());

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3107,6 +3107,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 }
 
 static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_hash_str, Dictionary &p_settings, const String &p_path_key, const String &p_fallback_path_key) {
+	ResourceUID *resource_uid = ResourceUID::get_singleton();
 	const String &raw_save_path = p_settings[p_path_key];
 	String save_path = ResourceUID::ensure_path(raw_save_path);
 	if (raw_save_path.begins_with("uid://")) {
@@ -3115,7 +3116,7 @@ static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_ha
 				String fallback_save_path = p_settings[p_fallback_path_key];
 				if (!fallback_save_path.is_empty() && DirAccess::exists(fallback_save_path.get_base_dir())) {
 					save_path = fallback_save_path;
-					ResourceUID::get_singleton()->add_id(ResourceUID::get_singleton()->text_to_id(raw_save_path), save_path);
+					resource_uid->add_id(resource_uid->text_to_id(raw_save_path), save_path);
 				}
 			}
 		} else {
@@ -3126,17 +3127,17 @@ static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_ha
 	if (!save_path.is_empty() && !raw_save_path.begins_with("uid://")) {
 		const ResourceUID::ID id = ResourceLoader::get_resource_uid(save_path);
 		if (id != ResourceUID::INVALID_ID) {
-			p_settings[p_path_key] = ResourceUID::get_singleton()->id_to_text(id);
+			p_settings[p_path_key] = resource_uid->id_to_text(id);
 		} else {
 			ResourceUID::ID save_id = hash64_murmur3_64(p_hash_str.hash64(), p_source_id) & 0x7FFFFFFFFFFFFFFF;
-			if (ResourceUID::get_singleton()->has_id(save_id)) {
-				if (save_path != ResourceUID::get_singleton()->get_id_path(save_id)) {
+			if (resource_uid->has_id(save_id)) {
+				if (save_path != resource_uid->get_id_path(save_id)) {
 					// The user has specified a path which does not match the default UID.
-					save_id = ResourceUID::get_singleton()->create_id_for_path(save_path);
+					save_id = resource_uid->create_id_for_path(save_path);
 				}
 			}
-			p_settings[p_path_key] = ResourceUID::get_singleton()->id_to_text(save_id);
-			ResourceUID::get_singleton()->add_id(save_id, save_path);
+			p_settings[p_path_key] = resource_uid->id_to_text(save_id);
+			resource_uid->add_id(save_id, save_path);
 		}
 		p_settings[p_fallback_path_key] = save_path;
 	}

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -229,25 +229,29 @@ void AudioStreamImportSettingsDialog::_preview_zoom_offset_changed(double) {
 }
 
 void AudioStreamImportSettingsDialog::_reset_master() {
-	master_state.bypass = AudioServer::get_singleton()->is_bus_bypassing_effects(0);
-	master_state.mute = AudioServer::get_singleton()->is_bus_mute(0);
-	master_state.volume = AudioServer::get_singleton()->get_bus_volume_db(0);
+	AudioServer *as = AudioServer::get_singleton();
 
-	AudioServer::get_singleton()->set_bus_bypass_effects(0, true); // We don't want effects interfering.
-	AudioServer::get_singleton()->set_bus_mute(0, false);
-	AudioServer::get_singleton()->set_bus_volume_db(0, 0);
+	master_state.bypass = as->is_bus_bypassing_effects(0);
+	master_state.mute = as->is_bus_mute(0);
+	master_state.volume = as->get_bus_volume_db(0);
+
+	as->set_bus_bypass_effects(0, true); // We don't want effects interfering.
+	as->set_bus_mute(0, false);
+	as->set_bus_volume_db(0, 0);
 
 	// Prevent the modifications from being saved.
-	AudioServer::get_singleton()->set_edited(false);
+	as->set_edited(false);
 }
 
 void AudioStreamImportSettingsDialog::_load_master_state() {
-	AudioServer::get_singleton()->set_bus_bypass_effects(0, master_state.bypass);
-	AudioServer::get_singleton()->set_bus_mute(0, master_state.mute);
-	AudioServer::get_singleton()->set_bus_volume_db(0, master_state.volume);
+	AudioServer *as = AudioServer::get_singleton();
+
+	as->set_bus_bypass_effects(0, master_state.bypass);
+	as->set_bus_mute(0, master_state.mute);
+	as->set_bus_volume_db(0, master_state.volume);
 
 	// Prevent the modifications from being saved.
-	AudioServer::get_singleton()->set_edited(false);
+	as->set_edited(false);
 }
 
 void AudioStreamImportSettingsDialog::_audio_changed() {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -312,7 +312,8 @@ void EditorProperty::_notification(int p_what) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
+			AccessibilityServer *accessibility_server = AccessibilityServer::get_singleton();
+			accessibility_server->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
 
 			bool use_help_bit = EDITOR_GET("interface/accessibility/property_descriptions");
 			String tooltip = get_tooltip_text();
@@ -330,21 +331,21 @@ void EditorProperty::_notification(int p_what) {
 							prologue += custom_description;
 						}
 					}
-					AccessibilityServer::get_singleton()->update_set_description(ae, EditorHelpBit::get_as_plain_text(symbol, prologue));
+					accessibility_server->update_set_description(ae, EditorHelpBit::get_as_plain_text(symbol, prologue));
 				} else {
-					AccessibilityServer::get_singleton()->update_set_description(ae, tooltip);
+					accessibility_server->update_set_description(ae, tooltip);
 				}
 			}
 
-			AccessibilityServer::get_singleton()->update_set_name(ae, vformat(TTR("Property: %s"), label));
+			accessibility_server->update_set_name(ae, vformat(TTR("Property: %s"), label));
 
-			AccessibilityServer::get_singleton()->update_set_popup_type(ae, AccessibilityServerEnums::AccessibilityPopupType::POPUP_MENU);
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SHOW_CONTEXT_MENU, callable_mp(this, &EditorProperty::_accessibility_action_menu));
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &EditorProperty::_accessibility_action_click));
+			accessibility_server->update_set_popup_type(ae, AccessibilityServerEnums::AccessibilityPopupType::POPUP_MENU);
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SHOW_CONTEXT_MENU, callable_mp(this, &EditorProperty::_accessibility_action_menu));
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &EditorProperty::_accessibility_action_click));
 
-			AccessibilityServer::get_singleton()->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_READONLY, read_only);
+			accessibility_server->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_READONLY, read_only);
 			if (checkable) {
-				AccessibilityServer::get_singleton()->update_set_checked(ae, checked);
+				accessibility_server->update_set_checked(ae, checked);
 			}
 		} break;
 
@@ -3550,12 +3551,14 @@ void ArrayPanelContainer::_notification(int p_what) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
+			AccessibilityServer *accessibility_server = AccessibilityServer::get_singleton();
 
-			AccessibilityServer::get_singleton()->update_set_name(ae, get_meta("text"));
+			accessibility_server->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
 
-			AccessibilityServer::get_singleton()->update_set_popup_type(ae, AccessibilityServerEnums::AccessibilityPopupType::POPUP_MENU);
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SHOW_CONTEXT_MENU, callable_mp(this, &ArrayPanelContainer::_accessibility_action_menu));
+			accessibility_server->update_set_name(ae, get_meta("text"));
+
+			accessibility_server->update_set_popup_type(ae, AccessibilityServerEnums::AccessibilityPopupType::POPUP_MENU);
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SHOW_CONTEXT_MENU, callable_mp(this, &ArrayPanelContainer::_accessibility_action_menu));
 		} break;
 	}
 }
@@ -5531,6 +5534,9 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	} else {
 		undo_redo->create_action(vformat(TTR("Set %s"), p_name), UndoRedo::MERGE_ENDS, nullptr, false, mark_unsaved);
 		undo_redo->add_do_property(object, p_name, p_value);
+
+		EditorNode *editor_node = EditorNode::get_singleton();
+
 		bool valid = false;
 		Variant value = object->get(p_name, &valid);
 		Variant::Type type = p_value.get_type();
@@ -5543,12 +5549,12 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 			Node *N = Object::cast_to<Node>(object);
 			bool double_counting = Object::cast_to<Node>(p_value) == N || Object::cast_to<Node>(value) == N;
 			if (N && !double_counting && (type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
-				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
-				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
+				undo_redo->add_do_method(editor_node, "update_node_reference", value, N, true);
+				undo_redo->add_do_method(editor_node, "update_node_reference", p_value, N, false);
 				// Perhaps an inefficient way of updating the resource count.
 				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
-				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
+				undo_redo->add_undo_method(editor_node, "update_node_reference", p_value, N, true);
+				undo_redo->add_undo_method(editor_node, "update_node_reference", value, N, false);
 			}
 		}
 
@@ -5601,15 +5607,15 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 
 		if (r) {
 			//Setting a Subresource. Since there's possibly multiple Nodes referencing 'r', we need to link them to the Subresource.
-			List<Node *> shared_nodes = EditorNode::get_singleton()->get_resource_node_list(r);
+			List<Node *> shared_nodes = editor_node->get_resource_node_list(r);
 			for (Node *N : shared_nodes) {
 				if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
-					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
-					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
+					undo_redo->add_do_method(editor_node, "update_node_reference", value, N, true);
+					undo_redo->add_do_method(editor_node, "update_node_reference", p_value, N, false);
 					// Perhaps an inefficient way of updating the resource count.
 					// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
-					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
+					undo_redo->add_undo_method(editor_node, "update_node_reference", p_value, N, true);
+					undo_redo->add_undo_method(editor_node, "update_node_reference", value, N, false);
 				}
 			}
 			if (String(p_name) == "resource_local_to_scene") {

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -360,41 +360,43 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const Ref<Resource> &p_from
 }
 
 EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
-	scenario = RS::get_singleton()->scenario_create();
+	RS *rs = RS::get_singleton();
 
-	viewport = RS::get_singleton()->viewport_create();
-	RS::get_singleton()->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
-	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
-	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
-	RS::get_singleton()->viewport_set_active(viewport, true);
-	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
+	scenario = rs->scenario_create();
 
-	camera = RS::get_singleton()->camera_create();
-	RS::get_singleton()->viewport_attach_camera(viewport, camera);
-	RS::get_singleton()->camera_set_transform(camera, Transform3D(Basis(), Vector3(0, 0, 3)));
-	RS::get_singleton()->camera_set_perspective(camera, 45, 0.1, 10);
+	viewport = rs->viewport_create();
+	rs->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
+	rs->viewport_set_scenario(viewport, scenario);
+	rs->viewport_set_size(viewport, 128, 128);
+	rs->viewport_set_transparent_background(viewport, true);
+	rs->viewport_set_active(viewport, true);
+	viewport_texture = rs->viewport_get_texture(viewport);
+
+	camera = rs->camera_create();
+	rs->viewport_attach_camera(viewport, camera);
+	rs->camera_set_transform(camera, Transform3D(Basis(), Vector3(0, 0, 3)));
+	rs->camera_set_perspective(camera, 45, 0.1, 10);
 
 	if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
-		camera_attributes = RS::get_singleton()->camera_attributes_create();
-		RS::get_singleton()->camera_attributes_set_exposure(camera_attributes, 1.0, 0.000032552); // Matches default CameraAttributesPhysical to work well with default DirectionalLight3Ds.
-		RS::get_singleton()->camera_set_camera_attributes(camera, camera_attributes);
+		camera_attributes = rs->camera_attributes_create();
+		rs->camera_attributes_set_exposure(camera_attributes, 1.0, 0.000032552); // Matches default CameraAttributesPhysical to work well with default DirectionalLight3Ds.
+		rs->camera_set_camera_attributes(camera, camera_attributes);
 	}
 
-	light = RS::get_singleton()->directional_light_create();
-	light_instance = RS::get_singleton()->instance_create2(light, scenario);
-	RS::get_singleton()->instance_set_transform(light_instance, Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
+	light = rs->directional_light_create();
+	light_instance = rs->instance_create2(light, scenario);
+	rs->instance_set_transform(light_instance, Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
 
-	light2 = RS::get_singleton()->directional_light_create();
-	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
-	//RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	light2 = rs->directional_light_create();
+	rs->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	//rs->light_set_color(light2, Color(0.7, 0.7, 0.7));
 
-	light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
+	light_instance2 = rs->instance_create2(light2, scenario);
 
-	RS::get_singleton()->instance_set_transform(light_instance2, Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
+	rs->instance_set_transform(light_instance2, Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
 
-	sphere = RS::get_singleton()->mesh_create();
-	sphere_instance = RS::get_singleton()->instance_create2(sphere, scenario);
+	sphere = rs->mesh_create();
+	sphere_instance = rs->instance_create2(sphere, scenario);
 
 	int lats = 32;
 	int lons = 32;
@@ -472,21 +474,22 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	arr[RSE::ARRAY_NORMAL] = normals;
 	arr[RSE::ARRAY_TANGENT] = tangents;
 	arr[RSE::ARRAY_TEX_UV] = uvs;
-	RS::get_singleton()->mesh_add_surface_from_arrays(sphere, RSE::PRIMITIVE_TRIANGLES, arr);
+	rs->mesh_add_surface_from_arrays(sphere, RSE::PRIMITIVE_TRIANGLES, arr);
 }
 
 EditorMaterialPreviewPlugin::~EditorMaterialPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free_rid(sphere);
-	RS::get_singleton()->free_rid(sphere_instance);
-	RS::get_singleton()->free_rid(viewport);
-	RS::get_singleton()->free_rid(light);
-	RS::get_singleton()->free_rid(light_instance);
-	RS::get_singleton()->free_rid(light2);
-	RS::get_singleton()->free_rid(light_instance2);
-	RS::get_singleton()->free_rid(camera);
-	RS::get_singleton()->free_rid(camera_attributes);
-	RS::get_singleton()->free_rid(scenario);
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
+	rs->free_rid(sphere);
+	rs->free_rid(sphere_instance);
+	rs->free_rid(viewport);
+	rs->free_rid(light);
+	rs->free_rid(light_instance);
+	rs->free_rid(light2);
+	rs->free_rid(light_instance2);
+	rs->free_rid(camera);
+	rs->free_rid(camera_attributes);
+	rs->free_rid(scenario);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -780,56 +783,59 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const Ref<Resource> &p_from, co
 }
 
 EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
-	scenario = RS::get_singleton()->scenario_create();
+	RS *rs = RS::get_singleton();
 
-	viewport = RS::get_singleton()->viewport_create();
-	RS::get_singleton()->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
-	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
-	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
-	RS::get_singleton()->viewport_set_active(viewport, true);
-	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
+	scenario = rs->scenario_create();
 
-	camera = RS::get_singleton()->camera_create();
-	RS::get_singleton()->viewport_attach_camera(viewport, camera);
-	RS::get_singleton()->camera_set_transform(camera, Transform3D(Basis(), Vector3(0, 0, 3)));
-	//RS::get_singleton()->camera_set_perspective(camera,45,0.1,10);
-	RS::get_singleton()->camera_set_orthogonal(camera, 1.0, 0.01, 1000.0);
+	viewport = rs->viewport_create();
+	rs->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
+	rs->viewport_set_scenario(viewport, scenario);
+	rs->viewport_set_size(viewport, 128, 128);
+	rs->viewport_set_transparent_background(viewport, true);
+	rs->viewport_set_active(viewport, true);
+	viewport_texture = rs->viewport_get_texture(viewport);
+
+	camera = rs->camera_create();
+	rs->viewport_attach_camera(viewport, camera);
+	rs->camera_set_transform(camera, Transform3D(Basis(), Vector3(0, 0, 3)));
+	//rs->camera_set_perspective(camera,45,0.1,10);
+	rs->camera_set_orthogonal(camera, 1.0, 0.01, 1000.0);
 
 	if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
-		camera_attributes = RS::get_singleton()->camera_attributes_create();
-		RS::get_singleton()->camera_attributes_set_exposure(camera_attributes, 1.0, 0.000032552); // Matches default CameraAttributesPhysical to work well with default DirectionalLight3Ds.
-		RS::get_singleton()->camera_set_camera_attributes(camera, camera_attributes);
+		camera_attributes = rs->camera_attributes_create();
+		rs->camera_attributes_set_exposure(camera_attributes, 1.0, 0.000032552); // Matches default CameraAttributesPhysical to work well with default DirectionalLight3Ds.
+		rs->camera_set_camera_attributes(camera, camera_attributes);
 	}
 
-	light = RS::get_singleton()->directional_light_create();
-	light_instance = RS::get_singleton()->instance_create2(light, scenario);
-	RS::get_singleton()->instance_set_transform(light_instance, Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
+	light = rs->directional_light_create();
+	light_instance = rs->instance_create2(light, scenario);
+	rs->instance_set_transform(light_instance, Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
 
-	light2 = RS::get_singleton()->directional_light_create();
-	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
-	//RS::get_singleton()->light_set_color(light2, RSE::LIGHT_COLOR_SPECULAR, Color(0.0, 0.0, 0.0));
-	light_instance2 = RS::get_singleton()->instance_create2(light2, scenario);
+	light2 = rs->directional_light_create();
+	rs->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	//rs->light_set_color(light2, RSE::LIGHT_COLOR_SPECULAR, Color(0.0, 0.0, 0.0));
+	light_instance2 = rs->instance_create2(light2, scenario);
 
-	RS::get_singleton()->instance_set_transform(light_instance2, Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
+	rs->instance_set_transform(light_instance2, Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
 
-	//sphere = RS::get_singleton()->mesh_create();
-	mesh_instance = RS::get_singleton()->instance_create();
-	RS::get_singleton()->instance_set_scenario(mesh_instance, scenario);
+	//sphere = rs->mesh_create();
+	mesh_instance = rs->instance_create();
+	rs->instance_set_scenario(mesh_instance, scenario);
 }
 
 EditorMeshPreviewPlugin::~EditorMeshPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	//RS::get_singleton()->free(sphere);
-	RS::get_singleton()->free_rid(mesh_instance);
-	RS::get_singleton()->free_rid(viewport);
-	RS::get_singleton()->free_rid(light);
-	RS::get_singleton()->free_rid(light_instance);
-	RS::get_singleton()->free_rid(light2);
-	RS::get_singleton()->free_rid(light_instance2);
-	RS::get_singleton()->free_rid(camera);
-	RS::get_singleton()->free_rid(camera_attributes);
-	RS::get_singleton()->free_rid(scenario);
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
+	//rs->free(sphere);
+	rs->free_rid(mesh_instance);
+	rs->free_rid(viewport);
+	rs->free_rid(light);
+	rs->free_rid(light_instance);
+	rs->free_rid(light2);
+	rs->free_rid(light_instance2);
+	rs->free_rid(camera);
+	rs->free_rid(camera_attributes);
+	rs->free_rid(scenario);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -898,24 +904,27 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate(const Ref<Resource> &p_from, co
 }
 
 EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
-	viewport = RS::get_singleton()->viewport_create();
-	RS::get_singleton()->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
-	RS::get_singleton()->viewport_set_active(viewport, true);
-	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
+	RS *rs = RS::get_singleton();
 
-	canvas = RS::get_singleton()->canvas_create();
-	canvas_item = RS::get_singleton()->canvas_item_create();
+	viewport = rs->viewport_create();
+	rs->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_DISABLED);
+	rs->viewport_set_size(viewport, 128, 128);
+	rs->viewport_set_active(viewport, true);
+	viewport_texture = rs->viewport_get_texture(viewport);
 
-	RS::get_singleton()->viewport_attach_canvas(viewport, canvas);
-	RS::get_singleton()->canvas_item_set_parent(canvas_item, canvas);
+	canvas = rs->canvas_create();
+	canvas_item = rs->canvas_item_create();
+
+	rs->viewport_attach_canvas(viewport, canvas);
+	rs->canvas_item_set_parent(canvas_item, canvas);
 }
 
 EditorFontPreviewPlugin::~EditorFontPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free_rid(canvas_item);
-	RS::get_singleton()->free_rid(canvas);
-	RS::get_singleton()->free_rid(viewport);
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
+	rs->free_rid(canvas_item);
+	rs->free_rid(canvas);
+	rs->free_rid(viewport);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1097,11 +1097,12 @@ void EditorResourcePicker::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Callable resource_saved = callable_mp(this, &EditorResourcePicker::_resource_saved);
 			Callable resource_counter_changed = callable_mp(this, &EditorResourcePicker::_update_resource);
-			if (EditorNode::get_singleton()->is_connected("resource_saved", resource_saved)) {
-				EditorNode::get_singleton()->disconnect("resource_saved", resource_saved);
+			EditorNode *editor_node = EditorNode::get_singleton();
+			if (editor_node->is_connected("resource_saved", resource_saved)) {
+				editor_node->disconnect("resource_saved", resource_saved);
 			}
-			if (EditorNode::get_singleton()->is_connected("resource_counter_changed", resource_counter_changed)) {
-				EditorNode::get_singleton()->disconnect("resource_counter_changed", resource_counter_changed);
+			if (editor_node->is_connected("resource_counter_changed", resource_counter_changed)) {
+				editor_node->disconnect("resource_counter_changed", resource_counter_changed);
 			}
 		} break;
 	}

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -105,12 +105,13 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 			Variant old_value = n->get(p_name);
 			Variant::Type type = old_value.get_type();
 			if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && old_value != new_value) {
-				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", old_value, n, true);
-				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", new_value, n, false);
+				EditorNode *editor_node = EditorNode::get_singleton();
+				ur->add_do_method(editor_node, "update_node_reference", old_value, n, true);
+				ur->add_do_method(editor_node, "update_node_reference", new_value, n, false);
 				// Perhaps an inefficient way of updating the resource count.
 				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-				ur->add_undo_method(EditorNode::get_singleton(), "update_node_reference", new_value, n, true);
-				ur->add_undo_method(EditorNode::get_singleton(), "update_node_reference", old_value, n, false);
+				ur->add_undo_method(editor_node, "update_node_reference", new_value, n, true);
+				ur->add_undo_method(editor_node, "update_node_reference", old_value, n, false);
 			}
 		}
 	}

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -129,21 +129,23 @@ void ProjectListItemControl::_notification(int p_what) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_LIST_BOX_OPTION);
-			AccessibilityServer::get_singleton()->update_set_name(ae, TTR("Project") + " " + project_title->get_text());
-			AccessibilityServer::get_singleton()->update_set_value(ae, project_title->get_text());
+			AccessibilityServer *accessibility_server = AccessibilityServer::get_singleton();
 
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &ProjectListItemControl::_accessibility_action_open));
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SCROLL_INTO_VIEW, callable_mp(this, &ProjectListItemControl::_accessibility_action_scroll_into_view));
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_FOCUS, callable_mp(this, &ProjectListItemControl::_accessibility_action_focus));
-			AccessibilityServer::get_singleton()->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_BLUR, callable_mp(this, &ProjectListItemControl::_accessibility_action_blur));
+			accessibility_server->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_LIST_BOX_OPTION);
+			accessibility_server->update_set_name(ae, TTR("Project") + " " + project_title->get_text());
+			accessibility_server->update_set_value(ae, project_title->get_text());
+
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &ProjectListItemControl::_accessibility_action_open));
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_SCROLL_INTO_VIEW, callable_mp(this, &ProjectListItemControl::_accessibility_action_scroll_into_view));
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_FOCUS, callable_mp(this, &ProjectListItemControl::_accessibility_action_focus));
+			accessibility_server->update_add_action(ae, AccessibilityServerEnums::AccessibilityAction::ACTION_BLUR, callable_mp(this, &ProjectListItemControl::_accessibility_action_blur));
 
 			ProjectList *pl = get_list();
 			if (pl) {
-				AccessibilityServer::get_singleton()->update_set_list_item_index(ae, pl->get_index(this));
+				accessibility_server->update_set_list_item_index(ae, pl->get_index(this));
 			}
-			AccessibilityServer::get_singleton()->update_set_list_item_level(ae, 0);
-			AccessibilityServer::get_singleton()->update_set_list_item_selected(ae, is_selected);
+			accessibility_server->update_set_list_item_level(ae, 0);
+			accessibility_server->update_set_list_item_selected(ae, is_selected);
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -180,16 +180,18 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 void ProjectManager::_update_size_limits() {
 	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
 
+	DisplayServer *ds = DisplayServer::get_singleton();
+
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
 	if (w) {
 		// Calling Window methods this early doesn't sync properties with DS.
 		w->set_min_size(minimum_size);
-		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
+		ds->window_set_min_size(minimum_size);
 	}
-	Size2 real_size = DisplayServer::get_singleton()->window_get_size();
+	Size2 real_size = ds->window_get_size();
 
-	Rect2i screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServer::get_singleton()->window_get_current_screen());
+	Rect2i screen_rect = ds->screen_get_usable_rect(ds->window_get_current_screen());
 	if (screen_rect.size != Vector2i()) {
 		// Center the window on the screen.
 		Vector2i window_position;

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -70,11 +70,12 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	args.push_back("--editor-pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
-	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
-	bool debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);
-	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
-	bool debug_avoidance = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_avoidance", false);
-	bool debug_canvas_redraw = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
+	EditorSettings *es = EditorSettings::get_singleton();
+	bool debug_collisions = es->get_project_metadata("debug_options", "run_debug_collisions", false);
+	bool debug_paths = es->get_project_metadata("debug_options", "run_debug_paths", false);
+	bool debug_navigation = es->get_project_metadata("debug_options", "run_debug_navigation", false);
+	bool debug_avoidance = es->get_project_metadata("debug_options", "run_debug_avoidance", false);
+	bool debug_canvas_redraw = es->get_project_metadata("debug_options", "run_debug_canvas_redraw", false);
 	bool debug_mute_audio = EditorDebuggerNode::get_singleton()->get_debug_mute_audio();
 
 	if (debug_collisions) {

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -259,7 +259,9 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 		return;
 	}
 
-	if (!EditorNode::get_singleton()->validate_custom_directory()) {
+	EditorNode *editor_node = EditorNode::get_singleton();
+
+	if (!editor_node->validate_custom_directory()) {
 		return;
 	}
 
@@ -270,7 +272,7 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 		String project_file_path = resource_path.path_join("project.godot");
 		if (!FileAccess::exists(project_file_path)) {
 			// TODO: Try to recover the "project.godot" file using ProjectSettings::get_singleton()->save()
-			EditorNode::get_singleton()->show_warning(
+			editor_node->show_warning(
 					TTRC("Failed to run the project because the project.godot file is missing."),
 					TTRC("Error!"));
 			return;
@@ -304,7 +306,7 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 
 		if (write_movie_file.is_empty()) {
 			// TODO: Provide options to directly resolve the issue with a custom dialog.
-			EditorNode::get_singleton()->show_accept(TTR("Movie Maker mode is enabled, but no movie file path has been specified.\nA default movie file path can be specified in the project settings under the Editor > Movie Writer category.\nAlternatively, for running single scenes, a `movie_file` string metadata can be added to the root node,\nspecifying the path to a movie file that will be used when recording that scene."), TTR("OK"));
+			editor_node->show_accept(TTR("Movie Maker mode is enabled, but no movie file path has been specified.\nA default movie file path can be specified in the project settings under the Editor > Movie Writer category.\nAlternatively, for running single scenes, a `movie_file` string metadata can be added to the root node,\nspecifying the path to a movie file that will be used when recording that scene."), TTR("OK"));
 			return;
 		}
 	}
@@ -325,12 +327,12 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 
 			Node *scene_root = get_tree()->get_edited_scene_root();
 			if (!scene_root) {
-				EditorNode::get_singleton()->show_accept(TTR("There is no defined scene to run."), TTR("OK"));
+				editor_node->show_accept(TTR("There is no defined scene to run."), TTR("OK"));
 				return;
 			}
 
 			if (scene_root->get_scene_file_path().is_empty()) {
-				EditorNode::get_singleton()->save_before_run();
+				editor_node->save_before_run();
 				return;
 			}
 
@@ -339,7 +341,7 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 		} break;
 
 		default: {
-			if (!EditorNode::get_singleton()->ensure_main_scene(false)) {
+			if (!editor_node->ensure_main_scene(false)) {
 				return;
 			}
 
@@ -347,24 +349,26 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 		} break;
 	}
 
-	EditorNode::get_singleton()->try_autosave();
-	if (!EditorNode::get_singleton()->call_build()) {
+	editor_node->try_autosave();
+	if (!editor_node->call_build()) {
 		return;
 	}
 
 	Vector<String> args = p_run_args;
-	EditorNode::get_singleton()->call_run_scene(run_filename, args);
+	editor_node->call_run_scene(run_filename, args);
+
+	EditorDebuggerNode *debug_node = EditorDebuggerNode::get_singleton();
 
 	// Use the existing URI, in case it is overridden by the CLI.
-	String uri = EditorDebuggerNode::get_singleton()->get_server_uri();
+	String uri = debug_node->get_server_uri();
 	if (uri.is_empty()) {
 		uri = "tcp://";
 	}
-	EditorDebuggerNode::get_singleton()->start(uri);
+	debug_node->start(uri);
 	Error error = editor_run.run(run_filename, write_movie_file, args);
 	if (error != OK) {
-		EditorDebuggerNode::get_singleton()->stop();
-		EditorNode::get_singleton()->show_accept(TTR("Could not start subprocess(es)!"), TTR("OK"));
+		debug_node->stop();
+		editor_node->show_accept(TTR("Could not start subprocess(es)!"), TTR("OK"));
 		return;
 	}
 
@@ -391,16 +395,19 @@ void EditorRunBar::_run_native(const Ref<EditorExportPreset> &p_preset) {
 }
 
 void EditorRunBar::_profiler_autostart_indicator_pressed() {
-	// Switch to the first profiler tab in the bottom panel.
-	EditorDebuggerNode::get_singleton()->make_visible();
+	EditorDebuggerNode *debug_node = EditorDebuggerNode::get_singleton();
+	EditorSettings *settings = EditorSettings::get_singleton();
 
-	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(3);
-	} else if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false)) {
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(4);
+	// Switch to the first profiler tab in the bottom panel.
+	debug_node->make_visible();
+
+	if (settings->get_project_metadata("debug_options", "autostart_profiler", false)) {
+		debug_node->get_current_debugger()->switch_to_debugger(3);
+	} else if (settings->get_project_metadata("debug_options", "autostart_visual_profiler", false)) {
+		debug_node->get_current_debugger()->switch_to_debugger(4);
 	} else {
 		// Switch to the network profiler tab.
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(8);
+		debug_node->get_current_debugger()->switch_to_debugger(8);
 	}
 }
 

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -977,12 +977,13 @@ Path2DEditor::Path2DEditor() {
 }
 
 Path2DEditor::~Path2DEditor() {
-	ERR_FAIL_NULL(RS::get_singleton());
-	RS::get_singleton()->free_rid(debug_mesh_rid);
-	RS::get_singleton()->free_rid(debug_handle_curve_multimesh_rid);
-	RS::get_singleton()->free_rid(debug_handle_sharp_multimesh_rid);
-	RS::get_singleton()->free_rid(debug_handle_smooth_multimesh_rid);
-	RS::get_singleton()->free_rid(debug_handle_mesh_rid);
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
+	rs->free_rid(debug_mesh_rid);
+	rs->free_rid(debug_handle_curve_multimesh_rid);
+	rs->free_rid(debug_handle_sharp_multimesh_rid);
+	rs->free_rid(debug_handle_smooth_multimesh_rid);
+	rs->free_rid(debug_handle_mesh_rid);
 }
 
 void Path2DEditorPlugin::edit(Object *p_object) {

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1332,11 +1332,12 @@ Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
 }
 
 Polygon2DEditor::Polygon2DEditor() {
-	snap_offset = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_offset", Vector2());
+	EditorSettings *editor_settings = EditorSettings::get_singleton();
+	snap_offset = editor_settings->get_project_metadata("polygon_2d_uv_editor", "snap_offset", Vector2());
 	// A power-of-two value works better as a default grid size.
-	snap_step = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(8, 8));
-	use_snap = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_enabled", false);
-	snap_show_grid = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "show_grid", false);
+	snap_step = editor_settings->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(8, 8));
+	use_snap = editor_settings->get_project_metadata("polygon_2d_uv_editor", "snap_enabled", false);
+	snap_show_grid = editor_settings->get_project_metadata("polygon_2d_uv_editor", "show_grid", false);
 
 	selected_action = ACTION_EDIT_POINT;
 

--- a/editor/scene/2d/tiles/tile_atlas_view.cpp
+++ b/editor/scene/2d/tiles/tile_atlas_view.cpp
@@ -308,10 +308,11 @@ RID TileAtlasView::_get_canvas_item_to_draw(const TileData *p_for_data, const Ca
 	} else if (p_material_map.has(mat)) {
 		return p_material_map[mat];
 	} else {
-		RID ci_rid = RS::get_singleton()->canvas_item_create();
-		RS::get_singleton()->canvas_item_set_parent(ci_rid, p_base_item->get_canvas_item());
-		RS::get_singleton()->canvas_item_set_material(ci_rid, mat->get_rid());
-		RS::get_singleton()->canvas_item_set_default_texture_filter(ci_rid, RSE::CanvasItemTextureFilter(p_base_item->get_texture_filter_in_tree()));
+		RS *rs = RS::get_singleton();
+		RID ci_rid = rs->canvas_item_create();
+		rs->canvas_item_set_parent(ci_rid, p_base_item->get_canvas_item());
+		rs->canvas_item_set_material(ci_rid, mat->get_rid());
+		rs->canvas_item_set_default_texture_filter(ci_rid, RSE::CanvasItemTextureFilter(p_base_item->get_texture_filter_in_tree()));
 		p_material_map[mat] = ci_rid;
 		return ci_rid;
 	}

--- a/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
@@ -43,10 +43,11 @@ Light3DGizmoPlugin::Light3DGizmoPlugin() {
 	create_material("lines_secondary", Color(1, 1, 1, 0.35), false, false, true);
 	create_material("lines_billboard", Color(1, 1, 1), true, false, true);
 
-	create_icon_material("light_directional_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoDirectionalLight"), EditorStringName(EditorIcons)));
-	create_icon_material("light_omni_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoLight"), EditorStringName(EditorIcons)));
-	create_icon_material("light_spot_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoSpotLight"), EditorStringName(EditorIcons)));
-	create_icon_material("light_area_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoAreaLight"), EditorStringName(EditorIcons)));
+	EditorNode *editor_node = EditorNode::get_singleton();
+	create_icon_material("light_directional_icon", editor_node->get_editor_theme()->get_icon(SNAME("GizmoDirectionalLight"), EditorStringName(EditorIcons)));
+	create_icon_material("light_omni_icon", editor_node->get_editor_theme()->get_icon(SNAME("GizmoLight"), EditorStringName(EditorIcons)));
+	create_icon_material("light_spot_icon", editor_node->get_editor_theme()->get_icon(SNAME("GizmoSpotLight"), EditorStringName(EditorIcons)));
+	create_icon_material("light_area_icon", editor_node->get_editor_theme()->get_icon(SNAME("GizmoAreaLight"), EditorStringName(EditorIcons)));
 
 	create_handle_material("handles");
 	create_handle_material("handles_billboard", true);

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -214,19 +214,20 @@ void EditorNode3DGizmo::set_node_3d(Node3D *p_node) {
 }
 
 void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden) {
-	instance = RS::get_singleton()->instance_create2(mesh->get_rid(), p_base->get_world_3d()->get_scenario());
-	RS::get_singleton()->instance_attach_object_instance_id(instance, p_base->get_instance_id());
+	RS *rs = RS::get_singleton();
+	instance = rs->instance_create2(mesh->get_rid(), p_base->get_world_3d()->get_scenario());
+	rs->instance_attach_object_instance_id(instance, p_base->get_instance_id());
 	if (skin_reference.is_valid()) {
-		RS::get_singleton()->instance_attach_skeleton(instance, skin_reference->get_skeleton());
+		rs->instance_attach_skeleton(instance, skin_reference->get_skeleton());
 	}
 	if (extra_margin) {
-		RS::get_singleton()->instance_set_extra_visibility_margin(instance, 1);
+		rs->instance_set_extra_visibility_margin(instance, 1);
 	}
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(instance, RSE::SHADOW_CASTING_SETTING_OFF);
+	rs->instance_geometry_set_cast_shadows_setting(instance, RSE::SHADOW_CASTING_SETTING_OFF);
 	int layer = p_hidden ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
-	RS::get_singleton()->instance_set_layer_mask(instance, layer); //gizmos are 26
-	RS::get_singleton()->instance_geometry_set_flag(instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	rs->instance_set_layer_mask(instance, layer); //gizmos are 26
+	rs->instance_geometry_set_flag(instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 }
 
 void EditorNode3DGizmo::add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p_material, const Transform3D &p_xform, const Ref<SkinReference> &p_skin_reference) {
@@ -810,8 +811,10 @@ void EditorNode3DGizmo::create() {
 void EditorNode3DGizmo::transform() {
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);
+
+	RS *rs = RS::get_singleton();
 	for (int i = 0; i < instances.size(); i++) {
-		RS::get_singleton()->instance_set_transform(instances[i].instance, spatial_node->get_global_transform() * instances[i].xform);
+		rs->instance_set_transform(instances[i].instance, spatial_node->get_global_transform() * instances[i].xform);
 	}
 
 	_update_bvh();
@@ -822,9 +825,10 @@ void EditorNode3DGizmo::free() {
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);
 
+	RS *rs = RS::get_singleton();
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
-			RS::get_singleton()->free_rid(instances[i].instance);
+			rs->free_rid(instances[i].instance);
 		}
 		instances.write[i].instance = RID();
 	}
@@ -840,8 +844,9 @@ void EditorNode3DGizmo::free() {
 void EditorNode3DGizmo::set_hidden(bool p_hidden) {
 	hidden = p_hidden;
 	int layer = hidden ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
+	RS *rs = RS::get_singleton();
 	for (int i = 0; i < instances.size(); ++i) {
-		RS::get_singleton()->instance_set_layer_mask(instances[i].instance, layer);
+		rs->instance_set_layer_mask(instances[i].instance, layer);
 	}
 }
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3607,6 +3607,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 				follow_mode->hide();
 			}
 
+			RS *rs = RS::get_singleton();
+
 			Node *scene_root = SceneTreeDock::get_singleton()->get_editor_data()->get_edited_scene_root();
 			if (previewing_cinema && scene_root != nullptr) {
 				Camera3D *cam = scene_root->get_viewport()->get_camera_3d();
@@ -3620,7 +3622,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 					previewing = cam;
 					previewing->connect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 					previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
-					RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
+					rs->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
 					surface->queue_redraw();
 				}
 			}
@@ -3687,10 +3689,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 					t_offset.basis = t_offset.basis * aabb_s;
 				}
 
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+				rs->instance_set_transform(se->sbox_instance, t);
+				rs->instance_set_transform(se->sbox_instance_offset, t_offset);
+				rs->instance_set_transform(se->sbox_instance_xray, t);
+				rs->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
 			}
 
 			if (changed || (spatial_editor->is_gizmo_visible() && !exist)) {
@@ -4795,92 +4797,95 @@ void Node3DEditorViewport::_update_centered_labels() {
 void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 	uint32_t layer = 1 << (GIZMO_BASE_LAYER + p_idx);
 
+	RS *rs = RS::get_singleton();
+
 	for (int i = 0; i < 3; i++) {
-		move_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(move_gizmo_instance[i], spatial_editor->get_move_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(move_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		move_gizmo_instance[i] = rs->instance_create();
+		rs->instance_set_base(move_gizmo_instance[i], spatial_editor->get_move_gizmo(i)->get_rid());
+		rs->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(move_gizmo_instance[i], false);
+		rs->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(move_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(move_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-		move_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(move_plane_gizmo_instance[i], spatial_editor->get_move_plane_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(move_plane_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		move_plane_gizmo_instance[i] = rs->instance_create();
+		rs->instance_set_base(move_plane_gizmo_instance[i], spatial_editor->get_move_plane_gizmo(i)->get_rid());
+		rs->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(move_plane_gizmo_instance[i], false);
+		rs->instance_geometry_set_cast_shadows_setting(move_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(move_plane_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(move_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-		scale_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(scale_gizmo_instance[i], spatial_editor->get_scale_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(scale_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		scale_gizmo_instance[i] = rs->instance_create();
+		rs->instance_set_base(scale_gizmo_instance[i], spatial_editor->get_scale_gizmo(i)->get_rid());
+		rs->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(scale_gizmo_instance[i], false);
+		rs->instance_geometry_set_cast_shadows_setting(scale_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(scale_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(scale_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-		scale_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(scale_plane_gizmo_instance[i], spatial_editor->get_scale_plane_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(scale_plane_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		scale_plane_gizmo_instance[i] = rs->instance_create();
+		rs->instance_set_base(scale_plane_gizmo_instance[i], spatial_editor->get_scale_plane_gizmo(i)->get_rid());
+		rs->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(scale_plane_gizmo_instance[i], false);
+		rs->instance_geometry_set_cast_shadows_setting(scale_plane_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(scale_plane_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(scale_plane_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-		axis_gizmo_instance[i] = RS::get_singleton()->instance_create();
+		axis_gizmo_instance[i] = rs->instance_create();
 	}
 
 	for (int i = 0; i < 3; i++) {
-		RS::get_singleton()->instance_set_base(axis_gizmo_instance[i], spatial_editor->get_axis_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(axis_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(axis_gizmo_instance[i], true);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(axis_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(axis_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		rs->instance_set_base(axis_gizmo_instance[i], spatial_editor->get_axis_gizmo(i)->get_rid());
+		rs->instance_set_scenario(axis_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(axis_gizmo_instance[i], true);
+		rs->instance_geometry_set_cast_shadows_setting(axis_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(axis_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(axis_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 
 	for (int i = 0; i < 4; i++) {
-		rotate_gizmo_instance[i] = RS::get_singleton()->instance_create();
-		RS::get_singleton()->instance_set_base(rotate_gizmo_instance[i], spatial_editor->get_rotate_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
-		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(rotate_gizmo_instance[i], layer);
-		RS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		rotate_gizmo_instance[i] = rs->instance_create();
+		rs->instance_set_base(rotate_gizmo_instance[i], spatial_editor->get_rotate_gizmo(i)->get_rid());
+		rs->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->instance_set_visible(rotate_gizmo_instance[i], false);
+		rs->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(rotate_gizmo_instance[i], layer);
+		rs->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(rotate_gizmo_instance[i], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 
 	// Create trackball sphere instance
-	trackball_sphere_instance = RS::get_singleton()->instance_create();
-	RS::get_singleton()->instance_set_base(trackball_sphere_instance, spatial_editor->get_trackball_sphere_gizmo()->get_rid());
-	RS::get_singleton()->instance_set_scenario(trackball_sphere_instance, get_tree()->get_root()->get_world_3d()->get_scenario());
-	RS::get_singleton()->instance_set_visible(trackball_sphere_instance, false);
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(trackball_sphere_instance, RSE::SHADOW_CASTING_SETTING_OFF);
-	RS::get_singleton()->instance_set_layer_mask(trackball_sphere_instance, layer);
-	RS::get_singleton()->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	trackball_sphere_instance = rs->instance_create();
+	rs->instance_set_base(trackball_sphere_instance, spatial_editor->get_trackball_sphere_gizmo()->get_rid());
+	rs->instance_set_scenario(trackball_sphere_instance, get_tree()->get_root()->get_world_3d()->get_scenario());
+	rs->instance_set_visible(trackball_sphere_instance, false);
+	rs->instance_geometry_set_cast_shadows_setting(trackball_sphere_instance, RSE::SHADOW_CASTING_SETTING_OFF);
+	rs->instance_set_layer_mask(trackball_sphere_instance, layer);
+	rs->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(trackball_sphere_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 }
 
 void Node3DEditorViewport::_finish_gizmo_instances() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
 	for (int i = 0; i < 3; i++) {
-		RS::get_singleton()->free_rid(move_gizmo_instance[i]);
-		RS::get_singleton()->free_rid(move_plane_gizmo_instance[i]);
-		RS::get_singleton()->free_rid(rotate_gizmo_instance[i]);
-		RS::get_singleton()->free_rid(scale_gizmo_instance[i]);
-		RS::get_singleton()->free_rid(scale_plane_gizmo_instance[i]);
-		RS::get_singleton()->free_rid(axis_gizmo_instance[i]);
+		rs->free_rid(move_gizmo_instance[i]);
+		rs->free_rid(move_plane_gizmo_instance[i]);
+		rs->free_rid(rotate_gizmo_instance[i]);
+		rs->free_rid(scale_gizmo_instance[i]);
+		rs->free_rid(scale_plane_gizmo_instance[i]);
+		rs->free_rid(axis_gizmo_instance[i]);
 	}
 	// Rotation white outline
-	RS::get_singleton()->free_rid(rotate_gizmo_instance[3]);
+	rs->free_rid(rotate_gizmo_instance[3]);
 
-	RS::get_singleton()->free_rid(trackball_sphere_instance);
+	rs->free_rid(trackball_sphere_instance);
 }
 
 void Node3DEditorViewport::_disable_follow_mode() {
@@ -5029,20 +5034,22 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 		return;
 	}
 
+	RS *rs = RS::get_singleton();
+
 	Transform3D xform = spatial_editor->get_gizmo_transform();
 
 	Transform3D camera_xform = camera->get_transform();
 
 	if (xform.origin.is_equal_approx(camera_xform.origin)) {
 		for (int i = 0; i < 3; i++) {
-			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(axis_gizmo_instance[i], false);
+			rs->instance_set_visible(move_gizmo_instance[i], false);
+			rs->instance_set_visible(move_plane_gizmo_instance[i], false);
+			rs->instance_set_visible(rotate_gizmo_instance[i], false);
+			rs->instance_set_visible(scale_gizmo_instance[i], false);
+			rs->instance_set_visible(scale_plane_gizmo_instance[i], false);
+			rs->instance_set_visible(axis_gizmo_instance[i], false);
 		}
-		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
+		rs->instance_set_visible(rotate_gizmo_instance[3], false);
 		return;
 	}
 
@@ -5067,14 +5074,14 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 	// this prevents supplying bad values to the renderer and then having to filter it out again.
 	if (xform.basis.determinant() == 0) {
 		for (int i = 0; i < 3; i++) {
-			RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
-			RenderingServer::get_singleton()->instance_set_visible(axis_gizmo_instance[i], false);
+			rs->instance_set_visible(move_gizmo_instance[i], false);
+			rs->instance_set_visible(move_plane_gizmo_instance[i], false);
+			rs->instance_set_visible(rotate_gizmo_instance[i], false);
+			rs->instance_set_visible(scale_gizmo_instance[i], false);
+			rs->instance_set_visible(scale_plane_gizmo_instance[i], false);
+			rs->instance_set_visible(axis_gizmo_instance[i], false);
 		}
-		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], false);
+		rs->instance_set_visible(rotate_gizmo_instance[3], false);
 		return;
 	}
 
@@ -5116,17 +5123,17 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 		}
 		axis_angle.basis.scale(scale);
 		axis_angle.origin = xform.origin;
-		RenderingServer::get_singleton()->instance_set_transform(move_gizmo_instance[i], axis_angle);
-		RenderingServer::get_singleton()->instance_set_visible(move_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
-		RenderingServer::get_singleton()->instance_set_transform(move_plane_gizmo_instance[i], axis_angle);
-		RenderingServer::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
-		RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[i], axis_angle);
-		RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], show_rotate_gizmo && i != arc_replaces_ring);
-		RenderingServer::get_singleton()->instance_set_transform(scale_gizmo_instance[i], axis_angle);
-		RenderingServer::get_singleton()->instance_set_visible(scale_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
-		RenderingServer::get_singleton()->instance_set_transform(scale_plane_gizmo_instance[i], axis_angle);
-		RenderingServer::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
-		RenderingServer::get_singleton()->instance_set_transform(axis_gizmo_instance[i], xform);
+		rs->instance_set_transform(move_gizmo_instance[i], axis_angle);
+		rs->instance_set_visible(move_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		rs->instance_set_transform(move_plane_gizmo_instance[i], axis_angle);
+		rs->instance_set_visible(move_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_MOVE));
+		rs->instance_set_transform(rotate_gizmo_instance[i], axis_angle);
+		rs->instance_set_visible(rotate_gizmo_instance[i], show_rotate_gizmo && i != arc_replaces_ring);
+		rs->instance_set_transform(scale_gizmo_instance[i], axis_angle);
+		rs->instance_set_visible(scale_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		rs->instance_set_transform(scale_plane_gizmo_instance[i], axis_angle);
+		rs->instance_set_visible(scale_plane_gizmo_instance[i], show_gizmo && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SCALE));
+		rs->instance_set_transform(axis_gizmo_instance[i], xform);
 	}
 
 	Transform3D view_rotation_xform = xform;
@@ -5136,17 +5143,16 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 	bool show_trackball_sphere = can_show_trackball && (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_TRANSFORM || spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_ROTATE) && !hide_gizmo_during_trackball;
 	Transform3D trackball_xform = view_rotation_xform;
 	trackball_xform.basis.scale(scale);
-	RenderingServer::get_singleton()->instance_set_transform(trackball_sphere_instance, trackball_xform);
-	RenderingServer::get_singleton()->instance_set_visible(trackball_sphere_instance, show_trackball_sphere);
+	rs->instance_set_transform(trackball_sphere_instance, trackball_xform);
+	rs->instance_set_visible(trackball_sphere_instance, show_trackball_sphere);
 
 	bool shrink_view_ring = arc_replaces_ring >= 0 && arc_replaces_ring < 3;
 	Vector3 view_ring_scale = shrink_view_ring ? scale : scale * (spatial_editor->gizmo_view_rotation_scale / GIZMO_CIRCLE_SIZE);
 	view_rotation_xform.basis.scale(view_ring_scale);
-	RenderingServer::get_singleton()->instance_set_transform(rotate_gizmo_instance[3], view_rotation_xform);
-	RenderingServer::get_singleton()->instance_set_visible(rotate_gizmo_instance[3], show_rotate_gizmo && arc_replaces_ring != 3);
+	rs->instance_set_transform(rotate_gizmo_instance[3], view_rotation_xform);
+	rs->instance_set_visible(rotate_gizmo_instance[3], show_rotate_gizmo && arc_replaces_ring != 3);
 
 	bool show_axes = spatial_editor->is_gizmo_visible() && _edit.mode != TRANSFORM_NONE && !hide_gizmo_during_trackball;
-	RenderingServer *rs = RenderingServer::get_singleton();
 	rs->instance_set_visible(axis_gizmo_instance[0], show_axes && (_edit.plane == TRANSFORM_X_AXIS || _edit.plane == TRANSFORM_XY || _edit.plane == TRANSFORM_XZ));
 	rs->instance_set_visible(axis_gizmo_instance[1], show_axes && (_edit.plane == TRANSFORM_Y_AXIS || _edit.plane == TRANSFORM_XY || _edit.plane == TRANSFORM_YZ));
 	rs->instance_set_visible(axis_gizmo_instance[2], show_axes && (_edit.plane == TRANSFORM_Z_AXIS || _edit.plane == TRANSFORM_XZ || _edit.plane == TRANSFORM_YZ));
@@ -6780,39 +6786,40 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	vbox->add_child(hbox);
 
 	view_display_menu = memnew(MenuButton);
+	PopupMenu *view_display_menu_popup = view_display_menu->get_popup();
 	view_display_menu->set_flat(false);
 	view_display_menu->set_h_size_flags(0);
 	view_display_menu->set_shortcut_context(this);
 	view_display_menu->set_accessibility_name(TTRC("View"));
 	view_display_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	view_display_menu->get_popup()->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+	view_display_menu_popup->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	hbox->add_child(view_display_menu);
 
-	view_display_menu->get_popup()->set_hide_on_checkable_item_selection(false);
+	view_display_menu_popup->set_hide_on_checkable_item_selection(false);
 
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/top_view"), VIEW_TOP);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/bottom_view"), VIEW_BOTTOM);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/left_view"), VIEW_LEFT);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/right_view"), VIEW_RIGHT);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/front_view"), VIEW_FRONT);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/rear_view"), VIEW_REAR);
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/switch_perspective_orthogonal"), VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL);
-	view_display_menu->get_popup()->add_radio_check_item(TTRC("Perspective"), VIEW_PERSPECTIVE);
-	view_display_menu->get_popup()->add_radio_check_item(TTRC("Orthogonal"), VIEW_ORTHOGONAL);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_PERSPECTIVE), true);
-	view_display_menu->get_popup()->add_check_item(TTRC("Auto Orthogonal Enabled"), VIEW_AUTO_ORTHOGONAL);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL), true);
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_lock_rotation", TTRC("Lock View Rotation")), VIEW_LOCK_ROTATION);
-	view_display_menu->get_popup()->add_separator();
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/top_view"), VIEW_TOP);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/bottom_view"), VIEW_BOTTOM);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/left_view"), VIEW_LEFT);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/right_view"), VIEW_RIGHT);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/front_view"), VIEW_FRONT);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/rear_view"), VIEW_REAR);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/switch_perspective_orthogonal"), VIEW_SWITCH_PERSPECTIVE_ORTHOGONAL);
+	view_display_menu_popup->add_radio_check_item(TTRC("Perspective"), VIEW_PERSPECTIVE);
+	view_display_menu_popup->add_radio_check_item(TTRC("Orthogonal"), VIEW_ORTHOGONAL);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_PERSPECTIVE), true);
+	view_display_menu_popup->add_check_item(TTRC("Auto Orthogonal Enabled"), VIEW_AUTO_ORTHOGONAL);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_AUTO_ORTHOGONAL), true);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_lock_rotation", TTRC("Lock View Rotation")), VIEW_LOCK_ROTATION);
+	view_display_menu_popup->add_separator();
 	// TRANSLATORS: "Normal" as in "normal life", not "normal vector".
-	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_normal", TTRC("Display Normal")), VIEW_DISPLAY_NORMAL);
-	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_wireframe", TTRC("Display Wireframe")), VIEW_DISPLAY_WIREFRAME);
-	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_overdraw", TTRC("Display Overdraw")), VIEW_DISPLAY_OVERDRAW);
-	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_lighting", TTRC("Display Lighting")), VIEW_DISPLAY_LIGHTING);
-	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTRC("Display Unshaded")), VIEW_DISPLAY_UNSHADED);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
+	view_display_menu_popup->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_normal", TTRC("Display Normal")), VIEW_DISPLAY_NORMAL);
+	view_display_menu_popup->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_wireframe", TTRC("Display Wireframe")), VIEW_DISPLAY_WIREFRAME);
+	view_display_menu_popup->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_overdraw", TTRC("Display Overdraw")), VIEW_DISPLAY_OVERDRAW);
+	view_display_menu_popup->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_lighting", TTRC("Display Lighting")), VIEW_DISPLAY_LIGHTING);
+	view_display_menu_popup->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTRC("Display Unshaded")), VIEW_DISPLAY_UNSHADED);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_DISPLAY_NORMAL), true);
 
 	display_submenu = memnew(PopupMenu);
 	display_submenu->set_hide_on_checkable_item_selection(false);
@@ -6872,35 +6879,35 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 			TTRC("Represents motion vectors with colored lines in the direction of motion. Gray dots represent areas with no per-pixel motion."));
 	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Internal Buffer"), VIEW_DISPLAY_INTERNAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
 			TTRC("Shows the scene rendered in linear colorspace before any tonemapping or post-processing."));
-	view_display_menu->get_popup()->add_submenu_node_item(TTRC("Display Advanced..."), display_submenu, VIEW_DISPLAY_ADVANCED);
+	view_display_menu_popup->add_submenu_node_item(TTRC("Display Advanced..."), display_submenu, VIEW_DISPLAY_ADVANCED);
 
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment")), VIEW_ENVIRONMENT);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos")), VIEW_GIZMOS);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_transform_gizmo", TTRC("View Transform Gizmo")), VIEW_TRANSFORM_GIZMO);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid")), VIEW_GRID);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information")), VIEW_INFORMATION);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time")), VIEW_FRAME_TIME);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ENVIRONMENT), true);
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTRC("Half Resolution")), VIEW_HALF_RESOLUTION);
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_listener", TTRC("Audio Listener")), VIEW_AUDIO_LISTENER);
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_doppler", TTRC("Enable Doppler")), VIEW_AUDIO_DOPPLER);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS), true);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO), true);
-	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID), true);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment")), VIEW_ENVIRONMENT);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos")), VIEW_GIZMOS);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_transform_gizmo", TTRC("View Transform Gizmo")), VIEW_TRANSFORM_GIZMO);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid")), VIEW_GRID);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information")), VIEW_INFORMATION);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time")), VIEW_FRAME_TIME);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_ENVIRONMENT), true);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_half_resolution", TTRC("Half Resolution")), VIEW_HALF_RESOLUTION);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_listener", TTRC("Audio Listener")), VIEW_AUDIO_LISTENER);
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_audio_doppler", TTRC("Enable Doppler")), VIEW_AUDIO_DOPPLER);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_GIZMOS), true);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_TRANSFORM_GIZMO), true);
+	view_display_menu_popup->set_item_checked(view_display_menu_popup->get_item_index(VIEW_GRID), true);
 
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
 
-	view_display_menu->get_popup()->add_separator();
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
-	view_display_menu->get_popup()->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
-	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
-	view_display_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
+	view_display_menu_popup->add_separator();
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
+	view_display_menu_popup->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
+	view_display_menu_popup->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
+	view_display_menu_popup->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
 	display_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
 	view_display_menu->set_disable_shortcuts(true);
 
@@ -7360,18 +7367,19 @@ Node3DEditorViewportContainer::Node3DEditorViewportContainer() {
 Node3DEditor *Node3DEditor::singleton = nullptr;
 
 Node3DEditorSelectedItem::~Node3DEditorSelectedItem() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RS *rs = RS::get_singleton();
+	ERR_FAIL_NULL(rs);
 	if (sbox_instance.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(sbox_instance);
+		rs->free_rid(sbox_instance);
 	}
 	if (sbox_instance_offset.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(sbox_instance_offset);
+		rs->free_rid(sbox_instance_offset);
 	}
 	if (sbox_instance_xray.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(sbox_instance_xray);
+		rs->free_rid(sbox_instance_xray);
 	}
 	if (sbox_instance_xray_offset.is_valid()) {
-		RenderingServer::get_singleton()->free_rid(sbox_instance_xray_offset);
+		rs->free_rid(sbox_instance_xray_offset);
 	}
 }
 
@@ -7485,49 +7493,51 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 		return nullptr;
 	}
 
+	RS *rs = RS::get_singleton();
+
 	Node3DEditorSelectedItem *si = memnew(Node3DEditorSelectedItem);
 
 	si->sp = sp;
-	si->sbox_instance = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance = rs->instance_create2(
 			selection_box->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	si->sbox_instance_offset = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance_offset = rs->instance_create2(
 			selection_box->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
+	rs->instance_geometry_set_cast_shadows_setting(
 			si->sbox_instance,
 			RSE::SHADOW_CASTING_SETTING_OFF);
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
+	rs->instance_geometry_set_cast_shadows_setting(
 			si->sbox_instance_offset,
 			RSE::SHADOW_CASTING_SETTING_OFF);
 	// Use the Edit layer to hide the selection box when View Gizmos is disabled, since it is a bit distracting.
 	// It's still possible to approximately guess what is selected by looking at the manipulation gizmo position.
-	RS::get_singleton()->instance_set_layer_mask(si->sbox_instance, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
-	RS::get_singleton()->instance_set_layer_mask(si->sbox_instance_offset, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-	si->sbox_instance_xray = RenderingServer::get_singleton()->instance_create2(
+	rs->instance_set_layer_mask(si->sbox_instance, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
+	rs->instance_set_layer_mask(si->sbox_instance_offset, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
+	rs->instance_geometry_set_flag(si->sbox_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(si->sbox_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	rs->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	si->sbox_instance_xray = rs->instance_create2(
 			selection_box_xray->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	si->sbox_instance_xray_offset = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance_xray_offset = rs->instance_create2(
 			selection_box_xray->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
+	rs->instance_geometry_set_cast_shadows_setting(
 			si->sbox_instance_xray,
 			RSE::SHADOW_CASTING_SETTING_OFF);
-	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
+	rs->instance_geometry_set_cast_shadows_setting(
 			si->sbox_instance_xray_offset,
 			RSE::SHADOW_CASTING_SETTING_OFF);
 	// Use the Edit layer to hide the selection box when View Gizmos is disabled, since it is a bit distracting.
 	// It's still possible to approximately guess what is selected by looking at the manipulation gizmo position.
-	RS::get_singleton()->instance_set_layer_mask(si->sbox_instance_xray, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
-	RS::get_singleton()->instance_set_layer_mask(si->sbox_instance_xray_offset, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	rs->instance_set_layer_mask(si->sbox_instance_xray, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
+	rs->instance_set_layer_mask(si->sbox_instance_xray_offset, 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER);
+	rs->instance_geometry_set_flag(si->sbox_instance_xray, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(si->sbox_instance_xray, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+	rs->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+	rs->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
 	return si;
 }
@@ -8079,31 +8089,35 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 		} break;
 		case MENU_VERTEX_SNAP_BASE_VERTEX: {
 			vertex_snap_origin_mode = false;
-			int idx_vertex = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX);
-			int idx_origin = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_BASE_ORIGIN);
-			transform_menu->get_popup()->set_item_checked(idx_vertex, true);
-			transform_menu->get_popup()->set_item_checked(idx_origin, false);
+			PopupMenu *transform_menu_popup = transform_menu->get_popup();
+			int idx_vertex = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX);
+			int idx_origin = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_BASE_ORIGIN);
+			transform_menu_popup->set_item_checked(idx_vertex, true);
+			transform_menu_popup->set_item_checked(idx_origin, false);
 		} break;
 		case MENU_VERTEX_SNAP_BASE_ORIGIN: {
 			vertex_snap_origin_mode = true;
-			int idx_vertex = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX);
-			int idx_origin = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_BASE_ORIGIN);
-			transform_menu->get_popup()->set_item_checked(idx_vertex, false);
-			transform_menu->get_popup()->set_item_checked(idx_origin, true);
+			PopupMenu *transform_menu_popup = transform_menu->get_popup();
+			int idx_vertex = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX);
+			int idx_origin = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_BASE_ORIGIN);
+			transform_menu_popup->set_item_checked(idx_vertex, false);
+			transform_menu_popup->set_item_checked(idx_origin, true);
 		} break;
 		case MENU_VERTEX_SNAP_SOURCE_MESH: {
 			vertex_snap_use_collision = false;
-			int idx_mesh = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH);
-			int idx_collision = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_SOURCE_COLLISION);
-			transform_menu->get_popup()->set_item_checked(idx_mesh, true);
-			transform_menu->get_popup()->set_item_checked(idx_collision, false);
+			PopupMenu *transform_menu_popup = transform_menu->get_popup();
+			int idx_mesh = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH);
+			int idx_collision = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_SOURCE_COLLISION);
+			transform_menu_popup->set_item_checked(idx_mesh, true);
+			transform_menu_popup->set_item_checked(idx_collision, false);
 		} break;
 		case MENU_VERTEX_SNAP_SOURCE_COLLISION: {
 			vertex_snap_use_collision = true;
-			int idx_mesh = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH);
-			int idx_collision = transform_menu->get_popup()->get_item_index(MENU_VERTEX_SNAP_SOURCE_COLLISION);
-			transform_menu->get_popup()->set_item_checked(idx_mesh, false);
-			transform_menu->get_popup()->set_item_checked(idx_collision, true);
+			PopupMenu *transform_menu_popup = transform_menu->get_popup();
+			int idx_mesh = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH);
+			int idx_collision = transform_menu_popup->get_item_index(MENU_VERTEX_SNAP_SOURCE_COLLISION);
+			transform_menu_popup->set_item_checked(idx_mesh, false);
+			transform_menu_popup->set_item_checked(idx_collision, true);
 		} break;
 		case MENU_TRANSFORM_DIALOG: {
 			for (int i = 0; i < 3; i++) {
@@ -8121,12 +8135,13 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				last_used_viewport = 0;
 			}
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), true);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), true);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
 
 		} break;
 		case MENU_VIEW_USE_2_VIEWPORTS: {
@@ -8135,12 +8150,13 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				last_used_viewport = 0;
 			}
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), true);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), true);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
 
 		} break;
 		case MENU_VIEW_USE_2_VIEWPORTS_ALT: {
@@ -8149,12 +8165,13 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				last_used_viewport = 0;
 			}
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), true);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), true);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
 
 		} break;
 		case MENU_VIEW_USE_3_VIEWPORTS: {
@@ -8163,12 +8180,13 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				last_used_viewport = 0;
 			}
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), true);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), true);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
 
 		} break;
 		case MENU_VIEW_USE_3_VIEWPORTS_ALT: {
@@ -8177,41 +8195,46 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				last_used_viewport = 0;
 			}
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), true);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), true);
 
 		} break;
 		case MENU_VIEW_USE_4_VIEWPORTS: {
 			viewport_base->set_view(Node3DEditorViewportContainer::VIEW_USE_4_VIEWPORTS);
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), true);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_1_VIEWPORT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_4_VIEWPORTS), true);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_2_VIEWPORTS_ALT), false);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(MENU_VIEW_USE_3_VIEWPORTS_ALT), false);
 
 		} break;
 		case MENU_VIEW_ORIGIN: {
-			bool is_checked = view_layout_menu->get_popup()->is_item_checked(view_layout_menu->get_popup()->get_item_index(p_option));
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+
+			bool is_checked = view_layout_menu_popup->is_item_checked(view_layout_menu_popup->get_item_index(p_option));
 
 			origin_enabled = !is_checked;
-			RenderingServer::get_singleton()->instance_set_visible(origin_instance, origin_enabled);
+			RS::get_singleton()->instance_set_visible(origin_instance, origin_enabled);
 			// Update the grid since its appearance depends on whether the origin is enabled
 			_finish_grid();
 			_init_grid();
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(p_option), origin_enabled);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(p_option), origin_enabled);
 		} break;
 		case MENU_VIEW_GRID: {
-			bool is_checked = view_layout_menu->get_popup()->is_item_checked(view_layout_menu->get_popup()->get_item_index(p_option));
+			PopupMenu *view_layout_menu_popup = view_layout_menu->get_popup();
+
+			bool is_checked = view_layout_menu_popup->is_item_checked(view_layout_menu_popup->get_item_index(p_option));
 
 			grid_enabled = !is_checked;
-
 			for (int i = 0; i < 3; ++i) {
 				if (grid_enable[i]) {
 					grid_visible[i] = grid_enabled;
@@ -8220,7 +8243,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			_finish_grid();
 			_init_grid();
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(p_option), grid_enabled);
+			view_layout_menu_popup->set_item_checked(view_layout_menu_popup->get_item_index(p_option), grid_enabled);
 
 		} break;
 		case MENU_VIEW_CAMERA_SETTINGS: {
@@ -9056,6 +9079,8 @@ void Node3DEditor::_init_grid() {
 		division_level_min = (int)(division_level_min / div);
 	}
 
+	RS *rs = RS::get_singleton();
+
 	for (int a = 0; a < 3; a++) {
 		if (!grid_enable[a]) {
 			continue; // If this grid plane is disabled, skip generation.
@@ -9177,37 +9202,39 @@ void Node3DEditor::_init_grid() {
 		}
 
 		// Create a mesh from the pushed vector points and colors.
-		grid[c] = RenderingServer::get_singleton()->mesh_create();
+		grid[c] = rs->mesh_create();
 		Array d;
 		d.resize(RSE::ARRAY_MAX);
 		d[RSE::ARRAY_VERTEX] = (Vector<Vector3>)grid_points[c];
 		d[RSE::ARRAY_COLOR] = (Vector<Color>)grid_colors[c];
 		d[RSE::ARRAY_NORMAL] = (Vector<Vector3>)grid_normals[c];
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(grid[c], RSE::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
-		grid_instance[c] = RenderingServer::get_singleton()->instance_create2(grid[c], get_tree()->get_root()->get_world_3d()->get_scenario());
+		rs->mesh_add_surface_from_arrays(grid[c], RSE::PRIMITIVE_LINES, d);
+		rs->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
+		grid_instance[c] = rs->instance_create2(grid[c], get_tree()->get_root()->get_world_3d()->get_scenario());
 
 		// Yes, the end of this line is supposed to be a.
-		RenderingServer::get_singleton()->instance_set_visible(grid_instance[c], grid_visible[a]);
-		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[c], RSE::SHADOW_CASTING_SETTING_OFF);
-		RS::get_singleton()->instance_set_layer_mask(grid_instance[c], 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
-		RS::get_singleton()->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-		RS::get_singleton()->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+		rs->instance_set_visible(grid_instance[c], grid_visible[a]);
+		rs->instance_geometry_set_cast_shadows_setting(grid_instance[c], RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_layer_mask(grid_instance[c], 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
+		rs->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+		rs->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	}
 }
 
 void Node3DEditor::_finish_indicators() {
-	RenderingServer::get_singleton()->free_rid(origin_instance);
-	RenderingServer::get_singleton()->free_rid(origin_multimesh);
-	RenderingServer::get_singleton()->free_rid(origin_mesh);
+	RS *rs = RS::get_singleton();
+	rs->free_rid(origin_instance);
+	rs->free_rid(origin_multimesh);
+	rs->free_rid(origin_mesh);
 
 	_finish_grid();
 }
 
 void Node3DEditor::_finish_grid() {
+	RS *rs = RS::get_singleton();
 	for (int i = 0; i < 3; i++) {
-		RenderingServer::get_singleton()->free_rid(grid_instance[i]);
-		RenderingServer::get_singleton()->free_rid(grid[i]);
+		rs->free_rid(grid_instance[i]);
+		rs->free_rid(grid[i]);
 	}
 }
 
@@ -9272,16 +9299,17 @@ void Node3DEditor::_selection_changed() {
 			continue;
 		}
 
+		RS *rs = RS::get_singleton();
 		if (sp == editor_selection->get_top_selected_node_list().back()->get()) {
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance, active_selection_box->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray, active_selection_box_xray->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_offset, active_selection_box->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray_offset, active_selection_box_xray->get_rid());
+			rs->instance_set_base(se->sbox_instance, active_selection_box->get_rid());
+			rs->instance_set_base(se->sbox_instance_xray, active_selection_box_xray->get_rid());
+			rs->instance_set_base(se->sbox_instance_offset, active_selection_box->get_rid());
+			rs->instance_set_base(se->sbox_instance_xray_offset, active_selection_box_xray->get_rid());
 		} else {
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance, selection_box->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray, selection_box_xray->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_offset, selection_box->get_rid());
-			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray_offset, selection_box_xray->get_rid());
+			rs->instance_set_base(se->sbox_instance, selection_box->get_rid());
+			rs->instance_set_base(se->sbox_instance_xray, selection_box_xray->get_rid());
+			rs->instance_set_base(se->sbox_instance_offset, selection_box->get_rid());
+			rs->instance_set_base(se->sbox_instance_xray_offset, selection_box_xray->get_rid());
 		}
 	}
 

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -1307,10 +1307,12 @@ Path3DGizmoPlugin::Path3DGizmoPlugin() {
 	create_material("path_thin_material", Color(0.6, 0.6, 0.6));
 	create_material("path_tilt_material", path_tilt_color);
 	create_material("path_tilt_muted_material", path_tilt_color * 0.7);
-	create_handle_material("handles", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
-	create_handle_material("first_pt_handle", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
-	create_handle_material("last_pt_handle", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
-	create_handle_material("closed_pt_handle", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
-	create_handle_material("selected_pt_handle", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
-	create_handle_material("sec_handles", false, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("EditorCurveHandle"), EditorStringName(EditorIcons)));
+
+	Ref<Theme> editor_theme = EditorNode::get_singleton()->get_editor_theme();
+	create_handle_material("handles", false, editor_theme->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
+	create_handle_material("first_pt_handle", false, editor_theme->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
+	create_handle_material("last_pt_handle", false, editor_theme->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
+	create_handle_material("closed_pt_handle", false, editor_theme->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
+	create_handle_material("selected_pt_handle", false, editor_theme->get_icon(SNAME("EditorPathSmoothHandle"), EditorStringName(EditorIcons)));
+	create_handle_material("sec_handles", false, editor_theme->get_icon(SNAME("EditorCurveHandle"), EditorStringName(EditorIcons)));
 }

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -967,12 +967,13 @@ void CanvasItemEditor::_commit_canvas_item_state(const List<CanvasItem *> &p_can
 void CanvasItemEditor::_snap_changed() {
 	static_cast<SnapDialog *>(snap_dialog)->get_fields(grid_offset, grid_step, primary_grid_step, snap_rotation_offset, snap_rotation_step, snap_scale_step);
 
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_offset", grid_offset);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_step", grid_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "primary_grid_step", primary_grid_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_offset", snap_rotation_offset);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_step", snap_rotation_step);
-	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_scale_step", snap_scale_step);
+	EditorSettings *es = EditorSettings::get_singleton();
+	es->set_project_metadata("2d_editor", "grid_offset", grid_offset);
+	es->set_project_metadata("2d_editor", "grid_step", grid_step);
+	es->set_project_metadata("2d_editor", "primary_grid_step", primary_grid_step);
+	es->set_project_metadata("2d_editor", "snap_rotation_offset", snap_rotation_offset);
+	es->set_project_metadata("2d_editor", "snap_rotation_step", snap_rotation_step);
+	es->set_project_metadata("2d_editor", "snap_scale_step", snap_scale_step);
 
 	grid_step_multiplier = 0;
 	viewport->queue_redraw();
@@ -1186,15 +1187,16 @@ void CanvasItemEditor::_switch_theme_preview(int p_mode) {
 
 bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_event) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 	Ref<InputEventMouseButton> b = p_event;
 	Ref<InputEventMouseMotion> m = p_event;
 
 	if (drag_type == DRAG_NONE) {
-		if (show_guides && show_rulers && EditorNode::get_singleton()->get_edited_scene()) {
+		if (show_guides && show_rulers && edited_scene) {
 			Transform2D xform = viewport_scrollable->get_transform() * transform;
 			// Retrieve the guide lists
-			Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_", Array());
-			Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_", Array());
+			Array vguides = edited_scene->get_meta("_edit_vertical_guides_", Array());
+			Array hguides = edited_scene->get_meta("_edit_horizontal_guides_", Array());
 
 			// Hover over guides
 			real_t minimum = 1e20;
@@ -1283,12 +1285,12 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 
 		// Release confirms the guide move
 		if (b.is_valid() && b->get_button_index() == MouseButton::LEFT && !b->is_pressed()) {
-			if (show_guides && EditorNode::get_singleton()->get_edited_scene()) {
+			if (show_guides && edited_scene) {
 				Transform2D xform = viewport_scrollable->get_transform() * transform;
 
 				// Retrieve the guide lists
-				Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_", Array());
-				Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_", Array());
+				Array vguides = edited_scene->get_meta("_edit_vertical_guides_", Array());
+				Array hguides = edited_scene->get_meta("_edit_horizontal_guides_", Array());
 
 				Point2 edited = snap_point(xform.affine_inverse().xform(b->get_position()), SNAP_GRID | SNAP_PIXEL | SNAP_OTHER_NODES);
 				if (drag_type == DRAG_V_GUIDE) {
@@ -1298,18 +1300,18 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							vguides[dragged_guide_index] = edited.x;
 							undo_redo->create_action(TTR("Move Vertical Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_do_method(edited_scene, "set_meta", "_edit_vertical_guides_", vguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_vertical_guides_", prev_vguides);
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						} else {
 							vguides.push_back(edited.x);
 							undo_redo->create_action(TTR("Create Vertical Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+							undo_redo->add_do_method(edited_scene, "set_meta", "_edit_vertical_guides_", vguides);
 							if (prev_vguides.is_empty()) {
-								undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
+								undo_redo->add_undo_method(edited_scene, "remove_meta", "_edit_vertical_guides_");
 							} else {
-								undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+								undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_vertical_guides_", prev_vguides);
 							}
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
@@ -1319,11 +1321,11 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							vguides.remove_at(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Vertical Guide"));
 							if (vguides.is_empty()) {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
+								undo_redo->add_do_method(edited_scene, "remove_meta", "_edit_vertical_guides_");
 							} else {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
+								undo_redo->add_do_method(edited_scene, "set_meta", "_edit_vertical_guides_", vguides);
 							}
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_vertical_guides_", prev_vguides);
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
@@ -1335,18 +1337,18 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						if (dragged_guide_index >= 0) {
 							hguides[dragged_guide_index] = edited.y;
 							undo_redo->create_action(TTR("Move Horizontal Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_do_method(edited_scene, "set_meta", "_edit_horizontal_guides_", hguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_horizontal_guides_", prev_hguides);
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						} else {
 							hguides.push_back(edited.y);
 							undo_redo->create_action(TTR("Create Horizontal Guide"));
-							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+							undo_redo->add_do_method(edited_scene, "set_meta", "_edit_horizontal_guides_", hguides);
 							if (prev_hguides.is_empty()) {
-								undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
+								undo_redo->add_undo_method(edited_scene, "remove_meta", "_edit_horizontal_guides_");
 							} else {
-								undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+								undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_horizontal_guides_", prev_hguides);
 							}
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
@@ -1356,11 +1358,11 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							hguides.remove_at(dragged_guide_index);
 							undo_redo->create_action(TTR("Remove Horizontal Guide"));
 							if (hguides.is_empty()) {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
+								undo_redo->add_do_method(edited_scene, "remove_meta", "_edit_horizontal_guides_");
 							} else {
-								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+								undo_redo->add_do_method(edited_scene, "set_meta", "_edit_horizontal_guides_", hguides);
 							}
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_horizontal_guides_", prev_hguides);
 							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
@@ -1373,17 +1375,17 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						vguides.push_back(edited.x);
 						hguides.push_back(edited.y);
 						undo_redo->create_action(TTR("Create Horizontal and Vertical Guides"));
-						undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
-						undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
+						undo_redo->add_do_method(edited_scene, "set_meta", "_edit_vertical_guides_", vguides);
+						undo_redo->add_do_method(edited_scene, "set_meta", "_edit_horizontal_guides_", hguides);
 						if (prev_vguides.is_empty()) {
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_vertical_guides_");
+							undo_redo->add_undo_method(edited_scene, "remove_meta", "_edit_vertical_guides_");
 						} else {
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_vertical_guides_", prev_vguides);
 						}
 						if (prev_hguides.is_empty()) {
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "remove_meta", "_edit_horizontal_guides_");
+							undo_redo->add_undo_method(edited_scene, "remove_meta", "_edit_horizontal_guides_");
 						} else {
-							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
+							undo_redo->add_undo_method(edited_scene, "set_meta", "_edit_horizontal_guides_", prev_hguides);
 						}
 						undo_redo->add_undo_method(viewport, "queue_redraw");
 						undo_redo->commit_action();
@@ -5518,12 +5520,13 @@ void CanvasItemEditor::clear() {
 	previous_update_view_offset = view_offset; // Moves the view a little bit to the left so that (0,0) is visible. The values a relative to a 16/10 screen.
 	_update_scrollbars();
 
-	grid_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_offset", Vector2());
-	grid_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_step", Vector2(8, 8));
-	primary_grid_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "primary_grid_step", Vector2i(8, 8));
-	snap_rotation_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_step", Math::deg_to_rad(15.0));
-	snap_rotation_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_offset", 0.0);
-	snap_scale_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_scale_step", 0.1);
+	EditorSettings *es = EditorSettings::get_singleton();
+	grid_offset = es->get_project_metadata("2d_editor", "grid_offset", Vector2());
+	grid_step = es->get_project_metadata("2d_editor", "grid_step", Vector2(8, 8));
+	primary_grid_step = es->get_project_metadata("2d_editor", "primary_grid_step", Vector2i(8, 8));
+	snap_rotation_step = es->get_project_metadata("2d_editor", "snap_rotation_step", Math::deg_to_rad(15.0));
+	snap_rotation_offset = es->get_project_metadata("2d_editor", "snap_rotation_offset", 0.0);
+	snap_scale_step = es->get_project_metadata("2d_editor", "snap_scale_step", 0.1);
 
 	if (auto_resampling_enabled) {
 		if (resample_timer->is_inside_tree()) {

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -270,23 +270,24 @@ void EditorSceneTabs::update_scene_tabs() {
 	}
 	menu_initialized = true;
 
-	if (NativeMenu::get_singleton()->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
-		RID dock_rid = NativeMenu::get_singleton()->get_system_menu(NativeMenu::DOCK_MENU_ID);
-		NativeMenu::get_singleton()->clear(dock_rid);
+	NativeMenu *native_menu = NativeMenu::get_singleton();
+	if (native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
+		RID dock_rid = native_menu->get_system_menu(NativeMenu::DOCK_MENU_ID);
+		native_menu->clear(dock_rid);
 	}
 
 	scene_tabs->set_block_signals(true);
 	scene_tabs->set_tab_count(EditorNode::get_editor_data().get_edited_scene_count());
 	scene_tabs->set_block_signals(false);
 
-	if (NativeMenu::get_singleton()->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
-		RID dock_rid = NativeMenu::get_singleton()->get_system_menu(NativeMenu::DOCK_MENU_ID);
+	if (native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
+		RID dock_rid = native_menu->get_system_menu(NativeMenu::DOCK_MENU_ID);
 		for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
-			int global_menu_index = NativeMenu::get_singleton()->add_item(dock_rid, EditorNode::get_editor_data().get_scene_title(i), callable_mp(this, &EditorSceneTabs::_global_menu_scene), Callable(), i);
+			int global_menu_index = native_menu->add_item(dock_rid, EditorNode::get_editor_data().get_scene_title(i), callable_mp(this, &EditorSceneTabs::_global_menu_scene), Callable(), i);
 			scene_tabs->set_tab_metadata(i, global_menu_index);
 		}
-		NativeMenu::get_singleton()->add_separator(dock_rid);
-		NativeMenu::get_singleton()->add_item(dock_rid, TTR("New Window"), callable_mp(this, &EditorSceneTabs::_global_menu_new_window));
+		native_menu->add_separator(dock_rid);
+		native_menu->add_item(dock_rid, TTR("New Window"), callable_mp(this, &EditorSceneTabs::_global_menu_new_window));
 	}
 
 	_update_tab_titles();
@@ -329,11 +330,12 @@ void EditorSceneTabs::_update_tab_titles() {
 			scene_tabs->set_font_color_override(i, TabBar::DRAW_PRESSED, get_theme_color(SNAME("font_selected_color"), SNAME("TabBar")));
 		}
 
-		if (NativeMenu::get_singleton()->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
-			RID dock_rid = NativeMenu::get_singleton()->get_system_menu(NativeMenu::DOCK_MENU_ID);
+		NativeMenu *native_menu = NativeMenu::get_singleton();
+		if (native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
+			RID dock_rid = native_menu->get_system_menu(NativeMenu::DOCK_MENU_ID);
 			int global_menu_index = scene_tabs->get_tab_metadata(i);
-			NativeMenu::get_singleton()->set_item_text(dock_rid, global_menu_index, EditorNode::get_editor_data().get_scene_title(i) + (unsaved ? "(*)" : ""));
-			NativeMenu::get_singleton()->set_item_tag(dock_rid, global_menu_index, i);
+			native_menu->set_item_text(dock_rid, global_menu_index, EditorNode::get_editor_data().get_scene_title(i) + (unsaved ? "(*)" : ""));
+			native_menu->set_item_tag(dock_rid, global_menu_index, i);
 		}
 
 		if (show_rb && EditorNode::get_editor_data().get_scene_root_script(i).is_valid()) {

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -82,8 +82,9 @@ void GroupSettingsEditor::_item_edited() {
 
 		undo_redo->create_action(TTR("Set Group Description"));
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), name, new_description);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, old_description);
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		undo_redo->add_do_property(ps, name, new_description);
+		undo_redo->add_undo_property(ps, name, old_description);
 
 		undo_redo->add_do_method(this, CoreStringName(call_deferred), "update_groups");
 		undo_redo->add_undo_method(this, CoreStringName(call_deferred), "update_groups");
@@ -159,8 +160,9 @@ void GroupSettingsEditor::_add_group(const String &p_name, const String &p_descr
 
 	name = GLOBAL_GROUP_PREFIX + name;
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, p_description);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, Variant());
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	undo_redo->add_do_property(ps, name, p_description);
+	undo_redo->add_undo_property(ps, name, Variant());
 
 	undo_redo->add_do_method(this, CoreStringName(call_deferred), "update_groups");
 	undo_redo->add_undo_method(this, CoreStringName(call_deferred), "update_groups");
@@ -348,11 +350,13 @@ void GroupSettingsEditor::_confirm_rename() {
 
 	String description = ti->get_meta("__description");
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), property_new_name, description);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_new_name, Variant());
+	ProjectSettings *ps = ProjectSettings::get_singleton();
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), property_old_name, Variant());
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), property_old_name, description);
+	undo_redo->add_do_property(ps, property_new_name, description);
+	undo_redo->add_undo_property(ps, property_new_name, Variant());
+
+	undo_redo->add_do_property(ps, property_old_name, Variant());
+	undo_redo->add_undo_property(ps, property_old_name, description);
 
 	if (rename_check_box->is_pressed()) {
 		undo_redo->add_do_method(this, "rename_references", old_name, new_name);

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -151,10 +151,12 @@ void TextureLayeredEditor::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	Input *input_singleton = Input::get_singleton();
+
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::RIGHT)) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
-			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
+		if (input_singleton->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			input_singleton->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 		}
 
 		y_rot += mm->get_relative().x * 0.01;
@@ -165,10 +167,10 @@ void TextureLayeredEditor::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
-			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
-			Input::get_singleton()->warp_mouse(original_mouse_pos);
-		} else if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+		if (input_singleton->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			input_singleton->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+			input_singleton->warp_mouse(original_mouse_pos);
+		} else if (input_singleton->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
 			original_mouse_pos = mb->get_global_position();
 		}
 	}

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -928,10 +928,11 @@ void TextureRegionEditor::_notification(int p_what) {
 			}
 
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_offset", snap_offset);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_step", snap_step);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_separation", snap_separation);
-				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_mode", snap_mode);
+				EditorSettings *es = EditorSettings::get_singleton();
+				es->set_project_metadata("texture_region_editor", "snap_offset", snap_offset);
+				es->set_project_metadata("texture_region_editor", "snap_step", snap_step);
+				es->set_project_metadata("texture_region_editor", "snap_separation", snap_separation);
+				es->set_project_metadata("texture_region_editor", "snap_mode", snap_mode);
 			}
 		} break;
 
@@ -1226,10 +1227,11 @@ TextureRegionEditor::TextureRegionEditor() {
 	set_close_on_escape(false);
 
 	// A power-of-two value works better as a default grid size.
-	snap_offset = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_offset", Vector2());
-	snap_step = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_step", Vector2(8, 8));
-	snap_separation = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_separation", Vector2());
-	snap_mode = (SnapMode)(int)EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_mode", SNAP_NONE);
+	EditorSettings *editor_settings = EditorSettings::get_singleton();
+	snap_offset = editor_settings->get_project_metadata("texture_region_editor", "snap_offset", Vector2());
+	snap_step = editor_settings->get_project_metadata("texture_region_editor", "snap_step", Vector2(8, 8));
+	snap_separation = editor_settings->get_project_metadata("texture_region_editor", "snap_separation", Vector2());
+	snap_mode = (SnapMode)(int)editor_settings->get_project_metadata("texture_region_editor", "snap_mode", SNAP_NONE);
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &TextureRegionEditor::_pan_callback), callable_mp(this, &TextureRegionEditor::_zoom_callback));

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1481,10 +1481,11 @@ void ScriptEditor::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			EditorSettings *es = EditorSettings::get_singleton();
 			if (EditorThemeManager::is_generated_theme_outdated() ||
-					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/fonts") ||
-					EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor") ||
-					EditorSettings::get_singleton()->check_changed_settings_in_group("docks/filesystem")) {
+					es->check_changed_settings_in_group("interface/editor/fonts") ||
+					es->check_changed_settings_in_group("text_editor") ||
+					es->check_changed_settings_in_group("docks/filesystem")) {
 				_apply_editor_settings();
 			}
 		} break;
@@ -1495,13 +1496,15 @@ void ScriptEditor::_notification(int p_what) {
 
 			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
 			InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
-			EditorNode::get_singleton()->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
-			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ScriptEditor::_close_builtin_scripts_from_scene));
-			EditorNode::get_singleton()->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
-			EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
-			EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
-			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
-			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
+			EditorNode *editor_node = EditorNode::get_singleton();
+			editor_node->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
+			editor_node->connect("scene_closed", callable_mp(this, &ScriptEditor::_close_builtin_scripts_from_scene));
+			editor_node->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
+			editor_node->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
+			editor_node->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
+			FileSystemDock *file_system_dock = FileSystemDock::get_singleton();
+			file_system_dock->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
+			file_system_dock->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
 			script_list->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditor::_script_selected));
 
 			members_overview->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditor::_members_overview_selected));
@@ -3934,6 +3937,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	set_process_shortcut_input(true);
 
 	file_menu = memnew(MenuButton);
+	PopupMenu *file_menu_popup = file_menu->get_popup();
 	file_menu->set_flat(false);
 	file_menu->set_theme_type_variation("FlatMenuButton");
 	file_menu->set_text(TTRC("File"));
@@ -3941,67 +3945,67 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	file_menu->set_shortcut_context(this);
 	menu_hb->add_child(file_menu);
 
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/new", TTRC("New Script..."), KeyModifierMask::CMD_OR_CTRL | Key::N), FILE_MENU_NEW_SCRIPT);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/new_textfile", TTRC("New Text File..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N), FILE_MENU_NEW_TEXTFILE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/open", TTRC("Open...")), FILE_MENU_OPEN);
-	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/reopen_closed_script"), FILE_MENU_REOPEN_CLOSED);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/new", TTRC("New Script..."), KeyModifierMask::CMD_OR_CTRL | Key::N), FILE_MENU_NEW_SCRIPT);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/new_textfile", TTRC("New Text File..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N), FILE_MENU_NEW_TEXTFILE);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/open", TTRC("Open...")), FILE_MENU_OPEN);
+	file_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_editor/reopen_closed_script"), FILE_MENU_REOPEN_CLOSED);
 
 	recent_scripts = memnew(PopupMenu);
 	recent_scripts->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	file_menu->get_popup()->add_submenu_node_item(TTRC("Open Recent"), recent_scripts, FILE_MENU_OPEN_RECENT);
+	file_menu_popup->add_submenu_node_item(TTRC("Open Recent"), recent_scripts, FILE_MENU_OPEN_RECENT);
 	recent_scripts->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_open_recent_script));
 
 	_update_recent_scripts();
 
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save", TTRC("Save"), KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_MENU_SAVE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save_as", TTRC("Save As...")), FILE_MENU_SAVE_AS);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save_all", TTRC("Save All"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::S), FILE_MENU_SAVE_ALL);
+	file_menu_popup->add_separator();
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/save", TTRC("Save"), KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_MENU_SAVE);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/save_as", TTRC("Save As...")), FILE_MENU_SAVE_AS);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/save_all", TTRC("Save All"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::S), FILE_MENU_SAVE_ALL);
 	ED_SHORTCUT_OVERRIDE("script_editor/save_all", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::S);
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/reload_script_soft", TTRC("Soft Reload Tool Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::R), FILE_MENU_SOFT_RELOAD_TOOL);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/copy_path", TTRC("Copy File Path")), FILE_MENU_COPY_PATH);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/copy_uid", TTRC("Copy File UID")), FILE_MENU_COPY_UID);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/show_in_file_system", TTRC("Show in FileSystem")), FILE_MENU_SHOW_IN_FILE_SYSTEM);
-	file_menu->get_popup()->add_separator();
+	file_menu_popup->add_separator();
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/reload_script_soft", TTRC("Soft Reload Tool Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::R), FILE_MENU_SOFT_RELOAD_TOOL);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/copy_path", TTRC("Copy File Path")), FILE_MENU_COPY_PATH);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/copy_uid", TTRC("Copy File UID")), FILE_MENU_COPY_UID);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/show_in_file_system", TTRC("Show in FileSystem")), FILE_MENU_SHOW_IN_FILE_SYSTEM);
+	file_menu_popup->add_separator();
 
-	file_menu->get_popup()->add_shortcut(
+	file_menu_popup->add_shortcut(
 			ED_SHORTCUT_ARRAY("script_editor/history_previous", TTRC("History Previous"),
 					{ int32_t(KeyModifierMask::ALT | Key::LEFT), int32_t(Key::BACK) }),
 			FILE_MENU_HISTORY_PREV);
-	file_menu->get_popup()->add_shortcut(
+	file_menu_popup->add_shortcut(
 			ED_SHORTCUT_ARRAY("script_editor/history_next", TTRC("History Next"),
 					{ int32_t(KeyModifierMask::ALT | Key::RIGHT), int32_t(Key::FORWARD) }),
 			FILE_MENU_HISTORY_NEXT);
 	ED_SHORTCUT_OVERRIDE("script_editor/history_previous", "macos", KeyModifierMask::ALT | KeyModifierMask::META | Key::LEFT);
 	ED_SHORTCUT_OVERRIDE("script_editor/history_next", "macos", KeyModifierMask::ALT | KeyModifierMask::META | Key::RIGHT);
 
-	file_menu->get_popup()->add_separator();
+	file_menu_popup->add_separator();
 
 	theme_submenu = memnew(PopupMenu);
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/import_theme", TTRC("Import Theme...")), THEME_IMPORT);
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/reload_theme", TTRC("Reload Theme")), THEME_RELOAD);
-	file_menu->get_popup()->add_submenu_node_item(TTRC("Theme"), theme_submenu, FILE_MENU_THEME_SUBMENU);
+	file_menu_popup->add_submenu_node_item(TTRC("Theme"), theme_submenu, FILE_MENU_THEME_SUBMENU);
 	theme_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_theme_option));
 
 	theme_submenu->add_separator();
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/save_theme_as", TTRC("Save Theme As...")), THEME_SAVE_AS);
 
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_file", TTRC("Close"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_MENU_CLOSE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_all", TTRC("Close All")), FILE_MENU_CLOSE_ALL);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_other_tabs", TTRC("Close Other Tabs")), FILE_MENU_CLOSE_OTHER_TABS);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_tabs_below", TTRC("Close Tabs Below")), FILE_MENU_CLOSE_TABS_BELOW);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_docs", TTRC("Close Docs")), FILE_MENU_CLOSE_DOCS);
+	file_menu_popup->add_separator();
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/close_file", TTRC("Close"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_MENU_CLOSE);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/close_all", TTRC("Close All")), FILE_MENU_CLOSE_ALL);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/close_other_tabs", TTRC("Close Other Tabs")), FILE_MENU_CLOSE_OTHER_TABS);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/close_tabs_below", TTRC("Close Tabs Below")), FILE_MENU_CLOSE_TABS_BELOW);
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/close_docs", TTRC("Close Docs")), FILE_MENU_CLOSE_DOCS);
 
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/run_file", TTRC("Run"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::X), FILE_MENU_RUN);
+	file_menu_popup->add_separator();
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/run_file", TTRC("Run"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::X), FILE_MENU_RUN);
 
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_files_panel", TTRC("Toggle Files Panel"), KeyModifierMask::CMD_OR_CTRL | Key::BACKSLASH), FILE_MENU_TOGGLE_FILES_PANEL);
-	file_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_menu_option));
-	file_menu->get_popup()->connect("about_to_popup", callable_mp(this, &ScriptEditor::_prepare_file_menu));
-	file_menu->get_popup()->connect("popup_hide", callable_mp(this, &ScriptEditor::_file_menu_closed));
+	file_menu_popup->add_separator();
+	file_menu_popup->add_shortcut(ED_SHORTCUT("script_editor/toggle_files_panel", TTRC("Toggle Files Panel"), KeyModifierMask::CMD_OR_CTRL | Key::BACKSLASH), FILE_MENU_TOGGLE_FILES_PANEL);
+	file_menu_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_menu_option));
+	file_menu_popup->connect("about_to_popup", callable_mp(this, &ScriptEditor::_prepare_file_menu));
+	file_menu_popup->connect("popup_hide", callable_mp(this, &ScriptEditor::_file_menu_closed));
 
 	script_search_menu = memnew(MenuButton);
 	script_search_menu->set_flat(false);

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -152,6 +152,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 	int column = tree->get_edited_column();
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
 	if (column == 0) {
 		String name = ti->get_text(0);
@@ -168,7 +169,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 			return;
 		}
 
-		if (ProjectSettings::get_singleton()->has_setting("autoload/" + name)) {
+		if (project_settings->has_setting("autoload/" + name)) {
 			ti->set_text(0, old_name);
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Autoload '%s' already exists!"), name));
 			return;
@@ -178,18 +179,18 @@ void EditorAutoloadSettings::_autoload_edited() {
 
 		name = "autoload/" + name;
 
-		int order = ProjectSettings::get_singleton()->get_order(selected_autoload);
+		int order = project_settings->get_order(selected_autoload);
 		String scr_path = GLOBAL_GET(selected_autoload);
 
 		undo_redo->create_action(TTR("Rename Autoload"));
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), name, scr_path);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, order);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", selected_autoload);
+		undo_redo->add_do_property(project_settings, name, scr_path);
+		undo_redo->add_do_method(project_settings, "set_order", name, order);
+		undo_redo->add_do_method(project_settings, "clear", selected_autoload);
 
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), selected_autoload, scr_path);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_autoload, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
+		undo_redo->add_undo_property(project_settings, selected_autoload, scr_path);
+		undo_redo->add_undo_method(project_settings, "set_order", selected_autoload, order);
+		undo_redo->add_undo_method(project_settings, "clear", name);
 
 		undo_redo->add_do_method(this, CoreStringName(call_deferred), "update_autoload");
 		undo_redo->add_undo_method(this, CoreStringName(call_deferred), "update_autoload");
@@ -206,7 +207,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 		bool checked = ti->is_checked(2);
 		String base = "autoload/" + ti->get_text(0);
 
-		int order = ProjectSettings::get_singleton()->get_order(base);
+		int order = project_settings->get_order(base);
 		String scr_path = GLOBAL_GET(base);
 
 		if (scr_path.begins_with("*")) {
@@ -220,11 +221,11 @@ void EditorAutoloadSettings::_autoload_edited() {
 
 		undo_redo->create_action(TTR("Toggle Autoload Globals"));
 
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), base, scr_path);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), base, GLOBAL_GET(base));
+		undo_redo->add_do_property(project_settings, base, scr_path);
+		undo_redo->add_undo_property(project_settings, base, GLOBAL_GET(base));
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", base, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", base, order);
+		undo_redo->add_do_method(project_settings, "set_order", base, order);
+		undo_redo->add_undo_method(project_settings, "set_order", base, order);
 
 		undo_redo->add_do_method(this, CoreStringName(call_deferred), "update_autoload");
 		undo_redo->add_undo_method(this, CoreStringName(call_deferred), "update_autoload");
@@ -247,6 +248,7 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 	String name = "autoload/" + ti->get_text(0);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
 	switch (p_button) {
 		case BUTTON_MOVE_UP:
@@ -265,16 +267,16 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 
 			String swap_name = "autoload/" + swap->get_text(0);
 
-			int order = ProjectSettings::get_singleton()->get_order(name);
-			int swap_order = ProjectSettings::get_singleton()->get_order(swap_name);
+			int order = project_settings->get_order(name);
+			int swap_order = project_settings->get_order(swap_name);
 
 			undo_redo->create_action(TTR("Move Autoload"));
 
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", name, swap_order);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
+			undo_redo->add_do_method(project_settings, "set_order", name, swap_order);
+			undo_redo->add_undo_method(project_settings, "set_order", name, order);
 
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", swap_name, order);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", swap_name, swap_order);
+			undo_redo->add_do_method(project_settings, "set_order", swap_name, order);
+			undo_redo->add_undo_method(project_settings, "set_order", swap_name, swap_order);
 
 			undo_redo->add_do_method(this, "update_autoload");
 			undo_redo->add_undo_method(this, "update_autoload");
@@ -285,14 +287,14 @@ void EditorAutoloadSettings::_autoload_button_pressed(Object *p_item, int p_colu
 			undo_redo->commit_action();
 		} break;
 		case BUTTON_DELETE: {
-			int order = ProjectSettings::get_singleton()->get_order(name);
+			int order = project_settings->get_order(name);
 
 			undo_redo->create_action(TTR("Remove Autoload"));
 
-			undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
+			undo_redo->add_do_property(project_settings, name, Variant());
 
-			undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, GLOBAL_GET(name));
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
+			undo_redo->add_undo_property(project_settings, name, GLOBAL_GET(name));
+			undo_redo->add_undo_method(project_settings, "set_order", name, order);
 
 			undo_redo->add_do_method(this, "update_autoload");
 			undo_redo->add_undo_method(this, "update_autoload");
@@ -685,6 +687,7 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 		move_to_back = true;
 	}
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	int order = ProjectSettings::get_singleton()->get_order("autoload/" + name);
 
 	AutoloadInfo aux;
@@ -744,8 +747,8 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 
 	idx = 0;
 	for (const AutoloadInfo &F : autoload_cache) {
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F.name, orders[idx++]);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", "autoload/" + F.name, F.order);
+		undo_redo->add_do_method(project_settings, "set_order", "autoload/" + F.name, orders[idx++]);
+		undo_redo->add_undo_method(project_settings, "set_order", "autoload/" + F.name, F.order);
 	}
 
 	orders.clear();
@@ -781,15 +784,16 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 	name = "autoload/" + name;
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
 	undo_redo->create_action(TTR("Add Autoload"));
 	// Singleton autoloads are represented with a leading "*" in their path.
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, "*" + ResourceUID::get_singleton()->path_to_uid(p_path));
+	undo_redo->add_do_property(project_settings, name, "*" + ResourceUID::get_singleton()->path_to_uid(p_path));
 
-	if (ProjectSettings::get_singleton()->has_setting(name)) {
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, GLOBAL_GET(name));
+	if (project_settings->has_setting(name)) {
+		undo_redo->add_undo_property(project_settings, name, GLOBAL_GET(name));
 	} else {
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, Variant());
+		undo_redo->add_undo_property(project_settings, name, Variant());
 	}
 
 	undo_redo->add_do_method(this, "update_autoload");
@@ -839,7 +843,8 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	// Make first cache
 	List<PropertyInfo> props;
-	ProjectSettings::get_singleton()->get_property_list(&props);
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	project_settings->get_property_list(&props);
 	for (const PropertyInfo &pi : props) {
 		if (!pi.name.begins_with("autoload/")) {
 			continue;
@@ -861,7 +866,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 		info.name = name;
 		info.path = ResourceUID::get_singleton()->path_to_uid(scr_path);
-		info.order = ProjectSettings::get_singleton()->get_order(pi.name);
+		info.order = project_settings->get_order(pi.name);
 
 		if (info.is_singleton) {
 			// Make sure name references work before parsing scripts

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1329,9 +1329,10 @@ void EditorSettings::_rename_setting(const String &p_old_name, const String &p_n
 		set_setting(p_new_name, get_setting(p_old_name));
 		erase(p_old_name);
 	}
-	if (ProjectSettings::get_singleton()->has_editor_setting_override(p_old_name)) {
-		ProjectSettings::get_singleton()->set_editor_setting_override(p_new_name, ProjectSettings::get_singleton()->get_editor_setting_override(p_old_name));
-		ProjectSettings::get_singleton()->set_editor_setting_override(p_old_name, Variant());
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps->has_editor_setting_override(p_old_name)) {
+		ps->set_editor_setting_override(p_new_name, ps->get_editor_setting_override(p_old_name));
+		ps->set_editor_setting_override(p_old_name, Variant());
 	}
 	compat_map[p_old_name] = p_new_name;
 }
@@ -1630,28 +1631,30 @@ void EditorSettings::set_initial_value(const StringName &p_setting, const Varian
 }
 
 Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
-	ERR_FAIL_NULL_V_MSG(EditorSettings::get_singleton(), p_default, "EditorSettings not instantiated yet.");
+	EditorSettings *es = EditorSettings::get_singleton();
+	ERR_FAIL_NULL_V_MSG(es, p_default, "EditorSettings not instantiated yet.");
 
 	Variant ret = p_default;
-	if (EditorSettings::get_singleton()->has_setting(p_setting)) {
+	if (es->has_setting(p_setting)) {
 		ret = EDITOR_GET(p_setting);
 	} else {
-		EditorSettings::get_singleton()->set_manually(p_setting, p_default);
+		es->set_manually(p_setting, p_default);
 	}
-	EditorSettings::get_singleton()->set_restart_if_changed(p_setting, p_restart_if_changed);
-	EditorSettings::get_singleton()->set_basic(p_setting, p_basic);
+	es->set_restart_if_changed(p_setting, p_restart_if_changed);
+	es->set_basic(p_setting, p_basic);
 
-	if (!EditorSettings::get_singleton()->has_default_value(p_setting)) {
-		EditorSettings::get_singleton()->set_initial_value(p_setting, p_default);
+	if (!es->has_default_value(p_setting)) {
+		es->set_initial_value(p_setting, p_default);
 	}
 
 	return ret;
 }
 
 Variant _EDITOR_GET(const String &p_setting) {
-	ERR_FAIL_NULL_V_MSG(EditorSettings::get_singleton(), Variant(), vformat(R"(EditorSettings not instantiated yet when getting setting "%s".)", p_setting));
-	ERR_FAIL_COND_V_MSG(!EditorSettings::get_singleton()->has_setting(p_setting), Variant(), vformat(R"(Editor setting "%s" does not exist.)", p_setting));
-	return EditorSettings::get_singleton()->get_setting(p_setting);
+	EditorSettings *es = EditorSettings::get_singleton();
+	ERR_FAIL_NULL_V_MSG(es, Variant(), vformat(R"(EditorSettings not instantiated yet when getting setting "%s".)", p_setting));
+	ERR_FAIL_COND_V_MSG(!es->has_setting(p_setting), Variant(), vformat(R"(Editor setting "%s" does not exist.)", p_setting));
+	return es->get_setting(p_setting);
 }
 
 bool EditorSettings::_property_can_revert(const StringName &p_name) const {
@@ -1806,14 +1809,15 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 	String favorites_file;
 	String favorite_properties_file;
 	String recent_dirs_file;
+	EditorPaths *editor_paths = EditorPaths::get_singleton();
 	if (Engine::get_singleton()->is_project_manager_hint()) {
-		favorites_file = EditorPaths::get_singleton()->get_config_dir().path_join("favorite_dirs");
-		favorite_properties_file = EditorPaths::get_singleton()->get_config_dir().path_join("favorite_properties");
-		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().path_join("recent_dirs");
+		favorites_file = editor_paths->get_config_dir().path_join("favorite_dirs");
+		favorite_properties_file = editor_paths->get_config_dir().path_join("favorite_properties");
+		recent_dirs_file = editor_paths->get_config_dir().path_join("recent_dirs");
 	} else {
-		favorites_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorites");
-		favorite_properties_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorite_properties");
-		recent_dirs_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join("recent_dirs");
+		favorites_file = editor_paths->get_project_settings_dir().path_join("favorites");
+		favorite_properties_file = editor_paths->get_project_settings_dir().path_join("favorite_properties");
+		recent_dirs_file = editor_paths->get_project_settings_dir().path_join("recent_dirs");
 	}
 
 	/// File Favorites
@@ -1972,11 +1976,12 @@ String EditorSettings::get_editor_layouts_config() const {
 }
 
 float EditorSettings::get_auto_display_scale() {
+	DisplayServer *ds = DisplayServer::get_singleton();
 #ifdef LINUXBSD_ENABLED
-	if (DisplayServer::get_singleton()->get_name() == "Wayland") {
-		float main_window_scale = DisplayServer::get_singleton()->screen_get_scale(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW);
+	if (ds->get_name() == "Wayland") {
+		float main_window_scale = ds->screen_get_scale(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW);
 
-		if (DisplayServer::get_singleton()->get_screen_count() == 1 || Math::fract(main_window_scale) != 0) {
+		if (ds->get_screen_count() == 1 || Math::fract(main_window_scale) != 0) {
 			// If we have a single screen or the screen of the window is fractional, all
 			// bets are off. At this point, let's just return the current's window scale,
 			// which is special-cased to the scale of `DisplayServerEnums::SCREEN_OF_MAIN_WINDOW`.
@@ -1987,26 +1992,26 @@ float EditorSettings::get_auto_display_scale() {
 		// properly anyways (we're need the ability to change the UI scale at runtime).
 		// At this point it's more convenient to "supersample" like we do with other
 		// platforms, hoping that the user is only using integer-scaled screens.
-		return DisplayServer::get_singleton()->screen_get_max_scale();
+		return ds->screen_get_max_scale();
 	}
 #endif
 
 #if defined(MACOS_ENABLED) || defined(ANDROID_ENABLED)
-	return DisplayServer::get_singleton()->screen_get_max_scale();
+	return ds->screen_get_max_scale();
 #else
-	const int screen = DisplayServer::get_singleton()->window_get_current_screen();
+	const int screen = ds->window_get_current_screen();
 
-	if (DisplayServer::get_singleton()->screen_get_size(screen) == Vector2i()) {
+	if (ds->screen_get_size(screen) == Vector2i()) {
 		// Invalid screen size, skip.
 		return 1.0;
 	}
 
 #if defined(WINDOWS_ENABLED)
-	return DisplayServer::get_singleton()->screen_get_dpi(screen) / 96.0;
+	return ds->screen_get_dpi(screen) / 96.0;
 #else
 	// Use the smallest dimension to use a correct display scale on portrait displays.
-	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
-	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
+	const int smallest_dimension = MIN(ds->screen_get_size(screen).x, ds->screen_get_size(screen).y);
+	if (ds->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
 		// hiDPI display.
 		return 2.0;
 	} else if (smallest_dimension >= 1700) {

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -169,10 +169,11 @@ void EditorSettingsDialog::update_navigation_preset() {
 	}
 	// Set settings to the desired preset values.
 	if (set_preset) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
+		EditorSettings *es = EditorSettings::get_singleton();
+		es->set_manually("editors/3d/navigation/orbit_mouse_button", (int)set_orbit_mouse_button);
+		es->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
+		es->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
+		es->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
 		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
 		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
 		_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);
@@ -198,28 +199,33 @@ void EditorSettingsDialog::_settings_save() {
 	if (!timer->is_stopped()) {
 		timer->stop();
 	}
-	EditorSettings::get_singleton()->notify_changes();
-	EditorSettings::get_singleton()->save();
+	EditorSettings *es = EditorSettings::get_singleton();
+	es->notify_changes();
+	es->save();
 }
 
 void EditorSettingsDialog::cancel_pressed() {
-	if (!EditorSettings::get_singleton()) {
+	EditorSettings *es = EditorSettings::get_singleton();
+
+	if (!es) {
 		return;
 	}
 
-	EditorSettings::get_singleton()->notify_changes();
+	es->notify_changes();
 }
 
 void EditorSettingsDialog::popup_edit_settings() {
-	if (!EditorSettings::get_singleton()) {
+	EditorSettings *es = EditorSettings::get_singleton();
+
+	if (!es) {
 		return;
 	}
 
-	EditorSettings::get_singleton()->update_text_editor_themes_list(); // Make sure we have an up to date list of themes.
+	es->update_text_editor_themes_list(); // Make sure we have an up to date list of themes.
 
 	_update_dynamic_property_hints();
 
-	inspector->edit(EditorSettings::get_singleton());
+	inspector->edit(es);
 	inspector->get_inspector()->update_tree();
 
 	_update_shortcuts();
@@ -228,7 +234,7 @@ void EditorSettingsDialog::popup_edit_settings() {
 	// Restore valid window bounds or pop up at default size.
 	Rect2 saved_size;
 	if (!_is_in_project_manager()) {
-		saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "editor_settings", Rect2());
+		saved_size = es->get_project_metadata("dialog_bounds", "editor_settings", Rect2());
 	}
 
 	if (saved_size != Rect2()) {
@@ -376,7 +382,8 @@ bool EditorSettingsDialog::_is_in_project_manager() const {
 }
 
 void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Array &p_events) {
-	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(p_name);
+	EditorSettings *editor_settings = EditorSettings::get_singleton();
+	Array old_input_array = editor_settings->get_builtin_action_overrides(p_name);
 	if (old_input_array.is_empty()) {
 		List<Ref<InputEvent>> defaults(InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier]);
 		old_input_array = _event_list_to_array_helper(defaults);
@@ -384,17 +391,17 @@ void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Ar
 
 	if (_is_in_project_manager()) {
 		// Project Manager doesn't have EditorUndoRedoManager, so apply changes directly.
-		EditorSettings::get_singleton()->mark_setting_changed("builtin_action_overrides");
-		EditorSettings::get_singleton()->set_builtin_action_override(p_name, p_events);
+		editor_settings->mark_setting_changed("builtin_action_overrides");
+		editor_settings->set_builtin_action_override(p_name, p_events);
 		_update_shortcuts();
 		_settings_changed();
 	} else {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(vformat(TTR("Edit Built-in Action: %s"), p_name));
-		undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
-		undo_redo->add_undo_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
-		undo_redo->add_do_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, p_events);
-		undo_redo->add_undo_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, old_input_array);
+		undo_redo->add_do_method(editor_settings, "mark_setting_changed", "builtin_action_overrides");
+		undo_redo->add_undo_method(editor_settings, "mark_setting_changed", "builtin_action_overrides");
+		undo_redo->add_do_method(editor_settings, "set_builtin_action_override", p_name, p_events);
+		undo_redo->add_undo_method(editor_settings, "set_builtin_action_override", p_name, old_input_array);
 		undo_redo->add_do_method(this, "_update_shortcuts");
 		undo_redo->add_undo_method(this, "_update_shortcuts");
 		undo_redo->add_do_method(this, "_settings_changed");
@@ -404,24 +411,25 @@ void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Ar
 }
 
 void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const Array &p_events) {
-	Ref<Shortcut> current_sc = EditorSettings::get_singleton()->get_shortcut(p_path);
+	EditorSettings *editor_settings = EditorSettings::get_singleton();
+	Ref<Shortcut> current_sc = editor_settings->get_shortcut(p_path);
 
 	if (_is_in_project_manager()) {
 		// Project Manager doesn't have EditorUndoRedoManager, so apply changes directly.
 		current_sc->set_events(p_events);
-		EditorSettings::get_singleton()->mark_setting_changed("shortcuts");
+		editor_settings->mark_setting_changed("shortcuts");
 		_update_shortcuts();
 		_settings_changed();
 	} else {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(vformat(TTR("Edit Shortcut: %s"), p_path), UndoRedo::MERGE_DISABLE, EditorSettings::get_singleton());
+		undo_redo->create_action(vformat(TTR("Edit Shortcut: %s"), p_path), UndoRedo::MERGE_DISABLE, editor_settings);
 		// History must be fixed based on the EditorSettings object because current_sc would
 		// incorrectly make this action use the scene history.
 		undo_redo->force_fixed_history();
 		undo_redo->add_do_method(current_sc.ptr(), "set_events", p_events);
 		undo_redo->add_undo_method(current_sc.ptr(), "set_events", current_sc->get_events());
-		undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");
-		undo_redo->add_undo_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");
+		undo_redo->add_do_method(editor_settings, "mark_setting_changed", "shortcuts");
+		undo_redo->add_undo_method(editor_settings, "mark_setting_changed", "shortcuts");
 		undo_redo->add_do_method(this, "_update_shortcuts");
 		undo_redo->add_undo_method(this, "_update_shortcuts");
 		undo_redo->add_do_method(this, "_settings_changed");
@@ -433,7 +441,7 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 	bool path_is_pan_mod = p_path == "spatial_editor/viewport_pan_modifier_1" || p_path == "spatial_editor/viewport_pan_modifier_2";
 	bool path_is_zoom_mod = p_path == "spatial_editor/viewport_zoom_modifier_1" || p_path == "spatial_editor/viewport_zoom_modifier_2";
 	if (path_is_orbit_mod || path_is_pan_mod || path_is_zoom_mod) {
-		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
+		editor_settings->set_manually("editors/3d/navigation/navigation_scheme", (int)View3DController::NAV_SCHEME_CUSTOM);
 	}
 }
 

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -141,7 +141,7 @@ void ProjectSettingsEditor::_on_editor_override_deleted(const String &p_setting)
 	const String full_name = general_settings_inspector->get_full_item_path(p_setting);
 	ERR_FAIL_COND(!full_name.begins_with(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX));
 
-	ProjectSettings::get_singleton()->set_setting(full_name, Variant());
+	ps->set_setting(full_name, Variant());
 	EditorSettings::get_singleton()->mark_setting_changed(full_name.trim_prefix(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX));
 	pending_override_notify = true;
 	_save();
@@ -149,8 +149,9 @@ void ProjectSettingsEditor::_on_editor_override_deleted(const String &p_setting)
 }
 
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
-	EditorSettings::get_singleton()->set("_project_settings_advanced_mode", p_button_pressed);
-	EditorSettings::get_singleton()->save();
+	EditorSettings *es = EditorSettings::get_singleton();
+	es->set("_project_settings_advanced_mode", p_button_pressed);
+	es->save();
 	_update_advanced(p_button_pressed);
 }
 
@@ -427,9 +428,10 @@ void ProjectSettingsEditor::_focus_current_path_box() {
 }
 
 void ProjectSettingsEditor::_editor_restart() {
-	ProjectSettings::get_singleton()->save();
-	EditorNode::get_singleton()->save_all_scenes();
-	EditorNode::get_singleton()->restart_editor();
+	ps->save();
+	EditorNode *en = EditorNode::get_singleton();
+	en->save_all_scenes();
+	en->restart_editor();
 }
 
 void ProjectSettingsEditor::_editor_restart_request() {
@@ -443,7 +445,7 @@ void ProjectSettingsEditor::_editor_restart_close() {
 void ProjectSettingsEditor::_action_added(const String &p_name) {
 	String name = "input/" + p_name;
 
-	ERR_FAIL_COND_MSG(ProjectSettings::get_singleton()->has_setting(name),
+	ERR_FAIL_COND_MSG(ps->has_setting(name),
 			"An action with this name already exists.");
 
 	Dictionary action;
@@ -452,8 +454,8 @@ void ProjectSettingsEditor::_action_added(const String &p_name) {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Input Action"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
+	undo_redo->add_do_method(ps, "set", name, action);
+	undo_redo->add_undo_method(ps, "clear", name);
 
 	undo_redo->add_do_method(this, "_update_action_map_editor");
 	undo_redo->add_undo_method(this, "_update_action_map_editor");
@@ -470,14 +472,14 @@ void ProjectSettingsEditor::_action_edited(const String &p_name, const Dictionar
 	if (old_val["deadzone"] != p_action["deadzone"]) {
 		// Deadzone Changed
 		undo_redo->create_action(TTR("Change Action deadzone"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", property_name, p_action);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", property_name, old_val);
+		undo_redo->add_do_method(ps, "set", property_name, p_action);
+		undo_redo->add_undo_method(ps, "set", property_name, old_val);
 
 	} else {
 		// Events changed
 		undo_redo->create_action(TTR("Change Input Action Event(s)"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", property_name, p_action);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", property_name, old_val);
+		undo_redo->add_do_method(ps, "set", property_name, p_action);
+		undo_redo->add_undo_method(ps, "set", property_name, old_val);
 	}
 
 	undo_redo->add_do_method(this, "_update_action_map_editor");
@@ -491,13 +493,13 @@ void ProjectSettingsEditor::_action_removed(const String &p_name) {
 	const String property_name = "input/" + p_name;
 
 	Dictionary old_val = GLOBAL_GET(property_name);
-	int order = ProjectSettings::get_singleton()->get_order(property_name);
+	int order = ps->get_order(property_name);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Erase Input Action"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", property_name);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", property_name, old_val);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", property_name, order);
+	undo_redo->add_do_method(ps, "clear", property_name);
+	undo_redo->add_undo_method(ps, "set", property_name, old_val);
+	undo_redo->add_undo_method(ps, "set_order", property_name, order);
 
 	undo_redo->add_do_method(this, "_update_action_map_editor");
 	undo_redo->add_undo_method(this, "_update_action_map_editor");
@@ -510,22 +512,22 @@ void ProjectSettingsEditor::_action_renamed(const String &p_old_name, const Stri
 	const String old_property_name = "input/" + p_old_name;
 	const String new_property_name = "input/" + p_new_name;
 
-	ERR_FAIL_COND_MSG(ProjectSettings::get_singleton()->has_setting(new_property_name),
+	ERR_FAIL_COND_MSG(ps->has_setting(new_property_name),
 			"An action with this name already exists.");
 
-	int order = ProjectSettings::get_singleton()->get_order(old_property_name);
+	int order = ps->get_order(old_property_name);
 	Dictionary action = GLOBAL_GET(old_property_name);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Rename Input Action"));
 	// Do: clear old, set new
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", old_property_name);
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", new_property_name, action);
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", new_property_name, order);
+	undo_redo->add_do_method(ps, "clear", old_property_name);
+	undo_redo->add_do_method(ps, "set", new_property_name, action);
+	undo_redo->add_do_method(ps, "set_order", new_property_name, order);
 	// Undo: clear new, set old
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", new_property_name);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", old_property_name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", old_property_name, order);
+	undo_redo->add_undo_method(ps, "clear", new_property_name);
+	undo_redo->add_undo_method(ps, "set", old_property_name, action);
+	undo_redo->add_undo_method(ps, "set_order", old_property_name, order);
 
 	undo_redo->add_do_method(this, "_update_action_map_editor");
 	undo_redo->add_undo_method(this, "_update_action_map_editor");
@@ -544,7 +546,7 @@ void ProjectSettingsEditor::_action_reordered(const String &p_action_name, const
 
 	List<PropertyInfo> props;
 	HashMap<String, Variant> action_values;
-	ProjectSettings::get_singleton()->get_property_list(&props);
+	ps->get_property_list(&props);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Update Input Action Order"));
@@ -552,14 +554,14 @@ void ProjectSettingsEditor::_action_reordered(const String &p_action_name, const
 	for (const PropertyInfo &prop : props) {
 		// Skip builtins and non-inputs
 		// Order matters here, checking for "input/" filters out properties that aren't settings and produce errors in is_builtin_setting().
-		if (!prop.name.begins_with("input/") || ProjectSettings::get_singleton()->is_builtin_setting(prop.name)) {
+		if (!prop.name.begins_with("input/") || ps->is_builtin_setting(prop.name)) {
 			continue;
 		}
 
 		action_values.insert(prop.name, ps->get(prop.name));
 
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", prop.name);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", prop.name);
+		undo_redo->add_do_method(ps, "clear", prop.name);
+		undo_redo->add_undo_method(ps, "clear", prop.name);
 	}
 
 	for (const KeyValue<String, Variant> &E : action_values) {
@@ -569,23 +571,23 @@ void ProjectSettingsEditor::_action_reordered(const String &p_action_name, const
 		if (name == target_name) {
 			if (p_before) {
 				// Insert before target
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", action_name, action_value);
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", target_name, target_value);
+				undo_redo->add_do_method(ps, "set", action_name, action_value);
+				undo_redo->add_do_method(ps, "set", target_name, target_value);
 
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", target_name, target_value);
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", action_name, action_value);
+				undo_redo->add_undo_method(ps, "set", target_name, target_value);
+				undo_redo->add_undo_method(ps, "set", action_name, action_value);
 			} else {
 				// Insert after target
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", target_name, target_value);
-				undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", action_name, action_value);
+				undo_redo->add_do_method(ps, "set", target_name, target_value);
+				undo_redo->add_do_method(ps, "set", action_name, action_value);
 
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", action_name, action_value);
-				undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", target_name, target_value);
+				undo_redo->add_undo_method(ps, "set", action_name, action_value);
+				undo_redo->add_undo_method(ps, "set", target_name, target_value);
 			}
 
 		} else if (name != action_name) {
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, value);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, value);
+			undo_redo->add_do_method(ps, "set", name, value);
+			undo_redo->add_undo_method(ps, "set", name, value);
 		}
 	}
 
@@ -600,7 +602,7 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 	Vector<ActionMapEditor::ActionInfo> actions;
 
 	List<PropertyInfo> props;
-	ProjectSettings::get_singleton()->get_property_list(&props);
+	ps->get_property_list(&props);
 
 	const Ref<Texture2D> builtin_icon = get_editor_theme_icon(SNAME("PinPressed"));
 	for (const PropertyInfo &E : props) {
@@ -624,12 +626,12 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 		action_info.editable = true;
 		action_info.name = display_name;
 
-		const bool is_builtin_input = ProjectSettings::get_singleton()->get_input_presets().find(property_name) != nullptr;
+		const bool is_builtin_input = ps->get_input_presets().find(property_name) != nullptr;
 		if (is_builtin_input) {
 			action_info.editable = false;
 			action_info.icon = builtin_icon;
 			action_info.has_initial = true;
-			action_info.action_initial = ProjectSettings::get_singleton()->property_get_revert(property_name);
+			action_info.action_initial = ps->property_get_revert(property_name);
 		}
 
 		actions.push_back(action_info);
@@ -660,7 +662,7 @@ void ProjectSettingsEditor::_notification(int p_what) {
 				for (const PropertyInfo &pi : infos) {
 					editor_settings_info[pi.name] = pi;
 				}
-				ProjectSettings::get_singleton()->editor_settings_info = editor_settings_info;
+				ps->editor_settings_info = editor_settings_info;
 			} else {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "project_settings", Rect2(get_position(), get_size()));
 				if (settings_changed) {

--- a/editor/shader/shader_globals_editor.cpp
+++ b/editor/shader/shader_globals_editor.cpp
@@ -81,9 +81,10 @@ class ShaderGlobalsEditorInterface : public Object {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 		undo_redo->create_action(TTR("Set Shader Global Variable"));
-		undo_redo->add_do_method(RS::get_singleton(), "global_shader_parameter_set", p_name, p_value);
-		undo_redo->add_undo_method(RS::get_singleton(), "global_shader_parameter_set", p_name, p_prev_value);
-		RSE::GlobalShaderParameterType type = RS::get_singleton()->global_shader_parameter_get_type(p_name);
+		RS *rs = RS::get_singleton();
+		undo_redo->add_do_method(rs, "global_shader_parameter_set", p_name, p_value);
+		undo_redo->add_undo_method(rs, "global_shader_parameter_set", p_name, p_prev_value);
+		RSE::GlobalShaderParameterType type = rs->global_shader_parameter_get_type(p_name);
 		Dictionary gv;
 		gv["type"] = global_var_type_names[type];
 		if (type >= RSE::GLOBAL_VAR_TYPE_SAMPLER2D) {
@@ -98,8 +99,9 @@ class ShaderGlobalsEditorInterface : public Object {
 		}
 
 		String path = "shader_globals/" + String(p_name);
-		undo_redo->add_do_property(ProjectSettings::get_singleton(), path, gv);
-		undo_redo->add_undo_property(ProjectSettings::get_singleton(), path, GLOBAL_GET(path));
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		undo_redo->add_do_property(ps, path, gv);
+		undo_redo->add_undo_property(ps, path, GLOBAL_GET(path));
 		undo_redo->add_do_method(this, "_var_changed");
 		undo_redo->add_undo_method(this, "_var_changed");
 		block_update = true;
@@ -385,8 +387,11 @@ void ShaderGlobalsEditor::_variable_name_text_changed(const String &p_variable_n
 void ShaderGlobalsEditor::_variable_added() {
 	String var = variable_name->get_text().strip_edges();
 
-	if (RenderingServer::get_singleton()->global_shader_parameter_get(var).get_type() != Variant::NIL) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Global shader parameter '%s' already exists."), var));
+	RS *rs = RS::get_singleton();
+	EditorNode *editor_node = EditorNode::get_singleton();
+
+	if (rs->global_shader_parameter_get(var).get_type() != Variant::NIL) {
+		editor_node->show_warning(vformat(TTR("Global shader parameter '%s' already exists."), var));
 		return;
 	}
 
@@ -394,7 +399,7 @@ void ShaderGlobalsEditor::_variable_added() {
 	ShaderLanguage::get_keyword_list(&keywords);
 
 	if (keywords.find(var) != nullptr || var == "script") {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Name '%s' is a reserved shader language keyword."), var));
+		editor_node->show_warning(vformat(TTR("Name '%s' is a reserved shader language keyword."), var));
 		return;
 	}
 
@@ -403,14 +408,15 @@ void ShaderGlobalsEditor::_variable_added() {
 	Variant value = create_var(RSE::GlobalShaderParameterType(variable_type->get_selected()));
 
 	undo_redo->create_action(TTR("Add Shader Global Parameter"));
-	undo_redo->add_do_method(RS::get_singleton(), "global_shader_parameter_add", var, RSE::GlobalShaderParameterType(variable_type->get_selected()), value);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_shader_parameter_remove", var);
+	undo_redo->add_do_method(rs, "global_shader_parameter_add", var, RSE::GlobalShaderParameterType(variable_type->get_selected()), value);
+	undo_redo->add_undo_method(rs, "global_shader_parameter_remove", var);
 	Dictionary gv;
 	gv["type"] = global_var_type_names[variable_type->get_selected()];
 	gv["value"] = value;
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + var, gv);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + var, Variant());
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	undo_redo->add_do_property(project_settings, "shader_globals/" + var, gv);
+	undo_redo->add_undo_property(project_settings, "shader_globals/" + var, Variant());
 	undo_redo->add_do_method(this, "_changed");
 	undo_redo->add_undo_method(this, "_changed");
 	undo_redo->commit_action();
@@ -421,12 +427,14 @@ void ShaderGlobalsEditor::_variable_added() {
 void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
+	RS *rs = RS::get_singleton();
 	undo_redo->create_action(TTR("Add Shader Global Parameter"));
-	undo_redo->add_do_method(RS::get_singleton(), "global_shader_parameter_remove", p_variable);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_shader_parameter_add", p_variable, RS::get_singleton()->global_shader_parameter_get_type(p_variable), RS::get_singleton()->global_shader_parameter_get(p_variable));
+	undo_redo->add_do_method(rs, "global_shader_parameter_remove", p_variable);
+	undo_redo->add_undo_method(rs, "global_shader_parameter_add", p_variable, RS::get_singleton()->global_shader_parameter_get_type(p_variable), RS::get_singleton()->global_shader_parameter_get(p_variable));
 
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, Variant());
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, GLOBAL_GET("shader_globals/" + p_variable));
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	undo_redo->add_do_property(ps, "shader_globals/" + p_variable, Variant());
+	undo_redo->add_undo_property(ps, "shader_globals/" + p_variable, GLOBAL_GET("shader_globals/" + p_variable));
 	undo_redo->add_do_method(this, "_changed");
 	undo_redo->add_undo_method(this, "_changed");
 	undo_redo->commit_action();

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -123,10 +123,11 @@ void TextShaderPreviewLineLayer::_notification(int p_what) {
 			}
 
 			const Rect2i visible_rect = scroll_container->get_global_rect();
-			RenderingServer::get_singleton()->canvas_item_set_custom_rect(
+			RS *rs = RS::get_singleton();
+			rs->canvas_item_set_custom_rect(
 					get_canvas_item(), true,
 					Rect2(get_global_transform().affine_inverse().xform(Vector2(visible_rect.position)), visible_rect.size + Vector2(code_editor->get_total_gutter_width(), 0)));
-			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), true);
+			rs->canvas_item_set_clip(get_canvas_item(), true);
 
 			int current_caret_line = code_editor->get_caret_line();
 			int idx = 0;
@@ -789,8 +790,9 @@ static uint32_t saved_warning_flags = 0U;
 void ShaderTextEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			get_text_editor()->add_theme_color_override("breakpoint_color", EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor)));
-			get_text_editor()->add_theme_icon_override("breakpoint", get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
+			CodeEdit *t_edit = get_text_editor();
+			t_edit->add_theme_color_override("breakpoint_color", EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor)));
+			t_edit->add_theme_icon_override("breakpoint", get_editor_theme_icon(SNAME("GuiVisibilityVisible")));
 
 			if (is_visible_in_tree()) {
 				_load_theme_settings();
@@ -865,11 +867,12 @@ void ShaderTextEditor::set_edited_shader_include(const Ref<ShaderInclude> &p_sha
 void ShaderTextEditor::set_edited_code(const String &p_code) {
 	_load_theme_settings();
 
-	get_text_editor()->set_text(p_code);
-	get_text_editor()->clear_undo_history();
-	callable_mp((TextEdit *)get_text_editor(), &TextEdit::set_h_scroll).call_deferred(0);
-	callable_mp((TextEdit *)get_text_editor(), &TextEdit::set_v_scroll).call_deferred(0);
-	get_text_editor()->tag_saved_version();
+	CodeEdit *t_edit = get_text_editor();
+	t_edit->set_text(p_code);
+	t_edit->clear_undo_history();
+	callable_mp((TextEdit *)t_edit, &TextEdit::set_h_scroll).call_deferred(0);
+	callable_mp((TextEdit *)t_edit, &TextEdit::set_v_scroll).call_deferred(0);
+	t_edit->tag_saved_version();
 
 	_validate_script();
 	_line_col_changed();
@@ -891,8 +894,9 @@ void ShaderTextEditor::redraw_preview_lines() {
 }
 
 void ShaderTextEditor::recompile_previews() {
+	String editor_text = get_text_editor()->get_text();
 	for (KeyValue<int, TextShaderPreview *> &E : previews) {
-		E.value->recompile(get_text_editor()->get_text());
+		E.value->recompile(editor_text);
 	}
 }
 
@@ -1013,21 +1017,22 @@ void ShaderTextEditor::_load_theme_settings() {
 		syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
 	}
 
+	ShaderTypes *shader_types = ShaderTypes::get_singleton();
+
 	// Colorize built-ins like `COLOR` differently to make them easier
 	// to distinguish from keywords at a quick glance.
-
 	List<String> built_ins;
 
 	if (shader_inc.is_valid()) {
 		for (int i = 0; i < RSE::SHADER_MAX; i++) {
-			for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &E : ShaderTypes::get_singleton()->get_functions(RSE::ShaderMode(i))) {
+			for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &E : shader_types->get_functions(RSE::ShaderMode(i))) {
 				for (const KeyValue<StringName, ShaderLanguage::BuiltInInfo> &F : E.value.built_ins) {
 					built_ins.push_back(F.key);
 				}
 			}
 
 			{
-				const Vector<ShaderLanguage::ModeInfo> &render_modes = ShaderTypes::get_singleton()->get_modes(RSE::ShaderMode(i));
+				const Vector<ShaderLanguage::ModeInfo> &render_modes = shader_types->get_modes(RSE::ShaderMode(i));
 
 				for (const ShaderLanguage::ModeInfo &mode_info : render_modes) {
 					if (!mode_info.options.is_empty()) {
@@ -1041,7 +1046,7 @@ void ShaderTextEditor::_load_theme_settings() {
 			}
 
 			{
-				const Vector<ShaderLanguage::ModeInfo> &stencil_modes = ShaderTypes::get_singleton()->get_stencil_modes(RSE::ShaderMode(i));
+				const Vector<ShaderLanguage::ModeInfo> &stencil_modes = shader_types->get_stencil_modes(RSE::ShaderMode(i));
 
 				for (const ShaderLanguage::ModeInfo &mode_info : stencil_modes) {
 					if (!mode_info.options.is_empty()) {
@@ -1055,14 +1060,14 @@ void ShaderTextEditor::_load_theme_settings() {
 			}
 		}
 	} else if (shader.is_valid()) {
-		for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &E : ShaderTypes::get_singleton()->get_functions(RSE::ShaderMode(shader->get_mode()))) {
+		for (const KeyValue<StringName, ShaderLanguage::FunctionInfo> &E : shader_types->get_functions(RSE::ShaderMode(shader->get_mode()))) {
 			for (const KeyValue<StringName, ShaderLanguage::BuiltInInfo> &F : E.value.built_ins) {
 				built_ins.push_back(F.key);
 			}
 		}
 
 		{
-			const Vector<ShaderLanguage::ModeInfo> &shader_modes = ShaderTypes::get_singleton()->get_modes(RSE::ShaderMode(shader->get_mode()));
+			const Vector<ShaderLanguage::ModeInfo> &shader_modes = shader_types->get_modes(RSE::ShaderMode(shader->get_mode()));
 
 			for (const ShaderLanguage::ModeInfo &mode_info : shader_modes) {
 				if (!mode_info.options.is_empty()) {
@@ -1076,7 +1081,7 @@ void ShaderTextEditor::_load_theme_settings() {
 		}
 
 		{
-			const Vector<ShaderLanguage::ModeInfo> &stencil_modes = ShaderTypes::get_singleton()->get_stencil_modes(RSE::ShaderMode(shader->get_mode()));
+			const Vector<ShaderLanguage::ModeInfo> &stencil_modes = shader_types->get_stencil_modes(RSE::ShaderMode(shader->get_mode()));
 
 			for (const ShaderLanguage::ModeInfo &mode_info : stencil_modes) {
 				if (!mode_info.options.is_empty()) {
@@ -1218,10 +1223,11 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 		return;
 	}
 	_check_shader_mode();
-	comp_info.functions = ShaderTypes::get_singleton()->get_functions(RSE::ShaderMode(shader->get_mode()));
-	comp_info.render_modes = ShaderTypes::get_singleton()->get_modes(RSE::ShaderMode(shader->get_mode()));
-	comp_info.stencil_modes = ShaderTypes::get_singleton()->get_stencil_modes(RSE::ShaderMode(shader->get_mode()));
-	comp_info.shader_types = ShaderTypes::get_singleton()->get_types();
+	ShaderTypes *st = ShaderTypes::get_singleton();
+	comp_info.functions = st->get_functions(RSE::ShaderMode(shader->get_mode()));
+	comp_info.render_modes = st->get_modes(RSE::ShaderMode(shader->get_mode()));
+	comp_info.stencil_modes = st->get_stencil_modes(RSE::ShaderMode(shader->get_mode()));
+	comp_info.shader_types = st->get_types();
 
 	sl.complete(code, comp_info, r_options, calltip);
 	if (sl.get_completion_type() == ShaderLanguage::COMPLETION_IDENTIFIER) {
@@ -1343,10 +1349,11 @@ void ShaderTextEditor::_validate_script() {
 			comp_info.is_include = true;
 		} else {
 			Shader::Mode mode = shader->get_mode();
-			comp_info.functions = ShaderTypes::get_singleton()->get_functions(RSE::ShaderMode(mode));
-			comp_info.render_modes = ShaderTypes::get_singleton()->get_modes(RSE::ShaderMode(mode));
-			comp_info.stencil_modes = ShaderTypes::get_singleton()->get_stencil_modes(RSE::ShaderMode(mode));
-			comp_info.shader_types = ShaderTypes::get_singleton()->get_types();
+			ShaderTypes *st = ShaderTypes::get_singleton();
+			comp_info.functions = st->get_functions(RSE::ShaderMode(mode));
+			comp_info.render_modes = st->get_modes(RSE::ShaderMode(mode));
+			comp_info.stencil_modes = st->get_stencil_modes(RSE::ShaderMode(mode));
+			comp_info.shader_types = st->get_types();
 		}
 
 		code = code_pp;
@@ -2162,14 +2169,15 @@ TextShaderEditor::TextShaderEditor() {
 	code_editor->connect(CoreStringName(script_changed), callable_mp(this, &TextShaderEditor::apply_shaders));
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextShaderEditor::_project_settings_changed));
 
-	code_editor->get_text_editor()->set_symbol_lookup_on_click_enabled(true);
-	code_editor->get_text_editor()->set_context_menu_enabled(false);
-	code_editor->get_text_editor()->set_draw_executing_lines_gutter(false);
-	code_editor->get_text_editor()->connect(SceneStringName(gui_input), callable_mp(this, &TextShaderEditor::_text_edit_gui_input));
-	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &TextShaderEditor::_on_shader_preview_toggled));
-	code_editor->get_text_editor()->connect("_fold_line_updated", callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines), CONNECT_DEFERRED);
-	code_editor->get_text_editor()->connect("theme_changed", callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines), CONNECT_DEFERRED);
-	code_editor->get_text_editor()->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines).unbind(1), CONNECT_DEFERRED);
+	CodeEdit *code_editor_text_editor = code_editor->get_text_editor();
+	code_editor_text_editor->set_symbol_lookup_on_click_enabled(true);
+	code_editor_text_editor->set_context_menu_enabled(false);
+	code_editor_text_editor->set_draw_executing_lines_gutter(false);
+	code_editor_text_editor->connect(SceneStringName(gui_input), callable_mp(this, &TextShaderEditor::_text_edit_gui_input));
+	code_editor_text_editor->connect("breakpoint_toggled", callable_mp(this, &TextShaderEditor::_on_shader_preview_toggled));
+	code_editor_text_editor->connect("_fold_line_updated", callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines), CONNECT_DEFERRED);
+	code_editor_text_editor->connect("theme_changed", callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines), CONNECT_DEFERRED);
+	code_editor_text_editor->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines).unbind(1), CONNECT_DEFERRED);
 
 	code_editor->update_editor_settings();
 
@@ -2189,28 +2197,29 @@ TextShaderEditor::TextShaderEditor() {
 	edit_menu->set_switch_on_hover(true);
 	edit_menu->connect("about_to_popup", callable_mp(this, &TextShaderEditor::_prepare_edit_menu));
 
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/join_lines"), EDIT_JOIN_LINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
-	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
+	PopupMenu *edit_menu_popup = edit_menu->get_popup();
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
+	edit_menu_popup->add_separator();
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
+	edit_menu_popup->add_separator();
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
+	edit_menu_popup->add_separator();
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent"), EDIT_INDENT);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/join_lines"), EDIT_JOIN_LINES);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_word_wrap"), EDIT_TOGGLE_WORD_WRAP);
+	edit_menu_popup->add_separator();
+	edit_menu_popup->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
+	edit_menu_popup->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_flat(false);
@@ -2219,11 +2228,12 @@ TextShaderEditor::TextShaderEditor() {
 	search_menu->set_text(TTRC("Search"));
 	search_menu->set_switch_on_hover(true);
 
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
-	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
-	search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
+	PopupMenu *search_menu_popup = search_menu->get_popup();
+	search_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
+	search_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
+	search_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
+	search_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
+	search_menu_popup->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
 
 	MenuButton *goto_menu = memnew(MenuButton);
 	goto_menu->set_flat(false);
@@ -2231,19 +2241,20 @@ TextShaderEditor::TextShaderEditor() {
 	goto_menu->set_shortcut_context(this);
 	goto_menu->set_text(TTRC("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
 
-	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
-	goto_menu->get_popup()->add_separator();
+	PopupMenu *goto_menu_popup = goto_menu->get_popup();
+	goto_menu_popup->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
+	goto_menu_popup->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
+	goto_menu_popup->add_separator();
 
 	bookmarks_menu = memnew(PopupMenu);
-	goto_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
+	goto_menu_popup->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
 	_update_bookmark_list();
 	bookmarks_menu->connect("about_to_popup", callable_mp(this, &TextShaderEditor::_update_bookmark_list));
 	bookmarks_menu->connect("index_pressed", callable_mp(this, &TextShaderEditor::_bookmark_item_pressed));
 
 	previews_menu = memnew(PopupMenu);
-	goto_menu->get_popup()->add_submenu_node_item(TTRC("Shader Previews"), previews_menu);
+	goto_menu_popup->add_submenu_node_item(TTRC("Shader Previews"), previews_menu);
 	_update_shader_preview_list();
 	previews_menu->connect("about_to_popup", callable_mp(this, &TextShaderEditor::_update_shader_preview_list));
 	previews_menu->connect("index_pressed", callable_mp(this, &TextShaderEditor::_shader_preview_item_pressed));

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -167,7 +167,9 @@ Ref<StyleBoxLine> EditorThemeManager::make_line_stylebox(Color p_color, int p_th
 // Theme generation and population routines.
 
 Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &p_old_theme) {
-	OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Create Base Theme");
+	OS *os = OS::get_singleton();
+
+	os->benchmark_begin_measure(get_benchmark_key(), "Create Base Theme");
 
 	Ref<EditorTheme> theme = memnew(EditorTheme);
 	ThemeConfiguration config = _create_theme_config();
@@ -186,7 +188,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 
 	// Register icons.
 	{
-		OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Register Icons");
+		os->benchmark_begin_measure(get_benchmark_key(), "Register Icons");
 
 		// External functions, see editor_icons.cpp.
 		editor_configure_icons(config.dark_icon_and_font);
@@ -202,12 +204,12 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 			editor_register_icons(theme, config.dark_icon_and_font, config.icon_saturation, config.thumb_size, config.gizmo_handle_scale);
 		}
 
-		OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Register Icons");
+		os->benchmark_end_measure(get_benchmark_key(), "Register Icons");
 	}
 
 	// Register fonts.
 	{
-		OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Register Fonts");
+		os->benchmark_begin_measure(get_benchmark_key(), "Register Fonts");
 
 		// TODO: Check if existing font definitions from the old theme are usable and copy them.
 
@@ -215,7 +217,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 		print_verbose("EditorTheme: Generating new fonts.");
 		editor_register_fonts(theme);
 
-		OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Register Fonts");
+		os->benchmark_end_measure(get_benchmark_key(), "Register Fonts");
 	}
 
 	// TODO: Check if existing style definitions from the old theme are usable and copy them.
@@ -233,7 +235,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 	_populate_text_editor_styles(theme, config);
 	_populate_visual_shader_styles(theme, config);
 
-	OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Create Base Theme");
+	os->benchmark_end_measure(get_benchmark_key(), "Create Base Theme");
 	return theme;
 }
 
@@ -269,6 +271,8 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.subresource_hue_tint = EDITOR_GET("docks/property_editor/subresource_hue_tint");
 	config.dragging_hover_wait_msec = (float)EDITOR_GET("interface/editor/timers/dragging_hover_wait_seconds") * 1000;
 
+	EditorSettings *editor_settings = EditorSettings::get_singleton();
+
 	// Handle theme style.
 	if (config.preset != "Custom") {
 		if (config.style == "Classic") {
@@ -279,12 +283,12 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			config.corner_radius = config.default_corner_radius;
 		}
 
-		EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
-		EditorSettings::get_singleton()->set_initial_value("interface/theme/corner_radius", config.corner_radius);
+		editor_settings->set_initial_value("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
+		editor_settings->set_initial_value("interface/theme/corner_radius", config.corner_radius);
 
 		// Enforce values in case they were adjusted or overridden.
-		EditorSettings::get_singleton()->set_manually("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
-		EditorSettings::get_singleton()->set_manually("interface/theme/corner_radius", config.corner_radius);
+		editor_settings->set_manually("interface/theme/draw_relationship_lines", config.draw_relationship_lines);
+		editor_settings->set_manually("interface/theme/corner_radius", config.corner_radius);
 	}
 
 	// Handle color preset.
@@ -367,11 +371,11 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			config.draw_extra_borders = preset_draw_extra_borders;
 			config.icon_saturation = preset_icon_saturation;
 
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/accent_color", config.accent_color);
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/base_color", config.base_color);
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/contrast", config.contrast);
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_extra_borders", config.draw_extra_borders);
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/icon_saturation", config.icon_saturation);
+			editor_settings->set_initial_value("interface/theme/accent_color", config.accent_color);
+			editor_settings->set_initial_value("interface/theme/base_color", config.base_color);
+			editor_settings->set_initial_value("interface/theme/contrast", config.contrast);
+			editor_settings->set_initial_value("interface/theme/draw_extra_borders", config.draw_extra_borders);
+			editor_settings->set_initial_value("interface/theme/icon_saturation", config.icon_saturation);
 		}
 
 		if (use_system_accent_color && system_accent_color != Color(0, 0, 0, 0)) {
@@ -380,12 +384,12 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		}
 
 		// Enforce values in case they were adjusted or overridden.
-		EditorSettings::get_singleton()->set_manually("interface/theme/color_preset", config.preset);
-		EditorSettings::get_singleton()->set_manually("interface/theme/accent_color", config.accent_color);
-		EditorSettings::get_singleton()->set_manually("interface/theme/base_color", config.base_color);
-		EditorSettings::get_singleton()->set_manually("interface/theme/contrast", config.contrast);
-		EditorSettings::get_singleton()->set_manually("interface/theme/draw_extra_borders", config.draw_extra_borders);
-		EditorSettings::get_singleton()->set_manually("interface/theme/icon_saturation", config.icon_saturation);
+		editor_settings->set_manually("interface/theme/color_preset", config.preset);
+		editor_settings->set_manually("interface/theme/accent_color", config.accent_color);
+		editor_settings->set_manually("interface/theme/base_color", config.base_color);
+		editor_settings->set_manually("interface/theme/contrast", config.contrast);
+		editor_settings->set_manually("interface/theme/draw_extra_borders", config.draw_extra_borders);
+		editor_settings->set_manually("interface/theme/icon_saturation", config.icon_saturation);
 	}
 
 	// Handle theme spacing preset.
@@ -413,14 +417,14 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			config.extra_spacing = preset_extra_spacing;
 			config.dialogs_buttons_min_size = preset_dialogs_buttons_min_size;
 
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/base_spacing", config.base_spacing);
-			EditorSettings::get_singleton()->set_initial_value("interface/theme/additional_spacing", config.extra_spacing);
+			editor_settings->set_initial_value("interface/theme/base_spacing", config.base_spacing);
+			editor_settings->set_initial_value("interface/theme/additional_spacing", config.extra_spacing);
 		}
 
 		// Enforce values in case they were adjusted or overridden.
-		EditorSettings::get_singleton()->set_manually("interface/theme/spacing_preset", config.spacing_preset);
-		EditorSettings::get_singleton()->set_manually("interface/theme/base_spacing", config.base_spacing);
-		EditorSettings::get_singleton()->set_manually("interface/theme/additional_spacing", config.extra_spacing);
+		editor_settings->set_manually("interface/theme/spacing_preset", config.spacing_preset);
+		editor_settings->set_manually("interface/theme/base_spacing", config.base_spacing);
+		editor_settings->set_manually("interface/theme/additional_spacing", config.extra_spacing);
 	}
 
 	// Generated properties.
@@ -684,11 +688,13 @@ void EditorThemeManager::_reset_dirty_flag() {
 // Public interface for theme generation.
 
 Ref<EditorTheme> EditorThemeManager::generate_theme(const Ref<EditorTheme> &p_old_theme) {
-	OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Generate Theme");
+	OS *os = OS::get_singleton();
+
+	os->benchmark_begin_measure(get_benchmark_key(), "Generate Theme");
 
 	Ref<EditorTheme> theme = _create_base_theme(p_old_theme);
 
-	OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Merge Custom Theme");
+	os->benchmark_begin_measure(get_benchmark_key(), "Merge Custom Theme");
 
 	const String custom_theme_path = EDITOR_GET("interface/theme/custom_theme");
 	if (!custom_theme_path.is_empty()) {
@@ -698,9 +704,9 @@ Ref<EditorTheme> EditorThemeManager::generate_theme(const Ref<EditorTheme> &p_ol
 		}
 	}
 
-	OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Merge Custom Theme");
+	os->benchmark_end_measure(get_benchmark_key(), "Merge Custom Theme");
 
-	OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Generate Theme");
+	os->benchmark_end_measure(get_benchmark_key(), "Generate Theme");
 	benchmark_run++;
 
 	return theme;
@@ -712,16 +718,17 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 	// without a restart, so there is no point regenerating the theme.
 
 	if (outdated_cache_dirty) {
+		EditorSettings *es = EditorSettings::get_singleton();
 		// TODO: We can use this information more intelligently to do partial theme updates and speed things up.
-		outdated_cache = EditorSettings::get_singleton()->check_changed_settings_in_group("interface/theme") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/fonts") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen/enable_touch_optimizations") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("editors/visual_editors") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/help") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("docks/property_editor/subresource_hue_tint") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("filesystem/file_dialog/thumbnail_size") ||
-				EditorSettings::get_singleton()->check_changed_settings_in_group("run/output/font_size");
+		outdated_cache = es->check_changed_settings_in_group("interface/theme") ||
+				es->check_changed_settings_in_group("interface/editor/fonts") ||
+				es->check_changed_settings_in_group("interface/touchscreen/enable_touch_optimizations") ||
+				es->check_changed_settings_in_group("editors/visual_editors") ||
+				es->check_changed_settings_in_group("text_editor/theme") ||
+				es->check_changed_settings_in_group("text_editor/help/help") ||
+				es->check_changed_settings_in_group("docks/property_editor/subresource_hue_tint") ||
+				es->check_changed_settings_in_group("filesystem/file_dialog/thumbnail_size") ||
+				es->check_changed_settings_in_group("run/output/font_size");
 
 		// The outdated flag is relevant at the moment of changing editor settings.
 		callable_mp_static(&EditorThemeManager::_reset_dirty_flag).call_deferred();

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -101,10 +101,11 @@ void LocalizationEditor::_translation_add(const PackedStringArray &p_paths) {
 		return;
 	}
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTRN("Add %d Translation", "Add %d Translations", count), count));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations", translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations", GLOBAL_GET("internationalization/locale/translations"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translations", translations);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translations", GLOBAL_GET("internationalization/locale/translations"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -132,10 +133,11 @@ void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p
 
 	translations.remove_at(idx);
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove Translation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations", translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations", GLOBAL_GET("internationalization/locale/translations"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translations", translations);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translations", GLOBAL_GET("internationalization/locale/translations"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -150,6 +152,8 @@ void LocalizationEditor::_translation_res_file_open() {
 void LocalizationEditor::_translation_res_add(const PackedStringArray &p_paths) {
 	Variant prev;
 	Dictionary remaps;
+
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 
 	if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translation_remaps")) {
 		remaps = GLOBAL_GET("internationalization/locale/translation_remaps");
@@ -170,8 +174,8 @@ void LocalizationEditor::_translation_res_add(const PackedStringArray &p_paths) 
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTRN("Translation Resource Remap: Add %d Path", "Translation Resource Remap: Add %d Paths", count), count));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", prev);
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translation_remaps", prev);
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -184,6 +188,7 @@ void LocalizationEditor::_translation_res_option_file_open() {
 }
 
 void LocalizationEditor::_translation_res_option_add(const PackedStringArray &p_paths) {
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting("internationalization/locale/translation_remaps"));
 
 	Dictionary remaps = GLOBAL_GET("internationalization/locale/translation_remaps");
@@ -202,8 +207,8 @@ void LocalizationEditor::_translation_res_option_add(const PackedStringArray &p_
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTRN("Translation Resource Remap: Add %d Remap", "Translation Resource Remap: Add %d Remaps", p_paths.size()), p_paths.size()));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -241,6 +246,8 @@ void LocalizationEditor::_translation_res_option_changed() {
 		return;
 	}
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
 	if (!ProjectSettings::get_singleton()->has_setting("internationalization/locale/translation_remaps")) {
 		return;
 	}
@@ -266,8 +273,8 @@ void LocalizationEditor::_translation_res_option_changed() {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change Resource Remap Language"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -285,6 +292,8 @@ void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, i
 		return;
 	}
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
 	if (!ProjectSettings::get_singleton()->has_setting("internationalization/locale/translation_remaps")) {
 		return;
 	}
@@ -300,8 +309,8 @@ void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, i
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove Resource Remap"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -318,7 +327,9 @@ void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_co
 		return;
 	}
 
-	if (!ProjectSettings::get_singleton()->has_setting("internationalization/locale/translation_remaps")) {
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	if (!project_settings->has_setting("internationalization/locale/translation_remaps")) {
 		return;
 	}
 
@@ -340,8 +351,8 @@ void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_co
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove Resource Remap Option"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translation_remaps", GLOBAL_GET("internationalization/locale/translation_remaps"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -362,10 +373,11 @@ void LocalizationEditor::_template_source_add(const PackedStringArray &p_paths) 
 		return;
 	}
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(TTRN("Add %d file for template generation", "Add %d files for template generation", count), count));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", sources);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", GLOBAL_GET("internationalization/locale/translations_pot_files"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translations_pot_files", sources);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translations_pot_files", GLOBAL_GET("internationalization/locale/translations_pot_files"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -389,10 +401,11 @@ void LocalizationEditor::_template_source_delete(Object *p_item, int p_column, i
 
 	sources.remove_at(idx);
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove file from template generation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", sources);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "internationalization/locale/translations_pot_files", GLOBAL_GET("internationalization/locale/translations_pot_files"));
+	undo_redo->add_do_property(project_settings, "internationalization/locale/translations_pot_files", sources);
+	undo_redo->add_undo_property(project_settings, "internationalization/locale/translations_pot_files", GLOBAL_GET("internationalization/locale/translations_pot_files"));
 	undo_redo->add_do_method(this, "update_translations");
 	undo_redo->add_undo_method(this, "update_translations");
 	undo_redo->add_do_method(this, "emit_signal", localization_changed);
@@ -420,8 +433,9 @@ void LocalizationEditor::_template_generate_command() {
 }
 
 void LocalizationEditor::_template_add_builtin_toggled() {
-	ProjectSettings::get_singleton()->set_setting("internationalization/locale/translation_add_builtin_strings_to_pot", template_add_builtin->is_pressed());
-	ProjectSettings::get_singleton()->save();
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	ps->set_setting("internationalization/locale/translation_add_builtin_strings_to_pot", template_add_builtin->is_pressed());
+	ps->save();
 }
 
 void LocalizationEditor::_template_generate(const String &p_file) {
@@ -617,13 +631,14 @@ void LocalizationEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	setting_value.remove_at(index_from);
 	setting_value.insert(target_index, path);
 
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	EditorUndoRedoManager *ur_man = EditorUndoRedoManager::get_singleton();
 	ur_man->create_action(TTR("Rearrange Localization Items"));
-	ur_man->add_do_method(ProjectSettings::get_singleton(), "set", setting, setting_value);
-	ur_man->add_do_method(ProjectSettings::get_singleton(), "save");
+	ur_man->add_do_method(project_settings, "set", setting, setting_value);
+	ur_man->add_do_method(project_settings, "save");
 	ur_man->add_do_method(this, "update_translations");
-	ur_man->add_undo_method(ProjectSettings::get_singleton(), "set", setting, original_setting_value);
-	ur_man->add_undo_method(ProjectSettings::get_singleton(), "save");
+	ur_man->add_undo_method(project_settings, "set", setting, original_setting_value);
+	ur_man->add_undo_method(project_settings, "save");
 	ur_man->add_undo_method(this, "update_translations");
 	ur_man->commit_action();
 }

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -82,30 +82,34 @@ void VersionControlEditorPlugin::_notification(int p_what) {
 }
 
 void VersionControlEditorPlugin::_update_theme() {
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("success_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_TYPECHANGE] = EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
+	EditorNode *editor_node = EditorNode::get_singleton();
+	Ref<Theme> editor_theme = editor_node->get_editor_theme();
+	Control *gui_base = editor_node->get_gui_base();
 
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusSuccess"), EditorStringName(EditorIcons));
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_TYPECHANGE] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusError"), EditorStringName(EditorIcons));
-	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_NEW] = editor_theme->get_color(SNAME("success_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = editor_theme->get_color(SNAME("warning_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_RENAMED] = editor_theme->get_color(SNAME("warning_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_DELETED] = editor_theme->get_color(SNAME("error_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_TYPECHANGE] = editor_theme->get_color(SceneStringName(font_color), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = editor_theme->get_color(SNAME("warning_color"), EditorStringName(Editor));
 
-	select_public_path_button->set_button_icon(EditorNode::get_singleton()->get_gui_base()->get_editor_theme_icon("Folder"));
-	select_private_path_button->set_button_icon(EditorNode::get_singleton()->get_gui_base()->get_editor_theme_icon("Folder"));
-	refresh_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
-	discard_all_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
-	stage_all_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MoveDown"), EditorStringName(EditorIcons)));
-	unstage_all_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MoveUp"), EditorStringName(EditorIcons)));
-	fetch_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
-	pull_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MoveDown"), EditorStringName(EditorIcons)));
-	push_button->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MoveUp"), EditorStringName(EditorIcons)));
-	extra_options->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GuiTabMenuHl"), EditorStringName(EditorIcons)));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_NEW] = editor_theme->get_icon(SNAME("StatusSuccess"), EditorStringName(EditorIcons));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = editor_theme->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_RENAMED] = editor_theme->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_TYPECHANGE] = editor_theme->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_DELETED] = editor_theme->get_icon(SNAME("StatusError"), EditorStringName(EditorIcons));
+	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = editor_theme->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
+
+	select_public_path_button->set_button_icon(gui_base->get_editor_theme_icon("Folder"));
+	select_private_path_button->set_button_icon(gui_base->get_editor_theme_icon("Folder"));
+	refresh_button->set_button_icon(editor_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+	discard_all_button->set_button_icon(editor_theme->get_icon(SNAME("Close"), EditorStringName(EditorIcons)));
+	stage_all_button->set_button_icon(editor_theme->get_icon(SNAME("MoveDown"), EditorStringName(EditorIcons)));
+	unstage_all_button->set_button_icon(editor_theme->get_icon(SNAME("MoveUp"), EditorStringName(EditorIcons)));
+	fetch_button->set_button_icon(editor_theme->get_icon(SNAME("Reload"), EditorStringName(EditorIcons)));
+	pull_button->set_button_icon(editor_theme->get_icon(SNAME("MoveDown"), EditorStringName(EditorIcons)));
+	push_button->set_button_icon(editor_theme->get_icon(SNAME("MoveUp"), EditorStringName(EditorIcons)));
+	extra_options->set_button_icon(editor_theme->get_icon(SNAME("GuiTabMenuHl"), EditorStringName(EditorIcons)));
 
 	if (EditorVCSInterface::get_singleton()) {
 		_refresh_stage_area();
@@ -150,9 +154,10 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 	String selected_plugin = set_up_choice->get_item_text(id);
 
 	if (_load_plugin(selected_plugin)) {
-		ProjectSettings::get_singleton()->set("editor/version_control/autoload_on_startup", true);
-		ProjectSettings::get_singleton()->set("editor/version_control/plugin_name", selected_plugin);
-		ProjectSettings::get_singleton()->save();
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		ps->set("editor/version_control/autoload_on_startup", true);
+		ps->set("editor/version_control/plugin_name", selected_plugin);
+		ps->save();
 	}
 }
 
@@ -178,9 +183,10 @@ void VersionControlEditorPlugin::_set_credentials() {
 			ssh_private_key,
 			ssh_passphrase);
 
-	EditorSettings::get_singleton()->set_setting("version_control/username", username);
-	EditorSettings::get_singleton()->set_setting("version_control/ssh_public_key_path", ssh_public_key);
-	EditorSettings::get_singleton()->set_setting("version_control/ssh_private_key_path", ssh_private_key);
+	EditorSettings *es = EditorSettings::get_singleton();
+	es->set_setting("version_control/username", username);
+	es->set_setting("version_control/ssh_public_key_path", ssh_public_key);
+	es->set_setting("version_control/ssh_private_key_path", ssh_private_key);
 }
 
 bool VersionControlEditorPlugin::_load_plugin(const String &p_name) {
@@ -393,8 +399,9 @@ void VersionControlEditorPlugin::_create_branch() {
 
 	String new_branch_name = branch_create_name_input->get_text().strip_edges();
 
-	EditorVCSInterface::get_singleton()->create_branch(new_branch_name);
-	EditorVCSInterface::get_singleton()->checkout_branch(new_branch_name);
+	EditorVCSInterface *ed_vsc_if = EditorVCSInterface::get_singleton();
+	ed_vsc_if->create_branch(new_branch_name);
+	ed_vsc_if->checkout_branch(new_branch_name);
 
 	branch_create_name_input->clear();
 	_refresh_branch_list();
@@ -631,6 +638,8 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 
 	diff->clear();
 
+	Ref<Theme> editor_theme = EditorNode::get_singleton()->get_editor_theme();
+
 	if (show_commit_diff_header) {
 		Dictionary meta_data = commit_list->get_selected()->get_metadata(0);
 		String commit_id = meta_data[SNAME("commit_id")];
@@ -639,8 +648,8 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 		String commit_author = meta_data[SNAME("commit_author")];
 		String commit_date_string = meta_data[SNAME("commit_date_string")];
 
-		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
-		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor)));
+		diff->push_font(editor_theme->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
+		diff->push_color(editor_theme->get_color(SNAME("accent_color"), EditorStringName(Editor)));
 		diff->add_text(TTR("Commit:") + " " + commit_id);
 		diff->add_newline();
 		diff->add_text(TTR("Author:") + " " + commit_author);
@@ -657,13 +666,13 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 	}
 
 	for (const EditorVCSInterface::DiffFile &diff_file : diff_content) {
-		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
-		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor)));
+		diff->push_font(editor_theme->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
+		diff->push_color(editor_theme->get_color(SNAME("accent_color"), EditorStringName(Editor)));
 		diff->add_text(TTR("File:") + " " + diff_file.new_file);
 		diff->pop();
 		diff->pop();
 
-		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("status_source"), EditorStringName(EditorFonts)));
+		diff->push_font(editor_theme->get_font(SNAME("status_source"), EditorStringName(EditorFonts)));
 		for (EditorVCSInterface::DiffHunk hunk : diff_file.diff_hunks) {
 			String old_start = String::num_int64(hunk.old_start);
 			String new_start = String::num_int64(hunk.new_start);
@@ -977,8 +986,9 @@ void VersionControlEditorPlugin::fetch_available_vcs_plugin_names() {
 }
 
 void VersionControlEditorPlugin::register_editor() {
-	EditorDockManager::get_singleton()->add_dock(version_commit_dock);
-	EditorDockManager::get_singleton()->add_dock(version_control_dock);
+	EditorDockManager *dock_manager = EditorDockManager::get_singleton();
+	dock_manager->add_dock(version_commit_dock);
+	dock_manager->add_dock(version_control_dock);
 
 	_set_vcs_ui_state(true);
 }
@@ -988,16 +998,18 @@ void VersionControlEditorPlugin::shut_down() {
 		return;
 	}
 
-	if (EditorFileSystem::get_singleton()->is_connected(SNAME("filesystem_changed"), callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area))) {
-		EditorFileSystem::get_singleton()->disconnect(SNAME("filesystem_changed"), callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
+	EditorFileSystem *file_system = EditorFileSystem::get_singleton();
+	if (file_system->is_connected(SNAME("filesystem_changed"), callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area))) {
+		file_system->disconnect(SNAME("filesystem_changed"), callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 	}
 
 	EditorVCSInterface::get_singleton()->shut_down();
 	memdelete(EditorVCSInterface::get_singleton());
 	EditorVCSInterface::set_singleton(nullptr);
 
-	EditorDockManager::get_singleton()->remove_dock(version_commit_dock);
-	EditorDockManager::get_singleton()->remove_dock(version_control_dock);
+	EditorDockManager *dock_manager = EditorDockManager::get_singleton();
+	dock_manager->remove_dock(version_commit_dock);
+	dock_manager->remove_dock(version_control_dock);
 
 	_set_vcs_ui_state(false);
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Implements section "_Use of RD::get_singleton()_" of https://github.com/godotengine/godot-proposals/issues/7366 for the folder `editor/` (if I did everything, the review process of this would be chaotic and probably never finish)

<img width="871" height="882" alt="image" src="https://github.com/user-attachments/assets/4faaba0b-6246-4238-a823-71321ed31058" />

Take a look aswell at the comments under that proposal:

https://github.com/godotengine/godot-proposals/issues/7366#issuecomment-1648788495
https://github.com/godotengine/godot-proposals/issues/7366#issuecomment-1649017617
https://github.com/godotengine/godot-proposals/issues/7366#issuecomment-1649157413

## Summary of changes

When there are a lot of `get_singleton()` calls next to each other, store the result of that call once and use it instead.

<img width="1172" height="480" alt="image" src="https://github.com/user-attachments/assets/4e74d257-bffc-4ad0-a60a-a6460000d659" />

This is already implemented in some places, so this makes it consistent.

## Testing

While the main goal of these changes is to make the code more readable, the performance gain may also exist:

When compiling, I noticed a 11 KB file size reduce, showing that the compiler doesn't optimize this:

`scons platform=windows target=editor optimize=speed`
base = 166123008
pr = 166111744
diff = -11264

`scons platform=windows target=editor optimize=speed lto=full`
base = 202290688
pr = 202279424
diff = -11264

The actual runtime impact is close to none (only a few instructions/clock cycles per function), but eliminating unnecessary work is good.

## Discussion

Is it worth it to do the change for only two calls?

How should the variable storing the pointer (result of the get_singleton) be named? Currently I did it by the feel of the function (sometimes `audio_server`, in other scenarios `as`), but I feel like we should establish some rules.

## AI Disclosure

A python program to detect excessive use of `::get_singleton()` was written by Claude.
All code was written by me.