### PR TITLE
Add support for CUSTOM3 shader built-in when importing glTF files, and related improvements

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -941,6 +941,16 @@ PackedVector3Array GLTFDocument::_decode_accessor_as_vec3(const Ref<GLTFState> p
 	return _decode_unpack_indexed_data<PackedVector3Array>(vectors, p_packed_vertex_ids);
 }
 
+PackedVector4Array GLTFDocument::_decode_accessor_as_vec4(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids) {
+	ERR_FAIL_INDEX_V(p_accessor_index, p_gltf_state->accessors.size(), PackedVector4Array());
+	Ref<GLTFAccessor> accessor = p_gltf_state->accessors[p_accessor_index];
+	PackedVector4Array vectors = accessor->decode_as_vector4s(p_gltf_state);
+	if (p_packed_vertex_ids.is_empty()) {
+		return vectors;
+	}
+	return _decode_unpack_indexed_data<PackedVector4Array>(vectors, p_packed_vertex_ids);
+}
+
 PackedColorArray GLTFDocument::_decode_accessor_as_color(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids) {
 	ERR_FAIL_INDEX_V(p_accessor_index, p_gltf_state->accessors.size(), PackedColorArray());
 	Ref<GLTFAccessor> accessor = p_gltf_state->accessors[p_accessor_index];
@@ -1071,7 +1081,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 					attributes["TEXCOORD_1"] = GLTFAccessor::encode_new_accessor_from_vector2s(p_state, a, GLTFBufferView::TARGET_ARRAY_BUFFER);
 				}
 			}
-			for (int custom_i = 0; custom_i < 3; custom_i++) {
+			for (int custom_i = 0; custom_i < 4; custom_i++) {
 				Vector<float> a = array[Mesh::ARRAY_CUSTOM0 + custom_i];
 				if (a.size()) {
 					int num_channels = 4;
@@ -1573,48 +1583,54 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 			if (a.has(mat_secondary_texture_coord)) {
 				array[Mesh::ARRAY_TEX_UV2] = _decode_accessor_as_vec2(p_state, a[mat_secondary_texture_coord], indices_mapping);
 			}
-			for (int custom_i = 0; custom_i < 3; custom_i++) {
+			for (int custom_i = 0; custom_i < 4; custom_i++) {
 				Vector<float> cur_custom;
-				Vector<Vector2> texcoord_first;
-				Vector<Vector2> texcoord_second;
-
-				int texcoord_i = 2 + 2 * custom_i;
-				String gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i);
 				int num_channels = 0;
-				if (a.has(gltf_texcoord_key)) {
-					texcoord_first = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
-					num_channels = 2;
-				}
-				gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i + 1);
-				if (a.has(gltf_texcoord_key)) {
-					texcoord_second = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
+
+				// Attempt to read from "_CUSTOM" attributes first.
+				String gltf_custom_key = vformat("_CUSTOM%d", custom_i);
+				if (a.has(gltf_custom_key)) {
 					num_channels = 4;
-				}
-				if (!num_channels) {
-					break;
-				}
-				if (num_channels == 2 || num_channels == 4) {
-					cur_custom.resize(vertex_num * num_channels);
-					for (int32_t uv_i = 0; uv_i < texcoord_first.size() && uv_i < vertex_num; uv_i++) {
-						cur_custom.write[uv_i * num_channels + 0] = texcoord_first[uv_i].x;
-						cur_custom.write[uv_i * num_channels + 1] = texcoord_first[uv_i].y;
+					Vector<Vector4> custom_vector4 = _decode_accessor_as_vec4(p_state, a[gltf_custom_key], indices_mapping);
+					cur_custom.resize_initialized(vertex_num * 4);
+					for (int32_t uv_i = 0; uv_i < custom_vector4.size() && uv_i < vertex_num; uv_i++) {
+						cur_custom.write[uv_i * 4 + 0] = custom_vector4[uv_i].x;
+						cur_custom.write[uv_i * 4 + 1] = custom_vector4[uv_i].y;
+						cur_custom.write[uv_i * 4 + 2] = custom_vector4[uv_i].z;
+						cur_custom.write[uv_i * 4 + 3] = custom_vector4[uv_i].w;
 					}
-					// Vector.resize seems to not zero-initialize. Ensure all unused elements are 0:
-					for (int32_t uv_i = texcoord_first.size(); uv_i < vertex_num; uv_i++) {
-						cur_custom.write[uv_i * num_channels + 0] = 0;
-						cur_custom.write[uv_i * num_channels + 1] = 0;
+				} else {
+					// Attempt to read from UVs 3 to 10 as an alternative source for custom data.
+					// Note that Blender has a limit of 8 UV sets; therefore, CUSTOM3 cannot be read this way
+					// for models exported from Blender. Use a custom attribute named "_CUSTOM3" instead.
+					Vector<Vector2> texcoord_first;
+					Vector<Vector2> texcoord_second;
+					int texcoord_i = 2 + 2 * custom_i;
+					String gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i);
+					if (a.has(gltf_texcoord_key)) {
+						texcoord_first = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
+						num_channels = 2;
 					}
-				}
-				if (num_channels == 4) {
-					for (int32_t uv_i = 0; uv_i < texcoord_second.size() && uv_i < vertex_num; uv_i++) {
-						// num_channels must be 4
-						cur_custom.write[uv_i * num_channels + 2] = texcoord_second[uv_i].x;
-						cur_custom.write[uv_i * num_channels + 3] = texcoord_second[uv_i].y;
+					gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i + 1);
+					if (a.has(gltf_texcoord_key)) {
+						texcoord_second = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
+						num_channels = 4;
 					}
-					// Vector.resize seems to not zero-initialize. Ensure all unused elements are 0:
-					for (int32_t uv_i = texcoord_second.size(); uv_i < vertex_num; uv_i++) {
-						cur_custom.write[uv_i * num_channels + 2] = 0;
-						cur_custom.write[uv_i * num_channels + 3] = 0;
+					if (!num_channels) {
+						break;
+					}
+					if (num_channels == 2 || num_channels == 4) {
+						cur_custom.resize_initialized(vertex_num * num_channels);
+						for (int32_t uv_i = 0; uv_i < texcoord_first.size() && uv_i < vertex_num; uv_i++) {
+							cur_custom.write[uv_i * num_channels + 0] = texcoord_first[uv_i].x;
+							cur_custom.write[uv_i * num_channels + 1] = texcoord_first[uv_i].y;
+						}
+						if (num_channels == 4) {
+							for (int32_t uv_i = 0; uv_i < texcoord_second.size() && uv_i < vertex_num; uv_i++) {
+								cur_custom.write[uv_i * num_channels + 2] = texcoord_second[uv_i].x;
+								cur_custom.write[uv_i * num_channels + 3] = texcoord_second[uv_i].y;
+							}
+						}
 					}
 				}
 				if (cur_custom.size() > 0) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -151,6 +151,7 @@ private:
 	PackedInt32Array _decode_accessor_as_int32s(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids = PackedInt32Array());
 	PackedVector2Array _decode_accessor_as_vec2(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids = PackedInt32Array());
 	PackedVector3Array _decode_accessor_as_vec3(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids = PackedInt32Array());
+	PackedVector4Array _decode_accessor_as_vec4(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids = PackedInt32Array());
 	PackedColorArray _decode_accessor_as_color(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, const PackedInt32Array &p_packed_vertex_ids = PackedInt32Array());
 	Vector<Quaternion> _decode_accessor_as_quaternion(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index);
 	Array _decode_accessor_as_variants(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, Variant::Type p_variant_type);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, it isn't possible to import values into Godot's built-in `CUSTOM3` shader variable using any file format. While Godot supports 4 custom attributes per vertex (`CUSTOM0`, `CUSTOM1`, `CUSTOM2`, `CUSTOM3`), the importer limits the number of custom vertex attributes to just 3 (`CUSTOM0`, `CUSTOM1`, `CUSTOM2`).

**Why this is an issue:** I attach custom values to the vertices of my meshes to specify custom animation options among other things. This allows me to add varied animations and interesting visual details to my meshes fully on the GPU via a custom shader, without burdening the CPU. Godot's shading language already supports 16 custom float values through `CUSTOM0`, `CUSTOM1`, `CUSTOM2`, `CUSTOM3` (in addition to `UV`, `UV2`, and the lower precision `COLOR`), which are sufficient for my needs. However, the glTF importer doesn't support `CUSTOM3`, which artificially limits the number of custom float values to 12. This is below the number of custom values I need to attach to each vertex, even after fully utilizing `UV`, `UV2`, and `COLOR`.

This commit lifts this limitation by allowing one to import `CUSTOM3`, while also giving developers an additional (optional and easier) way to specify the other CUSTOM shader built-ins (details below).

## Additional information

The existing limitation arises from the current importer's reliance on UV attributes for specifying the values of the CUSTOM shader built-ins, and Blender's limit of 8 UV sets in total. Because UV and UV2 are already used by Godot, 6 sets of UV attributes remain, allowing for a total of 12 custom floating point values per vertex. However, each CUSTOM shader built-in is made up of 4 floats, requiring a total of 16 custom floats to specify all four of them. As a result, the current importer only sets `CUSTOM0` (UV3 & UV4), `CUSTOM1` (UV5 & UV6), and `CUSTOM2` (UV7 & UV8).

This PR makes the following improvements to the glTF importer and exporter:

1. Allow import of attributes named "_CUSTOM0", "_CUSTOM1", "_CUSTOM2", "_CUSTOM3", each defined as 4 float values, and map these to Godot's `CUSTOM0`, `CUSTOM1`, `CUSTOM2`, `CUSTOM3` shader built-ins. These attributes are given priority over UV sets 3-8. (Notes: The underscore in front of each name is to ensure that Blender exports them. Each _CUSTOM attribute in the glTF file must be a vector of 4 floats, which corresponds to the type "Color" in Blender. Blender's "Byte Color" type should not be used for these attributes.)
2. Increase the limit of "TEXCOORD" (UV) imports from 3 pairs (UV3-UV8) to 4 pairs (UV3-UV10), so _CUSTOM3 can be specified via UV9 & UV10 when used with an exporter that supports UV9 & UV10. (Notes: This is for users who want to continue using UV sets for CUSTOM variables and for reimporting of glTF files exported from Godot. UV sets 3-10 are only used if a corresponding _CUSTOMn attribute doesn't exist. Blender only supports 8 UV sets in total; however, other content generation software and Godot itself -- see below -- can support UV9 and UV10 as the glTF standard doesn't limit the number of UV sets.)
3. Increase the limit of "TEXCOORD" (UV) exports from 3 pairs to 4 pairs, so that all CUSTOM values are exported, including `CUSTOM3` as UV9 and UV10.

This new workflow is fully optional. Users can continue to use UV sets to set `CUSTOM0`, `CUSTOM1` and `CUSTOM2` as they always did. Existing code isn't affected as long as a user doesn't happen to have custom attributes named "_CUSTOM0", "_CUSTOM1", "_CUSTOM2", "_CUSTOM3" in their glTF files. User code would also be affected if the user happens to have UV9 or UV10 included in their glTF files (which Blender doesn't support) and the user expects those UV sets to be thrown out instead of being written into `CUSTOM3`.

Limitations:
- This PR only improves glTF support. The FBX importer can be updated separately if `CUSTOM3` support in it is desired.
- The "Spatial shaders" page of the documentation will need to updated once this PR is accepted. (Just the lines that describe `CUSTOM0`, `CUSTOM1`, `CUSTOM2`, and `CUSTOM3`).