### PR TITLE
`SpinBox`: Make `KP_PERIOD` always write `.`

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -201,9 +201,9 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 	Ref<InputEventKey> k = p_event;
-	//Replace numpad decimal separator with a period, as in some languages this may be a comma
+	// Replace numpad decimal separator with a period, as in some languages this may be a comma.
 	if (k.is_valid() && line_edit->is_editing() && line_edit->has_focus()) {
-		if (k->get_physical_keycode() == Key::KP_PERIOD && k->is_pressed()) {
+		if (k->get_keycode() == Key::KP_PERIOD && k->is_pressed()) {
 			line_edit->insert_text_at_caret(".");
 			line_edit->accept_event();
 		}

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -198,6 +198,15 @@ LineEdit *SpinBox::get_line_edit() {
 void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 	if (drag.enabled) {
 		line_edit->accept_event();
+		return;
+	}
+	Ref<InputEventKey> k = p_event;
+	//Replace numpad decimal separator with a period, as in some languages this may be a comma
+	if (k.is_valid() && line_edit->is_editing() && line_edit->has_focus()) {
+		if (k->get_physical_keycode() == Key::KP_PERIOD && k->is_pressed()) {
+			line_edit->insert_text_at_caret(".");
+			line_edit->accept_event();
+		}
 	}
 }
 


### PR DESCRIPTION
Some languages use a comma instead of a period. This causes issues with the number parser, so the previous workaround was to replace the comma with a period in the string.

The main place where this is actually an issue is when using the numpad, as those languages replace the period with a comma in the numpad. So, this intercepts the KP_PERIOD and forces print a period.

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119946

## Additional information

Also replaced number literals in translation_server with their chars for improved readability.

Other ways to fix this that were considered:
- Add a language line in the translation server: overkill to translate the whole string just for a comma
- move the spinbox line out of update on change: this causes other issues, possibly with expressions

Maybe in the future doing number input completely using physical keycodes could allow to lessen the use of the language server in the spinbox to allow expressions in there ?