### PR TITLE
Add tooltips to Theme editor type tabs

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3636,16 +3636,22 @@ ThemeTypeEditor::ThemeTypeEditor() {
 
 	data_type_tabs = memnew(TabContainer);
 	data_type_tabs->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
-	main_vb->add_child(data_type_tabs);
 	data_type_tabs->set_v_size_flags(SIZE_EXPAND_FILL);
 	data_type_tabs->set_use_hidden_tabs_for_min_size(true);
+	main_vb->add_child(data_type_tabs);
 
 	color_items_list = _create_item_list(Theme::DATA_TYPE_COLOR);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Colors"));
 	constant_items_list = _create_item_list(Theme::DATA_TYPE_CONSTANT);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Constants"));
 	font_items_list = _create_item_list(Theme::DATA_TYPE_FONT);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Fonts"));
 	font_size_items_list = _create_item_list(Theme::DATA_TYPE_FONT_SIZE);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Font Sizes"));
 	icon_items_list = _create_item_list(Theme::DATA_TYPE_ICON);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("Icons"));
 	stylebox_items_list = _create_item_list(Theme::DATA_TYPE_STYLEBOX);
+	data_type_tabs->set_tab_tooltip(data_type_tabs->get_tab_count() - 1, TTRC("StyleBoxes"));
 
 	VBoxContainer *type_settings_tab = memnew(VBoxContainer);
 	type_settings_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

I've seen one person on Discord confused about theme type tabs. Indeed, they don't have any text, so unless you know what the icons mean, their meaning can be unclear.

## Additional information

<img width="365" height="191" alt="image" src="https://github.com/user-attachments/assets/e3bd741f-4c58-4c30-b28f-e8a3370e0c07" />
