### PR TITLE
Remove unnecessary `is_class()` usage in Object

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -514,7 +514,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
-	const uint32_t base_script_usage = is_class(Script::get_class_static()) ? PROPERTY_USAGE_NO_EDITOR : PROPERTY_USAGE_DEFAULT;
+	const uint32_t base_script_usage = Object::cast_to<Script>(this) ? PROPERTY_USAGE_NO_EDITOR : PROPERTY_USAGE_DEFAULT;
 	p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static(), base_script_usage | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_NEVER_DUPLICATE));
 
 	if (script_instance && !p_reversed) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Addresses https://github.com/godotengine/godot/pull/94062#discussion_r2769017630, which was not properly resolved for whatever reason.
