### PR TITLE
Show toast when copying version

### DIFF
--- a/editor/gui/editor_version_button.cpp
+++ b/editor/gui/editor_version_button.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/time.h"
 #include "core/version.h"
+#include "editor/gui/editor_toaster.h"
 #include "servers/display/display_server.h"
 
 String _get_version_string(EditorVersionButton::VersionFormat p_format) {
@@ -80,6 +81,10 @@ void EditorVersionButton::_notification(int p_what) {
 
 void EditorVersionButton::pressed() {
 	DisplayServer::get_singleton()->clipboard_set(_get_version_string(FORMAT_WITH_BUILD));
+	EditorToaster *toaster = EditorToaster::get_singleton();
+	if (toaster) {
+		toaster->popup_str(TTR("Copied Godot editor version."));
+	}
 }
 
 EditorVersionButton::EditorVersionButton(VersionFormat p_format) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The version button lacks visible feedback.  You press it, but nothing really happens.
This PR shows a toast.

## Additional information

https://github.com/user-attachments/assets/898247c7-87b7-4545-bd90-76cc1378a244

Has no effect in Project Manager.
