### PR TITLE
Expose two further native methods of LightmapGIData to GDScript.

### DIFF
--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -31,6 +31,20 @@
 				Returns the number of objects that are considered baked within this [LightmapGIData].
 			</description>
 		</method>
+		<method name="get_user_lightmap_slice_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="user_idx" type="int" />
+			<description>
+				Returns the slice index of the baked object within this [LightmapGIData] at index [param user_idx].
+			</description>
+		</method>
+		<method name="get_user_lightmap_uv_scale" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="user_idx" type="int" />
+			<description>
+				Returns a [Rect2] describing the scale of the baked object within this [LightmapGIData] at index [param user_idx].
+			</description>
+		</method>
 		<method name="get_user_path" qualifiers="const">
 			<return type="NodePath" />
 			<param index="0" name="user_idx" type="int" />

--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -38,6 +38,20 @@
 				Returns the [NodePath] of the baked object at index [param user_idx].
 			</description>
 		</method>
+		<method name="get_user_lightmap_uv_scale" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="user_idx" type="int" />
+			<description>
+				Returns a [Rect2] describing the scale of the baked object within this [LightmapGIData] at index [param user_idx].
+			</description>
+		</method>
+		<method name="get_user_lightmap_slice_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="user_idx" type="int" />
+			<description>
+				Returns the slice index of the baked object within this [LightmapGIData] at index [param user_idx].
+			</description>
+		</method>
 		<method name="is_using_spherical_harmonics" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -31,11 +31,11 @@
 				Returns the number of objects that are considered baked within this [LightmapGIData].
 			</description>
 		</method>
-		<method name="get_user_path" qualifiers="const">
-			<return type="NodePath" />
+		<method name="get_user_lightmap_slice_index" qualifiers="const">
+			<return type="int" />
 			<param index="0" name="user_idx" type="int" />
 			<description>
-				Returns the [NodePath] of the baked object at index [param user_idx].
+				Returns the slice index of the baked object within this [LightmapGIData] at index [param user_idx].
 			</description>
 		</method>
 		<method name="get_user_lightmap_uv_scale" qualifiers="const">
@@ -45,11 +45,11 @@
 				Returns a [Rect2] describing the scale of the baked object within this [LightmapGIData] at index [param user_idx].
 			</description>
 		</method>
-		<method name="get_user_lightmap_slice_index" qualifiers="const">
-			<return type="int" />
+		<method name="get_user_path" qualifiers="const">
+			<return type="NodePath" />
 			<param index="0" name="user_idx" type="int" />
 			<description>
-				Returns the slice index of the baked object within this [LightmapGIData] at index [param user_idx].
+				Returns the [NodePath] of the baked object at index [param user_idx].
 			</description>
 		</method>
 		<method name="is_using_spherical_harmonics" qualifiers="const">

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -357,6 +357,8 @@ void LightmapGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_user", "path", "uv_scale", "slice_index", "sub_instance"), &LightmapGIData::add_user);
 	ClassDB::bind_method(D_METHOD("get_user_count"), &LightmapGIData::get_user_count);
 	ClassDB::bind_method(D_METHOD("get_user_path", "user_idx"), &LightmapGIData::get_user_path);
+	ClassDB::bind_method(D_METHOD("get_user_lightmap_uv_scale", "user_idx"), &LightmapGIData::get_user_lightmap_uv_scale);
+	ClassDB::bind_method(D_METHOD("get_user_lightmap_slice_index", "user_idx"), &LightmapGIData::get_user_lightmap_slice_index);
 	ClassDB::bind_method(D_METHOD("clear_users"), &LightmapGIData::clear_users);
 
 	ClassDB::bind_method(D_METHOD("_set_probe_data", "data"), &LightmapGIData::_set_probe_data);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -361,6 +361,8 @@ void LightmapGIData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_user", "path", "uv_scale", "slice_index", "sub_instance"), &LightmapGIData::add_user);
 	ClassDB::bind_method(D_METHOD("get_user_count"), &LightmapGIData::get_user_count);
 	ClassDB::bind_method(D_METHOD("get_user_path", "user_idx"), &LightmapGIData::get_user_path);
+	ClassDB::bind_method(D_METHOD("get_user_lightmap_uv_scale", "user_idx"), &LightmapGIData::get_user_lightmap_uv_scale);
+	ClassDB::bind_method(D_METHOD("get_user_lightmap_slice_index", "user_idx"), &LightmapGIData::get_user_lightmap_slice_index);
 	ClassDB::bind_method(D_METHOD("clear_users"), &LightmapGIData::clear_users);
 
 	ClassDB::bind_method(D_METHOD("_set_probe_data", "data"), &LightmapGIData::_set_probe_data);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

`RenderingServer.instance_geometry_set_lightmap` is exposed to GDScript, but two of its parameters are currently hidden within LightmapGIData.  This exposes two further functions on LightmapGIData which can be used to retrieve their values.  This is needed for cases where it's necessary to re/connect a mesh instance to LightmapGI (for example, switching to a different mesh with compatible UV2).

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Tested on Ubuntu.