### PR TITLE
Check blend weight for AnimationNode error & remove `_validate_animation_graph()`

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -337,7 +337,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 		}
 	}
 
-	bool does_include_invalid_key = false;
 	points.clear();
 	for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
 		float point = blend_space->get_blend_point_position(i);
@@ -362,7 +361,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			Ref<AnimationNodeAnimation> anim_node = node;
 			if (anim_node.is_null()) {
 				is_key_valid = false;
-				does_include_invalid_key = true;
 			}
 		}
 		Vector2 gui_point = (ofs + Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
@@ -383,9 +381,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
-			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
-			: String();
 
 	// blend position
 	{
@@ -785,11 +780,6 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible_in_tree()) {
-				AnimationTreeEditor::get_singleton()->current_playback_error = String();
-			}
 		} break;
 	}
 }

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -636,7 +636,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 		blend_space_draw->draw_primitive(bl_points, colors, Vector<Vector2>());
 	}
 
-	bool does_include_invalid_key = false;
 	points.clear();
 	for (int i = 0; i < blend_space->get_blend_point_count(); i++) {
 		Vector2 point = blend_space->get_blend_point_position(i);
@@ -662,7 +661,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			Ref<AnimationNodeAnimation> anim_node = node;
 			if (anim_node.is_null()) {
 				is_key_valid = false;
-				does_include_invalid_key = true;
 			}
 		}
 		Vector2 gui_point = (ofs + point - icon->get_size() / 2).floor();
@@ -688,9 +686,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
-			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
-			: String();
 
 	if (making_triangle.size()) {
 		Vector<Vector2> bl_points;
@@ -1029,11 +1024,6 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible_in_tree()) {
-				AnimationTreeEditor::get_singleton()->current_playback_error = String();
-			}
 		} break;
 	}
 }

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -72,8 +72,6 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 		connected_nodes.clear();
 		_update_mode();
 		_update_graph();
-	} else {
-		AnimationTreeEditor::get_singleton()->current_playback_error = String();
 	}
 
 	if (read_only) {
@@ -1694,7 +1692,6 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 			const String playback_path = AnimationTreeEditor::get_singleton()->get_base_path() + "playback";
 			Ref<AnimationNodeStateMachinePlayback> playback = tree->get(playback_path);
-			AnimationTreeEditor::get_singleton()->current_playback_error = playback.is_null() ? vformat(TTR("No playback resource set at path: %s."), playback_path) : String();
 
 			for (int i = 0; i < transition_lines.size(); i++) {
 				int tidx = -1;
@@ -1831,8 +1828,6 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			hovered_node_name = StringName();
 			hovered_node_area = HOVER_NODE_NONE;
 			set_process(is_visible_in_tree());
-
-			AnimationTreeEditor::get_singleton()->current_playback_error = String();
 		} break;
 	}
 }

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -108,12 +108,25 @@ void AnimationTreeEditor::_meta_clicked(Variant p_meta) {
 	}
 }
 
-void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
+void AnimationTreeEditor::_update_error_message() {
+	const StringName base_path = get_base_path();
+	Ref<AnimationNode> inspected_node = tree->get_animation_node_by_path(base_path);
+	if (inspected_node.is_valid()) {
+		inspected_node->validate_node(tree, base_path);
+		LocalVector<AnimationNode::ChildNode> children;
+		inspected_node->get_child_nodes(&children);
+		for (const AnimationNode::ChildNode &child : children) {
+			if (child.node.is_valid()) {
+				child.node->validate_node(tree, String(base_path) + String(child.name) + "/");
+			}
+		}
+	}
+
 	const String editor_error_message = tree->get_editor_error_message();
 	const AHashMap<StringName, AnimationNode::InvalidInstance> &invalid_instances = tree->get_invalid_instances();
 
 	static String last_error_key;
-	if (editor_error_message.is_empty() && invalid_instances.is_empty() && (!p_other_errors || p_other_errors->is_empty())) {
+	if (editor_error_message.is_empty() && invalid_instances.is_empty()) {
 		last_error_key = String();
 		error_button->hide();
 		error_scroll->hide();
@@ -127,9 +140,6 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 		StringBuffer k;
 		k += get_base_path();
 		k += editor_error_message;
-		if (p_other_errors) {
-			k += *p_other_errors;
-		}
 		for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
 			k += kv.key;
 			for (const String &reason : kv.value.errors) {
@@ -173,14 +183,6 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 		error_label->append_text(editor_error_message);
 		error_label->add_newline();
 		count++;
-	}
-
-	if (p_other_errors) {
-		error_label->append_text(*p_other_errors);
-		error_label->add_newline();
-		count++;
-
-		scope_error_found = true;
 	}
 
 	error_label->push_table(2);
@@ -246,11 +248,7 @@ void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
 	error_label->pop(); // Table.
 
 	current_scope_error_label->clear();
-	if (p_other_errors) {
-		current_scope_error_label->push_color(current_scope_error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-		current_scope_error_label->append_text(TTR("Error: ") + *p_other_errors);
-		current_scope_error_label->pop(); // Color.
-	} else {
+	{
 		const StringName display_key = scope_error_found ? fallback_key : (!downstream_key.is_empty() ? downstream_key : fallback_key);
 		if (!display_key.is_empty()) {
 			const AnimationNode::InvalidInstance &inst = invalid_instances.get(display_key);
@@ -391,7 +389,7 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 	}
 
 	_update_path();
-	_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
+	_update_error_message();
 }
 
 void AnimationTreeEditor::_clear_editors() {
@@ -445,7 +443,7 @@ void AnimationTreeEditor::_notification(int p_what) {
 			}
 
 			if (tree) {
-				_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
+				_update_error_message();
 			}
 		} break;
 

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -77,7 +77,7 @@ class AnimationTreeEditor : public EditorDock {
 	void _animation_list_changed();
 
 	void _toggle_error_panel();
-	void _update_error_message(const String *p_other_errors = nullptr);
+	void _update_error_message();
 
 	static LocalVector<StringName> get_animation_list();
 
@@ -89,8 +89,6 @@ protected:
 	static AnimationTreeEditor *singleton;
 
 public:
-	String current_playback_error;
-
 	AnimationTree *get_animation_tree() { return tree; }
 	void add_plugin(AnimationTreeNodeEditorPlugin *p_editor);
 	void remove_plugin(AnimationTreeNodeEditorPlugin *p_editor);

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -78,7 +78,12 @@ void AnimationNodeBlendSpace1D::validate_node(const AnimationTree *p_tree, const
 	AnimationRootNode::validate_node(p_tree, p_path);
 
 	if (get_blend_point_count() == 0) {
-		add_validation_error(p_tree, p_path, RTR("No blend points exist, so blending cannot take place."));
+		add_validation_error(p_tree, p_path, RTR(ERR_NO_BLEND_POINT));
+	}
+
+	const_cast<AnimationNodeBlendSpace1D *>(this)->_check_can_sync();
+	if (is_contain_invalid_point) {
+		add_validation_error(p_tree, p_path, RTR(ERR_INVALID_POINT));
 	}
 }
 
@@ -424,7 +429,16 @@ void AnimationNodeBlendSpace1D::_check_can_sync() {
 }
 
 AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
-	if (!blend_points_used || is_contain_invalid_point) {
+	if (!blend_points_used) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, RTR(ERR_NO_BLEND_POINT));
+		}
+		return NodeTimeInfo();
+	}
+	if (is_contain_invalid_point) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, RTR(ERR_INVALID_POINT));
+		}
 		return NodeTimeInfo();
 	}
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -35,6 +35,9 @@
 class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace1D, AnimationRootNode);
 
+	const String ERR_NO_BLEND_POINT = "No blend points exist, so blending cannot take place.";
+	const String ERR_INVALID_POINT = "Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.";
+
 public:
 	enum BlendMode {
 		BLEND_MODE_INTERPOLATED,

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -572,7 +572,16 @@ void AnimationNodeBlendSpace2D::_check_can_sync() {
 AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	_update_triangles();
 
-	if (!blend_points_used || is_contain_invalid_point) {
+	if (!blend_points_used) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, RTR(ERR_NO_TRIANGLE));
+		}
+		return NodeTimeInfo();
+	}
+	if (is_contain_invalid_point) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, RTR(ERR_INVALID_POINT));
+		}
 		return NodeTimeInfo();
 	}
 
@@ -844,7 +853,12 @@ void AnimationNodeBlendSpace2D::validate_node(const AnimationTree *p_tree, const
 
 	const_cast<AnimationNodeBlendSpace2D *>(this)->_update_triangles();
 	if (get_triangle_count() == 0) {
-		add_validation_error(p_tree, p_path, RTR("No triangles exist, so blending cannot take place."));
+		add_validation_error(p_tree, p_path, RTR(ERR_NO_TRIANGLE));
+	}
+
+	const_cast<AnimationNodeBlendSpace2D *>(this)->_check_can_sync();
+	if (is_contain_invalid_point) {
+		add_validation_error(p_tree, p_path, RTR(ERR_INVALID_POINT));
 	}
 }
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -35,6 +35,9 @@
 class AnimationNodeBlendSpace2D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace2D, AnimationRootNode);
 
+	const String ERR_NO_TRIANGLE = "No triangles exist, so blending cannot take place.";
+	const String ERR_INVALID_POINT = "Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.";
+
 public:
 	enum BlendMode {
 		BLEND_MODE_INTERPOLATED,

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -102,8 +102,12 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const 
 AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	_update_animation_cache(p_process_state.tree, p_instance);
 	const Ref<Animation> &anim = p_instance.cached_animation;
-	// Should not ever happen due to validation earlier.
-	ERR_FAIL_COND_V(anim.is_null(), NodeTimeInfo());
+	if (unlikely(anim.is_null())) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, vformat(RTR("Animation '%s' not found."), animation));
+		}
+		return NodeTimeInfo();
+	}
 	double anim_size = anim->get_length();
 
 	double cur_len; // The animation length seen in NodeTimeInfo, propagated throughout the tree.

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1247,6 +1247,16 @@ AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
 
 ///////////////////////////////////////////////////////
 
+void AnimationNodeStateMachine::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
+	AnimationRootNode::validate_node(p_tree, p_path);
+
+	const String playback_path = String(p_path) + String(playback);
+	Ref<AnimationNodeStateMachinePlayback> pb = p_tree->get(playback_path);
+	if (pb.is_null()) {
+		add_validation_error(p_tree, p_path, vformat(RTR("No playback resource set at path: %s."), playback_path));
+	}
+}
+
 void AnimationNodeStateMachine::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeStateMachinePlayback::get_class_static(), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE)); // Don't store this object in .tres, it always needs to be made as unique object.

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -164,6 +164,8 @@ protected:
 	virtual void reset_state() override;
 
 public:
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+
 	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -127,6 +127,11 @@ void AnimationNode::add_validation_error(const AnimationTree *p_tree, const Stri
 void AnimationNode::make_invalid(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const String &p_reason) {
 	p_process_state.valid = false;
 
+	// TODO:
+	// Currently, if the AnimationTree stops due to an error as valid state at runtime, there is no way for the user to be aware of the error.
+	// I assume we should output an error when there is a change in p_process_state.valid between frames.
+	// Caching invalid_instance and checking the difference every frame is accurate, but it is somewhat costly and therefore likely not preferred.
+	// If we were to implement it, we should add an option in the project settings' animation tab, like `enum PrintErrorMode: {NONE, LOOSE, STRICT}`.
 	InvalidInstance &invalid_instance = p_process_state.invalid_instances[p_instance.path];
 	invalid_instance.errors.push_back(p_reason);
 }
@@ -138,8 +143,12 @@ AnimationNode::NodeTimeInfo AnimationNode::blend_input(ProcessState &p_process_s
 	if (likely(p_instance.connection_instances.size() > 0)) {
 		node_instance = p_instance.connection_instances[p_input];
 	}
-	// Should not ever happen due to validation earlier.
-	ERR_FAIL_NULL_V(node_instance, NodeTimeInfo());
+	if (unlikely(!node_instance)) {
+		if (!p_test_only && p_instance.is_blended()) {
+			make_invalid(p_process_state, p_instance, vformat(RTR("Nothing connected to input %d."), p_input));
+		}
+		return NodeTimeInfo();
+	}
 
 	real_t activity = 0.0;
 
@@ -253,6 +262,7 @@ AnimationNode::NodeTimeInfo AnimationNode::_blend_node(ProcessState &p_process_s
 	if (!p_playback_info.seeked && !p_sync && !any_valid) {
 		p_playback_info.delta = 0.0;
 	}
+	p_other.blended = any_valid;
 	return p_other.resource->_pre_process(p_process_state, p_other, p_playback_info, p_test_only);
 }
 
@@ -650,18 +660,9 @@ Ref<AnimationRootNode> AnimationTree::get_root_animation_node() const {
 bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
 	_update_properties(); // If properties need updating, update them.
 
-	bool was_validation_dirty = validation_dirty;
 	if (validation_dirty) {
-		process_state.invalid_instances.clear();
-		validation_successful = true;
-		_validate_animation_graph(Animation::PARAMETERS_BASE_PATH, root_animation_node);
-		validation_dirty = false;
-	}
-	if (!validation_successful) {
-		return false;
-	}
-	if (was_validation_dirty) {
 		_update_connections();
+		validation_dirty = false;
 	}
 
 	AnimationNodeInstance &instance = get_node_instance_by_path(SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data()));
@@ -690,6 +691,7 @@ bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const 
 		for (int i = 0; i < p_track_count; i++) {
 			src_blendsw[i] = 1.0; // By default all go to 1 for the root input.
 		}
+		instance.blended = true;
 		instance.path = SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data());
 	}
 
@@ -910,24 +912,6 @@ void AnimationTree::_update_properties() const {
 	const_cast<AnimationTree *>(this)->notify_property_list_changed();
 }
 
-void AnimationTree::_validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const {
-	if (p_node.is_null()) {
-		validation_successful = false;
-		return;
-	}
-
-	p_node->validate_node(this, p_path);
-	// We will continue even if the validation is not successful, to gather all errors.
-
-	LocalVector<AnimationNode::ChildNode> children;
-	p_node->get_child_nodes(&children);
-
-	for (const AnimationNode::ChildNode &E : children) {
-		const StringName child_path = String(p_path) + E.name + "/";
-		_validate_animation_graph(child_path, E.node);
-	}
-}
-
 void AnimationTree::_update_connections() {
 	for (KeyValue<StringName, AnimationNodeInstance> &E : instance_map) {
 		AnimationNodeInstance &parent_instance = E.value;
@@ -943,7 +927,6 @@ void AnimationTree::_update_connections() {
 			parent_instance.connection_instances.resize(1);
 			AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(output_connections->operator[](0));
 			parent_instance.connection_instances[0] = connected_instance;
-			CRASH_COND(!connected_instance); // Will never happen.
 		}
 
 		for (const KeyValue<StringName, AnimationNodeInstance *> &kv : parent_instance.child_instances) {
@@ -955,20 +938,24 @@ void AnimationTree::_update_connections() {
 				const StringName &connected_node_name = child_connections[input];
 				AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(connected_node_name);
 				child_instance->connection_instances[input] = connected_instance;
-				CRASH_COND(!connected_instance); // Will never happen.
 			}
 		}
 	}
 }
 
 void AnimationTree::_add_validation_error(const StringName &p_path, const String &p_error, int p_input_index) const {
-	validation_successful = false;
-
 	AnimationNode::InvalidInstance &invalid_instance = process_state.invalid_instances[p_path];
 
 	if (p_input_index == -1) {
-		invalid_instance.errors.push_back(p_error);
+		if (invalid_instance.errors.find(p_error) == -1) {
+			invalid_instance.errors.push_back(p_error);
+		}
 	} else {
+		for (const AnimationNode::InvalidInstance::InputError &E : invalid_instance.input_errors) {
+			if (E.index == p_input_index) {
+				return;
+			}
+		}
 		invalid_instance.input_errors.push_back({ p_input_index, p_error });
 	}
 }

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -267,6 +267,7 @@ struct AnimationNodeInstance {
 
 	mutable LocalVector<AnimationNodeInstance *> connection_instances; // AnimationNodeInstance* | nullptr
 	mutable LocalVector<real_t> track_weights;
+	mutable bool blended = false;
 	mutable LocalVector<int> filtered_track_indices_cache;
 	mutable uint32_t filters_version = 0;
 	mutable AHashMap<StringName, AnimationNodeInstance *> child_instances; // Child Name -> AnimationNodeInstance*
@@ -428,6 +429,10 @@ struct AnimationNodeInstance {
 		CRASH_COND_MSG(!instance, "Child instance pointer is null for path: \"" + String(p_path) + "\".");
 		return *instance;
 	}
+
+	_FORCE_INLINE_ bool is_blended() const {
+		return blended;
+	}
 };
 
 class AnimationTree : public AnimationMixer {
@@ -461,10 +466,8 @@ private:
 
 	mutable bool properties_dirty = true;
 	mutable bool validation_dirty = true;
-	mutable bool validation_successful = false;
 
 	void _update_properties() const;
-	void _validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const;
 	void _update_connections();
 	void _add_validation_error(const StringName &p_path, const String &p_error, int p_input_index = -1) const;
 	void _update_properties_for_node(const StringName &p_base_path, const Ref<AnimationNode> &p_node) const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119341

`_validate_animation_graph()` checks the entire AnimationTree, and if there is even a partial error, it stops the entire AnimationTree.

To restore the current state (4.6) for the time being, I remove `_validate_animation_graph()` and make the whole AnimationTree's invalid state dependent on the blend amount. Also, while error detection was previously handled in each editor for BlendTree/StateMachine/BlendSpace1(2)D, we will centralize error detection within the AnimationNode side.

In the future, we need to make the distinction between warnings and errors easier to see, but since this is too large a change to be included in the beta/RC scope, https://github.com/godotengine/godot/pull/119670 needs to be a follow-up for 4.8 or later. cc @Ryan-000

https://github.com/user-attachments/assets/d45404e9-8f94-452e-ab2c-5916a0d6df55

As you can see in the video, because there is no distinction between warnings and errors, an error is displayed; however, if it is internally a warning-level error, the AnimationTree itself continues to run. The AnimationTree stops only when the blend amount of an AnimationNode with an error becomes greater than 0.