### PR TITLE
Replace `RenderingServer` for `RS` in some editor code for consistency

### DIFF
--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -476,7 +476,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 }
 
 EditorMaterialPreviewPlugin::~EditorMaterialPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	RS::get_singleton()->free_rid(sphere);
 	RS::get_singleton()->free_rid(sphere_instance);
 	RS::get_singleton()->free_rid(viewport);
@@ -819,7 +819,7 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 }
 
 EditorMeshPreviewPlugin::~EditorMeshPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	//RS::get_singleton()->free(sphere);
 	RS::get_singleton()->free_rid(mesh_instance);
 	RS::get_singleton()->free_rid(viewport);
@@ -912,7 +912,7 @@ EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
 }
 
 EditorFontPreviewPlugin::~EditorFontPreviewPlugin() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	RS::get_singleton()->free_rid(canvas_item);
 	RS::get_singleton()->free_rid(canvas);
 	RS::get_singleton()->free_rid(viewport);

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -107,13 +107,13 @@ void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewp
 		SceneTree *st = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 		ERR_FAIL_NULL_MSG(st, "Editor's MainLoop is not a SceneTree. This is a bug.");
 		RID root_vp = st->get_root()->get_viewport_rid();
-		RenderingServer::get_singleton()->viewport_set_active(root_vp, false);
+		RS::get_singleton()->viewport_set_active(root_vp, false);
 
 		RS::get_singleton()->viewport_set_update_mode(p_viewport, RSE::VIEWPORT_UPDATE_ONCE);
 		RS::get_singleton()->draw(false);
 
 		// Let main viewport and children be drawn again.
-		RenderingServer::get_singleton()->viewport_set_active(root_vp, true);
+		RS::get_singleton()->viewport_set_active(root_vp, true);
 	}
 }
 

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -61,7 +61,7 @@ bool EditorNode3DGizmo::is_editable() const {
 }
 
 void EditorNode3DGizmo::clear() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
 			RS::get_singleton()->free_rid(instances[i].instance);
@@ -818,7 +818,7 @@ void EditorNode3DGizmo::transform() {
 }
 
 void EditorNode3DGizmo::free() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4868,7 +4868,7 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 }
 
 void Node3DEditorViewport::_finish_gizmo_instances() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(RS::get_singleton());
 	for (int i = 0; i < 3; i++) {
 		RS::get_singleton()->free_rid(move_gizmo_instance[i]);
 		RS::get_singleton()->free_rid(move_plane_gizmo_instance[i]);
@@ -7488,10 +7488,10 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	Node3DEditorSelectedItem *si = memnew(Node3DEditorSelectedItem);
 
 	si->sp = sp;
-	si->sbox_instance = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance = RS::get_singleton()->instance_create2(
 			selection_box->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	si->sbox_instance_offset = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance_offset = RS::get_singleton()->instance_create2(
 			selection_box->get_rid(),
 			sp->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
@@ -7508,10 +7508,10 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-	si->sbox_instance_xray = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance_xray = RS::get_singleton()->instance_create2(
 			selection_box_xray->get_rid(),
 			sp->get_world_3d()->get_scenario());
-	si->sbox_instance_xray_offset = RenderingServer::get_singleton()->instance_create2(
+	si->sbox_instance_xray_offset = RS::get_singleton()->instance_create2(
 			selection_box_xray->get_rid(),
 			sp->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(
@@ -8394,15 +8394,15 @@ void fragment() {
 		d.resize(RSE::ARRAY_MAX);
 		d[RSE::ARRAY_VERTEX] = origin_points;
 
-		origin_mesh = RenderingServer::get_singleton()->mesh_create();
+		origin_mesh = RS::get_singleton()->mesh_create();
 
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(origin_mesh, RSE::PRIMITIVE_TRIANGLES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(origin_mesh, 0, origin_mat->get_rid());
+		RS::get_singleton()->mesh_add_surface_from_arrays(origin_mesh, RSE::PRIMITIVE_TRIANGLES, d);
+		RS::get_singleton()->mesh_surface_set_material(origin_mesh, 0, origin_mat->get_rid());
 
-		origin_multimesh = RenderingServer::get_singleton()->multimesh_create();
-		RenderingServer::get_singleton()->multimesh_set_mesh(origin_multimesh, origin_mesh);
-		RenderingServer::get_singleton()->multimesh_allocate_data(origin_multimesh, 12, RSE::MultimeshTransformFormat::MULTIMESH_TRANSFORM_3D, true, false);
-		RenderingServer::get_singleton()->multimesh_set_visible_instances(origin_multimesh, -1);
+		origin_multimesh = RS::get_singleton()->multimesh_create();
+		RS::get_singleton()->multimesh_set_mesh(origin_multimesh, origin_mesh);
+		RS::get_singleton()->multimesh_allocate_data(origin_multimesh, 12, RSE::MultimeshTransformFormat::MULTIMESH_TRANSFORM_3D, true, false);
+		RS::get_singleton()->multimesh_set_visible_instances(origin_multimesh, -1);
 
 		LocalVector<float> distances;
 		distances.resize(5);
@@ -8441,17 +8441,17 @@ void fragment() {
 					t = t.scaled(axis * distances[j]);
 					t = t.translated(axis * distances[j + 1]);
 				}
-				RenderingServer::get_singleton()->multimesh_instance_set_transform(origin_multimesh, i * 4 + j, t);
-				RenderingServer::get_singleton()->multimesh_instance_set_color(origin_multimesh, i * 4 + j, origin_color);
+				RS::get_singleton()->multimesh_instance_set_transform(origin_multimesh, i * 4 + j, t);
+				RS::get_singleton()->multimesh_instance_set_color(origin_multimesh, i * 4 + j, origin_color);
 			}
 		}
 
-		origin_instance = RenderingServer::get_singleton()->instance_create2(origin_multimesh, get_tree()->get_root()->get_world_3d()->get_scenario());
+		origin_instance = RS::get_singleton()->instance_create2(origin_multimesh, get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, RSE::SHADOW_CASTING_SETTING_OFF);
 
 		Ref<Shader> grid_shader = memnew(Shader);
 		grid_shader->set_code(R"(
@@ -9177,19 +9177,19 @@ void Node3DEditor::_init_grid() {
 		}
 
 		// Create a mesh from the pushed vector points and colors.
-		grid[c] = RenderingServer::get_singleton()->mesh_create();
+		grid[c] = RS::get_singleton()->mesh_create();
 		Array d;
 		d.resize(RSE::ARRAY_MAX);
 		d[RSE::ARRAY_VERTEX] = (Vector<Vector3>)grid_points[c];
 		d[RSE::ARRAY_COLOR] = (Vector<Color>)grid_colors[c];
 		d[RSE::ARRAY_NORMAL] = (Vector<Vector3>)grid_normals[c];
-		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(grid[c], RSE::PRIMITIVE_LINES, d);
-		RenderingServer::get_singleton()->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
-		grid_instance[c] = RenderingServer::get_singleton()->instance_create2(grid[c], get_tree()->get_root()->get_world_3d()->get_scenario());
+		RS::get_singleton()->mesh_add_surface_from_arrays(grid[c], RSE::PRIMITIVE_LINES, d);
+		RS::get_singleton()->mesh_surface_set_material(grid[c], 0, grid_mat[c]->get_rid());
+		grid_instance[c] = RS::get_singleton()->instance_create2(grid[c], get_tree()->get_root()->get_world_3d()->get_scenario());
 
 		// Yes, the end of this line is supposed to be a.
-		RenderingServer::get_singleton()->instance_set_visible(grid_instance[c], grid_visible[a]);
-		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[c], RSE::SHADOW_CASTING_SETTING_OFF);
+		RS::get_singleton()->instance_set_visible(grid_instance[c], grid_visible[a]);
+		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[c], RSE::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(grid_instance[c], 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
 		RS::get_singleton()->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 		RS::get_singleton()->instance_geometry_set_flag(grid_instance[c], RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Replaces all occurences of `RenderingServer` for `RS` in `editor/*` files for consistency, but only if `RS` is used in the file already.

Edit: This description is invalid, AThousandShips wanted it diffrent, look at the comments below.

Definition of RS:
`#define RS RenderingServer`