### PR TITLE
Fix ZIPPacker creating empty directory entries

### DIFF
--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -70,7 +70,7 @@ int ZIPPacker::get_compression_level() const {
 Error ZIPPacker::start_file(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions, uint64_t p_modified_time) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
-	if (!p_path.get_base_dir().is_empty() && !directories.has(p_path.get_base_dir())) {
+	if (!p_path.get_base_dir().is_empty() && !directories.has(p_path.get_base_dir() + "/")) {
 		add_directory(p_path.get_base_dir(), 0755, p_modified_time);
 	}
 
@@ -136,8 +136,9 @@ Error ZIPPacker::close_file() {
 }
 
 Error ZIPPacker::add_directory(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions, uint64_t p_modified_time) {
+	String path = p_path.ends_with("/") ? p_path : p_path + "/";
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
-	ERR_FAIL_COND_V_MSG(directories.has(p_path), ERR_CANT_CREATE, vformat("Directory '%s' already exists.", p_path));
+	ERR_FAIL_COND_V_MSG(directories.has(path), ERR_CANT_CREATE, vformat("Directory '%s' already exists.", path));
 
 	uint64_t time = p_modified_time;
 	if (time == 0) {
@@ -168,7 +169,7 @@ Error ZIPPacker::add_directory(const String &p_path, BitField<FileAccess::UnixPe
 	zipfi.internal_fa = 0;
 
 	int err = zipOpenNewFileInZip4(zf,
-			p_path.utf8().get_data(),
+			path.utf8().get_data(),
 			&zipfi,
 			nullptr,
 			0,
@@ -190,7 +191,7 @@ Error ZIPPacker::add_directory(const String &p_path, BitField<FileAccess::UnixPe
 		return FAILED;
 	}
 
-	directories.insert(p_path);
+	directories.insert(path);
 	return OK;
 }
 


### PR DESCRIPTION
**What problem(s) does this PR solve?**
- Closes #120068

**Additional information**

When calling `start_file` with a path that includes a subdirectory (e.g. `"folder/file.txt"`), the packer auto creates the parent directory entry. Due to a missing trailing `/`, the entry is stored as `"folder"` instead of `"folder/"`, which ZIP tools interpret as a zero-byte file rather than a directory.

This results in the archive containing both a zero-byte file named `"folder"` and the intended file at `"folder/file.txt"`. This is a duplicate name conflict that causes Windows native ZIP extraction to fail or skip entries, and breaks repacked binary formats like `.aar` files which are sensitive to duplicate or malformed entries.

**Fix:** Append `"/"` to the path passed to `add_directory` in `start_file`.

---

See issue #120068 for full details, test case, and root cause analysis.

Note: 4.7 specific regression. Directory and permission support was added in https://github.com/godotengine/godot/pull/115946