### PR TITLE
[.Net] Keep C# available after an ALC unloading faliure

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
@@ -78,6 +78,24 @@ namespace GodotPlugins
         private static PluginLoadContextWrapper? _projectLoadContext;
         private static bool _editorHint = false;
 
+        // Cooperative unloading opcodes — keep in sync with gdmono::UnloadOpcode in gd_mono.h.
+        private const int UNLOAD_OPCODE_OK = 0;
+        private const int UNLOAD_OPCODE_ALC_LEAKED = 1;
+        private const int UNLOAD_OPCODE_NOT_COLLECTIBLE = 2;
+        private const int UNLOAD_OPCODE_EXCEPTION = 3;
+
+        // Blittable struct returned across the P/Invoke boundary so the C++ side can
+        // report the opcode AND leaked ALC count via ERR_PRINT_ED / WARN_PRINT_ED.
+        [StructLayout(LayoutKind.Sequential)]
+        private struct UnloadResult
+        {
+            public int Opcode;
+            public int LeakedAlcCount;
+        }
+
+        // Track how many ALCs have leaked so we can report the count to the user.
+        private static int _leakedAlcCount;
+
         private static readonly AssemblyLoadContext MainLoadContext =
             AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ??
             AssemblyLoadContext.Default;
@@ -133,7 +151,7 @@ namespace GodotPlugins
         {
             public unsafe delegate* unmanaged<char*, godot_string*, godot_bool> LoadProjectAssemblyCallback;
             public unsafe delegate* unmanaged<char*, IntPtr, int, IntPtr> LoadToolsAssemblyCallback;
-            public unsafe delegate* unmanaged<godot_bool> UnloadProjectPluginCallback;
+            public unsafe delegate* unmanaged<UnloadResult> UnloadProjectPluginCallback;
         }
 
         [UnmanagedCallersOnly]
@@ -216,33 +234,30 @@ namespace GodotPlugins
         }
 
         [UnmanagedCallersOnly]
-        private static godot_bool UnloadProjectPlugin()
+        private static UnloadResult UnloadProjectPlugin()
         {
             try
             {
-                return UnloadPlugin(ref _projectLoadContext).ToGodotBool();
+                return UnloadPlugin(ref _projectLoadContext);
             }
             catch (Exception e)
             {
                 Console.Error.WriteLine(e);
-                return godot_bool.False;
+                return new UnloadResult { Opcode = UNLOAD_OPCODE_EXCEPTION, LeakedAlcCount = _leakedAlcCount };
             }
         }
 
-        private static bool UnloadPlugin(ref PluginLoadContextWrapper? pluginLoadContext)
+        private static UnloadResult UnloadPlugin(ref PluginLoadContextWrapper? pluginLoadContext)
         {
             try
             {
                 if (pluginLoadContext == null)
-                    return true;
+                    return new UnloadResult { Opcode = UNLOAD_OPCODE_OK, LeakedAlcCount = _leakedAlcCount };
 
                 if (!pluginLoadContext.IsCollectible)
                 {
-                    Console.Error.WriteLine("Cannot unload a non-collectible assembly load context.");
-                    return false;
+                    return new UnloadResult { Opcode = UNLOAD_OPCODE_NOT_COLLECTIBLE, LeakedAlcCount = _leakedAlcCount };
                 }
-
-                Console.WriteLine("Unloading assembly load context...");
 
                 pluginLoadContext.Unload();
 
@@ -262,30 +277,27 @@ namespace GodotPlugins
                     if (!takingTooLong && elapsedTimeMs >= 200)
                     {
                         takingTooLong = true;
-
-                        // TODO: How to log from GodotPlugins? (delegate pointer?)
-                        Console.Error.WriteLine("Assembly unloading is taking longer than expected...");
                     }
                     else if (elapsedTimeMs >= 1000)
                     {
-                        // TODO: How to log from GodotPlugins? (delegate pointer?)
-                        Console.Error.WriteLine(
-                            "Failed to unload assemblies. Possible causes: Strong GC handles, running threads, etc.");
+                        // Cooperative unloading: abandon the old ALC (let it leak) and
+                        // proceed to load everything into a brand-new ALC. The C++ side
+                        // will report the leak to the user via ERR_PRINT_ED.
+                        _leakedAlcCount++;
 
-                        return false;
+                        // Abandon the old context — set to null so a new one can be created on next load
+                        pluginLoadContext = null;
+                        return new UnloadResult { Opcode = UNLOAD_OPCODE_ALC_LEAKED, LeakedAlcCount = _leakedAlcCount };
                     }
                 }
 
-                Console.WriteLine("Assembly load context unloaded successfully.");
-
                 pluginLoadContext = null;
-                return true;
+                return new UnloadResult { Opcode = UNLOAD_OPCODE_OK, LeakedAlcCount = _leakedAlcCount };
             }
             catch (Exception e)
             {
-                // TODO: How to log exceptions from GodotPlugins? (delegate pointer?)
                 Console.Error.WriteLine(e);
-                return false;
+                return new UnloadResult { Opcode = UNLOAD_OPCODE_EXCEPTION, LeakedAlcCount = _leakedAlcCount };
             }
         }
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
 using System.Text;
 
 #nullable enable
@@ -59,9 +61,23 @@ internal class ReflectionUtils
 
     public static Type? FindTypeInLoadedAssemblies(string assemblyName, string typeFullName)
     {
+        // With cooperative ALC unloading, there may be multiple assemblies with the same name
+        // loaded from different ALCs (one from a leaked old ALC, one from the new ALC).
+        // We must return the type from a non-leaked ALC. LastOrDefault prefers the most
+        // recently loaded assembly (from the newest ALC), which is the correct one.
+        // As an additional safety check, we filter out assemblies from ALCs that are being
+        // unloaded (leaked), in case the enumeration order is not reliable.
         return AppDomain.CurrentDomain.GetAssemblies()
-            .FirstOrDefault(a => a.GetName().Name == assemblyName)?
-            .GetType(typeFullName);
+            .Where(a => a.GetName().Name == assemblyName)
+            .Where(a =>
+            {
+                var alc = AssemblyLoadContext.GetLoadContext(a);
+                // alc is null for assemblies in the default ALC (shared assemblies),
+                // which are never being unloaded, so include them.
+                return alc == null || !CustomGCHandle.IsAlcBeingUnloaded(alc);
+            })
+            .Select(a => a.GetType(typeFullName))
+            .LastOrDefault(t => t != null);
     }
 
     public static string ConstructTypeName(Type type)

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -790,9 +790,11 @@ void GDMono::reload_failure() {
 	if (++project_load_failure_count >= (int)GLOBAL_GET("dotnet/project/assembly_reload_attempts")) {
 		// After reloading a project has failed n times in a row, update the path and modification time
 		// to stop any further attempts at loading this assembly, which probably is never going to work anyways.
+		// Note: With cooperative ALC unloading, unload failures result in a leaked ALC (handled on the C# side)
+		// rather than blocking the reload, so this path is only reached on actual load failures.
 		project_load_failure_count = 0;
 
-		ERR_PRINT_ED(".NET: Giving up on assembly reloading. Please restart the editor if unloading was failing.");
+		ERR_PRINT_ED(".NET: Giving up on assembly reloading. The project assembly could not be loaded. Please restart the editor.");
 
 		String assembly_name = Path::get_csharp_project_name();
 		String assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir().path_join(assembly_name + ".dll");
@@ -807,10 +809,33 @@ Error GDMono::reload_project_assemblies() {
 
 	finalizing_scripts_domain = true;
 
-	if (!get_plugin_callbacks().UnloadProjectPluginCallback()) {
-		ERR_PRINT_ED(".NET: Failed to unload assemblies. Please check https://github.com/godotengine/godot/issues/78513 for more information.");
-		reload_failure();
-		return FAILED;
+	// Cooperative ALC unloading: the C# side attempts to unload the old AssemblyLoadContext.
+	// Returns a struct with an opcode (see gdmono::UnloadOpcode) and a cumulative leak count.
+	gdmono::UnloadPluginResult result = get_plugin_callbacks().UnloadProjectPluginCallback();
+
+	switch (result.opcode) {
+		case gdmono::UNLOAD_OPCODE_OK:
+			if (result.leaked_alc_count > 0) {
+				// Unload succeeded this time, but previous ALCs have leaked.
+				WARN_PRINT_ED(vformat(
+						".NET: Assembly unloading succeeded, but %d AssemblyLoadContext(s) have leaked since the editor started and consume memory until the editor is restarted. \nPlease check https://github.com/godotengine/godot/issues/78513 for more information.",
+						result.leaked_alc_count));
+			}
+			break;
+		case gdmono::UNLOAD_OPCODE_ALC_LEAKED:
+			// ALC leaked — cooperative unloading. The old ALC has been abandoned and a new
+			// one will be loaded. Report the failure with the updated leaked count.
+			WARN_PRINT_ED(vformat(
+					".NET: Failed to unload the old AssemblyLoadContext. \nThe context has leaked and memory will not be reclaimed until editor restart (leaked ALCs so far: %d). \nThe editor will continue working using a new AssemblyLoadContext. \nPossible causes: Strong GC handles, running threads, static event handlers on AppDomain or AssemblyLoadContext.Default, or libraries that are not unloadability-friendly. \nPlease check https://github.com/godotengine/godot/issues/78513 for more information.",
+					result.leaked_alc_count));
+			break;
+		default:
+			// Critical error — cannot proceed with reload.
+			ERR_PRINT_ED(vformat(
+					".NET: Failed to unload assemblies due to a critical error (opcode: %d). \nPlease check https://github.com/godotengine/godot/issues/78513 for more information.",
+					result.opcode));
+			reload_failure();
+			return FAILED;
 	}
 
 	finalizing_scripts_domain = false;

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -46,10 +46,23 @@
 namespace gdmono {
 
 #ifdef TOOLS_ENABLED
+// Keep in sync with UNLOAD_OPCODE_* constants in GodotPlugins/Main.cs.
+enum UnloadOpcode : int32_t {
+	UNLOAD_OPCODE_OK = 0,
+	UNLOAD_OPCODE_ALC_LEAKED = 1,
+	UNLOAD_OPCODE_NOT_COLLECTIBLE = 2,
+	UNLOAD_OPCODE_EXCEPTION = 3,
+};
+
+struct UnloadPluginResult {
+	int32_t opcode;
+	int32_t leaked_alc_count;
+};
+
 struct PluginCallbacks {
 	using FuncLoadProjectAssemblyCallback = bool(GD_CLR_STDCALL *)(const char16_t *, String *);
 	using FuncLoadToolsAssemblyCallback = Object *(GD_CLR_STDCALL *)(const char16_t *, const void **, int32_t);
-	using FuncUnloadProjectPluginCallback = bool(GD_CLR_STDCALL *)();
+	using FuncUnloadProjectPluginCallback = UnloadPluginResult(GD_CLR_STDCALL *)();
 	FuncLoadProjectAssemblyCallback LoadProjectAssemblyCallback = nullptr;
 	FuncLoadToolsAssemblyCallback LoadToolsAssemblyCallback = nullptr;
 	FuncUnloadProjectPluginCallback UnloadProjectPluginCallback = nullptr;


### PR DESCRIPTION
Mitigates:
- #78513

- Closes: godotengine/godot-proposals#11819

Supersedes
- #118357

Unity ultimately hasn't managed to slip past the flaw in the modern ALC design: cooperative unloading, which means they are likely facing a similar issue to the one we are facing now (#78513) after they finish migrating to the modern dotnet. But in [this discussion](https://discussions.unity.com/t/path-to-coreclr-2026-upgrade-guide/1714279/7), one of the staff members mentioned that they decided to just keep the leaked ALC as is while loading the new code to a new ALC and report the leakage to the user later. 

Quote:
> What happens when an assembly can’t be unloaded? What are the possible issues? Will there be two instances of types in that assembly: one from the newly loaded assembly and one from the one that couldn’t be unloaded? Will a newly instantiated object correctly use the new assembly?

> Yes. We’re planning to report to the user after a suitable time that an AssemblyLoadContext has leaked.

This PR is a Godot implementation of the same idea, and it's shocking how little code it takes to implement such. 

https://github.com/user-attachments/assets/50e9954d-cbdb-4233-ba7c-e647b6dbd3c9

After this PR, when an unloading failure occurs, we stop disabling C#; instead, we increment an internal leak count and just report it to the user.

Disclaimer: This doesn't fix issue #78513; it just makes the consequences of the unloading failure into additional memory usage instead of disabling C#.

AI Usage: `DeepSeek V4 Pro` / `Github Copilot` is used to perform research and initial implementation; the PR author manually tested the functions against the pattern provided in #78513 to make sure the PR functions. After that, the Author made necessary manual changes so that the behavior complies with the standard Godot Editor experience.