### PR TITLE
Emit `changed` when `ColorPalette` colors are changed

### DIFF
--- a/scene/resources/color_palette.cpp
+++ b/scene/resources/color_palette.cpp
@@ -34,6 +34,7 @@
 
 void ColorPalette::set_colors(const PackedColorArray &p_colors) {
 	colors = p_colors;
+	emit_changed();
 }
 
 PackedColorArray ColorPalette::get_colors() const {


### PR DESCRIPTION
## What problem(s) does this PR solve?
Today there is no way to be notified when the colors in a `ColorPalette` resource are changed. This PR updates the `ColorPalette` resource to emit a `changed` signal when its colors are set.

Use case:
> I want to expose a `Resource` with a `ColorPalette`. When the color palette is updated in the editor, my plugin needs to respond by updating its internal state. Today, there's no way to know when the `ColorPalette` resource is updated in the editor. The workaround is to duplicate the `ColorPalette` into a new resource type that my plugin owns, but it's not quite as nice.