### PR TITLE
Mention `queue_redraw` when changing `SceneTree.debug_collisions_hint`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -265,7 +265,16 @@
 		</member>
 		<member name="debug_collisions_hint" type="bool" setter="set_debug_collisions_hint" getter="is_debugging_collisions_hint" default="false">
 			If [code]true[/code], collision shapes will be visible when running the game from the editor for debugging purposes.
-			[b]Note:[/b] This property is not designed to be changed at run-time. Changing the value of [member debug_collisions_hint] while the project is running will not have the desired effect.
+			[b]Note:[/b] This property is not designed to be changed at run-time, however queueing a redraw across the tree while the project is running after changing the value may have the desired effect.
+			[codeblocks]
+			[gdscript]
+			get_tree().root.propagate_call("queue_redraw")
+			[/gdscript]
+			[csharp]
+			GetTree().Root.PropagateCall(CanvasItem.MethodName.QueueRedraw);
+			[/csharp]
+			[/codeblocks]
+			[b]Note:[/b] This only applies to 2D [CanvasItem] nodes, and may cause a stutter in large scenes.
 		</member>
 		<member name="debug_navigation_hint" type="bool" setter="set_debug_navigation_hint" getter="is_debugging_navigation_hint" default="false">
 			If [code]true[/code], navigation polygons will be visible when running the game from the editor for debugging purposes.


### PR DESCRIPTION
Update the documentation for SceneTree.debug_collisions_hint to indicate how to update it properly at runtime for 2D scenes.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The current documentation does not indicate how runtime changes to `debug_collisions_hint` can be effectively used.  This updates the documentation to include an example invocation, making runtime changes of this parameter useful.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
