### PR TITLE
Fix ResourceLoader deadlocks

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -412,12 +412,15 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 					chain.push_back(current_thread);
 
 					// We made it back to us, we're in a cycle.
-					if (next_thread == thread_index) {
+					if (next_thread == thread_index || chain.has(next_thread)) {
 						cycle_detected = true;
 						break;
 					}
 
 					if (chain.size() > thread_load_tasks.size()) {
+						ERR_PRINT(vformat("chain.size() > thread_load_tasks.size() for '%s' on thread %d",
+								load_task.local_path, thread_index));
+						cycle_detected = true;
 						break;
 					}
 
@@ -451,11 +454,6 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 					}
 				}
 			} else {
-				if (thread_waiting_on_backup.is_empty()) {
-					thread_waiting_on.erase(thread_index);
-				} else {
-					thread_waiting_on[thread_index] = thread_waiting_on_backup;
-				}
 				wait = false;
 			}
 
@@ -509,6 +507,13 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 
 		if (status != THREAD_LOAD_IN_PROGRESS) {
 			load_task.load_token->unreference();
+			thread_load_mutex.lock();
+			if (thread_waiting_on_backup.is_empty()) {
+				thread_waiting_on.erase(thread_index);
+			} else {
+				thread_waiting_on[thread_index] = thread_waiting_on_backup;
+			}
+			thread_load_mutex.unlock();
 			return;
 		}
 
@@ -541,6 +546,11 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 	thread_load_mutex.lock();
 	bool thread_load_mutex_held = true;
 
+	bool was_finished = load_task.finished_load;
+	if (load_task.resource.is_valid()) {
+		load_task.finished_load = true;
+	}
+
 	load_task.resource = res;
 
 	load_task.progress = 1.0; // It was fully loaded at this point, so force progress to 1.0.
@@ -559,6 +569,16 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 			ResourceCache::lock.lock(); // Check and operations must happen atomically.
 			bool pending_unlock = true;
 			Ref<Resource> old_res = ResourceCache::get_ref(load_task.local_path);
+			if (was_finished) {
+				// If another thread already finished the entire load wait for it to complete
+				// cache registration, then use their instance.
+				while (!old_res.is_valid()) {
+					ResourceCache::lock.unlock();
+					OS::get_singleton()->delay_usec(1000);
+					ResourceCache::lock.lock();
+					old_res = ResourceCache::get_ref(load_task.local_path);
+				}
+			}
 			if (old_res.is_valid()) {
 				if (old_res != load_task.resource) {
 					// Resource can already exists at this point for two reasons:

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -203,6 +203,7 @@ private:
 		bool in_progress_check : 1; // Measure against recursion cycles in progress reporting. Cycles are not expected, but can happen due to how it's currently implemented.
 		bool use_sub_threads : 1;
 		bool started_load : 1;
+		bool finished_load : 1;
 		bool connections_propagated : 1;
 
 		struct ResourceChangedConnection {
@@ -218,6 +219,7 @@ private:
 				in_progress_check(false),
 				use_sub_threads(false),
 				started_load(false),
+				finished_load(false),
 				connections_propagated(false) {}
 	};
 	static void _run_load_task(void *p_userdata);


### PR DESCRIPTION
This fixes several issues:
 * There was a bug in the cycle detection. It was possible for the cycle detection to fail because the current thread isn't in the list. Fix this by just seeing if any of the next threads were already in the cycle.
 * By way of an optimization the thread_waiting_on bookkeeping was done under the same thread_load_mutex as the cycle detection. But there is also an early exit after yields. If we exit through the yield the thread_waiting_on entry is stale and can cause other threads to fail to do cycle detection.
 * When multiple threads end up finishing a resource simultaneously anyway, probably through cycle detection, there's a small chance that the original thread finished more-or-less at the same time if the original thing blocking load completed. We solve this now by letting only one of the threads do the initial registration.

Testing was done with MRPs from:
* #111202
* #115069
* #118085
* #119371
* #119374
* #84012
* #98865

In addition two projects that were shared with me privately. 

No regressions compared to current master were found, and the new issues were fixed.