### PR TITLE
[macOS] Check for resource fork when loading fonts.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -715,7 +715,11 @@ Vector<String> OS_MacOS::get_system_font_path_for_text(const String &p_font_name
 					CFURLRef url = (CFURLRef)CTFontDescriptorCopyAttribute(fallback_font, kCTFontURLAttribute);
 					if (url) {
 						NSString *font_path = [NSString stringWithString:[(__bridge NSURL *)url path]];
-						ret.push_back(String::utf8([font_path UTF8String]));
+						String path = String::utf8([font_path UTF8String]);
+						if (FileAccess::get_size(path) == 0 && FileAccess::get_size(path + "/..namedfork/rsrc") != 0) {
+							path += "/..namedfork/rsrc";
+						}
+						ret.push_back(path);
 						CFRelease(url);
 					}
 					CFRelease(fallback_font);
@@ -778,7 +782,11 @@ String OS_MacOS::get_system_font_path(const String &p_font_name, int p_weight, i
 		CFURLRef url = (CFURLRef)CTFontDescriptorCopyAttribute(font, kCTFontURLAttribute);
 		if (url) {
 			NSString *font_path = [NSString stringWithString:[(__bridge NSURL *)url path]];
-			ret = String::utf8([font_path UTF8String]);
+			String path = String::utf8([font_path UTF8String]);
+			if (FileAccess::get_size(path) == 0 && FileAccess::get_size(path + "/..namedfork/rsrc") != 0) {
+				path += "/..namedfork/rsrc";
+			}
+			ret = path;
 			CFRelease(url);
 		}
 		CFRelease(font);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/115061

## Additional information

Should fix handling of some legacy fonts.

Supersede https://github.com/godotengine/godot/pull/120079