### PR TITLE
GDScript: Remove `method_info` field from analyzer type representation

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -88,7 +88,6 @@ static GDScriptParser::DataType make_callable_type(const MethodInfo &p_info) {
 	type.kind = GDScriptParser::DataType::BUILTIN;
 	type.builtin_type = Variant::CALLABLE;
 	type.is_constant = true;
-	type.method_info = p_info;
 	return type;
 }
 
@@ -98,7 +97,6 @@ static GDScriptParser::DataType make_signal_type(const MethodInfo &p_info) {
 	type.kind = GDScriptParser::DataType::BUILTIN;
 	type.builtin_type = Variant::SIGNAL;
 	type.is_constant = true;
-	type.method_info = p_info;
 	return type;
 }
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -566,6 +566,13 @@ struct GDScriptCompletionIdentifier {
 	String enumeration;
 	Variant value;
 	const GDScriptParser::ExpressionNode *assigned_expression = nullptr;
+
+	/**
+	 * When the identifier refers to a method, this reflects the expected call signature.
+	 *
+	 * Empty if unresolved or no arguments are expected or this is not a method. The size might mismatch with actual arguments in the AST.
+	 */
+	Vector<PropertyInfo> expected_arguments;
 };
 
 // LOCATION METHODS
@@ -1789,7 +1796,7 @@ static GDScriptCompletionIdentifier _callable_type_from_method_info(const Method
 	ci.type.builtin_type = Variant::CALLABLE;
 	ci.type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 	ci.type.is_constant = true;
-	ci.type.method_info = p_method;
+	ci.expected_arguments = p_method.arguments;
 	return ci;
 }
 
@@ -2648,7 +2655,6 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 							r_type.type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 							r_type.type.kind = GDScriptParser::DataType::BUILTIN;
 							r_type.type.builtin_type = Variant::SIGNAL;
-							r_type.type.method_info = member.signal->method_info;
 							return true;
 						case GDScriptParser::ClassNode::Member::FUNCTION:
 							if (is_static && !member.function->is_static) {
@@ -2949,8 +2955,8 @@ static bool _guess_expecting_callable(GDScriptParser::CompletionContext &p_conte
 		GDScriptCompletionIdentifier ci;
 		if (_guess_expression_type(p_context, call_node->callee, ci)) {
 			if (ci.type.kind == GDScriptParser::DataType::BUILTIN && ci.type.builtin_type == Variant::CALLABLE) {
-				if (p_context.call.argument >= 0 && p_context.call.argument < ci.type.method_info.arguments.size()) {
-					return ci.type.method_info.arguments.get(p_context.call.argument).type == Variant::CALLABLE;
+				if (p_context.call.argument >= 0 && static_cast<unsigned int>(p_context.call.argument) < ci.expected_arguments.size()) {
+					return ci.expected_arguments[p_context.call.argument].type == Variant::CALLABLE;
 				}
 			}
 		}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -135,7 +135,6 @@ public:
 		String script_path;
 		ClassNode *class_type = nullptr;
 
-		MethodInfo method_info; // For callable/signals.
 		HashMap<StringName, int64_t> enum_values; // For enums.
 
 		_FORCE_INLINE_ bool is_set() const { return kind != RESOLVING && kind != UNRESOLVED; }
@@ -246,7 +245,6 @@ public:
 			script_type = p_other.script_type;
 			script_path = p_other.script_path;
 			class_type = p_other.class_type;
-			method_info = p_other.method_info;
 			enum_values = p_other.enum_values;
 			container_element_types = p_other.container_element_types;
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Revives https://github.com/godotengine/godot/pull/94465 

I originally blocked the PR for editor functionality. After having worked a bit more with the GDScript codebase I welcome any trimming down on `GDScriptParser::DataType`.
Instead of removing, this PR moves the relevant information that the editor needs into `GDScriptCompletionIdentifier` which is basically an extended type representation used by the editor. Since the editor does its own analyzing on the AST it is sufficient to populate the information in editor and not in the analyzer.

## Additional information

I did not do extensive testing, however the only usage of the property was from https://github.com/godotengine/godot/pull/96375. All test cases from this PR are still passing. Potential edge cases can be fixed in editor code if they come up.

In theory we could remove the `MethodInfo` argument from `make_callable_type` as well. I did not do this for now. Not sure if we should.