### PR TITLE
Fix first tile not being randomized

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -657,8 +657,8 @@ bool TileMapLayerEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEven
 		Vector2 mpos = xform.affine_inverse().xform(mm->get_position());
 
 		if (edited_layer->local_to_map(drag_last_mouse_pos) != edited_layer->local_to_map(mpos)) {
-			pattern_rng.seed(Math::rand());
-			rng_base_state = Math::rand();
+			pattern_rng.randomize();
+			rng_base_state = pattern_rng.get_state();
 		}
 
 		switch (drag_type) {

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -183,7 +183,7 @@ private:
 	RBSet<TileMapCell> tile_set_selection;
 
 	RandomPCG pattern_rng;
-	uint32_t rng_base_state = 0;
+	uint64_t rng_base_state = 0;
 
 	void _update_selection_pattern_from_tilemap_selection();
 	void _update_selection_pattern_from_tileset_tiles_selection();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/14976 (this is actually a regression, but no proper issue was opened)

## Additional information

I was able to fix the issue thanks to the great invention called _reading the docs_. Using that, and some experimentation, you can learn that:
- RandomNumberGenerator's `state` is not a number sequence in form of 0, 1, 2, 3... that starts after setting `seed`
- You are not supposed to set `state` to a random number
- Setting `seed` conveniently sets the `state` to a value that you can use as "base state"
- The `state` is a 64-bit integer

Unless you take the above into account, your random sequence may start with garbage, which in this case translated to always being the first tile in the pattern 🤦‍♂️