### PR TITLE
Add Clear Project Cache option

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3769,6 +3769,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case SCENE_QUIT:
 		case PROJECT_QUIT_TO_PROJECT_MANAGER:
+		case TOOLS_CLEAR_PROJECT_CACHE:
 		case PROJECT_RELOAD_CURRENT_PROJECT: {
 			if (p_confirmed && plugin_to_save) {
 				plugin_to_save->save_external_data();
@@ -3787,9 +3788,10 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				p_confirmed = false;
 			}
 
+			bool is_restart = (p_option == PROJECT_RELOAD_CURRENT_PROJECT || p_option == TOOLS_CLEAR_PROJECT_CACHE);
 			if (!p_confirmed) {
 				if (!stop_project_confirmation && project_run_bar->is_playing()) {
-					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+					if (is_restart) {
 						confirmation->set_text(TTR("Stop running project before reloading the current project?"));
 						confirmation->set_ok_button_text(TTR("Stop & Reload"));
 					} else {
@@ -3805,7 +3807,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				if (!stop_download_confirmation && export_template_manager->is_downloading()) {
 					confirmation->set_text(TTR("The export templates are still being downloaded."));
-					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+					if (is_restart) {
 						confirmation->set_ok_button_text(TTR("Stop & Reload"));
 					} else {
 						confirmation->set_ok_button_text(TTR("Stop & Quit"));
@@ -3820,7 +3822,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				bool save_each = EDITOR_GET("interface/editor/behavior/save_each_scene_on_quit");
 				if (_next_unsaved_scene(!save_each) == -1) {
 					if (EditorUndoRedoManager::get_singleton()->is_history_unsaved(EditorUndoRedoManager::GLOBAL_HISTORY)) {
-						if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+						if (is_restart) {
 							save_confirmation->set_ok_button_text(TTR("Save & Reload"));
 							save_confirmation->set_text(TTR("Save modified resources before reloading?"));
 						} else {
@@ -3836,7 +3838,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					for (int i = 0; i < editor_data.get_editor_plugin_count(); i++) {
 						const String unsaved_status = editor_data.get_editor_plugin(i)->get_unsaved_status();
 						if (!unsaved_status.is_empty()) {
-							if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+							if (is_restart) {
 								save_confirmation->set_ok_button_text(TTR("Save & Reload"));
 								save_confirmation->set_text(unsaved_status);
 							} else {
@@ -3871,7 +3873,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 						unsaved_scenes += "\n            " + editor_data.get_edited_scene_root(i)->get_scene_file_path();
 						i = _next_unsaved_scene(true, ++i);
 					}
-					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+					if (is_restart) {
 						save_confirmation->set_ok_button_text(TTR("Save & Reload"));
 						save_confirmation->set_text(TTR("Save changes to the following scene(s) before reloading?") + unsaved_scenes);
 					} else {
@@ -4155,6 +4157,9 @@ void EditorNode::_tool_menu_option(int p_idx) {
 		case TOOLS_PROJECT_UPGRADE: {
 			project_upgrade_tool->popup_dialog();
 		} break;
+		case TOOLS_CLEAR_PROJECT_CACHE: {
+			clear_cache_dialog->popup_centered();
+		} break;
 		case TOOLS_CUSTOM: {
 			if (tool_menu->get_item_submenu(p_idx) == "") {
 				Callable callback = tool_menu->get_item_metadata(p_idx);
@@ -4242,6 +4247,14 @@ void EditorNode::_exit_editor(int p_exit_code) {
 	// Unload addons before quitting to allow cleanup.
 	unload_editor_addons();
 
+	if (!files_to_delete_on_exit.is_empty()) {
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		for (const String &path : files_to_delete_on_exit) {
+			if (da->file_exists(path) || da->dir_exists(path)) {
+				OS::get_singleton()->move_to_trash(ProjectSettings::get_singleton()->globalize_path(path));
+			}
+		}
+	}
 	get_tree()->quit(p_exit_code);
 }
 
@@ -4287,6 +4300,21 @@ void EditorNode::_discard_changes(const String &p_str) {
 		case PROJECT_RELOAD_CURRENT_PROJECT: {
 			_restart_editor();
 		} break;
+		case TOOLS_CLEAR_PROJECT_CACHE: {
+			files_to_delete_on_exit = LocalVector<String>{
+				"res://.godot/imported",
+				"res://.godot/exported",
+				"res://.godot/mono",
+				"res://.godot/extension_list.cfg",
+				"res://.godot/global_script_class_cache.cfg",
+				"res://.godot/scene_groups_cache.cfg",
+				"res://.godot/uid_cache.bin",
+				"res://.godot/editor/editor_script_doc_cache.res",
+				"res://.godot/editor/" + EditorFileSystem::CACHE_FILE_NAME,
+				"res://.godot/editor/filesystem_update4",
+			};
+			_restart_editor(false);
+		} break;
 	}
 }
 
@@ -4311,6 +4339,10 @@ void EditorNode::_update_file_menu_opened() {
 void EditorNode::_palette_quick_open_dialog() {
 	quick_open_color_palette->popup_dialog({ "ColorPalette" }, palette_file_selected_callback);
 	quick_open_color_palette->set_title(TTRC("Quick Open Color Palette..."));
+}
+
+void EditorNode::_clear_cache_confirmed() {
+	_menu_option_confirm(TOOLS_CLEAR_PROJECT_CACHE, false);
 }
 
 void EditorNode::replace_resources_in_object(Object *p_object, const Vector<Ref<Resource>> &p_source_resources, const Vector<Ref<Resource>> &p_target_resource) {
@@ -6815,6 +6847,9 @@ void EditorNode::_restart_editor(bool p_goto_project_manager) {
 
 		args.push_back("-e");
 	}
+	if (!files_to_delete_on_exit.is_empty()) {
+		args.push_back("--clear-shader-cache");
+	}
 
 	if (!to_reopen.is_empty()) {
 		args.push_back(to_reopen);
@@ -8123,6 +8158,7 @@ void EditorNode::_build_project_menu(bool p_dark_mode) {
 		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/orphan_resource_explorer"), TOOLS_ORPHAN_RESOURCES);
 		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/engine_compilation_configuration_editor"), TOOLS_BUILD_PROFILE_MANAGER);
 		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/upgrade_project"), TOOLS_PROJECT_UPGRADE);
+		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/clear_project_cache"), TOOLS_CLEAR_PROJECT_CACHE);
 	}
 	project_menu->add_submenu_node_item(TTRC("Tools"), tool_menu);
 
@@ -8989,6 +9025,14 @@ EditorNode::EditorNode() {
 	warning->add_button(TTRC("Copy Text"), true, "copy");
 	warning->connect("custom_action", callable_mp(this, &EditorNode::_copy_warning));
 
+	clear_cache_dialog = memnew(ConfirmationDialog);
+	clear_cache_dialog->set_autowrap(true);
+	clear_cache_dialog->set_text(TTRC("Clear all caches for the current project, including the cache for imported assets, exported assets, shaders, UIDs, scripts, and scene groups. New caches will be built upon restarting or exporting the project.\n\nNote that clearing the cache is almost always a workaround for a bug. If you can consistently reproduce the invalid cache or unexpected behavior that is solved by clearing the cache, please report this bug (\"Help > Report a Bug\") with reproduction steps."));
+	clear_cache_dialog->set_ok_button_text(TTRC("Clear & Restart"));
+	clear_cache_dialog->get_label()->set_custom_minimum_size(Vector2(600 * EDSCALE, 0));
+	gui_base->add_child(clear_cache_dialog);
+	clear_cache_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_clear_cache_confirmed));
+
 	// Command palette and editor shortcuts.
 	command_palette = EditorCommandPalette::get_singleton();
 	command_palette->set_title(TTR("Command Palette"));
@@ -9031,6 +9075,7 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/orphan_resource_explorer", TTRC("Orphan Resource Explorer..."));
 	ED_SHORTCUT_AND_COMMAND("editor/engine_compilation_configuration_editor", TTRC("Engine Compilation Configuration Editor..."));
 	ED_SHORTCUT_AND_COMMAND("editor/upgrade_project", TTRC("Upgrade Project Files..."));
+	ED_SHORTCUT_AND_COMMAND("editor/clear_project_cache", TTRC("Clear Project Cache..."));
 
 	ED_SHORTCUT_AND_COMMAND("editor/reload_current_project", TTRC("Reload Current Project"));
 	ED_SHORTCUT_AND_COMMAND("editor/quit_to_project_list", TTRC("Quit to Project List"), KeyModifierMask::CTRL + KeyModifierMask::SHIFT + Key::Q);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -179,6 +179,7 @@ public:
 		TOOLS_ORPHAN_RESOURCES,
 		TOOLS_BUILD_PROFILE_MANAGER,
 		TOOLS_PROJECT_UPGRADE,
+		TOOLS_CLEAR_PROJECT_CACHE,
 		TOOLS_CUSTOM,
 
 		VCS_METADATA,
@@ -489,6 +490,9 @@ private:
 
 	ProjectUpgradeTool *project_upgrade_tool = nullptr;
 	bool run_project_upgrade_tool = false;
+	ConfirmationDialog *clear_cache_dialog = nullptr;
+
+	LocalVector<String> files_to_delete_on_exit;
 
 	bool was_window_windowed_last = false;
 
@@ -558,6 +562,7 @@ private:
 	void _export_as_menu_option(int p_idx);
 	void _update_file_menu_opened();
 	void _palette_quick_open_dialog();
+	void _clear_cache_confirmed();
 
 	void _remove_plugin_from_enabled(const String &p_name);
 	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object, bool p_set_current = true);

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -57,9 +57,6 @@ EditorFileSystem *EditorFileSystem::singleton = nullptr;
 int EditorFileSystem::nb_files_total = 0;
 EditorFileSystem::ScannedDirectory *EditorFileSystem::first_scan_root_dir = nullptr;
 
-//the name is the version, to keep compatibility with different versions of Godot
-#define CACHE_FILE_NAME "filesystem_cache10"
-
 int EditorFileSystemDirectory::find_file_index(const String &p_file) const {
 	for (int i = 0; i < files.size(); i++) {
 		if (files[i]->file == p_file) {

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -378,6 +378,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	// The name is the version, to keep compatibility with different versions of Godot.
+	static inline String CACHE_FILE_NAME = "filesystem_cache10";
+
 	static EditorFileSystem *get_singleton() { return singleton; }
 
 	EditorFileSystemDirectory *get_filesystem();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -597,6 +597,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--gpu-abort", "Abort on graphics API usage errors (usually validation layer errors). May help see the problem if your system freezes.\n", CLI_OPTION_AVAILABILITY_TEMPLATE_DEBUG);
 #endif
 	print_help_option("--generate-spirv-debug-info", "Generate SPIR-V debug information (Vulkan only). This allows source-level shader debugging with RenderDoc.\n");
+	print_help_option("--clear-shader-cache", "Clear the shader_cache directory at launch, so it's re-generated.\n");
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 	print_help_option("--extra-gpu-memory-tracking", "Enables additional memory tracking (see class reference for `RenderingDevice.get_driver_and_device_memory_report()` and linked methods). Currently only implemented for Vulkan. Enabling this feature may cause crashes on some systems due to buggy drivers or bugs in the Vulkan Loader. See https://github.com/godotengine/godot/issues/95967\n");
 	print_help_option("--accurate-breadcrumbs", "Force barriers between breadcrumbs. Useful for narrowing down a command causing GPU resets. Currently only implemented for Vulkan.\n");
@@ -1047,6 +1048,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String main_pack;
 	bool quiet_stdout = false;
 	int separate_thread_render = -1; // Tri-state: -1 = not set, 0 = false, 1 = true.
+	bool clear_shader_cache = false;
 
 #if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	String remotefs;
@@ -1289,6 +1291,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif
 		} else if (arg == "--generate-spirv-debug-info") {
 			Engine::singleton->generate_spirv_debug_info = true;
+		} else if (arg == "--clear-shader-cache") {
+			clear_shader_cache = true;
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
 		} else if (arg == "--extra-gpu-memory-tracking") {
 			Engine::singleton->extra_gpu_memory_tracking = true;
@@ -2060,6 +2064,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		goto error;
 #endif
+	}
+
+	if (clear_shader_cache && !project_path.is_empty()) {
+		const String cache_path = project_path.path_join(".godot").path_join("shader_cache");
+		if (DirAccess::dir_exists_absolute(cache_path)) {
+			OS::get_singleton()->move_to_trash(cache_path);
+		}
 	}
 
 	// Initialize WorkerThreadPool.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/14949

## Additional information

<img width="759" height="133" alt="image" src="https://github.com/user-attachments/assets/bb6d733d-2a7a-4cca-9387-2c51f3a75249" />
<img width="620" height="296" alt="image" src="https://github.com/user-attachments/assets/b415edc9-cb8c-4350-90ec-9e4ae255f8ab" />

The option deletes most of `.godot` folder contents, except some `editor/` stuff like favorites, folding data etc. Technically they can cause errors too, but nothing project-breaking.

The files are moved to trash. It's useful, because you can inspect the files if it turns out they were causing problems, but it also takes longer to delete them.