### PR TITLE
Improve scene instantiation performance when attached `@tool` script has overridden `_get_property_list()`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -163,6 +163,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instance->owner_id = p_owner->get_instance_id();
 #ifdef DEBUG_ENABLED
 	//needed for hot reloading
+	instance->member_indices_cache.reserve(member_indices.size());
 	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
 		instance->member_indices_cache[E.key] = E.value.index;
 	}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1557,8 +1557,8 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 		HashMap<StringName, GDScript::MemberInfo>::Iterator E = script->member_indices.find(p_name);
 		if (E) {
 			const GDScript::MemberInfo *member = &E->value;
-			Variant value = p_value;
-			if (!member->data_type.is_type(value)) {
+			if (!member->data_type.is_type(p_value)) {
+				Variant value = p_value;
 				const Variant *args = &p_value;
 				Callable::CallError err;
 				Variant::construct(member->data_type.builtin_type, value, &args, 1, err);
@@ -1567,12 +1567,12 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				}
 			}
 			if (likely(script->valid) && member->setter) {
-				const Variant *args = &value;
+				const Variant *args = &p_value;
 				Callable::CallError err;
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				members[member->index] = value;
+				members[member->index] = p_value;
 				return true;
 			}
 		}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -163,7 +163,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instance->owner_id = p_owner->get_instance_id();
 #ifdef DEBUG_ENABLED
 	//needed for hot reloading
-	instance->member_indices_cache.reserve(member_indices.size());
 	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
 		instance->member_indices_cache[E.key] = E.value.index;
 	}
@@ -1557,8 +1556,8 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 		HashMap<StringName, GDScript::MemberInfo>::Iterator E = script->member_indices.find(p_name);
 		if (E) {
 			const GDScript::MemberInfo *member = &E->value;
-			if (!member->data_type.is_type(p_value)) {
-				Variant value = p_value;
+			Variant value = p_value;
+			if (!member->data_type.is_type(value)) {
 				const Variant *args = &p_value;
 				Callable::CallError err;
 				Variant::construct(member->data_type.builtin_type, value, &args, 1, err);
@@ -1567,12 +1566,12 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				}
 			}
 			if (likely(script->valid) && member->setter) {
-				const Variant *args = &p_value;
+				const Variant *args = &value;
 				Callable::CallError err;
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				members[member->index] = p_value;
+				members[member->index] = value;
 				return true;
 			}
 		}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -813,18 +813,15 @@ Array SceneState::setup_resources_in_array(Array &p_array_to_scan, const SceneSt
 }
 
 Dictionary SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	const Array keys = p_dictionary_to_scan.keys();
-	const Array values = p_dictionary_to_scan.values();
-
-	if (has_local_resource(values) || has_local_resource(keys)) {
-		Array duplicated_keys = keys.duplicate(true);
-		Array duplicated_values = values.duplicate(true);
+	if (dictionary_has_local_resource(p_dictionary_to_scan)) {
+		Array duplicated_keys = p_dictionary_to_scan.keys().duplicate(true);
+		Array duplicated_values = p_dictionary_to_scan.values().duplicate(true);
 
 		duplicated_keys = setup_resources_in_array(duplicated_keys, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
 		duplicated_values = setup_resources_in_array(duplicated_values, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
 		p_dictionary_to_scan.clear();
 
-		for (int i = 0; i < keys.size(); i++) {
+		for (int i = 0; i < duplicated_keys.size(); i++) {
 			p_dictionary_to_scan[duplicated_keys[i]] = duplicated_values[i];
 		}
 	}
@@ -832,7 +829,24 @@ Dictionary SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary_to
 	return p_dictionary_to_scan;
 }
 
-bool SceneState::has_local_resource(const Array &p_array) const {
+bool SceneState::dictionary_has_local_resource(const Dictionary &p_dict) {
+	const Variant *v = p_dict.next();
+
+	while (v) {
+		Ref<Resource> res = *v;
+		if (res.is_valid() && res->is_local_to_scene()) {
+			return true;
+		}
+		res = p_dict[*v];
+		if (res.is_valid() && res->is_local_to_scene()) {
+			return true;
+		}
+		v = p_dict.next(v);
+	}
+	return false;
+}
+
+bool SceneState::array_has_local_resource(const Array &p_array) {
 	for (int i = 0; i < p_array.size(); i++) {
 		Ref<Resource> res = p_array[i];
 		if (res.is_valid() && res->is_local_to_scene()) {
@@ -1055,11 +1069,11 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, &is_valid_default, &states_stack, true);
 
 			if (is_valid_default && !PropertyUtils::is_property_value_different(p_node, value, default_value)) {
-				if (value.get_type() == Variant::ARRAY && has_local_resource(value)) {
+				if (value.get_type() == Variant::ARRAY && array_has_local_resource(value)) {
 					// Save anyway
 				} else if (value.get_type() == Variant::DICTIONARY) {
 					Dictionary dictionary = value;
-					if (!has_local_resource(dictionary.values()) && !has_local_resource(dictionary.keys())) {
+					if (!dictionary_has_local_resource(dictionary)) {
 						continue;
 					}
 				} else {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -534,7 +534,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								}
 							}
 
-							value = setup_resources_in_array(set_array, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
+							setup_resources_in_array(set_array, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
+							value = set_array;
 						}
 
 						if (value.get_type() == Variant::DICTIONARY) {
@@ -551,7 +552,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								}
 							}
 
-							value = setup_resources_in_dictionary(set_dict, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
+							setup_resources_in_dictionary(set_dict, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
+							value = set_dict;
 						}
 
 						bool set_valid = true;
@@ -803,30 +805,27 @@ Variant SceneState::make_local_resource(Variant &p_value, const SceneState::Node
 	return local_dupe;
 }
 
-Array SceneState::setup_resources_in_array(Array &p_array_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	for (int i = 0; i < p_array_to_scan.size(); i++) {
-		if (p_array_to_scan[i].get_type() == Variant::OBJECT) {
-			p_array_to_scan[i] = make_local_resource(p_array_to_scan[i], p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+void SceneState::setup_resources_in_array(Array &p_array, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
+	for (int i = 0; i < p_array.size(); i++) {
+		if (p_array[i].get_type() == Variant::OBJECT) {
+			p_array[i] = make_local_resource(p_array[i], p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
 		}
 	}
-	return p_array_to_scan;
 }
 
-Dictionary SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	if (dictionary_has_local_resource(p_dictionary_to_scan)) {
-		Array duplicated_keys = p_dictionary_to_scan.keys().duplicate(true);
-		Array duplicated_values = p_dictionary_to_scan.values().duplicate(true);
+void SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
+	if (dictionary_has_local_resource(p_dictionary)) {
+		Array duplicated_keys = p_dictionary.keys().duplicate(true);
+		Array duplicated_values = p_dictionary.values().duplicate(true);
 
-		duplicated_keys = setup_resources_in_array(duplicated_keys, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
-		duplicated_values = setup_resources_in_array(duplicated_values, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
-		p_dictionary_to_scan.clear();
+		setup_resources_in_array(duplicated_keys, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+		setup_resources_in_array(duplicated_values, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+		p_dictionary.clear();
 
 		for (int i = 0; i < duplicated_keys.size(); i++) {
-			p_dictionary_to_scan[duplicated_keys[i]] = duplicated_values[i];
+			p_dictionary[duplicated_keys[i]] = duplicated_values[i];
 		}
 	}
-
-	return p_dictionary_to_scan;
 }
 
 bool SceneState::dictionary_has_local_resource(const Dictionary &p_dict) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -521,39 +521,37 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						}
 
 						if (value.get_type() == Variant::ARRAY) {
-							Array set_array = value;
+							Array *set_array = VariantInternal::get_array(&value);
 							bool is_get_valid = false;
 							Variant get_value = node->get(snames[nprops[j].name], &is_get_valid);
 
 							if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
-								Array get_array = get_value;
-								if (set_array.is_same_typed(get_array)) {
-									set_array = set_array.duplicate();
+								Array *get_array = VariantInternal::get_array(&get_value);
+								if (set_array->is_same_typed(*get_array)) {
+									*set_array = set_array->duplicate();
 								} else {
-									set_array = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+									*set_array = Array(*set_array, get_array->get_typed_builtin(), get_array->get_typed_class_name(), get_array->get_typed_script());
 								}
 							}
 
-							setup_resources_in_array(set_array, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
-							value = set_array;
+							setup_resources_in_array(*set_array, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
 						}
 
 						if (value.get_type() == Variant::DICTIONARY) {
-							Dictionary set_dict = value;
+							Dictionary *set_dict = VariantInternal::get_dictionary(&value);
 							bool is_get_valid = false;
 							Variant get_value = node->get(snames[nprops[j].name], &is_get_valid);
 
 							if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
-								Dictionary get_dict = get_value;
-								if (set_dict.is_same_typed(get_dict)) {
-									set_dict = set_dict.duplicate();
+								Dictionary *get_dict = VariantInternal::get_dictionary(&get_value);
+								if (set_dict->is_same_typed(*get_dict)) {
+									*set_dict = set_dict->duplicate();
 								} else {
-									set_dict = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(), get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+									*set_dict = Dictionary(*set_dict, get_dict->get_typed_key_builtin(), get_dict->get_typed_key_class_name(), get_dict->get_typed_key_script(), get_dict->get_typed_value_builtin(), get_dict->get_typed_value_class_name(), get_dict->get_typed_value_script());
 								}
 							}
 
-							setup_resources_in_dictionary(set_dict, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
-							value = set_dict;
+							setup_resources_in_dictionary(*set_dict, n, resources_local_to_scenes, node, snames[nprops[j].name], i, ret_nodes, p_edit_state);
 						}
 
 						bool set_valid = true;
@@ -567,9 +565,6 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 						if (set_valid) {
 							node->set(snames[nprops[j].name], value, &valid);
-						}
-						if (p_edit_state == GEN_EDIT_STATE_INSTANCE && value.get_type() != Variant::OBJECT) {
-							value = value.duplicate(true); // Duplicate arrays and dictionaries for the editor.
 						}
 					}
 				}
@@ -775,7 +770,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	return ret_nodes[0];
 }
 
-Variant SceneState::make_local_resource(Variant &p_value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
+Variant SceneState::make_local_resource(Variant &p_value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName &p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
 	Ref<Resource> res = p_value;
 	if (res.is_null() || !res->is_local_to_scene()) {
 		return p_value;
@@ -805,36 +800,33 @@ Variant SceneState::make_local_resource(Variant &p_value, const SceneState::Node
 	return local_dupe;
 }
 
-void SceneState::setup_resources_in_array(Array &p_array, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	for (Variant &v : p_array) {
-		if (v.get_type() == Variant::OBJECT) {
-			v = make_local_resource(v, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+void SceneState::setup_resources_in_array(Array &p_array, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName &p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
+	for (Variant &element : p_array) {
+		if (element.get_type() == Variant::OBJECT) {
+			Ref<Resource> res = element;
+			if (res.is_valid() && res->is_local_to_scene()) {
+				element = make_local_resource(element, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+			}
 		}
 	}
 }
 
-void SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	if (dictionary_has_local_resource(p_dictionary)) {
-		Array duplicated_keys = p_dictionary.keys().duplicate(true);
-		Array duplicated_values = p_dictionary.values().duplicate(true);
-
-		setup_resources_in_array(duplicated_keys, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
-		setup_resources_in_array(duplicated_values, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
-		p_dictionary.clear();
-
-		for (int i = 0; i < duplicated_keys.size(); i++) {
-			p_dictionary[duplicated_keys[i]] = duplicated_values[i];
-		}
-	}
-}
-
-bool SceneState::dictionary_has_local_resource(const Dictionary &p_dict) {
-	for (const KeyValue<Variant, Variant> &kv : p_dict) {
-		Ref<Resource> res = kv.key;
+void SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName &p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
+	// local to scene resources can only be in values.
+	for (const KeyValue<Variant, Variant> &kv : p_dictionary) {
+		Ref<Resource> res = kv.value;
 		if (res.is_valid() && res->is_local_to_scene()) {
-			return true;
+			// Get around the const pointer
+			Variant &value = p_dictionary[kv.key];
+			value = make_local_resource(value, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
 		}
-		res = kv.value;
+	}
+}
+
+bool SceneState::dictionary_has_local_resource(const Dictionary &p_dictionary) {
+	for (const KeyValue<Variant, Variant> &kv : p_dictionary) {
+		// local to scene resources can only be in values.
+		Ref<Resource> res = kv.value;
 		if (res.is_valid() && res->is_local_to_scene()) {
 			return true;
 		}
@@ -1068,8 +1060,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				if (value.get_type() == Variant::ARRAY && array_has_local_resource(value)) {
 					// Save anyway
 				} else if (value.get_type() == Variant::DICTIONARY) {
-					Dictionary dictionary = value;
-					if (!dictionary_has_local_resource(dictionary)) {
+					if (!dictionary_has_local_resource(value)) {
 						continue;
 					}
 				} else {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -806,9 +806,9 @@ Variant SceneState::make_local_resource(Variant &p_value, const SceneState::Node
 }
 
 void SceneState::setup_resources_in_array(Array &p_array, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const {
-	for (int i = 0; i < p_array.size(); i++) {
-		if (p_array[i].get_type() == Variant::OBJECT) {
-			p_array[i] = make_local_resource(p_array[i], p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
+	for (Variant &v : p_array) {
+		if (v.get_type() == Variant::OBJECT) {
+			v = make_local_resource(v, p_n, p_resources_local_to_scenes, p_node, p_sname, p_i, p_ret_nodes, p_edit_state);
 		}
 	}
 }
@@ -829,18 +829,15 @@ void SceneState::setup_resources_in_dictionary(Dictionary &p_dictionary, const S
 }
 
 bool SceneState::dictionary_has_local_resource(const Dictionary &p_dict) {
-	const Variant *v = p_dict.next();
-
-	while (v) {
-		Ref<Resource> res = *v;
+	for (const KeyValue<Variant, Variant> &kv : p_dict) {
+		Ref<Resource> res = kv.key;
 		if (res.is_valid() && res->is_local_to_scene()) {
 			return true;
 		}
-		res = p_dict[*v];
+		res = kv.value;
 		if (res.is_valid() && res->is_local_to_scene()) {
 			return true;
 		}
-		v = p_dict.next(v);
 	}
 	return false;
 }

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -164,8 +164,8 @@ public:
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
 
-	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
-	Dictionary setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
+	void setup_resources_in_array(Array &array, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
+	void setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Variant make_local_resource(Variant &value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
 	static bool array_has_local_resource(const Array &p_array);
 	static bool dictionary_has_local_resource(const Dictionary &p_dict);

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -164,9 +164,9 @@ public:
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
 
-	void setup_resources_in_array(Array &array, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
-	void setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
-	Variant make_local_resource(Variant &value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
+	void setup_resources_in_array(Array &array, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName &sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
+	void setup_resources_in_dictionary(Dictionary &p_dictionary, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName &p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
+	Variant make_local_resource(Variant &value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName &p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
 	static bool array_has_local_resource(const Array &p_array);
 	static bool dictionary_has_local_resource(const Dictionary &p_dict);
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -167,7 +167,8 @@ public:
 	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *node, const StringName sname, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Dictionary setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Variant make_local_resource(Variant &value, const SceneState::NodeData &p_node_data, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &p_resources_local_to_scenes, Node *p_node, const StringName p_sname, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
-	bool has_local_resource(const Array &p_array) const;
+	static bool array_has_local_resource(const Array &p_array);
+	static bool dictionary_has_local_resource(const Dictionary &p_dict);
 
 	Ref<SceneState> get_base_scene_state() const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Addresses #97829 (decreases `@tool` and non-tool discrepancy from 1.6x->1.3x)
- Optimizes a few low-hanging fruits in the `PackedScene::instantiate` code-path.
  - Most are by reducing Variant-subtype copies and assignments.

## Additional information

I profiled the scene with properties from #97829 and targeted a few of the code-paths.

<img width="451" height="260" alt="image" src="https://github.com/user-attachments/assets/56ad18cb-93e4-4579-b216-ad918b4b4bd2" />

'O' marks an optimization, while '*' marks that an optimization was added for one of the deeper branches.

The bulk of the performance improvements from this PR come from optimizations to `setup_resources_in_dictionary`.

Profiling results with the PR changes:

<img width="457" height="282" alt="image" src="https://github.com/user-attachments/assets/4a13c52c-46d4-4833-8bda-0e7b554189d8" />

## Testing

<details>
<summary>Testing cases</summary>

### A

The scene with properties from #97829. N = 50,000

### B

Scene with 100 member empty dictionaries all included in `_get_property_list`. N = 10,000

### C

Scene with 100 member empty arrays all included in `_get_property_list`. N = 10,000
</details>

Each scenario is run 10 times and the 25th percentile is shown. Built on W11 MinGW.

### Editor

| Scenario | PR | Master | % diff |
| --- | --- | --- | --- |
| A (various types) | 0.562s | 0.667s | -16% |
| B (Dictionary) | 0.340s | 0.489s | -30% |
| C (Array) | 0.256s | 0.313s | -18% |

### Release templates

| Scenario | PR | Master | % diff |
| --- | --- | --- | --- |
| A (various types) | 0.387s | 0.480s | -19% |
| B (Dictionary) | 0.252s | 0.371s | -32% |
| C (Array) | 0.167s | 0.214s | -22% |


Test project: [scene_property_list.zip](https://github.com/user-attachments/files/28734374/scene_property_list.zip)

## Future Work

The duplication of Dictionaries and Arrays are responsible for a large share of the remaining difference. I am not sure if this is necessary. I think we should either deep duplicate or not at all - we currently shallow duplicate.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
