### PR TITLE
Add null check for `root_animation_node` in AnimationTree

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -660,6 +660,11 @@ Ref<AnimationRootNode> AnimationTree::get_root_animation_node() const {
 bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
 	_update_properties(); // If properties need updating, update them.
 
+	if (root_animation_node.is_null()) {
+		process_state = AnimationNode::ProcessState();
+		return false; // Abort after _update_properties() and init process_state.
+	}
+
 	if (validation_dirty) {
 		_update_connections();
 		validation_dirty = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120096

A crash occurred due to a null access during validation when the RootAnimationNode was null. This occurred when the RootAnimationNode was cleared and when a new AnimationTree was created. Fixed.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
