### PR TITLE
Don't flush the message queue before a MainLoop is iterating (Reverted)

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -31,6 +31,7 @@
 #include "message_queue.h"
 
 #include "core/config/project_settings.h"
+#include "main/main.h"
 
 #include <cstdio>
 
@@ -222,6 +223,10 @@ void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args
 }
 
 Error CallQueue::flush() {
+	if (!Main::is_iterating()) {
+		return ERR_BUSY;
+	}
+
 	LOCK_MUTEX;
 
 	if (pages.is_empty()) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -875,6 +875,7 @@ Error Main::test_setup() {
 
 	ClassDB::set_current_api(ClassDB::API_NONE);
 
+	iterating++;
 	_start_success = true;
 
 	return OK;
@@ -883,6 +884,7 @@ Error Main::test_setup() {
 // The order is the same as in `Main::cleanup()`.
 void Main::test_cleanup() {
 	ERR_FAIL_COND(!_start_success);
+	iterating--;
 
 	// Printing in the usual way can become problematic during/after cleanup.
 	CoreGlobals::print_ready = false;


### PR DESCRIPTION
Allowing this breaks several assumptions in the engine, normally this doesn't occur but when using the WTP it can occur. For instance during resource loading the message queue is serviced during tear down.

This means this situation can be created from user code if they do async resource loading in the `_load` of a resource in the main scene.

This also makes the MainLoop report that it IS iterating during tests as the tests expect the message queue to be serviced even though no main loop is running.

This is a prerequisite for #120072 