### PR TITLE
[macOS] Fix x86-64 build with Xcode 27.

### DIFF
--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -484,7 +484,7 @@ void CameraApple::update_feeds() {
 		devices = session.devices;
 	}
 #else // APPLE_EMBEDDED_ENABLED
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 	if (@available(macOS 10.15, *)) {
 #endif // __x86_64__
 		AVCaptureDeviceDiscoverySession *session;
@@ -494,7 +494,7 @@ void CameraApple::update_feeds() {
 			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 		}
 		devices = session.devices;
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 	} else {
 		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 	}

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -103,6 +103,10 @@ def configure(env: "SConsEnvironment"):
     if "OSXCROSS_ROOT" in os.environ:
         env["osxcross"] = True
 
+    cc_version = get_compiler_version(env)
+    cc_version_major = cc_version["apple_major"]
+    cc_version_minor = cc_version["apple_minor"]
+
     # CPU architecture.
     if env["arch"] == "arm64":
         print("Building for macOS 11.0+.")
@@ -110,17 +114,20 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
     elif env["arch"] == "x86_64":
-        print("Building for macOS 10.13+.")
-        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
-        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
-        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+        if (cc_version_major, cc_version_minor) >= (2100, 3):
+            # Xcode 27 only supports building for 11.0+
+            print("Building for macOS 11.0+.")
+            env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+            env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+            env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        else:
+            print("Building for macOS 10.13+.")
+            env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+            env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+            env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
     env.Append(CCFLAGS=["-fobjc-arc", "-fvisibility=hidden"])
-
-    cc_version = get_compiler_version(env)
-    cc_version_major = cc_version["apple_major"]
-    cc_version_minor = cc_version["apple_minor"]
 
     # Workaround for Xcode 15 linker bug.
     if is_apple_clang(env) and cc_version_major == 1500 and cc_version_minor == 0:

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -814,7 +814,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 		for (const String &arg : p_arguments) {
 			[arguments addObject:[NSString stringWithUTF8String:arg.utf8().get_data()]];
 		}
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 		if (@available(macOS 10.15, *)) {
 #endif
 			NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
@@ -846,7 +846,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 			}
 
 			return err;
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 		} else {
 			Error err = ERR_TIMEOUT;
 			NSError *error = nullptr;
@@ -925,7 +925,7 @@ Error OS_MacOS::open_with_program(const String &p_program_path, const List<Strin
 		return ERR_INVALID_PARAMETER;
 	}
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 	if (@available(macOS 10.15, *)) {
 #endif
 		NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
@@ -948,7 +948,7 @@ Error OS_MacOS::open_with_program(const String &p_program_path, const List<Strin
 		dispatch_semaphore_wait(lock, dispatch_time(DISPATCH_TIME_NOW, 20000000000)); // 20 sec timeout, wait for app to launch.
 
 		return err;
-#if defined(__x86_64__)
+#if defined(__x86_64__) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
 	} else {
 		NSError *error = nullptr;
 		[[NSWorkspace sharedWorkspace] openURLs:urls_to_open withApplicationAtURL:app_url options:NSWorkspaceLaunchDefault configuration:@{} error:&error];


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes x86-64 build with Xcode 27 beta.

## Additional information

Xcode 27 dropped support for targets older than macOS 11.0.