### PR TITLE
[RTL] Do not add zero-width space to last line without content.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -715,7 +715,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	String txt;
 	String txt_sub;
 	Item *it_to = (p_line + 1 < (int)p_frame->lines.size()) ? p_frame->lines[p_line + 1].from : nullptr;
-	Item *it_prev = l.from ? l.from : current;
+	Item *it_prev = l.from;
 	int remaining_characters = visible_characters - l.char_offset;
 	for (Item *it = l.from; it && it != it_to; it = _get_next_item(it)) {
 		it_prev = it;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/120115

## Additional information

Fixes side effect from https://github.com/godotengine/godot/pull/119987 (old behavior is questionable, but it's better to keep it as it was for 4.7), https://github.com/godotengine/godot/issues/119986 is still fixed (but only applies to lines with content, not the empty line at the end of paragraph).