### PR TITLE
Fix assets with license type of "Other" not showing up

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1425,6 +1425,8 @@ void EditorAssetLibrary::_licenses_id_pressed(int p_id) {
 }
 
 void EditorAssetLibrary::_licenses_popup_hide() {
+	licenses_all_toggled = true;
+
 	bool research = false;
 	PopupMenu *pm = licenses->get_popup();
 	for (unsigned int i = 0; i < licenses_toggled.size(); i++) {
@@ -1432,6 +1434,10 @@ void EditorAssetLibrary::_licenses_popup_hide() {
 		if (toggled != licenses_toggled[i]) {
 			licenses_toggled[i] = toggled;
 			research = true;
+		}
+
+		if (!toggled) {
+			licenses_all_toggled = false;
 		}
 	}
 
@@ -1459,12 +1465,14 @@ void EditorAssetLibrary::_search(int p_page) {
 		args += "." + itos(GODOT_VERSION_PATCH);
 	}
 
-	int license_count = licenses->get_item_count();
-	if (license_count > 0) {
-		PopupMenu *popup = licenses->get_popup();
-		for (int i = 0; i < license_count; i++) {
-			if (popup->is_item_checked(i)) {
-				args += "&licenses=" + (String)popup->get_item_metadata(i);
+	if (!licenses_all_toggled) {
+		int license_count = licenses->get_item_count();
+		if (license_count > 0) {
+			PopupMenu *popup = licenses->get_popup();
+			for (int i = 0; i < license_count; i++) {
+				if (popup->is_item_checked(i)) {
+					args += "&licenses=" + (String)popup->get_item_metadata(i);
+				}
 			}
 		}
 	}
@@ -1714,6 +1722,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 		case REQUESTING_LICENSES: {
 			licenses_toggled.clear();
+			licenses_all_toggled = true;
 
 			Array arr = dt;
 			PopupMenu *popup = licenses->get_popup();
@@ -1938,7 +1947,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 						}
 					}
 					if (!is_compat) {
-						continue; // This release is for an older version of Godot.
+						continue; // This release is for a newer version of Godot.
 					}
 				}
 
@@ -1957,7 +1966,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 						}
 					}
 					if (!is_compat) {
-						continue; // This release is for a newer version of Godot.
+						continue; // This release is for an older version of Godot.
 					}
 				}
 

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -296,6 +296,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _force_online_mode();
 
 	LocalVector<bool> licenses_toggled;
+	bool licenses_all_toggled = true;
 
 	void _licenses_id_pressed(int p_id);
 	void _licenses_popup_hide();


### PR DESCRIPTION
Since "Other" is not an actual type, we can't ask to fetch them in the query, so refrain from adding the toggled licenses in the args if all of them are checked.