### PR TITLE
Tweak casing of "OK" in editor immediate confirmation dialog

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -785,7 +785,7 @@ public:
 	static void add_init_callback(EditorNodeInitCallback p_callback) { _init_callbacks.push_back(p_callback); }
 	static void add_build_callback(EditorBuildCallback p_callback);
 
-	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTR("Ok"), const String &p_cancel_text = TTR("Cancel"), uint32_t p_wrap_width = 0);
+	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTRC("OK"), const String &p_cancel_text = TTRC("Cancel"), uint32_t p_wrap_width = 0);
 
 	static bool is_cmdline_mode();
 


### PR DESCRIPTION
- Use `TTRC()` to support runtime language changes (tested with the editor in French).

I noticed this while working on https://github.com/godotengine/godot/pull/80518#issuecomment-4664325261.
