### PR TITLE
Fix memory leak in ConstantNode

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10628,7 +10628,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 								array_size = constant.array_size;
 
-								ConstantNode *expr = memnew(ConstantNode);
+								ConstantNode *expr = alloc_node<ConstantNode>();
 
 								expr->datatype = constant.type;
 


### PR DESCRIPTION
Nodes in shader_language.cpp should be allocated using alloc_node. This node was allocated using memnew
which caused a memory leak since nothing deletes it.

Fixed by using alloc_node instead of memnew

## What problem(s) does this PR solve?
memory leak in shader_language.cpp
when using constants with braces initialization
example:
const float numbers[5] = {0.0, 1.0, 2.0, 3.0, 4.0};

## Additional information
found using asan