### PR TITLE
Fix Variant double initialization

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -861,7 +861,7 @@ struct VariantInitializer {
 template <typename T>
 struct VariantInitializer<T, std::enable_if_t<VariantInternalAccessor<T>::is_local>> {
 	static _FORCE_INLINE_ void init(Variant *v) {
-		memnew_placement(&VariantInternalAccessor<T>::get(v), T);
+		memnew_placement(&VariantInternalAccessor<T>::get(v), T());
 		VariantInternal::set_type(*v, GetTypeInfo<T>::VARIANT_TYPE);
 	}
 };
@@ -969,9 +969,9 @@ struct VariantTypeChanger {
 		if (v->get_type() != GetTypeInfo<T>::VARIANT_TYPE || GetTypeInfo<T>::VARIANT_TYPE >= Variant::PACKED_BYTE_ARRAY) { //second condition removed by optimizer
 			VariantInternal::clear(v);
 			VariantInitializer<T>::init(v);
+		} else {
+			VariantDefaultInitializer<T>::init(v);
 		}
-
-		VariantDefaultInitializer<T>::init(v);
 	}
 };
 

--- a/tests/core/variant/test_variant_initialization.cpp
+++ b/tests/core/variant/test_variant_initialization.cpp
@@ -1,0 +1,648 @@
+/**************************************************************************/
+/*  test_variant_initialization.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_variant_initialization)
+
+#include "core/variant/variant_internal.h"
+
+namespace TestVariantInitialization {
+
+TEST_CASE("[VariantInitialization] change_and_reset") {
+	// Garbage data
+	Variant *p = new Variant();
+	std::memset((void *)p, -1, sizeof(Variant));
+	VariantInternal::set_type(*p, Variant::Type::NIL);
+
+	SUBCASE("bool") {
+		VariantTypeChanger<bool>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BOOL);
+		CHECK(*p == Variant(false));
+
+		*p = Variant(true);
+		VariantTypeChanger<bool>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BOOL);
+		CHECK(*p == Variant(false));
+
+		*p = Variant(1);
+		VariantTypeChanger<bool>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BOOL);
+		CHECK(*p == Variant(false));
+	}
+
+	SUBCASE("int") {
+		VariantTypeChanger<int64_t>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::INT);
+		CHECK(*p == Variant(0));
+
+		*p = Variant(1);
+		VariantTypeChanger<int64_t>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::INT);
+		CHECK(*p == Variant(0));
+
+		*p = Variant(true);
+		VariantTypeChanger<int64_t>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::INT);
+		CHECK(*p == Variant(0));
+	}
+
+	SUBCASE("float") {
+		VariantTypeChanger<double>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::FLOAT);
+		CHECK(*p == Variant(0.));
+
+		*p = Variant(1.0);
+		VariantTypeChanger<double>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::FLOAT);
+		CHECK(*p == Variant(0.));
+
+		*p = Variant(true);
+		VariantTypeChanger<double>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::FLOAT);
+		CHECK(*p == Variant(0.));
+	}
+
+	SUBCASE("String") {
+		VariantTypeChanger<String>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING);
+		CHECK(*p == Variant(""));
+
+		*p = Variant(1.0);
+		VariantTypeChanger<String>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING);
+		CHECK(*p == Variant(""));
+
+		*p = Variant(true);
+		VariantTypeChanger<String>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING);
+		CHECK(*p == Variant(""));
+	}
+
+	SUBCASE("Vector2") {
+		VariantTypeChanger<Vector2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2);
+		CHECK(*p == Variant(Vector2()));
+
+		*p = Variant(Vector2(1., 1.));
+		VariantTypeChanger<Vector2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2);
+		CHECK(*p == Variant(Vector2()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2);
+		CHECK(*p == Variant(Vector2()));
+	}
+
+	SUBCASE("Vector2i") {
+		VariantTypeChanger<Vector2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2I);
+		CHECK(*p == Variant(Vector2i()));
+
+		*p = Variant(Vector2i(1, 1));
+		VariantTypeChanger<Vector2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2I);
+		CHECK(*p == Variant(Vector2i()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR2I);
+		CHECK(*p == Variant(Vector2i()));
+	}
+
+	SUBCASE("Vector3") {
+		VariantTypeChanger<Vector3>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3);
+		CHECK(*p == Variant(Vector3()));
+
+		*p = Variant(Vector3(1., 1., 1.));
+		VariantTypeChanger<Vector3>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3);
+		CHECK(*p == Variant(Vector3()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector3>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3);
+		CHECK(*p == Variant(Vector3()));
+	}
+
+	SUBCASE("Vector3i") {
+		VariantTypeChanger<Vector3i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3I);
+		CHECK(*p == Variant(Vector3i()));
+
+		*p = Variant(Vector3i(1, 1, 1));
+		VariantTypeChanger<Vector3i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3I);
+		CHECK(*p == Variant(Vector3i()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector3i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR3I);
+		CHECK(*p == Variant(Vector3i()));
+	}
+
+	SUBCASE("Vector4") {
+		VariantTypeChanger<Vector4>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4);
+		CHECK(*p == Variant(Vector4()));
+
+		*p = Variant(Vector4(1., 1., 1., 1.));
+		VariantTypeChanger<Vector4>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4);
+		CHECK(*p == Variant(Vector4()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector4>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4);
+		CHECK(*p == Variant(Vector4()));
+	}
+
+	SUBCASE("Vector4i") {
+		VariantTypeChanger<Vector4i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4I);
+		CHECK(*p == Variant(Vector4i()));
+
+		*p = Variant(Vector4i(1, 1, 1, 1));
+		VariantTypeChanger<Vector4i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4I);
+		CHECK(*p == Variant(Vector4i()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Vector4i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::VECTOR4I);
+		CHECK(*p == Variant(Vector4i()));
+	}
+
+	SUBCASE("Rect2") {
+		VariantTypeChanger<Rect2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2);
+		CHECK(*p == Variant(Rect2()));
+
+		*p = Variant(Rect2(1., 1., 1., 1.));
+		VariantTypeChanger<Rect2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2);
+		CHECK(*p == Variant(Rect2()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Rect2>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2);
+		CHECK(*p == Variant(Rect2()));
+	}
+
+	SUBCASE("Rect2i") {
+		VariantTypeChanger<Rect2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2I);
+		CHECK(*p == Variant(Rect2i()));
+
+		*p = Variant(Rect2i(1, 1, 1, 1));
+		VariantTypeChanger<Rect2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2I);
+		CHECK(*p == Variant(Rect2i()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Rect2i>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RECT2I);
+		CHECK(*p == Variant(Rect2i()));
+	}
+
+	SUBCASE("Transform3D") {
+		VariantTypeChanger<Transform3D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM3D);
+		CHECK(*p == Variant(Transform3D()));
+
+		Transform3D t;
+		t.origin = Vector3(1, 1, 1);
+		*p = Variant(t);
+		VariantTypeChanger<Transform3D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM3D);
+		CHECK(*p == Variant(Transform3D()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Transform3D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM3D);
+		CHECK(*p == Variant(Transform3D()));
+	}
+
+	SUBCASE("Projection") {
+		VariantTypeChanger<Projection>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PROJECTION);
+		CHECK(*p == Variant(Projection()));
+
+		Projection pj;
+		pj.columns[0].x = 1;
+		*p = Variant(pj);
+		VariantTypeChanger<Projection>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PROJECTION);
+		CHECK(*p == Variant(Projection()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Projection>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PROJECTION);
+		CHECK(*p == Variant(Projection()));
+	}
+
+	SUBCASE("Transform2D") {
+		VariantTypeChanger<Transform2D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM2D);
+		CHECK(*p == Variant(Transform2D()));
+
+		Transform2D t;
+		t *= 2;
+		*p = Variant(t);
+		VariantTypeChanger<Transform2D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM2D);
+		CHECK(*p == Variant(Transform2D()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Transform2D>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::TRANSFORM2D);
+		CHECK(*p == Variant(Transform2D()));
+	}
+
+	SUBCASE("Quaternion") {
+		VariantTypeChanger<Quaternion>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::QUATERNION);
+		CHECK(*p == Variant(Quaternion()));
+
+		*p = Variant(Quaternion(1., 2., 3., 4.));
+		VariantTypeChanger<Quaternion>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::QUATERNION);
+		CHECK(*p == Variant(Quaternion()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Quaternion>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::QUATERNION);
+		CHECK(*p == Variant(Quaternion()));
+	}
+
+	SUBCASE("Plane") {
+		VariantTypeChanger<Plane>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PLANE);
+		CHECK(*p == Variant(Plane()));
+
+		*p = Variant(Plane(Vector3(), 1.));
+		VariantTypeChanger<Plane>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PLANE);
+		CHECK(*p == Variant(Plane()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Plane>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PLANE);
+		CHECK(*p == Variant(Plane()));
+	}
+
+	SUBCASE("Basis") {
+		VariantTypeChanger<Basis>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BASIS);
+		CHECK(*p == Variant(Basis()));
+
+		*p = Variant(Basis::from_scale(Vector3::UP));
+		VariantTypeChanger<Basis>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BASIS);
+		CHECK(*p == Variant(Basis()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Basis>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::BASIS);
+		CHECK(*p == Variant(Basis()));
+	}
+
+	SUBCASE("AABB") {
+		VariantTypeChanger<AABB>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::AABB);
+		CHECK(*p == Variant(AABB()));
+
+		*p = Variant(AABB(Vector3::UP, Vector3::RIGHT));
+		VariantTypeChanger<AABB>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::AABB);
+		CHECK(*p == Variant(AABB()));
+
+		*p = Variant(true);
+		VariantTypeChanger<AABB>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::AABB);
+		CHECK(*p == Variant(AABB()));
+	}
+
+	SUBCASE("Color") {
+		VariantTypeChanger<Color>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::COLOR);
+		CHECK(*p == Variant(Color()));
+
+		*p = Variant(Color::from_hsv(0.5, 0.5, 0.5));
+		VariantTypeChanger<Color>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::COLOR);
+		CHECK(*p == Variant(Color()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Color>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::COLOR);
+		CHECK(*p == Variant(Color()));
+	}
+
+	SUBCASE("StringName") {
+		VariantTypeChanger<StringName>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING_NAME);
+		CHECK(*p == Variant(StringName()));
+
+		*p = Variant(StringName("abc"));
+		VariantTypeChanger<StringName>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING_NAME);
+		CHECK(*p == Variant(StringName()));
+
+		*p = Variant(true);
+		VariantTypeChanger<StringName>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::STRING_NAME);
+		CHECK(*p == Variant(StringName()));
+	}
+
+	SUBCASE("NodePath") {
+		VariantTypeChanger<NodePath>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::NODE_PATH);
+		CHECK(*p == Variant(NodePath()));
+
+		*p = Variant(NodePath("abc"));
+		VariantTypeChanger<NodePath>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::NODE_PATH);
+		CHECK(*p == Variant(NodePath()));
+
+		*p = Variant(true);
+		VariantTypeChanger<NodePath>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::NODE_PATH);
+		CHECK(*p == Variant(NodePath()));
+	}
+
+	SUBCASE("RID") {
+		VariantTypeChanger<RID>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RID);
+		CHECK(*p == Variant(RID()));
+
+		*p = Variant(RID::from_uint64(123ull));
+		VariantTypeChanger<RID>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RID);
+		CHECK(*p == Variant(RID()));
+
+		*p = Variant(true);
+		VariantTypeChanger<RID>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::RID);
+		CHECK(*p == Variant(RID()));
+	}
+
+	SUBCASE("Callable") {
+		VariantTypeChanger<Callable>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::CALLABLE);
+		CHECK(*p == Variant(Callable()));
+
+		Object o;
+		*p = Variant(Callable(&o, "abc"));
+		VariantTypeChanger<Callable>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::CALLABLE);
+		CHECK(*p == Variant(Callable()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Callable>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::CALLABLE);
+		CHECK(*p == Variant(Callable()));
+	}
+
+	SUBCASE("Signal") {
+		VariantTypeChanger<Signal>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::SIGNAL);
+		CHECK(*p == Variant(Signal()));
+
+		Object o;
+		*p = Variant(Signal(&o, "abc"));
+		VariantTypeChanger<Signal>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::SIGNAL);
+		CHECK(*p == Variant(Signal()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Signal>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::SIGNAL);
+		CHECK(*p == Variant(Signal()));
+	}
+
+	SUBCASE("Dictionary") {
+		VariantTypeChanger<Dictionary>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::DICTIONARY);
+		CHECK(*p == Variant(Dictionary()));
+
+		*p = Variant(Dictionary{ KeyValue{ Variant(1), Variant(2) } });
+		VariantTypeChanger<Dictionary>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::DICTIONARY);
+		CHECK(*p == Variant(Dictionary()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Dictionary>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::DICTIONARY);
+		CHECK(*p == Variant(Dictionary()));
+	}
+
+	SUBCASE("Array") {
+		VariantTypeChanger<Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::ARRAY);
+		CHECK(*p == Variant(Array()));
+
+		*p = Variant(Array{ Variant(1) });
+		VariantTypeChanger<Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::ARRAY);
+		CHECK(*p == Variant(Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::ARRAY);
+		CHECK(*p == Variant(Array()));
+	}
+
+	SUBCASE("PackedByteArray") {
+		VariantTypeChanger<PackedByteArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_BYTE_ARRAY);
+		CHECK(*p == Variant(PackedByteArray()));
+
+		*p = Variant(PackedByteArray{ 1, 2 });
+		VariantTypeChanger<PackedByteArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_BYTE_ARRAY);
+		CHECK(*p == Variant(PackedByteArray()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedByteArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_BYTE_ARRAY);
+		CHECK(*p == Variant(PackedByteArray()));
+	}
+
+	SUBCASE("PackedInt32Array") {
+		VariantTypeChanger<PackedInt32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT32_ARRAY);
+		CHECK(*p == Variant(PackedInt32Array()));
+
+		*p = Variant(PackedInt32Array{ 1, 2 });
+		VariantTypeChanger<PackedInt32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT32_ARRAY);
+		CHECK(*p == Variant(PackedInt32Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedInt32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT32_ARRAY);
+		CHECK(*p == Variant(PackedInt32Array()));
+	}
+
+	SUBCASE("PackedInt64Array") {
+		VariantTypeChanger<PackedInt64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT64_ARRAY);
+		CHECK(*p == Variant(PackedInt64Array()));
+
+		*p = Variant(PackedInt64Array{ 1, 2 });
+		VariantTypeChanger<PackedInt64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT64_ARRAY);
+		CHECK(*p == Variant(PackedInt64Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedInt64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_INT64_ARRAY);
+		CHECK(*p == Variant(PackedInt64Array()));
+	}
+
+	SUBCASE("PackedFloat32Array") {
+		VariantTypeChanger<PackedFloat32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT32_ARRAY);
+		CHECK(*p == Variant(PackedFloat32Array()));
+
+		*p = Variant(PackedFloat32Array{ 1, 2 });
+		VariantTypeChanger<PackedFloat32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT32_ARRAY);
+		CHECK(*p == Variant(PackedFloat32Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedFloat32Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT32_ARRAY);
+		CHECK(*p == Variant(PackedFloat32Array()));
+	}
+
+	SUBCASE("PackedFloat64Array") {
+		VariantTypeChanger<PackedFloat64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);
+		CHECK(*p == Variant(PackedFloat64Array()));
+
+		*p = Variant(PackedFloat64Array{ 1, 2 });
+		VariantTypeChanger<PackedFloat64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);
+		CHECK(*p == Variant(PackedFloat64Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedFloat64Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);
+		CHECK(*p == Variant(PackedFloat64Array()));
+	}
+
+	SUBCASE("PackedStringArray") {
+		VariantTypeChanger<PackedStringArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_STRING_ARRAY);
+		CHECK(*p == Variant(PackedStringArray()));
+
+		*p = Variant(PackedStringArray{ "1", "2" });
+		VariantTypeChanger<PackedStringArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_STRING_ARRAY);
+		CHECK(*p == Variant(PackedStringArray()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedStringArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_STRING_ARRAY);
+		CHECK(*p == Variant(PackedStringArray()));
+	}
+
+	SUBCASE("PackedVector2Array") {
+		VariantTypeChanger<PackedVector2Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR2_ARRAY);
+		CHECK(*p == Variant(PackedVector2Array()));
+
+		*p = Variant(PackedVector2Array{ Vector2::UP, Vector2::RIGHT });
+		VariantTypeChanger<PackedVector2Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR2_ARRAY);
+		CHECK(*p == Variant(PackedVector2Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedVector2Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR2_ARRAY);
+		CHECK(*p == Variant(PackedVector2Array()));
+	}
+
+	SUBCASE("PackedVector3Array") {
+		VariantTypeChanger<PackedVector3Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR3_ARRAY);
+		CHECK(*p == Variant(PackedVector3Array()));
+
+		*p = Variant(PackedVector3Array{ Vector3::UP, Vector3::RIGHT });
+		VariantTypeChanger<PackedVector3Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR3_ARRAY);
+		CHECK(*p == Variant(PackedVector3Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedVector3Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR3_ARRAY);
+		CHECK(*p == Variant(PackedVector3Array()));
+	}
+
+	SUBCASE("PackedColorArray") {
+		VariantTypeChanger<PackedColorArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_COLOR_ARRAY);
+		CHECK(*p == Variant(PackedColorArray()));
+
+		*p = Variant(PackedColorArray{ Color::from_hsv(0., .1, .2) });
+		VariantTypeChanger<PackedColorArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_COLOR_ARRAY);
+		CHECK(*p == Variant(PackedColorArray()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedColorArray>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_COLOR_ARRAY);
+		CHECK(*p == Variant(PackedColorArray()));
+	}
+
+	SUBCASE("PackedVector4Array") {
+		VariantTypeChanger<PackedVector4Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR4_ARRAY);
+		CHECK(*p == Variant(PackedVector4Array()));
+
+		*p = Variant(PackedVector4Array{ Vector4(1, 2, 3, 4) });
+		VariantTypeChanger<PackedVector4Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR4_ARRAY);
+		CHECK(*p == Variant(PackedVector4Array()));
+
+		*p = Variant(true);
+		VariantTypeChanger<PackedVector4Array>::change_and_reset(p);
+		CHECK(p->get_type() == Variant::Type::PACKED_VECTOR4_ARRAY);
+		CHECK(*p == Variant(PackedVector4Array()));
+	}
+
+	delete p;
+}
+
+} // namespace TestVariantInitialization


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes double Variant initialization in `VariantTypeChanger::change_and_reset`

## Problem

While profiling I discovered that two Dictionaries are created when an empty Dictionary is constructed.

```
Dictionary()
```

<img width="489" height="282" alt="image" src="https://github.com/user-attachments/assets/d7a20285-8f8a-4473-ab77-30f66a222249" />

<details open>
<summary>Technical deep dive</summary>

The reason lies in `VariantTypeChanger::change_and_reset`.

https://github.com/godotengine/godot/blob/df6235838b63dd49f448547406e339848455c140/core/variant/variant_internal.h#L968-L975

In our scenario and all initializations the Variant has `type = NIL` and so we take the if branch.

`VariantInitializer<T>::init` has a few cases, but the common case is where `is_local = true`. 

https://github.com/godotengine/godot/blob/df6235838b63dd49f448547406e339848455c140/core/variant/variant_internal.h#L861-L867

`VariantDefaultInitializer<T>::init` has the same specialization for all Variants:

https://github.com/godotengine/godot/blob/df6235838b63dd49f448547406e339848455c140/core/variant/variant_internal.h#L953-L958

Both of these call the default constructor for class types. Since we call both these init functions when the condition is true, we call the constructor twice.

</details>

## Solution

The idea is that since `VariantInitializer` already initialized the object, we can skip doing it again in `VariantDefaultInitializer`.

<details open>
<summary>Technical explanation of subtle differences</summary>

We initialize in two similar but different ways:

| VariantInitializer | VariantDefaultInitializer |
| --- | --- |
| `memnew_placement(&VariantInternalAccessor<T>::get(v), T);` | `VariantInternalAccessor<T>::get(v) = T();` |
| `new (&VariantInternalAccessor<T>::get(v)) T;` | |
| Per the [new-expression docs](https://en.cppreference.com/cpp/language/new): since the _initializer-list_ is absent this [default-initializes](https://en.cppreference.com/cpp/language/default_initialization) the type.  | [value-initialize](https://en.cppreference.com/cpp/language/value_initialization) the type and assign it to the pointed address. |
| For class types, calls constructor. For primitives, does not initialize | For class types, calls constructor. For primitives, [zero-initializes](https://en.cppreference.com/cpp/language/zero_initialization). |

Due to the difference in behaviour, primitives may contain garbage values if only initialized with `VariantInitializer`. The fix is to change the `VariantInitializer<T>::init` case to use value-initialization. We can do this easily by adding an initializer list to the new expression.

> If type is not an array type, the single object is constructed in the acquired memory area:
> - If new-initializer is absent, the object is [default-initialized](https://en.cppreference.com/cpp/language/default_initialization).
> - If new-initializer is a parentheses-enclosed expression list, the object is [direct-initialized](https://en.cppreference.com/cpp/language/direct_initialization).

The docs are not clear but I think in the primitive case, the direct-initialization becomes value-initialization. Alternatively, we can use braces for [list-initialization](https://en.cppreference.com/cpp/language/list_initialization) which explicitly uses value-initialization for non-class, non-array types.

```cpp
memnew_placement(&VariantInternalAccessor<T>::get(v), T());
memnew_placement(&VariantInternalAccessor<T>::get(v), T{});
```

</details>
<details>
<summary>We covered the <code>is_local</code> <code>VariantInitializer</code> case, but there are two other categories of specializations. Both of these do some different allocation and call a default constructor. Thus we can skip <code>VariantDefaultInitializer</code> in these cases too.</summary>

### Accessor is a `_VariantInternalAccessorElsewhere`

These are `Transform2D`, `Transform3D`, `Projection`, `Basis`, `AABB`. These all have their own specializations for the `VariantInitializer` template where they first call `VariantPools::alloc<T>()` and then do a `memnew_placement`. Since these are all class types, their default constructors are called.

### Accessor is a `_VariantInternalAccessorPackedArrayRef`

These also have their own `VariantInitializer` specialization in which it calls a Vector constructor for the inner type and passes it to `memnew`.

```cpp
v->_data.packed_array = Variant::PackedArrayRef<T>::create(Vector<T>());
```

This does the same thing as the `VariantDefaultInitializer` case since the `PackedXArray` types are aliases for the `Vector` specialization.

</details>


## Testing

I wrote unit tests for all Variant types (except for Object). 3 cases are checked in each type.
1. Not initialized, NIL type. Takes the `if` branch
2. Same type, non-default value. Takes the `else` branch (except for PackedArrays)
3. Empty Variant. Takes the `if` branch.

## Results

Profiling shows that we now only construct one `Dictionary`.

<img width="485" height="188" alt="image" src="https://github.com/user-attachments/assets/97daa381-beb7-4754-99b0-fc627a8f1549" />

Benchmark setup

```
for i in 10_000_000:
    Dictionary() 
```

Run 10 times and averaged on release templates. Windows 11.

| Type | PR (MinGW) | 4.7 RC 1 | Diff |
| --- | --- | --- | --- |
| Dictionary | 0.2856s | 0.5851s | -51% |
| Array | 0.2797s | 0.5685s | -51% |
| ~Vector2~ | ~0.0234s~ | ~0.0225s~ | ~+4%~ |
| Transform2D | 0.0235s | 0.0231s | +2% |
| PackedByteArray | 0.2869s | 0.2865s | +0.1% |

This change mainly affects performance of Variant types with expensive constructors/destructors such as `Dictionary` and `Array` which allocate and deallocate respectively. The others should see little difference and results are within a margin of error. In GDScript, primitive types may have to be tested another way as it does not currently trigger the codepath.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
