### PR TITLE
LSP: Fix `gdscript_client/changeWorkspace` notification

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -228,41 +228,15 @@ Variant GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 		}
 
 		if (ProjectSettings::get_singleton()->localize_path(root) != "res://") {
+			// Show a general warning, which works for all clients.
 			LSP::ShowMessageParams params{
 				LSP::MessageType::Warning,
 				"The GDScript Language Server might not work correctly with other projects than the one opened in Godot."
 			};
 			notify_client("window/showMessage", params.to_json());
-		}
-	}
 
-	String root_uri = p_params["rootUri"];
-	String root = p_params.get("rootPath", "");
-	bool is_same_workspace;
-#ifndef WINDOWS_ENABLED
-	is_same_workspace = root.to_lower() == workspace->root.to_lower();
-#else
-	is_same_workspace = root.replace_char('\\', '/').to_lower() == workspace->root.to_lower();
-#endif
-
-	if (root_uri.length() && is_same_workspace) {
-		workspace->root_uri = root_uri;
-	} else {
-		String r_root = workspace->root;
-		r_root = r_root.lstrip("/");
-		workspace->root_uri = "file:///" + r_root;
-
-		Dictionary params;
-		params["path"] = workspace->root;
-		Dictionary request = make_notification("gdscript_client/changeWorkspace", params);
-
-		ERR_FAIL_COND_V_MSG(!clients.has(latest_client_id), ret.to_json(),
-				vformat("GDScriptLanguageProtocol: Can't initialize invalid peer '%d'.", latest_client_id));
-		Ref<LSPeer> peer = clients.get(latest_client_id);
-		if (peer.is_valid()) {
-			String msg = Variant(request).to_json_string();
-			msg = format_output(msg);
-			(*peer)->res_queue.push_back(msg.utf8());
+			// Send gdscript_client/changeWorkspace to prompt client side handling, where supported. (Currently known users: VSCode extension, Rider extension).
+			notify_client("gdscript_client/changeWorkspace", Dictionary({ { "path", ProjectSettings::get_singleton()->get_resource_path() } }));
 		}
 	}
 
@@ -702,8 +676,6 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 
 	set_method("initialize", callable_mp(this, &GDScriptLanguageProtocol::initialize));
 	set_method("initialized", callable_mp(this, &GDScriptLanguageProtocol::initialized));
-
-	workspace->root = ProjectSettings::get_singleton()->get_resource_path();
 }
 
 #undef SET_DOCUMENT_METHOD

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -72,9 +72,6 @@ protected:
 	void apply_new_signal(Object *obj, String function, PackedStringArray args);
 
 public:
-	String root;
-	String root_uri;
-
 	HashMap<StringName, ClassMembers> native_members;
 
 public:

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -106,11 +106,6 @@ GDScriptLanguageProtocol *initialize(const String &p_root) {
 	GDScriptLanguageProtocol *proto = memnew(GDScriptLanguageProtocol);
 	TestGDScriptLanguageProtocolInitializer::setup_client();
 
-	Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
-	workspace->root = absolute_root;
-	// On windows: `C:/...` -> `C%3A/...`.
-	workspace->root_uri = "file:///" + absolute_root.lstrip("/").replace_first(":", "%3A");
-
 	return proto;
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/111702 (in combination with https://github.com/godotengine/godot/pull/120087)
- Also solves what @Calinou noticed in https://github.com/godotengine/godot/pull/118598#issuecomment-4605070195

> As an aside, I noticed Rider on Linux thinks the project path is mismatched if it's a symlinked folder (both the Godot editor and Rider project use the same symlinked folder path). I had to open Rider and Godot on the actual folder for the paths to actually be considered matching, and the LSP to be functional.

## Additional information

`gdscript_client/changeWorkspace` is a custom notification of the GDScript LSP. When a supporting client (Rider and VSCode are the only ones I know of) receives it they treat it as project mismatch and disable LSP functionality for the workspace.

The logic for emitting this notification was flawed and didn't rely on proper symlink handling. This PR unifies the logic for emitting it with the symlink aware implementation from https://github.com/godotengine/godot/pull/104401. (The PR introduced a warning for the same situation, using a standardized approach supported by all clients. This PR reuses the logic for that.)
