### PR TITLE
Editor: Remove unnecessary `EditorHelpHighlighter::scripts` field

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -66,7 +66,6 @@
 // For syntax highlighting.
 #ifdef MODULE_GDSCRIPT_ENABLED
 #include "modules/gdscript/editor/gdscript_highlighter.h"
-#include "modules/gdscript/gdscript.h"
 #endif
 
 // For syntax highlighting.
@@ -5091,9 +5090,6 @@ EditorHelpHighlighter::HighlightData EditorHelpHighlighter::_get_highlight_data(
 	}
 
 	text_edits[p_language]->set_text(p_source);
-	if (scripts[p_language].is_valid()) { // See GH-89610.
-		scripts[p_language]->set_source_code(p_source);
-	}
 	highlighters[p_language]->_update_cache();
 
 	HighlightData result;
@@ -5170,16 +5166,11 @@ EditorHelpHighlighter::EditorHelpHighlighter() {
 	TextEdit *gdscript_text_edit = memnew(TextEdit);
 	gdscript_text_edit->add_theme_color_override(SceneStringName(font_color), text_color);
 
-	Ref<GDScript> gdscript;
-	gdscript.instantiate();
-
 	Ref<GDScriptSyntaxHighlighter> gdscript_highlighter;
 	gdscript_highlighter.instantiate();
 	gdscript_highlighter->set_text_edit(gdscript_text_edit);
-	gdscript_highlighter->_set_edited_resource(gdscript);
 
 	text_edits[LANGUAGE_GDSCRIPT] = gdscript_text_edit;
-	scripts[LANGUAGE_GDSCRIPT] = gdscript;
 	highlighters[LANGUAGE_GDSCRIPT] = gdscript_highlighter;
 #endif
 
@@ -5187,18 +5178,12 @@ EditorHelpHighlighter::EditorHelpHighlighter() {
 	TextEdit *csharp_text_edit = memnew(TextEdit);
 	csharp_text_edit->add_theme_color_override(SceneStringName(font_color), text_color);
 
-	// See GH-89610.
-	//Ref<CSharpScript> csharp;
-	//csharp.instantiate();
-
 	Ref<EditorStandardSyntaxHighlighter> csharp_highlighter;
 	csharp_highlighter.instantiate();
 	csharp_highlighter->set_text_edit(csharp_text_edit);
-	//csharp_highlighter->_set_edited_resource(csharp);
 	csharp_highlighter->_set_script_language(CSharpLanguage::get_singleton());
 
 	text_edits[LANGUAGE_CSHARP] = csharp_text_edit;
-	//scripts[LANGUAGE_CSHARP] = csharp;
 	highlighters[LANGUAGE_CSHARP] = csharp_highlighter;
 #endif
 }

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -410,7 +410,6 @@ private:
 	HashMap<String, HighlightData> highlight_data_caches[LANGUAGE_MAX];
 
 	TextEdit *text_edits[LANGUAGE_MAX];
-	Ref<Script> scripts[LANGUAGE_MAX];
 	Ref<EditorSyntaxHighlighter> highlighters[LANGUAGE_MAX];
 
 	HighlightData _get_highlight_data(Language p_language, const String &p_source, bool p_use_cache);


### PR DESCRIPTION
## What problem(s) does this PR solve?

This field seems redundant because we guarantee that `GDScriptSyntaxHighlighter` can be used without a script (see #95764). And for C#, this isn't supported for technical reasons (see #89610). I thought the `GDScript` resource might be useful for highlighting class members:

https://github.com/godotengine/godot/blob/ec67cbe92628bdaf979b10594359ba6f02cf8838/modules/gdscript/editor/gdscript_highlighter.cpp#L875-L954

But it looks like class members aren't being highlighted in the Editor Help for some reason. In this light, we're probably better off avoiding the hiddenly used script and the overhead of calling `set_source_code()`.

## Additional information

_None._