### PR TITLE
Fix GLES3 sky rendering on legacy Adreno GPUs

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1595,6 +1595,7 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 	} else if (is_environment(p_render_data->environment)) {
 		RSE::EnvironmentBG env_bg = environment_get_background(p_render_data->environment);
 		RSE::EnvironmentAmbientSource ambient_src = environment_get_ambient_source(p_render_data->environment);
+		const bool use_legacy_adreno_sky_workaround = GLES3::Config::get_singleton()->use_legacy_adreno_sky_workaround;
 
 		float bg_energy_multiplier = environment_get_bg_energy_multiplier(p_render_data->environment);
 
@@ -1633,6 +1634,20 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 			scene_state.data.use_reflection_cubemap = true;
 		} else {
 			scene_state.data.use_reflection_cubemap = false;
+		}
+
+		if (use_legacy_adreno_sky_workaround && scene_state.data.use_ambient_cubemap) {
+			scene_state.data.use_ambient_light = true;
+
+			if (Math::is_zero_approx(scene_state.data.ambient_light_color_energy[0]) &&
+					Math::is_zero_approx(scene_state.data.ambient_light_color_energy[1]) &&
+					Math::is_zero_approx(scene_state.data.ambient_light_color_energy[2])) {
+				// Keep a small amount of ambient light when sky radiance is not used.
+				const float fallback_ambient = 0.2f * bg_energy_multiplier;
+				scene_state.data.ambient_light_color_energy[0] = fallback_ambient;
+				scene_state.data.ambient_light_color_energy[1] = fallback_ambient;
+				scene_state.data.ambient_light_color_energy[2] = fallback_ambient;
+			}
 		}
 
 		scene_state.data.fog_enabled = environment_get_fog_enabled(p_render_data->environment);
@@ -2808,6 +2823,26 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		scene_state.enable_gl_depth_draw(true);
 	}
 
+	const bool draw_sky_before_opaque = GLES3::Config::get_singleton()->use_legacy_adreno_sky_workaround && (draw_sky || draw_sky_fog_only);
+	if (draw_sky_before_opaque) {
+		RENDER_TIMESTAMP("Render Sky Before Opaque");
+
+		// Avoid drawing the sky over opaque objects on legacy Adreno drivers.
+		scene_state.enable_gl_depth_test(false);
+		scene_state.enable_gl_depth_draw(false);
+		scene_state.enable_gl_blend(false);
+		scene_state.set_gl_cull_mode(RSE::CULL_MODE_BACK);
+
+		Transform3D transform = render_data.cam_transform;
+		Projection projection = render_data.cam_projection;
+
+		_draw_sky(render_data.environment, projection, transform, sky_energy_multiplier, render_data.luminance_multiplier, p_camera_data->view_count > 1, flip_y, apply_environment_effects_in_post);
+
+		scene_state.enable_gl_depth_test(true);
+		scene_state.enable_gl_depth_draw(true);
+		scene_state.set_gl_depth_func(GL_GEQUAL);
+	}
+
 	RENDER_TIMESTAMP("Render Opaque Pass");
 	uint64_t spec_constant_base_flags = 0;
 
@@ -2864,7 +2899,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	scene_state.enable_gl_depth_draw(false);
 	scene_state.enable_gl_stencil_test(false);
 
-	if (draw_sky || draw_sky_fog_only) {
+	if ((draw_sky || draw_sky_fog_only) && !draw_sky_before_opaque) {
 		RENDER_TIMESTAMP("Render Sky");
 
 		scene_state.enable_gl_depth_test(true);
@@ -3192,7 +3227,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		GLuint texture_to_bind = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_CUBEMAP_BLACK))->tex_id;
 		if (p_render_data->environment.is_valid()) {
 			Sky *sky = sky_owner.get_or_null(environment_get_sky(p_render_data->environment));
-			if (sky && sky->radiance != 0) {
+			if (sky && sky->radiance != 0 && !config->use_legacy_adreno_sky_workaround) {
 				texture_to_bind = sky->radiance;
 				base_spec_constants |= SceneShaderGLES3::USE_RADIANCE_MAP;
 			}

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -243,6 +243,17 @@ Config::Config() {
 			//https://github.com/godotengine/godot/issues/92662#issuecomment-2161199477
 			//disable_particles_workaround = false;
 		}
+	} else if (rendering_device_name.begins_with("Adreno (TM) ")) {
+		const String model = rendering_device_name.trim_prefix("Adreno (TM) ").get_slicec(' ', 0);
+		if (model.is_valid_int()) {
+			const int model_number = model.to_int();
+			if (model_number <= 510) {
+				// Work around legacy Adreno drivers crashing in the GLES3 sky radiance draw path.
+				// See also: https://github.com/godotengine/godot/issues/75507
+				use_legacy_adreno_sky_workaround = true;
+				print_line("GLES3: Disabling sky radiance on " + rendering_device_name + " due to driver compatibility issues.");
+			}
+		}
 	} else if (rendering_device_name.contains("PowerVR")) {
 		disable_transform_feedback_shader_cache = true;
 	}

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -103,6 +103,9 @@ public:
 	// Adreno 3XX compatibility.
 	bool disable_particles_workaround = false; // Set to 'true' to disable 'GPUParticles'.
 
+	// Legacy Adreno <= 510 sky rendering compatibility.
+	bool use_legacy_adreno_sky_workaround = false;
+
 	// PowerVR GE 8320 workaround.
 	bool disable_transform_feedback_shader_cache = false;
 


### PR DESCRIPTION
Legacy Adreno GPUs up to Adreno 510 can crash in the GLES3 sky radiance draw path when using the Compatibility renderer. Avoid using the sky radiance map in the scene shader path on affected devices, draw the sky before opaque geometry, and keep a small ambient fallback so scenes remain visible when sky radiance is unavailable. This mitigates crashes similar to godotengine/godot#75507 and was tested on a Xiaomi Max with Adreno 510 running Android 7.0.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Mitigates godotengine/godot#75507.

Legacy Adreno GPUs up to Adreno 510 can crash in the GLES3 sky radiance draw path when using the Compatibility renderer.

This workaround:
- Detects Adreno GPUs up to Adreno 510.
- Avoids using the sky radiance map in the GLES3 scene shader path on affected devices.
- Draws the sky before opaque geometry on affected devices.
- Keeps a small ambient fallback so scenes remain visible when sky radiance is unavailable.

Tested on:
- Xiaomi Max
- Android 7.0
- Qualcomm Adreno (TM) 510
- Compatibility / GLES3 renderer

Without this workaround, the app crashes in `/system/vendor/lib64/egl/libGLESv2_adreno.so` around the GLES3 scene draw path. With this workaround, the same project runs without crashing, the sky remains visible, and both 3D and 2D rendering work correctly.
