### PR TITLE
Add support for named `[url]` tags in `print_rich()` ANSI conversion

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -119,6 +119,7 @@ void __print_line_rich(const String &p_string) {
 
 	String output;
 	int pos = 0;
+	bool in_named_url = false;
 	while (pos <= p_string.length()) {
 		int brk_pos = p_string.find_char('[', pos);
 
@@ -167,10 +168,24 @@ void __print_line_rich(const String &p_string) {
 			output += "\u001b[2m";
 		} else if (tag == "/code") {
 			output += "\u001b[22m";
+		} else if (tag.begins_with("url=")) {
+			// Support named URLs using OSC 8 escape codes:
+			// <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>
+			in_named_url = true;
+			const String url_link = tag.substr(strlen("url="));
+			output += vformat("\u001b]8;;%s\u001b\\", url_link);
 		} else if (tag == "url") {
 			output += "";
 		} else if (tag == "/url") {
-			output += "";
+			if (in_named_url) {
+				output += "\u001b]8;;\u001b\\";
+				in_named_url = false;
+			} else {
+				// While it's legal to close an URL that was never opened using OSC 8 escape codes,
+				// it would result in the code being printed to unsupported terminal emulators
+				// when using unnamed URLs.
+				output += "";
+			}
 		} else if (tag == "center") {
 			output += "\n\t\t\t";
 		} else if (tag == "/center") {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -865,7 +865,7 @@
 			<description>
 				Converts one or more arguments of any type to string in the best way possible and prints them to the console.
 				The following BBCode tags are supported: [code]b[/code], [code]i[/code], [code]u[/code], [code]s[/code], [code]indent[/code], [code]code[/code], [code]url[/code], [code]center[/code], [code]right[/code], [code]color[/code], [code]bgcolor[/code], [code]fgcolor[/code].
-				URL tags only support URLs wrapped by a URL tag, not URLs with a different title.
+				URL tags support both URLs wrapped by a URL tag and URLs with a different title ([code skip-lint][url=address]text[/url][/code]). Support for URLs with a different title varies across terminal emulators. Most modern terminal emulators support them, but Terminal.app and conhost (the legacy Windows console) do not.
 				When printing to standard output, the supported subset of BBCode is converted to ANSI escape codes for the terminal emulator to display. Support for ANSI escape codes varies across terminal emulators, especially for italic and strikethrough. In standard output, [code]code[/code] is represented with faint text but without any font change. Unsupported tags are left as-is in standard output.
 				[codeblocks]
 				[gdscript skip-lint]


### PR DESCRIPTION
This uses OSC 8 escape codes, which are well-supported in modern terminal emulators.

Note that macOS' own Terminal.app and conhost (the legacy Windows console) don't support named URLs, but unnamed URLs can still be used.

- This closes https://github.com/godotengine/godot-proposals/issues/14992.

**Testing project:** [test_print_rich_named_url.zip](https://github.com/user-attachments/files/28802932/test_print_rich_named_url.zip)

## Preview

```gdscript
extends Node


func _ready() -> void:
        print_rich("  Named link: [url=https://example.com]This text points to example.com[/url]. Some more text.")
        print_rich("Unnamed link: [url]https://example.com[/url]. Some more text.")
```

Displayed in the editor Output panel:

<img width="523" height="47" alt="image" src="https://github.com/user-attachments/assets/5230b127-6c2d-4f14-bc8c-e3b4737c317b" />

Displayed in the VS Code terminal:

<img width="515" height="50" alt="image" src="https://github.com/user-attachments/assets/d6ee4859-54c1-47d2-afbc-a6819789107d" />