### PR TITLE
Add Hierarchical Pathfinding (HPA*) to AStarGrid2D

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -104,6 +104,18 @@ void AStarGrid2D::set_cell_size(const Size2 &p_cell_size) {
 	}
 }
 
+void AStarGrid2D::set_hpa_cluster_size(int32_t p_cluster_size) {
+	ERR_FAIL_COND(p_cluster_size <= 0);
+	if (p_cluster_size != hpa_cluster_size) {
+		hpa_cluster_size = p_cluster_size;
+		hpa_dirty = true;
+	}
+}
+
+int32_t AStarGrid2D::get_hpa_cluster_size() const {
+	return hpa_cluster_size;
+}
+
 Size2 AStarGrid2D::get_cell_size() const {
 	return cell_size;
 }
@@ -167,6 +179,28 @@ void AStarGrid2D::update() {
 	}
 
 	dirty = false;
+	// The grid was rebuilt, so any previously built abstract graph is now invalid.
+	hpa_dirty = true;
+}
+
+bool AStarGrid2D::is_hpa_enabled() const {
+	return hpa_enabled;
+}
+
+void AStarGrid2D::set_hpa_enabled(bool p_enabled) {
+	if (hpa_enabled != p_enabled) {
+		hpa_enabled = p_enabled;
+		hpa_dirty = true;
+
+		if (!p_enabled) {
+			// Free the abstract graph immediately so disabling HPA* reclaims its memory.
+			hpa_clusters.reset();
+			hpa_entrances.reset();
+			hpa_nodes.reset();
+			hpa_cluster_cols = 0;
+			hpa_cluster_rows = 0;
+		}
+	}
 }
 
 bool AStarGrid2D::is_in_bounds(int32_t p_x, int32_t p_y) const {
@@ -179,6 +213,10 @@ bool AStarGrid2D::is_in_boundsv(const Vector2i &p_id) const {
 
 bool AStarGrid2D::is_dirty() const {
 	return dirty;
+}
+
+bool AStarGrid2D::is_hpa_dirty() const {
+	return hpa_dirty;
 }
 
 void AStarGrid2D::set_jumping_enabled(bool p_enabled) {
@@ -219,7 +257,11 @@ AStarGrid2D::Heuristic AStarGrid2D::get_default_estimate_heuristic() const {
 void AStarGrid2D::set_point_solid(const Vector2i &p_id, bool p_solid) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_MSG(!is_in_boundsv(p_id), vformat("Can't set if point is disabled. Point %s out of bounds %s.", p_id, region));
-	_set_solid_unchecked(p_id, p_solid);
+	if (_get_solid_unchecked(p_id) != p_solid) {
+		_set_solid_unchecked(p_id, p_solid);
+		// The abstract graph depends on which cells are solid, so it must be rebuilt.
+		hpa_dirty = true;
+	}
 }
 
 bool AStarGrid2D::is_point_solid(const Vector2i &p_id) const {
@@ -252,6 +294,11 @@ void AStarGrid2D::fill_solid_region(const Rect2i &p_region, bool p_solid) {
 		for (int32_t x = safe_region.position.x; x < end_x; x++) {
 			_set_solid_unchecked(x, y, p_solid);
 		}
+	}
+
+	if (safe_region.has_area()) {
+		// The abstract graph depends on which cells are solid, so it must be rebuilt.
+		hpa_dirty = true;
 	}
 }
 
@@ -603,6 +650,13 @@ real_t AStarGrid2D::_compute_cost(const Vector2i &p_from_id, const Vector2i &p_t
 void AStarGrid2D::clear() {
 	points.clear();
 	region = Rect2i();
+
+	hpa_clusters.reset();
+	hpa_entrances.reset();
+	hpa_nodes.reset();
+	hpa_cluster_cols = 0;
+	hpa_cluster_rows = 0;
+	hpa_dirty = true;
 }
 
 Vector2 AStarGrid2D::get_point_position(const Vector2i &p_id) const {
@@ -642,6 +696,30 @@ Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vec
 	ERR_FAIL_COND_V_MSG(dirty, Vector<Vector2>(), "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_from_id), Vector<Vector2>(), vformat("Can't get id path. Point %s out of bounds %s.", p_from_id, region));
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_to_id), Vector<Vector2>(), vformat("Can't get id path. Point %s out of bounds %s.", p_to_id, region));
+
+	if (hpa_enabled) {
+		if (hpa_dirty) {
+			update_hpa();
+		}
+		LocalVector<Vector2i> cells;
+		const HPAPathResult result = _hpa_get_cell_path(p_from_id, p_to_id, cells);
+		if (result == HPA_PATH_RESULT_FOUND) {
+			Vector<Vector2> path;
+			path.resize(cells.size());
+			Vector2 *w = path.ptrw();
+			for (uint32_t i = 0; i < cells.size(); i++) {
+				w[i] = _get_point_unchecked(cells[i])->pos;
+			}
+			return path;
+		}
+		if (result == HPA_PATH_RESULT_UNREACHABLE && !p_allow_partial_path) {
+			// The abstract graph encodes all inter-cluster connectivity, so an unreachable
+			// goal can be reported without running a full search on the cell grid.
+			return Vector<Vector2>();
+		}
+		// The abstract path could not be refined (or a partial path was requested);
+		// fall back to regular A*.
+	}
 
 	Point *begin_point = _get_point(p_from_id.x, p_from_id.y);
 	Point *end_point = _get_point(p_to_id.x, p_to_id.y);
@@ -687,6 +765,29 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_from_id), TypedArray<Vector2i>(), vformat("Can't get id path. Point %s out of bounds %s.", p_from_id, region));
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_to_id), TypedArray<Vector2i>(), vformat("Can't get id path. Point %s out of bounds %s.", p_to_id, region));
 
+	if (hpa_enabled) {
+		if (hpa_dirty) {
+			update_hpa();
+		}
+		LocalVector<Vector2i> cells;
+		const HPAPathResult result = _hpa_get_cell_path(p_from_id, p_to_id, cells);
+		if (result == HPA_PATH_RESULT_FOUND) {
+			TypedArray<Vector2i> path;
+			path.resize(cells.size());
+			for (uint32_t i = 0; i < cells.size(); i++) {
+				path[i] = cells[i];
+			}
+			return path;
+		}
+		if (result == HPA_PATH_RESULT_UNREACHABLE && !p_allow_partial_path) {
+			// The abstract graph encodes all inter-cluster connectivity, so an unreachable
+			// goal can be reported without running a full search on the cell grid.
+			return TypedArray<Vector2i>();
+		}
+		// The abstract path could not be refined (or a partial path was requested);
+		// fall back to regular A*.
+	}
+
 	Point *begin_point = _get_point(p_from_id.x, p_from_id.y);
 	Point *end_point = _get_point(p_to_id.x, p_to_id.y);
 
@@ -722,6 +823,597 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 	}
 
 	return path;
+}
+
+AStarGrid2D::ClusterAdjacency AStarGrid2D::_clusters_are_adjacent(const Cluster *p_c1, const Cluster *p_c2) const {
+	const int32_t c1_left = p_c1->cluster_pos.x;
+	const int32_t c1_bottom = p_c1->cluster_pos.y;
+	const int32_t c1_right = c1_left + p_c1->cluster_width;
+	const int32_t c1_top = c1_bottom + p_c1->cluster_height;
+
+	const int32_t c2_left = p_c2->cluster_pos.x;
+	const int32_t c2_bottom = p_c2->cluster_pos.y;
+	const int32_t c2_right = c2_left + p_c2->cluster_width;
+	const int32_t c2_top = c2_bottom + p_c2->cluster_height;
+
+	const bool overlap_x = c1_left == c2_left;
+	const bool overlap_y = c1_bottom == c2_bottom;
+
+	if (overlap_x) {
+		if (c1_top == c2_bottom || c2_top == c1_bottom) {
+			return CLUSTER_ADJACENCY_VERTICAL;
+		}
+	}
+
+	if (overlap_y) {
+		if (c1_right == c2_left || c2_right == c1_left) {
+			return CLUSTER_ADJACENCY_LATERAL;
+		}
+	}
+
+	if (diagonal_mode != DIAGONAL_MODE_NEVER) {
+		if ((c1_right == c2_left || c2_right == c1_left) && (c1_bottom == c2_top || c2_bottom == c1_top)) {
+			return CLUSTER_ADJACENCY_DIAGONAL;
+		}
+	}
+
+	return CLUSTER_ADJACENCY_NONE;
+}
+
+void AStarGrid2D::_build_clusters() {
+	hpa_clusters.clear();
+
+	const int32_t start_x = region.position.x;
+	const int32_t start_y = region.position.y;
+	const int32_t end_x = region.get_end().x;
+	const int32_t end_y = region.get_end().y;
+
+	// Cache the cluster grid dimensions so a cell can be mapped to its cluster in O(1).
+	// Clusters are stored in column-major order (see the loops below), so the index of a
+	// cell's cluster is `column * hpa_cluster_rows + row`.
+	hpa_cluster_cols = (end_x - start_x + hpa_cluster_size - 1) / hpa_cluster_size;
+	hpa_cluster_rows = (end_y - start_y + hpa_cluster_size - 1) / hpa_cluster_size;
+
+	Cluster c;
+
+	// We create the clusters in column-major order.
+	for (int32_t x = start_x; x < end_x; x += hpa_cluster_size) {
+		// Check if the cluster would extend beyond the map.
+		if (x + hpa_cluster_size > end_x) {
+			c.cluster_width = end_x - x;
+		} else {
+			c.cluster_width = hpa_cluster_size;
+		}
+
+		for (int32_t y = start_y; y < end_y; y += hpa_cluster_size) {
+			// Check if the cluster would extend beyond the map.
+			if (y + hpa_cluster_size > end_y) {
+				c.cluster_height = end_y - y;
+			} else {
+				c.cluster_height = hpa_cluster_size;
+			}
+
+			c.cluster_pos = Vector2i(x, y);
+			hpa_clusters.push_back(c);
+		}
+	}
+}
+
+void AStarGrid2D::_build_entrances() {
+	hpa_entrances.clear();
+
+	const uint32_t num_clusters = hpa_clusters.size();
+
+	// TODO: If more levels of hierarchy are added, it would be wise to store multiple entrances between clusters.
+	for (uint32_t i = 0; i < num_clusters; i++) {
+		for (uint32_t k = i + 1; k < num_clusters; k++) {
+			const ClusterAdjacency adjacent_dir = _clusters_are_adjacent(&hpa_clusters[i], &hpa_clusters[k]);
+
+			if (adjacent_dir != CLUSTER_ADJACENCY_NONE) {
+				_create_entrances(i, k, adjacent_dir);
+			}
+		}
+	}
+}
+
+void AStarGrid2D::_add_entrance(int32_t p_c1_idx, int32_t p_c2_idx, const Vector2i &p_c1_pos, const Vector2i &p_c2_pos, int32_t p_width, int32_t p_height, ClusterAdjacency p_dir) {
+	hpa_entrances.push_back(Entrance{ p_c1_idx, p_c2_idx, p_c1_pos, p_c2_pos, p_width, p_height, p_dir });
+}
+
+void AStarGrid2D::_create_entrances(int32_t p_c1_idx, int32_t p_c2_idx, ClusterAdjacency p_adjacent_dir) {
+	ERR_FAIL_INDEX(p_c1_idx, (int32_t)hpa_clusters.size());
+	ERR_FAIL_INDEX(p_c2_idx, (int32_t)hpa_clusters.size());
+	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
+
+	const Cluster *c1 = &hpa_clusters[p_c1_idx];
+	const Cluster *c2 = &hpa_clusters[p_c2_idx];
+
+	switch (p_adjacent_dir) {
+		case CLUSTER_ADJACENCY_LATERAL: {
+			const bool c1_is_left = c1->cluster_pos.x <= c2->cluster_pos.x;
+			const int32_t c1_x = c1_is_left ? (c1->cluster_pos.x + c1->cluster_width - 1) : c1->cluster_pos.x;
+			const int32_t c2_x = c1_is_left ? c2->cluster_pos.x : (c2->cluster_pos.x + c2->cluster_width - 1);
+			const int32_t start_y = MAX(c1->cluster_pos.y, c2->cluster_pos.y);
+			const int32_t end_y = MIN(c1->cluster_pos.y + c1->cluster_height, c2->cluster_pos.y + c2->cluster_height);
+
+			int32_t entrance_start = -1;
+			for (int32_t y = start_y; y < end_y; y++) {
+				const bool walkable = !is_point_solid(Vector2i(c1_x, y)) && !is_point_solid(Vector2i(c2_x, y));
+
+				if (walkable) {
+					if (entrance_start == -1) {
+						entrance_start = y;
+					}
+				} else if (entrance_start != -1) {
+					_add_entrance(p_c1_idx, p_c2_idx, Vector2i(c1_x, entrance_start), Vector2i(c2_x, entrance_start), 1, y - entrance_start, p_adjacent_dir);
+					entrance_start = -1;
+				}
+			}
+
+			if (entrance_start != -1) {
+				_add_entrance(p_c1_idx, p_c2_idx, Vector2i(c1_x, entrance_start), Vector2i(c2_x, entrance_start), 1, end_y - entrance_start, p_adjacent_dir);
+			}
+		} break;
+
+		case CLUSTER_ADJACENCY_VERTICAL: {
+			const bool c1_is_bottom = c1->cluster_pos.y <= c2->cluster_pos.y;
+			const int32_t c1_y = c1_is_bottom ? (c1->cluster_pos.y + c1->cluster_height - 1) : c1->cluster_pos.y;
+			const int32_t c2_y = c1_is_bottom ? c2->cluster_pos.y : (c2->cluster_pos.y + c2->cluster_height - 1);
+			const int32_t start_x = MAX(c1->cluster_pos.x, c2->cluster_pos.x);
+			const int32_t end_x = MIN(c1->cluster_pos.x + c1->cluster_width, c2->cluster_pos.x + c2->cluster_width);
+
+			int32_t entrance_start = -1;
+			for (int32_t x = start_x; x < end_x; x++) {
+				const bool walkable = !is_point_solid(Vector2i(x, c1_y)) && !is_point_solid(Vector2i(x, c2_y));
+
+				if (walkable) {
+					if (entrance_start == -1) {
+						entrance_start = x;
+					}
+				} else if (entrance_start != -1) {
+					_add_entrance(p_c1_idx, p_c2_idx, Vector2i(entrance_start, c1_y), Vector2i(entrance_start, c2_y), x - entrance_start, 1, p_adjacent_dir);
+					entrance_start = -1;
+				}
+			}
+
+			if (entrance_start != -1) {
+				_add_entrance(p_c1_idx, p_c2_idx, Vector2i(entrance_start, c1_y), Vector2i(entrance_start, c2_y), end_x - entrance_start, 1, p_adjacent_dir);
+			}
+		} break;
+
+		case CLUSTER_ADJACENCY_DIAGONAL: {
+			Vector2i c1_pos;
+			Vector2i c2_pos;
+
+			if (c1->cluster_pos.x + c1->cluster_width == c2->cluster_pos.x) {
+				c1_pos.x = c1->cluster_pos.x + c1->cluster_width - 1;
+				c2_pos.x = c2->cluster_pos.x;
+			} else {
+				c1_pos.x = c1->cluster_pos.x;
+				c2_pos.x = c2->cluster_pos.x + c2->cluster_width - 1;
+			}
+
+			if (c1->cluster_pos.y + c1->cluster_height == c2->cluster_pos.y) {
+				c1_pos.y = c1->cluster_pos.y + c1->cluster_height - 1;
+				c2_pos.y = c2->cluster_pos.y;
+			} else {
+				c1_pos.y = c1->cluster_pos.y;
+				c2_pos.y = c2->cluster_pos.y + c2->cluster_height - 1;
+			}
+
+			if (!is_point_solid(c1_pos) && !is_point_solid(c2_pos)) {
+				_add_entrance(p_c1_idx, p_c2_idx, c1_pos, c2_pos, 1, 1, p_adjacent_dir);
+			}
+		} break;
+
+		default:
+			break;
+	}
+}
+
+void AStarGrid2D::_create_hpa_nodes() {
+	const int32_t NODE_MIN_DISTANCE = 6;
+
+	hpa_nodes.clear();
+
+	for (uint32_t i = 0; i < hpa_entrances.size(); i++) {
+		const Entrance &entrance = hpa_entrances[i];
+		const int32_t c1_idx = entrance.cluster_1_idx;
+		const int32_t c2_idx = entrance.cluster_2_idx;
+
+		switch (entrance.dir) {
+			case CLUSTER_ADJACENCY_LATERAL: {
+				// The entrance is a vertical strip, so we place transition nodes along the y axis.
+				const int32_t end_y = entrance.c1_pos.y + entrance.height;
+
+				for (int32_t y = entrance.c1_pos.y; y < end_y - 1; y += NODE_MIN_DISTANCE) {
+					_build_node_and_inter_edges(Vector2i(entrance.c1_pos.x, y), c1_idx, Vector2i(entrance.c2_pos.x, y), c2_idx);
+				}
+
+				// Always place a node at the far end of the entrance.
+				const int32_t last_y = end_y - 1;
+				_build_node_and_inter_edges(Vector2i(entrance.c1_pos.x, last_y), c1_idx, Vector2i(entrance.c2_pos.x, last_y), c2_idx);
+			} break;
+
+			case CLUSTER_ADJACENCY_VERTICAL: {
+				// The entrance is a horizontal strip, so we place transition nodes along the x axis.
+				const int32_t end_x = entrance.c1_pos.x + entrance.width;
+
+				for (int32_t x = entrance.c1_pos.x; x < end_x - 1; x += NODE_MIN_DISTANCE) {
+					_build_node_and_inter_edges(Vector2i(x, entrance.c1_pos.y), c1_idx, Vector2i(x, entrance.c2_pos.y), c2_idx);
+				}
+
+				// Always place a node at the far end of the entrance.
+				const int32_t last_x = end_x - 1;
+				_build_node_and_inter_edges(Vector2i(last_x, entrance.c1_pos.y), c1_idx, Vector2i(last_x, entrance.c2_pos.y), c2_idx);
+			} break;
+
+			case CLUSTER_ADJACENCY_DIAGONAL: {
+				_build_node_and_inter_edges(entrance.c1_pos, c1_idx, entrance.c2_pos, c2_idx);
+			} break;
+
+			default:
+				break;
+		}
+	}
+}
+
+void AStarGrid2D::_build_node_and_inter_edges(const Vector2i &p_pos1, int32_t p_c1_idx, const Vector2i &p_pos2, int32_t p_c2_idx) {
+	const int32_t n1_idx = hpa_nodes.size();
+	const int32_t n2_idx = n1_idx + 1;
+	const real_t cost = _compute_cost(p_pos1, p_pos2);
+
+	HierNode n1;
+	n1.id = n1_idx;
+	n1.pos = p_pos1;
+	n1.cluster_idx = p_c1_idx;
+
+	HierNode n2;
+	n2.id = n2_idx;
+	n2.pos = p_pos2;
+	n2.cluster_idx = p_c2_idx;
+
+	n1.edges.push_back(HierEdge{ n2_idx, cost, true });
+	n2.edges.push_back(HierEdge{ n1_idx, cost, true });
+
+	hpa_nodes.push_back(n1);
+	hpa_nodes.push_back(n2);
+
+	hpa_clusters[p_c1_idx].node_ids.push_back(n1_idx);
+	hpa_clusters[p_c2_idx].node_ids.push_back(n2_idx);
+}
+
+void AStarGrid2D::_build_intra_edges() {
+	for (uint32_t i = 0; i < hpa_clusters.size(); i++) {
+		Cluster &cluster = hpa_clusters[i];
+
+		if (cluster.node_ids.size() < 2) {
+			continue;
+		}
+
+		for (uint32_t j = 0; j < cluster.node_ids.size(); j++) {
+			for (uint32_t k = j + 1; k < cluster.node_ids.size(); k++) {
+				const int32_t n1_idx = cluster.node_ids[j];
+				const int32_t n2_idx = cluster.node_ids[k];
+
+				HierNode &n1 = hpa_nodes[n1_idx];
+				HierNode &n2 = hpa_nodes[n2_idx];
+
+				const real_t path_cost = _solve_bounded(n1.pos, n2.pos, _cluster_rect(&cluster));
+
+				if (path_cost >= 0.0) {
+					n1.edges.push_back(HierEdge{ n2_idx, path_cost, false });
+					n2.edges.push_back(HierEdge{ n1_idx, path_cost, false });
+				}
+			}
+		}
+	}
+}
+
+int32_t AStarGrid2D::_get_cluster_index(const Vector2i &p_pos) const {
+	if (hpa_cluster_rows <= 0 || !region.has_point(p_pos)) {
+		return -1;
+	}
+	const int32_t col = (p_pos.x - region.position.x) / hpa_cluster_size;
+	const int32_t row = (p_pos.y - region.position.y) / hpa_cluster_size;
+	const int32_t idx = col * hpa_cluster_rows + row;
+	if (idx < 0 || idx >= (int32_t)hpa_clusters.size()) {
+		return -1;
+	}
+	return idx;
+}
+
+// Bounded A* over the cell grid: expansion is restricted to `p_bounds`. Returns the path
+// cost, or -1.0 if no route exists. When `r_path` is given it is filled with the cells from
+// `p_from` to `p_to` (inclusive). Used both to weight intra-cluster edges and to refine the
+// abstract path into concrete cells.
+real_t AStarGrid2D::_solve_bounded(const Vector2i &p_from, const Vector2i &p_to, const Rect2i &p_bounds, LocalVector<Vector2i> *r_path) {
+	pass++;
+
+	Point *begin_point = _get_point_unchecked(p_from);
+	Point *end_point = _get_point_unchecked(p_to);
+
+	if (_get_solid_unchecked(begin_point->id) || _get_solid_unchecked(end_point->id)) {
+		return -1.0;
+	}
+
+	begin_point->g_score = 0;
+	begin_point->f_score = _estimate_cost(begin_point->id, end_point->id);
+	begin_point->open_pass = pass;
+	begin_point->prev_point = nullptr;
+
+	LocalVector<Point *> open_list;
+	SortArray<Point *, SortPoints> sorter;
+	LocalVector<Point *> nbors;
+
+	open_list.push_back(begin_point);
+
+	bool found = false;
+	while (!open_list.is_empty()) {
+		Point *p = open_list[0];
+
+		if (p == end_point) {
+			found = true;
+			break;
+		}
+
+		sorter.pop_heap(0, open_list.size(), open_list.ptr());
+		open_list.remove_at(open_list.size() - 1);
+		p->closed_pass = pass;
+
+		nbors.clear();
+		_get_nbors(p, nbors);
+
+		for (Point *e : nbors) {
+			// Restrict the search to the bounded region.
+			if (!p_bounds.has_point(e->id)) {
+				continue;
+			}
+			if (e->closed_pass == pass || _get_solid_unchecked(e->id)) {
+				continue;
+			}
+
+			const real_t tentative_g_score = p->g_score + _compute_cost(p->id, e->id) * e->weight_scale;
+			bool new_point = false;
+
+			if (e->open_pass != pass) {
+				e->open_pass = pass;
+				open_list.push_back(e);
+				new_point = true;
+			} else if (tentative_g_score >= e->g_score) {
+				continue;
+			}
+
+			e->prev_point = p;
+			e->g_score = tentative_g_score;
+			e->f_score = tentative_g_score + _estimate_cost(e->id, end_point->id);
+
+			if (new_point) {
+				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptr());
+			} else {
+				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptr());
+			}
+		}
+	}
+
+	if (!found) {
+		return -1.0;
+	}
+
+	if (r_path) {
+		r_path->clear();
+		for (Point *p = end_point; p != nullptr; p = p->prev_point) {
+			r_path->push_back(p->id);
+		}
+		const uint32_t count = r_path->size();
+		for (uint32_t i = 0; i < count / 2; i++) {
+			SWAP((*r_path)[i], (*r_path)[count - 1 - i]);
+		}
+	}
+
+	return end_point->g_score;
+}
+
+// A* over the abstract graph. Operates on node indices and uses each node's edge list as the
+// adjacency. Fills `r_node_path` with the sequence of node positions from start to goal.
+bool AStarGrid2D::_abstract_astar(int32_t p_start_idx, int32_t p_goal_idx, LocalVector<Vector2i> &r_node_path) {
+	hpa_pass++;
+
+	const Vector2i goal_pos = hpa_nodes[p_goal_idx].pos;
+
+	hpa_nodes[p_start_idx].g_score = 0;
+	hpa_nodes[p_start_idx].f_score = _estimate_cost(hpa_nodes[p_start_idx].pos, goal_pos);
+	hpa_nodes[p_start_idx].prev_node_idx = -1;
+	hpa_nodes[p_start_idx].open_pass = hpa_pass;
+
+	LocalVector<int32_t> open;
+	open.push_back(p_start_idx);
+
+	while (!open.is_empty()) {
+		// Pick the open node with the lowest f_score (linear scan; the abstract graph is small).
+		uint32_t best_i = 0;
+		for (uint32_t i = 1; i < open.size(); i++) {
+			if (hpa_nodes[open[i]].f_score < hpa_nodes[open[best_i]].f_score) {
+				best_i = i;
+			}
+		}
+
+		const int32_t curr = open[best_i];
+		if (curr == p_goal_idx) {
+			for (int32_t n = p_goal_idx; n != -1; n = hpa_nodes[n].prev_node_idx) {
+				r_node_path.push_back(hpa_nodes[n].pos);
+			}
+			const uint32_t count = r_node_path.size();
+			for (uint32_t i = 0; i < count / 2; i++) {
+				SWAP(r_node_path[i], r_node_path[count - 1 - i]);
+			}
+			return true;
+		}
+
+		open.remove_at(best_i);
+		hpa_nodes[curr].closed_pass = hpa_pass;
+
+		const LocalVector<HierEdge> &edges = hpa_nodes[curr].edges;
+		for (uint32_t i = 0; i < edges.size(); i++) {
+			const int32_t nb = edges[i].to_node_idx;
+			if (hpa_nodes[nb].closed_pass == hpa_pass) {
+				continue;
+			}
+
+			const real_t tentative_g = hpa_nodes[curr].g_score + edges[i].distance;
+			if (hpa_nodes[nb].open_pass != hpa_pass) {
+				hpa_nodes[nb].open_pass = hpa_pass;
+				hpa_nodes[nb].g_score = tentative_g;
+				hpa_nodes[nb].f_score = tentative_g + _estimate_cost(hpa_nodes[nb].pos, goal_pos);
+				hpa_nodes[nb].prev_node_idx = curr;
+				open.push_back(nb);
+			} else if (tentative_g < hpa_nodes[nb].g_score) {
+				hpa_nodes[nb].g_score = tentative_g;
+				hpa_nodes[nb].f_score = tentative_g + _estimate_cost(hpa_nodes[nb].pos, goal_pos);
+				hpa_nodes[nb].prev_node_idx = curr;
+			}
+		}
+	}
+
+	return false;
+}
+
+// Inserts the start and goal as temporary nodes, connects them to their clusters, runs the
+// abstract search, then removes the temporary nodes (and the edges that referenced them) so the
+// static graph is left untouched. The abstract graph encodes all inter-cluster connectivity,
+// so a failed search means the goal is genuinely unreachable.
+AStarGrid2D::HPAPathResult AStarGrid2D::_hpa_solve_abstract(const Vector2i &p_from, const Vector2i &p_to, LocalVector<Vector2i> &r_node_path) {
+	const int32_t from_cluster = _get_cluster_index(p_from);
+	const int32_t to_cluster = _get_cluster_index(p_to);
+	if (from_cluster < 0 || to_cluster < 0) {
+		return HPA_PATH_RESULT_FAILED;
+	}
+
+	const int32_t static_count = (int32_t)hpa_nodes.size();
+	const int32_t start_idx = static_count;
+	const int32_t goal_idx = static_count + 1;
+
+	// Append the two temporary nodes. No further pushes to `hpa_nodes` happen afterwards, so
+	// indices into it remain stable for the rest of this function.
+	HierNode start_node;
+	start_node.id = start_idx;
+	start_node.pos = p_from;
+	start_node.cluster_idx = from_cluster;
+	hpa_nodes.push_back(start_node);
+
+	HierNode goal_node;
+	goal_node.id = goal_idx;
+	goal_node.pos = p_to;
+	goal_node.cluster_idx = to_cluster;
+	hpa_nodes.push_back(goal_node);
+
+	// Start: outgoing edges to the static nodes of its cluster (stored on the temp node only).
+	const Rect2i from_rect = _cluster_rect(&hpa_clusters[from_cluster]);
+	for (uint32_t i = 0; i < hpa_clusters[from_cluster].node_ids.size(); i++) {
+		const int32_t sn = hpa_clusters[from_cluster].node_ids[i];
+		const real_t cost = _solve_bounded(p_from, hpa_nodes[sn].pos, from_rect);
+		if (cost >= 0.0) {
+			hpa_nodes[start_idx].edges.push_back(HierEdge{ sn, cost, false });
+		}
+	}
+
+	// Goal: incoming edges from the static nodes of its cluster (temporarily added to those
+	// static nodes, removed during cleanup below).
+	const Rect2i to_rect = _cluster_rect(&hpa_clusters[to_cluster]);
+	for (uint32_t i = 0; i < hpa_clusters[to_cluster].node_ids.size(); i++) {
+		const int32_t sn = hpa_clusters[to_cluster].node_ids[i];
+		const real_t cost = _solve_bounded(hpa_nodes[sn].pos, p_to, to_rect);
+		if (cost >= 0.0) {
+			hpa_nodes[sn].edges.push_back(HierEdge{ goal_idx, cost, false });
+		}
+	}
+
+	// If start and goal share a cluster, connect them directly as well.
+	if (from_cluster == to_cluster) {
+		const real_t cost = _solve_bounded(p_from, p_to, from_rect);
+		if (cost >= 0.0) {
+			hpa_nodes[start_idx].edges.push_back(HierEdge{ goal_idx, cost, false });
+		}
+	}
+
+	const bool found = _abstract_astar(start_idx, goal_idx, r_node_path);
+
+	// Cleanup: drop the temporary goal edges from the static nodes, then drop the temp nodes.
+	for (uint32_t i = 0; i < hpa_clusters[to_cluster].node_ids.size(); i++) {
+		const int32_t sn = hpa_clusters[to_cluster].node_ids[i];
+		LocalVector<HierEdge> &edges = hpa_nodes[sn].edges;
+		while (!edges.is_empty() && edges[edges.size() - 1].to_node_idx == goal_idx) {
+			edges.remove_at(edges.size() - 1);
+		}
+	}
+	hpa_nodes.resize(static_count);
+
+	return found ? HPA_PATH_RESULT_FOUND : HPA_PATH_RESULT_UNREACHABLE;
+}
+
+// Produces the full concrete cell path by refining each leg of the abstract path with a bounded
+// low-level A* restricted to the clusters the two abstract nodes belong to.
+AStarGrid2D::HPAPathResult AStarGrid2D::_hpa_get_cell_path(const Vector2i &p_from, const Vector2i &p_to, LocalVector<Vector2i> &r_cells) {
+	LocalVector<Vector2i> node_path;
+	const HPAPathResult abstract_result = _hpa_solve_abstract(p_from, p_to, node_path);
+	if (abstract_result != HPA_PATH_RESULT_FOUND) {
+		return abstract_result;
+	}
+
+	r_cells.clear();
+
+	if (node_path.size() == 1) {
+		r_cells.push_back(node_path[0]);
+		return HPA_PATH_RESULT_FOUND;
+	}
+
+	LocalVector<Vector2i> segment;
+	for (uint32_t i = 0; i + 1 < node_path.size(); i++) {
+		const Vector2i a = node_path[i];
+		const Vector2i b = node_path[i + 1];
+
+		Rect2i bounds = _cluster_rect(&hpa_clusters[_get_cluster_index(a)]);
+		const int32_t b_cluster = _get_cluster_index(b);
+		if (b_cluster >= 0) {
+			bounds = bounds.merge(_cluster_rect(&hpa_clusters[b_cluster]));
+		}
+
+		segment.clear();
+		const real_t cost = _solve_bounded(a, b, bounds, &segment);
+		if (cost < 0.0 || segment.is_empty()) {
+			return HPA_PATH_RESULT_FAILED;
+		}
+
+		// Append the segment, skipping its first cell when it would duplicate the last appended one.
+		const uint32_t first = r_cells.is_empty() ? 0 : 1;
+		for (uint32_t j = first; j < segment.size(); j++) {
+			r_cells.push_back(segment[j]);
+		}
+	}
+
+	return HPA_PATH_RESULT_FOUND;
+}
+
+void AStarGrid2D::update_hpa() {
+	hpa_clusters.clear();
+	hpa_entrances.clear();
+	hpa_nodes.clear();
+	hpa_cluster_cols = 0;
+	hpa_cluster_rows = 0;
+
+	if (!hpa_enabled) {
+		hpa_dirty = false;
+		return;
+	}
+
+	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
+
+	_build_clusters();
+	_build_entrances();
+	_create_hpa_nodes();
+	_build_intra_edges();
+
+	hpa_dirty = false;
 }
 
 void AStarGrid2D::_bind_methods() {
@@ -760,6 +1452,13 @@ void AStarGrid2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_point_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_id_path, DEFVAL(false));
 
+	ClassDB::bind_method(D_METHOD("set_hpa_enabled", "enabled"), &AStarGrid2D::set_hpa_enabled);
+	ClassDB::bind_method(D_METHOD("is_hpa_enabled"), &AStarGrid2D::is_hpa_enabled);
+	ClassDB::bind_method(D_METHOD("is_hpa_dirty"), &AStarGrid2D::is_hpa_dirty);
+	ClassDB::bind_method(D_METHOD("set_hpa_cluster_size", "cluster_size"), &AStarGrid2D::set_hpa_cluster_size);
+	ClassDB::bind_method(D_METHOD("get_hpa_cluster_size"), &AStarGrid2D::get_hpa_cluster_size);
+	ClassDB::bind_method(D_METHOD("update_hpa"), &AStarGrid2D::update_hpa);
+
 	GDVIRTUAL_BIND(_estimate_cost, "from_id", "end_id")
 	GDVIRTUAL_BIND(_compute_cost, "from_id", "to_id")
 
@@ -773,6 +1472,10 @@ void AStarGrid2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_compute_heuristic", PROPERTY_HINT_ENUM, "Euclidean,Manhattan,Octile,Chebyshev"), "set_default_compute_heuristic", "get_default_compute_heuristic");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_estimate_heuristic", PROPERTY_HINT_ENUM, "Euclidean,Manhattan,Octile,Chebyshev"), "set_default_estimate_heuristic", "get_default_estimate_heuristic");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "diagonal_mode", PROPERTY_HINT_ENUM, "Always,Never,At Least One Walkable,Only If No Obstacles"), "set_diagonal_mode", "get_diagonal_mode");
+
+	ADD_GROUP("HPA*", "hpa_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hpa_enabled"), "set_hpa_enabled", "is_hpa_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hpa_cluster_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_hpa_cluster_size", "get_hpa_cluster_size");
 
 	BIND_ENUM_CONSTANT(HEURISTIC_EUCLIDEAN);
 	BIND_ENUM_CONSTANT(HEURISTIC_MANHATTAN);

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -62,6 +62,19 @@ public:
 	};
 
 private:
+	enum ClusterAdjacency {
+		CLUSTER_ADJACENCY_NONE,
+		CLUSTER_ADJACENCY_LATERAL,
+		CLUSTER_ADJACENCY_VERTICAL,
+		CLUSTER_ADJACENCY_DIAGONAL,
+	};
+
+	enum HPAPathResult {
+		HPA_PATH_RESULT_FOUND,
+		HPA_PATH_RESULT_UNREACHABLE,
+		HPA_PATH_RESULT_FAILED,
+	};
+
 	Rect2i region;
 	Vector2 offset;
 	Size2 cell_size = Size2(1, 1);
@@ -72,6 +85,16 @@ private:
 	DiagonalMode diagonal_mode = DIAGONAL_MODE_ALWAYS;
 	Heuristic default_compute_heuristic = HEURISTIC_EUCLIDEAN;
 	Heuristic default_estimate_heuristic = HEURISTIC_EUCLIDEAN;
+
+	bool hpa_enabled = false;
+	bool hpa_dirty = false;
+	int32_t hpa_cluster_size = 5;
+
+	// Number of clusters along each axis, used to map a cell to its cluster index.
+	int32_t hpa_cluster_cols = 0;
+	int32_t hpa_cluster_rows = 0;
+	// Separate pass counter for the abstract graph search (independent of the cell-level `pass`).
+	uint64_t hpa_pass = 1;
 
 	struct Point {
 		Vector2i id;
@@ -107,6 +130,47 @@ private:
 			}
 		}
 	};
+
+	struct HierEdge {
+		int32_t to_node_idx = -1;
+		real_t distance = 0.0;
+		bool is_inter_cluster = false;
+	};
+
+	struct HierNode {
+		int32_t id = -1;
+		Vector2i pos;
+		int32_t cluster_idx = -1;
+		LocalVector<HierEdge> edges;
+
+		// Used for the abstract A* search.
+		real_t g_score = 0;
+		real_t f_score = 0;
+		int32_t prev_node_idx = -1;
+		uint64_t open_pass = 0;
+		uint64_t closed_pass = 0;
+	};
+
+	struct Cluster {
+		int32_t cluster_width = 0;
+		int32_t cluster_height = 0;
+		Vector2i cluster_pos;
+		LocalVector<int32_t> node_ids;
+	};
+
+	struct Entrance {
+		int32_t cluster_1_idx = -1;
+		int32_t cluster_2_idx = -1;
+		Vector2i c1_pos; // First boundary cell of the entrance on cluster 1's side.
+		Vector2i c2_pos; // First boundary cell of the entrance on cluster 2's side.
+		int32_t width = 0;
+		int32_t height = 0;
+		ClusterAdjacency dir = CLUSTER_ADJACENCY_NONE;
+	};
+
+	LocalVector<Cluster> hpa_clusters;
+	LocalVector<Entrance> hpa_entrances;
+	LocalVector<HierNode> hpa_nodes;
 
 	LocalVector<bool> solid_mask;
 	LocalVector<LocalVector<Point>> points;
@@ -156,6 +220,22 @@ private: // Internal routines.
 	}
 
 	void _get_nbors(Point *p_point, LocalVector<Point *> &r_nbors);
+	ClusterAdjacency _clusters_are_adjacent(const Cluster *p_c1, const Cluster *p_c2) const;
+	void _create_entrances(int32_t p_c1_idx, int32_t p_c2_idx, ClusterAdjacency p_adjacent_dir);
+	void _add_entrance(int32_t p_c1_idx, int32_t p_c2_idx, const Vector2i &p_c1_pos, const Vector2i &p_c2_pos, int32_t p_width, int32_t p_height, ClusterAdjacency p_dir);
+	void _build_clusters();
+	void _build_entrances();
+	void _create_hpa_nodes();
+	void _build_node_and_inter_edges(const Vector2i &p_pos1, int32_t p_c1_idx, const Vector2i &p_pos2, int32_t p_c2_idx);
+	void _build_intra_edges();
+	_FORCE_INLINE_ Rect2i _cluster_rect(const Cluster *p_c) const {
+		return Rect2i(p_c->cluster_pos, Size2i(p_c->cluster_width, p_c->cluster_height));
+	}
+	int32_t _get_cluster_index(const Vector2i &p_pos) const;
+	real_t _solve_bounded(const Vector2i &p_from, const Vector2i &p_to, const Rect2i &p_bounds, LocalVector<Vector2i> *r_path = nullptr);
+	bool _abstract_astar(int32_t p_start_idx, int32_t p_goal_idx, LocalVector<Vector2i> &r_node_path);
+	HPAPathResult _hpa_solve_abstract(const Vector2i &p_from, const Vector2i &p_to, LocalVector<Vector2i> &r_node_path);
+	HPAPathResult _hpa_get_cell_path(const Vector2i &p_from, const Vector2i &p_to, LocalVector<Vector2i> &r_cells);
 	Point *_jump(Point *p_from, Point *p_to);
 	bool _solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path);
 	Point *_forced_successor(int32_t p_x, int32_t p_y, int32_t p_dx, int32_t p_dy, bool p_inclusive = false);
@@ -196,6 +276,13 @@ public:
 	bool is_in_bounds(int32_t p_x, int32_t p_y) const;
 	bool is_in_boundsv(const Vector2i &p_id) const;
 	bool is_dirty() const;
+
+	bool is_hpa_enabled() const;
+	bool is_hpa_dirty() const;
+	void set_hpa_enabled(bool p_enabled);
+	int32_t get_hpa_cluster_size() const;
+	void set_hpa_cluster_size(int32_t p_cluster_size);
+	void update_hpa();
 
 	void set_jumping_enabled(bool p_enabled);
 	bool is_jumping_enabled() const;

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -124,6 +124,12 @@
 				Indicates that the grid parameters were changed and [method update] needs to be called.
 			</description>
 		</method>
+		<method name="is_hpa_dirty" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Indicates that the grid or its solid cells were changed and the hierarchical abstract graph needs to be rebuilt with [method update_hpa]. When [member hpa_enabled] is [code]true[/code], the rebuild is performed automatically the next time a path is requested.
+			</description>
+		</method>
 		<method name="is_in_bounds" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="x" type="int" />
@@ -171,6 +177,12 @@
 				[b]Note:[/b] All point data (solidity and weight scale) will be cleared.
 			</description>
 		</method>
+		<method name="update_hpa">
+			<return type="void" />
+			<description>
+				Rebuilds the hierarchical pathfinding abstract graph (clusters, entrances, nodes and edges) used when [member hpa_enabled] is [code]true[/code]. This is normally called automatically the first time a path is requested after the grid or its solid cells change, but it can be called manually to pay the build cost up front. Has no effect while [member hpa_enabled] is [code]false[/code]. Requires the grid to be up to date (see [method update]).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="cell_shape" type="int" setter="set_cell_shape" getter="get_cell_shape" enum="AStarGrid2D.CellShape" default="0">
@@ -187,6 +199,12 @@
 		</member>
 		<member name="diagonal_mode" type="int" setter="set_diagonal_mode" getter="get_diagonal_mode" enum="AStarGrid2D.DiagonalMode" default="0">
 			A specific [enum DiagonalMode] mode which will force the path to avoid or accept the specified diagonals.
+		</member>
+		<member name="hpa_cluster_size" type="int" setter="set_hpa_cluster_size" getter="get_hpa_cluster_size" default="5">
+			The side length, in cells, of the square clusters the grid is divided into when [member hpa_enabled] is [code]true[/code]. Larger clusters produce a smaller abstract graph (faster searches, less memory) at the cost of more expensive intra-cluster refinement; smaller clusters do the opposite. Changing this value rebuilds the abstract graph before the next path is requested.
+		</member>
+		<member name="hpa_enabled" type="bool" setter="set_hpa_enabled" getter="is_hpa_enabled" default="false">
+			If [code]true[/code], [method get_id_path] and [method get_point_path] use Hierarchical Pathfinding A* (HPA*). The grid is divided into clusters (see [member hpa_cluster_size]) connected through an abstract graph, which is searched first and then refined into a concrete path. This can be substantially faster than a full A* search on large, sparse grids, at the cost of paths that may be slightly longer than optimal. Disabling it frees the memory used by the abstract graph.
 		</member>
 		<member name="jumping_enabled" type="bool" setter="set_jumping_enabled" getter="is_jumping_enabled" default="false">
 			Enables or disables jumping to skip up the intermediate points and speeds up the searching algorithm.

--- a/tests/core/math/test_a_star_grid_2d.cpp
+++ b/tests/core/math/test_a_star_grid_2d.cpp
@@ -1,0 +1,217 @@
+/**************************************************************************/
+/*  test_a_star_grid_2d.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_a_star_grid_2d)
+
+#include "core/math/a_star_grid_2d.h"
+#include "core/variant/typed_array.h"
+
+namespace TestAStarGrid2D {
+
+// Checks that `p_path` is a contiguous, walkable chain of cells from `p_from` to `p_to`.
+static bool is_valid_path(AStarGrid2D &p_grid, const TypedArray<Vector2i> &p_path, const Vector2i &p_from, const Vector2i &p_to) {
+	if (p_path.is_empty()) {
+		return false;
+	}
+	if ((Vector2i)p_path[0] != p_from) {
+		return false;
+	}
+	if ((Vector2i)p_path[p_path.size() - 1] != p_to) {
+		return false;
+	}
+	for (int i = 0; i < p_path.size(); i++) {
+		const Vector2i cell = p_path[i];
+		if (!p_grid.is_in_boundsv(cell) || p_grid.is_point_solid(cell)) {
+			return false;
+		}
+		if (i > 0) {
+			const Vector2i prev = p_path[i - 1];
+			const int dx = Math::abs(cell.x - prev.x);
+			const int dy = Math::abs(cell.y - prev.y);
+			// Each step must move to an 8-connected neighbor (and actually move).
+			if (MAX(dx, dy) != 1) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+TEST_CASE("[AStarGrid2D] HPA* returns a valid path on an open grid") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 32, 32));
+	grid.update();
+	grid.set_hpa_enabled(true);
+
+	const Vector2i from(0, 0);
+	const Vector2i to(31, 31);
+
+	TypedArray<Vector2i> path = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, path, from, to));
+
+	// The hierarchical path may be slightly longer than optimal, but not wildly so.
+	AStarGrid2D reference;
+	reference.set_region(Rect2i(0, 0, 32, 32));
+	reference.update();
+	TypedArray<Vector2i> reference_path = reference.get_id_path(from, to);
+	CHECK(reference_path.size() > 0);
+	// Any valid path cannot be shorter than the optimal one A* finds.
+	CHECK(path.size() >= reference_path.size());
+	// HPA* trades a little path quality for speed, but should stay in the same ballpark.
+	CHECK(path.size() <= reference_path.size() * 2 + 16);
+}
+
+TEST_CASE("[AStarGrid2D] HPA* and regular A* agree on reachability with obstacles") {
+	// A vertical wall splitting the grid, with a single one-cell gap near the bottom.
+	const Rect2i region(0, 0, 30, 30);
+	const Vector2i from(2, 2);
+	const Vector2i to(27, 2);
+
+	AStarGrid2D reference;
+	reference.set_region(region);
+	reference.update();
+	reference.fill_solid_region(Rect2i(15, 0, 1, 29)); // Leaves (15, 29) walkable.
+	TypedArray<Vector2i> reference_path = reference.get_id_path(from, to);
+
+	AStarGrid2D grid;
+	grid.set_region(region);
+	grid.update();
+	grid.set_hpa_enabled(true);
+	grid.fill_solid_region(Rect2i(15, 0, 1, 29));
+	TypedArray<Vector2i> path = grid.get_id_path(from, to);
+
+	// Both should find a route (around the gap), and the HPA* one must be valid.
+	CHECK(reference_path.size() > 0);
+	CHECK(path.size() > 0);
+	CHECK(is_valid_path(grid, path, from, to));
+}
+
+TEST_CASE("[AStarGrid2D] HPA* handles identical start and goal") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 16, 16));
+	grid.update();
+	grid.set_hpa_enabled(true);
+
+	TypedArray<Vector2i> path = grid.get_id_path(Vector2i(4, 4), Vector2i(4, 4));
+	REQUIRE(path.size() == 1);
+	CHECK((Vector2i)path[0] == Vector2i(4, 4));
+}
+
+TEST_CASE("[AStarGrid2D] HPA* returns no path when the goal is walled off") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 20, 20));
+	grid.update();
+	grid.set_hpa_enabled(true);
+
+	// Completely enclose the goal cell (10, 10).
+	grid.fill_solid_region(Rect2i(9, 9, 3, 3));
+	grid.set_point_solid(Vector2i(10, 10), false); // Goal itself is walkable but surrounded.
+
+	TypedArray<Vector2i> path = grid.get_id_path(Vector2i(0, 0), Vector2i(10, 10));
+	CHECK(path.is_empty());
+
+	// When a partial path is requested, the fallback to regular A* must still produce one.
+	TypedArray<Vector2i> partial = grid.get_id_path(Vector2i(0, 0), Vector2i(10, 10), true);
+	CHECK(partial.size() > 0);
+}
+
+TEST_CASE("[AStarGrid2D] HPA* rebuilds when solid cells change") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 24, 24));
+	grid.update();
+	grid.set_hpa_enabled(true);
+
+	const Vector2i from(0, 12);
+	const Vector2i to(23, 12);
+
+	TypedArray<Vector2i> first = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, first, from, to));
+	CHECK_FALSE(grid.is_hpa_dirty());
+
+	// Block a full vertical wall (no gap): the path must now be impossible.
+	grid.fill_solid_region(Rect2i(12, 0, 1, 24));
+	CHECK(grid.is_hpa_dirty()); // Changing solid cells invalidates the abstract graph.
+
+	TypedArray<Vector2i> blocked = grid.get_id_path(from, to);
+	CHECK(blocked.is_empty());
+
+	// Re-open a gap and confirm a valid path is found again.
+	grid.set_point_solid(Vector2i(12, 12), false);
+	TypedArray<Vector2i> reopened = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, reopened, from, to));
+}
+
+TEST_CASE("[AStarGrid2D] Toggling HPA* keeps pathfinding working") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 20, 20));
+	grid.update();
+
+	const Vector2i from(0, 0);
+	const Vector2i to(19, 19);
+
+	// Regular A* baseline.
+	TypedArray<Vector2i> plain = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, plain, from, to));
+
+	// Enable, then disable HPA*: results must remain valid in both cases.
+	grid.set_hpa_enabled(true);
+	TypedArray<Vector2i> hpa = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, hpa, from, to));
+
+	grid.set_hpa_enabled(false);
+	CHECK_FALSE(grid.is_hpa_enabled());
+	TypedArray<Vector2i> plain_again = grid.get_id_path(from, to);
+	CHECK(is_valid_path(grid, plain_again, from, to));
+}
+
+TEST_CASE("[AStarGrid2D] HPA* point path matches id path positions") {
+	AStarGrid2D grid;
+	grid.set_region(Rect2i(0, 0, 24, 24));
+	grid.update();
+	grid.set_hpa_enabled(true);
+
+	const Vector2i from(1, 1);
+	const Vector2i to(22, 20);
+
+	TypedArray<Vector2i> id_path = grid.get_id_path(from, to);
+	Vector<Vector2> point_path = grid.get_point_path(from, to);
+
+	REQUIRE(id_path.size() > 0);
+	REQUIRE(id_path.size() == point_path.size());
+
+	// The point path should be the world positions of the id path cells.
+	for (int i = 0; i < id_path.size(); i++) {
+		CHECK(point_path[i].is_equal_approx(grid.get_point_position((Vector2i)id_path[i])));
+	}
+}
+
+} // namespace TestAStarGrid2D


### PR DESCRIPTION
Closes godotengine/godot-proposals#14671

Adds an optional Hierarchical Pathfinding A* (HPA*) mode to `AStarGrid2D`, following the approach described in [this research](https://alexmelenchon.github.io/Hierarchial-Pathfinding-Research/).
Co-Autored by @Uauses


## How it works

When `hpa_enabled` is `true`, the grid is divided into square clusters of `hpa_cluster_size` cells. Walkable borders between adjacent clusters become *entrances*, which are sampled into transition nodes connected by inter-cluster edges; nodes inside the same cluster are connected by intra-cluster edges weighted with a bounded low-level A* search. Path queries then run A* on this much smaller abstract graph and refine each leg into concrete cells with a cluster-bounded A*.

The abstract graph is built lazily on the first path query and cached. It is invalidated (and rebuilt on the next query) when the grid is updated, solid cells change, or the cluster size changes; `update_hpa()` allows paying the build cost up front, and `is_hpa_dirty()` exposes the invalidation state. Disabling HPA* frees the graph's memory. 

## Public API

- `hpa_enabled` (bool, default `false`)
- `hpa_cluster_size` (int, default `5`)
- `update_hpa()`
- `is_hpa_dirty()`

## Performance

Benchmark on a 256 x 256 maze, cluster size 16, 300 queries: **2.40x faster** (738.54 ms -> 308.29 ms), with paths averaging 102.2% of optimal length. The speedup grows with the number of queries, as the one-time graph build is amortized.

HPA* trades a small amount of path quality for query speed, which is why it is opt-in and off by default. This way, existing projects are unaffected.

## Tests and docs

- Adds `tests/core/math/test_a_star_grid_2d.cpp` covering: path validity and near-optimality on open grids, reachability agreement with regular A* around obstacles, identical start/goal, walled-off goals, graph invalidation when solid cells change, toggling HPA* on/off, and `get_point_path`/`get_id_path` consistency.
- Updates the `AStarGrid2D` class reference for all new members and methods.

## Showcase

https://github.com/user-attachments/assets/afc63b9a-a716-4e76-8926-ad1f959578a1


