### PR TITLE
Fix some issues and crashes in the asset store

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1099,20 +1099,27 @@ void EditorAssetLibrary::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("asset_library") &&
-					!EditorSettings::get_singleton()->check_changed_settings_in_group("network")) {
-				break;
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("asset_store/use_threads") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("network/http_proxy")) {
+				setup_http_request(request);
 			}
 
-			_update_repository_options();
-			setup_http_request(request);
-
-			const bool loading_blocked_new = ((int)EDITOR_GET("network/connection/network_mode") == EditorSettings::NETWORK_OFFLINE);
-			if (loading_blocked_new != loading_blocked) {
-				loading_blocked = loading_blocked_new;
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("asset_store/available_urls")) {
+				_update_repository_options();
 
 				if (!loading_blocked && is_visible()) {
-					_request_current_config(); // Reload config now that the network is available.
+					_request_current_config();
+				}
+			}
+
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("network/connection/network_mode")) {
+				const bool loading_blocked_new = ((int)EDITOR_GET("network/connection/network_mode") == EditorSettings::NETWORK_OFFLINE);
+				if (loading_blocked_new != loading_blocked) {
+					loading_blocked = loading_blocked_new;
+
+					if (!loading_blocked && is_visible()) {
+						_request_current_config(); // Reload config now that the network is available.
+					}
 				}
 			}
 		} break;
@@ -1408,9 +1415,20 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, int p_asset_id, const St
 void EditorAssetLibrary::_repository_changed(int p_repository_id) {
 	_set_library_message(TTRC("Loading..."));
 
-	asset_top_page->hide();
-	asset_bottom_page->hide();
-	asset_items->hide();
+	if (asset_items) {
+		memdelete(asset_items);
+		asset_items = nullptr;
+	}
+
+	if (asset_top_page) {
+		memdelete(asset_top_page);
+		asset_top_page = nullptr;
+	}
+
+	if (asset_bottom_page) {
+		memdelete(asset_bottom_page);
+		asset_bottom_page = nullptr;
+	}
 
 	filter->set_editable(false);
 	sort->set_disabled(true);
@@ -1736,19 +1754,26 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			if (asset_items) {
 				memdelete(asset_items);
+				asset_items = nullptr;
 			}
 
 			if (asset_top_page) {
 				memdelete(asset_top_page);
+				asset_top_page = nullptr;
 			}
 
 			if (asset_bottom_page) {
 				memdelete(asset_bottom_page);
+				asset_bottom_page = nullptr;
 			}
 
 			Dictionary d = dt;
-			ERR_FAIL_COND(!d.has("count"));
-			ERR_FAIL_COND(!d.has("hits"));
+			if (!d.has("count") || !d.has("hits")) {
+				_set_library_message_with_action(TTRC("Repository returned with invalid data."), TTRC("Retry"), callable_mp(this, &EditorAssetLibrary::_request_current_config));
+				error_hb->show();
+
+				return;
+			}
 
 			int page_len = 24; // API's default batch size.
 			int total_items = d["count"];
@@ -2012,6 +2037,10 @@ void EditorAssetLibrary::_install_external_asset(const String &p_zip_path, const
 }
 
 void EditorAssetLibrary::_update_asset_items_columns() {
+	if (!asset_items) {
+		return;
+	}
+
 	int new_columns = get_size().x / (450.0 * EDSCALE);
 	new_columns = MAX(1, new_columns);
 


### PR DESCRIPTION
- Fixes incorrect string check for changes in the editor settings.
- Narrowed down changes to more specific settings.
- Fixed possible crashes when changing certain settings to quickly.
- Properly handle when a search query returns invalid data.