### PR TITLE
Fix volumetric fog corner misalignment due to incorrect near frustum size

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -1078,7 +1078,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 	if (p_cam_projection.is_orthogonal()) {
 		fog_near_size = fog_far_size;
 	} else {
-		fog_near_size = frustum_near_size.maxf(0.001);
+		fog_near_size = Vector2(0.0f, 0.0f);
 	}
 
 	params.fog_frustum_size_begin[0] = fog_near_size.x;

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -592,7 +592,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 		if (p_cam_projection.is_orthogonal()) {
 			fog_near_size = fog_far_size;
 		} else {
-			fog_near_size = frustum_near_size.maxf(0.001);
+			fog_near_size = Vector2(0.0f, 0.0f);
 		}
 
 		params.fog_frustum_size_begin[0] = fog_near_size.x;

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -353,9 +353,9 @@ void main() {
 			// Min z prevents view_pos from collapsing to camera origin (broke with frustum_size_begin=(0,0) fix).
 			// Min xy prevents potential underflow in uvec2 cast of screen_pos.
 			// Max keeps within the froxel buffer.
-			fog_unit_pos = clamp(fog_unit_pos,
-				fog_cell_size * 0.5,        // half cell inset from zero
-				vec3(1.0) - fog_cell_size * 0.5); // half cell inset from one
+
+			fog_unit_pos = clamp(fog_unit_pos, fog_cell_size * 0.5, vec3(1.0) - fog_cell_size * 0.5);
+
 			screen_pos = uvec2(fog_unit_pos.xy * params.screen_size);
 			cluster_pos = screen_pos >> params.cluster_shift;
 			cluster_offset = (params.cluster_width * cluster_pos.y + cluster_pos.x) * (params.max_cluster_element_count_div_32 + 32);

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -349,6 +349,13 @@ void main() {
 
 			fog_unit_pos = posf * fog_cell_size + fog_cell_size * halton_map[params.temporal_frame]; //center of voxels, offset by halton table
 
+			// Clamp to prevent jitter pushing froxels into degenerate positions.
+			// Min z prevents view_pos from collapsing to camera origin (broke with frustum_size_begin=(0,0) fix).
+			// Min xy prevents potential underflow in uvec2 cast of screen_pos.
+			// Max keeps within the froxel buffer.
+			fog_unit_pos = clamp(fog_unit_pos,
+				fog_cell_size * 0.5,        // half cell inset from zero
+				vec3(1.0) - fog_cell_size * 0.5); // half cell inset from one
 			screen_pos = uvec2(fog_unit_pos.xy * params.screen_size);
 			cluster_pos = screen_pos >> params.cluster_shift;
 			cluster_offset = (params.cluster_width * cluster_pos.y + cluster_pos.x) * (params.max_cluster_element_count_div_32 + 32);


### PR DESCRIPTION
For perspective projections, fog_near_size was set to the frustum half-extents at z_near, but the GLSL shader maps fog_unit_pos.z = 0 to view_pos.z = 0 (the camera origin). This mismatch caused the mix() in the shader to apply a spurious offset proportional to NDC position, which is zero at the screen center but maximally visible at the corners.

Orthographic projection is unaffected as it retains fog_near_size = fog_far_size.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Would fix an underlying issue with how the volumetric fog is implemented. Where by, due to a mismatch between fog_frustrum_size_begin and how it maps onto the fog shader causes a misalignment of the volumetric fog at the corners of the screen. The issue itself isn't that massive but keen eyes will see it immediately.

## Additional information


This PR does not fix the additional issue of Stereo Volumetric Fog for VR
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
