### PR TITLE
Expose `get_stream_name` in `AudioStream`

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -94,6 +94,12 @@
 				Returns the length of the audio stream in seconds. If this stream is an [AudioStreamRandomizer], returns the length of the last played stream. If this stream has an indefinite length (such as for [AudioStreamGenerator] and [AudioStreamMicrophone]), returns [code]0.0[/code].
 			</description>
 		</method>
+		<method name="get_stream_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name assigned to this stream.
+			</description>
+		</method>
 		<method name="instantiate_playback">
 			<return type="AudioStreamPlayback" />
 			<description>

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -45,7 +45,7 @@ Ref<AudioStreamPlayback> AudioStreamInteractive::instantiate_playback() {
 }
 
 String AudioStreamInteractive::get_stream_name() const {
-	return "Transitioner";
+	return "Interactive";
 }
 
 void AudioStreamInteractive::set_clip_count(int p_count) {

--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -212,7 +212,7 @@ Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
 }
 
 String AudioStreamMP3::get_stream_name() const {
-	return ""; //return stream_name;
+	return "MP3";
 }
 
 void AudioStreamMP3::clear_data() {

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -429,7 +429,7 @@ Ref<AudioStreamPlayback> AudioStreamOggVorbis::instantiate_playback() {
 }
 
 String AudioStreamOggVorbis::get_stream_name() const {
-	return ""; //return stream_name;
+	return "OggVorbis";
 }
 
 void AudioStreamOggVorbis::maybe_update_info() {

--- a/scene/resources/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio_stream_polyphonic.cpp
@@ -45,7 +45,7 @@ Ref<AudioStreamPlayback> AudioStreamPolyphonic::instantiate_playback() {
 }
 
 String AudioStreamPolyphonic::get_stream_name() const {
-	return "AudioStreamPolyphonic";
+	return "Polyphonic";
 }
 
 bool AudioStreamPolyphonic::is_monophonic() const {

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -626,7 +626,7 @@ Ref<AudioStreamPlayback> AudioStreamWAV::instantiate_playback() {
 }
 
 String AudioStreamWAV::get_stream_name() const {
-	return "";
+	return "WAV";
 }
 
 Ref<AudioSample> AudioStreamWAV::generate_sample() const {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -332,6 +332,7 @@ Ref<AudioSample> AudioStream::generate_sample() const {
 }
 
 void AudioStream::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_stream_name"), &AudioStream::get_stream_name);
 	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
 	ClassDB::bind_method(D_METHOD("is_monophonic"), &AudioStream::is_monophonic);
 	ClassDB::bind_method(D_METHOD("instantiate_playback"), &AudioStream::instantiate_playback);

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -79,7 +79,7 @@ Ref<AudioStreamPlayback> AudioStreamGenerator::instantiate_playback() {
 }
 
 String AudioStreamGenerator::get_stream_name() const {
-	return "UserFeed";
+	return "Generator";
 }
 
 double AudioStreamGenerator::get_length() const {

--- a/tests/scene/test_audio_stream_wav.cpp
+++ b/tests/scene/test_audio_stream_wav.cpp
@@ -203,7 +203,7 @@ TEST_CASE("[Audio][AudioStreamWAV] Default values") {
 	CHECK(stream->get_length() == 0);
 	CHECK(stream->is_monophonic() == false);
 	CHECK(stream->get_data() == Vector<uint8_t>{});
-	CHECK(stream->get_stream_name() == "");
+	CHECK(stream->get_stream_name() == "WAV");
 }
 
 TEST_CASE("[Audio][AudioStreamWAV] Save empty file") {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/86935

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

As mentioned in the issue `AudioStream._get_stream_name()` (virtual) is exposed, but `AudioStream.get_stream_name()` is not.
The method has no real uses in the engine (aside from a test), but names for each stream were already defined. This PR, aside from exposing the method, also changes the defined names to make them more consistent and expected.
There might be some niche uses for this method, but I can see it being much more useful if a `set_stream_name()` method exists. I could either add that to this PR or another one, if it's a good idea.

I also wonder if the names should be just the last part of the entire class name, or just the class name: `"Randomizer"` vs `"AudioStreamRandomizer"`.

`audio_stream.cpp` also has an outdated comment inside `AudioStreamMicrophone::get_stream_name()`. I could clean that up for this PR since it's related, but since I didn't directly touch that specific method, I thought I should leave it alone until I'm given the green light. ([line](https://github.com/godotengine/godot/blob/3df26a02c446710c979daa541b74f87edeca81b0/servers/audio/audio_stream.cpp#L371))