### PR TITLE
Add option for cross axis expansion in flow containers

### DIFF
--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -40,6 +40,7 @@ struct _LineData {
 	int min_line_length = 0;
 	int stretch_avail = 0;
 	float stretch_ratio_total = 0;
+	float line_cross_stretch_ratio = 0;
 	bool is_filled = false;
 };
 
@@ -65,6 +66,10 @@ void FlowContainer::_resort() {
 	int children_in_current_line = 0;
 	Control *last_child = nullptr;
 
+	float line_cross_stretch_ratio = 0;
+	float container_cross_stretch_total = 0;
+	float container_cross_axis_stretch_available_space = vertical ? get_size().x : get_size().y;
+
 	// First pass for line wrapping and minimum size calculation.
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *child = as_sortable_control(get_child(i));
@@ -81,11 +86,17 @@ void FlowContainer::_resort() {
 			}
 			if (ofs.y + child_msc.y > current_container_size) {
 				line_length = ofs.y - theme_cache.v_separation;
-				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, true });
+				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, line_cross_stretch_ratio, true });
 
 				// Move in new column (vertical line).
 				ofs.x += line_height + theme_cache.h_separation;
 				ofs.y = 0;
+				if (line_cross_stretch_ratio == 0) {
+					container_cross_axis_stretch_available_space -= line_height;
+				} else {
+					container_cross_stretch_total += line_cross_stretch_ratio;
+					line_cross_stretch_ratio = 0;
+				}
 				line_height = 0;
 				line_stretch_ratio_total = 0;
 				children_in_current_line = 0;
@@ -95,6 +106,9 @@ void FlowContainer::_resort() {
 			if (child->get_v_size_flags().has_flag(SIZE_EXPAND)) {
 				line_stretch_ratio_total += child->get_stretch_ratio();
 			}
+			if (child->get_h_size_flags().has_flag(SIZE_EXPAND)) {
+				line_cross_stretch_ratio = MAX(line_cross_stretch_ratio, child->get_stretch_ratio());
+			}
 			ofs.y += child_msc.y;
 
 		} else { /* HORIZONTAL */
@@ -103,11 +117,19 @@ void FlowContainer::_resort() {
 			}
 			if (ofs.x + child_msc.x > current_container_size) {
 				line_length = ofs.x - theme_cache.h_separation;
-				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, true });
+				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, line_cross_stretch_ratio, true });
 
 				// Move in new line.
 				ofs.y += line_height + theme_cache.v_separation;
 				ofs.x = 0;
+				if (line_cross_stretch_ratio == 0) {
+					container_cross_axis_stretch_available_space -= line_height;
+				} else
+				{
+					container_cross_stretch_total += line_cross_stretch_ratio;
+					line_cross_stretch_ratio = 0;
+				}
+
 				line_height = 0;
 				line_stretch_ratio_total = 0;
 				children_in_current_line = 0;
@@ -116,6 +138,9 @@ void FlowContainer::_resort() {
 			line_height = MAX(line_height, child_msc.y);
 			if (child->get_h_size_flags().has_flag(SIZE_EXPAND)) {
 				line_stretch_ratio_total += child->get_stretch_ratio();
+			}
+			if (child->get_v_size_flags().has_flag(SIZE_EXPAND)) {
+				line_cross_stretch_ratio = MAX(line_cross_stretch_ratio, child->get_stretch_ratio());
 			}
 			ofs.x += child_msc.x;
 		}
@@ -130,9 +155,64 @@ void FlowContainer::_resort() {
 	if (last_child != nullptr) {
 		is_filled = vertical ? (ofs.y + last_child->get_bound_minimum_size().y > current_container_size ? true : false) : (ofs.x + last_child->get_bound_minimum_size().x > current_container_size ? true : false);
 	}
-	lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, is_filled });
 
-	// Second pass for in-line expansion and alignment.
+	lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, line_cross_stretch_ratio, is_filled });
+
+	if (line_cross_stretch_ratio == 0) {
+		container_cross_axis_stretch_available_space -= line_height;
+	} else {
+		container_cross_stretch_total += line_cross_stretch_ratio;
+	}
+	container_cross_axis_stretch_available_space -= vertical ? theme_cache.h_separation * MAX(0, lines_data.size() - 1) : theme_cache.v_separation * MAX(0, lines_data.size() - 1);
+
+	// Second pass to distribute extra space among stretchable lines and compute final line heights
+
+	if (container_cross_stretch_total > 0 && container_cross_axis_stretch_available_space > 0) {
+		Vector<_LineData *> stretch_lines;
+		Vector<bool> stretch_lines_active;
+
+		for (int i = 0; i < lines_data.size(); i++) {
+			if (lines_data[i].line_cross_stretch_ratio != 0) {
+				stretch_lines.push_back(&lines_data.write[i]);
+				stretch_lines_active.push_back(true);
+			}
+		}
+
+		while (container_cross_stretch_total > 0) {
+			bool refit_successful = true;
+
+			for (int j = 0; j < stretch_lines.size(); j++) {
+				if (!stretch_lines_active[j]) {
+					continue;
+				}
+
+				_LineData *line = stretch_lines[j];
+				const float max_stretch = container_cross_axis_stretch_available_space * (line->line_cross_stretch_ratio / container_cross_stretch_total);
+
+				if (line->min_line_height > max_stretch) {
+					stretch_lines_active.write[j] = false;
+					container_cross_stretch_total -= line->line_cross_stretch_ratio;
+					refit_successful = false;
+					break;
+				}
+			}
+
+			if (refit_successful) {
+				for (int j = 0; j < stretch_lines.size(); j++) {
+					if (!stretch_lines_active[j]) {
+						continue;
+					}
+
+					_LineData *line = stretch_lines[j];
+					line->min_line_height = container_cross_axis_stretch_available_space * line->line_cross_stretch_ratio / container_cross_stretch_total;
+				}
+				break;
+			}
+		}
+	}
+
+
+	// Third pass for in-line expansion and alignment.
 
 	int current_line_idx = 0;
 	int child_idx_in_line = 0;
@@ -382,9 +462,7 @@ Size2 FlowContainer::get_desired_size() const {
 Vector<int> FlowContainer::get_allowed_size_flags_horizontal() const {
 	Vector<int> flags;
 	flags.append(SIZE_FILL);
-	if (!vertical) {
-		flags.append(SIZE_EXPAND);
-	}
+	flags.append(SIZE_EXPAND);
 	flags.append(SIZE_SHRINK_BEGIN);
 	flags.append(SIZE_SHRINK_CENTER);
 	flags.append(SIZE_SHRINK_END);
@@ -394,9 +472,7 @@ Vector<int> FlowContainer::get_allowed_size_flags_horizontal() const {
 Vector<int> FlowContainer::get_allowed_size_flags_vertical() const {
 	Vector<int> flags;
 	flags.append(SIZE_FILL);
-	if (vertical) {
-		flags.append(SIZE_EXPAND);
-	}
+	flags.append(SIZE_EXPAND);
 	flags.append(SIZE_SHRINK_BEGIN);
 	flags.append(SIZE_SHRINK_CENTER);
 	flags.append(SIZE_SHRINK_END);

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -173,16 +173,16 @@ void FlowContainer::_resort() {
 		while (container_cross_stretch_total > 0) {
 			bool refit_successful = true;
 
-			for (int j = 0; j < stretch_lines.size(); j++) {
-				if (!stretch_lines_active[j]) {
+			for (int i = 0; i < stretch_lines.size(); i++) {
+				if (!stretch_lines_active[i]) {
 					continue;
 				}
 
-				_LineData *line = stretch_lines[j];
+				_LineData *line = stretch_lines[i];
 				const float max_stretch = container_cross_axis_stretch_available_space * (line->line_cross_stretch_ratio / container_cross_stretch_total);
 
 				if (line->min_line_height > max_stretch) {
-					stretch_lines_active.write[j] = false;
+					stretch_lines_active.write[i] = false;
 					container_cross_stretch_total -= line->line_cross_stretch_ratio;
 					container_cross_axis_stretch_available_space -= line->min_line_height;
 					refit_successful = false;

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -148,7 +148,6 @@ void FlowContainer::_resort() {
 	if (last_child != nullptr) {
 		is_filled = vertical ? (ofs.y + last_child->get_bound_minimum_size().y > current_container_size ? true : false) : (ofs.x + last_child->get_bound_minimum_size().x > current_container_size ? true : false);
 	}
-
 	lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, line_cross_stretch_ratio, is_filled });
 
 	container_cross_stretch_total += line_cross_stretch_ratio;
@@ -166,8 +165,7 @@ void FlowContainer::_resort() {
 			if (lines_data[i].line_cross_stretch_ratio != 0) {
 				stretch_lines.push_back(&lines_data.write[i]);
 				stretch_lines_active.push_back(true);
-			} else
-			{
+			} else {
 				container_cross_axis_stretch_available_space -= lines_data[i].min_line_height;
 			}
 		}
@@ -205,7 +203,6 @@ void FlowContainer::_resort() {
 			}
 		}
 	}
-
 
 	// Third pass for in-line expansion and alignment.
 

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -186,6 +186,7 @@ void FlowContainer::_resort() {
 				if (line->min_line_height > max_stretch) {
 					stretch_lines_active.write[j] = false;
 					container_cross_stretch_total -= line->line_cross_stretch_ratio;
+					container_cross_axis_stretch_available_space -= line->min_line_height;
 					refit_successful = false;
 					break;
 				}

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -68,7 +68,6 @@ void FlowContainer::_resort() {
 
 	float line_cross_stretch_ratio = 0;
 	float container_cross_stretch_total = 0;
-	float container_cross_axis_stretch_available_space = vertical ? get_size().x : get_size().y;
 
 	// First pass for line wrapping and minimum size calculation.
 	for (int i = 0; i < get_child_count(); i++) {
@@ -91,12 +90,10 @@ void FlowContainer::_resort() {
 				// Move in new column (vertical line).
 				ofs.x += line_height + theme_cache.h_separation;
 				ofs.y = 0;
-				if (line_cross_stretch_ratio == 0) {
-					container_cross_axis_stretch_available_space -= line_height;
-				} else {
-					container_cross_stretch_total += line_cross_stretch_ratio;
-					line_cross_stretch_ratio = 0;
-				}
+
+				container_cross_stretch_total += line_cross_stretch_ratio;
+				line_cross_stretch_ratio = 0;
+
 				line_height = 0;
 				line_stretch_ratio_total = 0;
 				children_in_current_line = 0;
@@ -122,13 +119,9 @@ void FlowContainer::_resort() {
 				// Move in new line.
 				ofs.y += line_height + theme_cache.v_separation;
 				ofs.x = 0;
-				if (line_cross_stretch_ratio == 0) {
-					container_cross_axis_stretch_available_space -= line_height;
-				} else
-				{
-					container_cross_stretch_total += line_cross_stretch_ratio;
-					line_cross_stretch_ratio = 0;
-				}
+
+				container_cross_stretch_total += line_cross_stretch_ratio;
+				line_cross_stretch_ratio = 0;
 
 				line_height = 0;
 				line_stretch_ratio_total = 0;
@@ -158,23 +151,24 @@ void FlowContainer::_resort() {
 
 	lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total, line_cross_stretch_ratio, is_filled });
 
-	if (line_cross_stretch_ratio == 0) {
-		container_cross_axis_stretch_available_space -= line_height;
-	} else {
-		container_cross_stretch_total += line_cross_stretch_ratio;
-	}
-	container_cross_axis_stretch_available_space -= vertical ? theme_cache.h_separation * MAX(0, lines_data.size() - 1) : theme_cache.v_separation * MAX(0, lines_data.size() - 1);
+	container_cross_stretch_total += line_cross_stretch_ratio;
 
 	// Second pass to distribute extra space among stretchable lines and compute final line heights
 
-	if (container_cross_stretch_total > 0 && container_cross_axis_stretch_available_space > 0) {
+	if (container_cross_stretch_total > 0) {
 		Vector<_LineData *> stretch_lines;
 		Vector<bool> stretch_lines_active;
+
+		float container_cross_axis_stretch_available_space = vertical ? get_size().x : get_size().y;
+		container_cross_axis_stretch_available_space -= vertical ? theme_cache.h_separation * MAX(0, lines_data.size() - 1) : theme_cache.v_separation * MAX(0, lines_data.size() - 1);
 
 		for (int i = 0; i < lines_data.size(); i++) {
 			if (lines_data[i].line_cross_stretch_ratio != 0) {
 				stretch_lines.push_back(&lines_data.write[i]);
 				stretch_lines_active.push_back(true);
+			} else
+			{
+				container_cross_axis_stretch_available_space -= lines_data[i].min_line_height;
 			}
 		}
 

--- a/tests/scene/test_flow_container.cpp
+++ b/tests/scene/test_flow_container.cpp
@@ -645,7 +645,7 @@ TEST_CASE("[SceneTree][FlowContainer] VFlowContainer") {
 		memdelete(child_control_1);
 	}
 
-		SUBCASE("Cross axis expand") {
+	SUBCASE("Cross axis expand") {
 		Control *child_control_1 = memnew(Control);
 		Control *child_control_2 = memnew(Control);
 		Control *child_control_3 = memnew(Control);

--- a/tests/scene/test_flow_container.cpp
+++ b/tests/scene/test_flow_container.cpp
@@ -301,6 +301,81 @@ TEST_CASE("[SceneTree][FlowContainer] HFlowContainer") {
 		memdelete(child_control_1);
 	}
 
+	SUBCASE("Cross axis expand") {
+		Control *child_control_1 = memnew(Control);
+		Control *child_control_2 = memnew(Control);
+		Control *child_control_3 = memnew(Control);
+		child_control_1->set_custom_minimum_size(Size2(50, 30));
+		child_control_1->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		child_control_1->set_v_size_flags(Control::SIZE_SHRINK_BEGIN);
+		child_control_2->set_custom_minimum_size(Size2(20, 0));
+		child_control_2->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		child_control_3->set_custom_minimum_size(Size2(20, 0));
+		child_control_3->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		hflow_container->set_size(Size2(100, 100));
+		hflow_container->add_child(child_control_1);
+		hflow_container->add_child(child_control_2);
+		hflow_container->add_child(child_control_3);
+
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_1->get_size().is_equal_approx(Point2(60, 30)),
+				"First child control does not expand to fill cross-axis.");
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(20, 100)),
+				"Second child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(20, 100)),
+				"Third child control expands to fill cross-axis.");
+
+		hflow_container->set_size(Size2(80, 100));
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_1->get_size().is_equal_approx(Point2(60, 30)),
+				"With wrapping, first child control does not expand to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(20, 50)),
+				"With wrapping, second child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(20, 50)),
+				"With wrapping, third child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_position().is_equal_approx(Point2(0, 50)),
+				"With wrapping, third child control is positioned on second line.");
+
+		child_control_2->set_stretch_ratio(3.0f);
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(20, 75)),
+				"Second child control expands respects stretch ratio.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(20, 25)),
+				"Third child control expands respects stretch ratio.");
+
+		child_control_2->set_stretch_ratio(0.25f);
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(20, 30)),
+				"Second child control does not expand when minimum size is bigger than stretch size");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(20, 70)),
+				"Third child control expands to fill available stretch space.");
+
+		memdelete(child_control_3);
+		memdelete(child_control_2);
+		memdelete(child_control_1);
+	}
+
 	memdelete(hflow_container);
 }
 
@@ -564,6 +639,81 @@ TEST_CASE("[SceneTree][FlowContainer] VFlowContainer") {
 		CHECK_MESSAGE(
 				child_control_3->get_position().is_equal_approx(Point2(40, 0)),
 				"Third child control follows left-to-right order in vertical mode with RTL and reverse fill.");
+
+		memdelete(child_control_3);
+		memdelete(child_control_2);
+		memdelete(child_control_1);
+	}
+
+		SUBCASE("Cross axis expand") {
+		Control *child_control_1 = memnew(Control);
+		Control *child_control_2 = memnew(Control);
+		Control *child_control_3 = memnew(Control);
+		child_control_1->set_custom_minimum_size(Size2(30, 50));
+		child_control_1->set_h_size_flags(Control::SIZE_SHRINK_BEGIN);
+		child_control_1->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		child_control_2->set_custom_minimum_size(Size2(0, 20));
+		child_control_2->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		child_control_3->set_custom_minimum_size(Size2(0, 20));
+		child_control_3->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		vflow_container->set_size(Size2(100, 100));
+		vflow_container->add_child(child_control_1);
+		vflow_container->add_child(child_control_2);
+		vflow_container->add_child(child_control_3);
+
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_1->get_size().is_equal_approx(Point2(30, 60)),
+				"First child control does not expand to fill cross-axis.");
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(100, 20)),
+				"Second child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(100, 20)),
+				"Third child control expands to fill cross-axis.");
+
+		vflow_container->set_size(Size2(100, 80));
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_1->get_size().is_equal_approx(Point2(30, 60)),
+				"With wrapping, first child control does not expand to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(50, 20)),
+				"With wrapping, second child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(50, 20)),
+				"With wrapping, third child control expands to fill cross-axis.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_position().is_equal_approx(Point2(50, 0)),
+				"With wrapping, third child control is positioned on second line.");
+
+		child_control_2->set_stretch_ratio(3.0f);
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(75, 20)),
+				"Second child control expands respects stretch ratio.");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(25, 20)),
+				"Third child control expands respects stretch ratio.");
+
+		child_control_2->set_stretch_ratio(0.25f);
+		SceneTree::get_singleton()->process(0);
+
+		CHECK_MESSAGE(
+				child_control_2->get_size().is_equal_approx(Point2(30, 20)),
+				"Second child control does not expand when minimum size is bigger than stretch size");
+
+		CHECK_MESSAGE(
+				child_control_3->get_size().is_equal_approx(Point2(70, 20)),
+				"Third child control expands to fill available stretch space.");
 
 		memdelete(child_control_3);
 		memdelete(child_control_2);


### PR DESCRIPTION
## What problem(s) does this PR solve?

The option for cross axis expansion on flow container children was explicitly disabled. This limited the feasibility and ease of creating some layouts without having additional code.

For example, imagine a layout where a list of elements are on the bottom and a "details panel" displays information about the selected element.

<img width="493" height="365" alt="image" src="https://github.com/user-attachments/assets/4137af55-577f-483a-b3eb-dcf9a99122bd" />

When there is additional space, it would be preferable for the "details panel" to move back to the bottom and fill all available space, but this is not currently possible. Currently, even if the container fills the entire space, each line of a flow container fits the minimum cross axis size. This means that the "details panel" is not able to grow.

<img width="574" height="367" alt="image" src="https://github.com/user-attachments/assets/7bcaab29-161d-4dc6-b636-2c8f3271c155" />

This change adds the option for an element in a flow container to request expansion on the cross axis, enabling the desired behavior.

<img width="574" height="367" alt="image" src="https://github.com/user-attachments/assets/fb52797f-9a3d-46ab-8fc2-88568725fb61" />

## Additional information

This change is backward-compatible. No change should occur unless the option is checked on one of the flow container children.
This change aims to keep the cost of this new option to a minimum while not in use. The performance cost should be negligible.
This change was tested in editor and with unit tests.
This change mimics the logic already used when stretching a line. While additional optimizations would be possible, consistency was considered first when making this change. Generally, flow containers only have few lines, so optimizations would rarely have a non-negligible impact.

Demo:
https://github.com/user-attachments/assets/cec8961e-e511-45ff-a784-d89a2f9e296b

