### PR TITLE
Add unit tests for Math::fast_ftoi

### DIFF
--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -639,4 +639,41 @@ TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {
 	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0) == doctest::Approx((T)1.0));
 }
 
+TEST_CASE("[Math] fast_ftoi") {
+	CHECK(Math::fast_ftoi(0.0f) == 0);
+
+	CHECK(Math::fast_ftoi(-0.0f) == 0);
+
+	CHECK(Math::fast_ftoi(0.49f) == 0);
+	CHECK(Math::fast_ftoi(1.2f) == 1);
+	CHECK(Math::fast_ftoi(1.49f) == 1);
+	CHECK(Math::fast_ftoi(1.6f) == 2);
+	CHECK(Math::fast_ftoi(1.99f) == 2);
+
+	CHECK(Math::fast_ftoi(-0.49f) == 0);
+	CHECK(Math::fast_ftoi(-1.2f) == -1);
+	CHECK(Math::fast_ftoi(-1.49f) == -1);
+	CHECK(Math::fast_ftoi(-1.6f) == -2);
+	CHECK(Math::fast_ftoi(-1.99f) == -2);
+
+	// Halfway values round to even
+	CHECK(Math::fast_ftoi(0.5f) == 0);
+	CHECK(Math::fast_ftoi(1.5f) == 2);
+	CHECK(Math::fast_ftoi(2.5f) == 2);
+	CHECK(Math::fast_ftoi(3.5f) == 4);
+	CHECK(Math::fast_ftoi(4.5f) == 4);
+	CHECK(Math::fast_ftoi(5.5f) == 6);
+
+	CHECK(Math::fast_ftoi(-0.5f) == 0);
+	CHECK(Math::fast_ftoi(-1.5f) == -2);
+	CHECK(Math::fast_ftoi(-2.5f) == -2);
+	CHECK(Math::fast_ftoi(-3.5f) == -4);
+
+	CHECK(Math::fast_ftoi(16777216.0f) == 16777216);
+	CHECK(Math::fast_ftoi(-16777216.0f) == -16777216);
+
+	CHECK(Math::fast_ftoi(2147483520.0f) == 2147483520);
+	CHECK(Math::fast_ftoi(-2147483520.0f) == -2147483520);
+}
+
 } // namespace TestMathFuncs


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR improves test coverage in `core/math` by adding unit tests for the `Math::fast_ftoi` function. 

## Additional information

The tests verify:
- Basic positive and negative float conversions.
- Banker's rounding behavior (rounding half to even, e.g., `1.5` -> `2`, `2.5` -> `2`).
- Edge cases like negative zero and large bounds limits.

*AI Disclosure: I used an AI assistant to help me understand Godot's SCons build system and the doctest framework for this first-time contribution. The AI also assisted me in drafting this description to ensure it is clear and professional.*