### PR TITLE
[MenuBar] Fix popup scale handling.

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -132,18 +132,24 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 	}
 
 	Rect2 item_rect = _get_menu_item_rect(p_index);
-	Size2 canvas_scale = get_canvas_transform().get_scale();
-	Point2 screen_pos = get_screen_position() + item_rect.position * canvas_scale;
-	Size2 screen_size = item_rect.size * canvas_scale;
+	item_rect.position *= get_screen_transform().get_scale();
+	item_rect.size *= get_screen_transform().get_scale();
+
+	Rect2 rect = get_screen_rect();
+	rect.position.x += item_rect.position.x;
+	rect.position.y += rect.size.height;
+	if (get_viewport()->is_embedding_subwindows() && pm->get_force_native()) {
+		Transform2D xform = get_viewport()->get_popup_base_transform_native();
+		rect = xform.xform(rect);
+	}
 
 	active_menu = p_index;
 
-	pm->set_size(Size2(screen_size.x, 0));
-	screen_pos.y += screen_size.y;
+	pm->set_size(Size2(item_rect.size.x, 0));
 	if (is_layout_rtl()) {
-		screen_pos.x += screen_size.x - pm->get_size().width;
+		rect.position.x += rect.size.width - pm->get_size().width;
 	}
-	pm->set_position(screen_pos);
+	pm->set_position(rect.position);
 	pm->popup();
 
 	if (p_focus_item) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/120171

## Additional information

Changes `MenuBar` popup code to match `MenuButton`/`OptionButton` equivalents.