### PR TITLE
[TextServer] Fix some emoji sequences with skin tone modifier not rendered correctly.

### DIFF
--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -47,7 +47,7 @@ inline bool ScriptIterator::is_emoji(UChar32 p_c, UChar32 p_next) {
 	} else if (p_next == VARIATION_SELECTOR_16 && (u_hasBinaryProperty(p_c, UCHAR_EMOJI) || u_hasBinaryProperty(p_c, UCHAR_EXTENDED_PICTOGRAPHIC))) {
 		return true;
 	} else {
-		return u_hasBinaryProperty(p_c, UCHAR_EMOJI_PRESENTATION) || u_hasBinaryProperty(p_c, UCHAR_EMOJI_MODIFIER) || u_hasBinaryProperty(p_c, UCHAR_REGIONAL_INDICATOR);
+		return u_hasBinaryProperty(p_c, UCHAR_EMOJI_PRESENTATION) || u_hasBinaryProperty(p_c, UCHAR_EMOJI_MODIFIER) || u_hasBinaryProperty(p_c, UCHAR_REGIONAL_INDICATOR) || (u_hasBinaryProperty(p_c, UCHAR_EMOJI) && u_hasBinaryProperty(p_next, UCHAR_EMOJI_MODIFIER));
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/120182

## Additional information

Fixes cases when emoji modifier follows emoji directly, without VS-16 in between.

Before:
<img width="759" height="53" alt="Screenshot 2026-06-11 at 10 42 51" src="https://github.com/user-attachments/assets/d913c9b7-8987-4c55-80cb-db5e543729f9" />

After:
<img width="484" height="53" alt="Screenshot 2026-06-11 at 10 42 04" src="https://github.com/user-attachments/assets/bda39e26-9467-475d-95e9-240502e14218" />
