### PR TITLE
GDScript: Prevent error spam during compile-time evaluation of some functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3286,6 +3286,16 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			// Reference types are not suited for compile-time construction.
 			// Because in this case they would be the same reference in all constructed values.
 			if (all_is_constant && !Variant::is_type_shared(builtin_type)) {
+				// A workaround for GH-89357.
+				if (builtin_type == Variant::COLOR && !p_call->arguments.is_empty() && p_call->arguments[0]->reduced_value.get_type() == Variant::STRING) {
+					const String code = p_call->arguments[0]->reduced_value;
+					if (!Color::html_is_valid(code) && Color::find_named_color(code) == -1) {
+						push_error(vformat(R"(Invalid color code "%s".)", code), p_call->arguments[0]);
+						p_call->set_datatype(call_type);
+						return;
+					}
+				}
+
 				// Construct here.
 				Vector<const Variant *> args;
 				for (int i = 0; i < p_call->arguments.size(); i++) {

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -121,7 +121,8 @@ struct GDScriptUtilityFunctionsDefinitions {
 		DEBUG_VALIDATE_ARG_COUNT(1, 1);
 		DEBUG_VALIDATE_ARG_TYPE(0, Variant::INT);
 		const int64_t code = *p_args[0];
-		VALIDATE_ARG_CUSTOM(0, Variant::INT, code < 0 || code > UINT32_MAX, RTR("Expected an integer between 0 and 2^32 - 1."));
+		VALIDATE_ARG_CUSTOM(0, Variant::INT, code <= 0 || (code & 0xFFFFF800) == 0xD800 || code > 0x10FFFF,
+				vformat(RTR("%d is not a valid character code."), code));
 		*r_ret = String::chr(code);
 	}
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/compile_time_errors.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/compile_time_errors.gd
@@ -1,0 +1,10 @@
+func test():
+	# GH-89357
+	print(Color(""))
+	print(Color("invalid"))
+
+	# GH-120049
+	print(char(-1))
+	print(char(0)) # The NUL character is not currently supported.
+	print(char(0xD800))
+	print(char(0x110000))

--- a/modules/gdscript/tests/scripts/analyzer/errors/compile_time_errors.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/compile_time_errors.out
@@ -1,0 +1,7 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 3: Invalid color code "".
+>> ERROR at line 4: Invalid color code "invalid".
+>> ERROR at line 7: Invalid argument for "char()" function: -1 is not a valid character code.
+>> ERROR at line 8: Invalid argument for "char()" function: 0 is not a valid character code.
+>> ERROR at line 9: Invalid argument for "char()" function: 55296 is not a valid character code.
+>> ERROR at line 10: Invalid argument for "char()" function: 1114112 is not a valid character code.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #89357.
- Does **not** close :x: #118414.
- Closes #120049.

## Additional information

Thanks to @bruvzg for the Unicode [tip](https://github.com/godotengine/godot/issues/120049#issuecomment-4670881817).