### PR TITLE
Fix editor language not being switched until a restart in some locations

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -355,7 +355,7 @@ void EditorAudioBus::update_bus() {
 	add->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
 	add->set_editable(0, true);
 	add->set_selectable(0, false);
-	add->set_text(0, TTR("Add Effect"));
+	add->set_text(0, TTRC("Add Effect"));
 
 	update_send();
 
@@ -912,7 +912,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	buses = p_buses;
 	is_master = p_is_master;
 
-	set_tooltip_text(TTR("Drag & drop to rearrange."));
+	set_tooltip_text(TTRC("Drag & drop to rearrange."));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	vb->add_theme_constant_override("separation", 4 * EDSCALE);
@@ -931,21 +931,21 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	solo = memnew(Button);
 	solo->set_theme_type_variation(SceneStringName(FlatButton));
 	solo->set_toggle_mode(true);
-	solo->set_tooltip_text(TTR("Solo"));
+	solo->set_tooltip_text(TTRC("Solo"));
 	solo->set_focus_mode(FOCUS_ACCESSIBILITY);
 	solo->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_solo_toggled));
 	hbc->add_child(solo);
 	mute = memnew(Button);
 	mute->set_theme_type_variation(SceneStringName(FlatButton));
 	mute->set_toggle_mode(true);
-	mute->set_tooltip_text(TTR("Mute"));
+	mute->set_tooltip_text(TTRC("Mute"));
 	mute->set_focus_mode(FOCUS_ACCESSIBILITY);
 	mute->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_mute_toggled));
 	hbc->add_child(mute);
 	bypass = memnew(Button);
 	bypass->set_theme_type_variation(SceneStringName(FlatButton));
 	bypass->set_toggle_mode(true);
-	bypass->set_tooltip_text(TTR("Bypass"));
+	bypass->set_tooltip_text(TTRC("Bypass"));
 	bypass->set_focus_mode(FOCUS_ACCESSIBILITY);
 	bypass->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBus::_bypass_toggled));
 	hbc->add_child(bypass);
@@ -1168,7 +1168,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bus_options->set_shortcut_context(this);
 	bus_options->set_h_size_flags(SIZE_SHRINK_END);
 	bus_options->set_anchor(SIDE_RIGHT, 0.0);
-	bus_options->set_tooltip_text(TTR("Bus Options"));
+	bus_options->set_tooltip_text(TTRC("Bus Options"));
 	hbc->add_child(bus_options);
 
 	bus_popup = bus_options->get_popup();
@@ -1179,7 +1179,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bus_popup->connect("index_pressed", callable_mp(this, &EditorAudioBus::_bus_popup_pressed));
 
 	delete_effect_popup = memnew(PopupMenu);
-	delete_effect_popup->add_item(TTR("Delete Effect"));
+	delete_effect_popup->add_item(TTRC("Delete Effect"));
 	add_child(delete_effect_popup);
 	delete_effect_popup->connect("index_pressed", callable_mp(this, &EditorAudioBus::_delete_effect_pressed));
 }
@@ -1349,7 +1349,7 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 	EditorAudioBus *bus = Object::cast_to<EditorAudioBus>(p_which);
 	int index = bus->get_index();
 	if (index == 0) {
-		EditorNode::get_singleton()->show_warning(TTR("Master bus can't be deleted!"));
+		EditorNode::get_singleton()->show_warning(TTRC("Master bus can't be deleted!"));
 		return;
 	}
 
@@ -1454,7 +1454,7 @@ void EditorAudioBuses::_select_layout() {
 
 void EditorAudioBuses::_save_as_layout() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	file_dialog->set_title(TTR("Save Audio Bus Layout As..."));
+	file_dialog->set_title(TTRC("Save Audio Bus Layout As..."));
 	file_dialog->set_current_path(ResourceUID::ensure_path(edited_path));
 	file_dialog->popup_file_dialog();
 	new_layout = false;
@@ -1470,7 +1470,7 @@ void EditorAudioBuses::_new_layout() {
 
 void EditorAudioBuses::_load_layout() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-	file_dialog->set_title(TTR("Open Audio Bus Layout"));
+	file_dialog->set_title(TTRC("Open Audio Bus Layout"));
 	file_dialog->set_current_path(ResourceUID::ensure_path(edited_path));
 	file_dialog->popup_file_dialog();
 	new_layout = false;
@@ -1545,34 +1545,34 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	add = memnew(Button);
 	top_hb->add_child(add);
-	add->set_text(TTR("Add Bus"));
-	add->set_tooltip_text(TTR("Add a new Audio Bus to this layout."));
+	add->set_text(TTRC("Add Bus"));
+	add->set_tooltip_text(TTRC("Add a new Audio Bus to this layout."));
 	add->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_add_bus));
 
 	VSeparator *separator = memnew(VSeparator);
 	top_hb->add_child(separator);
 
 	load = memnew(Button);
-	load->set_text(TTR("Load"));
-	load->set_tooltip_text(TTR("Load an existing Bus Layout."));
+	load->set_text(TTRC("Load"));
+	load->set_tooltip_text(TTRC("Load an existing Bus Layout."));
 	top_hb->add_child(load);
 	load->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_load_layout));
 
 	save_as = memnew(Button);
-	save_as->set_text(TTR("Save As"));
-	save_as->set_tooltip_text(TTR("Save this Bus Layout to a file."));
+	save_as->set_text(TTRC("Save As"));
+	save_as->set_tooltip_text(TTRC("Save this Bus Layout to a file."));
 	top_hb->add_child(save_as);
 	save_as->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_save_as_layout));
 
 	_default = memnew(Button);
-	_default->set_text(TTR("Load Default"));
-	_default->set_tooltip_text(TTR("Load the default Bus Layout."));
+	_default->set_text(TTRC("Load Default"));
+	_default->set_tooltip_text(TTRC("Load the default Bus Layout."));
 	top_hb->add_child(_default);
 	_default->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_load_default_layout));
 
 	_new = memnew(Button);
-	_new->set_text(TTR("Create"));
-	_new->set_tooltip_text(TTR("Create a new Bus Layout."));
+	_new->set_text(TTRC("Create"));
+	_new->set_tooltip_text(TTRC("Create a new Bus Layout."));
 	top_hb->add_child(_new);
 	_new->connect(SceneStringName(pressed), callable_mp(this, &EditorAudioBuses::_new_layout));
 
@@ -1602,7 +1602,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", &ext);
 	for (const String &E : ext) {
-		file_dialog->add_filter("*." + E, TTR("Audio Bus Layout"));
+		file_dialog->add_filter("*." + E, TTRC("Audio Bus Layout"));
 	}
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));

--- a/editor/doc/editor_help_search.cpp
+++ b/editor/doc/editor_help_search.cpp
@@ -306,10 +306,10 @@ EditorHelpSearch::EditorHelpSearch() {
 	set_hide_on_ok(false);
 	set_clamp_to_embedder(true);
 
-	set_title(TTR("Search Help"));
+	set_title(TTRC("Search Help"));
 
 	get_ok_button()->set_disabled(true);
-	set_ok_button_text(TTR("Open"));
+	set_ok_button_text(TTRC("Open"));
 
 	// Split search and results area.
 	VBoxContainer *vbox = memnew(VBoxContainer);
@@ -329,7 +329,7 @@ EditorHelpSearch::EditorHelpSearch() {
 
 	case_sensitive_button = memnew(Button);
 	case_sensitive_button->set_theme_type_variation(SceneStringName(FlatButton));
-	case_sensitive_button->set_tooltip_text(TTR("Case Sensitive"));
+	case_sensitive_button->set_tooltip_text(TTRC("Case Sensitive"));
 	case_sensitive_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelpSearch::_update_results));
 	case_sensitive_button->set_toggle_mode(true);
 	case_sensitive_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
@@ -337,7 +337,7 @@ EditorHelpSearch::EditorHelpSearch() {
 
 	hierarchy_button = memnew(Button);
 	hierarchy_button->set_theme_type_variation(SceneStringName(FlatButton));
-	hierarchy_button->set_tooltip_text(TTR("Show Hierarchy"));
+	hierarchy_button->set_tooltip_text(TTRC("Show Hierarchy"));
 	hierarchy_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelpSearch::_update_results));
 	hierarchy_button->set_toggle_mode(true);
 	hierarchy_button->set_pressed(true);
@@ -348,17 +348,17 @@ EditorHelpSearch::EditorHelpSearch() {
 	filter_combo->set_accessibility_name(TTRC("Filter"));
 	filter_combo->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	filter_combo->set_stretch_ratio(0); // Fixed width.
-	filter_combo->add_item(TTR("Display All"), SEARCH_ALL);
+	filter_combo->add_item(TTRC("Display All"), SEARCH_ALL);
 	filter_combo->add_separator();
-	filter_combo->add_item(TTR("Classes Only"), SEARCH_CLASSES);
-	filter_combo->add_item(TTR("Constructors Only"), SEARCH_CONSTRUCTORS);
-	filter_combo->add_item(TTR("Methods Only"), SEARCH_METHODS);
-	filter_combo->add_item(TTR("Operators Only"), SEARCH_OPERATORS);
-	filter_combo->add_item(TTR("Signals Only"), SEARCH_SIGNALS);
-	filter_combo->add_item(TTR("Annotations Only"), SEARCH_ANNOTATIONS);
-	filter_combo->add_item(TTR("Constants Only"), SEARCH_CONSTANTS);
-	filter_combo->add_item(TTR("Properties Only"), SEARCH_PROPERTIES);
-	filter_combo->add_item(TTR("Theme Properties Only"), SEARCH_THEME_ITEMS);
+	filter_combo->add_item(TTRC("Classes Only"), SEARCH_CLASSES);
+	filter_combo->add_item(TTRC("Constructors Only"), SEARCH_CONSTRUCTORS);
+	filter_combo->add_item(TTRC("Methods Only"), SEARCH_METHODS);
+	filter_combo->add_item(TTRC("Operators Only"), SEARCH_OPERATORS);
+	filter_combo->add_item(TTRC("Signals Only"), SEARCH_SIGNALS);
+	filter_combo->add_item(TTRC("Annotations Only"), SEARCH_ANNOTATIONS);
+	filter_combo->add_item(TTRC("Constants Only"), SEARCH_CONSTANTS);
+	filter_combo->add_item(TTRC("Properties Only"), SEARCH_PROPERTIES);
+	filter_combo->add_item(TTRC("Theme Properties Only"), SEARCH_THEME_ITEMS);
 	filter_combo->connect(SceneStringName(item_selected), callable_mp(this, &EditorHelpSearch::_filter_combo_item_selected));
 	hbox->add_child(filter_combo);
 
@@ -373,9 +373,9 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_accessibility_name(TTRC("Search Results"));
 	results_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	results_tree->set_columns(2);
-	results_tree->set_column_title(0, TTR("Name"));
+	results_tree->set_column_title(0, TTRC("Name"));
 	results_tree->set_column_clip_content(0, true);
-	results_tree->set_column_title(1, TTR("Member Type"));
+	results_tree->set_column_title(1, TTRC("Member Type"));
 	results_tree->set_column_expand(1, false);
 	results_tree->set_column_custom_minimum_width(1, 150 * EDSCALE);
 	results_tree->set_column_clip_content(1, true);
@@ -1139,16 +1139,16 @@ TreeItem *EditorHelpSearch::Runner::_create_class_item(TreeItem *p_parent, const
 	TreeItem *item = nullptr;
 	if (_find_or_create_item(p_parent, item_meta, item)) {
 		item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_doc->name));
-		item->set_text(1, TTR("Class"));
+		item->set_text(1, TTRC("Class"));
 		item->set_tooltip_text(0, tooltip);
 		item->set_tooltip_text(1, tooltip);
 		item->set_metadata(0, item_meta);
 		if (p_doc->is_deprecated) {
 			Ref<Texture2D> error_icon = ui_service->get_editor_theme_icon(SNAME("StatusError"));
-			item->add_button(0, error_icon, 0, false, TTR("This class is marked as deprecated."));
+			item->add_button(0, error_icon, 0, false, TTRC("This class is marked as deprecated."));
 		} else if (p_doc->is_experimental) {
 			Ref<Texture2D> warning_icon = ui_service->get_editor_theme_icon(SNAME("NodeWarning"));
-			item->add_button(0, warning_icon, 0, false, TTR("This class is marked as experimental."));
+			item->add_button(0, warning_icon, 0, false, TTRC("This class is marked as experimental."));
 		}
 	}
 	// Cached item might be collapsed.
@@ -1257,10 +1257,10 @@ TreeItem *EditorHelpSearch::Runner::_create_member_item(TreeItem *p_parent, cons
 
 		if (p_is_deprecated) {
 			Ref<Texture2D> error_icon = ui_service->get_editor_theme_icon(SNAME("StatusError"));
-			item->add_button(0, error_icon, 0, false, TTR("This member is marked as deprecated."));
+			item->add_button(0, error_icon, 0, false, TTRC("This member is marked as deprecated."));
 		} else if (p_is_experimental) {
 			Ref<Texture2D> warning_icon = ui_service->get_editor_theme_icon(SNAME("NodeWarning"));
-			item->add_button(0, warning_icon, 0, false, TTR("This member is marked as experimental."));
+			item->add_button(0, warning_icon, 0, false, TTRC("This member is marked as experimental."));
 		}
 	}
 

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1706,7 +1706,7 @@ void SceneTreeDock::_notification(int p_what) {
 			// create_root_dialog
 			HBoxContainer *top_row = memnew(HBoxContainer);
 			top_row->set_h_size_flags(SIZE_EXPAND_FILL);
-			Label *l = memnew(Label(TTR("Create Root Node:")));
+			Label *l = memnew(Label(TTRC("Create Root Node:")));
 			l->set_theme_type_variation("HeaderSmall");
 			top_row->add_child(l);
 			top_row->add_spacer();
@@ -1716,7 +1716,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts_toggle->set_accessibility_name(TTRC("Favorite Nodes"));
 			node_shortcuts_toggle->set_button_icon(get_editor_theme_icon(SNAME("Favorites")));
 			node_shortcuts_toggle->set_toggle_mode(true);
-			node_shortcuts_toggle->set_tooltip_text(TTR("Toggle the display of favorite nodes."));
+			node_shortcuts_toggle->set_tooltip_text(TTRC("Toggle the display of favorite nodes."));
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
 			node_shortcuts_toggle->set_anchors_and_offsets_preset(Control::PRESET_CENTER_RIGHT);
 			node_shortcuts_toggle->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_update_create_root_dialog).bind(false));
@@ -1738,19 +1738,19 @@ void SceneTreeDock::_notification(int p_what) {
 
 			button_2d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_2d);
-			button_2d->set_text(TTR("2D Scene"));
+			button_2d->set_text(TTRC("2D Scene"));
 			button_2d->set_button_icon(get_editor_theme_icon(SNAME("Node2D")));
 			button_2d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_2D_SCENE, false));
 
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
-			button_3d->set_text(TTR("3D Scene"));
+			button_3d->set_text(TTRC("3D Scene"));
 			button_3d->set_button_icon(get_editor_theme_icon(SNAME("Node3D")));
 			button_3d->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_3D_SCENE, false));
 
 			button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
-			button_ui->set_text(TTR("User Interface"));
+			button_ui->set_text(TTRC("User Interface"));
 			button_ui->set_button_icon(get_editor_theme_icon(SNAME("Control")));
 			button_ui->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_USER_INTERFACE, false));
 
@@ -1759,13 +1759,13 @@ void SceneTreeDock::_notification(int p_what) {
 
 			button_custom = memnew(Button);
 			node_shortcuts->add_child(button_custom);
-			button_custom->set_text(TTR("Other Node"));
+			button_custom->set_text(TTRC("Other Node"));
 			button_custom->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			button_custom->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_NEW, false));
 
 			button_clipboard = memnew(Button);
 			node_shortcuts->add_child(button_clipboard);
-			button_clipboard->set_text(TTR("Paste From Clipboard"));
+			button_clipboard->set_text(TTRC("Paste From Clipboard"));
 			button_clipboard->set_button_icon(get_editor_theme_icon(SNAME("ActionPaste")));
 			button_clipboard->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_PASTE, false));
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -542,7 +542,7 @@ EditorLog::EditorLog() {
 	collapse_button = memnew(Button);
 	collapse_button->set_theme_type_variation("BottomPanelButton");
 	collapse_button->set_focus_mode(FOCUS_ACCESSIBILITY);
-	collapse_button->set_tooltip_text(TTR("Collapse duplicate messages into one log entry. Shows number of occurrences."));
+	collapse_button->set_tooltip_text(TTRC("Collapse duplicate messages into one log entry. Shows number of occurrences."));
 	collapse_button->set_toggle_mode(true);
 	collapse_button->set_pressed(false);
 	collapse_button->connect(SceneStringName(toggled), callable_mp(this, &EditorLog::_set_collapse));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8929,7 +8929,7 @@ EditorNode::EditorNode() {
 
 	// Command palette and editor shortcuts.
 	command_palette = EditorCommandPalette::get_singleton();
-	command_palette->set_title(TTR("Command Palette"));
+	command_palette->set_title(TTRC("Command Palette"));
 	gui_base->add_child(command_palette);
 
 	ED_SHORTCUT("editor/next_tab", TTRC("Next Scene Tab"), KeyModifierMask::CTRL + Key::TAB);
@@ -9275,14 +9275,14 @@ EditorNode::EditorNode() {
 	save_confirmation->connect("about_to_popup", callable_mp(this, &EditorNode::_prepare_save_confirmation_popup));
 
 	gradle_build_manage_templates = memnew(ConfirmationDialog);
-	gradle_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
-	gradle_build_manage_templates->set_ok_button_text(TTR("Manage Templates"));
-	gradle_build_manage_templates->add_button(TTR("Install from file"))->connect(SceneStringName(pressed), callable_mp(this, &EditorNode::_android_install_build_template));
+	gradle_build_manage_templates->set_text(TTRC("Android build template is missing, please install relevant templates."));
+	gradle_build_manage_templates->set_ok_button_text(TTRC("Manage Templates"));
+	gradle_build_manage_templates->add_button(TTRC("Install from file"))->connect(SceneStringName(pressed), callable_mp(this, &EditorNode::_android_install_build_template));
 	gradle_build_manage_templates->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_option).bind(EDITOR_MANAGE_EXPORT_TEMPLATES));
 	gui_base->add_child(gradle_build_manage_templates);
 
 	file_android_build_source = memnew(EditorFileDialog);
-	file_android_build_source->set_title(TTR("Select Android sources file"));
+	file_android_build_source->set_title(TTRC("Select Android sources file"));
 	file_android_build_source->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_android_build_source->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	file_android_build_source->add_filter("*.zip");
@@ -9302,7 +9302,7 @@ EditorNode::EditorNode() {
 		vbox->add_child(choose_android_export_profile);
 
 		install_android_build_template = memnew(ConfirmationDialog);
-		install_android_build_template->set_ok_button_text(TTR("Install"));
+		install_android_build_template->set_ok_button_text(TTRC("Install"));
 		install_android_build_template->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_confirm_current));
 		install_android_build_template->add_child(vbox);
 		install_android_build_template->set_min_size(Vector2(500.0 * EDSCALE, 0));
@@ -9315,13 +9315,13 @@ EditorNode::EditorNode() {
 	gui_base->add_child(remove_android_build_template);
 
 	file_templates = memnew(EditorFileDialog);
-	file_templates->set_title(TTR("Import Templates From ZIP File"));
+	file_templates->set_title(TTRC("Import Templates From ZIP File"));
 
 	gui_base->add_child(file_templates);
 	file_templates->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	file_templates->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_templates->clear_filters();
-	file_templates->add_filter("*.tpz", TTR("Template Package"));
+	file_templates->add_filter("*.tpz", TTRC("Template Package"));
 
 	file = memnew(EditorFileDialog);
 	gui_base->add_child(file);
@@ -9329,11 +9329,11 @@ EditorNode::EditorNode() {
 	file->set_transient_to_focused(true);
 
 	file_export_lib = memnew(EditorFileDialog);
-	file_export_lib->set_title(TTR("Export Library"));
+	file_export_lib->set_title(TTRC("Export Library"));
 	file_export_lib->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_export_lib->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
-	file_export_lib->add_option(TTR("Merge With Existing"), Vector<String>(), true);
-	file_export_lib->add_option(TTR("Apply MeshInstance Transforms"), Vector<String>(), false);
+	file_export_lib->add_option(TTRC("Merge With Existing"), Vector<String>(), true);
+	file_export_lib->add_option(TTRC("Apply MeshInstance Transforms"), Vector<String>(), false);
 	gui_base->add_child(file_export_lib);
 
 	file_pack_zip = memnew(EditorFileDialog);
@@ -9341,7 +9341,7 @@ EditorNode::EditorNode() {
 	file_pack_zip->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_pack_zip->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_pack_zip->add_filter("*.zip", "ZIP Archive");
-	file_pack_zip->set_title(TTR("Pack Project as ZIP..."));
+	file_pack_zip->set_title(TTRC("Pack Project as ZIP..."));
 	gui_base->add_child(file_pack_zip);
 
 	file->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
@@ -9354,13 +9354,13 @@ EditorNode::EditorNode() {
 
 	disk_changed = memnew(ConfirmationDialog);
 	{
-		disk_changed->set_title(TTR("Files have been modified outside Godot"));
+		disk_changed->set_title(TTRC("Files have been modified outside Godot"));
 
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		disk_changed->add_child(vbc);
 
 		Label *dl = memnew(Label);
-		dl->set_text(TTR("The following files are newer on disk:"));
+		dl->set_text(TTRC("The following files are newer on disk:"));
 		vbc->add_child(dl);
 
 		disk_changed_list = memnew(Tree);
@@ -9369,14 +9369,14 @@ EditorNode::EditorNode() {
 		disk_changed_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 		Label *what_action_label = memnew(Label);
-		what_action_label->set_text(TTR("What action should be taken?"));
+		what_action_label->set_text(TTRC("What action should be taken?"));
 		vbc->add_child(what_action_label);
 
 		disk_changed->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_reload_modified_scenes));
 		disk_changed->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_reload_project_settings));
-		disk_changed->set_ok_button_text(TTR("Reload from disk"));
+		disk_changed->set_ok_button_text(TTRC("Reload from disk"));
 
-		disk_changed->add_button(TTR("Ignore external changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
+		disk_changed->add_button(TTRC("Ignore external changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &EditorNode::_resave_externally_modified_scenes));
 	}
 
@@ -9531,8 +9531,8 @@ EditorNode::EditorNode() {
 	set_process(true);
 
 	open_imported = memnew(ConfirmationDialog);
-	open_imported->set_ok_button_text(TTR("Open Anyway"));
-	new_inherited_button = open_imported->add_button(TTR("New Inherited"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "inherit");
+	open_imported->set_ok_button_text(TTRC("Open Anyway"));
+	new_inherited_button = open_imported->add_button(TTRC("New Inherited"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "inherit");
 	open_imported->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_open_imported));
 	open_imported->connect("custom_action", callable_mp(this, &EditorNode::_inherit_imported));
 	gui_base->add_child(open_imported);
@@ -9551,7 +9551,7 @@ EditorNode::EditorNode() {
 	load_error_dialog = memnew(AcceptDialog);
 	load_error_dialog->set_unparent_when_invisible(true);
 	load_error_dialog->add_child(load_errors);
-	load_error_dialog->set_title(TTR("Load Errors"));
+	load_error_dialog->set_title(TTRC("Load Errors"));
 	load_error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &EditorNode::_load_error_dialog_visibility_changed));
 
 	execute_outputs = memnew(RichTextLabel);
@@ -9572,9 +9572,9 @@ EditorNode::EditorNode() {
 
 	pick_main_scene = memnew(ConfirmationDialog);
 	gui_base->add_child(pick_main_scene);
-	pick_main_scene->set_ok_button_text(TTR("Select"));
+	pick_main_scene->set_ok_button_text(TTRC("Select"));
 	pick_main_scene->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_option).bind(SETTINGS_PICK_MAIN_SCENE));
-	select_current_scene_button = pick_main_scene->add_button(TTR("Select Current"), true, "select_current");
+	select_current_scene_button = pick_main_scene->add_button(TTRC("Select Current"), true, "select_current");
 	pick_main_scene->connect("custom_action", callable_mp(this, &EditorNode::_pick_main_scene_custom_action));
 
 	open_project_settings = memnew(ConfirmationDialog);

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -383,12 +383,12 @@ DependencyEditor::DependencyEditor() {
 	tree->connect("button_clicked", callable_mp(this, &DependencyEditor::_load_pressed));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
-	Label *label = memnew(Label(TTR("Dependencies:")));
+	Label *label = memnew(Label(TTRC("Dependencies:")));
 	label->set_theme_type_variation("HeaderSmall");
 
 	hbc->add_child(label);
 	hbc->add_spacer();
-	fixdeps = memnew(Button(TTR("Fix Broken")));
+	fixdeps = memnew(Button(TTRC("Fix Broken")));
 	hbc->add_child(fixdeps);
 	fixdeps->connect(SceneStringName(pressed), callable_mp(this, &DependencyEditor::_fix_all));
 
@@ -432,7 +432,7 @@ DependencyEditor::DependencyEditor() {
 	warning_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	vb->add_child(warning_label);
 
-	set_title(TTR("Dependency Editor"));
+	set_title(TTRC("Dependency Editor"));
 	search = memnew(EditorFileDialog);
 	search->connect("file_selected", callable_mp(this, &DependencyEditor::_searched));
 	search->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
@@ -462,7 +462,7 @@ void DependencyEditorOwners::_list_rmb_clicked(int p_item, const Vector2 &p_pos,
 		if (only_scenes_selected) {
 			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTRN("Open Scene", "Open Scenes", selected_items.size()), FILE_MENU_OPEN);
 		} else if (selected_items.size() == 1) {
-			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTR("Open"), FILE_MENU_OPEN);
+			file_options->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTRC("Open"), FILE_MENU_OPEN);
 		} else {
 			return;
 		}
@@ -1198,7 +1198,7 @@ void OrphanResourcesDialog::_button_pressed(Object *p_item, int p_column, int p_
 }
 
 OrphanResourcesDialog::OrphanResourcesDialog() {
-	set_title(TTR("Orphan Resource Explorer"));
+	set_title(TTRC("Orphan Resource Explorer"));
 	delete_confirm = memnew(ConfirmationDialog);
 	set_ok_button_text(TTR("Delete"));
 	add_child(delete_confirm);
@@ -1220,8 +1220,8 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files->set_column_clip_content(0, true);
 	files->set_column_expand(1, false);
 	files->set_column_clip_content(1, true);
-	files->set_column_title(0, TTR("Resource"));
-	files->set_column_title(1, TTR("Owns"));
+	files->set_column_title(0, TTRC("Resource"));
+	files->set_column_title(1, TTRC("Owns"));
 	files->set_hide_root(true);
 	files->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 	files->connect("button_clicked", callable_mp(this, &OrphanResourcesDialog::_button_pressed));

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -72,10 +72,10 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 
 	if (p_replace_mode) {
 		set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
-		set_ok_button_text(TTR("Change"));
+		set_ok_button_text(TTRC("Change"));
 	} else {
 		set_title(vformat(TTR("Create New %s"), base_type));
-		set_ok_button_text(TTR("Create"));
+		set_ok_button_text(TTRC("Create"));
 	}
 
 	_load_favorites_and_history();
@@ -1007,7 +1007,7 @@ CreateDialog::CreateDialog() {
 	favorites->add_theme_constant_override("draw_guides", 1);
 	favorites->set_theme_type_variation("TreeSecondary");
 	SET_DRAG_FORWARDING_GCD(favorites, CreateDialog);
-	fav_vb->add_margin_child(TTR("Favorites:"), favorites, true);
+	fav_vb->add_margin_child(TTRC("Favorites:"), favorites, true);
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
@@ -1017,7 +1017,7 @@ CreateDialog::CreateDialog() {
 	recent = memnew(ItemList);
 	recent->set_accessibility_name(TTRC("Recent:"));
 	recent->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
+	rec_vb->add_margin_child(TTRC("Recent:"), recent, true);
 	recent->set_allow_reselect(true);
 	recent->connect(SceneStringName(item_selected), callable_mp(this, &CreateDialog::_history_selected));
 	recent->connect("item_activated", callable_mp(this, &CreateDialog::_history_activated));
@@ -1040,10 +1040,10 @@ CreateDialog::CreateDialog() {
 
 	favorite = memnew(Button);
 	favorite->set_toggle_mode(true);
-	favorite->set_tooltip_text(TTR("(Un)favorite selected item."));
+	favorite->set_tooltip_text(TTRC("(Un)favorite selected item."));
 	favorite->connect(SceneStringName(pressed), callable_mp(this, &CreateDialog::_favorite_toggled));
 	search_hb->add_child(favorite);
-	vbc->add_margin_child(TTR("Search:"), search_hb);
+	vbc->add_margin_child(TTRC("Search:"), search_hb);
 
 	HBoxContainer *matches_hb = memnew(HBoxContainer);
 	vbc->add_child(matches_hb);
@@ -1094,7 +1094,7 @@ CreateDialog::CreateDialog() {
 
 	VBoxContainer *vbc_desc = memnew(VBoxContainer);
 	vbc_desc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	vbc_desc->add_margin_child(TTR("Description:"), help_bit, true);
+	vbc_desc->add_margin_child(TTRC("Description:"), help_bit, true);
 
 	vsc_right->add_child(vbc_desc);
 

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -121,7 +121,7 @@ EditorQuickOpenDialog::EditorQuickOpenDialog() {
 
 		search_box = memnew(LineEdit);
 		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		search_box->set_placeholder(TTR("Search files..."));
+		search_box->set_placeholder(TTRC("Search files..."));
 		search_box->set_accessibility_name(TTRC("Search"));
 		search_box->set_clear_button_enabled(true);
 		mc->add_child(search_box);
@@ -450,14 +450,14 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 
 		fuzzy_search_toggle = memnew(CheckButton);
 		style_button(fuzzy_search_toggle);
-		fuzzy_search_toggle->set_text(TTR("Fuzzy Search"));
+		fuzzy_search_toggle->set_text(TTRC("Fuzzy Search"));
 		fuzzy_search_toggle->set_tooltip_text(TTRC("Include approximate matches."));
 		fuzzy_search_toggle->connect(SceneStringName(toggled), callable_mp(this, &QuickOpenResultContainer::_toggle_fuzzy_search));
 		bottom_bar->add_child(fuzzy_search_toggle);
 
 		include_addons_toggle = memnew(CheckButton);
 		style_button(include_addons_toggle);
-		include_addons_toggle->set_text(TTR("Addons"));
+		include_addons_toggle->set_text(TTRC("Addons"));
 		include_addons_toggle->set_tooltip_text(TTR("Include files from addons"));
 		include_addons_toggle->connect(SceneStringName(toggled), callable_mp(this, &QuickOpenResultContainer::_toggle_include_addons));
 		bottom_bar->add_child(include_addons_toggle);
@@ -1060,10 +1060,10 @@ void QuickOpenResultContainer::_set_display_mode(QuickOpenDisplayMode p_display_
 
 	if (content_display_mode == QuickOpenDisplayMode::LIST) {
 		display_mode_toggle->set_button_icon(get_editor_theme_icon(SNAME("FileThumbnail")));
-		display_mode_toggle->set_tooltip_text(TTR("Grid view"));
+		display_mode_toggle->set_tooltip_text(TTRC("Grid view"));
 	} else {
 		display_mode_toggle->set_button_icon(get_editor_theme_icon(SNAME("FileList")));
-		display_mode_toggle->set_tooltip_text(TTR("List view"));
+		display_mode_toggle->set_tooltip_text(TTRC("List view"));
 	}
 }
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1984,8 +1984,8 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 
 	item_save_path = memnew(EditorFileDialog);
 	item_save_path->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	item_save_path->add_filter("*.tres", TTR("Text Resource"));
-	item_save_path->add_filter("*.res", TTR("Binary Resource"));
+	item_save_path->add_filter("*.tres", TTRC("Text Resource"));
+	item_save_path->add_filter("*.res", TTRC("Binary Resource"));
 	add_child(item_save_path);
 	item_save_path->connect("file_selected", callable_mp(this, &SceneImportSettingsDialog::_save_path_changed));
 

--- a/editor/import/fbx_importer_manager.cpp
+++ b/editor/import/fbx_importer_manager.cpp
@@ -62,10 +62,10 @@ void FBXImporterManager::show_dialog(bool p_exclusive) {
 	set_close_on_escape(!p_exclusive);
 
 	if (is_importing) {
-		get_cancel_button()->set_text(TTR("Disable FBX2glTF & Restart"));
-		get_cancel_button()->set_tooltip_text(TTR("Canceling this dialog will disable the FBX2glTF importer and use the ufbx importer.\nYou can re-enable FBX2glTF in the Project Settings under Filesystem > Import > FBX > Enabled.\n\nThe editor will restart as importers are registered when the editor starts."));
+		get_cancel_button()->set_text(TTRC("Disable FBX2glTF & Restart"));
+		get_cancel_button()->set_tooltip_text(TTRC("Canceling this dialog will disable the FBX2glTF importer and use the ufbx importer.\nYou can re-enable FBX2glTF in the Project Settings under Filesystem > Import > FBX > Enabled.\n\nThe editor will restart as importers are registered when the editor starts."));
 	} else {
-		get_cancel_button()->set_text(TTR("Cancel"));
+		get_cancel_button()->set_text(TTRC("Cancel"));
 		get_cancel_button()->set_tooltip_text("");
 	}
 
@@ -77,9 +77,9 @@ void FBXImporterManager::_validate_path(const String &p_path) {
 	bool success = false;
 
 	if (p_path == "") {
-		error = TTR("Path to FBX2glTF executable is empty.");
+		error = TTRC("Path to FBX2glTF executable is empty.");
 	} else if (!FileAccess::exists(p_path)) {
-		error = TTR("Path to FBX2glTF executable is invalid.");
+		error = TTRC("Path to FBX2glTF executable is invalid.");
 	} else {
 		List<String> args;
 		args.push_back("--version");
@@ -89,12 +89,12 @@ void FBXImporterManager::_validate_path(const String &p_path) {
 		if (err == OK && exitcode == 0) {
 			success = true;
 		} else {
-			error = TTR("Error executing this file (wrong version or architecture).");
+			error = TTRC("Error executing this file (wrong version or architecture).");
 		}
 	}
 
 	if (success) {
-		path_status->set_text(TTR("FBX2glTF executable is valid."));
+		path_status->set_text(TTRC("FBX2glTF executable is valid."));
 		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
 		get_ok_button()->set_disabled(false);
 	} else {
@@ -139,12 +139,12 @@ FBXImporterManager *FBXImporterManager::singleton = nullptr;
 FBXImporterManager::FBXImporterManager() {
 	singleton = this;
 
-	set_title(TTR("Configure FBX Importer"));
+	set_title(TTRC("Configure FBX Importer"));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
-	vb->add_child(memnew(Label(TTR("FBX2glTF is required for importing FBX files if using FBX2glTF.\nAlternatively, you can use ufbx by disabling FBX2glTF.\nPlease download the necessary tool and provide a valid path to the binary:"))));
+	vb->add_child(memnew(Label(TTRC("FBX2glTF is required for importing FBX files if using FBX2glTF.\nAlternatively, you can use ufbx by disabling FBX2glTF.\nPlease download the necessary tool and provide a valid path to the binary:"))));
 	LinkButton *lb = memnew(LinkButton);
-	lb->set_text(TTR("Click this link to download FBX2glTF"));
+	lb->set_text(TTRC("Click this link to download FBX2glTF"));
 	lb->set_uri("https://godotengine.org/fbx-import");
 	vb->add_child(lb);
 
@@ -155,7 +155,7 @@ FBXImporterManager::FBXImporterManager() {
 	fbx_path->set_accessibility_name(TTRC("Path"));
 	hb->add_child(fbx_path);
 	fbx_path_browse = memnew(Button);
-	fbx_path_browse->set_text(TTR("Browse"));
+	fbx_path_browse->set_text(TTRC("Browse"));
 	fbx_path_browse->connect(SceneStringName(pressed), callable_mp(this, &FBXImporterManager::_browse_install));
 	hb->add_child(fbx_path_browse);
 	hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -171,7 +171,7 @@ FBXImporterManager::FBXImporterManager() {
 
 	fbx_path->connect(SceneStringName(text_changed), callable_mp(this, &FBXImporterManager::_validate_path));
 
-	get_ok_button()->set_text(TTR("Confirm Path"));
+	get_ok_button()->set_text(TTRC("Confirm Path"));
 	get_cancel_button()->connect(SceneStringName(pressed), callable_mp(this, &FBXImporterManager::_cancel_setup));
 
 	browse_dialog = memnew(EditorFileDialog);

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -175,11 +175,11 @@ void PluginConfigDialog::config(const String &p_config_path) {
 		script_edit->set_text(cf->get_value("plugin", "script", ""));
 
 		_edit_mode = true;
-		set_title(TTR("Edit a Plugin"));
+		set_title(TTRC("Edit a Plugin"));
 	} else {
 		_clear_fields();
 		_edit_mode = false;
-		set_title(TTR("Create a Plugin"));
+		set_title(TTRC("Create a Plugin"));
 	}
 
 	for (Control *control : plugin_edit_hidden_controls) {
@@ -189,7 +189,7 @@ void PluginConfigDialog::config(const String &p_config_path) {
 	validation_panel->update();
 
 	get_ok_button()->set_disabled(!_edit_mode);
-	set_ok_button_text(_edit_mode ? TTR("Update") : TTR("Create"));
+	set_ok_button_text(_edit_mode ? TTRC("Update") : TTRC("Create"));
 }
 
 void PluginConfigDialog::_bind_methods() {
@@ -212,27 +212,27 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	// Plugin Name
 	Label *name_lb = memnew(Label);
-	name_lb->set_text(TTR("Plugin Name:"));
+	name_lb->set_text(TTRC("Plugin Name:"));
 	name_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(name_lb);
 
 	name_edit = memnew(LineEdit);
 	name_edit->set_placeholder("MyPlugin");
-	name_edit->set_tooltip_text(TTR("Required. This name will be displayed in the list of plugins."));
+	name_edit->set_tooltip_text(TTRC("Required. This name will be displayed in the list of plugins."));
 	name_edit->set_accessibility_name(TTRC("Plugin Name:"));
 	name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(name_edit);
 
 	// Subfolder
 	Label *subfolder_lb = memnew(Label);
-	subfolder_lb->set_text(TTR("Subfolder:"));
+	subfolder_lb->set_text(TTRC("Subfolder:"));
 	subfolder_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(subfolder_lb);
 	plugin_edit_hidden_controls.push_back(subfolder_lb);
 
 	subfolder_edit = memnew(LineEdit);
 	subfolder_edit->set_placeholder(U"\"my_plugin\" → res://addons/my_plugin");
-	subfolder_edit->set_tooltip_text(TTR("Optional. The folder name should generally use `snake_case` naming (avoid spaces and special characters).\nIf left empty, the folder will be named after the plugin name converted to `snake_case`."));
+	subfolder_edit->set_tooltip_text(TTRC("Optional. The folder name should generally use `snake_case` naming (avoid spaces and special characters).\nIf left empty, the folder will be named after the plugin name converted to `snake_case`."));
 	subfolder_edit->set_accessibility_name(TTRC("Subfolder:"));
 	subfolder_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(subfolder_edit);
@@ -240,12 +240,12 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	// Description
 	Label *desc_lb = memnew(Label);
-	desc_lb->set_text(TTR("Description:"));
+	desc_lb->set_text(TTRC("Description:"));
 	desc_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(desc_lb);
 
 	desc_edit = memnew(TextEdit);
-	desc_edit->set_tooltip_text(TTR("Optional. This description should be kept relatively short (up to 5 lines).\nIt will display when hovering the plugin in the list of plugins."));
+	desc_edit->set_tooltip_text(TTRC("Optional. This description should be kept relatively short (up to 5 lines).\nIt will display when hovering the plugin in the list of plugins."));
 	desc_edit->set_accessibility_name(TTRC("Description:"));
 	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
 	desc_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
@@ -255,25 +255,25 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	// Author
 	Label *author_lb = memnew(Label);
-	author_lb->set_text(TTR("Author:"));
+	author_lb->set_text(TTRC("Author:"));
 	author_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(author_lb);
 
 	author_edit = memnew(LineEdit);
 	author_edit->set_placeholder("Godette");
 	author_edit->set_accessibility_name(TTRC("Author:"));
-	author_edit->set_tooltip_text(TTR("Optional. The author's username, full name, or organization name."));
+	author_edit->set_tooltip_text(TTRC("Optional. The author's username, full name, or organization name."));
 	author_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(author_edit);
 
 	// Version
 	Label *version_lb = memnew(Label);
-	version_lb->set_text(TTR("Version:"));
+	version_lb->set_text(TTRC("Version:"));
 	version_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(version_lb);
 
 	version_edit = memnew(LineEdit);
-	version_edit->set_tooltip_text(TTR("Optional. A human-readable version identifier used for informational purposes only."));
+	version_edit->set_tooltip_text(TTRC("Optional. A human-readable version identifier used for informational purposes only."));
 	version_edit->set_placeholder("1.0");
 	version_edit->set_accessibility_name(TTRC("Version:"));
 	version_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -281,12 +281,12 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	// Language dropdown
 	Label *script_option_lb = memnew(Label);
-	script_option_lb->set_text(TTR("Language:"));
+	script_option_lb->set_text(TTRC("Language:"));
 	script_option_lb->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(script_option_lb);
 
 	script_option_edit = memnew(OptionButton);
-	script_option_edit->set_tooltip_text(TTR("Required. The scripting language to use for the script.\nNote that a plugin may use several languages at once by adding more scripts to the plugin."));
+	script_option_edit->set_tooltip_text(TTRC("Required. The scripting language to use for the script.\nNote that a plugin may use several languages at once by adding more scripts to the plugin."));
 	script_option_edit->set_accessibility_name(TTRC("Language:"));
 	int default_lang = 0;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
@@ -301,12 +301,12 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	// Plugin Script Name
 	Label *script_name_label = memnew(Label);
-	script_name_label->set_text(TTR("Script Name:"));
+	script_name_label->set_text(TTRC("Script Name:"));
 	script_name_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	grid->add_child(script_name_label);
 
 	script_edit = memnew(LineEdit);
-	script_edit->set_tooltip_text(TTR("Optional. The name of the script file. If left empty, will default to the subfolder name."));
+	script_edit->set_tooltip_text(TTRC("Optional. The name of the script file. If left empty, will default to the subfolder name."));
 	script_edit->set_placeholder(U"\"plugin.gd\" → res://addons/my_plugin/plugin.gd");
 	script_edit->set_accessibility_name(TTRC("Script Name:"));
 	script_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -422,8 +422,8 @@ void ProjectDialog::_browse_project_path() {
 	if (mode == MODE_IMPORT) {
 		fdialog_project->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_ANY);
 		fdialog_project->clear_filters();
-		fdialog_project->add_filter("project.godot", vformat("%s %s", GODOT_VERSION_NAME, TTR("Project")));
-		fdialog_project->add_filter("*.zip", TTR("ZIP File"));
+		fdialog_project->add_filter("project.godot", vformat("%s %s", GODOT_VERSION_NAME, TTRC("Project")));
+		fdialog_project->add_filter("*.zip", TTRC("ZIP File"));
 	} else {
 		fdialog_project->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
 	}

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -86,7 +86,7 @@ void RunInstancesDialog::_create_instance(InstanceData &p_instance, const Dictio
 
 	instance_item->set_cell_mode(COLUMN_OVERRIDE_ARGS, TreeItem::CELL_MODE_CHECK);
 	instance_item->set_editable(COLUMN_OVERRIDE_ARGS, true);
-	instance_item->set_text(COLUMN_OVERRIDE_ARGS, TTR("Enabled"));
+	instance_item->set_text(COLUMN_OVERRIDE_ARGS, TTRC("Enabled"));
 	instance_item->set_checked(COLUMN_OVERRIDE_ARGS, p_data.get("override_args", false));
 
 	instance_item->set_editable(COLUMN_LAUNCH_ARGUMENTS, true);
@@ -94,7 +94,7 @@ void RunInstancesDialog::_create_instance(InstanceData &p_instance, const Dictio
 
 	instance_item->set_cell_mode(COLUMN_OVERRIDE_FEATURES, TreeItem::CELL_MODE_CHECK);
 	instance_item->set_editable(COLUMN_OVERRIDE_FEATURES, true);
-	instance_item->set_text(COLUMN_OVERRIDE_FEATURES, TTR("Enabled"));
+	instance_item->set_text(COLUMN_OVERRIDE_FEATURES, TTRC("Enabled"));
 	instance_item->set_checked(COLUMN_OVERRIDE_FEATURES, p_data.get("override_features", false));
 
 	instance_item->set_editable(COLUMN_FEATURE_TAGS, true);
@@ -182,7 +182,7 @@ void RunInstancesDialog::_instance_tree_rmb(const Vector2 &p_pos, MouseButton p_
 	}
 
 	popup_menu->clear();
-	popup_menu->add_item(TTR("Clear"), CLEAR_ITEM);
+	popup_menu->add_item(TTRC("Clear"), CLEAR_ITEM);
 
 	TreeItem *item = instance_tree->get_item_at_position(p_pos);
 	if (item) {
@@ -191,7 +191,7 @@ void RunInstancesDialog::_instance_tree_rmb(const Vector2 &p_pos, MouseButton p_
 		popup_menu->set_item_disabled(0, true);
 	}
 
-	popup_menu->add_item(TTR("Clear All"), CLEAR_ALL);
+	popup_menu->add_item(TTRC("Clear All"), CLEAR_ALL);
 	popup_menu->set_position(instance_tree->get_screen_position() + p_pos);
 	popup_menu->reset_size();
 	popup_menu->popup();
@@ -297,7 +297,7 @@ void RunInstancesDialog::apply_custom_features(int p_instance_idx) {
 
 RunInstancesDialog::RunInstancesDialog() {
 	singleton = this;
-	set_title(TTR("Run Instances"));
+	set_title(TTRC("Run Instances"));
 
 	main_apply_timer = memnew(Timer);
 	main_apply_timer->set_wait_time(0.5);
@@ -320,13 +320,13 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	{
 		Label *l = memnew(Label);
-		l->set_text(TTR("Main Run Args:"));
+		l->set_text(TTRC("Main Run Args:"));
 		main_gc->add_child(l);
 	}
 
 	{
 		Label *l = memnew(Label);
-		l->set_text(TTR("Main Feature Tags:"));
+		l->set_text(TTRC("Main Feature Tags:"));
 		main_gc->add_child(l);
 	}
 
@@ -334,7 +334,7 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	main_args_edit = memnew(LineEdit);
 	main_args_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	main_args_edit->set_placeholder(TTR("Space-separated arguments, example: host player1 blue"));
+	main_args_edit->set_placeholder(TTRC("Space-separated arguments, example: host player1 blue"));
 	main_args_edit->set_accessibility_name(TTRC("Main Run Args:"));
 	main_gc->add_child(main_args_edit);
 	_fetch_main_args();
@@ -343,7 +343,7 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	main_features_edit = memnew(LineEdit);
 	main_features_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	main_features_edit->set_placeholder(TTR("Comma-separated tags, example: demo, steam, event"));
+	main_features_edit->set_placeholder(TTRC("Comma-separated tags, example: demo, steam, event"));
 	main_features_edit->set_text(EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_main_feature_tags", ""));
 	main_features_edit->set_accessibility_name(TTRC("Main Feature Tags:"));
 	main_gc->add_child(main_features_edit);
@@ -384,12 +384,12 @@ RunInstancesDialog::RunInstancesDialog() {
 	instance_tree->set_hide_folding(true);
 	instance_tree->set_columns(4);
 	instance_tree->set_column_titles_visible(true);
-	instance_tree->set_column_title(COLUMN_OVERRIDE_ARGS, TTR("Override Main Run Args"));
+	instance_tree->set_column_title(COLUMN_OVERRIDE_ARGS, TTRC("Override Main Run Args"));
 	instance_tree->set_column_expand(COLUMN_OVERRIDE_ARGS, false);
-	instance_tree->set_column_title(COLUMN_LAUNCH_ARGUMENTS, TTR("Launch Arguments"));
-	instance_tree->set_column_title(COLUMN_OVERRIDE_FEATURES, TTR("Override Main Tags"));
+	instance_tree->set_column_title(COLUMN_LAUNCH_ARGUMENTS, TTRC("Launch Arguments"));
+	instance_tree->set_column_title(COLUMN_OVERRIDE_FEATURES, TTRC("Override Main Tags"));
 	instance_tree->set_column_expand(COLUMN_OVERRIDE_FEATURES, false);
-	instance_tree->set_column_title(COLUMN_FEATURE_TAGS, TTR("Feature Tags"));
+	instance_tree->set_column_title(COLUMN_FEATURE_TAGS, TTRC("Feature Tags"));
 	instance_tree->set_hide_root(true);
 	instance_tree->set_allow_rmb_select(true);
 	instance_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3959,7 +3959,7 @@ void TileMapLayerEditor::_advanced_menu_button_id_pressed(int p_id) {
 
 	if (p_id == ADVANCED_MENU_REPLACE_WITH_PROXIES) { // Replace Tile Proxies
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTRC("Replace Tiles with Proxies"));
+		undo_redo->create_action(TTR("Replace Tiles with Proxies"));
 		TypedArray<Vector2i> used_cells = edited_layer->get_used_cells();
 		for (int i = 0; i < used_cells.size(); i++) {
 			Vector2i cell_coords = used_cells[i];
@@ -3984,7 +3984,7 @@ void TileMapLayerEditor::_advanced_menu_button_id_pressed(int p_id) {
 		ERR_FAIL_NULL(edited_scene_root);
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTRC("Extract TileMap layers as individual TileMapLayer nodes"));
+		undo_redo->create_action(TTR("Extract TileMap layers as individual TileMapLayer nodes"));
 
 		TileMap *tile_map = Object::cast_to<TileMap>(edited_layer->get_parent());
 		for (int i = 0; i < tile_map->get_layers_count(); i++) {

--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -192,7 +192,7 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	// TODO: Rework this as a dedicated toolbar control so we can hook into theme changes and update it
 	// when the editor theme updates.
 	bake->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Bake"), EditorStringName(EditorIcons)));
-	bake->set_text(TTR("Bake Lightmaps"));
+	bake->set_text(TTRC("Bake Lightmaps"));
 
 #ifdef MODULE_LIGHTMAPPER_RD_ENABLED
 	// Disable lightmap baking if not supported on the current GPU.
@@ -217,8 +217,8 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	file_dialog->add_filter("*.lmbake", TTR("LightMap Bake"));
-	file_dialog->set_title(TTR("Select lightmap bake file:"));
+	file_dialog->add_filter("*.lmbake", TTRC("LightMap Bake"));
+	file_dialog->set_title(TTRC("Select lightmap bake file:"));
 	file_dialog->connect("file_selected", callable_mp(this, &LightmapGIEditorPlugin::_bake_select_file));
 	bake->add_child(file_dialog);
 }

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -10832,7 +10832,7 @@ Node3DEditor::Node3DEditor() {
 	snap_translate->set_suffix("m");
 	snap_translate->set_allow_greater(true);
 	snap_translate->set_accessibility_name(TTRC("Translate Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Translate Snap:"), snap_translate);
+	snap_dialog_vbc->add_margin_child(TTRC("Translate Snap:"), snap_translate);
 
 	snap_rotate = memnew(EditorSpinSlider);
 	snap_rotate->set_min(0.0);
@@ -10840,7 +10840,7 @@ Node3DEditor::Node3DEditor() {
 	snap_rotate->set_max(360);
 	snap_rotate->set_suffix(U"°");
 	snap_rotate->set_accessibility_name(TTRC("Rotate Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Rotate Snap:"), snap_rotate);
+	snap_dialog_vbc->add_margin_child(TTRC("Rotate Snap:"), snap_rotate);
 
 	snap_scale = memnew(EditorSpinSlider);
 	snap_scale->set_min(0.0);
@@ -10848,7 +10848,7 @@ Node3DEditor::Node3DEditor() {
 	snap_scale->set_max(100);
 	snap_scale->set_suffix("%");
 	snap_scale->set_accessibility_name(TTRC("Scale Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Scale Snap:"), snap_scale);
+	snap_dialog_vbc->add_margin_child(TTRC("Scale Snap:"), snap_scale);
 
 	/* SETTINGS DIALOG */
 

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2167,7 +2167,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("Theme", &ext);
 	for (const String &E : ext) {
-		import_another_theme_dialog->add_filter("*." + E, TTR("Theme Resource"));
+		import_another_theme_dialog->add_filter("*." + E, TTRC("Theme Resource"));
 	}
 	import_another_file_hb->add_child(import_another_theme_dialog);
 	import_another_theme_dialog->connect("file_selected", callable_mp(this, &ThemeItemEditorDialog::_select_another_theme_cbk));
@@ -2177,7 +2177,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	import_another_theme_vb->add_child(import_other_theme_items);
 
 	import_tc->add_child(import_another_theme_vb);
-	import_tc->set_tab_title(2, TTR("Another Theme"));
+	import_tc->set_tab_title(2, TTRC("Another Theme"));
 	import_other_theme_items->connect("items_imported", callable_mp(this, &ThemeItemEditorDialog::_update_edit_types));
 
 	confirm_closing_dialog = memnew(ConfirmationDialog);
@@ -4100,7 +4100,7 @@ ThemeEditor::ThemeEditor() {
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &ext);
 	for (const String &E : ext) {
-		preview_scene_dialog->add_filter("*." + E, TTR("Scene"));
+		preview_scene_dialog->add_filter("*." + E, TTRC("Scene"));
 	}
 	main_hs->add_child(preview_scene_dialog);
 	preview_scene_dialog->connect("file_selected", callable_mp(this, &ThemeEditor::_preview_scene_dialog_cbk));

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -436,7 +436,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile.is_empty());
 	profile_actions[PROFILE_SET]->set_disabled(selected_profile.is_empty());
 
-	current_profile_name->set_text(!current_profile.is_empty() ? current_profile : TTR("(none)"));
+	current_profile_name->set_text(!current_profile.is_empty() ? current_profile : TTRC("(none)"));
 
 	_update_selected_profile();
 }
@@ -493,12 +493,12 @@ void EditorFeatureProfileManager::_erase_selected_profile() {
 void EditorFeatureProfileManager::_create_new_profile() {
 	String name = new_profile_name->get_text().strip_edges();
 	if (!name.is_valid_filename() || name.contains_char('.')) {
-		EditorNode::get_singleton()->show_warning(TTR("Profile must be a valid filename and must not contain '.'"));
+		EditorNode::get_singleton()->show_warning(TTRC("Profile must be a valid filename and must not contain '.'"));
 		return;
 	}
 	String file = EditorPaths::get_singleton()->get_feature_profiles_dir().path_join(name + ".profile");
 	if (FileAccess::exists(file)) {
-		EditorNode::get_singleton()->show_warning(TTR("Profile with this name already exists."));
+		EditorNode::get_singleton()->show_warning(TTRC("Profile with this name already exists."));
 		return;
 	}
 
@@ -600,7 +600,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 	updating_features = true;
 	TreeItem *root = property_list->create_item();
 	TreeItem *options = property_list->create_item(root);
-	options->set_text(0, TTR("Class Options:"));
+	options->set_text(0, TTRC("Class Options:"));
 
 	{
 		TreeItem *option = property_list->create_item(options);
@@ -608,7 +608,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		option->set_editable(0, true);
 		option->set_selectable(0, true);
 		option->set_checked(0, !edited->is_class_editor_disabled(class_name));
-		option->set_text(0, TTR("Enable Contextual Editor"));
+		option->set_text(0, TTRC("Enable Contextual Editor"));
 		option->set_metadata(0, CLASS_OPTION_DISABLE_EDITOR);
 	}
 
@@ -625,7 +625,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 
 	if (has_editor_props) {
 		TreeItem *properties = property_list->create_item(root);
-		properties->set_text(0, TTR("Class Properties:"));
+		properties->set_text(0, TTRC("Class Properties:"));
 
 		const EditorPropertyNameProcessor::Style text_style = EditorPropertyNameProcessor::get_settings_style();
 		const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(text_style);
@@ -790,7 +790,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 
 	TreeItem *features = class_list->create_item(root);
 	TreeItem *last_feature = nullptr;
-	features->set_text(0, TTR("Main Features:"));
+	features->set_text(0, TTRC("Main Features:"));
 	for (int i = 0; i < EditorFeatureProfile::FEATURE_MAX; i++) {
 		TreeItem *feature;
 		if (i == EditorFeatureProfile::FEATURE_IMPORT_DOCK) {
@@ -814,7 +814,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	}
 
 	TreeItem *classes = class_list->create_item(root);
-	classes->set_text(0, TTR("Nodes and Classes:"));
+	classes->set_text(0, TTRC("Nodes and Classes:"));
 
 	_fill_classes_from(classes, "Node", class_selected);
 	_fill_classes_from(classes, "Resource", class_selected);
@@ -944,15 +944,15 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	current_profile_name = memnew(LineEdit);
 	name_hbc->add_child(current_profile_name);
 	current_profile_name->set_accessibility_name(TTRC("Current Profile:"));
-	current_profile_name->set_text(TTR("(none)"));
+	current_profile_name->set_text(TTRC("(none)"));
 	current_profile_name->set_editable(false);
 	current_profile_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	profile_actions[PROFILE_CLEAR] = memnew(Button(TTR("Reset to Default")));
+	profile_actions[PROFILE_CLEAR] = memnew(Button(TTRC("Reset to Default")));
 	name_hbc->add_child(profile_actions[PROFILE_CLEAR]);
 	profile_actions[PROFILE_CLEAR]->set_disabled(true);
 	profile_actions[PROFILE_CLEAR]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_CLEAR));
 
-	main_vbc->add_margin_child(TTR("Current Profile:"), name_hbc);
+	main_vbc->add_margin_child(TTRC("Current Profile:"), name_hbc);
 
 	main_vbc->add_child(memnew(HSeparator));
 
@@ -964,31 +964,31 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profiles_hbc->add_child(profile_list);
 	profile_list->connect(SceneStringName(item_selected), callable_mp(this, &EditorFeatureProfileManager::_profile_selected));
 
-	profile_actions[PROFILE_NEW] = memnew(Button(TTR("Create Profile")));
+	profile_actions[PROFILE_NEW] = memnew(Button(TTRC("Create Profile")));
 	profiles_hbc->add_child(profile_actions[PROFILE_NEW]);
 	profile_actions[PROFILE_NEW]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_NEW));
 
-	profile_actions[PROFILE_ERASE] = memnew(Button(TTR("Remove Profile")));
+	profile_actions[PROFILE_ERASE] = memnew(Button(TTRC("Remove Profile")));
 	profiles_hbc->add_child(profile_actions[PROFILE_ERASE]);
 	profile_actions[PROFILE_ERASE]->set_disabled(true);
 	profile_actions[PROFILE_ERASE]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_ERASE));
 
-	main_vbc->add_margin_child(TTR("Available Profiles:"), profiles_hbc);
+	main_vbc->add_margin_child(TTRC("Available Profiles:"), profiles_hbc);
 
 	HBoxContainer *current_profile_hbc = memnew(HBoxContainer);
 
-	profile_actions[PROFILE_SET] = memnew(Button(TTR("Make Current")));
+	profile_actions[PROFILE_SET] = memnew(Button(TTRC("Make Current")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_SET]);
 	profile_actions[PROFILE_SET]->set_disabled(true);
 	profile_actions[PROFILE_SET]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_SET));
 
 	current_profile_hbc->add_child(memnew(VSeparator));
 
-	profile_actions[PROFILE_IMPORT] = memnew(Button(TTR("Import")));
+	profile_actions[PROFILE_IMPORT] = memnew(Button(TTRC("Import")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_IMPORT]);
 	profile_actions[PROFILE_IMPORT]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_IMPORT));
 
-	profile_actions[PROFILE_EXPORT] = memnew(Button(TTR("Export")));
+	profile_actions[PROFILE_EXPORT] = memnew(Button(TTRC("Export")));
 	current_profile_hbc->add_child(profile_actions[PROFILE_EXPORT]);
 	profile_actions[PROFILE_EXPORT]->set_disabled(true);
 	profile_actions[PROFILE_EXPORT]->connect(SceneStringName(pressed), callable_mp(this, &EditorFeatureProfileManager::_profile_action).bind(PROFILE_EXPORT));
@@ -1005,7 +1005,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 
 	class_list = memnew(Tree);
 	class_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	class_list_vbc->add_margin_child(TTR("Configure Selected Profile:"), class_list, true);
+	class_list_vbc->add_margin_child(TTRC("Configure Selected Profile:"), class_list, true);
 	class_list->set_hide_root(true);
 	class_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	class_list->connect("cell_selected", callable_mp(this, &EditorFeatureProfileManager::_class_list_item_selected));
@@ -1022,10 +1022,10 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	description_bit = memnew(EditorHelpBit);
 	description_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);
 	description_bit->connect("request_hide", callable_mp(this, &EditorFeatureProfileManager::_hide_requested));
-	property_list_vbc->add_margin_child(TTR("Description:"), description_bit, false);
+	property_list_vbc->add_margin_child(TTRC("Description:"), description_bit, false);
 
 	property_list = memnew(Tree);
-	property_list_vbc->add_margin_child(TTR("Extra Options:"), property_list, true);
+	property_list_vbc->add_margin_child(TTRC("Extra Options:"), property_list, true);
 	property_list->set_hide_root(true);
 	property_list->set_hide_folding(true);
 	property_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
@@ -1034,7 +1034,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	// It will be displayed once the user creates or chooses a profile.
 	property_list_vbc->hide();
 
-	no_profile_selected_help = memnew(Label(TTR("Create or import a profile to edit available classes and properties.")));
+	no_profile_selected_help = memnew(Label(TTRC("Create or import a profile to edit available classes and properties.")));
 	// Add some spacing above the help label.
 	Ref<StyleBoxEmpty> sb = memnew(StyleBoxEmpty);
 	sb->set_content_margin(SIDE_TOP, 20 * EDSCALE);
@@ -1044,11 +1044,11 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	h_split->add_child(no_profile_selected_help);
 
 	new_profile_dialog = memnew(ConfirmationDialog);
-	new_profile_dialog->set_title(TTR("Create Profile"));
+	new_profile_dialog->set_title(TTRC("Create Profile"));
 	VBoxContainer *new_profile_vb = memnew(VBoxContainer);
 	new_profile_dialog->add_child(new_profile_vb);
 	Label *new_profile_label = memnew(Label);
-	new_profile_label->set_text(TTR("New profile name:"));
+	new_profile_label->set_text(TTRC("New profile name:"));
 	new_profile_vb->add_child(new_profile_label);
 	new_profile_name = memnew(LineEdit);
 	new_profile_vb->add_child(new_profile_name);
@@ -1057,30 +1057,30 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	add_child(new_profile_dialog);
 	new_profile_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorFeatureProfileManager::_create_new_profile));
 	new_profile_dialog->register_text_enter(new_profile_name);
-	new_profile_dialog->set_ok_button_text(TTR("Create"));
+	new_profile_dialog->set_ok_button_text(TTRC("Create"));
 
 	erase_profile_dialog = memnew(ConfirmationDialog);
 	add_child(erase_profile_dialog);
-	erase_profile_dialog->set_title(TTR("Remove Profile"));
+	erase_profile_dialog->set_title(TTRC("Remove Profile"));
 	erase_profile_dialog->connect(SceneStringName(confirmed), callable_mp(this, &EditorFeatureProfileManager::_erase_selected_profile));
 
 	import_profiles = memnew(EditorFileDialog);
 	add_child(import_profiles);
 	import_profiles->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
-	import_profiles->add_filter("*.profile", TTR("Godot Feature Profile"));
+	import_profiles->add_filter("*.profile", TTRC("Godot Feature Profile"));
 	import_profiles->connect("files_selected", callable_mp(this, &EditorFeatureProfileManager::_import_profiles));
-	import_profiles->set_title(TTR("Import Profile(s)"));
+	import_profiles->set_title(TTRC("Import Profile(s)"));
 	import_profiles->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
 	export_profile = memnew(EditorFileDialog);
 	add_child(export_profile);
 	export_profile->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	export_profile->add_filter("*.profile", TTR("Godot Feature Profile"));
+	export_profile->add_filter("*.profile", TTRC("Godot Feature Profile"));
 	export_profile->connect("file_selected", callable_mp(this, &EditorFeatureProfileManager::_export_profile));
-	export_profile->set_title(TTR("Export Profile"));
+	export_profile->set_title(TTRC("Export Profile"));
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
-	set_title(TTR("Manage Editor Feature Profiles"));
+	set_title(TTRC("Manage Editor Feature Profiles"));
 	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	EDITOR_DEF("_default_feature_profile", "");
 

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -139,7 +139,7 @@ void VersionControlEditorPlugin::popup_vcs_set_up_dialog(const Control *p_gui_ba
 		set_up_dialog->popup_centered_clamped(popup_size * EDSCALE);
 	} else {
 		// TODO: Give info to user on how to fix this error.
-		EditorNode::get_singleton()->show_warning(TTR("No VCS plugins are available in the project. Install a VCS plugin to use VCS integration features."), TTR("Error"));
+		EditorNode::get_singleton()->show_warning(TTRC("No VCS plugins are available in the project. Install a VCS plugin to use VCS integration features."), TTRC("Error"));
 	}
 }
 
@@ -218,7 +218,7 @@ void VersionControlEditorPlugin::_update_set_up_warning(const String &p_new_text
 
 	if (empty_settings) {
 		set_up_warning_text->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor)));
-		set_up_warning_text->set_text(TTR("Remote settings are empty. VCS features that use the network may not work."));
+		set_up_warning_text->set_text(TTRC("Remote settings are empty. VCS features that use the network may not work."));
 	} else {
 		set_up_warning_text->set_text("");
 	}
@@ -491,9 +491,9 @@ void VersionControlEditorPlugin::_add_new_item(Tree *p_tree, const String &p_fil
 	new_item->set_meta(SNAME("change_type"), p_change);
 	new_item->set_custom_color(0, change_type_to_color[p_change]);
 
-	new_item->add_button(0, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("File"), EditorStringName(EditorIcons)), BUTTON_TYPE_OPEN, false, TTR("Open in editor"));
+	new_item->add_button(0, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("File"), EditorStringName(EditorIcons)), BUTTON_TYPE_OPEN, false, TTRC("Open in editor"));
 	if (p_tree == unstaged_files) {
-		new_item->add_button(0, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Close"), EditorStringName(EditorIcons)), BUTTON_TYPE_DISCARD, false, TTR("Discard changes"));
+		new_item->add_button(0, EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Close"), EditorStringName(EditorIcons)), BUTTON_TYPE_DISCARD, false, TTRC("Discard changes"));
 	}
 }
 
@@ -558,12 +558,12 @@ void VersionControlEditorPlugin::_load_diff(Object *p_tree) {
 	if (tree == staged_files) {
 		show_commit_diff_header = false;
 		String file_path = tree->get_selected()->get_meta(SNAME("file_path"));
-		diff_title->set_text(TTR("Staged Changes"));
+		diff_title->set_text(TTRC("Staged Changes"));
 		diff_content = EditorVCSInterface::get_singleton()->get_diff(file_path, EditorVCSInterface::TREE_AREA_STAGED);
 	} else if (tree == unstaged_files) {
 		show_commit_diff_header = false;
 		String file_path = tree->get_selected()->get_meta(SNAME("file_path"));
-		diff_title->set_text(TTR("Unstaged Changes"));
+		diff_title->set_text(TTRC("Unstaged Changes"));
 		diff_content = EditorVCSInterface::get_singleton()->get_diff(file_path, EditorVCSInterface::TREE_AREA_UNSTAGED);
 	} else if (tree == commit_list) {
 		show_commit_diff_header = true;
@@ -867,9 +867,9 @@ void VersionControlEditorPlugin::_display_diff_unified_view(List<EditorVCSInterf
 void VersionControlEditorPlugin::_update_commit_button() {
 	commit_button->set_disabled(commit_message->get_text().strip_edges().is_empty());
 	if (toggle_amend_commit->is_pressed()) {
-		commit_button->set_text(TTR("Amend Commit Changes"));
+		commit_button->set_text(TTRC("Amend Commit Changes"));
 	} else {
-		commit_button->set_text(TTR("Commit Changes"));
+		commit_button->set_text(TTRC("Commit Changes"));
 	}
 }
 
@@ -1008,7 +1008,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	version_control_actions = memnew(PopupMenu);
 
 	metadata_dialog = memnew(ConfirmationDialog);
-	metadata_dialog->set_title(TTR("Create Version Control Metadata"));
+	metadata_dialog->set_title(TTRC("Create Version Control Metadata"));
 	metadata_dialog->set_min_size(Size2(200, 40));
 	metadata_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_create_vcs_metadata_files));
 	EditorInterface::get_singleton()->get_base_control()->add_child(metadata_dialog);
@@ -1021,7 +1021,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	metadata_vb->add_child(metadata_hb);
 
 	Label *l = memnew(Label);
-	l->set_text(TTR("Create VCS metadata files for:"));
+	l->set_text(TTRC("Create VCS metadata files for:"));
 	metadata_hb->add_child(l);
 
 	metadata_selection = memnew(OptionButton);
@@ -1031,18 +1031,18 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	metadata_hb->add_child(metadata_selection);
 
 	l = memnew(Label);
-	l->set_text(TTR("Existing VCS metadata files will be overwritten."));
+	l->set_text(TTRC("Existing VCS metadata files will be overwritten."));
 	metadata_vb->add_child(l);
 
 	set_up_dialog = memnew(AcceptDialog);
-	set_up_dialog->set_title(TTR("Local Settings"));
+	set_up_dialog->set_title(TTRC("Local Settings"));
 	set_up_dialog->set_min_size(Size2(600, 100));
-	set_up_dialog->add_cancel_button("Cancel");
+	set_up_dialog->add_cancel_button(TTRC("Cancel"));
 	set_up_dialog->set_hide_on_ok(true);
 	EditorInterface::get_singleton()->get_base_control()->add_child(set_up_dialog);
 
 	Button *set_up_apply_button = set_up_dialog->get_ok_button();
-	set_up_apply_button->set_text(TTR("Apply"));
+	set_up_apply_button->set_text(TTRC("Apply"));
 	set_up_apply_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_set_credentials));
 
 	set_up_vbc = memnew(VBoxContainer);
@@ -1055,7 +1055,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *set_up_vcs_label = memnew(Label);
 	set_up_vcs_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	set_up_vcs_label->set_text(TTR("VCS Provider"));
+	set_up_vcs_label->set_text(TTRC("VCS Provider"));
 	set_up_hbc->add_child(set_up_vcs_label);
 
 	set_up_choice = memnew(OptionButton);
@@ -1068,7 +1068,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *toggle_vcs_label = memnew(Label);
 	toggle_vcs_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	toggle_vcs_label->set_text(TTR("Connect to VCS"));
+	toggle_vcs_label->set_text(TTRC("Connect to VCS"));
 	toggle_vcs_hbc->add_child(toggle_vcs_label);
 
 	toggle_vcs_choice = memnew(CheckButton);
@@ -1086,7 +1086,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	Label *remote_login = memnew(Label);
 	remote_login->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	remote_login->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	remote_login->set_text(TTR("Remote Login"));
+	remote_login->set_text(TTRC("Remote Login"));
 	set_up_settings_vbc->add_child(remote_login);
 
 	HBoxContainer *set_up_username_input = memnew(HBoxContainer);
@@ -1095,7 +1095,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *set_up_username_label = memnew(Label);
 	set_up_username_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	set_up_username_label->set_text(TTR("Username"));
+	set_up_username_label->set_text(TTRC("Username"));
 	set_up_username_input->add_child(set_up_username_label);
 
 	set_up_username = memnew(LineEdit);
@@ -1109,7 +1109,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_settings_vbc->add_child(set_up_password_input);
 
 	Label *set_up_password_label = memnew(Label);
-	set_up_password_label->set_text(TTR("Password"));
+	set_up_password_label->set_text(TTRC("Password"));
 	set_up_password_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_password_input->add_child(set_up_password_label);
 
@@ -1126,7 +1126,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_settings_vbc->add_child(set_up_ssh_public_key_input);
 
 	Label *set_up_ssh_public_key_label = memnew(Label);
-	set_up_ssh_public_key_label->set_text(TTR("SSH Public Key Path"));
+	set_up_ssh_public_key_label->set_text(TTRC("SSH Public Key Path"));
 	set_up_ssh_public_key_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_ssh_public_key_input->add_child(set_up_ssh_public_key_label);
 
@@ -1151,7 +1151,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	select_public_path_button = memnew(Button);
 	select_public_path_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_popup_file_dialog).bind(set_up_ssh_public_key_file_dialog));
-	select_public_path_button->set_tooltip_text(TTR("Select SSH public key path"));
+	select_public_path_button->set_tooltip_text(TTRC("Select SSH public key path"));
 	select_public_path_button->set_accessibility_name(TTRC("Select SSH public key path"));
 	set_up_ssh_public_key_input_hbc->add_child(select_public_path_button);
 
@@ -1160,7 +1160,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_settings_vbc->add_child(set_up_ssh_private_key_input);
 
 	Label *set_up_ssh_private_key_label = memnew(Label);
-	set_up_ssh_private_key_label->set_text(TTR("SSH Private Key Path"));
+	set_up_ssh_private_key_label->set_text(TTRC("SSH Private Key Path"));
 	set_up_ssh_private_key_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_ssh_private_key_input->add_child(set_up_ssh_private_key_label);
 
@@ -1185,7 +1185,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	select_private_path_button = memnew(Button);
 	select_private_path_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_popup_file_dialog).bind(set_up_ssh_private_key_file_dialog));
-	select_private_path_button->set_tooltip_text(TTR("Select SSH private key path"));
+	select_private_path_button->set_tooltip_text(TTRC("Select SSH private key path"));
 	set_up_ssh_private_key_input_hbc->add_child(select_private_path_button);
 
 	HBoxContainer *set_up_ssh_passphrase_input = memnew(HBoxContainer);
@@ -1193,7 +1193,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_settings_vbc->add_child(set_up_ssh_passphrase_input);
 
 	Label *set_up_ssh_passphrase_label = memnew(Label);
-	set_up_ssh_passphrase_label->set_text(TTR("SSH Passphrase"));
+	set_up_ssh_passphrase_label->set_text(TTRC("SSH Passphrase"));
 	set_up_ssh_passphrase_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_ssh_passphrase_input->add_child(set_up_ssh_passphrase_label);
 
@@ -1230,12 +1230,12 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	unstage_area->add_child(unstage_title);
 
 	Label *unstage_label = memnew(Label);
-	unstage_label->set_text(TTR("Unstaged Changes"));
+	unstage_label->set_text(TTRC("Unstaged Changes"));
 	unstage_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	unstage_title->add_child(unstage_label);
 
 	refresh_button = memnew(Button);
-	refresh_button->set_tooltip_text(TTR("Detect new changes"));
+	refresh_button->set_tooltip_text(TTRC("Detect new changes"));
 	refresh_button->set_theme_type_variation(SceneStringName(FlatButton));
 	refresh_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_refresh_stage_area));
 	refresh_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_refresh_commit_list));
@@ -1244,18 +1244,18 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	unstage_title->add_child(refresh_button);
 
 	discard_all_confirm = memnew(AcceptDialog);
-	discard_all_confirm->set_title(TTR("Discard all changes"));
+	discard_all_confirm->set_title(TTRC("Discard all changes"));
 	discard_all_confirm->set_min_size(Size2i(400, 50));
-	discard_all_confirm->set_text(TTR("This operation is IRREVERSIBLE. Your changes will be deleted FOREVER."));
+	discard_all_confirm->set_text(TTRC("This operation is IRREVERSIBLE. Your changes will be deleted FOREVER."));
 	discard_all_confirm->set_hide_on_ok(true);
-	discard_all_confirm->set_ok_button_text(TTR("Permanentally delete my changes"));
+	discard_all_confirm->set_ok_button_text(TTRC("Permanentally delete my changes"));
 	discard_all_confirm->add_cancel_button();
 	dock_vb->add_child(discard_all_confirm);
 
 	discard_all_confirm->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_discard_all));
 
 	discard_all_button = memnew(Button);
-	discard_all_button->set_tooltip_text(TTR("Discard all changes"));
+	discard_all_button->set_tooltip_text(TTRC("Discard all changes"));
 	discard_all_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_confirm_discard_all));
 	discard_all_button->set_theme_type_variation(SceneStringName(FlatButton));
 	unstage_title->add_child(discard_all_button);
@@ -1263,7 +1263,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_all_button = memnew(Button);
 	stage_all_button->set_accessibility_name(TTRC("Stage all changes"));
 	stage_all_button->set_theme_type_variation(SceneStringName(FlatButton));
-	stage_all_button->set_tooltip_text(TTR("Stage all changes"));
+	stage_all_button->set_tooltip_text(TTRC("Stage all changes"));
 	unstage_title->add_child(stage_all_button);
 
 	MarginContainer *mc = memnew(MarginContainer);
@@ -1290,14 +1290,14 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_area->add_child(stage_title);
 
 	Label *stage_label = memnew(Label);
-	stage_label->set_text(TTR("Staged Changes"));
+	stage_label->set_text(TTRC("Staged Changes"));
 	stage_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	stage_title->add_child(stage_label);
 
 	unstage_all_button = memnew(Button);
 	unstage_all_button->set_accessibility_name(TTRC("Unstage all changes"));
 	unstage_all_button->set_theme_type_variation(SceneStringName(FlatButton));
-	unstage_all_button->set_tooltip_text(TTR("Unstage all changes"));
+	unstage_all_button->set_tooltip_text(TTRC("Unstage all changes"));
 	stage_title->add_child(unstage_all_button);
 
 	mc = memnew(MarginContainer);
@@ -1323,7 +1323,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	dock_vb->add_child(commit_area);
 
 	Label *commit_label = memnew(Label);
-	commit_label->set_text(TTR("Commit Message"));
+	commit_label->set_text(TTRC("Commit Message"));
 	commit_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	commit_area->add_child(commit_label);
 
@@ -1345,13 +1345,13 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	commit_button = memnew(Button);
 	commit_button->set_h_size_flags(Tree::SIZE_EXPAND_FILL);
-	commit_button->set_text(TTR("Commit Changes"));
+	commit_button->set_text(TTRC("Commit Changes"));
 	commit_button->set_disabled(true);
 	commit_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_commit));
 	hbox->add_child(commit_button);
 
 	toggle_amend_commit = memnew(CheckButton);
-	toggle_amend_commit->set_text(TTR("Amend"));
+	toggle_amend_commit->set_text(TTRC("Amend"));
 	toggle_amend_commit->set_pressed_no_signal(false);
 	toggle_amend_commit->connect(SceneStringName(toggled), callable_mp(this, &VersionControlEditorPlugin::_toggle_amend_commit));
 	hbox->add_child(toggle_amend_commit);
@@ -1362,12 +1362,12 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	dock_vb->add_child(commit_list_hbc);
 
 	Label *commit_list_label = memnew(Label);
-	commit_list_label->set_text(TTR("Commit List"));
+	commit_list_label->set_text(TTRC("Commit List"));
 	commit_list_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	commit_list_hbc->add_child(commit_list_label);
 
 	commit_list_size_button = memnew(OptionButton);
-	commit_list_size_button->set_tooltip_text(TTR("Commit list size"));
+	commit_list_size_button->set_tooltip_text(TTRC("Commit list size"));
 	commit_list_size_button->add_item("10");
 	commit_list_size_button->set_item_metadata(0, 10);
 	commit_list_size_button->add_item("20");
@@ -1400,7 +1400,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	dock_vb->add_child(menu_bar);
 
 	branch_select = memnew(OptionButton);
-	branch_select->set_tooltip_text(TTR("Branches"));
+	branch_select->set_tooltip_text(TTRC("Branches"));
 	branch_select->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	branch_select->set_clip_text(true);
 	branch_select->connect(SceneStringName(item_selected), callable_mp(this, &VersionControlEditorPlugin::_branch_item_selected));
@@ -1408,23 +1408,23 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	menu_bar->add_child(branch_select);
 
 	branch_create_confirm = memnew(AcceptDialog);
-	branch_create_confirm->set_title(TTR("Create New Branch"));
+	branch_create_confirm->set_title(TTRC("Create New Branch"));
 	branch_create_confirm->set_min_size(Size2(400, 100));
 	branch_create_confirm->set_hide_on_ok(true);
 	version_commit_dock->add_child(branch_create_confirm);
 
 	branch_create_ok = branch_create_confirm->get_ok_button();
-	branch_create_ok->set_text(TTR("Create"));
+	branch_create_ok->set_text(TTRC("Create"));
 	branch_create_ok->set_disabled(true);
 	branch_create_ok->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_create_branch));
 
 	branch_remove_confirm = memnew(AcceptDialog);
-	branch_remove_confirm->set_title(TTR("Remove Branch"));
+	branch_remove_confirm->set_title(TTRC("Remove Branch"));
 	branch_remove_confirm->add_cancel_button();
 	version_commit_dock->add_child(branch_remove_confirm);
 
 	Button *branch_remove_ok = branch_remove_confirm->get_ok_button();
-	branch_remove_ok->set_text(TTR("Remove"));
+	branch_remove_ok->set_text(TTRC("Remove"));
 	branch_remove_ok->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_remove_branch));
 
 	VBoxContainer *branch_create_vbc = memnew(VBoxContainer);
@@ -1437,7 +1437,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *branch_create_name_label = memnew(Label);
 	branch_create_name_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	branch_create_name_label->set_text(TTR("Branch Name"));
+	branch_create_name_label->set_text(TTRC("Branch Name"));
 	branch_create_hbc->add_child(branch_create_name_label);
 
 	branch_create_name_input = memnew(LineEdit);
@@ -1447,7 +1447,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	branch_create_hbc->add_child(branch_create_name_input);
 
 	remote_select = memnew(OptionButton);
-	remote_select->set_tooltip_text(TTR("Remotes"));
+	remote_select->set_tooltip_text(TTRC("Remotes"));
 	remote_select->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	remote_select->set_clip_text(true);
 	remote_select->connect(SceneStringName(item_selected), callable_mp(this, &VersionControlEditorPlugin::_remote_selected));
@@ -1455,23 +1455,23 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	menu_bar->add_child(remote_select);
 
 	remote_create_confirm = memnew(AcceptDialog);
-	remote_create_confirm->set_title(TTR("Create New Remote"));
+	remote_create_confirm->set_title(TTRC("Create New Remote"));
 	remote_create_confirm->set_min_size(Size2(400, 100));
 	remote_create_confirm->set_hide_on_ok(true);
 	version_commit_dock->add_child(remote_create_confirm);
 
 	remote_create_ok = remote_create_confirm->get_ok_button();
-	remote_create_ok->set_text(TTR("Create"));
+	remote_create_ok->set_text(TTRC("Create"));
 	remote_create_ok->set_disabled(true);
 	remote_create_ok->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_create_remote));
 
 	remote_remove_confirm = memnew(AcceptDialog);
-	remote_remove_confirm->set_title(TTR("Remove Remote"));
+	remote_remove_confirm->set_title(TTRC("Remove Remote"));
 	remote_remove_confirm->add_cancel_button();
 	version_commit_dock->add_child(remote_remove_confirm);
 
 	Button *remote_remove_ok = remote_remove_confirm->get_ok_button();
-	remote_remove_ok->set_text(TTR("Remove"));
+	remote_remove_ok->set_text(TTRC("Remove"));
 	remote_remove_ok->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_remove_remote));
 
 	VBoxContainer *remote_create_vbc = memnew(VBoxContainer);
@@ -1484,7 +1484,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *remote_create_name_label = memnew(Label);
 	remote_create_name_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	remote_create_name_label->set_text(TTR("Remote Name"));
+	remote_create_name_label->set_text(TTRC("Remote Name"));
 	remote_create_name_hbc->add_child(remote_create_name_label);
 
 	remote_create_name_input = memnew(LineEdit);
@@ -1499,7 +1499,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	Label *remote_create_url_label = memnew(Label);
 	remote_create_url_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	remote_create_url_label->set_text(TTR("Remote URL"));
+	remote_create_url_label->set_text(TTRC("Remote URL"));
 	remote_create_hbc->add_child(remote_create_url_label);
 
 	remote_create_url_input = memnew(LineEdit);
@@ -1510,19 +1510,19 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	fetch_button = memnew(Button);
 	fetch_button->set_theme_type_variation(SceneStringName(FlatButton));
-	fetch_button->set_tooltip_text(TTR("Fetch"));
+	fetch_button->set_tooltip_text(TTRC("Fetch"));
 	fetch_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_fetch));
 	menu_bar->add_child(fetch_button);
 
 	pull_button = memnew(Button);
 	pull_button->set_theme_type_variation(SceneStringName(FlatButton));
-	pull_button->set_tooltip_text(TTR("Pull"));
+	pull_button->set_tooltip_text(TTRC("Pull"));
 	pull_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_pull));
 	menu_bar->add_child(pull_button);
 
 	push_button = memnew(Button);
 	push_button->set_theme_type_variation(SceneStringName(FlatButton));
-	push_button->set_tooltip_text(TTR("Push"));
+	push_button->set_tooltip_text(TTRC("Push"));
 	push_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_push));
 	menu_bar->add_child(push_button);
 
@@ -1532,20 +1532,20 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	extra_options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &VersionControlEditorPlugin::_extra_option_selected));
 	menu_bar->add_child(extra_options);
 
-	extra_options->get_popup()->add_item(TTR("Force Push"), EXTRA_OPTION_FORCE_PUSH);
+	extra_options->get_popup()->add_item(TTRC("Force Push"), EXTRA_OPTION_FORCE_PUSH);
 	extra_options->get_popup()->add_separator();
-	extra_options->get_popup()->add_item(TTR("Create New Branch"), EXTRA_OPTION_CREATE_BRANCH);
+	extra_options->get_popup()->add_item(TTRC("Create New Branch"), EXTRA_OPTION_CREATE_BRANCH);
 
 	extra_options_remove_branch_list = memnew(PopupMenu);
 	extra_options_remove_branch_list->connect(SceneStringName(id_pressed), callable_mp(this, &VersionControlEditorPlugin::_popup_branch_remove_confirm));
-	extra_options->get_popup()->add_submenu_node_item(TTR("Remove Branch"), extra_options_remove_branch_list);
+	extra_options->get_popup()->add_submenu_node_item(TTRC("Remove Branch"), extra_options_remove_branch_list);
 
 	extra_options->get_popup()->add_separator();
-	extra_options->get_popup()->add_item(TTR("Create New Remote"), EXTRA_OPTION_CREATE_REMOTE);
+	extra_options->get_popup()->add_item(TTRC("Create New Remote"), EXTRA_OPTION_CREATE_REMOTE);
 
 	extra_options_remove_remote_list = memnew(PopupMenu);
 	extra_options_remove_remote_list->connect(SceneStringName(id_pressed), callable_mp(this, &VersionControlEditorPlugin::_popup_remote_remove_confirm));
-	extra_options->get_popup()->add_submenu_node_item(TTR("Remove Remote"), extra_options_remove_remote_list);
+	extra_options->get_popup()->add_submenu_node_item(TTRC("Remove Remote"), extra_options_remove_remote_list);
 
 	change_type_to_strings[EditorVCSInterface::CHANGE_TYPE_NEW] = TTR("New");
 	change_type_to_strings[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = TTR("Modified");
@@ -1571,7 +1571,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	HBoxContainer *diff_heading = memnew(HBoxContainer);
 	diff_heading->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	diff_heading->set_tooltip_text(TTR("View file diffs before committing them to the latest version"));
+	diff_heading->set_tooltip_text(TTRC("View file diffs before committing them to the latest version"));
 	vbc->add_child(diff_heading);
 
 	diff_title = memnew(Label);
@@ -1580,13 +1580,13 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff_heading->add_child(diff_title);
 
 	Label *view = memnew(Label);
-	view->set_text(TTR("View:"));
+	view->set_text(TTRC("View:"));
 	diff_heading->add_child(view);
 
 	diff_view_type_select = memnew(OptionButton);
 	diff_view_type_select->set_accessibility_name(TTRC("View:"));
-	diff_view_type_select->add_item(TTR("Split"), DIFF_VIEW_TYPE_SPLIT);
-	diff_view_type_select->add_item(TTR("Unified"), DIFF_VIEW_TYPE_UNIFIED);
+	diff_view_type_select->add_item(TTRC("Split"), DIFF_VIEW_TYPE_SPLIT);
+	diff_view_type_select->add_item(TTRC("Unified"), DIFF_VIEW_TYPE_UNIFIED);
 	diff_view_type_select->connect(SceneStringName(item_selected), callable_mp(this, &VersionControlEditorPlugin::_display_diff));
 	diff_heading->add_child(diff_view_type_select);
 


### PR DESCRIPTION
This swaps out uses of `TTR()` for `TTRC()` where appropriate throughout the editor. Nearly all instances should be fixed, but a few may have been missed.

I didn't change any source strings in this PR, so translations should be unaffected.

## Preview

*Switching the editor from French to English at runtime to highlight the original issue.*

Before | After
-|-
<img width="288" height="259" alt="Screenshot_20260609_235411" src="https://github.com/user-attachments/assets/18ecb261-f4e5-4af7-bb9a-48e8a4792099" /> | <img width="285" height="265" alt="Screenshot_20260610_183426" src="https://github.com/user-attachments/assets/9148a007-c93a-4f2d-9857-81b5567f9ca3" />

## TODO

- [ ] Some tooltips still don't switch to the correct language after changing language, despite their shortcut definition using `TTRC()`:

<img width="361" height="80" alt="Screenshot_20260611_181002" src="https://github.com/user-attachments/assets/e174348a-8a28-4036-b3ca-d8cd7f429ae8" />

This affects all dock and bottom panel tooltips.

These tooltips in the EditorLog are also affected by this issue:

https://github.com/Calinou/godot/blob/940f572b3e0644fb9d04d1459dd373f730724cc2/editor/editor_log.cpp#L564-L584

