### PR TITLE
Make compression docs and messages more clear

### DIFF
--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -49,7 +49,7 @@ static int current_zstd_window_log_size;
 int64_t Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int64_t p_src_size, Mode p_mode) {
 	switch (p_mode) {
 		case MODE_BROTLI: {
-			ERR_FAIL_V_MSG(-1, "Only brotli decompression is supported.");
+			ERR_FAIL_V_MSG(-1, "Only Brotli decompression is supported.");
 		} break;
 		case MODE_FASTLZ: {
 			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a FastLZ/LZ77 file 2 GiB or larger. LZ77 supports larger files, but FastLZ's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
@@ -65,7 +65,7 @@ int64_t Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int64_t p_sr
 		} break;
 		case MODE_DEFLATE:
 		case MODE_GZIP: {
-			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a Deflate or GZip file 2 GiB or larger. Deflate and GZip are both limited to 4 GiB, and ZLib's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
+			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a DEFLATE or gzip file 2 GiB or larger. DEFLATE and gzip are both limited to 4 GiB, and zlib's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
 			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
@@ -109,7 +109,7 @@ int64_t Compression::compress(uint8_t *p_dst, const uint8_t *p_src, int64_t p_sr
 int64_t Compression::get_max_compressed_buffer_size(int64_t p_src_size, Mode p_mode) {
 	switch (p_mode) {
 		case MODE_BROTLI: {
-			ERR_FAIL_V_MSG(-1, "Only brotli decompression is supported.");
+			ERR_FAIL_V_MSG(-1, "Only Brotli decompression is supported.");
 		} break;
 		case MODE_FASTLZ: {
 			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a FastLZ/LZ77 file 2 GiB or larger. LZ77 supports larger files, but FastLZ's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
@@ -122,7 +122,7 @@ int64_t Compression::get_max_compressed_buffer_size(int64_t p_src_size, Mode p_m
 		} break;
 		case MODE_DEFLATE:
 		case MODE_GZIP: {
-			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a Deflate or GZip file 2 GiB or larger. Deflate and GZip are both limited to 4 GiB, and ZLib's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
+			ERR_FAIL_COND_V_MSG(p_src_size > INT32_MAX, -1, "Cannot compress a DEFLATE or gzip file 2 GiB or larger. DEFLATE and gzip are both limited to 4 GiB, and zlib's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
 			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
@@ -154,11 +154,11 @@ int64_t Compression::decompress(uint8_t *p_dst, int64_t p_dst_max_size, const ui
 			ERR_FAIL_COND_V(res != BROTLI_DECODER_RESULT_SUCCESS, -1);
 			return ret_size;
 #else
-			ERR_FAIL_V_MSG(-1, "Godot was compiled without brotli support.");
+			ERR_FAIL_V_MSG(-1, "Godot was compiled without Brotli support.");
 #endif
 		} break;
 		case MODE_FASTLZ: {
-			ERR_FAIL_COND_V_MSG(p_dst_max_size > INT32_MAX, -1, "Cannot decompress a FastLZ/LZ77 file 2 GiB or larger. LZ77 supports larger files, but FastLZ's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
+			ERR_FAIL_COND_V_MSG(p_dst_max_size > INT32_MAX, -1, "Cannot decompress a FastLZ/LZ77 file 2 GiB or larger. LZ77 supports larger files, but FastLZ's implementation uses C++ `int` so is limited to 2 GiB.");
 			int ret_size = 0;
 
 			if (p_dst_max_size < 16) {
@@ -173,7 +173,7 @@ int64_t Compression::decompress(uint8_t *p_dst, int64_t p_dst_max_size, const ui
 		} break;
 		case MODE_DEFLATE:
 		case MODE_GZIP: {
-			ERR_FAIL_COND_V_MSG(p_dst_max_size > INT32_MAX, -1, "Cannot decompress a Deflate or GZip file 2 GiB or larger. Deflate and GZip are both limited to 4 GiB, and ZLib's implementation uses C++ `int` so is limited to 2 GiB. Consider using Zstd instead.");
+			ERR_FAIL_COND_V_MSG(p_dst_max_size > INT32_MAX, -1, "Cannot decompress a DEFLATE or gzip file 2 GiB or larger. DEFLATE and gzip are both limited to 4 GiB, and zlib's implementation uses C++ `int` so is limited to 2 GiB.");
 			int window_bits = p_mode == MODE_DEFLATE ? 15 : 15 + 16;
 
 			z_stream strm;
@@ -287,11 +287,11 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int64_t p_max_d
 		BrotliDecoderDestroyInstance(state);
 		return Z_OK;
 #else
-		ERR_FAIL_V_MSG(Z_ERRNO, "Godot was compiled without brotli support.");
+		ERR_FAIL_V_MSG(Z_ERRNO, "Godot was compiled without Brotli support.");
 #endif
 	} else {
-		// This function only supports GZip and Deflate.
-		ERR_FAIL_COND_V_MSG(p_mode != MODE_DEFLATE && p_mode != MODE_GZIP, Z_ERRNO, "Dynamic decompression is only supported with gzip, DEFLATE, and Brotli compression methods.");
+		// This function only supports GZIP and DEFLATE.
+		ERR_FAIL_COND_V_MSG(p_mode != MODE_DEFLATE && p_mode != MODE_GZIP, Z_ERRNO, "Dynamic decompression is only supported with gzip, DEFLATE, and Brotli compression algorithms.");
 
 		int ret;
 		z_stream strm;

--- a/core/io/delta_encoding.cpp
+++ b/core/io/delta_encoding.cpp
@@ -37,7 +37,7 @@
 #include <zstd.h>
 
 #define ERR_FAIL_ZSTD_V_MSG(m_result, m_retval, m_msg) \
-	ERR_FAIL_COND_V_MSG(ZSTD_isError(m_result), m_retval, vformat("%s Zstandard reported error code %d: \"%s\".", m_msg, ZSTD_getErrorCode(m_result), ZSTD_getErrorString(ZSTD_getErrorCode(m_result))))
+	ERR_FAIL_COND_V_MSG(ZSTD_isError(m_result), m_retval, vformat("%s Zstd reported error code %d: \"%s\".", m_msg, ZSTD_getErrorCode(m_result), ZSTD_getErrorString(ZSTD_getErrorCode(m_result))))
 
 struct ZstdCompressionContext {
 	ZSTD_CCtx *context = ZSTD_createCCtx();

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -662,19 +662,22 @@
 			[b]Note:[/b] When creating a file it must be in an already existing directory. To recursively create directories for a file path, see [method DirAccess.make_dir_recursive].
 		</constant>
 		<constant name="COMPRESSION_FASTLZ" value="0" enum="CompressionMode">
-			Uses the [url=https://fastlz.org/]FastLZ[/url] compression method.
+			Uses the [url=https://ariya.github.io/FastLZ/]FastLZ[/url] compression algorithm.
 		</constant>
 		<constant name="COMPRESSION_DEFLATE" value="1" enum="CompressionMode">
-			Uses the [url=https://en.wikipedia.org/wiki/DEFLATE]DEFLATE[/url] compression method.
+			Uses the [url=https://datatracker.ietf.org/doc/html/rfc1951]DEFLATE[/url] compression algorithm in [url=https://datatracker.ietf.org/doc/html/rfc1950]zlib[/url] format.
+			When compressing data, the compression level defined in [member ProjectSettings.compression/formats/zlib/compression_level] will be used.
 		</constant>
 		<constant name="COMPRESSION_ZSTD" value="2" enum="CompressionMode">
-			Uses the [url=https://facebook.github.io/zstd/]Zstandard[/url] compression method.
+			Uses the [url=https://facebook.github.io/zstd/]Zstandard[/url] compression algorithm.
+			When compressing data, the compression level defined in [member ProjectSettings.compression/formats/zstd/compression_level] will be used.
 		</constant>
 		<constant name="COMPRESSION_GZIP" value="3" enum="CompressionMode">
-			Uses the [url=https://www.gzip.org/]gzip[/url] compression method.
+			Uses the [url=https://datatracker.ietf.org/doc/html/rfc1951]DEFLATE[/url] compression algorithm in [url=https://datatracker.ietf.org/doc/html/rfc1952]gzip[/url] format.
+			When compressing data, the compression level defined in [member ProjectSettings.compression/formats/gzip/compression_level] will be used.
 		</constant>
 		<constant name="COMPRESSION_BROTLI" value="4" enum="CompressionMode">
-			Uses the [url=https://github.com/google/brotli]brotli[/url] compression method (only decompression is supported).
+			Uses the [url=https://www.brotli.org/]Brotli[/url] compression algorithm (only decompression is supported).
 		</constant>
 		<constant name="UNIX_READ_OWNER" value="256" enum="UnixPermissionFlags" is_bitfield="true">
 			Read for owner bit.

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -200,7 +200,7 @@
 			<param index="1" name="compression_mode" type="int" default="0" />
 			<description>
 				Returns a new [PackedByteArray] with the data decompressed. Set [param buffer_size] to the size of the uncompressed data. Set the compression mode using one of [enum FileAccess.CompressionMode]'s constants.
-				[b]Note:[/b] Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the deflate compression mode lacks a checksum or header.
+				[b]Note:[/b] Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the DEFLATE compression algorithm lacks a checksum or header.
 			</description>
 		</method>
 		<method name="decompress_dynamic" qualifiers="const">
@@ -208,10 +208,10 @@
 			<param index="0" name="max_output_size" type="int" />
 			<param index="1" name="compression_mode" type="int" default="0" />
 			<description>
-				Returns a new [PackedByteArray] with the data decompressed. Set the compression mode using one of [enum FileAccess.CompressionMode]'s constants. [b]This method only accepts brotli, gzip, and deflate compression modes.[/b]
+				Returns a new [PackedByteArray] with the data decompressed. Set the compression mode using one of [enum FileAccess.CompressionMode]'s constants. [b]This method only accepts Brotli, gzip, and DEFLATE compression algorithms.[/b]
 				This method is potentially slower than [method decompress], as it may have to re-allocate its output buffer multiple times while decompressing, whereas [method decompress] knows it's output buffer size from the beginning.
-				GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [param max_output_size]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
-				[b]Note:[/b] Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the deflate compression mode lacks a checksum or header.
+				DEFLATE/gzip has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [param max_output_size]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
+				[b]Note:[/b] Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the DEFLATE compression algorithm lacks a checksum or header.
 			</description>
 		</method>
 		<method name="duplicate" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -507,7 +507,7 @@
 			The default compression level for gzip. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
 		</member>
 		<member name="compression/formats/zlib/compression_level" type="int" setter="" getter="" default="-1">
-			The default compression level for Zlib. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
+			The default compression level for DEFLATE/zlib. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
 		</member>
 		<member name="compression/formats/zstd/compression_level" type="int" setter="" getter="" default="3">
 			The default compression level for Zstandard. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level.

--- a/doc/classes/StreamPeerGZIP.xml
+++ b/doc/classes/StreamPeerGZIP.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerGZIP" inherits="StreamPeer" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A stream peer that handles GZIP and deflate compression/decompression.
+		A stream peer that handles gzip and zlib compression/decompression.
 	</brief_description>
 	<description>
-		This class allows to compress or decompress data using GZIP/deflate in a streaming fashion. This is particularly useful when compressing or decompressing files that have to be sent through the network without needing to allocate them all in memory.
+		This class allows to compress or decompress data using gzip/zlib in a streaming fashion. This is particularly useful when compressing or decompressing files that have to be sent through the network without needing to allocate them all in memory.
 		After starting the stream via [method start_compression] (or [method start_decompression]), calling [method StreamPeer.put_partial_data] on this stream will compress (or decompress) the data, writing it to the internal buffer. Calling [method StreamPeer.get_available_bytes] will return the pending bytes in the internal buffer, and [method StreamPeer.get_partial_data] will retrieve the compressed (or decompressed) bytes from it. When the stream is over, you must call [method finish] to ensure the internal buffer is properly flushed (make sure to call [method StreamPeer.get_available_bytes] on last time to check if more data needs to be read after that).
 	</description>
 	<tutorials>
@@ -28,7 +28,7 @@
 			<param index="0" name="use_deflate" type="bool" default="false" />
 			<param index="1" name="buffer_size" type="int" default="65535" />
 			<description>
-				Start the stream in compression mode with the given [param buffer_size], if [param use_deflate] is [code]true[/code] uses deflate instead of GZIP.
+				Start the stream in compression mode with the given [param buffer_size], if [param use_deflate] is [code]true[/code] uses zlib instead of gzip.
 			</description>
 		</method>
 		<method name="start_decompression">
@@ -36,7 +36,7 @@
 			<param index="0" name="use_deflate" type="bool" default="false" />
 			<param index="1" name="buffer_size" type="int" default="65535" />
 			<description>
-				Start the stream in decompression mode with the given [param buffer_size], if [param use_deflate] is [code]true[/code] uses deflate instead of GZIP.
+				Start the stream in decompression mode with the given [param buffer_size], if [param use_deflate] is [code]true[/code] uses zlib instead of gzip.
 			</description>
 		</method>
 	</methods>

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1782,7 +1782,7 @@ ProjectExportDialog::ProjectExportDialog() {
 						"Higher positive levels will reduce patch sizes, at the cost of longer export time, but do not affect the time it takes to apply patches.\n"
 						"Negative levels will reduce the time it takes to apply patches, at the cost of worse compression.\n"
 						"Levels above 19 require more memory both during export and when applying patches, usually for very little benefit.\n"
-						"Level 0 will cause Zstandard to use its default compression level, which is currently level %d."),
+						"Level 0 will cause Zstd to use its default compression level, which is currently level %d."),
 					ZSTD_CLEVEL_DEFAULT));
 	patch_delta_zstd_level->connect(SceneStringName(value_changed), callable_mp(this, &ProjectExportDialog::_patch_delta_zstd_level_changed));
 	patch_vb->add_margin_child(TTRC("Delta Encoding Compression Level"), patch_delta_zstd_level);

--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -172,7 +172,7 @@
 			[url=https://fastlz.org/]FastLZ[/url] compression. This option uses less CPU resources compared to [constant COMPRESS_ZLIB], at the expense of using more bandwidth.
 		</constant>
 		<constant name="COMPRESS_ZLIB" value="3" enum="CompressionMode">
-			[url=https://www.zlib.net/]Zlib[/url] compression. This option uses less bandwidth compared to [constant COMPRESS_FASTLZ], at the expense of using more CPU resources.
+			[url=https://datatracker.ietf.org/doc/html/rfc1950]zlib[/url] compression. This option uses less bandwidth compared to [constant COMPRESS_FASTLZ], at the expense of using more CPU resources.
 		</constant>
 		<constant name="COMPRESS_ZSTD" value="4" enum="CompressionMode">
 			[url=https://facebook.github.io/zstd/]Zstandard[/url] compression. Note that this algorithm is not very efficient on packets smaller than 4 KB. Therefore, it's recommended to use other compression algorithms in most cases.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -699,7 +699,7 @@ namespace Godot
 
         /// <summary>
         /// Returns a new byte array with the data decompressed.
-        /// <para>Note: Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the deflate compression mode lacks a checksum or header.</para>
+        /// <para>Note: Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the DEFLATE compression algorithm lacks a checksum or header.</para>
         /// </summary>
         /// <param name="instance">The byte array to decompress.</param>
         /// <param name="bufferSize">The size of the uncompressed data.</param>
@@ -714,10 +714,10 @@ namespace Godot
         }
 
         /// <summary>
-        ///	Returns a new byte array with the data decompressed. <b>This method only accepts brotli, gzip, and deflate compression modes</b>.
+        ///	Returns a new byte array with the data decompressed. <b>This method only accepts Brotli, gzip, and DEFLATE compression algorithms</b>.
         /// <para>This method is potentially slower than <see cref="Decompress"/>, as it may have to re-allocate its output buffer multiple times while decompressing, whereas <see cref="Decompress"/> knows it's output buffer size from the beginning.</para>
-        /// <para>GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [param max_output_size]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.</para>
-        /// <para>Note: Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the deflate compression mode lacks a checksum or header.</para>
+        /// <para>DEFLATE/gzip has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [param max_output_size]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.</para>
+        /// <para>Note: Decompression is not guaranteed to work with data not compressed by Godot, for example if data compressed with the DEFLATE compression algorithm lacks a checksum or header.</para>
         /// </summary>
         /// <param name="instance">The byte array to decompress.</param>
         /// <param name="maxOutputSize">The maximum size this function is allowed to allocate in bytes.</param>

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -772,7 +772,7 @@ Files extracted from upstream source:
 
 - Upstream: https://github.com/madler/zlib
 - Version: 1.3.2 (da607da739fa6047df13e66a2af6b8bec7c2a498, 2026)
-- License: zlib
+- License: Zlib
 
 Files extracted from the upstream source:
 
@@ -816,7 +816,7 @@ Collection of single-file libraries used in Godot components.
 - `mikktspace.{c,h}`
   * Upstream: https://archive.blender.org/wiki/index.php/Dev:Shading/Tangent_Space_Normal_Maps/
   * Version: 1.0 (2011)
-  * License: zlib
+  * License: Zlib
 - `nvapi_minimal.h`
   * Upstream: http://download.nvidia.com/XFree86/nvapi-open-source-sdk
   * Version: R525
@@ -941,7 +941,7 @@ Files extracted from upstream source:
 
 - Upstream: https://github.com/recastnavigation/recastnavigation
 - Version: 1.6.0 (6dc1667f580357e8a2154c28b7867bea7e8ad3a7, 2023)
-- License: zlib
+- License: Zlib
 
 Files extracted from upstream source:
 
@@ -1293,7 +1293,7 @@ Files extracted from upstream source:
 
 - Upstream: https://github.com/madler/zlib
 - Version: 1.3.2 (da607da739fa6047df13e66a2af6b8bec7c2a498, 2026)
-- License: zlib
+- License: Zlib
 
 Files extracted from upstream source:
 


### PR DESCRIPTION
### Naming convention

I tried to split implementation and specification names:

|Library/Implementation|IETF Specification Format Name|
|-|-|
|Various|DEFLATE|
|zlib|ZLIB|
|Zstd|Zstandard|
|gzip|GZIP|
|brotli|Brotli|

To keep it less confusing (some people may not know the difference), I did the following:
- Instances of "deflate" or "Deflate" referring to the algorithm were changed into "DEFLATE".
- Instances of "Zlib" or "ZLib" referring to software or algorithm were changed into "zlib".
- Instances of "zlib" in `#thirdparty/README.md` referring to the license's short identifier were renamed to ["Zlib"](https://spdx.org/licenses/Zlib.html) (the full license name has "zlib" all lowercase, but the identifier is Zlib in title case).
- Instances of "Zstandard" referring to the software instead of algorithm were changed into "Zstd".
- Instances of "GZip" and "GZIP" are now "gzip".
- Instances of "brotli" are now "Brotli".


### Links

All formats link to their format specification instead of Wikipedia page or reference program/library (DEFLATE, ZLIB, GZIP), unless they don't have a specification page or their main page prioritizes the format over software (FastLZ, Zstandard, Brotli).

## The `COMPRESSION_DEFLATE` case

Despite the compression mode being named `COMPRESSION_DEFLATE`, it actually uses the ZLIB format (checksum and header) instead of raw DEFLATE. While the value can't be changed as it would break compatibility, we should at least make that clear in the documentation.

It's technically not incorrect, as both ZLIB and GZIP formats do use DEFLATE internally, the only difference being checksum and header, but when we have an option named `COMPRESSION_GZIP`, this could mislead that the format being used is raw DEFLATE, also supported and writable by `zlib`, when the format is actually ZLIB.

I've modified most mentions of DEFLATE to zlib, unless we're trying to point to `COMPRESSION_DEFLATE` or it actually means raw DEFLATE and not zlib (the `decompress` and `decompress_dynamic` descriptions are excellent examples).