### PR TITLE
Add EditorSettingTracker for more efficient usage of editor settings

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -135,14 +135,6 @@ void EditorLog::_update_theme() {
 	theme_cache.message_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.6);
 }
 
-void EditorLog::_editor_settings_changed() {
-	int new_line_limit = int(EDITOR_GET("run/output/max_lines"));
-	if (new_line_limit != line_limit) {
-		line_limit = new_line_limit;
-		_rebuild_log();
-	}
-}
-
 void EditorLog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -189,19 +181,18 @@ void EditorLog::_start_state_save_timer() {
 
 void EditorLog::_save_state() {
 	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
-		EditorSettings::get_singleton()->set_setting("_editor_log_filter_" + itos(E.key), E.value->is_active());
+		filter_settings[E.key].set(E.value->is_active());
 	}
-	EditorSettings::get_singleton()->set_setting("_editor_log_collapse", collapse);
-	EditorSettings::save();
+	collapse_setting.set(collapse);
 }
 
 void EditorLog::_load_state() {
 	is_loading_state = true;
 
 	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
-		E.value->set_active(EDITOR_DEF("_editor_log_filter_" + itos(E.key), true));
+		E.value->set_active(filter_settings[E.key].get());
 	}
-	collapse_button->set_pressed(EDITOR_DEF("_editor_log_collapse", false));
+	collapse_button->set_pressed(collapse_setting.get());
 
 	is_loading_state = false;
 }
@@ -333,8 +324,8 @@ void EditorLog::_rebuild_log() {
 				}
 			}
 		}
-		if (line_count >= line_limit) {
-			initial_skip = line_count - line_limit;
+		if (line_count >= max_lines_setting.get<int>()) {
+			initial_skip = line_count - max_lines_setting.get<int>();
 			break;
 		}
 		if (start_message_index == 0) {
@@ -436,6 +427,8 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 			// Distinguish editor messages from messages printed by the project
 			log->push_color(theme_cache.message_color);
 		} break;
+		case MSG_TYPE_MAX: {
+		} break;
 	}
 
 	// If collapsing, add the count of this message in bold at the start of the line.
@@ -463,7 +456,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		}
 	}
 
-	while (log->get_paragraph_count() > line_limit + 1) {
+	while (log->get_paragraph_count() > max_lines_setting.get<int>() + 1) {
 		log->remove_paragraph(0, true);
 	}
 }
@@ -498,9 +491,6 @@ EditorLog::EditorLog() {
 	save_state_timer->set_one_shot(true);
 	save_state_timer->connect("timeout", callable_mp(this, &EditorLog::_save_state));
 	add_child(save_state_timer);
-
-	line_limit = int(EDITOR_GET("run/output/max_lines"));
-	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorLog::_editor_settings_changed));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -588,6 +578,11 @@ EditorLog::EditorLog() {
 	eh.errfunc = _error_handler;
 	eh.userdata = this;
 	add_error_handler(&eh);
+
+	max_lines_setting.set_changed_callback(callable_mp(this, &EditorLog::_rebuild_log));
+	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
+		filter_settings[E.key].setup("_editor_log_filter_" + itos(E.key), true);
+	}
 }
 
 void EditorLog::deinit() {

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -32,6 +32,7 @@
 
 #include "core/os/thread.h"
 #include "editor/docks/editor_dock.h"
+#include "editor/settings/editor_setting_tracker.h"
 #include "scene/gui/button.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/rich_text_label.h"
@@ -49,6 +50,7 @@ public:
 		MSG_TYPE_STD_RICH,
 		MSG_TYPE_WARNING,
 		MSG_TYPE_EDITOR,
+		MSG_TYPE_MAX,
 	};
 
 private:
@@ -124,7 +126,9 @@ private:
 		}
 	};
 
-	int line_limit = 10000;
+	EditorSettingTracker max_lines_setting = { "run/output/max_lines" };
+	EditorSettingTracker collapse_setting = { "_editor_log_collapse", false };
+	EditorSettingTracker filter_settings[MSG_TYPE_MAX];
 
 	Vector<LogMessage> messages;
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
@@ -172,7 +176,6 @@ private:
 	void _load_state();
 
 	void _update_theme();
-	void _editor_settings_changed();
 
 protected:
 	void _notification(int p_what);

--- a/editor/settings/editor_setting_tracker.cpp
+++ b/editor/settings/editor_setting_tracker.cpp
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  editor_setting_tracker.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_setting_tracker.h"
+
+#include "editor/settings/editor_settings.h"
+
+void EditorSettingTracker::setup(const StringName &p_setting) {
+	DEV_ASSERT(setting.is_empty());
+
+	setting = p_setting;
+	value = EDITOR_GET(setting);
+	EditorSettings::get_singleton()->setting_trackers.insert(this);
+}
+
+void EditorSettingTracker::setup(const StringName &p_setting, const Variant &p_default) {
+	DEV_ASSERT(setting.is_empty());
+
+	setting = p_setting;
+	value = EDITOR_DEF(setting, p_default);
+	EditorSettings::get_singleton()->setting_trackers.insert(this);
+}
+
+void EditorSettingTracker::set(const Variant &p_value) {
+	EditorSettings::get_singleton()->set_setting(setting, p_value);
+}
+
+EditorSettingTracker::~EditorSettingTracker() {
+	EditorSettings::get_singleton()->setting_trackers.erase(this);
+}

--- a/editor/settings/editor_setting_tracker.h
+++ b/editor/settings/editor_setting_tracker.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  editor_setting_tracker.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/variant/variant.h"
+
+class EditorSettingTracker {
+	friend class EditorSettings;
+
+	StringName setting;
+	Variant value;
+	Callable changed_callback;
+
+public:
+	void setup(const StringName &p_setting);
+	void setup(const StringName &p_setting, const Variant &p_default);
+	void set_changed_callback(const Callable &p_callable) { changed_callback = p_callable; }
+
+	template <typename T>
+	const T get() const { return value.operator T(); }
+	const Variant &get() const { return value; }
+
+	void set(const Variant &p_value);
+
+	EditorSettingTracker() {}
+	EditorSettingTracker(const StringName &p_setting) { setup(p_setting); }
+	EditorSettingTracker(const StringName &p_setting, const Variant &p_default) { setup(p_setting, p_default); }
+	~EditorSettingTracker();
+};

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -52,6 +52,7 @@
 #include "editor/file_system/editor_paths.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/project_manager/engine_update_label.h"
+#include "editor/settings/editor_setting_tracker.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "editor/translations/editor_translation.h"
 #include "main/main.h"
@@ -82,6 +83,16 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 	bool changed = _set_only(p_name, p_value);
 	if (changed && initialized) {
+		for (EditorSettingTracker *tracker : setting_trackers) {
+			if (tracker->setting != p_name) {
+				continue;
+			}
+			tracker->value = p_value;
+			if (!tracker->changed_callback.is_null()) {
+				tracker->changed_callback.call();
+			}
+		}
+
 		changed_settings.insert(p_name);
 		if (p_name == SNAME("text_editor/external/exec_path")) {
 			const StringName exec_args_name = "text_editor/external/exec_flags";

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -36,11 +36,14 @@
 #include "core/os/thread_safe.h"
 
 class EditorPlugin;
+class EditorSettingTracker;
 
 class EditorSettings : public Resource {
 	GDCLASS(EditorSettings, Resource);
 
 	_THREAD_SAFE_CLASS_
+
+	friend class EditorSettingTracker;
 
 public:
 	struct Plugin {
@@ -88,6 +91,8 @@ private:
 	};
 
 	static Ref<EditorSettings> singleton;
+
+	HashSet<EditorSettingTracker *> setting_trackers;
 
 	HashSet<String> changed_settings;
 	mutable String auto_language;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Somewhat inspired by https://github.com/godotengine/godot/pull/105910#issuecomment-4415417658

ProjectSettings have GLOBAL_GET_CACHED, EditorSettings lack the equivalent. Which means that to use editor settings, you either use the relatively slow EDITOR_GET method, or cache the value and connect `settings_changed` signal, which might be cumbersome (you need to check if the setting actually changed etc.). Adding EDITOR_GET_CACHED only solves the access problem, but does not improve the usage.

This PR adds an EditorSettingTracker class, which is a simple object that caches and tracks changes of a setting. Some benefits:
- It's more performant than EDITOR_GET (although probably less performant than manually cached value, because Variant)
- Allows to designate a callback that gets called directly for this specific setting.
- The change detection is handled by EditorSettings without involving any Strings, like `check_changed_settings_in_group()` does, so it's more efficient.
- To access EditorSettings, a file needs to include only the tracker, not the whole EditorSettings file.
- The tracker is allocated on stack, so more friendly for memory or something.

Also some drawbacks I guess:
- The value is always cached as Variant.
- I provided a convenience method that retrieves the value as a specific type, but `setting.get<type>()` is arguably awkward to use.
- The tracker has to be included in the header, not in cpp file.

## Additional information

This is more of a proof of concept than anything, although if it turns out viable, it could eventually replace EDITOR_GET, and get ProjectSettings equivalent.

I applied it in EditorLog as an example.