### PR TITLE
GDScript: Add all early-applied annotations to outer class annotation list

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -737,9 +737,8 @@ void GDScriptParser::parse_program() {
 						// Some annotations need to be resolved and applied in the parser.
 						// The root class is not in any class, so `head->outer == nullptr`.
 						annotation->apply(this, head, nullptr);
-					} else {
-						head->annotations.push_back(annotation);
 					}
+					head->annotations.push_back(annotation);
 				} else if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
 					if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
 						push_error(R"(Expected newline after a standalone annotation.)");


### PR DESCRIPTION
This makes it possible for the analyzer to use the annotation's range for the REDUNDANT_STATIC_UNLOAD warning.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120174

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

With this PR, the `@static_unload` annotation is added to the outer class's list of annotations. This way, later on in `GDScriptAnalyzer::resolve_class_interface` when the analyzer is attempting to push the `REDUNDANT_STATIC_UNLOAD` warning, it can find the annotation in the class's annotation list and use the correct character range instead of defaulting to sending the entire class (i.e., the entire file) as the character range.

With the PR in effect, only the `@static_unload` line gets the yellow squiggles for this warning:

<img width="749" height="361" alt="CleanShot 2026-06-11 at 13 15 20@2x" src="https://github.com/user-attachments/assets/3a133f28-d444-433b-bf39-194009eb4809" />

(The other yellow squiggles are for `UNTYPED_DECLARATION` and `UNUSED_PARAMETER` warnings in those functions.)

<!--
> [!note]
> To prevent this from having unexpected ripple effects, I kept the change very limited to only the `@static_unload` annotation within this conditional. I could well see it being that a better change would be to have the annotation always be pushed regardless of its name, like so:
> ```cpp
> if (annotation->name == SNAME("@tool") || annotation->name == SNAME("@icon") || annotation->name == SNAME("@static_unload")) {
> 	// Some annotations need to be resolved and applied in the parser.
> 	// The root class is not in any class, so `head->outer == nullptr`.
> 	annotation->apply(this, head, nullptr);
> }
> head->annotations.push_back(annotation);
> ```
> I skimmed through the parser code and didn't notice any cases where it looked like this would result in annotations being double-added to the list, but I may have missed something. If GDScript maintainers/experts think this would work fine, though, I can certainly make this change!
-->