### PR TITLE
Print warning when zero array is passed in RandomPCG::rand_weighted

### DIFF
--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -49,6 +49,7 @@ int64_t RandomPCG::rand_weighted(const Vector<float> &p_weights) {
 	const float *weights = p_weights.ptr();
 	float weights_sum = 0.0;
 	for (int64_t i = 0; i < weights_size; ++i) {
+		ERR_FAIL_COND_V_MSG(weights[i] < 0.0, -1, vformat("Weight array contains the negative value %f at index %d.", weights[i], i));
 		weights_sum += weights[i];
 	}
 

--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -60,6 +60,10 @@ int64_t RandomPCG::rand_weighted(const Vector<float> &p_weights) {
 			return i;
 		}
 	}
+	if (weights_sum == 0.0) {
+		WARN_PRINT("Weight array sum is zero.");
+		return -1;
+	}
 
 	for (int64_t i = weights_size - 1; i >= 0; --i) {
 		if (weights[i] > 0) {

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -21,9 +21,9 @@
 			<return type="int" />
 			<param index="0" name="weights" type="PackedFloat32Array" />
 			<description>
-				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
+				Returns a random integer between [code]0[/code] and the size of the array that is passed as a parameter. Each value in the array should be a non-negative floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of [code]0[/code] means it will never be returned as an index.
 				For example, if [code skip-lint][0.5, 1, 1, 2][/code] is passed as a parameter, then the method is twice as likely to return [code]3[/code] (the index of the value [code]2[/code]) and twice as unlikely to return [code]0[/code] (the index of the value [code]0.5[/code]) compared to the indices [code]1[/code] and [code]2[/code].
-				Prints an error and returns [code]-1[/code] if the array is empty.
+				Prints an error and returns [code]-1[/code] if the array is empty or contains any negative values.
 				[codeblocks]
 				[gdscript]
 				var rng = RandomNumberGenerator.new()


### PR DESCRIPTION
## What problem(s) does this PR solve?
When passing a zero array into RandomPCG::rand_weighted the function will fallback to returning `-1`.
As this most likely is due to a mistake being made when calling the function a warning is printed to notify the user of this.

## Additional information
This PR is built on #120004 and should be merged second to the original PR.
The solution I arrived at is based on the discussion in #120004 but may be subject to further discussion.

Short summary of #120004:
- Passing negative values make no sense and leads to nonsensical outcomes, thus now errors are thrown
- Handling that PR it was noticed that passing zero arrays doesn't make sense either in the face of "relative likelihoods"; currently returns `-1` without throwing an error or printing a warning, which could lead to issues.
- Discussed throwing an error which lead to a larger discussion, thus the fix was postponed to this PR.

I see three ways of handling zero arrays:

1. Throw an error and return `-1`
2. **Print a warning and return `-1`** (solution implemented)
3. *Return a uniformly random index, since all elements have the same relative `0` likelihood.*

I went with 2. for now, because it seemed to have the most people agreeing with it. Also i liked the reasoning "Since single elements are permitted 0 to have "0" value, why isn't all-0?" by @Ivorforce, so throwing an error felt kinda harsh.
About *3.*: This will surely not get implemented since it breaks stuff, I just wanted to mention it here because it could be what people expect to happen when a zero array is passed (same as any other array of all equal likelihoods). 