### PR TITLE
GDScript: Use extends line as range for MISSING_TOOL warning

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -452,7 +452,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 
 #ifdef DEBUG_ENABLED
 			if (!parser->_is_tool && ext_parser->get_parser()->_is_tool) {
-				parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
+				parser->push_warning(p_class->extends_start_line, p_class->extends_start_column, p_class->extends_end_line, p_class->extends_end_column, GDScriptWarning::MISSING_TOOL);
 			}
 #endif // DEBUG_ENABLED
 
@@ -486,7 +486,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 
 #ifdef DEBUG_ENABLED
 					if (!parser->_is_tool && base_parser->get_parser()->_is_tool) {
-						parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
+						parser->push_warning(p_class->extends_start_line, p_class->extends_start_column, p_class->extends_end_line, p_class->extends_end_column, GDScriptWarning::MISSING_TOOL);
 					}
 #endif // DEBUG_ENABLED
 
@@ -513,7 +513,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 
 #ifdef DEBUG_ENABLED
 				if (!parser->_is_tool && info_parser->get_parser()->_is_tool) {
-					parser->push_warning(p_class, GDScriptWarning::MISSING_TOOL);
+					parser->push_warning(p_class->extends_start_line, p_class->extends_start_column, p_class->extends_end_line, p_class->extends_end_column, GDScriptWarning::MISSING_TOOL);
 				}
 #endif // DEBUG_ENABLED
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1024,6 +1024,8 @@ void GDScriptParser::parse_class_name() {
 
 void GDScriptParser::parse_extends() {
 	current_class->extends_used = true;
+	current_class->extends_start_line = previous.start_line;
+	current_class->extends_start_column = previous.start_column;
 
 	int chain_index = 0;
 
@@ -1034,6 +1036,8 @@ void GDScriptParser::parse_extends() {
 		current_class->extends_path = previous.literal;
 
 		if (!match(GDScriptTokenizer::Token::PERIOD)) {
+			current_class->extends_end_line = previous.end_line;
+			current_class->extends_end_column = previous.end_column;
 			return;
 		}
 	}
@@ -1041,6 +1045,8 @@ void GDScriptParser::parse_extends() {
 	make_completion_context(COMPLETION_INHERIT_TYPE, current_class, chain_index++);
 
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected superclass name after "extends".)")) {
+		current_class->extends_end_line = previous.end_line;
+		current_class->extends_end_column = previous.end_column;
 		return;
 	}
 	current_class->extends.push_back(parse_identifier());
@@ -1048,10 +1054,15 @@ void GDScriptParser::parse_extends() {
 	while (match(GDScriptTokenizer::Token::PERIOD)) {
 		make_completion_context(COMPLETION_INHERIT_TYPE, current_class, chain_index++);
 		if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected superclass name after ".".)")) {
+			current_class->extends_end_line = previous.end_line;
+			current_class->extends_end_column = previous.end_column;
 			return;
 		}
 		current_class->extends.push_back(parse_identifier());
 	}
+
+	current_class->extends_end_line = previous.end_line;
+	current_class->extends_end_column = previous.end_column;
 }
 
 template <typename T>

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -762,6 +762,13 @@ public:
 		Vector<IdentifierNode *> extends; // List for indexing: extends A.B.C
 		DataType base_type;
 		String fqcn; // Fully-qualified class name. Identifies uniquely any class in the project.
+
+		// Range for a class's "extends <CLASS_NAME>" line.
+		// Used as range for some warnings/errors.
+		int extends_start_line = -1;
+		int extends_start_column = -1;
+		int extends_end_line = -1;
+		int extends_end_column = -1;
 #ifdef TOOLS_ENABLED
 		ClassDocData doc_data;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120175 

## Additional information

This PR allows the GDScript parser to capture the range of the `extends` line for a class, so that the `MISSING_TOOL` warning can specifically highlight that line instead of the entire contents of the class.

<img width="394" height="281" alt="CleanShot 2026-06-11 at 14 03 13@2x" src="https://github.com/user-attachments/assets/8ad83a4d-38c2-4a08-892a-6fc991103a06" />


> [!note]
> This PR contains duplicate code from #118552 which allows warnings to be applied for arbitrary ranges instead of whole parser nodes at a time. When one of these PRs is merged, I will edit the remaining one to remove the duplicate code.