### PR TITLE
Fix some 2D editor plugins not updating immediately with certain changes

### DIFF
--- a/editor/scene/2d/line_2d_editor_plugin.cpp
+++ b/editor/scene/2d/line_2d_editor_plugin.cpp
@@ -30,14 +30,26 @@
 
 #include "line_2d_editor_plugin.h"
 
+#include "core/object/callable_mp.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/scene/canvas_item_editor_plugin.h"
 
 Node2D *Line2DEditor::_get_node() const {
 	return node;
 }
 
 void Line2DEditor::_set_node(Node *p_line) {
+	CanvasItem *ci_editor_control = CanvasItemEditor::get_singleton()->get_viewport_control();
+
+	if (node) {
+		node->disconnect(SceneStringName(draw), callable_mp(ci_editor_control, &CanvasItem::queue_redraw));
+	}
+
 	node = Object::cast_to<Line2D>(p_line);
+	if (node) {
+		// Update the canvas overlay.
+		node->connect(SceneStringName(draw), callable_mp(ci_editor_control, &CanvasItem::queue_redraw));
+	}
 }
 
 bool Line2DEditor::_is_line() const {

--- a/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
@@ -138,8 +138,14 @@ void Cast2DEditor::edit(Node2D *p_node) {
 		canvas_item_editor = CanvasItemEditor::get_singleton();
 	}
 
+	if (node) {
+		node->disconnect(SceneStringName(draw), callable_mp((CanvasItem *)canvas_item_editor->get_viewport_control(), &CanvasItem::queue_redraw));
+	}
+
 	if (Object::cast_to<RayCast2D>(p_node) || Object::cast_to<ShapeCast2D>(p_node)) {
 		node = p_node;
+		// Update the canvas overlay.
+		node->connect(SceneStringName(draw), callable_mp((CanvasItem *)canvas_item_editor->get_viewport_control(), &CanvasItem::queue_redraw));
 	} else {
 		node = nullptr;
 	}

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -64,14 +64,19 @@ Node2D *Polygon2DEditor::_get_node() const {
 }
 
 void Polygon2DEditor::_set_node(Node *p_polygon) {
+	CanvasItem *ci_editor_control = CanvasItemEditor::get_singleton()->get_viewport_control();
+
 	CanvasItem *draw = Object::cast_to<CanvasItem>(canvas);
 	if (node) {
 		node->disconnect(SceneStringName(draw), callable_mp(draw, &CanvasItem::queue_redraw));
 		node->disconnect(SceneStringName(draw), callable_mp(this, &Polygon2DEditor::_update_available_modes));
+		node->disconnect(SceneStringName(draw), callable_mp(ci_editor_control, &CanvasItem::queue_redraw));
 	}
+
 	node = Object::cast_to<Polygon2D>(p_polygon);
 	_update_polygon_editing_state();
 	canvas->queue_redraw();
+
 	if (node) {
 		canvas->set_texture_filter(node->get_texture_filter_in_tree());
 
@@ -87,6 +92,8 @@ void Polygon2DEditor::_set_node(Node *p_polygon) {
 		// Whenever polygon gets redrawn, there's possible changes for the editor as well.
 		node->connect(SceneStringName(draw), callable_mp(draw, &CanvasItem::queue_redraw));
 		node->connect(SceneStringName(draw), callable_mp(this, &Polygon2DEditor::_update_available_modes));
+		// Update the canvas overlay.
+		node->connect(SceneStringName(draw), callable_mp(ci_editor_control, &CanvasItem::queue_redraw));
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120155.

## Additional information

`CanvasItemEditor` checks, on its own, if it needs to redraw if the surrounding rect of the node changes. The nodes detailed in the report can be modified without said rect changing, causing the issue.

I opted to fix this by ~adding signals for when the property used by the plugins are modified. If this method is too intrusive, another option is to just~ check if the nodes are queuing for a redraw, and then redraw the plugin when that happens.