### PR TITLE
Tiny portability fixes

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -52,7 +52,9 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 #include <cstdio>
 
 #ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS // to disable build-time warning which suggested to use strcpy_s instead strcpy
+#endif
 #endif
 
 #if defined(MINGW_ENABLED) || defined(_MSC_VER)

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -491,8 +491,7 @@ void RasterizerGLES3::set_boot_image_with_stretch(const Ref<Image> &p_image, con
 
 	Rect2 screenrect = RenderingServerTypes::get_splash_stretched_screen_rect(p_image->get_size(), win_size, p_stretch_mode);
 
-	if (!screen_flipped_y)
-	{
+	if (!screen_flipped_y) {
 		// Flip Y.
 		screenrect.position.y = win_size.y - screenrect.position.y;
 		screenrect.size.y = -screenrect.size.y;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -94,9 +94,7 @@
 #endif
 #endif // GLAD_ENABLED || EGL_ENABLED || ANDROID_ENABLED
 
-#ifdef WINDOWS_ENABLED
 bool RasterizerGLES3::screen_flipped_y = false;
-#endif
 
 void RasterizerGLES3::begin_frame(double frame_step) {
 	frame++;
@@ -416,11 +414,9 @@ void RasterizerGLES3::_blit_render_target_to_screen(DisplayServerEnums::WindowID
 		linear_to_srgb = true;
 	}
 
-#ifdef WINDOWS_ENABLED
 	if (screen_flipped_y) {
 		flip_y = !flip_y;
 	}
-#endif
 
 	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 
@@ -495,9 +491,7 @@ void RasterizerGLES3::set_boot_image_with_stretch(const Ref<Image> &p_image, con
 
 	Rect2 screenrect = RenderingServerTypes::get_splash_stretched_screen_rect(p_image->get_size(), win_size, p_stretch_mode);
 
-#ifdef WINDOWS_ENABLED
 	if (!screen_flipped_y)
-#endif
 	{
 		// Flip Y.
 		screenrect.position.y = win_size.y - screenrect.position.y;

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -57,9 +57,7 @@ private:
 
 	double time_total = 0.0;
 
-#ifdef WINDOWS_ENABLED
 	static bool screen_flipped_y;
-#endif
 
 protected:
 	GLES3::Config *config = nullptr;
@@ -113,11 +111,9 @@ public:
 
 	static void make_current(bool p_gles_over_gl);
 
-#ifdef WINDOWS_ENABLED
 	static void set_screen_flipped_y(bool p_flipped) {
 		screen_flipped_y = p_flipped;
 	}
-#endif
 
 	_ALWAYS_INLINE_ uint64_t get_frame_number() const { return frame; }
 	_ALWAYS_INLINE_ double get_frame_delta_time() const { return delta; }


### PR DESCRIPTION
Found these tiny problems when doing console ports. I don't think they should be controversial. 

1. Assuming _CRT_SECURE_NO_WARNINGS isn't defined is an error. 
2. If you don't want a check of screen_flipped_y or extra variable where it's not needed then I can infer some kind of build flag for it. 