### PR TITLE
Add custom ResourceLoaders and ResourceSavers after Autoloads are registered

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4489,9 +4489,6 @@ int Main::start() {
 			sml->get_root()->set_embedding_subwindows(true);
 		}
 
-		ResourceLoader::add_custom_loaders();
-		ResourceSaver::add_custom_savers();
-
 		if (!project_manager && !editor) { // game
 			if (!game_path.is_empty() || !script.is_empty()) {
 				//autoload
@@ -4563,6 +4560,9 @@ int Main::start() {
 				OS::get_singleton()->benchmark_end_measure("Startup", "Load Autoloads");
 			}
 		}
+
+		ResourceLoader::add_custom_loaders();
+		ResourceSaver::add_custom_savers();
 
 #ifdef TOOLS_ENABLED
 #ifdef MODULE_GDSCRIPT_ENABLED


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/120225 by adding custom `ResourceFormatLoaders` and `ResourceFormatSavers` after Autoload Singletons are registered as global constants with the Language Server.