### PR TITLE
Initialize multimesh buffers to 0

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1627,9 +1627,14 @@ void MeshStorage::_multimesh_allocate_data(RID p_multimesh, int p_instances, RSE
 	multimesh->visible_instances = MIN(multimesh->visible_instances, multimesh->instances);
 
 	if (multimesh->instances) {
+		uint32_t buffer_size = multimesh->instances * multimesh->stride_cache * sizeof(float);
+
+		LocalVector<uint8_t> zeros;
+		zeros.resize_initialized(buffer_size);
+
 		glGenBuffers(1, &multimesh->buffer[0]);
 		glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer[0]);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, multimesh->buffer[0], multimesh->instances * multimesh->stride_cache * sizeof(float), nullptr, GL_STATIC_DRAW, "MultiMesh buffer");
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, multimesh->buffer[0], buffer_size, zeros.ptr(), GL_STATIC_DRAW, "MultiMesh buffer");
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1595,7 +1595,9 @@ void MeshStorage::_multimesh_allocate_data(RID p_multimesh, int p_instances, RSE
 
 	if (multimesh->instances) {
 		uint32_t buffer_size = multimesh->instances * multimesh->stride_cache * sizeof(float);
-		multimesh->buffer = RD::get_singleton()->storage_buffer_create(buffer_size);
+		LocalVector<uint8_t> zeros;
+		zeros.resize_initialized(buffer_size);
+		multimesh->buffer = RD::get_singleton()->storage_buffer_create(buffer_size, zeros.span());
 	}
 
 	multimesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MULTIMESH);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes: https://github.com/godotengine/godot/issues/75485

## Additional information

In the editor, we read back the data from the GPU to display the buffer values. So when we create the buffer uninitialized, we end up reading back garbage data and displaying it in the editor.

Many GPUs zero-initialize buffers by default, but it isn't guaranteed behaviour, so its best to initialize it ourselves to be safe.

