### PR TITLE
Metal: Add depth resolve to the Metal rendering driver

### DIFF
--- a/drivers/metal/metal3_objects.cpp
+++ b/drivers/metal/metal3_objects.cpp
@@ -1144,7 +1144,21 @@ void MDCommandBuffer::render_next_subpass() {
 		ERR_FAIL_NULL_MSG(tex, "Frame buffer depth / stencil texture is null.");
 		if (attachment.type & MDAttachmentType::Depth) {
 			MTL::RenderPassDepthAttachmentDescriptor *da = desc->depthAttachment();
-			if (attachment.configureDescriptor(da, pf, subpass, tex, render.is_rendering_entire_area, false, false, false)) {
+
+			uint32_t resolveIdx = subpass.depth_resolve_reference.attachment;
+			bool has_resolve = resolveIdx != RDD::AttachmentReference::UNUSED;
+			bool can_resolve = true;
+			if (has_resolve) {
+				MTL::Texture *resolve_tex = fb.get_texture(resolveIdx);
+				can_resolve = flags::all(pf.getCapabilities(resolve_tex->pixelFormat()), kMTLFmtCapsResolve);
+				if (can_resolve) {
+					da->setResolveTexture(resolve_tex);
+				} else {
+					CRASH_NOW_MSG("unimplemented: using a texture format that is not supported for resolve");
+				}
+			}
+
+			if (attachment.configureDescriptor(da, pf, subpass, tex, render.is_rendering_entire_area, has_resolve, can_resolve, false)) {
 				da->setClearDepth(render.clear_values[idx].depth);
 			}
 		}

--- a/drivers/metal/metal_device_properties.cpp
+++ b/drivers/metal/metal_device_properties.cpp
@@ -152,6 +152,7 @@ void MetalDeviceProperties::init_features(MTL::Device *p_device) {
 	features.argument_buffers_tier = p_device->argumentBuffersSupport();
 	features.supports_image_atomic_32_bit = p_device->supportsFamily(MTL::GPUFamilyApple6);
 	features.supports_image_atomic_64_bit = p_device->supportsFamily(GPUFamilyApple9) || (p_device->supportsFamily(MTL::GPUFamilyApple8) && p_device->supportsFamily(MTL::GPUFamilyMac2));
+	features.supports_msaa_depth_resolve = p_device->supportsFamily(MTL::GPUFamilyMetal3) || p_device->supportsFamily(MTL::GPUFamilyApple3) || p_device->supportsFamily(MTL::GPUFamilyMac2);
 
 	if (features.msl_target_version >= MSL_VERSION_31) {
 		// Native atomics are only supported on 3.1 and above.

--- a/drivers/metal/metal_device_properties.h
+++ b/drivers/metal/metal_device_properties.h
@@ -121,6 +121,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalFeatures {
 	bool supports_native_image_atomics = false; /**< If true, native image atomic operations are supported by the OS. */
 	bool supports_border_color = false; /**< If true, sampler border color (clamp-to-border) is supported. Requires Apple7+. */
 	bool supports_residency_sets = false; /**< If true, residency sets (MTLResidencySet) are supported by the OS. */
+	bool supports_msaa_depth_resolve = false;
 
 	/*!
 	 * Check if argument buffers are fully supported, which requires tier 2 support and no need for argument encoders.

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -396,6 +396,7 @@ struct MDSubpass {
 	LocalVector<RDD::AttachmentReference> color_references;
 	RDD::AttachmentReference depth_stencil_reference;
 	LocalVector<RDD::AttachmentReference> resolve_references;
+	RDD::AttachmentReference depth_resolve_reference;
 
 	MTLFmtCaps getRequiredFmtCapsForAttachmentAt(uint32_t p_index) const;
 };

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1610,6 +1610,7 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 		subpass.color_references = p_subpasses[i].color_references;
 		subpass.depth_stencil_reference = p_subpasses[i].depth_stencil_reference;
 		subpass.resolve_references = p_subpasses[i].resolve_references;
+		subpass.depth_resolve_reference = p_subpasses[i].depth_resolve_reference;
 	}
 
 	static const MTL::LoadAction LOAD_ACTIONS[] = {
@@ -2691,6 +2692,8 @@ bool RenderingDeviceDriverMetal::has_feature(Features p_feature) {
 			return true;
 		case SUPPORTS_POINT_SIZE:
 			return true;
+		case SUPPORTS_FRAMEBUFFER_DEPTH_RESOLVE:
+			return device_properties->features.supports_msaa_depth_resolve;
 		default:
 			return false;
 	}

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -209,15 +209,15 @@ bool OpenXRMetalExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int
 			break;
 		case MTLPixelFormatDepth32Float:
 			format = RenderingDevice::DATA_FORMAT_D32_SFLOAT;
-			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RenderingDevice::TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT;
 			break;
 		case MTLPixelFormatDepth24Unorm_Stencil8:
 			format = RenderingDevice::DATA_FORMAT_D24_UNORM_S8_UINT;
-			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RenderingDevice::TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT;
 			break;
 		case MTLPixelFormatDepth32Float_Stencil8:
 			format = RenderingDevice::DATA_FORMAT_D32_SFLOAT_S8_UINT;
-			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RenderingDevice::TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT;
 			break;
 		default:
 			// Continue with our default value.


### PR DESCRIPTION
Dear Godot Community,

We are contributing visionOS support in https://github.com/godotengine/godot/pull/109975. This follow-up fully wires up depth resolve to the Metal rendering driver, enabling MSAA support for the visionOS XR Module (visionOS requires a valid depth texture to render).

Note, this was independently implemented by @huseindenanhai in https://github.com/godotengine/godot/pull/112439 The approach in his implementation is equivalent (thanks!).

_Disclaimer: Claude Code was used to assist in development. Claude was used to extract the isolated change from a larger change-set, and to assist in rebasing on top of master. The code was written and reviewed by Apple employees, and tested on real hardware before being submitted._