### PR TITLE
Automatically focus the renaming field when adding/renaming an animation marker in AnimationPlayer

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -9669,6 +9669,8 @@ void AnimationMarkerEdit::_insert_marker(float p_ofs) {
 	}
 
 	marker_insert_new_name->set_text(base);
+	marker_insert_new_name->select_all();
+	marker_insert_new_name->grab_focus();
 	_marker_insert_new_name_changed(base);
 	marker_insert_ofs = p_ofs;
 }
@@ -9677,6 +9679,8 @@ void AnimationMarkerEdit::_rename_marker(const StringName &p_name) {
 	marker_rename_confirm->popup_centered(Size2i(200, 0) * EDSCALE);
 	marker_rename_prev_name = p_name;
 	marker_rename_new_name->set_text(p_name);
+	marker_rename_new_name->select_all();
+	marker_rename_new_name->grab_focus();
 }
 
 void AnimationMarkerEdit::_marker_insert_confirmed() {


### PR DESCRIPTION
Fixes [godotengine/godot-proposals/issues/14989](https://github.com/godotengine/godot-proposals/issues/14989) 

Automatically focus and select all of the text label when adding/renaming an animation marker. Similar to adding a new animation.

<img width="1228" height="554" alt="automatically_focus_marker" src="https://github.com/user-attachments/assets/9d56cda4-5fae-42de-9072-ab193c87e33d" />



