### PR TITLE
Enable Quick Open Dialog to open text files

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -941,10 +941,11 @@ bool EditorFileSystem::_update_scan_actions() {
 
 						ia.new_file->uid = existing_id;
 					}
-				} else if (ResourceLoader::should_create_uid_file(new_file_path)) {
+				} else if (_should_create_uid_file(new_file_path)) {
 					Ref<FileAccess> f = FileAccess::open(new_file_path + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
 						ia.new_file->uid = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
+						ResourceUID::get_singleton()->add_id(ia.new_file->uid, new_file_path);
 						f->store_line(ResourceUID::get_singleton()->id_to_text(ia.new_file->uid));
 					}
 				}
@@ -1381,7 +1382,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				}
 			}
 
-			if (ResourceLoader::should_create_uid_file(path)) {
+			if (_should_create_uid_file(path)) {
 				// Create a UID file and new UID, if it's invalid.
 				Ref<FileAccess> f = FileAccess::open(path + ".uid", FileAccess::WRITE);
 				if (f.is_valid()) {
@@ -2502,7 +2503,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 
 				ResourceUID::get_singleton()->update_cache();
 			} else {
-				if (ResourceLoader::should_create_uid_file(file)) {
+				if (_should_create_uid_file(file)) {
 					Ref<FileAccess> f = FileAccess::open(file + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
 						const ResourceUID::ID id = ResourceUID::get_singleton()->create_id_for_path(file);
@@ -3141,7 +3142,7 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 
 		// Make sure it's immediately added to the map so we can remap dependencies if we want to after this.
 		ResourceUID::get_singleton()->add_id(res_uid, p_to);
-	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID) {
+	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID || textfile_extensions.has(p_from.get_extension().to_lower())) {
 		// Files which do not use an uid can just be copied.
 		Error err = da->copy(p_from, p_to);
 		if (err != OK) {
@@ -3772,6 +3773,16 @@ bool EditorFileSystem::_can_import_file(const String &p_file) {
 	}
 
 	return false;
+}
+
+bool EditorFileSystem::_should_create_uid_file(const String &p_path) {
+	if (FileAccess::exists(p_path + ".uid")) {
+		return false;
+	}
+	if (textfile_extensions.has(p_path.get_extension().to_lower())) {
+		return true;
+	}
+	return ResourceLoader::should_create_uid_file(p_path);
 }
 
 void EditorFileSystem::add_import_format_support_query(Ref<EditorFileSystemImportFormatSupportQuery> p_query) {

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -373,6 +373,8 @@ class EditorFileSystem : public Node {
 
 	void _register_global_class_script(const String &p_search_path, const String &p_target_path, const ScriptClassInfoUpdate &p_script_update);
 
+	bool _should_create_uid_file(const String &p_path);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -683,7 +683,7 @@ void QuickOpenResultContainer::_find_uids_in_folder(EditorFileSystemDirectory *p
 		const StringName &actual_type = is_engine_type ? engine_type : script_type;
 
 		for (const StringName &parent_type : base_types) {
-			bool is_valid = ClassDB::is_parent_class(engine_type, parent_type) || (!is_engine_type && EditorNode::get_editor_data().script_class_is_parent(script_type, parent_type));
+			bool is_valid = ClassDB::is_parent_class(engine_type, parent_type) || (!is_engine_type && EditorNode::get_editor_data().script_class_is_parent(script_type, parent_type)) || (engine_type == "TextFile");
 
 			if (is_valid) {
 				uids.push_back(uid);


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Enable Quick Open Dialog to open text files
- Closes #119969

## Additional information
-QuickOpenDialog uses uid instead of file path,so I add .uid files to text files for QuickOpenDialog to use.
-I add “ engine_type == "TextFile" ” expression to solve the problem that Quick Open does not find text files before they are opened.