### PR TITLE
Fix oversampling not updating when parent scale changes

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -336,7 +336,7 @@ void CanvasItem::_update_oversampling(bool p_propagate) {
 	if (p_propagate) {
 		for (uint32_t n = 0; n < data.canvas_item_children.size(); n++) {
 			CanvasItem *ci = data.canvas_item_children[n];
-			if (!ci->top_level && ci->get_oversampling_with_scale() == OVERSAMPLING_WITH_SCALE_PARENT_NODE) {
+			if (!ci->top_level && ci->get_oversampling_with_scale() != OVERSAMPLING_WITH_SCALE_DISABLED) {
 				ci->_update_oversampling(p_propagate);
 			}
 		}
@@ -1175,7 +1175,7 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 	 * notification anyway).
 	 */
 
-	_update_oversampling(false);
+	p_node->_update_oversampling(true);
 
 	if (/*p_node->xform_change.in_list() &&*/ p_node->_is_global_invalid()) {
 		return; //nothing to do


### PR DESCRIPTION
Fixes #120235

### Description

When a parent CanvasItem's scale was modified, child CanvasItems with `oversampling_with_scale` enabled would not automatically resample their textures (especially DPITexture) and fonts until the child's transform was directly modified (e.g., by changing position).