### PR TITLE
Deprecate `_get_stream_name`

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -45,10 +45,10 @@
 				Return the controllable parameters of this stream. This array contains dictionaries with a property info description format (see [method Object.get_property_list]). Additionally, the default value for this parameter must be added tho each dictionary in "default_value" field.
 			</description>
 		</method>
-		<method name="_get_stream_name" qualifiers="virtual const">
+		<method name="_get_stream_name" qualifiers="virtual const" deprecated="This method is not used by the engine.">
 			<return type="String" />
 			<description>
-				Override this method to customize the name assigned to this audio stream. Unused by the engine.
+				Override this method to customize the name assigned to this audio stream.
 			</description>
 		</method>
 		<method name="_get_tags" qualifiers="virtual const">

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -44,10 +44,6 @@ Ref<AudioStreamPlayback> AudioStreamInteractive::instantiate_playback() {
 	return playback_transitioner;
 }
 
-String AudioStreamInteractive::get_stream_name() const {
-	return "Transitioner";
-}
-
 void AudioStreamInteractive::set_clip_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0 || p_count > MAX_CLIPS);
 

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -180,7 +180,6 @@ public:
 	PackedInt32Array get_transition_list() const;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 	virtual double get_length() const override { return 0; }
 	virtual bool is_meta_stream() const override { return true; }
 

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -42,10 +42,6 @@ Ref<AudioStreamPlayback> AudioStreamPlaylist::instantiate_playback() {
 	return playback_playlist;
 }
 
-String AudioStreamPlaylist::get_stream_name() const {
-	return "Playlist";
-}
-
 void AudioStreamPlaylist::set_list_stream(int p_stream_index, Ref<AudioStream> p_stream) {
 	ERR_FAIL_COND(p_stream == this);
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -67,7 +67,6 @@ public:
 	Ref<AudioStream> get_list_stream(int p_stream_index) const;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 	virtual double get_length() const override;
 	virtual bool is_meta_stream() const override { return true; }
 

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -45,10 +45,6 @@ Ref<AudioStreamPlayback> AudioStreamSynchronized::instantiate_playback() {
 	return playback_playlist;
 }
 
-String AudioStreamSynchronized::get_stream_name() const {
-	return "Synchronized";
-}
-
 void AudioStreamSynchronized::set_sync_stream(int p_stream_index, Ref<AudioStream> p_stream) {
 	ERR_FAIL_COND(p_stream == this);
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -63,7 +63,6 @@ public:
 	float get_sync_stream_volume(int p_stream_index) const;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 	virtual double get_length() const override;
 	virtual bool is_meta_stream() const override { return true; }
 

--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -211,10 +211,6 @@ Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
 	return mp3s;
 }
 
-String AudioStreamMP3::get_stream_name() const {
-	return ""; //return stream_name;
-}
-
 void AudioStreamMP3::clear_data() {
 	data.clear();
 }

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -131,7 +131,6 @@ public:
 	virtual int get_bar_beats() const override;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	void set_data(const Vector<uint8_t> &p_data);
 	Vector<uint8_t> get_data() const;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -428,10 +428,6 @@ Ref<AudioStreamPlayback> AudioStreamOggVorbis::instantiate_playback() {
 	return nullptr;
 }
 
-String AudioStreamOggVorbis::get_stream_name() const {
-	return ""; //return stream_name;
-}
-
 void AudioStreamOggVorbis::maybe_update_info() {
 	ERR_FAIL_COND(packet_sequence.is_null());
 

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -161,7 +161,6 @@ public:
 	virtual Dictionary get_tags() const override;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	void set_packet_sequence(Ref<OggPacketSequence> p_packet_sequence);
 	Ref<OggPacketSequence> get_packet_sequence() const;

--- a/scene/resources/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio_stream_polyphonic.cpp
@@ -44,10 +44,6 @@ Ref<AudioStreamPlayback> AudioStreamPolyphonic::instantiate_playback() {
 	return playback;
 }
 
-String AudioStreamPolyphonic::get_stream_name() const {
-	return "AudioStreamPolyphonic";
-}
-
 bool AudioStreamPolyphonic::is_monophonic() const {
 	return true; // This avoids stream players to instantiate more than one of these.
 }

--- a/scene/resources/audio_stream_polyphonic.h
+++ b/scene/resources/audio_stream_polyphonic.h
@@ -45,7 +45,6 @@ class AudioStreamPolyphonic : public AudioStream {
 
 public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 	virtual bool is_monophonic() const override;
 
 	void set_polyphony(int p_voices);

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -625,10 +625,6 @@ Ref<AudioStreamPlayback> AudioStreamWAV::instantiate_playback() {
 	return sample;
 }
 
-String AudioStreamWAV::get_stream_name() const {
-	return "";
-}
-
 Ref<AudioSample> AudioStreamWAV::generate_sample() const {
 	Ref<AudioSample> sample;
 	sample.instantiate();

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -164,7 +164,6 @@ public:
 	Error save_to_wav(const String &p_path);
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	virtual bool can_be_sampled() const override {
 		return true;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -244,11 +244,6 @@ Ref<AudioStreamPlayback> AudioStream::instantiate_playback() {
 	GDVIRTUAL_CALL(_instantiate_playback, ret);
 	return ret;
 }
-String AudioStream::get_stream_name() const {
-	String ret;
-	GDVIRTUAL_CALL(_get_stream_name, ret);
-	return ret;
-}
 
 double AudioStream::get_length() const {
 	double ret = 0;
@@ -340,7 +335,9 @@ void AudioStream::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_meta_stream"), &AudioStream::is_meta_stream);
 
 	GDVIRTUAL_BIND(_instantiate_playback);
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_get_stream_name);
+#endif
 	GDVIRTUAL_BIND(_get_length);
 	GDVIRTUAL_BIND(_is_monophonic);
 	GDVIRTUAL_BIND(_get_bpm)
@@ -365,13 +362,6 @@ Ref<AudioStreamPlayback> AudioStreamMicrophone::instantiate_playback() {
 	playback->active = false;
 
 	return playback;
-}
-
-String AudioStreamMicrophone::get_stream_name() const {
-	//if (audio_stream.is_valid()) {
-	//return "Random: " + audio_stream->get_name();
-	//}
-	return "Microphone";
 }
 
 double AudioStreamMicrophone::get_length() const {
@@ -718,10 +708,6 @@ Ref<AudioStreamPlayback> AudioStreamRandomizer::instantiate_playback() {
 		default:
 			ERR_FAIL_V_MSG(nullptr, "Unhandled playback mode.");
 	}
-}
-
-String AudioStreamRandomizer::get_stream_name() const {
-	return "Randomizer";
 }
 
 double AudioStreamRandomizer::get_length() const {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -170,7 +170,9 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL0RC_REQUIRED(Ref<AudioStreamPlayback>, _instantiate_playback)
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL0RC(String, _get_stream_name)
+#endif
 	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)
 	GDVIRTUAL0RC(double, _get_bpm)
@@ -182,7 +184,6 @@ protected:
 
 public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback();
-	virtual String get_stream_name() const;
 
 	virtual double get_bpm() const;
 	virtual bool has_loop() const;
@@ -227,7 +228,6 @@ class AudioStreamMicrophone : public AudioStream {
 
 public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	virtual double get_length() const override; //if supported, otherwise return 0
 
@@ -337,7 +337,6 @@ public:
 	PlaybackMode get_playback_mode() const;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	virtual double get_length() const override; //if supported, otherwise return 0
 	virtual bool is_monophonic() const override;

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -78,10 +78,6 @@ Ref<AudioStreamPlayback> AudioStreamGenerator::instantiate_playback() {
 	return playback;
 }
 
-String AudioStreamGenerator::get_stream_name() const {
-	return "UserFeed";
-}
-
 double AudioStreamGenerator::get_length() const {
 	return 0;
 }

--- a/servers/audio/effects/audio_stream_generator.h
+++ b/servers/audio/effects/audio_stream_generator.h
@@ -65,7 +65,6 @@ public:
 	float get_buffer_length() const;
 
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
-	virtual String get_stream_name() const override;
 
 	virtual double get_length() const override;
 	virtual bool is_monophonic() const override;

--- a/tests/scene/test_audio_stream_wav.cpp
+++ b/tests/scene/test_audio_stream_wav.cpp
@@ -203,7 +203,6 @@ TEST_CASE("[Audio][AudioStreamWAV] Default values") {
 	CHECK(stream->get_length() == 0);
 	CHECK(stream->is_monophonic() == false);
 	CHECK(stream->get_data() == Vector<uint8_t>{});
-	CHECK(stream->get_stream_name() == "");
 }
 
 TEST_CASE("[Audio][AudioStreamWAV] Save empty file") {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/86935
- Supersedes https://github.com/godotengine/godot/pull/120168

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Alternative PR for https://github.com/godotengine/godot/pull/120168
Deprecating because the normal method isn't exposed, and there's really no need for this to exist.
Metadata title is available through` AudioStreamWAV.tags` (MP3 and OggVorbis do not have this method). Resource name isn't available since `Resource.name` isn't set by default.