### PR TITLE
Jolt: Remove forced area event queuing during body exit

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -611,52 +611,6 @@ bool JoltArea3D::shape_exited(const JPH::BodyID &p_body_id, const JPH::SubShapeI
 	return body_shape_exited(p_body_id, p_other_shape_id, p_self_shape_id) || area_shape_exited(p_body_id, p_other_shape_id, p_self_shape_id);
 }
 
-void JoltArea3D::body_exited(const JPH::BodyID &p_body_id, bool p_notify) {
-	Overlap *overlap = bodies_by_id.getptr(p_body_id);
-	if (unlikely(overlap == nullptr)) {
-		return;
-	}
-
-	if (unlikely(overlap->shape_pairs.is_empty())) {
-		return;
-	}
-
-	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		if (!overlap->pending_added.erase(E.value)) {
-			overlap->pending_removed.push_back(E.value);
-		}
-	}
-
-	_events_changed();
-
-	overlap->shape_pairs.clear();
-
-	if (p_notify) {
-		_notify_body_exited(p_body_id);
-	}
-}
-
-void JoltArea3D::area_exited(const JPH::BodyID &p_body_id) {
-	Overlap *overlap = areas_by_id.getptr(p_body_id);
-	if (unlikely(overlap == nullptr)) {
-		return;
-	}
-
-	if (unlikely(overlap->shape_pairs.is_empty())) {
-		return;
-	}
-
-	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		if (!overlap->pending_added.erase(E.value)) {
-			overlap->pending_removed.push_back(E.value);
-		}
-	}
-
-	_events_changed();
-
-	overlap->shape_pairs.clear();
-}
-
 void JoltArea3D::call_queries() {
 	_flush_events(bodies_by_id, body_monitor_callback);
 	_flush_events(areas_by_id, area_monitor_callback);

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -241,8 +241,6 @@ public:
 	bool area_shape_exited(const JPH::BodyID &p_body_id, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 
 	bool shape_exited(const JPH::BodyID &p_body_id, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
-	void body_exited(const JPH::BodyID &p_body_id, bool p_notify = true);
-	void area_exited(const JPH::BodyID &p_body_id);
 
 	void call_queries();
 

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -389,17 +389,12 @@ void JoltBody3D::_destroy_joint_constraints() {
 	}
 }
 
-void JoltBody3D::_exit_all_areas() {
+void JoltBody3D::_clear_areas() {
 	if (!in_space()) {
 		return;
 	}
 
-	for (JoltArea3D *area : areas) {
-		area->body_exited(jolt_body->GetID(), false);
-	}
-
 	areas.clear();
-
 	_areas_changed();
 }
 
@@ -435,7 +430,7 @@ void JoltBody3D::_space_changing() {
 	sleep_initially = is_sleeping();
 
 	_destroy_joint_constraints();
-	_exit_all_areas();
+	_clear_areas();
 	_dequeue_call_queries();
 }
 

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -135,7 +135,7 @@ private:
 
 	void _destroy_joint_constraints();
 
-	void _exit_all_areas();
+	void _clear_areas();
 
 	void _mode_changed();
 	virtual void _shapes_committed() override;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120193.

## Additional information

`JoltBody3D::_exit_all_areas` currently notifies every overlapping `Area3D` of its removal whenever it leaves a physics space, forcing the overlapping areas to add the relevant events and queue up a flush of said events.

This code stems back to the Godot Jolt extension days, and `JoltArea3D` has seen a number of simplifications since then, and when looking at `JoltBody3D::_exit_all_areas` and `JoltArea3D::body_exited` now I'm fairly convinced that none of this needs to happen in the first place.

Instead we can simply change `JoltBody3D::_exit_all_areas` to be `JoltBody3D::_clear_areas` and have it only deal with clearing out the body's internal references to the areas it overlaps, which still needs to happen.

That way we don't have to worry about whether or not to queue up `JoltArea3D::Overlap::pending_removed` and all that if/when there's a `pending_added` event already, we can instead just rely on `JoltContactListener3D` to notify the area like it normally does, once Jolt itself picks up on the body's removal at the simulation step.

This seems to solve #120193 while not regressing on #118285 nor the issue that prompted this code in the first place, godot-jolt/godot-jolt#773.

(`JoltArea3D::area_exited` was dead code from the start, and something I likely just added for "symmetry".)