### PR TITLE
Fix parameter "scenario" is null

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -852,6 +852,9 @@ void RendererSceneCull::instance_set_scenario(RID p_instance, RID p_scenario) {
 			case RSE::INSTANCE_REFLECTION_PROBE: {
 				InstanceReflectionProbeData *reflection_probe = static_cast<InstanceReflectionProbeData *>(instance->base_data);
 				RSG::light_storage->reflection_probe_release_atlas_index(reflection_probe->instance);
+				if (reflection_probe->update_list.in_list()) {
+					reflection_probe_render_list.remove(&reflection_probe->update_list);
+				}
 
 			} break;
 			case RSE::INSTANCE_PARTICLES_COLLISION: {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #86456

## Additional information
It seems that some cleanup is required not only in [void RendererSceneCull::instance_set_base(RID p_instance, RID p_base)](https://github.com/godotengine/godot/blob/eb03ae8fc5465793f8f617d7a320e3b208f16919/servers/rendering/renderer_scene_cull.cpp#L639) but also in [void RendererSceneCull::instance_set_scenario(RID p_instance, RID p_scenario)](https://github.com/godotengine/godot/blob/eb03ae8fc5465793f8f617d7a320e3b208f16919/servers/rendering/renderer_scene_cull.cpp#L852).