### PR TITLE
Fix navigation agents unconditionally getting added to avoidance simulation after pause resume

### DIFF
--- a/modules/navigation_2d/nav_agent_2d.cpp
+++ b/modules/navigation_2d/nav_agent_2d.cpp
@@ -284,7 +284,7 @@ void NavAgent2D::set_paused(bool p_paused) {
 	if (map) {
 		if (paused) {
 			map->remove_agent_as_controlled(this);
-		} else {
+		} else if (avoidance_enabled) {
 			map->set_agent_as_controlled(this);
 		}
 	}

--- a/modules/navigation_3d/nav_agent_3d.cpp
+++ b/modules/navigation_3d/nav_agent_3d.cpp
@@ -394,7 +394,7 @@ void NavAgent3D::set_paused(bool p_paused) {
 	if (map) {
 		if (paused) {
 			map->remove_agent_as_controlled(this);
-		} else {
+		} else if (avoidance_enabled) {
 			map->set_agent_as_controlled(this);
 		}
 	}


### PR DESCRIPTION
Fixes #120246

### Description

When `SceneTree.set_pause(false)` was called, NavigationAgent2D and NavigationAgent3D would cause massive CPU usage increase (from ~5% to ~40% with 2000 agents). 

The root cause was in the `set_paused()` method in both `NavAgent2D` and `NavAgent3D` classes. When unpausing, agents were unconditionally added to the `active_avoidance_agents` list via `map->set_agent_as_controlled(this)`, regardless of whether `avoidance_enabled` was true.

This meant all agents (even those with avoidance disabled) were being processed by the RVO collision avoidance simulation every frame, creating unnecessary CPU load.