### PR TITLE
Revert "Fix a deadlock in WorkerThreadPool"

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -31,7 +31,6 @@
 #include "message_queue.h"
 
 #include "core/config/project_settings.h"
-#include "main/main.h"
 
 #include <cstdio>
 
@@ -223,10 +222,6 @@ void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args
 }
 
 Error CallQueue::flush() {
-	if (!Main::is_iterating()) {
-		return ERR_BUSY;
-	}
-
 	LOCK_MUTEX;
 
 	if (pages.is_empty()) {

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -452,18 +452,7 @@ Error WorkerThreadPool::wait_for_task_completion(TaskID p_task_id) {
 		}
 	} else {
 		task_mutex.unlock();
-		if (Thread::is_main_thread()) {
-			// If we are the main thread we can't block the messagequeue
-			while (!task->done_semaphore.try_wait()) {
-				if (MessageQueue::get_singleton()) {
-					MessageQueue::get_singleton()->flush();
-				}
-
-				OS::get_singleton()->delay_usec(100);
-			}
-		} else {
-			task->done_semaphore.wait();
-		}
+		task->done_semaphore.wait();
 		task_mutex.lock();
 		task->waiting_user--;
 		if (task->waiting_pool == 0 && task->waiting_user == 0) {
@@ -750,18 +739,7 @@ void WorkerThreadPool::wait_for_group_task_completion(GroupID p_group) {
 		if (this == singleton) {
 			_unlock_unlockable_mutexes();
 		}
-		if (Thread::is_main_thread()) {
-			// If we are the main thread we can't block the messagequeue
-			while (!group->done_semaphore.try_wait()) {
-				if (MessageQueue::get_singleton()) {
-					MessageQueue::get_singleton()->flush();
-				}
-
-				OS::get_singleton()->delay_usec(100);
-			}
-		} else {
-			group->done_semaphore.wait();
-		}
+		group->done_semaphore.wait();
 		if (this == singleton) {
 			_lock_unlockable_mutexes();
 		}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -875,7 +875,6 @@ Error Main::test_setup() {
 
 	ClassDB::set_current_api(ClassDB::API_NONE);
 
-	iterating++;
 	_start_success = true;
 
 	return OK;
@@ -884,7 +883,6 @@ Error Main::test_setup() {
 // The order is the same as in `Main::cleanup()`.
 void Main::test_cleanup() {
 	ERR_FAIL_COND(!_start_success);
-	iterating--;
 
 	// Printing in the usual way can become problematic during/after cleanup.
 	CoreGlobals::print_ready = false;


### PR DESCRIPTION
This turned out to break a lot of things in the engine unexpectedly. The actual deadlock that this fixes seems rare so a better approach is needed.

For 4.7 we should drop this one.

This reverts commit ae564feb2afa67a209b6eab52080639c73f20bd9.
This reverts commit 7ab83282045b5031f07a6709d5f90af023ae8090.

This fixes #120223
This fixes #120228

* *Bugsquad edit, reverts: https://github.com/godotengine/godot/pull/120111*
* *Bugsquad edit, reverts: https://github.com/godotengine/godot/pull/120072*