### PR TITLE
Fix for voxelGI global illumination center on AreaLight3Ds being calculated incorrectly

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
@@ -362,7 +362,7 @@ bool compute_area_light(uint index, vec3 pos, vec3 normal, inout vec3 light) {
 	vec3 area_height_norm = normalize(area_height);
 	float a_half_len = a_len / 2.0;
 	float b_half_len = b_len / 2.0;
-	vec3 light_center = lights.data[index].position + (area_width + area_height) / 2.0;
+	vec3 light_center = lights.data[index].position;
 	vec3 light_to_vert = vertex - light_center;
 	vec3 pos_local_to_light = vec3(dot(light_to_vert, area_width_norm), dot(light_to_vert, area_height_norm), dot(light_to_vert, -area_direction)); // vertex in LIGHT SPACE
 	vec3 closest_point_local_to_light = vec3(clamp(pos_local_to_light.x, -a_half_len, a_half_len), clamp(pos_local_to_light.y, -b_half_len, b_half_len), 0); // LIGHT SPACE


### PR DESCRIPTION
This change fixes an issue where voxelGI global illumination wouldn't show up on large AreaLight3D nodes due to their center being calculated incorrectly.

## What problem(s) does this PR solve?

- Closes #120178 

## Additional information
Fix comes from @sarcen on the godot discord server (https://discord.com/channels/1235157165589794909/1514447746700939294/1514798604618043463), just implementing their fix into a pull request.