### PR TITLE
Fix MultiMeshInstance3D normal scaling with non-uniform transforms

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -343,7 +343,20 @@ void vertex_shader(vec3 vertex_input,
 		model_matrix = read_model_matrix;
 #endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 #endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
-		model_normal_matrix = model_normal_matrix * mat3(matrix);
+		mat3 multimesh_transform = mat3(matrix);
+		vec3 scale_vec = vec3(
+				length(multimesh_transform[0]),
+				length(multimesh_transform[1]),
+				length(multimesh_transform[2]));
+		const float scale_epsilon = 0.0001;
+		bool has_non_uniform_scale = (abs(scale_vec.x - scale_vec.y) > scale_epsilon) ||
+				(abs(scale_vec.x - scale_vec.z) > scale_epsilon) ||
+				(abs(scale_vec.y - scale_vec.z) > scale_epsilon);
+		if (has_non_uniform_scale) {
+			model_normal_matrix = model_normal_matrix * transpose(inverse(multimesh_transform));
+		} else {
+			model_normal_matrix = model_normal_matrix * multimesh_transform;
+		}
 	}
 
 	vec3 vertex = vertex_input;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -383,7 +383,20 @@ void vertex_shader(in vec3 vertex,
 		model_matrix = read_model_matrix;
 #endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 #endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
-		model_normal_matrix = model_normal_matrix * mat3(matrix);
+		mat3 multimesh_transform = mat3(matrix);
+		vec3 scale_vec = vec3(
+				length(multimesh_transform[0]),
+				length(multimesh_transform[1]),
+				length(multimesh_transform[2]));
+		const float scale_epsilon = 0.0001;
+		bool has_non_uniform_scale = (abs(scale_vec.x - scale_vec.y) > scale_epsilon) ||
+				(abs(scale_vec.x - scale_vec.z) > scale_epsilon) ||
+				(abs(scale_vec.y - scale_vec.z) > scale_epsilon);
+		if (has_non_uniform_scale) {
+			model_normal_matrix = model_normal_matrix * transpose(inverse(multimesh_transform));
+		} else {
+			model_normal_matrix = model_normal_matrix * multimesh_transform;
+		}
 	}
 
 #ifdef UV_USED


### PR DESCRIPTION
Fixes #120219

### Description

Fixes incorrect normal transformation for MultiMeshInstance3D when individual instances have non-uniform scaling applied via the buffer. Previously, normals were transformed using the instance transform matrix directly, which caused incorrect lighting when meshes were scaled non-uniformly (e.g., scale of `<1, 3, 1>`).