### PR TITLE
Jolt: Fix gravity scale not updating when set from code

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -1246,6 +1246,7 @@ void JoltBody3D::set_gravity_scale(float p_scale) {
 		jolt_settings->mGravityFactor = p_scale;
 	} else {
 		jolt_body->GetMotionPropertiesUnchecked()->SetGravityFactor(p_scale);
+		_update_environmental_properties();
 	}
 }
 


### PR DESCRIPTION
Fixes #120256.

### Description

After PR #118197, setting `gravity_scale` on a `RigidBody3D` from code in `_ready()` or `_physics_process()` had no effect when using Jolt Physics. This happened because `set_gravity_scale()` wasn't calling `_update_environmental_properties()` to recalculate `total_gravity` with the new gravity factor.