### PR TITLE
Clean up & shorten PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,21 @@
 <!--
-Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
-
-Before submitting, please read our checklist for contributors:
+Please target the `master` branch and read our checklist for contributors:
 https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-
-Use of AI must be disclosed and should include a description of how it was used.
 -->
 
-## What problem(s) does this PR solve?
+## Problem(s) solved by this PR
 
 - Closes #
 
 ## Additional information
 
 <!--
-Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
+Provide an explanation of your PR, including parts that you are uncertain of or require special attention from reviewers. PR description guidelines can be found here: 
+https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
+-->
+
+## Author disclosure
+
+<!--
+If you did not write any part of this PR yourself, disclose that here. If you used AI for this PR, disclose what you used AI for specifically.
 -->


### PR DESCRIPTION
## Problem(s) solved by this PR

The current PR template is a bit verbose. I've heard many contributors say they dislike it, despite understanding why it's there. To weaken that ever-so-strong desire to want to `Ctrl` + `A` and `delete` the whole thing, this PR is an attempt to make it more succinct while keeping the most meaningful / guiding / educational info present.

## Additional information

- I removed a few boilerplate niceties and new lines so the whole header can be shrunk down a few lines. Really makes a difference in readability.
- I removed the unnecessary explaining of why master needs to be targeted. That info could be (should be) found under the linked page; the rule is simple, and the explanation doesn't need to be there.
- Links in plain text are annoying for… reasons. In the latest revision I left them, but I would personally probably remove the second link...
- The links are sooooooo long, my god. Can't we have a shorter link that redirects or something? Like... `https://godotengine.org/pr-checklist`?
- I included https://github.com/godotengine/godot/pull/119894

## Author disclosure

No generative AI was used for this PR.