### PR TITLE
EditorPropertyArray clipping fix

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -263,7 +263,8 @@ void EditorPropertyArray::_update_slots_size() {
 
 			Ref<Font> font = theme_cache.font;
 			int font_size = theme_cache.font_size;
-			name_size = slots[0].reorder_button->get_minimum_size().x + theme_cache.horizontal_separation + font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+			int half_padding = theme_cache.padding / 2;
+			name_size = slots[0].reorder_button->get_minimum_size().x + theme_cache.horizontal_separation + half_padding + font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 		}
 		slot.prop->set_name_fixed_size(name_size);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120260

## Additional information

`update_slots_size()` does not include `theme_cache.padding / 2` when computing the fixed label column width, making it too narrow for two-digit indices.

<img width="250" src="https://github.com/user-attachments/assets/d353cae2-1039-42bc-8302-702ee3f3b493" />

before


<img width="250" src="https://github.com/user-attachments/assets/4521c242-95a6-4b03-80e4-f8c61081b491" />

after


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
