### PR TITLE
Fix array index labels truncated after index 9 in inspector

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -263,10 +263,7 @@ void EditorPropertyArray::_update_slots_size() {
 
 			Ref<Font> font = theme_cache.font;
 			int font_size = theme_cache.font_size;
-			name_size = slots[0].reorder_button->get_minimum_size().x
-					+ theme_cache.horizontal_separation
-					+ theme_cache.font_offset
-					+ font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+			name_size = slots[0].reorder_button->get_minimum_size().x + theme_cache.horizontal_separation + theme_cache.font_offset + font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 		}
 		slot.prop->set_name_fixed_size(name_size);
 	}

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -539,7 +539,7 @@ void EditorPropertyArray::update_property() {
 				}
 				new_prop->set_selectable(false);
 				new_prop->set_use_folding(is_using_folding());
-				new_prop->set_name_split_ratio(0.0);
+				// new_prop->set_name_split_ratio(0.0);
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyArray::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
 				if (value_type == Variant::OBJECT) {

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -263,7 +263,10 @@ void EditorPropertyArray::_update_slots_size() {
 
 			Ref<Font> font = theme_cache.font;
 			int font_size = theme_cache.font_size;
-			name_size = slots[0].reorder_button->get_minimum_size().x + theme_cache.horizontal_separation + font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+			name_size = slots[0].reorder_button->get_minimum_size().x
+					+ theme_cache.horizontal_separation
+					+ theme_cache.font_offset
+					+ font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 		}
 		slot.prop->set_name_fixed_size(name_size);
 	}
@@ -539,7 +542,7 @@ void EditorPropertyArray::update_property() {
 				}
 				new_prop->set_selectable(false);
 				new_prop->set_use_folding(is_using_folding());
-				// new_prop->set_name_split_ratio(0.0);
+				new_prop->set_name_split_ratio(0.0);
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyArray::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
 				if (value_type == Variant::OBJECT) {


### PR DESCRIPTION
Fixes #120260

Removes `set_name_split_ratio(0.0)` from EditorPropertyArray::update_property()
when creating new property slots. This call was overriding the fixed name size
set by `_update_slots_size()`, causing index labels with more than one digit
(10, 11, 12...) to be truncated to only the first character.

Removing this call allows `set_name_fixed_size()` to work correctly,
which already handles the label column width properly.