### PR TITLE
Expose `PacketPeerUDP.poll()` and remove internal `poll()` call from `get_available_packet_count()`

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -88,17 +88,11 @@ Error PacketPeerUDP::_set_dest_address(const String &p_address, int p_port) {
 }
 
 int PacketPeerUDP::get_available_packet_count() const {
-	// TODO we should deprecate this, and expose poll instead!
-	Error err = const_cast<PacketPeerUDP *>(this)->_poll();
-	if (err != OK) {
-		return -1;
-	}
-
 	return queue_count;
 }
 
 Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	Error err = _poll();
+	Error err = poll();
 	if (err != OK) {
 		return err;
 	}
@@ -281,7 +275,7 @@ Error PacketPeerUDP::wait() {
 	return _sock->poll(NetSocket::POLL_TYPE_IN, -1);
 }
 
-Error PacketPeerUDP::_poll() {
+Error PacketPeerUDP::poll() {
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 
 	if (!_sock->is_open()) {
@@ -373,6 +367,7 @@ void PacketPeerUDP::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_broadcast_enabled", "enabled"), &PacketPeerUDP::set_broadcast_enabled);
 	ClassDB::bind_method(D_METHOD("join_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::join_multicast_group);
 	ClassDB::bind_method(D_METHOD("leave_multicast_group", "multicast_address", "interface_name"), &PacketPeerUDP::leave_multicast_group);
+	ClassDB::bind_method(D_METHOD("poll"), &PacketPeerUDP::poll);
 }
 
 PacketPeerUDP::PacketPeerUDP() :

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -64,7 +64,6 @@ protected:
 	String _get_packet_ip() const;
 
 	Error _set_dest_address(const String &p_address, int p_port);
-	Error _poll();
 
 public:
 	void set_blocking_mode(bool p_enable);
@@ -87,6 +86,7 @@ public:
 
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
+	Error poll();
 	int get_available_packet_count() const override;
 	int get_max_packet_size() const override;
 	void set_broadcast_enabled(bool p_enabled);

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -25,6 +25,7 @@
 
 
 		func _process(_delta):
+			peer.poll()
 			if peer.get_available_packet_count() &gt; 0:
 				var array_bytes = peer.get_packet()
 				var packet_string = array_bytes.get_string_from_ascii()
@@ -108,6 +109,13 @@
 			<param index="1" name="interface_name" type="String" />
 			<description>
 				Removes the interface identified by [param interface_name] from the multicast group specified by [param multicast_address].
+			</description>
+		</method>
+		<method name="poll">
+			<return type="int" enum="Error" />
+			<description>
+				Reads incoming packets and stores them for later reading via [method PacketPeer.get_packet] or [method PacketPeer.get_var].
+				Also updates the return value of [method PacketPeer.get_available_packet_count].
 			</description>
 		</method>
 		<method name="set_broadcast_enabled">

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -87,6 +87,7 @@
 			if !connected:
 				# Try to contact server
 				udp.put_packet("The answer is... 42!".to_utf8_buffer())
+			udp.poll()
 			if udp.get_available_packet_count() &gt; 0:
 				print("Connected: %s" % udp.get_packet().get_string_from_utf8())
 				connected = true

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -59,6 +59,7 @@ int PacketPeerMbedDTLS::bio_recv(void *ctx, unsigned char *buf, size_t len) {
 
 	ERR_FAIL_NULL_V(sp, 0);
 
+	sp->base->poll();
 	int pc = sp->base->get_available_packet_count();
 	if (pc == 0) {
 		return MBEDTLS_ERR_SSL_WANT_READ;

--- a/tests/core/io/test_udp_server.cpp
+++ b/tests/core/io/test_udp_server.cpp
@@ -118,9 +118,11 @@ TEST_CASE("[UDPServer] Accept a connection and receive/send data") {
 	CHECK_EQ(client_from_server->put_var(pi), Error::OK);
 
 	wait_for_condition([&]() {
+		client->poll();
 		return client->get_available_packet_count() > 0;
 	});
 
+	CHECK_EQ(client->poll(), Error::OK);
 	CHECK_GT(client->get_available_packet_count(), 0);
 
 	Variant pi_received;
@@ -170,6 +172,7 @@ TEST_CASE("[UDPServer] Handle multiple clients at the same time") {
 	wait_for_condition([&]() {
 		bool should_exit = true;
 		for (Ref<PacketPeerUDP> &c : clients) {
+			c->poll();
 			int count = c->get_available_packet_count();
 			if (count < 0) {
 				return true;
@@ -182,6 +185,7 @@ TEST_CASE("[UDPServer] Handle multiple clients at the same time") {
 	});
 
 	for (int i = 0; i < clients.size(); i++) {
+		CHECK_EQ(clients[i]->poll(), Error::OK);
 		CHECK_GT(clients[i]->get_available_packet_count(), 0);
 
 		Variant received_var;


### PR DESCRIPTION
## What issue(s) or proposal does this PR address?

TODO in PacketPeerUDP:
https://github.com/godotengine/godot/blob/df6235838b63dd49f448547406e339848455c140/core/io/packet_peer_udp.cpp#L90-L98

## Details

Exposes `PacketPeerUDP::poll()` (renamed from `_poll`) and removes the internal `poll()` call from `get_available_packet_count()`. This gives the user more control and also makes the functionality clearer. 

It isn't possible to implement it the way the TODO suggested, because `get_available_packet_count()` is a method of the parent class `PacketPeer`, but I think that this is even better.

Also made necessary changes to tests, documentation and existing usages of PacketPeerUDP to make this work.

## Additional info

Example usage of the new API:

```gdscript
var peer := PacketPeerUDP.new()

func _ready() -> void:
	peer.bind(33445, "*")
	
func _process(_delta: float) -> void:
	peer.poll()
	for i in peer.get_available_packet_count():
		var packet_data := peer.get_packet()
		print("New packet from %s!" % [peer.get_packet_ip()])

```

## Author disclosure

No AI was used for this PR.