### PR TITLE
Jolt Physics: intersect_shape detects duplicate collisions when colliding with ConcavePolygonShape3D

### DIFF
--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -578,31 +578,52 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const PS3DT::ShapeParameters 
 	settings.mMaxSeparationDistance = (float)p_parameters.margin;
 
 	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude);
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeCollector, 32> collector(p_result_max);
-	_collide_shape_queries(jolt_shape, to_jolt(scale), to_jolt_r(transform_com), settings, to_jolt_r(transform_com.origin), collector, query_filter, query_filter, query_filter);
 
-	const int hit_count = collector.get_hit_count();
+	// Calculate bounds for query shape and expand by max separation distance
+	JPH::RMat44 jolt_transform_com = to_jolt_r(transform_com);
+	JPH::Vec3 jolt_scale = to_jolt(scale);
+	JPH::AABox jolt_bounds = jolt_shape->GetWorldSpaceBounds(jolt_transform_com, jolt_scale);
+	jolt_bounds.ExpandBy(JPH::Vec3::sReplicate(settings.mMaxSeparationDistance));
 
-	for (int i = 0; i < hit_count; ++i) {
-		const JPH::CollideShapeResult &hit = collector.get_hit(i);
-		const JoltObject3D *object = space->try_get_object(hit.mBodyID2);
-		ERR_FAIL_NULL_V(object, 0);
+	// Collect all transformed shapes that intersect with the bounding box of the query shape
+	JoltQueryCollectorAll<JPH::TransformedShapeCollector, 32> ts_collector;
+	space->get_narrow_phase_query().CollectTransformedShapes(jolt_bounds, ts_collector, query_filter, query_filter, query_filter);
 
-		PS3DT::ShapeResult &result = *r_results++;
+	// Loop over all collected transformed shapes
+	int hit_count = 0;
+	for (int ts = 0, nts = ts_collector.get_hit_count(); ts < nts; ts++) {
+		const JPH::TransformedShape &transformed_shape = ts_collector.get_hit(ts);
 
-		result.shape = 0;
+		JoltQueryCollectorAny<JPH::CollideShapeCollector> leaf_collector;
+		transformed_shape.CollideShape(jolt_shape, jolt_scale, jolt_transform_com, settings, jolt_transform_com.GetTranslation(), leaf_collector);
 
-		if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
-			const int shape_index = shaped_object->find_shape_index(hit.mSubShapeID2);
-			ERR_FAIL_COND_V(shape_index == -1, 0);
-			result.shape = shape_index;
+		if (leaf_collector.had_hit()) {
+			const JPH::CollideShapeResult &hit = leaf_collector.get_hit();
+
+			const JoltObject3D *object = space->try_get_object(transformed_shape.mBodyID);
+			ERR_FAIL_NULL_V(object, 0);
+
+			PS3DT::ShapeResult &result = *r_results++;
+
+			result.shape = 0;
+
+			if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
+				const int shape_index = shaped_object->find_shape_index(hit.mSubShapeID2);
+				ERR_FAIL_COND_V(shape_index == -1, 0);
+				result.shape = shape_index;
+			}
+
+			result.rid = object->get_rid();
+			result.collider_id = object->get_instance_id();
+			result.collider = object->get_instance();
+
+			hit_count++;
+			if (hit_count >= p_result_max) {
+				// Early out if we reach the maximum number of results
+				return hit_count;
+			}
 		}
-
-		result.rid = object->get_rid();
-		result.collider_id = object->get_instance_id();
-		result.collider = object->get_instance();
 	}
-
 	return hit_count;
 }
 


### PR DESCRIPTION
By default Jolt returns 1 hit per intersecting triangle of a ConcavePolygonShape3D. ShapeResult only contains the ID of the leaf shape and not the triangle ID. This means that when the query intersects with multiple triangles of the same leaf shape, there will be multiple duplicate results. Rewrote the query to return max 1 hit per leaf shape.

Closes #119868 

Here is an updated the MRP that includes multiple bodies and a body that is outside of the query shape to see that it gets ignored:

[intersect-shape-test.zip](https://github.com/user-attachments/files/28917531/intersect-shape-test.zip)
