### PR TITLE
Remove Limiter from audio effect list

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1153,6 +1153,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	add_child(effect_options);
 	LocalVector<StringName> effect_list;
 	ClassDB::get_inheriters_from_class("AudioEffect", effect_list);
+#ifndef DISABLE_DEPRECATED
+	effect_list.erase("AudioEffectLimiter");
+#endif
 	effect_list.sort_custom<StringName::AlphCompare>();
 	for (const StringName &E : effect_list) {
 		if (!ClassDB::can_instantiate(E) || ClassDB::is_virtual(E)) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Removes a deprecated effect from the popup list. This PR doesn't close any GitHub issue that I'm aware of.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Let me know if there's a better approach.

Related proposal (does not close it): https://github.com/godotengine/godot-proposals/issues/15008