### PR TITLE
Remove base classes from the audio effect list

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1158,6 +1158,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 #ifndef DISABLE_DEPRECATED
 	effect_list.erase("AudioEffectLimiter");
 #endif
+	// TODO Godot 5.0: AudioEffectEQ and AudioEffectFilter should be abstract
+	effect_list.erase("AudioEffectEQ"); // Base classes, shouldn't be used directly.
+	effect_list.erase("AudioEffectFilter");
 	effect_list.sort_custom<StringName::AlphCompare>();
 	for (const StringName &E : effect_list) {
 		if (!ClassDB::can_instantiate(E) || ClassDB::is_virtual(E)) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15008
- Related to: https://github.com/godotengine/godot/issues/80391

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
The proposal has a bunch of information. `EQ` and `Filter` are base classes, they're not supposed to be used directly. Doing so can cause confusion (see related issue).
This PR removes them from the list, because the user cannot see that an effect should not be selected (similarly to deprecated effects), unless they read the documentation, which not everyone does.