### PR TITLE
Fix `BoxContainer` size when theme scale is not an integer

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -301,7 +301,7 @@ Size2 BoxContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 			continue;
 		}
 
-		Size2i size = p_use_desired_sizes ? c->get_bound_desired_size() : c->get_bound_minimum_size();
+		Size2i size = p_use_desired_sizes ? c->get_bound_desired_size().ceil() : c->get_bound_minimum_size().ceil();
 
 		if (vertical) { /* VERTICAL */
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120272
- Regression from #118488

## Additional information

On some different editor scales than `1.0` (or some round variants like 2.0 or 1.5), functions like `Control.get_bound_desired_size()` return fractional values, which when converting from `Size2` to `Size2i` are rounded down. That decreases the size of the container, and because `_resort()` already uses `ceil()`, the actual space is less than is needed, resulting in weird spacing bugs.

**Before:** (4.7 RC2, editor scale is 111%)
<img width="454" height="212" alt="image" src="https://github.com/user-attachments/assets/062121f7-0c78-4965-8c4a-3174170119ba" />

**After:** (this PR, editor scale is 111%)
<img width="467" height="229" alt="image" src="https://github.com/user-attachments/assets/a771d37c-fc73-42f4-9104-5e9409f7fd9c" />

Note that diffrent editor scales are quite common on phones for example.