### PR TITLE
Jolt: Fix default area parameter updates not propagating to bodies

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -206,9 +206,13 @@ void JoltArea3D::_notify_body_exited(const JPH::BodyID &p_body_id) {
 }
 
 void JoltArea3D::_notify_bodies_updated(bool p_priority_changed) {
-	for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
-		if (JoltBody3D *body = space->try_get_body(E.key)) {
-			body->update_area(this, p_priority_changed);
+	if (this == space->get_default_area()) {
+		space->notify_all_bodies_default_area_changed();
+	} else {
+		for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
+			if (JoltBody3D *body = space->try_get_body(E.key)) {
+				body->update_area(this, p_priority_changed);
+			}
 		}
 	}
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -57,6 +57,7 @@ public:
 
 private:
 	friend class JoltBodyActivationListener3D;
+	friend class JoltSpace3D;
 
 	SelfList<JoltBody3D> call_queries_element;
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -43,6 +43,8 @@ class JoltArea3D;
 class JoltSpace3D;
 
 class JoltSoftBody3D final : public JoltObject3D {
+	friend class JoltSpace3D;
+
 	HashSet<int> pinned_vertices;
 
 	LocalVector<int> mesh_to_physics;

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -36,6 +36,7 @@
 #include "../misc/jolt_stream_wrappers.h"
 #include "../objects/jolt_area_3d.h"
 #include "../objects/jolt_body_3d.h"
+#include "../objects/jolt_soft_body_3d.h"
 #include "../shapes/jolt_shape_3d.h"
 #include "jolt_body_activation_listener_3d.h"
 #include "jolt_contact_listener_3d.h"
@@ -382,6 +383,25 @@ JoltPhysicsDirectSpaceState3D *JoltSpace3D::get_direct_state() {
 	}
 
 	return direct_state;
+}
+
+void JoltSpace3D::notify_all_bodies_default_area_changed() {
+	JPH::BodyIDVector all_body_ids;
+	physics_system->GetBodies(all_body_ids);
+
+	for (const JPH::BodyID &body_id : all_body_ids) {
+		if (JoltArea3D *area = try_get_area(body_id)) {
+			if (area == default_area) {
+				continue;
+			}
+		}
+
+		if (JoltBody3D *body = try_get_body(body_id)) {
+			body->_areas_changed();
+		} else if (JoltSoftBody3D *soft_body = try_get_soft_body(body_id)) {
+			soft_body->_areas_changed();
+		}
+	}
 }
 
 JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -129,6 +129,8 @@ public:
 	JoltArea3D *get_default_area() const { return default_area; }
 	void set_default_area(JoltArea3D *p_area) { default_area = p_area; }
 
+	void notify_all_bodies_default_area_changed();
+
 	float get_last_step() const { return last_step; }
 
 	JPH::Body *add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);


### PR DESCRIPTION
Fixes #120279

### Description

After PR #118197, `JoltArea3D` notifies overlapping bodies when its parameters change. However, the default area does not track body overlaps (since it applies to all bodies by default), so parameter changes were never propagated.