### PR TITLE
Fix visiblity bugs in `SceneTreeDock._update_create_root_dialog`

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4711,6 +4711,8 @@ void SceneTreeDock::_update_create_root_dialog(bool p_initializing) {
 			favorite_node_shortcuts->get_child(i)->queue_free();
 		}
 
+		bool favorite_node_shortcuts_empty = true;
+
 		Ref<FileAccess> f = FileAccess::open(EditorPaths::get_singleton()->get_project_settings_dir().path_join("favorites.Node"), FileAccess::READ);
 		if (f.is_valid()) {
 			while (!f->eof_reached()) {
@@ -4719,6 +4721,7 @@ void SceneTreeDock::_update_create_root_dialog(bool p_initializing) {
 				if (!l.is_empty()) {
 					Button *button = memnew(Button);
 					favorite_node_shortcuts->add_child(button);
+					favorite_node_shortcuts_empty = false;
 					button->set_text(l);
 					button->set_clip_text(true);
 					String name = l.get_slicec(' ', 0);
@@ -4731,17 +4734,13 @@ void SceneTreeDock::_update_create_root_dialog(bool p_initializing) {
 			}
 		}
 
-		if (!favorite_node_shortcuts->is_visible_in_tree()) {
-			favorite_node_shortcuts->show();
-			beginner_node_shortcuts->hide();
-		}
+		favorite_node_shortcuts->set_visible(!favorite_node_shortcuts_empty);
+		beginner_node_shortcuts->hide();
 	} else {
-		if (!beginner_node_shortcuts->is_visible_in_tree()) {
-			beginner_node_shortcuts->show();
-			favorite_node_shortcuts->hide();
-		}
-		button_clipboard->set_visible(!node_clipboard.is_empty());
+		beginner_node_shortcuts->show();
+		favorite_node_shortcuts->hide();
 	}
+	button_clipboard->set_visible(!node_clipboard.is_empty());
 }
 
 void SceneTreeDock::_favorite_root_selected(const String &p_class) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Combined two issues into one PR to avoid merge conflicts, and because they are in the same lines of code.

## 

**Issue 1** - When launching the editor and "Show Favorites" is enabled, "Paste from clipboard" appears even if the clipboard is empty.

<img width="421" height="162" alt="image" src="https://github.com/user-attachments/assets/93269d48-319c-4241-a929-379531b7be6f" />

## 

**Issue 2** - When there are no favorite nodes, the empty VBoxContainer causes another seperator to appear.

<img width="824" height="263" alt="image" src="https://github.com/user-attachments/assets/e8088847-f692-4160-adea-60fa07151ef5" />
<img width="824" height="263" alt="image" src="https://github.com/user-attachments/assets/432e2961-0438-4a21-8703-824bba75b529" />

## Additional info

Removed `!is_visible_in_tree()` checks, because they serve no real purpose and are an additional surface for bugs to appear.