### PR TITLE
Fix `AudioEffectPhaser`'s `depth`

### DIFF
--- a/servers/audio/effects/audio_effect_phaser.cpp
+++ b/servers/audio/effects/audio_effect_phaser.cpp
@@ -41,6 +41,8 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 
 	float increment = Math::TAU * (base->rate / sampling_rate);
 
+	float mix = base->depth / max_depth;
+
 	for (int i = 0; i < p_frame_count; i++) {
 		phase += increment;
 
@@ -65,7 +67,7 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 												allpass[0][5].update(p_src_frames[i].left + h.left * base->feedback))))));
 		h.left = y;
 
-		p_dst_frames[i].left = p_src_frames[i].left + y * base->depth;
+		p_dst_frames[i].left = p_src_frames[i].left * (1.0 - mix) + y * mix;
 
 		y = allpass[1][0].update(
 				allpass[1][1].update(
@@ -75,7 +77,7 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 												allpass[1][5].update(p_src_frames[i].right + h.right * base->feedback))))));
 		h.right = y;
 
-		p_dst_frames[i].right = p_src_frames[i].right + y * base->depth;
+		p_dst_frames[i].right = p_src_frames[i].right * (1.0 - mix) + y * mix;
 	}
 }
 
@@ -85,6 +87,7 @@ Ref<AudioEffectInstance> AudioEffectPhaser::instantiate() {
 	ins->base = Ref<AudioEffectPhaser>(this);
 	ins->phase = 0;
 	ins->h = AudioFrame(0, 0);
+	ins->max_depth = 4.0;
 
 	return ins;
 }

--- a/servers/audio/effects/audio_effect_phaser.h
+++ b/servers/audio/effects/audio_effect_phaser.h
@@ -41,6 +41,7 @@ class AudioEffectPhaserInstance : public AudioEffectInstance {
 
 	float phase;
 	AudioFrame h;
+	float max_depth;
 
 	class AllpassDelay {
 		float a, h;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120293

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
This PR decreases the output level of the dry signal while the output level of the wet signal increases. This helps maintain volume balance.

Before:

https://github.com/user-attachments/assets/79e9d8db-8ca5-41c0-9eb6-8eb16ab34f53


After:

https://github.com/user-attachments/assets/9fb7736c-dbc6-4869-a302-a4dc50f5b0c4



Note: it'd be preferred to have this be a value between 0.0 and 1.0, like most depth/mix parameters do. The current range makes no sense.