### PR TITLE
Fix dangling pointer in `DLTS` classes in `_create_func` (regression)

### DIFF
--- a/core/io/dtls_server.cpp
+++ b/core/io/dtls_server.cpp
@@ -32,7 +32,7 @@
 
 #include "core/object/class_db.h"
 
-DTLSServer *DTLSServer::create(bool p_notify_postinitialize) {
+Ref<DTLSServer> DTLSServer::create(bool p_notify_postinitialize) {
 	if (_create) {
 		return _create(p_notify_postinitialize);
 	}

--- a/core/io/dtls_server.h
+++ b/core/io/dtls_server.h
@@ -36,14 +36,14 @@ class DTLSServer : public RefCounted {
 	GDCLASS(DTLSServer, RefCounted);
 
 protected:
-	static inline DTLSServer *(*_create)(bool p_notify_postinitialize) = nullptr;
+	static inline Ref<DTLSServer> (*_create)(bool p_notify_postinitialize) = nullptr;
 	static void _bind_methods();
 
 	static inline bool available = false;
 
 public:
 	static bool is_available();
-	static DTLSServer *create(bool p_notify_postinitialize = true);
+	static Ref<DTLSServer> create(bool p_notify_postinitialize = true);
 
 	virtual Error setup(Ref<TLSOptions> p_options) = 0;
 	virtual void stop() = 0;

--- a/core/io/packet_peer_dtls.cpp
+++ b/core/io/packet_peer_dtls.cpp
@@ -32,7 +32,7 @@
 
 #include "core/object/class_db.h"
 
-PacketPeerDTLS *PacketPeerDTLS::create(bool p_notify_postinitialize) {
+Ref<PacketPeerDTLS> PacketPeerDTLS::create(bool p_notify_postinitialize) {
 	if (_create) {
 		return _create(p_notify_postinitialize);
 	}

--- a/core/io/packet_peer_dtls.h
+++ b/core/io/packet_peer_dtls.h
@@ -37,7 +37,7 @@ class PacketPeerDTLS : public PacketPeer {
 	GDCLASS(PacketPeerDTLS, PacketPeer);
 
 protected:
-	static inline PacketPeerDTLS *(*_create)(bool p_notify_postinitialize) = nullptr;
+	static inline Ref<PacketPeerDTLS> (*_create)(bool p_notify_postinitialize) = nullptr;
 	static void _bind_methods();
 
 	static inline bool available = false;
@@ -56,7 +56,7 @@ public:
 	virtual void disconnect_from_peer() = 0;
 	virtual Status get_status() const = 0;
 
-	static PacketPeerDTLS *create(bool p_notify_postinitialize = true);
+	static Ref<PacketPeerDTLS> create(bool p_notify_postinitialize = true);
 	static bool is_available();
 };
 

--- a/modules/mbedtls/dtls_server_mbedtls.cpp
+++ b/modules/mbedtls/dtls_server_mbedtls.cpp
@@ -56,8 +56,8 @@ Ref<PacketPeerDTLS> DTLSServerMbedTLS::take_connection(Ref<PacketPeerUDP> p_udp_
 	return out;
 }
 
-DTLSServer *DTLSServerMbedTLS::_create_func(bool p_notify_postinitialize) {
-	return static_cast<DTLSServer *>(ClassDB::creator<DTLSServerMbedTLS>(p_notify_postinitialize));
+Ref<DTLSServer> DTLSServerMbedTLS::_create_func(bool p_notify_postinitialize) {
+	return memnew(DTLSServerMbedTLS);
 }
 
 void DTLSServerMbedTLS::initialize() {

--- a/modules/mbedtls/dtls_server_mbedtls.h
+++ b/modules/mbedtls/dtls_server_mbedtls.h
@@ -36,7 +36,7 @@
 
 class DTLSServerMbedTLS : public DTLSServer {
 private:
-	static DTLSServer *_create_func(bool p_notify_postinitialize);
+	static Ref<DTLSServer> _create_func(bool p_notify_postinitialize);
 	Ref<TLSOptions> tls_options;
 	Ref<CookieContextMbedTLS> cookies;
 

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -269,8 +269,8 @@ PacketPeerMbedDTLS::Status PacketPeerMbedDTLS::get_status() const {
 	return status;
 }
 
-PacketPeerDTLS *PacketPeerMbedDTLS::_create_func(bool p_notify_postinitialize) {
-	return static_cast<PacketPeerDTLS *>(ClassDB::creator<PacketPeerMbedDTLS>(p_notify_postinitialize));
+Ref<PacketPeerDTLS> PacketPeerMbedDTLS::_create_func(bool p_notify_postinitialize) {
+	return memnew(PacketPeerMbedDTLS);
 }
 
 void PacketPeerMbedDTLS::initialize_dtls() {

--- a/modules/mbedtls/packet_peer_mbed_dtls.h
+++ b/modules/mbedtls/packet_peer_mbed_dtls.h
@@ -49,7 +49,7 @@ private:
 
 	Ref<PacketPeerUDP> base;
 
-	static PacketPeerDTLS *_create_func(bool p_notify_postinitialize);
+	static Ref<PacketPeerDTLS> _create_func(bool p_notify_postinitialize);
 
 	static int bio_recv(void *ctx, unsigned char *buf, size_t len);
 	static int bio_send(void *ctx, const unsigned char *buf, size_t len);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes (NOT) #120291 
- Regression from https://github.com/godotengine/godot/pull/111965

## Additional information

Changes the functions to return a `Ref` instead of a pointer to the object, and to use `memnew`.
Avoids the object being destroyed immediately after creation due to the `Ref` going out of scope.