### PR TITLE
Jolt Physics: Fix default area parameter updates not propagating to bodies

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -206,9 +206,17 @@ void JoltArea3D::_notify_body_exited(const JPH::BodyID &p_body_id) {
 }
 
 void JoltArea3D::_notify_bodies_updated(bool p_priority_changed) {
-	for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
-		if (JoltBody3D *body = space->try_get_body(E.key)) {
-			body->update_area(this, p_priority_changed);
+	if (unlikely(!in_space())) {
+		return;
+	}
+
+	if (space->get_default_area() == this) {
+		space->increment_default_area_changed_count();
+	} else {
+		for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
+			if (JoltBody3D *body = space->try_get_body(E.key)) {
+				body->update_area(this, p_priority_changed);
+			}
 		}
 	}
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -279,6 +279,14 @@ void JoltBody3D::_update_mass_properties() {
 	}
 }
 
+bool JoltBody3D::_needs_update_environmental_properties() const {
+	if (unlikely(!in_space())) {
+		return false;
+	}
+
+	return has_point_gravity || space->get_default_area_changed_count() != default_area_changed_count;
+}
+
 void JoltBody3D::_update_environmental_properties() {
 	if (unlikely(!in_space())) {
 		return;
@@ -349,6 +357,8 @@ void JoltBody3D::_update_environmental_properties() {
 			total_angular_damp = angular_damp;
 		} break;
 	}
+
+	default_area_changed_count = space->get_default_area_changed_count();
 }
 
 void JoltBody3D::_update_kinematic_transform() {
@@ -1104,14 +1114,14 @@ void JoltBody3D::pre_step(float p_step) {
 		} break;
 		case PhysicsServer3D::BODY_MODE_RIGID:
 		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {
-			if (has_point_gravity) {
+			if (_needs_update_environmental_properties()) {
 				_update_environmental_properties();
 			}
 
 			_integrate_forces(p_step);
 		} break;
 		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
-			if (has_point_gravity) {
+			if (_needs_update_environmental_properties()) {
 				_update_environmental_properties();
 			}
 

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -98,6 +98,8 @@ private:
 
 	uint32_t locked_axes = 0;
 
+	uint16_t default_area_changed_count = 0;
+
 	bool sleep_allowed = true;
 	bool sleep_initially = false;
 	bool custom_center_of_mass = false;
@@ -126,6 +128,7 @@ private:
 	void _on_wake_up();
 
 	void _update_mass_properties();
+	bool _needs_update_environmental_properties() const;
 	void _update_environmental_properties();
 	void _update_kinematic_transform();
 	void _update_group_filter();

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -78,6 +78,8 @@ class JoltSpace3D {
 
 	float last_step = 0.0f;
 
+	uint16_t default_area_changed_count = 0;
+
 	bool active = false;
 	bool stepping = false;
 
@@ -128,6 +130,9 @@ public:
 
 	JoltArea3D *get_default_area() const { return default_area; }
 	void set_default_area(JoltArea3D *p_area) { default_area = p_area; }
+
+	void increment_default_area_changed_count() { default_area_changed_count++; }
+	uint16_t get_default_area_changed_count() const { return default_area_changed_count; }
 
 	float get_last_step() const { return last_step; }
 


### PR DESCRIPTION
After PR #118197, JoltArea3D notifies overlapping bodies when its parameters change. However, the default area does not track body overlaps (since it applies to all bodies by default), so parameter changes were never propagated.

Closes #120279