### PR TITLE
[XR] Fix a crash when spatial entity marker trackers are detected

### DIFF
--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -607,7 +607,7 @@ void OpenXRSpatialMarkerTrackingCapability::do_entity_update(RID p_spatial_conte
 	// And we get our update snapshot, this is NOT async!
 	RID snapshot = se_extension->update_spatial_entities(p_spatial_context, entities, component_types, p_next_snapshot_create);
 	if (snapshot.is_valid()) {
-		_process_snapshot(snapshot, p_spatial_context, false, p_component_data, p_next_snapshot_query, nullptr);
+		_process_snapshot(snapshot, p_spatial_context, false, p_component_data, p_next_snapshot_query);
 	}
 }
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
@@ -273,7 +273,7 @@ private:
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 
-	void _process_snapshot(RID p_snapshot, RID p_spatial_context, bool p_is_discovery, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback);
+	void _process_snapshot(RID p_snapshot, RID p_spatial_context, bool p_is_discovery, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback = Callable());
 
 	// Trackers; maps each Spatial Context RID to their marker entities and trackers
 	HashMap<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>>> marker_trackers;


### PR DESCRIPTION


## What problem(s) does this PR solve?

As the title states, this fixes a crash that occurs on detection of spatial marker trackers.

## Additional information

Regression from https://github.com/godotengine/godot/pull/118128
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
