### PR TITLE
Remove unnecessary gain parameters in some audio filters

### DIFF
--- a/servers/audio/effects/audio_effect_filter.h
+++ b/servers/audio/effects/audio_effect_filter.h
@@ -137,6 +137,13 @@ public:
 class AudioEffectNotchFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectNotchFilter, AudioEffectFilter);
 
+protected:
+	void _validate_property(PropertyInfo &p_property) const {
+		if (p_property.name == "gain") {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
+
 public:
 	AudioEffectNotchFilter() :
 			AudioEffectFilter(AudioFilterSW::NOTCH) {}
@@ -144,6 +151,13 @@ public:
 
 class AudioEffectBandLimitFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectBandLimitFilter, AudioEffectFilter);
+
+protected:
+	void _validate_property(PropertyInfo &p_property) const {
+		if (p_property.name == "gain") {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
 
 public:
 	AudioEffectBandLimitFilter() :


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

`gain` is not used in neither `AudioEffectNotchFilter` nor `AudioEffectBandLimitFilter`. Users could try to change that and wonder why it has no effect, and assume something is broken.
As far as I'm aware, there's no issue open for this.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Basically a continuation of https://github.com/godotengine/godot/commit/256bbd3561135c7886501a865be27cde3d26d47d

You can check this `switch` block to see how neither `gain` nor `tmpgain` is used in the cases `NOTCH` and `BANDLIMIT`:
https://github.com/godotengine/godot/blob/df6235838b63dd49f448547406e339848455c140/servers/audio/audio_filter_sw.cpp#L93-L178