### PR TITLE
Fix SSR inverted reflections in VR

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1499,6 +1499,7 @@ void RenderForwardClustered::_process_ssr(Ref<RenderSceneBuffersRD> p_render_buf
 		correction.set_depth_correction(true);
 
 		Projection projection = correction * p_projections[v];
+
 		reprojections[v] = rb_data->ss_effects_data.ssr_last_frame_projections[v] * Projection(rb_data->ss_effects_data.ssr_last_frame_transform.affine_inverse()) * Projection(p_transform) * projection.inverse();
 
 		rb_data->ss_effects_data.ssr_last_frame_projections[v] = projection;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1499,13 +1499,11 @@ void RenderForwardClustered::_process_ssr(Ref<RenderSceneBuffersRD> p_render_buf
 
 		Projection projection = correction * p_projections[v];
 
-		Transform3D eye_transform = p_transform;
-		eye_transform.origin += p_transform.basis.xform(p_eye_offsets[v]);
-		reprojections[v] = rb_data->ss_effects_data.ssr_last_frame_projections[v] * Projection(rb_data->ss_effects_data.ssr_last_frame_transform[v].affine_inverse()) * Projection(eye_transform) * projection.inverse();
+		reprojections[v] = rb_data->ss_effects_data.ssr_last_frame_projections[v] * Projection(rb_data->ss_effects_data.ssr_last_frame_transform.affine_inverse()) * Projection(p_transform) * projection.inverse();
 
 		rb_data->ss_effects_data.ssr_last_frame_projections[v] = projection;
-		rb_data->ss_effects_data.ssr_last_frame_transform[v] = eye_transform;
 	}
+	rb_data->ss_effects_data.ssr_last_frame_transform = p_transform;
 
 	ss_effects->screen_space_reflection(p_render_buffers, rb_data->ss_effects_data.ssr, p_normal_slices, environment_get_ssr_max_steps(p_environment), environment_get_ssr_fade_in(p_environment), environment_get_ssr_fade_out(p_environment), environment_get_ssr_depth_tolerance(p_environment), p_projections, reprojections, p_eye_offsets, *copy_effects);
 }

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1498,11 +1498,14 @@ void RenderForwardClustered::_process_ssr(Ref<RenderSceneBuffersRD> p_render_buf
 		correction.set_depth_correction(true);
 
 		Projection projection = correction * p_projections[v];
-		reprojections[v] = rb_data->ss_effects_data.ssr_last_frame_projections[v] * Projection(rb_data->ss_effects_data.ssr_last_frame_transform.affine_inverse()) * Projection(p_transform) * projection.inverse();
+
+		Transform3D eye_transform = p_transform;
+		eye_transform.origin += p_transform.basis.xform(p_eye_offsets[v]);
+		reprojections[v] = rb_data->ss_effects_data.ssr_last_frame_projections[v] * Projection(rb_data->ss_effects_data.ssr_last_frame_transform[v].affine_inverse()) * Projection(eye_transform) * projection.inverse();
 
 		rb_data->ss_effects_data.ssr_last_frame_projections[v] = projection;
+		rb_data->ss_effects_data.ssr_last_frame_transform[v] = eye_transform;
 	}
-	rb_data->ss_effects_data.ssr_last_frame_transform = p_transform;
 
 	ss_effects->screen_space_reflection(p_render_buffers, rb_data->ss_effects_data.ssr, p_normal_slices, environment_get_ssr_max_steps(p_environment), environment_get_ssr_fade_in(p_environment), environment_get_ssr_fade_out(p_environment), environment_get_ssr_depth_tolerance(p_environment), p_projections, reprojections, p_eye_offsets, *copy_effects);
 }

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -108,7 +108,7 @@ public:
 			Transform3D ssil_last_frame_transform;
 
 			Projection ssr_last_frame_projections[RendererSceneRender::MAX_RENDER_VIEWS];
-			Transform3D ssr_last_frame_transform[RendererSceneRender::MAX_RENDER_VIEWS];
+			Transform3D ssr_last_frame_transform;
 
 			RendererRD::SSEffects::SSILRenderBuffers ssil;
 			RendererRD::SSEffects::SSAORenderBuffers ssao;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -108,7 +108,7 @@ public:
 			Transform3D ssil_last_frame_transform;
 
 			Projection ssr_last_frame_projections[RendererSceneRender::MAX_RENDER_VIEWS];
-			Transform3D ssr_last_frame_transform;
+			Transform3D ssr_last_frame_transform[RendererSceneRender::MAX_RENDER_VIEWS];
 
 			RendererRD::SSEffects::SSILRenderBuffers ssil;
 			RendererRD::SSEffects::SSAORenderBuffers ssao;

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -134,7 +134,7 @@ void main() {
 		pos += geom_normal * (1.0 - pow(clamp(dot(normal, geom_normal), 0.0, 1.0), 8.0));
 		screen_pos = compute_screen_pos(pos);
 
-		vec3 view_dir = params.orthogonal ? vec3(0.0, 0.0, -1.0) : normalize(pos + scene_data.eye_offset[params.view_index].xyz);
+		vec3 view_dir = params.orthogonal ? vec3(0.0, 0.0, -1.0) : normalize(pos - scene_data.eye_offset[params.view_index].xyz);
 		vec3 ray_dir = normalize(reflect(view_dir, normal));
 
 		// Check if the ray is immediately intersecting with itself. If so, bounce!

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -325,9 +325,6 @@ void main() {
 	}
 
 
-	// Debug
-
-	//imageStore(output_color, pixel_pos, vec4(debug, 1.0));
 	imageStore(output_color, pixel_pos, color);
 	imageStore(output_mip_level, pixel_pos, vec4(mip_level / 14.0, 0.0, 0.0, 0.0));
 }

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -101,7 +101,6 @@ void main() {
 		return;
 	}
 
-	vec3 debug;
 	vec4 color = vec4(0.0);
 	float mip_level = 0.0;
 
@@ -249,6 +248,7 @@ void main() {
 				validity = 0.0;
 			}
 		}
+
 		vec3 cur_pos = compute_view_pos(cur_screen_pos);
 		vec3 hit_pos = compute_view_pos(vec3(cur_screen_pos.xy, hit_depth));
 
@@ -323,7 +323,7 @@ void main() {
 		// We can fade the mip level near the end to make it significantly less visible.
 		mip_level *= pow(clamp(1.25 - ray_len, 0.0, 1.0), 0.2);
 	}
-	
+
 	imageStore(output_color, pixel_pos, color);
 	imageStore(output_mip_level, pixel_pos, vec4(mip_level / 14.0, 0.0, 0.0, 0.0));
 }

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -101,6 +101,7 @@ void main() {
 		return;
 	}
 
+	vec3 debug;
 	vec4 color = vec4(0.0);
 	float mip_level = 0.0;
 
@@ -134,7 +135,7 @@ void main() {
 		pos += geom_normal * (1.0 - pow(clamp(dot(normal, geom_normal), 0.0, 1.0), 8.0));
 		screen_pos = compute_screen_pos(pos);
 
-		vec3 view_dir = params.orthogonal ? vec3(0.0, 0.0, -1.0) : normalize(pos + scene_data.eye_offset[params.view_index].xyz);
+		vec3 view_dir = params.orthogonal ? vec3(0.0, 0.0, -1.0) : normalize(pos - scene_data.eye_offset[params.view_index].xyz);
 		vec3 ray_dir = normalize(reflect(view_dir, normal));
 
 		// Check if the ray is immediately intersecting with itself. If so, bounce!
@@ -248,7 +249,6 @@ void main() {
 				validity = 0.0;
 			}
 		}
-
 		vec3 cur_pos = compute_view_pos(cur_screen_pos);
 		vec3 hit_pos = compute_view_pos(vec3(cur_screen_pos.xy, hit_depth));
 
@@ -324,6 +324,10 @@ void main() {
 		mip_level *= pow(clamp(1.25 - ray_len, 0.0, 1.0), 0.2);
 	}
 
+
+	// Debug
+
+	//imageStore(output_color, pixel_pos, vec4(debug, 1.0));
 	imageStore(output_color, pixel_pos, color);
 	imageStore(output_mip_level, pixel_pos, vec4(mip_level / 14.0, 0.0, 0.0, 0.0));
 }

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -323,8 +323,7 @@ void main() {
 		// We can fade the mip level near the end to make it significantly less visible.
 		mip_level *= pow(clamp(1.25 - ray_len, 0.0, 1.0), 0.2);
 	}
-
-
+	
 	imageStore(output_color, pixel_pos, color);
 	imageStore(output_mip_level, pixel_pos, vec4(mip_level / 14.0, 0.0, 0.0, 0.0));
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes issue with Screenspace Reflection in VR. Where the reflections would appear offset from each eye.
- Added per eye reprojection matrixes for SSR effect.
- *Bugsquad edit:* Fixes #118637.

## Additional information

I'm unsure if per eye reprojection matrix is necessary but it's a good thing in my opinion. Without this fix SSR in VR is completely unusable.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
