### PR TITLE
Increase marker popup size to support longer languages

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -9650,7 +9650,7 @@ void AnimationMarkerEdit::_insert_marker(float p_ofs) {
 
 	editor->resolve_insertion_offset(p_ofs);
 
-	marker_insert_confirm->popup_centered(Size2(200, 100) * EDSCALE);
+	marker_insert_confirm->popup_centered(Size2(300, 100) * EDSCALE);
 	marker_insert_color->set_pick_color(Color(1, 1, 1));
 
 	String base = "new_marker";


### PR DESCRIPTION
## What problem(s) does this PR solve?
https://github.com/godotengine/godot/pull/120233#issuecomment-4698325849

## Additional information

Increased the popup size to allow for some wiggle room for different languages.

<img width="1263" height="522" alt="Screenshot 2026-06-14 171748" src="https://github.com/user-attachments/assets/d7fce682-fcf5-41f2-a967-3ca1bf8790de" />
