### PR TITLE
Preprocess shader code before passing it to `get_shader_type()`

### DIFF
--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -656,7 +656,11 @@ void TextShaderPreview::set_shader_code(const String &p_code, int p_line, bool p
 	in_comment = p_in_comment;
 	goto_button->set_text(itos(line + 1));
 
-	String shader_type = ShaderLanguage::get_shader_type(p_code);
+	String preprocessed_code;
+	ShaderPreprocessor preprocessor;
+	preprocessor.preprocess(p_code, "", preprocessed_code);
+
+	String shader_type = ShaderLanguage::get_shader_type(preprocessed_code);
 	bool mode_3d = shader_type == "spatial";
 
 	if (shader_type != "canvas_item" && !mode_3d) {
@@ -879,7 +883,12 @@ void ShaderTextEditor::_load_theme_settings() {
 }
 
 void ShaderTextEditor::_check_shader_mode() {
-	String type = ShaderLanguage::get_shader_type(code_editor->get_text_editor()->get_text());
+	String code = code_editor->get_text_editor()->get_text();
+	String preprocessed_code;
+	ShaderPreprocessor preprocessor;
+	preprocessor.preprocess(code, "", preprocessed_code);
+
+	String type = ShaderLanguage::get_shader_type(preprocessed_code);
 
 	Shader::Mode mode;
 	Ref<Shader> shader = edited_res;


### PR DESCRIPTION
- Closes #120197

Ideally all code given to `ShaderLanguage::get_shader_type()` would be preprocessed inside the function, as it would cover all possible code paths, but I didn't in order to minimize changes and to avoid creating a `ShaderPreprocessor` object every time it's called. Instead I added preprocessing to code it recieves on paths that need it.

(Edit - I wrote the fix that changes `get_shader_type()` instead anyway - here it is: https://github.com/mechalynx/godot/commit/a461148bc745af49fdb5268dd4ebb69b281b01d6. I didn't remove any cases where preprocessed code is already fed to `get_shader_type()` because the only case I know if is from here godotengine/godot#79287 and I would be effectively reverting it)

I've only tested with the MRP since the changes are limited in scope.

## Additional information

 * Though with this change `_get_first_ident_pos()` does redundant comment skipping, this should be kept for cases where `get_shader_type()` is called on non-preprocessed code.

 * Related to the above, currently none of the built-in default shaders are passed through a preprocessor. This isn't an issue now but if there are ever default shaders with preprocessor directives prior to `shader_type`, those parts of the code will also have the same bug.

 * I didn't add any extra error checking in case the preprocessor fails. That's because I saw other parts of the code do the same and I'm honestly not sure where to throw an error this deep in the code.

 * This is mostly unrelated but while searching for issues and PRs related to `MaterialStorage` because I wasn't sure what it did (it's a code path related to this PR's fix), I came across godotengine/godot#116203 which fixes a race condition for the RD version of `MaterialStorage` but the GLES3 and Dummy versions don't seem to have that fix. I don't understand enough to know if this is a problem or warrants opening an issue for it.