### PR TITLE
[CI] Remove `build_deps` from Windows artifacts.

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Prepare artifact
         if: matrix.compiler == 'msvc'
         run: |
+          Remove-Item bin/build_deps -Recurse -Force -ErrorAction SilentlyContinue
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
 
       - name: Upload artifact


### PR DESCRIPTION
## What problem(s) does this PR solve?

Removes unnecessary `duild_deps` from CI artifacts.

## Additional information

https://github.com/godotengine/godot/pull/120007 moved `build_deps` to the `bin` folder if MSYS2 is set up.