### PR TITLE
[Docs] Add platform support notes to window flags.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -3304,12 +3304,15 @@
 		</constant>
 		<constant name="WINDOW_FLAG_RESIZE_DISABLED" value="0" enum="WindowFlags">
 			The window can't be resized by dragging its resize grip. It's still possible to resize the window using [method window_set_size]. This flag is ignored for full screen windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_BORDERLESS" value="1" enum="WindowFlags">
 			The window do not have native title bar and other decorations. This flag is ignored for full-screen windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11/Wayland), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_ALWAYS_ON_TOP" value="2" enum="WindowFlags">
 			The window is floating on top of all other windows. This flag is ignored for full-screen windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_TRANSPARENT" value="3" enum="WindowFlags">
 			The window background can be transparent.
@@ -3319,9 +3322,11 @@
 		</constant>
 		<constant name="WINDOW_FLAG_NO_FOCUS" value="4" enum="WindowFlags">
 			The window can't be focused. No-focus window will ignore all input, except mouse clicks.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_POPUP" value="5" enum="WindowFlags">
 			Window is part of menu or [OptionButton] dropdown. This flag can't be changed when the window is visible. An active popup window will exclusively receive all input, without stealing focus from its parent. Popup windows are automatically closed when uses click outside it, or when an application is switched. Popup window must have transient parent set (see [method window_set_transient]).
+			[b]Note:[/b] This flag is implemented on Linux (X11/Wayland), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_EXTEND_TO_TITLE" value="6" enum="WindowFlags">
 			Window content is expanded to the full size of the window. Unlike borderless window, the frame is left intact and can be used to resize the window, title bar is transparent, but have minimize/maximize/close buttons.
@@ -3331,6 +3336,7 @@
 		</constant>
 		<constant name="WINDOW_FLAG_MOUSE_PASSTHROUGH" value="7" enum="WindowFlags">
 			All mouse events are passed to the underlying window of the same application.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_SHARP_CORNERS" value="8" enum="WindowFlags">
 			Window style is overridden, forcing sharp corners.
@@ -3343,14 +3349,15 @@
 		</constant>
 		<constant name="WINDOW_FLAG_POPUP_WM_HINT" value="10" enum="WindowFlags">
 			Signals the window manager that this window is supposed to be an implementation-defined "popup" (usually a floating, borderless, untileable and immovable child window).
+			[b]Note:[/b] This flag is implemented on Linux (Wayland).
 		</constant>
 		<constant name="WINDOW_FLAG_MINIMIZE_DISABLED" value="11" enum="WindowFlags">
 			Window minimize button is disabled.
-			[b]Note:[/b] This flag is implemented on macOS and Windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_MAXIMIZE_DISABLED" value="12" enum="WindowFlags">
 			Window maximize button is disabled.
-			[b]Note:[/b] This flag is implemented on macOS and Windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="WINDOW_FLAG_MAX" value="13" enum="WindowFlags">
 			Represents the size of the [enum WindowFlags] enum.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -942,32 +942,38 @@
 		</constant>
 		<constant name="FLAG_RESIZE_DISABLED" value="0" enum="Flags">
 			The window can't be resized by dragging its resize grip. It's still possible to resize the window using [member size]. This flag is ignored for full screen windows. Set with [member unresizable].
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, Windows, and embedded windows.
 		</constant>
 		<constant name="FLAG_BORDERLESS" value="1" enum="Flags">
 			The window do not have native title bar and other decorations. This flag is ignored for full-screen windows. Set with [member borderless].
+			[b]Note:[/b] This flag is implemented on Linux (X11/Wayland), macOS, Windows, and embedded windows.
 		</constant>
 		<constant name="FLAG_ALWAYS_ON_TOP" value="2" enum="Flags">
 			The window is floating on top of all other windows. This flag is ignored for full-screen windows. Set with [member always_on_top].
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, Windows, and embedded windows.
 		</constant>
 		<constant name="FLAG_TRANSPARENT" value="3" enum="Flags">
 			The window background can be transparent. Set with [member transparent].
 			[b]Note:[/b] This flag has no effect if either [member ProjectSettings.display/window/per_pixel_transparency/allowed], or the window's [member Viewport.transparent_bg] is set to [code]false[/code].
+			[b]Note:[/b] Transparency support is implemented on Linux (X11/Wayland), macOS, Windows, and embedded windows.
 		</constant>
 		<constant name="FLAG_NO_FOCUS" value="4" enum="Flags">
 			The window can't be focused. No-focus window will ignore all input, except mouse clicks. Set with [member unfocusable].
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, Windows, and embedded windows.
 		</constant>
 		<constant name="FLAG_POPUP" value="5" enum="Flags">
 			Window is part of menu or [OptionButton] dropdown. This flag can't be changed when the window is visible. An active popup window will exclusively receive all input, without stealing focus from its parent. Popup windows are automatically closed when uses click outside it, or when an application is switched. Popup window must have transient parent set (see [member transient]).
-			[b]Note:[/b] This flag has no effect in embedded windows (unless said window is a [Popup]).
+			[b]Note:[/b] This flag is implemented on Linux (X11/Wayland), macOS, Windows, and embedded [Popup] windows.
 		</constant>
 		<constant name="FLAG_EXTEND_TO_TITLE" value="6" enum="Flags">
 			Window content is expanded to the full size of the window. Unlike borderless window, the frame is left intact and can be used to resize the window, title bar is transparent, but have minimize/maximize/close buttons. Set with [member extend_to_title].
-			[b]Note:[/b] This flag is implemented only on macOS.
 			[b]Note:[/b] This flag has no effect in embedded windows.
+			[b]Note:[/b] This flag is implemented only on macOS.
 		</constant>
 		<constant name="FLAG_MOUSE_PASSTHROUGH" value="7" enum="Flags">
 			All mouse events are passed to the underlying window of the same application.
 			[b]Note:[/b] This flag has no effect in embedded windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, Windows.
 		</constant>
 		<constant name="FLAG_SHARP_CORNERS" value="8" enum="Flags">
 			Window style is overridden, forcing sharp corners.
@@ -982,14 +988,18 @@
 		</constant>
 		<constant name="FLAG_POPUP_WM_HINT" value="10" enum="Flags">
 			Signals the window manager that this window is supposed to be an implementation-defined "popup" (usually a floating, borderless, untileable and immovable child window).
+			[b]Note:[/b] This flag has no effect in embedded windows.
+			[b]Note:[/b] This flag is implemented on Linux (Wayland).
 		</constant>
 		<constant name="FLAG_MINIMIZE_DISABLED" value="11" enum="Flags">
 			Window minimize button is disabled.
-			[b]Note:[/b] This flag is implemented on macOS and Windows.
+			[b]Note:[/b] This flag has no effect in embedded windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="FLAG_MAXIMIZE_DISABLED" value="12" enum="Flags">
 			Window maximize button is disabled.
-			[b]Note:[/b] This flag is implemented on macOS and Windows.
+			[b]Note:[/b] This flag has no effect in embedded windows.
+			[b]Note:[/b] This flag is implemented on Linux (X11), macOS, and Windows.
 		</constant>
 		<constant name="FLAG_MAX" value="13" enum="Flags">
 			Max value of the [enum Flags].


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/120301

## Additional information

Adds missing platform support notes to window flags.