### PR TITLE
[RTL] Make empty line behavior more consistent.

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -758,7 +758,6 @@ Error EditorHelp::_goto_desc(const String &p_class, bool p_can_trigger_save_hist
 
 void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocData::MethodDoc> &p_methods) {
 	class_desc->add_newline();
-	class_desc->add_newline();
 
 	static const char *titles_by_type[METHOD_TYPE_MAX] = {
 		TTRC("Methods"),
@@ -791,8 +790,12 @@ void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocD
 
 		if (any_previous && !m.is_empty()) {
 			class_desc->push_cell();
+			class_desc->push_font_size(1);
+			class_desc->pop(); // font_size
 			class_desc->pop(); // cell
 			class_desc->push_cell();
+			class_desc->push_font_size(1);
+			class_desc->pop(); // font_size
 			class_desc->pop(); // cell
 		}
 
@@ -811,8 +814,12 @@ void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocD
 
 			if (is_new_group && pass == 1) {
 				class_desc->push_cell();
+				class_desc->push_font_size(1);
+				class_desc->pop(); // font_size
 				class_desc->pop(); // cell
 				class_desc->push_cell();
+				class_desc->push_font_size(1);
+				class_desc->pop(); // font_size
 				class_desc->pop(); // cell
 			}
 
@@ -1081,7 +1088,6 @@ void EditorHelp::_update_doc() {
 
 	// Class description
 	class_desc->add_newline();
-	class_desc->add_newline();
 
 	section_line.push_back(Pair<String, int>(TTR("Description"), class_desc->get_paragraph_count() - 2));
 	description_line = class_desc->get_paragraph_count() - 2;
@@ -1153,7 +1159,6 @@ void EditorHelp::_update_doc() {
 	// Online tutorials
 	if (!cd.tutorials.is_empty()) {
 		class_desc->add_newline();
-		class_desc->add_newline();
 
 		section_line.push_back(Pair<String, int>(TTR("Online Tutorials"), class_desc->get_paragraph_count() - 2));
 		description_line = class_desc->get_paragraph_count() - 2;
@@ -1216,7 +1221,6 @@ void EditorHelp::_update_doc() {
 
 	if (has_properties) {
 		class_desc->add_newline();
-		class_desc->add_newline();
 
 		section_line.push_back(Pair<String, int>(TTR("Properties"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
@@ -1246,12 +1250,20 @@ void EditorHelp::_update_doc() {
 				// No need for the extra spacing when there's no overridden property.
 				if (overridden_property_exists) {
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 				}
 			}
@@ -2220,6 +2232,8 @@ void EditorHelp::_update_doc() {
 
 				if (!prop.setter.is_empty()) {
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 
 					class_desc->push_cell();
@@ -2247,6 +2261,8 @@ void EditorHelp::_update_doc() {
 
 				if (!prop.getter.is_empty()) {
 					class_desc->push_cell();
+					class_desc->push_font_size(1);
+					class_desc->pop(); // font_size
 					class_desc->pop(); // cell
 
 					class_desc->push_cell();
@@ -2274,8 +2290,6 @@ void EditorHelp::_update_doc() {
 			}
 
 			class_desc->pop(); // table
-
-			class_desc->add_newline();
 
 			class_desc->push_indent(1);
 			_push_normal_font();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -715,7 +715,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	String txt;
 	String txt_sub;
 	Item *it_to = (p_line + 1 < (int)p_frame->lines.size()) ? p_frame->lines[p_line + 1].from : nullptr;
-	Item *it_prev = l.from;
+	Item *it_prev = l.from ? l.from : current;
 	int remaining_characters = visible_characters - l.char_offset;
 	for (Item *it = l.from; it && it != it_to; it = _get_next_item(it)) {
 		it_prev = it;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Reverts https://github.com/godotengine/godot/pull/120116 (which make sense for 4.7) and fixes help page spacing by adjusting empty cell font size and removing duplicate line breaks.

## Additional information

See comments in https://github.com/godotengine/godot/pull/120116