### PR TITLE
ItemList, Tree: Fix analog stick moving through many items at once.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -30,6 +30,7 @@
 
 #include "input_event.h"
 
+#include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/input/shortcut.h"
 #include "core/math/transform_2d.h"
@@ -61,6 +62,10 @@ bool InputEvent::is_action_released(const StringName &p_action, bool p_exact_mat
 	bool pressed_state;
 	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>(const_cast<InputEvent *>(this)), p_action, p_exact_match, &pressed_state, nullptr, nullptr);
 	return valid && !pressed_state;
+}
+
+bool InputEvent::is_action_just_pressed_or_echo(const StringName &p_action, bool p_exact_match) const {
+	return is_action(p_action, p_exact_match) && (is_echo() || Input::get_singleton()->is_action_just_pressed_by_event(p_action, const_cast<InputEvent *>(this)));
 }
 
 float InputEvent::get_action_strength(const StringName &p_action, bool p_exact_match) const {

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -72,6 +72,7 @@ public:
 	bool is_action(const StringName &p_action, bool p_exact_match = false) const;
 	bool is_action_pressed(const StringName &p_action, bool p_allow_echo = false, bool p_exact_match = false) const;
 	bool is_action_released(const StringName &p_action, bool p_exact_match = false) const;
+	bool is_action_just_pressed_or_echo(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact_match = false) const;
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -934,7 +934,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			accept_event();
 		}
 
-		else if (p_event->is_action("ui_up", true)) {
+		else if (p_event->is_action_just_pressed_or_echo("ui_up", true)) {
 			if (!search_string.is_empty()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
@@ -981,7 +981,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			accept_event();
 		}
 
-		else if (p_event->is_action("ui_down", true)) {
+		else if (p_event->is_action_just_pressed_or_echo("ui_down", true)) {
 			if (!search_string.is_empty()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
@@ -1058,7 +1058,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			accept_event();
 		}
 
-		else if (p_event->is_action("ui_left", true)) {
+		else if (p_event->is_action_just_pressed_or_echo("ui_left", true)) {
 			search_string = ""; //any mousepress cancels
 
 			if (current % current_columns != 0) {
@@ -1087,7 +1087,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 			accept_event();
 		}
 
-		else if (p_event->is_action("ui_right", true)) {
+		else if (p_event->is_action_just_pressed_or_echo("ui_right", true)) {
 			search_string = ""; //any mousepress cancels
 
 			if (current % current_columns != (current_columns - 1) && current + 1 < items.size()) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3899,7 +3899,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	bool is_command = k.is_valid() && k->is_command_or_control_pressed();
-	if (p_event->is_action(cache.rtl ? "ui_left" : "ui_right") && p_event->is_pressed()) {
+	if (p_event->is_action_just_pressed_or_echo(cache.rtl ? "ui_left" : "ui_right")) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}
@@ -3917,7 +3917,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			_go_down();
 		}
-	} else if (p_event->is_action(cache.rtl ? "ui_right" : "ui_left") && p_event->is_pressed()) {
+	} else if (p_event->is_action_just_pressed_or_echo(cache.rtl ? "ui_right" : "ui_left")) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}
@@ -3935,7 +3935,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			_go_up();
 		}
-	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
+	} else if (p_event->is_action_just_pressed_or_echo("ui_up") && !is_command) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}
@@ -3947,7 +3947,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			_go_up();
 		}
 
-	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
+	} else if (p_event->is_action_just_pressed_or_echo("ui_down") && !is_command) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}


### PR DESCRIPTION
This fixes moving the selection by one item for each motion event past the deadzone. Now requires that the input is just pressed, but also changes selection on echo events (so that keyboard event echo still selects through multiple items).

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #73241

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

- I wanted to add a small local function to `tree.cpp` so I added an anonymous namespace to the top, but I'm not sure what the convention is in this codebase for doing so.
- The check of `is_action_just_pressed_by_event` is designed to apply to joypad events, only responding to the first event that goes past the deadzone and not the spam of continuous motion after that. It has the side-effect of preventing keyboard echo events, hence why I also add "or is_echo" to keep that functionality. I notice that other parts of the codebase (`PopupMenu` and `Viewport` (dealing with inter-control focus) deals with this by special-casing joypad motion events, but that seems messier to me.
- This whole area feels a bit ad-hoc: I noticed that every control (e.g. PopupMenu, Slider, etc) has its own logic for dealing with joypad motion specially. Those that did not (`ItemList` and `Tree`) get spammed by joypad motion. Others like `PopupMenu` handle it correctly, with built-in repeat logic, but there is a lot of joypad-specific logic in each control.1 I have thoughts about generalizing this and standardizing across all controls, but the immediate issue is that `ItemList` and `Tree` are basically broken for joypad motion actions, and this fixes it.

### Updates

- This adds a new method to `InputEvent`: `is_action_just_pressed_or_echo`. The intent of this method is to capture the question "did this event cause an action to either be pressed for the first time, or is an echo", which is the correct question to ask for discrete events such as UI navigation. `ItemList` and `Tree` use this new method. Other built-in UI navigation code could plausibly use it but it is not trivial to change them to use this method.

### Obsolete

~~Note: This can wait until after 4.7 is completed, as it is fixing a long-standing issue.~~