### PR TITLE
Rename "Asset Store" main screen to "Assets" to optimize screen real estate

### DIFF
--- a/doc/classes/EditorFeatureProfile.xml
+++ b/doc/classes/EditorFeatureProfile.xml
@@ -98,13 +98,13 @@
 	</methods>
 	<constants>
 		<constant name="FEATURE_3D" value="0" enum="Feature">
-			The 3D editor. If this feature is disabled, the 3D editor won't display but 3D nodes will still display in the Create New Node dialog.
+			The 3D editor main screen. If this feature is disabled, the 3D editor won't display but 3D nodes will still display in the Create New Node dialog.
 		</constant>
 		<constant name="FEATURE_SCRIPT" value="1" enum="Feature">
-			The Script tab, which contains the script editor and class reference browser. If this feature is disabled, the Script tab won't display.
+			The Script main screen, which contains the script editor and class reference browser. If this feature is disabled, the Script tab won't display.
 		</constant>
 		<constant name="FEATURE_ASSET_LIB" value="2" enum="Feature">
-			The Asset Store tab. If this feature is disabled, the Asset Store tab won't display.
+			The Asset Store main screen. If this feature is disabled, the Assets tab won't display.
 		</constant>
 		<constant name="FEATURE_SCENE_TREE" value="3" enum="Feature">
 			Scene tree editing. If this feature is disabled, the Scene tree dock will still be visible but will be read-only.

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -500,7 +500,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Sets the editor's current main screen to the one specified in [param name]. [param name] must match the title of the tab in question exactly (e.g. [code]2D[/code], [code]3D[/code], [code skip-lint]Script[/code], [code]Game[/code], or [code]Asset Store[/code] for default tabs).
+				Sets the editor's current main screen to the one specified in [param name]. [param name] must match the title of the tab in question exactly (e.g. [code]2D[/code], [code]3D[/code], [code skip-lint]Script[/code], [code]Game[/code], or [code]Assets[/code] for default tabs).
 			</description>
 		</method>
 		<method name="set_object_edited">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -234,7 +234,7 @@
 			<return type="Texture2D" />
 			<description>
 				Override this method in your plugin to return a [Texture2D] in order to give it an icon.
-				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Game", and "Asset Store" buttons.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Game", and "Assets" buttons.
 				Ideally, the plugin icon should be white with a transparent background and 16×16 pixels in size.
 				[codeblocks]
 				[gdscript]
@@ -260,7 +260,7 @@
 			<return type="String" />
 			<description>
 				Override this method in your plugin to provide the name of the plugin when displayed in the Godot editor.
-				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Game", and "Asset Store" buttons.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Game", and "Assets" buttons.
 			</description>
 		</method>
 		<method name="_get_state" qualifiers="virtual const">
@@ -329,7 +329,7 @@
 		<method name="_has_main_screen" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this is a main screen editor plugin (it goes in the workspace selector together with [b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], and [b]Asset Store[/b]).
+				Returns [code]true[/code] if this is a main screen editor plugin (it goes in the workspace selector together with [b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], and [b]Assets[/b]).
 				When the plugin's workspace is selected, other main screen plugins will be hidden, but your plugin will not appear automatically. It needs to be added as a child of [method EditorInterface.get_editor_main_screen] and made visible inside [method _make_visible].
 				Use [method _get_plugin_name] and [method _get_plugin_icon] to customize the plugin button's appearance.
 				[codeblock]
@@ -814,7 +814,7 @@
 		<signal name="main_screen_changed">
 			<param index="0" name="screen_name" type="String" />
 			<description>
-				Emitted when user changes the workspace ([b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], [b]Asset Store[/b]). Also works with custom screens defined by plugins.
+				Emitted when user changes the workspace ([b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], [b]Assets[/b]). Also works with custom screens defined by plugins.
 			</description>
 		</signal>
 		<signal name="project_settings_changed" deprecated="Use [signal ProjectSettings.settings_changed] instead.">

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -412,7 +412,7 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 public:
 	static bool is_available();
 
-	virtual String get_plugin_name() const override { return TTRC("Asset Store"); }
+	virtual String get_plugin_name() const override { return TTRC("Assets"); }
 	virtual const Ref<Texture2D> get_plugin_icon() const override;
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override {}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9406,7 +9406,11 @@ EditorNode::EditorNode() {
 	if (AssetLibraryEditorPlugin::is_available()) {
 		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
-		print_verbose("Asset Store not available (due to using Web editor, or SSL support disabled).");
+#ifdef WEB_ENABLED
+		print_verbose("The Asset Store is not available in the Web editor.");
+#else
+		print_verbose("The Asset Store is not available due to TLS support being disabled at compile-time.");
+#endif // WEB_ENABLED
 	}
 
 	// More visually meaningful to have this later.

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1734,14 +1734,18 @@ ProjectManager::ProjectManager() {
 	if (AssetLibraryEditorPlugin::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
 		asset_library->set_name("AssetLibraryTab");
-		_add_main_view(MAIN_VIEW_ASSETLIB, TTRC("Asset Store"), Ref<Texture2D>(), asset_library);
+		_add_main_view(MAIN_VIEW_ASSETLIB, TTRC("Assets"), Ref<Texture2D>(), asset_library);
 		asset_library->connect("install_asset", callable_mp(this, &ProjectManager::_install_project));
 	} else {
 		VBoxContainer *asset_library_filler = memnew(VBoxContainer);
 		asset_library_filler->set_name("AssetLibraryTab");
-		Button *asset_library_toggle = _add_main_view(MAIN_VIEW_ASSETLIB, TTRC("Asset Store"), Ref<Texture2D>(), asset_library_filler);
+		Button *asset_library_toggle = _add_main_view(MAIN_VIEW_ASSETLIB, TTRC("Assets"), Ref<Texture2D>(), asset_library_filler);
 		asset_library_toggle->set_disabled(true);
-		asset_library_toggle->set_tooltip_text(TTRC("Asset Store not available (due to using Web editor, or because SSL support disabled)."));
+#ifdef WEB_ENABLED
+		asset_library_toggle->set_tooltip_text(TTRC("The Asset Store is not available in the Web editor."));
+#else
+		asset_library_toggle->set_tooltip_text(TTRC("The Asset Store is not available due to TLS support being disabled at compile-time."));
+#endif // WEB_ENABLED
 	}
 
 	// Footer bar.


### PR DESCRIPTION
The current "Asset Store" button had several issues:

- In terms of percentage, the Asset Store button takes the most space compared to the other buttons besides it which are clicked more often.
- When the editor is at minimum width, the main screen buttons are very close to the menu bar and the run bar. This reduced separation makes it harder to distinguish the UI elements at a glance.
- When adding more main screens through plugins, it's more likely that the bar will overflow (as there is no overflow handling for main screen buttons currently):

<img width="1103" height="33" alt="image" src="https://github.com/user-attachments/assets/d432827f-2310-4091-8d6b-018905224386" />

This applies both in the editor and project manager for consistency.

- This closes https://github.com/godotengine/godot-proposals/issues/15005.

## Preview

Before | After
-|-
<img width="1133" height="33" alt="Screenshot_20260615_221903" src="https://github.com/user-attachments/assets/a48e055b-8314-4283-b6bd-760fc64cb91f" /> | <img width="1133" height="33" alt="Screenshot_20260615_221922" src="https://github.com/user-attachments/assets/60e30bc9-d406-4057-a739-720afdcb6ab9" />
