### PR TITLE
Feature: Enable plugins to have their editor tab icons update when the theme changes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1114,6 +1114,7 @@ void EditorNode::_notification(int p_what) {
 				_update_theme();
 				_build_icon_type_cache();
 				recent_scenes->reset_size();
+				callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::reimport_theme_dependent_textures).call_deferred();
 			}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/timers/dragging_")) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2394,6 +2394,50 @@ void EditorFileSystem::_get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet
 	}
 }
 
+void EditorFileSystem::_collect_theme_dependent_textures(EditorFileSystemDirectory *p_dir, Vector<String> &r_files) const {
+	for (int i = 0; i < p_dir->get_file_count(); i++) {
+		if (p_dir->get_file_type(i) != SNAME("CompressedTexture2D")) {
+			continue;
+		}
+		const String path = p_dir->get_file_path(i);
+		const Variant metadata = ResourceFormatImporter::get_singleton()->get_resource_metadata(path);
+		if (metadata.get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+		if (!bool(Dictionary(metadata).get("has_editor_variant", false))) {
+			continue;
+		}
+		// On a theme switch, editor variants are what this reports stale.
+		if (!ResourceFormatImporter::get_singleton()->are_import_settings_valid(path)) {
+			r_files.push_back(path);
+		}
+	}
+
+	for (int i = 0; i < p_dir->get_subdir_count(); i++) {
+		_collect_theme_dependent_textures(p_dir->get_subdir(i), r_files);
+	}
+}
+
+void EditorFileSystem::reimport_theme_dependent_textures() {
+	EditorFileSystemDirectory *root = get_filesystem();
+	if (!root) {
+		return;
+	}
+
+	Vector<String> to_reimport;
+	_collect_theme_dependent_textures(root, to_reimport);
+	if (to_reimport.is_empty()) {
+		return;
+	}
+
+	// Not reimport_files(): it pops a modal progress dialog on every theme change.
+	emit_signal(SNAME("resources_reimporting"), to_reimport);
+	for (const String &path : to_reimport) {
+		_reimport_file(path);
+	}
+	emit_signal(SNAME("resources_reimported"), to_reimport);
+}
+
 void EditorFileSystem::update_file(const String &p_file) {
 	ERR_FAIL_COND(p_file.is_empty());
 	update_files({ p_file });

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -327,6 +327,7 @@ class EditorFileSystem : public Node {
 	void _update_scene_groups();
 	void _update_pending_scene_groups();
 	void _get_all_scenes(EditorFileSystemDirectory *p_dir, HashSet<String> &r_list);
+	void _collect_theme_dependent_textures(EditorFileSystemDirectory *p_dir, Vector<String> &r_files) const;
 
 	ScriptClassInfo _get_global_script_class(const String &p_type, const String &p_path) const;
 
@@ -397,6 +398,7 @@ public:
 	ResourceUID::ID get_file_uid(const String &p_path) const;
 
 	void reimport_files(const Vector<String> &p_files);
+	void reimport_theme_dependent_textures();
 	Error reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters);
 
 	void reimport_file_with_custom_parameters(const String &p_file, const String &p_importer, const HashMap<StringName, Variant> &p_custom_params);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Right now, plugin developers who use the dock tabs cannot have their icons change when the editor theme changes.

Demo video + repro example: https://github.com/dginovker/Godot-Editor-Theme-Tab-Bug

## Additional information

Here's what it looks like after being fixed:

https://github.com/user-attachments/assets/b3b0f735-e659-45c5-9899-66dc4f3e4829

AI disclaimer: I used Claude Code to fix this since I don't know C++, and iterated with it to make the change as "least invasive" as possible + tested by hand. I was also concerned about performance impact of recursively calling EditorFileSystemDirectory to find CompressedTexture2Ds, but Claude told me that this is in memory so we should be good here