### PR TITLE
Document that duplicating instantiated scenes modified at runtime can cause problems

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -283,6 +283,7 @@
 				Duplicates the node, returning a new node with all of its properties, signals, groups, and children copied from the original, recursively. The behavior can be tweaked through the [param flags] (see [enum DuplicateFlags]). Internal nodes are not duplicated.
 				[b]Note:[/b] For nodes with a [Script] attached, if [method Object._init] has been defined with required parameters, the duplicated node will not have a [Script].
 				[b]Note:[/b] By default, this method will duplicate only properties marked for serialization (i.e. using [constant @GlobalScope.PROPERTY_USAGE_STORAGE], or in GDScript, [annotation @GDScript.@export]). If you want to duplicate all properties, use [constant DUPLICATE_INTERNAL_STATE].
+				[b]Note:[/b] By default, if the node comes from an instantiated scene saved on disk, the original children structure will be used for the copy. If the structure has been modified at runtime, this can result in properties being set with wrong values. In such cases, use this method without [constant DUPLICATE_USE_INSTANTIATION].
 			</description>
 		</method>
 		<method name="find_child" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2817,12 +2817,13 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 	}
 
 	List<const Node *> hidden_roots;
-	List<const Node *> node_tree;
-	node_tree.push_front(this);
 
 	if (instantiated) {
 		// Since nodes in the instantiated hierarchy won't be duplicated explicitly, we need to make an inventory
 		// of all the nodes in the tree of the instantiated scene in order to transfer the values of the properties
+
+		List<const Node *> node_tree;
+		node_tree.push_front(this);
 
 		Vector<const Node *> instance_roots;
 		instance_roots.push_back(this);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #111091.

## Additional information

The most non-intrusive "solution" to the issue. This adds a note to the `Node.duplicate()` method description about how `DUPLICATE_USE_INSTANTIATION` can break if the child structure is modified, and its uses the original mapping of child indexes instead of the runtime one.