### PR TITLE
[Web] Build web editor without assertions by default

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -144,6 +144,10 @@ def configure(env: "SConsEnvironment"):
     ## Configure assertions.
     if env["use_assertions"] == "auto":
         env["use_assertions"] = "yes" if env.debug_features else "no"
+        # Build editor without assertions by default.
+        if env["target"] == "editor":
+            env["use_assertions"] = "no"
+
     if env["use_assertions"] == "yes":
         print_info("Building with runtime assertions.")
         env.Append(LINKFLAGS=["-sASSERTIONS=1"])


### PR DESCRIPTION
## What problem(s) does this PR solve?

Symptomatically treats https://github.com/godotengine/godot/issues/120323 .

## Additional information

Before https://github.com/godotengine/godot/pull/117018 web editor didn't use assertions, this PR restores that behaviour. @adamscott (https://github.com/godotengine/godot/pull/117018#issuecomment-3991235446) I'm not sure if this PR is the correct move as it doesn't fix the underlying issue.