### PR TITLE
Partly revert updated warning in `Label`

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -647,8 +647,8 @@ PackedStringArray Label::get_configuration_warnings() const {
 	// but for now we have to warn about this impossible to resolve combination.
 	// See GH-83546.
 	if (is_inside_tree() && get_tree()->get_edited_scene_root() != this) {
-		if (autowrap_mode != TextServer::AUTOWRAP_OFF && get_combined_maximum_size().width <= 0) {
-			warnings.push_back(RTR("Labels with autowrapping enabled must have a positive custom maximum width configured to work correctly."));
+		if (autowrap_mode != TextServer::AUTOWRAP_OFF && get_combined_maximum_size().width <= 0 && get_custom_minimum_size().width <= 0) {
+			warnings.push_back(RTR("Labels with autowrapping enabled must have a positive custom minimum or maximum width configured to work correctly."));
 		}
 	}
 


### PR DESCRIPTION

## What problem(s) does this PR solve?

As part of #116640, I updated the warning for `Label` to now suggest the user use a maximum width for the autowrapping `Label` to work correctly. However, since that PR has been merged, some issues/limitations were discovered with the way it works (#120167, #119325, and #119346).

This PR partially updates the warning to: 
* No longer show when a minimum size is configured. 
  * The intent was that the new system should supersede the old one (whilst keeping both functional). As the new system isn't fully reliable, I do not believe this is the correct approach at this moment.
* Recommend setting a minimum size first, or a maximum width second
  * This should hopefully lead to people trying the minimum size first, which is a proven system without limitations. However, we still let the user know they can use a maximum width. 

## Additional information

None
