### PR TITLE
Fix `BoxContainer` not using `get_bound_minimum_size` when calculating layout

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -67,7 +67,7 @@ void BoxContainer::_resort() {
 		if (propagating_max_size) {
 			c->set_parent_maximum_size_cache(combined_max_size);
 		}
-		Size2i min_size = c->get_combined_minimum_size().ceil();
+		Size2i min_size = c->get_bound_minimum_size().ceil();
 		Size2i max_size = c->get_combined_maximum_size();
 		_MinSizeCache msc;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

~~Previously, when enabling `fit_content_*`, the scrollbar calculation would consider `max_size`, but the `get_minimum_size` calculation did not.~~
~~Added `max_size` calculation to `get_minimum_size`.~~

See https://github.com/godotengine/godot/pull/120351#pullrequestreview-4510565532
The actual issue is that `BoxContainer::_resort()` in `BoxContainer` uses `get_combined_minimum_size` instead of `get_bound_minimum_size` when calculating the layout. The PR has been updated.

Before:  
<img width="301" height="332" alt="屏幕截图_20260616_233458" src="https://github.com/user-attachments/assets/f6ba41fd-be7a-414a-a018-edce7386edca" />

After:
<img width="301" height="268" alt="屏幕截图_20260616_233257" src="https://github.com/user-attachments/assets/1d9b25a0-b947-4a64-bb5b-a7368826218d" />

test:
[textedit_test_2026-06-16_23-33-09.zip](https://github.com/user-attachments/files/29009227/textedit_test_2026-06-16_23-33-09.zip)
