### PR TITLE
Add missing mutex unlock in `AudioDriverPulseAudio` in error state.

### DIFF
--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -374,6 +374,7 @@ float AudioDriverPulseAudio::get_latency() {
 	lock();
 
 	if (pa_str == nullptr) {
+		unlock();
 		return 0;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes regression from https://github.com/godotengine/godot/pull/119975/

The above PR traded a crash for an audio server deadlock, which IS better but still not correct.

Reported by `gardeningcosmic` on RC.

## Additional information

Can't believe I missed that during review 😅

Untested; but should be trivially correct.