### PR TITLE
Fix wrong values when duplicating scene instances with reordered children

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2817,12 +2817,13 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 	}
 
 	List<const Node *> hidden_roots;
-	List<const Node *> node_tree;
-	node_tree.push_front(this);
 
 	if (instantiated) {
 		// Since nodes in the instantiated hierarchy won't be duplicated explicitly, we need to make an inventory
 		// of all the nodes in the tree of the instantiated scene in order to transfer the values of the properties
+
+		List<const Node *> node_tree;
+		node_tree.push_front(this);
 
 		Vector<const Node *> instance_roots;
 		instance_roots.push_back(this);
@@ -2933,7 +2934,7 @@ Node *Node::duplicate(int p_flags) const {
 	ERR_FAIL_NULL_V_MSG(dupe, nullptr, "Failed to duplicate node.");
 
 	if (p_flags & DUPLICATE_SCRIPTS) {
-		_duplicate_scripts(this, dupe);
+		_duplicate_scripts(this, dupe, p_flags);
 	}
 
 	_duplicate_properties(this, this, dupe, p_flags);
@@ -2958,7 +2959,7 @@ Node *Node::duplicate_from_editor(HashMap<const Node *, Node *> &r_duplimap, Nod
 	ERR_FAIL_NULL_V_MSG(dupe, nullptr, "Failed to duplicate node.");
 
 	if (flags & DUPLICATE_SCRIPTS) {
-		_duplicate_scripts(this, dupe);
+		_duplicate_scripts(this, dupe, flags);
 	}
 
 	_duplicate_properties(this, this, dupe, flags);
@@ -3051,17 +3052,21 @@ void Node::_emit_editor_state_changed() {
 }
 #endif
 
-void Node::_duplicate_scripts(const Node *p_original, Node *p_copy) const {
+void Node::_duplicate_scripts(const Node *p_original, Node *p_copy, int p_flags) const {
 	bool is_valid = false;
 	Variant scr = p_original->get(CoreStringName(script), &is_valid);
 	if (is_valid) {
 		p_copy->set(CoreStringName(script), scr);
 	}
 
+	bool instantiated = (p_flags & DUPLICATE_USE_INSTANTIATION) && is_instance();
 	for (int i = 0; i < p_original->get_child_count(false); i++) {
-		Node *copy_child = p_copy->get_child(i, false);
-		ERR_FAIL_NULL_MSG(copy_child, "Child node disappeared while duplicating.");
-		_duplicate_scripts(p_original->get_child(i, false), copy_child);
+		Node *original = p_original->get_child(i, false);
+		// If using instantiation and the child structure changed, getting it by index will result in
+		// fetching values from the wrong nodes. So use the slower (but more accurate) path method.
+		Node *copy = instantiated ? p_copy->get_node(get_path_to(original)) : p_copy->get_child(i, false);
+		ERR_FAIL_NULL_MSG(copy, "Child node disappeared while duplicating.");
+		_duplicate_scripts(original, copy, p_flags);
 	}
 }
 
@@ -3118,10 +3123,14 @@ void Node::_duplicate_properties(const Node *p_root, const Node *p_original, Nod
 		}
 	}
 
+	bool instantiated = (p_flags & DUPLICATE_USE_INSTANTIATION) && is_instance();
 	for (int i = 0; i < p_original->get_child_count(false); i++) {
-		Node *copy_child = p_copy->get_child(i, false);
-		ERR_FAIL_NULL_MSG(copy_child, "Child node disappeared while duplicating.");
-		_duplicate_properties(p_root, p_original->get_child(i, false), copy_child, p_flags);
+		Node *original = p_original->get_child(i, false);
+		// If using instantiation and the child structure changed, getting it by index will result in
+		// fetching values from the wrong nodes. So use the slower (but more accurate) path method.
+		Node *copy = instantiated ? p_copy->get_node(get_path_to(original)) : p_copy->get_child(i, false);
+		ERR_FAIL_NULL_MSG(copy, "Child node disappeared while duplicating.");
+		_duplicate_properties(p_root, original, copy, p_flags);
 	}
 }
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -319,7 +319,7 @@ private:
 	void _propagate_translation_domain_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
 
-	void _duplicate_scripts(const Node *p_original, Node *p_copy) const;
+	void _duplicate_scripts(const Node *p_original, Node *p_copy, int p_flags) const;
 	void _duplicate_properties(const Node *p_root, const Node *p_original, Node *p_copy, int p_flags) const;
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	Node *_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap = nullptr) const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #111091.
- Supersedes #120339.

## Additional information

An actual solution for the regression caused by #91329. It changes the code to use `get_node()` instead of `get_child()` when duplicating an instantiated scene. This should fix the issue without completely undoing the performance increase of that PR.

It also fixes a similar non-regressive issue, but with scripts.