### PR TITLE
Don't defer scrolling change when ensuring the `Tree` cursor is visible

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6152,7 +6152,7 @@ void Tree::ensure_cursor_is_visible() {
 			v_scroll->set_value(y_offset);
 		} else if (y_offset + cell_h > v_scroll->get_value() + screen_h) {
 			delta_v = y_offset - screen_h + cell_h - v_scroll->get_value();
-			callable_mp((Range *)v_scroll, &Range::set_value).call_deferred(y_offset - screen_h + cell_h);
+			v_scroll->set_value(y_offset - screen_h + cell_h);
 		} else if (y_offset < v_scroll->get_value()) {
 			delta_v = y_offset - v_scroll->get_value();
 			v_scroll->set_value(y_offset);
@@ -6174,7 +6174,7 @@ void Tree::ensure_cursor_is_visible() {
 			h_scroll->set_value(x_offset);
 		} else if (x_offset + cell_w > h_scroll->get_value() + screen_w) {
 			delta_h = x_offset - screen_w + cell_w - h_scroll->get_value();
-			callable_mp((Range *)h_scroll, &Range::set_value).call_deferred(x_offset - screen_w + cell_w);
+			h_scroll->set_value(x_offset - screen_w + cell_w);
 		} else if (x_offset < h_scroll->get_value()) {
 			delta_h = x_offset - h_scroll->get_value();
 			h_scroll->set_value(x_offset);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #115747.
- Alternative to #115760.

## Additional information

`git blame` indicates that those calls where set to be deferred several years ago. I did some testing to see if any regressions appeared if the values were set directly, and didn't find anything. Maybe the reason they were is not present anymore.