### PR TITLE
[BaseButton] Emit `button_down/up` signals when button is activated by screen reader command.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -115,6 +115,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void BaseButton::_accessibility_action_click(const Variant &p_data) {
+	emit_signal(SNAME("button_down"));
 	if (toggle_mode) {
 		status.pressed = !status.pressed;
 
@@ -130,6 +131,7 @@ void BaseButton::_accessibility_action_click(const Variant &p_data) {
 	} else {
 		_pressed();
 	}
+	emit_signal(SNAME("button_up"));
 	queue_accessibility_update();
 	queue_redraw();
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

See https://github.com/godotengine/godot/issues/120324
