### PR TITLE
Fix GraphFrame expansion when dragging selected contents

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -919,6 +919,10 @@ Rect2 GraphEdit::_compute_shrinked_frame_rect(const GraphFrame *p_frame) {
 }
 
 void GraphEdit::_update_graph_frame(GraphFrame *p_frame) {
+	if (dragging && p_frame->is_selected() && !p_frame->is_autoshrink_enabled()) {
+		return;
+	}
+
 	Rect2 frame_rect = _compute_shrinked_frame_rect(p_frame);
 
 	Vector2 min_point = frame_rect.position;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
- Closes #115393 

## Additional information
When dragging a selected Frame while also having all contents selected
and auto-shrink disabled, the frame would grow in size rapidly.

This happened because attached elements would trigger
_update_graph_frame() on the selected frame.

Avoid updating selected frames with autoshrink disabled while being
dragged.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
