### PR TITLE
Fix broken icons when moving the FileSystem dock to the bottom

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -561,6 +561,10 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				_update_file_list(!selected_files.is_empty(), selected_files);
 			} else {
 				tree->ensure_cursor_is_visible();
+
+				// Always update to avoid broken icons, as previous updates
+				// could have happened before the dock was inside the tree.
+				update_all();
 			}
 		} break;
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120325.

## Additional information

Fixes the regression caused by #119642.
