### PR TITLE
Don't let `Resource` metadata be `null` when created via the inspector

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -271,7 +271,13 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 	} else {
 		Variant **V = metadata_properties.getptr(p_name);
 		if (V) {
-			**V = p_value;
+			// Don't allow to clear resource metadata, as making it null erases it.
+			if (p_value.get_type() == Variant::OBJECT && p_value.is_null()) {
+				**V = memnew(Resource);
+			} else {
+				**V = p_value;
+			}
+
 			if (r_valid) {
 				*r_valid = true;
 			}

--- a/editor/inspector/add_metadata_dialog.cpp
+++ b/editor/inspector/add_metadata_dialog.cpp
@@ -95,9 +95,15 @@ StringName AddMetadataDialog::get_meta_name() {
 }
 
 Variant AddMetadataDialog::get_meta_defval() {
+	Variant::Type type = add_meta_type->get_selected_type();
+	if (type == Variant::OBJECT) {
+		// Give it a placeholder resource, as meta with null values aren't saved.
+		return memnew(Resource);
+	}
+
 	Variant defval;
 	Callable::CallError ce;
-	Variant::construct(add_meta_type->get_selected_type(), defval, nullptr, 0, ce);
+	Variant::construct(type, defval, nullptr, 0, ce);
 	return defval;
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #97597.

## Additional information

When adding metadata of type `Resource`using the inspector, they start as `null`. Setting metadata with a `null` value implicitly deletes it, which means that if the user doesn't set a value to them, they will vanish once they reopen the scene. This PR makes so that it will always have a placeholder `Resource` if nothing else is set.