### PR TITLE
Fix UDP server peer connections.

### DIFF
--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -80,10 +80,20 @@ Error UDPServer::poll() {
 			Peer peer;
 			peer.ip = ip;
 			peer.port = port;
-			peer.peer = memnew(PacketPeerUDP);
+			Ref<PacketPeerUDP> peer_ref = memnew(PacketPeerUDP);
+			peer.peer = peer_ref.ptr();
 			peer.peer->connect_shared_socket(_sock, ip, port, this);
 			peer.peer->store_packet(ip, port, recv_buffer, read);
 			pending.push_back(peer);
+
+			// FIXME: peer.peer is intentionally leaked such that it can destruct
+			//        when the client no longer needs it.
+			//        The current system 'abuses' the refcount_init semantics, such
+			//        that the first take_connection call takes ownership. A refactor
+			//        with a better "transfer ownership" semantics is warranted to avoid
+			//        accidental leaks.
+			peer_ref->reference();
+			peer_ref->deinit_ref();
 		}
 	}
 	return OK;
@@ -149,6 +159,7 @@ void UDPServer::set_max_pending_connections(int p_max) {
 		if (!E) {
 			break;
 		}
+		memdelete(E->get().peer);
 		pending.erase(E);
 	}
 }
@@ -186,11 +197,13 @@ void UDPServer::stop() {
 	List<Peer>::Element *E = peers.front();
 	while (E) {
 		E->get().peer->disconnect_shared_socket();
+		// Don't delete peer; it's intentionally weakly owned.
 		E = E->next();
 	}
 	E = pending.front();
 	while (E) {
 		E->get().peer->disconnect_shared_socket();
+		memdelete(E->get().peer);
 		E = E->next();
 	}
 	peers.clear();

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -42,7 +42,10 @@ protected:
 	};
 
 	struct Peer {
-		Ref<PacketPeerUDP> peer;
+		// Weakly owned in peers, strongly owned in pending.
+		// Peers are weakly owned such that it can self-destruct (and thus unregister itself)
+		// when the user no longer needs it.
+		PacketPeerUDP *peer;
 		IPAddress ip;
 		uint16_t port = 0;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120291#issuecomment-4730031454

(confirmed with the MRP)

## Additional information

The `peers` is intentionally not owned to allow callers to take ownership, such that `PacketPeerUDP` can destruct when the caller no longer needs it.

My change in https://github.com/godotengine/godot/pull/111965/ accidentally made it owning, so the server co-owns the peer and it essentially leaks.

This hotfix restores previous behavior (in practice). It should be seen as a temporary solution since it abuses the "initial refcount" semantics of `RefCounted` (as it did previously); a 'proper' weak ref should reason about ownership instead.

## Author disclosure

Problem diagnosed with the help of AI. Solution designed and written by me.

Big thanks to @NoNormalDev for the bisect and the excellent MRP!!