### PR TITLE
Set inited=false on `CookieContextMbedTLS::clear` to avoid accidental double destruction.

### DIFF
--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -79,6 +79,7 @@ void CookieContextMbedTLS::clear() {
 	mbedtls_ctr_drbg_free(&ctr_drbg);
 	mbedtls_entropy_free(&entropy);
 	mbedtls_ssl_cookie_free(&cookie_ctx);
+	inited = false;
 }
 
 CookieContextMbedTLS::CookieContextMbedTLS() {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Avoids an error like the following on mbedtls shutdown (present since at least 4.6)

```
ERROR: Parameter "p_mutex->mutex" is null.
   at: godot_mbedtls_mutex_free (modules/mbedtls/register_types.cpp:54
```

## Author disclosure

Co-written by @akien-mga and found by AI.