### PR TITLE
GDScript: reload stale depended scripts during compile

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -843,6 +843,19 @@ Error GDScript::reload(bool p_keep_state) {
 		return ERR_PARSE_ERROR;
 	}
 
+#ifdef TOOLS_ENABLED
+	// reload depended scripts if they have been modified since last reload
+	for (const KeyValue<String, Ref<GDScriptParserRef>> &p : parser.get_depended_parsers()) {
+		Ref<GDScript> script = GDScriptCache::get_cached_script(p.key);
+		if (script.is_valid() && script->is_valid() && !script->is_edited() && !script->reloading) {
+			if (FileAccess::exists(p.key) && FileAccess::get_modified_time(p.key) > script->get_last_modified_time() && !script->reloading) {
+				GDScriptCache::get_full_script(p.key, err, path, true);
+				ERR_CONTINUE_MSG(err, "Failed to reload dependent script: " + p.key);
+			}
+		}
+	}
+#endif
+
 	can_run = ScriptServer::is_scripting_enabled() || parser.is_tool();
 
 	GDScriptCompiler compiler;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes #120374

## Additional Information

I put a check in `reload()` right after the analyze pass that checks if any of the depended scripts need to be reloaded by comparing their modified time with the modified time on disk. I pragma'd it to only occur during editor builds, since we don't have to worry about scripts changing in release builds.

This is the earliest place where we could do this, since right after the analyzer pass we'll know which scripts the current script depends on. If there's a more appropriate place to do this, let me know.