### PR TITLE
Fix `.godot` file icon saturation in editor file dialogs

### DIFF
--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -110,6 +110,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	HashSet<StringName> saturation_exceptions;
 	saturation_exceptions.insert("DefaultProjectIcon");
 	saturation_exceptions.insert("Godot");
+	saturation_exceptions.insert("GodotFile");
 	saturation_exceptions.insert("Logo");
 	saturation_exceptions.insert("TitleBarLogo");
 


### PR DESCRIPTION
## Preview

Before | After
-|-
<img width="302" height="117" alt="Screenshot 2026-06-17 201800" src="https://github.com/user-attachments/assets/79ab077e-e6de-4dbc-8fbc-a57f44c2a1b5" /> | <img width="329" height="129" alt="Screenshot 2026-06-17 202115" src="https://github.com/user-attachments/assets/1faa5653-aa23-4dc6-be85-f48590c0b8e8" />
