### PR TITLE
Implement BaseMaterial3D::reset_state

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -3905,10 +3905,11 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(STENCIL_COMPARE_GREATER_OR_EQUAL);
 }
 
-BaseMaterial3D::BaseMaterial3D(bool p_orm) :
-		element(this) {
-	orm = p_orm;
-	// Initialize to the same values as the shader
+void BaseMaterial3D::reset_state() {
+	Resource::reset_state();
+	for (int i = 0; i < TEXTURE_MAX; i++) {
+		set_texture(TextureParam(i), Ref<Texture2D>());
+	}
 	set_albedo(Color(1.0, 1.0, 1.0, 1.0));
 	set_specular(0.5);
 	set_roughness(1.0);
@@ -3966,15 +3967,54 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 
 	set_heightmap_deep_parallax_min_layers(8);
 	set_heightmap_deep_parallax_max_layers(32);
-	set_heightmap_deep_parallax_flip_tangent(false); //also sets binormal
+	set_heightmap_deep_parallax_flip_tangent(false);
+	set_heightmap_deep_parallax_flip_binormal(false);
 
 	set_z_clip_scale(1.0);
 	set_fov_override(75.0);
 
 	set_stencil_mode(STENCIL_MODE_DISABLED);
-
+	set_stencil_flags(0);
+	set_stencil_compare(STENCIL_COMPARE_ALWAYS);
+	set_stencil_reference(1);
+	set_stencil_effect_color(Color(0, 0, 0, 1));
+	set_stencil_effect_outline_thickness(0.01f);
+	set_grow_enabled(false);
+	set_heightmap_deep_parallax(false);
+	set_proximity_fade_enabled(false);
+	set_distance_fade(DISTANCE_FADE_DISABLED);
+	set_emission_operator(EMISSION_OP_ADD);
+	// emission_intensity setter rejects calls if PLU is disabled
+	if (GLOBAL_GET_CACHED(bool, "rendering/lights_and_shadows/use_physical_light_units")) {
+		set_emission_intensity(1000.0f);
+	}
+	set_texture_filter(TEXTURE_FILTER_LINEAR_WITH_MIPMAPS);
+	for (int i = 0; i < FLAG_MAX; i++) {
+		set_flag(Flags(i), false);
+	}
 	flags[FLAG_ALBEDO_TEXTURE_MSDF] = false;
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;
+	for (int i = 0; i < FEATURE_MAX; i++) {
+		set_feature(Feature(i), false);
+	}
+	set_shading_mode(SHADING_MODE_PER_PIXEL);
+	set_diffuse_mode(DIFFUSE_BURLEY);
+	set_specular_mode(SPECULAR_SCHLICK_GGX);
+	set_blend_mode(BLEND_MODE_MIX);
+	set_depth_draw_mode(DEPTH_DRAW_OPAQUE_ONLY);
+	set_depth_test(DEPTH_TEST_DEFAULT);
+	set_cull_mode(CULL_BACK);
+	set_detail_blend_mode(BLEND_MODE_MIX);
+	set_detail_uv(DETAIL_UV_1);
+
+	set_render_priority(0);
+	set_next_pass(Ref<Material>());
+}
+
+BaseMaterial3D::BaseMaterial3D(bool p_orm) :
+		element(this) {
+	orm = p_orm;
+	reset_state();
 
 	current_key.invalid_key = 1;
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -883,6 +883,7 @@ public:
 
 	virtual Shader::Mode get_shader_mode() const override;
 
+	virtual void reset_state() override;
 	BaseMaterial3D(bool p_orm);
 	virtual ~BaseMaterial3D();
 };

--- a/tests/scene/test_material.cpp
+++ b/tests/scene/test_material.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  test_material.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_material)
+
+#ifndef _3D_DISABLED
+
+#include "scene/resources/image_texture.h"
+#include "scene/resources/material.h"
+
+namespace TestMaterial {
+
+// Properties that material will not reset.
+static bool _is_ignored_property(const String &p_name) {
+	return p_name == "resource_local_to_scene" ||
+			p_name == "resource_name" ||
+			p_name == "resource_path" ||
+			p_name == "resource_scene_unique_id" ||
+			p_name == "script" ||
+			p_name.begins_with("metadata/");
+}
+
+// Produce a value different from the property's default so that reset_state()
+// actually has something to revert.
+static bool _perturb_value(const PropertyInfo &p_prop, const Variant &p_default, const Ref<Texture2D> &p_texture, Variant &r_out) {
+	switch (p_prop.type) {
+		case Variant::BOOL:
+			r_out = !bool(p_default);
+			return true;
+		case Variant::INT:
+			r_out = int64_t(p_default) + 1;
+			return true;
+		case Variant::FLOAT:
+			r_out = double(p_default) + 1.0;
+			return true;
+		case Variant::COLOR:
+			r_out = Color(0.12, 0.34, 0.56, 0.78);
+			return true;
+		case Variant::VECTOR3:
+			r_out = Vector3(p_default) + Vector3(1.5, 2.5, 3.5);
+			return true;
+		case Variant::OBJECT:
+			// Only texture slots can take our dummy texture; other object
+			// properties (e.g. next_pass) expect different types.
+			if (p_prop.hint_string.containsn("Texture")) {
+				r_out = p_texture;
+				return true;
+			}
+			return false;
+		default:
+			return false;
+	}
+}
+
+TEST_CASE("[SceneTree][Material] reset_state restores all properties to defaults") {
+	Ref<StandardMaterial3D> fresh;
+	fresh.instantiate();
+
+	Ref<StandardMaterial3D> mat;
+	mat.instantiate();
+
+	// Texture to assign to every texture slot.
+	Ref<Image> image = Image::create_empty(2, 2, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 1, 1, 1));
+	Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
+
+	List<PropertyInfo> props;
+	mat->get_property_list(&props);
+
+	for (const PropertyInfo &E : props) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE) || _is_ignored_property(E.name)) {
+			continue;
+		}
+		Variant perturbed;
+		if (!_perturb_value(E, mat->get(E.name), texture, perturbed)) {
+			continue;
+		}
+		mat->set(E.name, perturbed);
+	}
+
+	// At least confirm the perturbation took effect for a representative property.
+	CHECK(mat->get_texture(BaseMaterial3D::TEXTURE_ALBEDO).is_valid());
+	CHECK(mat->get_metallic() != fresh->get_metallic());
+
+	mat->reset_state();
+
+	// Every storage property must now match a freshly-constructed material.
+	for (const PropertyInfo &E : props) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE) || _is_ignored_property(E.name)) {
+			continue;
+		}
+		const Variant expected = fresh->get(E.name);
+		const Variant actual = mat->get(E.name);
+		CHECK_MESSAGE(actual == expected,
+				vformat("Property '%s' was not reset (expected %s, got %s).", E.name, expected, actual).get_data());
+	}
+
+	CHECK(mat->get_texture(BaseMaterial3D::TEXTURE_ALBEDO).is_null());
+}
+
+} // namespace TestMaterial
+
+#endif // _3D_DISABLED


### PR DESCRIPTION
When editing materials externally, reimport will run, save the scene to a file and then ResourceBinaryLoader will be called with CACHE_MODE_REPLACE. It will take the existing resource and perform reset_state, then load the stored properties from the file.

Since BaseMaterial3D does not override reset_state, this is a no-op for the material properties and if the new material does not define them, they will stay in place.

## What problem(s) does this PR solve?

- Closes #104937
- Closes #119131
- Closes #105474

## Additional information

Before and after video

https://github.com/user-attachments/assets/681c70ff-a0c7-45a7-a180-43d335088272

[project](https://github.com/user-attachments/files/29065482/material.zip)


