### PR TITLE
Add Callable support to EditorUndoRedoManager

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -85,6 +85,62 @@ bool UndoRedo::_redo(bool p_execute) {
 	return true;
 }
 
+void UndoRedo::_add_callable_do_operation(const Callable &p_callable, Operation::Type p_type) {
+	ERR_FAIL_COND(!p_callable.is_valid());
+	ERR_FAIL_COND(action_level <= 0);
+	ERR_FAIL_COND((current_action + 1) >= actions.size());
+
+	ObjectID object_id = p_callable.get_object_id();
+	Object *object = ObjectDB::get_instance(object_id);
+	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
+
+	Operation do_op;
+	do_op.callable = p_callable;
+	do_op.object = object_id;
+	if (Object::cast_to<RefCounted>(object)) {
+		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
+	}
+	do_op.type = p_type;
+	do_op.name = p_callable.get_method();
+	if (do_op.name == StringName()) {
+		// There's no `get_method()` for custom callables, so use `operator String()` instead.
+		do_op.name = static_cast<String>(p_callable);
+	}
+
+	actions.write[current_action + 1].do_ops.push_back(do_op);
+}
+
+void UndoRedo::_add_callable_undo_operation(const Callable &p_callable, Operation::Type p_type) {
+	ERR_FAIL_COND(!p_callable.is_valid());
+	ERR_FAIL_COND(action_level <= 0);
+	ERR_FAIL_COND((current_action + 1) >= actions.size());
+
+	// No undo if the merge mode is MERGE_ENDS
+	if (!force_keep_in_merge_ends && merge_mode == MERGE_ENDS) {
+		return;
+	}
+
+	ObjectID object_id = p_callable.get_object_id();
+	Object *object = ObjectDB::get_instance(object_id);
+	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
+
+	Operation undo_op;
+	undo_op.callable = p_callable;
+	undo_op.object = object_id;
+	if (Object::cast_to<RefCounted>(object)) {
+		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
+	}
+	undo_op.type = p_type;
+	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
+	undo_op.name = p_callable.get_method();
+	if (undo_op.name == StringName()) {
+		// There's no `get_method()` for custom callables, so use `operator String()` instead.
+		undo_op.name = static_cast<String>(p_callable);
+	}
+
+	actions.write[current_action + 1].undo_ops.push_back(undo_op);
+}
+
 void UndoRedo::create_action(const String &p_name, MergeMode p_mode, bool p_backward_undo_ops) {
 	uint64_t ticks = OS::get_singleton()->get_ticks_msec();
 
@@ -144,59 +200,11 @@ void UndoRedo::create_action(const String &p_name, MergeMode p_mode, bool p_back
 }
 
 void UndoRedo::add_do_method(const Callable &p_callable) {
-	ERR_FAIL_COND(!p_callable.is_valid());
-	ERR_FAIL_COND(action_level <= 0);
-	ERR_FAIL_COND((current_action + 1) >= actions.size());
-
-	ObjectID object_id = p_callable.get_object_id();
-	Object *object = ObjectDB::get_instance(object_id);
-	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
-
-	Operation do_op;
-	do_op.callable = p_callable;
-	do_op.object = object_id;
-	if (Object::cast_to<RefCounted>(object)) {
-		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
-	}
-	do_op.type = Operation::TYPE_METHOD;
-	do_op.name = p_callable.get_method();
-	if (do_op.name == StringName()) {
-		// There's no `get_method()` for custom callables, so use `operator String()` instead.
-		do_op.name = static_cast<String>(p_callable);
-	}
-
-	actions.write[current_action + 1].do_ops.push_back(do_op);
+	_add_callable_do_operation(p_callable, Operation::TYPE_METHOD);
 }
 
 void UndoRedo::add_undo_method(const Callable &p_callable) {
-	ERR_FAIL_COND(!p_callable.is_valid());
-	ERR_FAIL_COND(action_level <= 0);
-	ERR_FAIL_COND((current_action + 1) >= actions.size());
-
-	// No undo if the merge mode is MERGE_ENDS
-	if (!force_keep_in_merge_ends && merge_mode == MERGE_ENDS) {
-		return;
-	}
-
-	ObjectID object_id = p_callable.get_object_id();
-	Object *object = ObjectDB::get_instance(object_id);
-	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
-
-	Operation undo_op;
-	undo_op.callable = p_callable;
-	undo_op.object = object_id;
-	if (Object::cast_to<RefCounted>(object)) {
-		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
-	}
-	undo_op.type = Operation::TYPE_METHOD;
-	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
-	undo_op.name = p_callable.get_method();
-	if (undo_op.name == StringName()) {
-		// There's no `get_method()` for custom callables, so use `operator String()` instead.
-		undo_op.name = static_cast<String>(p_callable);
-	}
-
-	actions.write[current_action + 1].undo_ops.push_back(undo_op);
+	_add_callable_undo_operation(p_callable, Operation::TYPE_METHOD);
 }
 
 void UndoRedo::add_do_property(Object *p_object, const StringName &p_property, const Variant &p_value) {
@@ -272,6 +280,16 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
 	actions.write[current_action + 1].undo_ops.push_back(undo_op);
 }
+
+#ifdef TOOLS_ENABLED
+void UndoRedo::add_do_custom_callable(const Callable &p_callable) {
+	_add_callable_do_operation(p_callable, Operation::TYPE_CUSTOM_CALLABLE);
+}
+
+void UndoRedo::add_undo_custom_callable(const Callable &p_callable) {
+	_add_callable_undo_operation(p_callable, Operation::TYPE_CUSTOM_CALLABLE);
+}
+#endif
 
 void UndoRedo::start_force_keep_in_merge_ends() {
 	ERR_FAIL_COND(action_level <= 0);
@@ -358,7 +376,8 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *r_elements, boo
 		}
 
 		switch (op.type) {
-			case Operation::TYPE_METHOD: {
+			case Operation::TYPE_METHOD:
+			case Operation::TYPE_CUSTOM_CALLABLE: {
 				if (p_execute) {
 					Callable::CallError ce;
 					Variant ret;
@@ -374,7 +393,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *r_elements, boo
 #endif
 				}
 
-				if (method_callback) {
+				if (method_callback && op.type == Operation::TYPE_METHOD) {
 					Vector<Variant> binds;
 					if (op.callable.is_custom()) {
 						CallableCustomBind *ccb = dynamic_cast<CallableCustomBind *>(op.callable.get_custom());

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -53,8 +53,9 @@ private:
 	struct Operation {
 		enum Type {
 			TYPE_METHOD,
+			TYPE_CUSTOM_CALLABLE,
 			TYPE_PROPERTY,
-			TYPE_REFERENCE
+			TYPE_REFERENCE,
 		} type;
 
 		bool force_keep_in_merge_ends = false;
@@ -90,6 +91,9 @@ private:
 	void _discard_redo();
 	bool _redo(bool p_execute);
 
+	void _add_callable_do_operation(const Callable &p_callable, Operation::Type p_type);
+	void _add_callable_undo_operation(const Callable &p_callable, Operation::Type p_type);
+
 	CommitNotifyCallback callback = nullptr;
 	void *callback_ud = nullptr;
 	void *method_callback_ud = nullptr;
@@ -112,6 +116,11 @@ public:
 	void add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_do_reference(Object *p_object);
 	void add_undo_reference(Object *p_object);
+#ifdef TOOLS_ENABLED
+	// For EditorUndoRedoManager.
+	void add_do_custom_callable(const Callable &p_callable);
+	void add_undo_custom_callable(const Callable &p_callable);
+#endif
 
 	void start_force_keep_in_merge_ends();
 	void end_force_keep_in_merge_ends();

--- a/doc/classes/EditorUndoRedoManager.xml
+++ b/doc/classes/EditorUndoRedoManager.xml
@@ -16,6 +16,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_do_callable">
+			<return type="void" />
+			<param index="0" name="callable" type="Callable" />
+			<description>
+				Registers a method that will be called when the action is committed (i.e. the "do" action).
+				Unlike [method add_do_method], this method does not support live editing, meaning the operation will not be replicated in the running project. It also does not support undo history deduction. The undo history is determined by the previous operations or [method create_action], otherwise defaults to global.
+			</description>
+		</method>
 		<method name="add_do_method" qualifiers="vararg">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
@@ -40,6 +48,14 @@
 			<param index="0" name="object" type="Object" />
 			<description>
 				Register a reference for "do" that will be erased if the "do" history is lost. This is useful mostly for new nodes created for the "do" call. Do not use for resources.
+			</description>
+		</method>
+		<method name="add_undo_callable">
+			<return type="void" />
+			<param index="0" name="callable" type="Callable" />
+			<description>
+				Registers a method that will be called when the action is undone (i.e. the "undo" action).
+				Unlike [method add_undo_method], this method does not support live editing, meaning the operation will not be replicated in the running project. It also does not support undo history deduction. The undo history is determined by the previous operations or [method create_action], otherwise defaults to global.
 			</description>
 		</method>
 		<method name="add_undo_method" qualifiers="vararg">

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -243,6 +243,16 @@ void EditorUndoRedoManager::add_undo_reference(Object *p_object) {
 	undo_redo->add_undo_reference(p_object);
 }
 
+void EditorUndoRedoManager::add_do_callable(const Callable &p_callable) {
+	UndoRedo *undo_redo = get_history_for_object(nullptr).undo_redo;
+	undo_redo->add_do_custom_callable(p_callable);
+}
+
+void EditorUndoRedoManager::add_undo_callable(const Callable &p_callable) {
+	UndoRedo *undo_redo = get_history_for_object(nullptr).undo_redo;
+	undo_redo->add_undo_custom_callable(p_callable);
+}
+
 void EditorUndoRedoManager::commit_action(bool p_execute) {
 	if (pending_action.history_id == INVALID_HISTORY) {
 		return; // Empty action, do nothing.
@@ -565,6 +575,8 @@ void EditorUndoRedoManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_undo_property", "object", "property", "value"), &EditorUndoRedoManager::add_undo_property);
 	ClassDB::bind_method(D_METHOD("add_do_reference", "object"), &EditorUndoRedoManager::add_do_reference);
 	ClassDB::bind_method(D_METHOD("add_undo_reference", "object"), &EditorUndoRedoManager::add_undo_reference);
+	ClassDB::bind_method(D_METHOD("add_do_callable", "callable"), &EditorUndoRedoManager::add_do_callable);
+	ClassDB::bind_method(D_METHOD("add_undo_callable", "callable"), &EditorUndoRedoManager::add_undo_callable);
 
 	ClassDB::bind_method(D_METHOD("get_object_history_id", "object"), &EditorUndoRedoManager::get_history_id_for_object);
 	ClassDB::bind_method(D_METHOD("get_history_undo_redo", "id"), &EditorUndoRedoManager::get_history_undo_redo);

--- a/editor/editor_undo_redo_manager.h
+++ b/editor/editor_undo_redo_manager.h
@@ -123,6 +123,8 @@ public:
 	void add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_do_reference(Object *p_object);
 	void add_undo_reference(Object *p_object);
+	void add_do_callable(const Callable &p_callable);
+	void add_undo_callable(const Callable &p_callable);
 
 	void commit_action(bool p_execute = true);
 	bool is_committing_action() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

I've seen people asking from time to time why EditorUndoRedoManager does not support Callables, like UndoRedo. The answer is always that live editing expects a regular callables, hence the API does not allow anything fancy.
However there are some use-cases where you don't really care about live editing, or just using a custom callable is easier.

This PR adds a new method to EditorUndoRedoManager that allows adding operations which are explicitly excluded from all UndoRedo hooks. Meaning the editor will not try to send the Callable to running project, so you can use any Callable, even ones that aren't supported.