### PR TITLE
Add queue on change SceneTree to prevent over accessing `FileAccess`

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2267,6 +2267,8 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 				HashMap<Node *, NodePath>::Iterator found_root_path = p_renames->find(root);
 				NodePath new_root_path = found_root_path ? found_root_path->value : root->get_path();
 				if (!new_root_path.is_empty()) { // No renaming if root node is deleted.
+					bool update_scene_folding = false;
+					LocalVector<Pair<Ref<Resource>, String>> res_folds;
 					for (const StringName &E : mixer->get_sorted_animation_list()) {
 						Ref<Animation> anim = mixer->get_animation(E);
 						if (!r_rem_anims->has(anim)) {
@@ -2338,6 +2340,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 						//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheOldName
 						// value of p_renames is like:
 						//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheNewName
+						bool folding_changed = false;
 						for (const KeyValue<Node *, NodePath> &rename : *p_renames) {
 							NodePath old_path = rename.key->get_path();
 							NodePath new_path = rename.value;
@@ -2349,19 +2352,31 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 							StringName old_node_name = rename.key->get_name();
 							StringName new_node_name = rel_path[rel_path.size() - 1];
 
-							anim->editor_set_group_folded(new_node_name, anim->editor_is_group_folded(old_node_name));
-							anim->editor_set_group_folded(old_node_name, false);
+							if (anim->editor_is_group_folded(old_node_name)) {
+								anim->editor_set_group_folded(new_node_name, true);
+								anim->editor_set_group_folded(old_node_name, false);
+								folding_changed = true;
+							}
 						}
 
-						if (!anim->get_path().is_resource_file()) {
-							EditorNode::get_editor_folding().save_scene_folding(
-									EditorNode::get_singleton()->get_edited_scene(),
-									EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
-						} else {
-							EditorNode::get_editor_folding().save_resource_folding(
-									anim,
-									anim->get_path());
+						if (folding_changed) {
+							if (!anim->get_path().is_resource_file()) {
+								update_scene_folding = true;
+							} else {
+								Pair<Ref<Resource>, String> res_path;
+								res_path.first = anim;
+								res_path.second = anim->get_path();
+								res_folds.push_back(res_path);
+							}
 						}
+					}
+					if (res_folds.size()) {
+						EditorNode::get_editor_folding().save_resource_foldings(res_folds);
+					}
+					if (update_scene_folding) {
+						EditorNode::get_editor_folding().save_scene_folding(
+								EditorNode::get_singleton()->get_edited_scene(),
+								EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
 					}
 				}
 			}

--- a/editor/settings/editor_folding.cpp
+++ b/editor/settings/editor_folding.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/config_file.h"
 #include "core/io/file_access.h"
+#include "core/object/worker_thread_pool.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/inspector/editor_inspector.h"
 #include "scene/animation/animation_mixer.h"
@@ -51,7 +52,7 @@ Vector<String> EditorFolding::_get_unfolds(const Object *p_object) {
 	return sections;
 }
 
-void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const String &p_path) {
+Ref<ConfigFile> EditorFolding::_build_resource_folding(const Ref<Resource> &p_resource, const String &p_path, String &r_file) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 	Vector<String> unfolds = _get_unfolds(p_resource.ptr());
@@ -64,8 +65,41 @@ void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const
 	}
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
+	r_file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
+	return config;
+}
+
+void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const String &p_path) {
+	String file;
+	Ref<ConfigFile> config = _build_resource_folding(p_resource, p_path, file);
 	config->save(file);
+}
+
+void EditorFolding::_save_resource_folding(uint32_t p_index, FoldingFileSave *p_files) {
+	p_files[p_index].config->save(p_files[p_index].file);
+}
+
+void EditorFolding::save_resource_foldings(const LocalVector<Pair<Ref<Resource>, String>> &p_resource_paths) {
+	if (p_resource_paths.is_empty()) {
+		return;
+	}
+
+	LocalVector<FoldingFileSave> files;
+	files.resize(p_resource_paths.size());
+	for (uint32_t i = 0; i < p_resource_paths.size(); i++) {
+		files[i].config = _build_resource_folding(p_resource_paths[i].first, p_resource_paths[i].second, files[i].file);
+	}
+
+	if (files.size() == 1 || WorkerThreadPool::get_singleton()->get_thread_count() <= 1) {
+		for (const FoldingFileSave &E : files) {
+			E.config->save(E.file);
+		}
+		return;
+	}
+
+	WorkerThreadPool::GroupID group_id = WorkerThreadPool::get_singleton()->add_template_group_task(
+			this, &EditorFolding::_save_resource_folding, files.ptr(), files.size(), -1, true, SNAME("SaveResourceFoldings"));
+	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_id);
 }
 
 void EditorFolding::_set_unfolds(Object *p_object, const Vector<String> &p_unfolds) {

--- a/editor/settings/editor_folding.h
+++ b/editor/settings/editor_folding.h
@@ -33,6 +33,7 @@
 #include "scene/main/node.h"
 
 class Animation;
+class ConfigFile;
 
 class EditorFolding {
 	Vector<String> _get_unfolds(const Object *p_object);
@@ -46,15 +47,21 @@ class EditorFolding {
 	Vector<String> _get_animation_folds(const Animation *p_animation);
 	void _set_animation_folds(Animation *p_animation, const Vector<String> &p_unfolds);
 
+	Ref<ConfigFile> _build_resource_folding(const Ref<Resource> &p_resource, const String &p_path, String &r_file);
+
+	struct FoldingFileSave {
+		Ref<ConfigFile> config;
+		String file;
+	};
+	void _save_resource_folding(uint32_t p_index, FoldingFileSave *p_files);
+
 public:
 	void save_resource_folding(const Ref<Resource> &p_resource, const String &p_path);
+	void save_resource_foldings(const LocalVector<Pair<Ref<Resource>, String>> &p_resource_paths);
 	void load_resource_folding(Ref<Resource> p_resource, const String &p_path);
 
 	void save_scene_folding(const Node *p_scene, const String &p_path);
 	void load_scene_folding(Node *p_scene, const String &p_path);
-
-	void save_animation_folding(const Ref<Animation> &p_animation, const String &p_path);
-	void load_animation_folding(Ref<Animation> p_animation, const String &p_path);
 
 	void unfold_scene(Node *p_scene);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120379
- Follow up https://github.com/godotengine/godot/pull/113479

`save_scene_folding()` contains FileAccess internally, so it blocks the thread. Since the same argument is passed multiple times within a for-loop, it is changed to be called only once outside of the for-loop.

cc @Meorge 