### PR TITLE
Fix OBJ importer ignoring vertex color alpha channel

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -292,6 +292,9 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 				c.r = v[4].to_float();
 				c.g = v[5].to_float();
 				c.b = v[6].to_float();
+				if (v.size() >= 8) {
+					c.a = v[7].to_float();
+				}
 				colors.push_back(c);
 			} else if (!colors.is_empty()) {
 				colors.push_back(Color(1.0, 1.0, 1.0));


### PR DESCRIPTION
## What problem(s) does this PR solve?

support for parsing the alpha channel in vertex colors when importing Wavefront .obj files.

## Additional information

Currently, Godot ignores the 8th value (alpha) on the OBJ `v` line. The [Wikipedia](https://en.wikipedia.org/wiki/Wavefront_.obj_file) only mentions RGB after the vertex position, which is likely why the current code was written this way.

This PR does not break backward or forward compatibility. Also, since Godot already uses memory for a PackedColorArray(Vector4) when storing vertex colors, it is much better to keep this meaningful alpha value instead of throwing it away.

[TreeIt](https://www.evolved-software.com/treeit/treeit) (a popular vegetation generator) exports `.obj` models with mapping vertex color rgb is wind animation blending weights and  alpha to Ambient Occlusion by default.

Example data from a TreeIt export:
```
// Created by Tree IT
mtllib maple_a.mtl
o tree
# Position
v 0.77411 2.13307 0.85744 0.00392 0.06275 0.18039 0.98897
```