### PR TITLE
Add flag on change SceneTree to prevent over accessing `FileAccess`

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2267,6 +2267,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 				HashMap<Node *, NodePath>::Iterator found_root_path = p_renames->find(root);
 				NodePath new_root_path = found_root_path ? found_root_path->value : root->get_path();
 				if (!new_root_path.is_empty()) { // No renaming if root node is deleted.
+					bool update_scene_folding = false;
 					for (const StringName &E : mixer->get_sorted_animation_list()) {
 						Ref<Animation> anim = mixer->get_animation(E);
 						if (!r_rem_anims->has(anim)) {
@@ -2338,6 +2339,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 						//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheOldName
 						// value of p_renames is like:
 						//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheNewName
+						bool folding_changed = false;
 						for (const KeyValue<Node *, NodePath> &rename : *p_renames) {
 							NodePath old_path = rename.key->get_path();
 							NodePath new_path = rename.value;
@@ -2349,19 +2351,27 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 							StringName old_node_name = rename.key->get_name();
 							StringName new_node_name = rel_path[rel_path.size() - 1];
 
-							anim->editor_set_group_folded(new_node_name, anim->editor_is_group_folded(old_node_name));
-							anim->editor_set_group_folded(old_node_name, false);
+							if (anim->editor_is_group_folded(old_node_name)) {
+								anim->editor_set_group_folded(new_node_name, true);
+								anim->editor_set_group_folded(old_node_name, false);
+								folding_changed = true;
+							}
 						}
 
-						if (!anim->get_path().is_resource_file()) {
-							EditorNode::get_editor_folding().save_scene_folding(
-									EditorNode::get_singleton()->get_edited_scene(),
-									EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
-						} else {
-							EditorNode::get_editor_folding().save_resource_folding(
-									anim,
-									anim->get_path());
+						if (folding_changed) {
+							if (!anim->get_path().is_resource_file()) {
+								update_scene_folding = true;
+							} else {
+								EditorNode::get_editor_folding().save_resource_folding(
+										anim,
+										anim->get_path());
+							}
 						}
+					}
+					if (update_scene_folding) {
+						EditorNode::get_editor_folding().save_scene_folding(
+								EditorNode::get_singleton()->get_edited_scene(),
+								EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
 					}
 				}
 			}

--- a/editor/settings/editor_folding.h
+++ b/editor/settings/editor_folding.h
@@ -53,9 +53,6 @@ public:
 	void save_scene_folding(const Node *p_scene, const String &p_path);
 	void load_scene_folding(Node *p_scene, const String &p_path);
 
-	void save_animation_folding(const Ref<Animation> &p_animation, const String &p_path);
-	void load_animation_folding(Ref<Animation> p_animation, const String &p_path);
-
 	void unfold_scene(Node *p_scene);
 
 	bool has_folding_data(const String &p_path);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120379

This is a simple version of https://github.com/godotengine/godot/pull/120384 without the multithreading. This should avoid freezes and crashes in common cases where no folding is used by animation at all.

As mentioned in the https://github.com/godotengine/godot/pull/120384#issuecomment-4738228737, considering that we can improve it later and include it in 4.7, #120379 's multithreading seems a bit excessive, so I have made minimal changes.
