### PR TITLE
Vulkan: Silence loader warning about incompatible drivers

### DIFF
--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -573,6 +573,12 @@ VKAPI_ATTR VkBool32 VKAPI_CALL RenderingContextDriverVulkan::_debug_messenger_ca
 		return VK_FALSE;
 	}
 
+	// Suppress warning about incompatible drivers (-9), even though this should arguably be the loader's responsibility.
+	// This was generating noise on Linux when Mesa Dozen is provided.
+	if (strstr(p_callback_data->pMessage, "Received return code -9 from call to vkCreateInstance in ICD") != nullptr && strstr(p_callback_data->pMessage, "Skipping this driver") != nullptr) {
+		return VK_FALSE;
+	}
+
 	if (p_callback_data->pMessageIdName && strstr(p_callback_data->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != nullptr) {
 		return VK_FALSE;
 	}
@@ -635,6 +641,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL RenderingContextDriverVulkan::_debug_messenger_ca
 			objects_string + labels_string);
 
 	// Convert VK severity to our own log macros.
+	// Note: Which severity we receive depends on what's set in VkDebugUtilsMessengerCreateInfoEXT,
+	// we don't enable everything by default.
 	switch (p_message_severity) {
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
 			print_verbose(error_message);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Silences this benign but annoying warning on Fedora 44 where Mesa ships the D3D12/WSL Dozen driver:

```
WARNING: GENERAL - Message Id Number: 0 | Message Id Name: Loader Message
        terminator_CreateInstance: Received return code -9 from call to vkCreateInstance in ICD /usr/lib64/libvulkan_dzn.so. Skipping this driver.
        Objects - 1
                Object[0] - VK_OBJECT_TYPE_INSTANCE, Handle 850961280
     at: _debug_messenger_callback (drivers/vulkan/rendering_context_driver_vulkan.cpp:646)
```

## Additional information

The warning was also present on Fedora 43 with an earlier version of Mesa, albeit with return code -3 (`VK_ERROR_INITIALIZATION_FAILED`). This was changed in https://gitlab.freedesktop.org/mesa/mesa/-/work_items/14341, which I hoped would fully remove this warning, but it seems the Vulkan loader still raises it if the error code is `VK_ERROR_INCOMPATIBLE_DRIVER`.

This should probably be changed in the loader itself, but for now let's silence it downstream. I'm not silencing the `code -3` case, as this could still flag actual initialization errors that the user may need to be aware of.

- *Edit:* I proposed a change to Vulkan-Loader to silence it directly there: https://github.com/KhronosGroup/Vulkan-Loader/pull/1937. If that is accepted, we don't need to do it downstream, unless we want to do it temporarily until all common Linux distros are up-to-date (might take a year).
  * *Edit 2:* This doesn't seem to be appropriate for upstream, so let's go with the downstream hack.