### PR TITLE
Do not inline `new` operators.

### DIFF
--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -44,6 +44,14 @@ static SafeNumeric<uint64_t> _current_mem_usage;
 static SafeNumeric<uint64_t> _max_mem_usage;
 #endif
 
+void *operator new(size_t p_size, DefaultAllocator p_allocator) {
+	return Memory::alloc_static(p_size);
+}
+
+void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
+	return p_allocfunc(p_size);
+}
+
 void *Memory::alloc_aligned_static(size_t p_bytes, size_t p_alignment) {
 	DEV_ASSERT(Math::is_power_of_2(p_alignment));
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -104,15 +104,13 @@ public:
 	_FORCE_INLINE_ static void free(void *p_ptr) { Memory::free_static(p_ptr, false); }
 };
 
-// Overload of new operator to use the Memory::alloc_static function.
-// The DefaultAllocator parameter is just a tag to select this overload.
-inline void *operator new(size_t p_size, DefaultAllocator p_allocator) {
-	return Memory::alloc_static(p_size);
-}
-// Overload of new operator to use a custom allocation function.
-inline void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size)) {
-	return p_allocfunc(p_size);
-}
+// Overload of `new` operator to use the `Memory::alloc_static()` function.
+// The `DefaultAllocator` parameter is just a tag to select this overload.
+// NOTE: do not inline `new` operators due to GCC+LTO compiler bug (see GH-119752).
+void *operator new(size_t p_size, DefaultAllocator p_allocator);
+
+// Overload of `new` operator to use a custom allocation function.
+void *operator new(size_t p_size, void *(*p_allocfunc)(size_t p_size));
 
 #if defined(_MSC_VER) && !defined(__clang__)
 // When compiling with VC++ 2017, the above declarations of placement new generate many irrelevant warnings (C4291).


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119752
- Closes https://github.com/godotengine/godot/issues/119740

## Additional information

See https://github.com/godotengine/godot/issues/119752#issuecomment-4740244430, most likely a LTO related GCC bug.