### PR TITLE
Ignore joypads on unfocused window by default for new projects

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8348,6 +8348,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["display/window/stretch/aspect"] = "expand";
 	settings["display/window/stretch/mode"] = "canvas_items";
+	settings["input_devices/joypads/ignore_joypad_on_unfocused_application"] = true;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	return settings;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR makes the joypads be ignored when the game window is unfocused as the default behavior for new projects.
See also the discussion at https://github.com/godotengine/godot/pull/115119#issuecomment-4743725953

Is it a good idea? What do you think?

CC @Yolwoocle
