### PR TITLE
Fix errors with unique `VisualShader`s when something triggers an update

### DIFF
--- a/modules/visual_shader/visual_shader.cpp
+++ b/modules/visual_shader/visual_shader.cpp
@@ -1830,8 +1830,12 @@ bool VisualShader::_set(const StringName &p_name, const Variant &p_value) {
 		String what = prop_name.get_slicec('/', 3);
 
 		if (what == "node") {
-			add_node(type, p_value, Vector2(), id);
-			return true;
+			Graph *g = &graph[type];
+			// Avoid errors when updating if the nodes have already been added.
+			if (!g->nodes.has(id)) {
+				add_node(type, p_value, Vector2(), id);
+				return true;
+			}
 		} else if (what == "position") {
 			set_node_position(type, id, p_value);
 			return true;


### PR DESCRIPTION
This PR fixes the following error when a unique `VisualShader` resource is updated:
```
ERROR: modules/visual_shader/visual_shader.cpp:939 - Condition "g->nodes.has(p_id)" is true.
```

This error can be replicated with the following MRP by renaming the script file in the editor:
[visual_shader_bug.zip](https://github.com/user-attachments/files/29108822/visual_shader_bug.zip)