### PR TITLE
Add one-way direction to TileMap

### DIFF
--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1602,11 +1602,17 @@ void TileDataCollisionEditor::_polygons_changed() {
 		add_child(header);
 
 		StringName one_way_property = vformat("polygon_%d_one_way", i);
+		StringName one_way_direction_property = vformat("polygon_%d_one_way_direction", i);
 		StringName one_way_margin_property = vformat("polygon_%d_one_way_margin", i);
 
 		if (!dummy_object->has_dummy_property(one_way_property)) {
 			dummy_object->add_dummy_property(one_way_property);
 			dummy_object->set(one_way_property, false);
+		}
+
+		if (!dummy_object->has_dummy_property(one_way_direction_property)) {
+			dummy_object->add_dummy_property(one_way_direction_property);
+			dummy_object->set(one_way_direction_property, Vector2(0, 1));
 		}
 
 		if (!dummy_object->has_dummy_property(one_way_margin_property)) {
@@ -1627,6 +1633,19 @@ void TileDataCollisionEditor::_polygons_changed() {
 		} else {
 			move_child(property_editors[one_way_property], -1);
 		}
+		if (!property_editors.has(one_way_direction_property)) {
+			EditorProperty *one_way_direction_property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::VECTOR2, one_way_direction_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
+			one_way_direction_property_editor->set_object_and_property(dummy_object, one_way_direction_property);
+			one_way_direction_property_editor->set_label(TTRC("One Way Direction"));
+			one_way_direction_property_editor->connect("property_changed", callable_mp(this, &TileDataCollisionEditor::_property_value_changed).unbind(1));
+			one_way_direction_property_editor->connect("selected", callable_mp(this, &TileDataCollisionEditor::_property_selected));
+			one_way_direction_property_editor->set_tooltip_text(one_way_direction_property_editor->get_edited_property());
+			one_way_direction_property_editor->update_property();
+			add_child(one_way_direction_property_editor);
+			property_editors[one_way_direction_property] = one_way_direction_property_editor;
+		} else {
+			move_child(property_editors[one_way_direction_property], -1);
+		}
 		if (!property_editors.has(one_way_margin_property)) {
 			EditorProperty *one_way_margin_property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::FLOAT, one_way_margin_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 			one_way_margin_property_editor->set_object_and_property(dummy_object, one_way_margin_property);
@@ -1646,6 +1665,9 @@ void TileDataCollisionEditor::_polygons_changed() {
 	for (int i = polygon_editor->get_polygon_count(); dummy_object->has_dummy_property(vformat("polygon_%d_one_way", i)); i++) {
 		dummy_object->remove_dummy_property(vformat("polygon_%d_one_way", i));
 	}
+	for (int i = polygon_editor->get_polygon_count(); dummy_object->has_dummy_property(vformat("polygon_%d_one_way_direction", i)); i++) {
+		dummy_object->remove_dummy_property(vformat("polygon_%d_one_way_direction", i));
+	}
 	for (int i = polygon_editor->get_polygon_count(); dummy_object->has_dummy_property(vformat("polygon_%d_one_way_margin", i)); i++) {
 		dummy_object->remove_dummy_property(vformat("polygon_%d_one_way_margin", i));
 	}
@@ -1653,9 +1675,13 @@ void TileDataCollisionEditor::_polygons_changed() {
 		property_editors[vformat("polygon_%d_one_way", i)]->queue_free();
 		property_editors.erase(vformat("polygon_%d_one_way", i));
 	}
-	for (int i = polygon_editor->get_polygon_count(); property_editors.has(vformat("polygon_%d_one_way_margin", i)); i++) {
+	for (int i = polygon_editor->get_polygon_count(); property_editors.has(vformat("polygon_%d_one_way_direction", i)); i++) {
 		property_editors[vformat("polygon_%d_one_way_margin", i)]->queue_free();
 		property_editors.erase(vformat("polygon_%d_one_way_margin", i));
+	}
+	for (int i = polygon_editor->get_polygon_count(); property_editors.has(vformat("polygon_%d_one_way_direction", i)); i++) {
+		property_editors[vformat("polygon_%d_one_way_direction", i)]->queue_free();
+		property_editors.erase(vformat("polygon_%d_one_way_direction", i));
 	}
 }
 
@@ -1669,6 +1695,7 @@ Variant TileDataCollisionEditor::_get_painted_value() {
 		Dictionary polygon_dict;
 		polygon_dict["points"] = polygon_editor->get_polygon(i);
 		polygon_dict["one_way"] = dummy_object->get(vformat("polygon_%d_one_way", i));
+		polygon_dict["one_way_direction"] = dummy_object->get(vformat("polygon_%d_one_way_direction", i));
 		polygon_dict["one_way_margin"] = dummy_object->get(vformat("polygon_%d_one_way_margin", i));
 		array.push_back(polygon_dict);
 	}
@@ -1694,6 +1721,7 @@ void TileDataCollisionEditor::_set_painted_value(TileSetAtlasSource *p_tile_set_
 	dummy_object->set("angular_velocity", tile_data->get_constant_angular_velocity(physics_layer));
 	for (int i = 0; i < tile_data->get_collision_polygons_count(physics_layer); i++) {
 		dummy_object->set(vformat("polygon_%d_one_way", i), tile_data->is_collision_polygon_one_way(physics_layer, i));
+		dummy_object->set(vformat("polygon_%d_one_way_direction", i), tile_data->get_collision_polygon_one_way_margin_direction(physics_layer, i));
 		dummy_object->set(vformat("polygon_%d_one_way_margin", i), tile_data->get_collision_polygon_one_way_margin(physics_layer, i));
 	}
 	for (const KeyValue<StringName, EditorProperty *> &E : property_editors) {
@@ -1716,6 +1744,7 @@ void TileDataCollisionEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_so
 		Dictionary polygon_dict = array[i];
 		tile_data->set_collision_polygon_points(physics_layer, i, polygon_dict["points"]);
 		tile_data->set_collision_polygon_one_way(physics_layer, i, polygon_dict["one_way"]);
+		tile_data->set_collision_polygon_one_way_direction(physics_layer, i, polygon_dict["one_way_direction"]);
 		tile_data->set_collision_polygon_one_way_margin(physics_layer, i, polygon_dict["one_way_margin"]);
 	}
 
@@ -1734,6 +1763,7 @@ Variant TileDataCollisionEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas
 		Dictionary polygon_dict;
 		polygon_dict["points"] = tile_data->get_collision_polygon_points(physics_layer, i);
 		polygon_dict["one_way"] = tile_data->is_collision_polygon_one_way(physics_layer, i);
+		polygon_dict["one_way_direction"] = tile_data->get_collision_polygon_one_way_margin_direction(physics_layer, i);
 		polygon_dict["one_way_margin"] = tile_data->get_collision_polygon_one_way_margin(physics_layer, i);
 		array.push_back(polygon_dict);
 	}
@@ -1756,6 +1786,7 @@ void TileDataCollisionEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile
 			Dictionary polygon_dict = old_polygon_array[i];
 			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["points"]);
 			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way"]);
+			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_direction", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way_direction"]);
 			undo_redo->add_undo_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way_margin"]);
 		}
 
@@ -1767,6 +1798,7 @@ void TileDataCollisionEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile
 			Dictionary polygon_dict = new_polygon_array[i];
 			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/points", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["points"]);
 			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way"]);
+			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_direction", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way_direction"]);
 			undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/physics_layer_%d/polygon_%d/one_way_margin", coords.x, coords.y, E.key.alternative_tile, physics_layer, i), polygon_dict["one_way_margin"]);
 		}
 	}

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -599,6 +599,7 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 							for (int polygon_index = 0; polygon_index < tile_data->get_collision_polygons_count(layer_index); polygon_index++) {
 								ADD_UNDO(tile_data, vformat("physics_layer_%d/polygon_%d/points", layer_index, polygon_index));
 								ADD_UNDO(tile_data, vformat("physics_layer_%d/polygon_%d/one_way", layer_index, polygon_index));
+								ADD_UNDO(tile_data, vformat("physics_layer_%d/polygon_%d/one_way_direction", layer_index, polygon_index));
 								ADD_UNDO(tile_data, vformat("physics_layer_%d/polygon_%d/one_way_margin", layer_index, polygon_index));
 							}
 						}

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -880,6 +880,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 							physics_body_key.linear_velocity = linear_velocity;
 							physics_body_key.angular_velocity = angular_velocity;
 							physics_body_key.one_way_collision = tile_data->is_collision_polygon_one_way(tile_set_physics_layer, polygon_index);
+							physics_body_key.one_way_collision_direction = tile_data->get_collision_polygon_one_way_margin_direction(tile_set_physics_layer, polygon_index);
 							physics_body_key.one_way_collision_margin = tile_data->get_collision_polygon_one_way_margin(tile_set_physics_layer, polygon_index);
 							physics_body_key.y_origin = map_to_local(cell_data.coords).y;
 
@@ -943,7 +944,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 						shape.instantiate();
 						shape->set_points(convex_polygon);
 						ps->body_add_shape(kvbody.value.body, shape->get_rid());
-						ps->body_set_shape_as_one_way_collision(kvbody.value.body, body_shape_index, kvbody.key.one_way_collision, kvbody.key.one_way_collision_margin);
+						ps->body_set_shape_as_one_way_collision(kvbody.value.body, body_shape_index, kvbody.key.one_way_collision, kvbody.key.one_way_collision_margin, kvbody.key.one_way_collision_direction);
 						physics_quadrant->shapes.push_back(shape);
 						body_shape_index++;
 					}

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -246,6 +246,7 @@ public:
 		real_t angular_velocity = 0.0;
 
 		bool one_way_collision = false;
+		Vector2 one_way_collision_direction = Vector2(0, 1);
 		real_t one_way_collision_margin = 0.0;
 
 		int64_t y_origin = 0; // This is only used if one_way_collision is on, to avoid merging polygons vertically in that case.

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6455,6 +6455,19 @@ bool TileData::is_collision_polygon_one_way(int p_layer_id, int p_polygon_index)
 	return physics[p_layer_id].polygons[p_polygon_index].one_way;
 }
 
+void TileData::set_collision_polygon_one_way_direction(int p_layer_id, int p_polygon_index, const Vector2 &p_one_way_direction) {
+	ERR_FAIL_INDEX(p_layer_id, physics.size());
+	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
+	physics.write[p_layer_id].polygons.write[p_polygon_index].one_way_direction = p_one_way_direction;
+	emit_signal(CoreStringName(changed));
+}
+
+Vector2 TileData::get_collision_polygon_one_way_margin_direction(int p_layer_id, int p_polygon_index) const {
+	ERR_FAIL_INDEX_V(p_layer_id, physics.size(), Vector2(0, -1));
+	ERR_FAIL_INDEX_V(p_polygon_index, physics[p_layer_id].polygons.size(), Vector2(0, 1));
+	return physics[p_layer_id].polygons[p_polygon_index].one_way_direction;
+}
+
 void TileData::set_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index, float p_one_way_margin) {
 	ERR_FAIL_INDEX(p_layer_id, physics.size());
 	ERR_FAIL_INDEX(p_polygon_index, physics[p_layer_id].polygons.size());
@@ -6801,7 +6814,7 @@ bool TileData::_set(const StringName &p_name, const Variant &p_value) {
 			int polygon_index = components[1].trim_prefix("polygon_").to_int();
 			ERR_FAIL_COND_V(polygon_index < 0, false);
 
-			if (components[2] == "points" || components[2] == "one_way" || components[2] == "one_way_margin") {
+			if (components[2] == "points" || components[2] == "one_way" || components[2] == "one_way_direction" || components[2] == "one_way_margin") {
 				if (layer_index >= physics.size()) {
 					if (tile_set) {
 						return false;
@@ -6820,6 +6833,8 @@ bool TileData::_set(const StringName &p_name, const Variant &p_value) {
 				return true;
 			} else if (components[2] == "one_way") {
 				set_collision_polygon_one_way(layer_index, polygon_index, p_value);
+			} else if (components[2] == "one_way_direction") {
+				set_collision_polygon_one_way_direction(layer_index, polygon_index, p_value);
 				return true;
 			} else if (components[2] == "one_way_margin") {
 				set_collision_polygon_one_way_margin(layer_index, polygon_index, p_value);
@@ -6953,6 +6968,9 @@ bool TileData::_get(const StringName &p_name, Variant &r_ret) const {
 				} else if (components[2] == "one_way") {
 					r_ret = is_collision_polygon_one_way(layer_index, polygon_index);
 					return true;
+				} else if (components[2] == "one_way_direction") {
+					r_ret = get_collision_polygon_one_way_margin_direction(layer_index, polygon_index);
+					return true;
 				} else if (components[2] == "one_way_margin") {
 					r_ret = get_collision_polygon_one_way_margin(layer_index, polygon_index);
 					return true;
@@ -7048,6 +7066,13 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 				// physics_layer_%d/polygon_%d/one_way
 				property_info = PropertyInfo(Variant::BOOL, vformat("physics_layer_%d/polygon_%d/%s", i, j, PNAME("one_way")));
 				if (physics[i].polygons[j].one_way == false) {
+					property_info.usage ^= PROPERTY_USAGE_STORAGE;
+				}
+				p_list->push_back(property_info);
+
+				// physics_layer_%d/polygon_%d/one_way_direction
+				property_info = PropertyInfo(Variant::VECTOR2, vformat("physics_layer_%d/polygon_%d/%s", i, j, PNAME("one_way_direction")));
+				if (physics[i].polygons[j].one_way_direction == Vector2(0, 1)) {
 					property_info.usage ^= PROPERTY_USAGE_STORAGE;
 				}
 				p_list->push_back(property_info);

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -876,6 +876,7 @@ private:
 			LocalVector<Ref<ConvexPolygonShape2D>> shapes;
 			mutable HashMap<int, LocalVector<Ref<ConvexPolygonShape2D>>> transformed_shapes;
 			bool one_way = false;
+			Vector2 one_way_direction = Vector2(0, 1);
 			float one_way_margin = 1.0;
 		};
 
@@ -997,6 +998,8 @@ public:
 	Vector<Vector2> get_collision_polygon_points(int p_layer_id, int p_polygon_index) const;
 	void set_collision_polygon_one_way(int p_layer_id, int p_polygon_index, bool p_one_way);
 	bool is_collision_polygon_one_way(int p_layer_id, int p_polygon_index) const;
+	void set_collision_polygon_one_way_direction(int p_layer_id, int p_polygon_index, const Vector2 &p_one_way_direction);
+	Vector2 get_collision_polygon_one_way_margin_direction(int p_layer_id, int p_polygon_index) const;
 	void set_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index, float p_one_way_margin);
 	float get_collision_polygon_one_way_margin(int p_layer_id, int p_polygon_index) const;
 	int get_collision_polygon_shapes_count(int p_layer_id, int p_polygon_index) const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Follow-up to #104736
Adds one-way direction support to TileMapLayer.

## Additional information

https://github.com/user-attachments/assets/e0c4fd43-9a9b-4cc0-b458-bbfd258ce340

https://github.com/user-attachments/assets/a15c89b6-d730-49a5-9712-854b98059bc9

There are 2 problems though:
- The one way indicator in the Paint mode always shows down arrows
<img width="328" height="70" alt="image" src="https://github.com/user-attachments/assets/90f69425-8b6a-4604-9cc0-f1dc28eeaf19" />
- The collision shape merging does not account for direction (#109820).

The main problem with these is that the direction supports any 360° angle, so not sure how to rotate the indicator to support that, and how to adjust the merging (maybe it should only check sign of the axis?).

Another thing is that it might be expected that rotated tiles also rotate their one-way direction, but I did not implement that.