### PR TITLE
Add search to ResourcePreloaderEditor

### DIFF
--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -177,6 +178,25 @@ void ResourcePreloaderEditor::_paste_pressed() {
 	undo_redo->add_do_method(this, "_update_library");
 	undo_redo->add_undo_method(this, "_update_library");
 	undo_redo->commit_action();
+}
+
+void ResourcePreloaderEditor::_search_text_changed(const String &p_new_text) const {
+	TreeItem *root = tree->get_root();
+
+	if (root == nullptr) {
+		return;
+	}
+
+	if (p_new_text.is_empty()) {
+		for (TreeItem *child = root->get_first_child(); child; child = child->get_next()) {
+			child->set_visible(true);
+		}
+		return;
+	}
+
+	for (TreeItem *child = root->get_first_child(); child; child = child->get_next()) {
+		child->set_visible(child->get_text(0).containsn(p_new_text));
+	}
 }
 
 void ResourcePreloaderEditor::_update_library() {
@@ -387,6 +407,16 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	paste->set_text(TTRC("Paste"));
 	hbc->add_child(paste);
 
+	search = memnew(FilterLineEdit);
+	search->set_placeholder(TTRC("Search"));
+	search->set_h_size_flags(SIZE_EXPAND_FILL);
+	search->set_stretch_ratio(0.4);
+	hbc->add_child(search);
+
+	Control *dummy = memnew(Control);
+	dummy->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc->add_child(dummy);
+
 	file = memnew(EditorFileDialog);
 	add_child(file);
 
@@ -406,6 +436,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 
 	SET_DRAG_FORWARDING_GCD(tree, ResourcePreloaderEditor);
 	mc->add_child(tree);
+	search->set_forward_control(tree);
 
 	dialog = memnew(AcceptDialog);
 	dialog->set_title(TTRC("Error!"));
@@ -414,6 +445,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 
 	load->connect(SceneStringName(pressed), callable_mp(this, &ResourcePreloaderEditor::_load_pressed));
 	paste->connect(SceneStringName(pressed), callable_mp(this, &ResourcePreloaderEditor::_paste_pressed));
+	search->connect(SceneStringName(text_changed), callable_mp(this, &ResourcePreloaderEditor::_search_text_changed));
 	file->connect("files_selected", callable_mp(this, &ResourcePreloaderEditor::_files_load_request));
 	tree->connect("item_edited", callable_mp(this, &ResourcePreloaderEditor::_item_edited));
 	loading_scene = false;

--- a/editor/scene/resource_preloader_editor_plugin.h
+++ b/editor/scene/resource_preloader_editor_plugin.h
@@ -35,6 +35,7 @@
 
 class AcceptDialog;
 class Button;
+class FilterLineEdit;
 class EditorFileDialog;
 class ResourcePreloader;
 class Tree;
@@ -50,6 +51,7 @@ class ResourcePreloaderEditor : public EditorDock {
 
 	Button *load = nullptr;
 	Button *paste = nullptr;
+	FilterLineEdit *search = nullptr;
 	MarginContainer *mc = nullptr;
 	Tree *tree = nullptr;
 
@@ -65,6 +67,7 @@ class ResourcePreloaderEditor : public EditorDock {
 	void _load_pressed();
 	void _files_load_request(const Vector<String> &p_paths);
 	void _paste_pressed();
+	void _search_text_changed(const String &p_new_text) const;
 	void _remove_resource(const String &p_to_remove);
 	void _update_library();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

It adds simple substring search to the `ResourcePreloaderEditor`.

### Simple Example

[Βίντεο Οθόνης από 2026-06-18 22-10-16.webm](https://github.com/user-attachments/assets/034084f9-10bd-4a68-b4c7-dd146915f2c6)

## Stress Test x1000

[Βίντεο Οθόνης από 2026-06-18 22-16-05.webm](https://github.com/user-attachments/assets/dacd06b4-afa1-4192-a12f-d37350384b00)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
