### PR TITLE
Add `Image::load_from_buffer()`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -33,6 +33,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
+#include "core/io/file_access_memory.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_funcs.h"
@@ -2789,6 +2790,45 @@ Ref<Image> Image::load_from_file(const String &p_path) {
 	return image;
 }
 
+Ref<Image> Image::load_from_buffer(const String &p_extension, const Vector<uint8_t> &p_array) {
+	String extension = p_extension.to_lower();
+	Ref<Image> image;
+	image.instantiate();
+	Error err = OK;
+	if (extension == "png") {
+		err = image->load_png_from_buffer(p_array);
+	} else if (extension == "jpg" || extension == "jpeg") {
+		err = image->load_jpg_from_buffer(p_array);
+	} else if (extension == "webp") {
+		err = image->load_webp_from_buffer(p_array);
+	} else if (extension == "tga") {
+		err = image->load_tga_from_buffer(p_array);
+	} else if (extension == "bmp") {
+		err = image->load_bmp_from_buffer(p_array);
+	} else if (extension == "ktx") {
+		err = image->load_ktx_from_buffer(p_array);
+	} else if (extension == "dds") {
+		err = image->load_dds_from_buffer(p_array);
+	} else if (extension == "exr") {
+		err = image->load_exr_from_buffer(p_array);
+	} else if (extension == "svg") {
+		err = image->load_svg_from_buffer(p_array);
+	}
+	if (err == ERR_UNAVAILABLE) {
+		return Ref<Image>();
+	}
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Image>(), vformat("Failed to load image format '%s' from buffer", extension));
+
+	Ref<FileAccessMemory> memfile;
+	memfile.instantiate();
+	memfile->open_custom(p_array.ptr(), p_array.size());
+
+	err = ImageLoader::load_image(vformat("i.%s", extension), image, memfile);
+	ERR_FAIL_COND_V_MSG(err == ERR_FILE_UNRECOGNIZED, Ref<Image>(), vformat("Unsupported image format: %s", extension));
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Image>(), vformat("Failed to load image format '%s' from buffer", extension));
+	return image;
+}
+
 Error Image::save_png(const String &p_path) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
@@ -3879,6 +3919,7 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
+	ClassDB::bind_static_method("Image", D_METHOD("load_from_buffer", "extension", "buffer"), &Image::load_from_buffer);
 	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -368,6 +368,7 @@ public:
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);
+	static Ref<Image> load_from_buffer(const String &p_extension, const Vector<uint8_t> &p_array);
 	Error save_png(const String &p_path) const;
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Error save_dds(const String &p_path) const;

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -363,6 +363,14 @@
 				Loads an image from the binary contents of an OpenEXR file.
 			</description>
 		</method>
+		<method name="load_from_buffer" qualifiers="static">
+			<return type="Image" />
+			<param index="0" name="extension" type="String" />
+			<param index="1" name="buffer" type="PackedByteArray" />
+			<description>
+				Creates a new [Image] and loads data from the binary contents of an image file with the specified [param extension].
+			</description>
+		</method>
 		<method name="load_from_file" qualifiers="static">
 			<return type="Image" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Implements https://github.com/godotengine/godot-proposals/issues/15027

## Additional information

Fairly simple; we instantiate a `FileAccessMemory` with the contents of the buffer and load it with `ImageLoader::load_image`.

I added in explicit calls to the `load_x_from_buffer` functions so that we could still get the "module isn't enabled" error messages; if we don't care about about those, we can just remove them.