### PR TITLE
Fix folding of animation tracks

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3920,7 +3920,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 			draw_line(Point2(get_size().width - timeline->get_buttons_width(), 0), Point2(get_size().width - timeline->get_buttons_width(), get_size().height), v_line_color, Math::round(EDSCALE));
 
 			int ofs = stylebox_header->get_margin(SIDE_LEFT);
-			bool is_group_folded = editor->get_current_animation()->editor_is_group_folded(node_name);
+			bool is_group_folded = editor->get_current_animation()->editor_is_group_folded(node);
 			Ref<Texture2D> fold_icon = get_theme_icon(is_group_folded ? SNAME("arrow_collapsed") : SNAME("arrow"), SNAME("Tree"));
 			Size2 fold_icon_size = fold_icon->get_size();
 			draw_texture_rect(fold_icon, Rect2(Point2(ofs, (get_size().height - fold_icon_size.y) / 2 + v_margin_offset).round(), fold_icon_size));
@@ -3975,14 +3975,14 @@ void AnimationTrackEditGroup::gui_input(const Ref<InputEvent> &p_event) {
 		Point2 pos = mb->get_position();
 
 		int left_ofs = get_theme_stylebox(SNAME("header"), SNAME("AnimationTrackEditGroup"))->get_margin(SIDE_LEFT);
-		bool is_group_folded = editor->get_current_animation()->editor_is_group_folded(node_name);
+		bool is_group_folded = editor->get_current_animation()->editor_is_group_folded(node);
 		Ref<Texture2D> fold_icon = get_theme_icon(is_group_folded ? SNAME("arrow_collapsed") : SNAME("arrow"), SNAME("Tree"));
 		int fold_icon_width = fold_icon->get_size().width;
 		Rect2 fold_area_rect = Rect2(0, 0, left_ofs + fold_icon_width, get_size().height);
 
 		if (fold_area_rect.has_point(pos)) {
-			bool current_group_folded = !editor->get_current_animation()->editor_is_group_folded(node_name);
-			editor->get_current_animation()->editor_set_group_folded(node_name, current_group_folded);
+			bool current_group_folded = !editor->get_current_animation()->editor_is_group_folded(node);
+			editor->get_current_animation()->editor_set_group_folded(node, current_group_folded);
 
 			for (AnimationTrackEdit *i : track_edits) {
 				i->set_visible(!current_group_folded);
@@ -5411,7 +5411,7 @@ void AnimationTrackEditor::_update_tracks() {
 			AnimationTrackEditGroup *g = Object::cast_to<AnimationTrackEditGroup>(vb->get_child(0));
 			if (g) {
 				for (AnimationTrackEdit *i : g->track_edits) {
-					i->set_visible(!animation->editor_is_group_folded(g->node_name));
+					i->set_visible(!animation->editor_is_group_folded(g->node));
 				}
 			}
 		}

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2241,7 +2241,7 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 	return false;
 }
 
-void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims, LocalVector<Pair<StringName, StringName>> *r_folded_group_renames) {
+void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims) {
 	HashMap<Ref<Animation>, HashSet<int>> rem_anims;
 	if (!r_rem_anims) {
 		r_rem_anims = &rem_anims;
@@ -2262,28 +2262,6 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 	}
 
 	bool autorename_animation_tracks = bool(EDITOR_GET("editors/animation/autorename_animation_tracks"));
-
-	// key.get_path() of p_renames is like:
-	//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheOldName
-	// value of p_renames is like:
-	//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheNewName
-	LocalVector<Pair<StringName, StringName>> folded_group_renames;
-	if (!r_folded_group_renames) {
-		r_folded_group_renames = &folded_group_renames;
-		if (autorename_animation_tracks) {
-			for (const KeyValue<Node *, NodePath> &rename : *p_renames) {
-				if (rename.value.get_name_count() == 0) {
-					continue; // Node will be deleted (empty path), not renamed.
-				}
-				const StringName old_node_name = rename.key->get_name();
-				const StringName new_node_name = rename.value.get_name(rename.value.get_name_count() - 1);
-				if (old_node_name == new_node_name) {
-					continue; // Only the parent path changed; the name itself didn't.
-				}
-				r_folded_group_renames->push_back(Pair<StringName, StringName>(old_node_name, new_node_name));
-			}
-		}
-	}
 
 	AnimationMixer *mixer = Object::cast_to<AnimationMixer>(p_base);
 	if (autorename_animation_tracks && mixer) {
@@ -2373,10 +2351,21 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 
 						// Prevent to rewrite an editable child's inner fold state by parent renaming.
 						if (p_base == edited_scene || (p_base->get_owner() == edited_scene && p_base->get_scene_file_path().is_empty())) {
-							for (const Pair<StringName, StringName> &group_rename : *r_folded_group_renames) {
-								if (anim->editor_is_group_folded(group_rename.first)) {
-									anim->editor_set_group_folded(group_rename.second, true);
-									anim->editor_set_group_folded(group_rename.first, false);
+							// key.get_path() of p_renames is like:
+							//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheOldName
+							// value of p_renames is like:
+							//  /root/@EditorNode@18033/@Panel@14/.../Scene/TheNewName
+							for (const KeyValue<Node *, NodePath> &rename : *p_renames) {
+								if (rename.value.is_empty()) {
+									continue; // Node will be deleted (empty path), not renamed.
+								}
+
+								NodePath old_group_path = root->get_path_to(rename.key);
+								NodePath new_group_path = new_root_path.rel_path_to(rename.value);
+
+								if (anim->editor_is_group_folded(old_group_path)) {
+									anim->editor_set_group_folded(new_group_path, true);
+									anim->editor_set_group_folded(old_group_path, false);
 								}
 							}
 						}
@@ -2390,7 +2379,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 	_check_object_properties_recursive(p_base, p_base, p_renames);
 
 	for (int i = 0; i < p_base->get_child_count(); i++) {
-		perform_node_renames(p_base->get_child(i), p_renames, r_rem_anims, r_folded_group_renames);
+		perform_node_renames(p_base->get_child(i), p_renames, r_rem_anims);
 	}
 }
 

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -338,7 +338,7 @@ public:
 	void set_selection(const Vector<Node *> &p_nodes);
 	void set_selected(Node *p_node, bool p_emit_selected = false);
 	void fill_path_renames(Node *p_node, Node *p_new_parent, HashMap<Node *, NodePath> *p_renames);
-	void perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims = nullptr, LocalVector<Pair<StringName, StringName>> *r_folded_group_renames = nullptr);
+	void perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims = nullptr);
 	void perform_node_replace(Node *p_base, Node *p_node, Node *p_by_node);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
 	EditorData *get_editor_data() { return editor_data; }

--- a/editor/settings/editor_folding.cpp
+++ b/editor/settings/editor_folding.cpp
@@ -377,6 +377,41 @@ Vector<String> EditorFolding::_get_animation_folds(const Animation *p_animation)
 
 void EditorFolding::_set_animation_folds(Animation *p_animation, const Vector<String> &p_folds) {
 	p_animation->editor_clear_folded_groups();
+
+#ifndef DISABLE_DEPRECATED
+	// Folded groups were keyed by node name, but are now keyed by the full node
+	// path. Check if we have some node paths as indicator of the new format.
+	bool legacy = true;
+	for (const String &group_name : p_folds) {
+		if (group_name.contains("/")) {
+			legacy = false;
+			break;
+		}
+	}
+
+	if (legacy) {
+		// The legacy keys are ambiguous when several groups share the same name
+		// (e.g. "char_a/Skeleton3D" and "char_b/Skeleton3D"). If we have multiple
+		// with the same name, we can't distinguish and give up.
+		HashMap<StringName, StringName> seen_names;
+		for (int i = 0; i < p_animation->get_track_count(); i++) {
+			NodePath path = p_animation->track_get_path(i);
+			int name_count = path.get_name_count();
+			if (name_count == 0) {
+				continue;
+			}
+			StringName node_name = path.get_name(name_count - 1);
+			StringName group_key = path.get_concatenated_names();
+			HashMap<StringName, StringName>::Iterator existing = seen_names.find(node_name);
+			if (existing && existing->value != group_key) {
+				// Duplicate node name across different groups, bail out.
+				return;
+			}
+			seen_names.insert(node_name, group_key);
+		}
+	}
+#endif // DISABLE_DEPRECATED
+
 	for (const String &group_name : p_folds) {
 		p_animation->editor_add_folded_group(group_name);
 	}

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -553,15 +553,15 @@ public:
 	void editor_clear_folded_groups() { folded_groups.clear(); }
 	void editor_add_folded_group(const StringName &p_group_name) { folded_groups.insert(p_group_name); }
 	void editor_remove_folded_group(const StringName &p_group_name) { folded_groups.erase(p_group_name); }
-	bool editor_is_group_folded(const StringName &p_group_name) const { return folded_groups.has(p_group_name); }
-	void editor_set_group_folded(const StringName &p_group_name, bool p_folded) {
-		if (editor_is_group_folded(p_group_name) == p_folded) {
+	bool editor_is_group_folded(const NodePath &p_group_path) const { return folded_groups.has(p_group_path.get_concatenated_names()); }
+	void editor_set_group_folded(const NodePath &p_group_path, bool p_folded) {
+		if (editor_is_group_folded(p_group_path) == p_folded) {
 			return; // Do nothing.
 		}
 		if (p_folded) {
-			editor_add_folded_group(p_group_name);
+			editor_add_folded_group(p_group_path.get_concatenated_names());
 		} else {
-			editor_remove_folded_group(p_group_name);
+			editor_remove_folded_group(p_group_path.get_concatenated_names());
 		}
 		folded_groups_dirty = true;
 	}


### PR DESCRIPTION
Key groups by full node path, not just the end name.

With multiple tracks that have the same end name e.g. character_a/Skeleton3D and character_b/Skeleton3D, the folding used to use "Skeleton3D" for tracking the folded bit. Use the full NodePath instead.

## What problem(s) does this PR solve?

- Closes #120415