### PR TITLE
Allow empty documentation comments to act as line breaks

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3953,6 +3953,10 @@ static void _process_doc_line(const String &p_line, String &r_text, const String
 				r_text = r_text.left(-4); // `-len("[br]")`.
 				line = "[br]" + line;
 			} else if (!r_text.ends_with("\n")) {
+				if (line.is_empty()) {
+					r_text += "\n";
+					return;
+				}
 				line_join = " ";
 			}
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?
Closes https://github.com/godotengine/godot-proposals/issues/13157

Blank lines in documentation comments will be automatically interpreted as line breaks. Example:
```gdscript
## Example description for this variable.
##
## This variable can be true or false.
@export var my_variable: bool = true
```
<img width="606" height="111" alt="image" src="https://github.com/user-attachments/assets/ccc3f6e2-5b11-4845-b32b-8a6a7421c5cb" />

## Additional information
To try to maintain compatibility with previously written documentation comments, users who use `[br][br]` to make these kind of line breaks won't result in blank documentation comments creating additional line breaks. For example, users who write this won't have extra line breaks as a result:
```gdscript
## Example description for this variable. [br][br]
##
## This variable can be true or false.
@export var my_variable: bool = true
```
(The resulting documentation generated will be the same)
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
