### PR TITLE
Add 'Auto Unfold' and 'Collapse All' functionality to EditorInspector

### DIFF
--- a/editor/icons/GuiTreeThreeArrowsDown.svg
+++ b/editor/icons/GuiTreeThreeArrowsDown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".4" stroke-width="2" d="m2.95 4.5 3 3 3-3M2.95 1l3 3 3-3M2.95 8l3 3 3-3"/></svg>

--- a/editor/icons/GuiTreeTwoArrowsDown.svg
+++ b/editor/icons/GuiTreeTwoArrowsDown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".4" stroke-width="2" d="m3 3 3 3 3-3M3 7l3 3 3-3"/></svg>

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -59,6 +59,7 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/timer.h"
 #include "scene/property_utils.h"
@@ -2207,6 +2208,97 @@ Ref<Texture2D> EditorInspectorSection::_get_checkbox() {
 	return checkbox;
 }
 
+bool EditorInspectorSection::_should_auto_unfold(const String &p_class_name) const {
+	if (!EditorSettings::get_singleton()) {
+		return false;
+	}
+
+	PackedStringArray any_class_sections = EDITOR_DEF("_interface/inspector/auto_unfold_any_class", PackedStringArray());
+	if (any_class_sections.has(section)) {
+		return true;
+	}
+
+	Dictionary same_class_dict = EDITOR_DEF("_interface/inspector/auto_unfold_same_class", Dictionary());
+	if (same_class_dict.has(p_class_name)) {
+		PackedStringArray class_sections = same_class_dict[p_class_name];
+		if (class_sections.has(section)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void EditorInspectorSection::_toggle_auto_unfold(int p_id) const {
+	String class_name = object->get_class();
+
+	if (p_id == MENU_AUTO_UNFOLD_ANY_CLASS) {
+		PackedStringArray any_class_sections = EDITOR_GET("_interface/inspector/auto_unfold_any_class");
+		if (any_class_sections.has(section)) {
+			any_class_sections.remove_at(any_class_sections.find(section));
+		} else {
+			any_class_sections.push_back(section);
+			const_cast<EditorInspectorSection *>(this)->unfold();
+		}
+		EditorSettings::get_singleton()->set("_interface/inspector/auto_unfold_any_class", any_class_sections);
+	} else if (p_id == MENU_AUTO_UNFOLD_SAME_CLASS) {
+		Dictionary same_class_dict = Dictionary(EDITOR_GET("_interface/inspector/auto_unfold_same_class")).duplicate();
+		PackedStringArray class_sections;
+
+		if (same_class_dict.has(class_name)) {
+			class_sections = same_class_dict[class_name];
+		}
+
+		if (class_sections.has(section)) {
+			class_sections.remove_at(class_sections.find(section));
+		} else {
+			class_sections.push_back(section);
+			const_cast<EditorInspectorSection *>(this)->unfold();
+		}
+
+		if (class_sections.is_empty()) {
+			same_class_dict.erase(class_name);
+		} else {
+			same_class_dict[class_name] = class_sections;
+		}
+
+		EditorSettings::get_singleton()->set("_interface/inspector/auto_unfold_same_class", same_class_dict);
+	}
+}
+
+bool EditorInspectorSection::_is_unfolded_by_any_class() const {
+	if (!EditorSettings::get_singleton()) {
+		return false;
+	}
+	PackedStringArray any_class_sections = EDITOR_GET("_interface/inspector/auto_unfold_any_class");
+	return any_class_sections.has(section);
+}
+
+bool EditorInspectorSection::_is_unfolded_by_same_class() const {
+	if (!EditorSettings::get_singleton()) {
+		return false;
+	}
+	Dictionary same_class_dict = EDITOR_GET("_interface/inspector/auto_unfold_same_class");
+	String class_name = object->get_class();
+	if (same_class_dict.has(class_name)) {
+		PackedStringArray class_sections = same_class_dict[class_name];
+		return class_sections.has(section);
+	}
+	return false;
+}
+
+void EditorInspectorSection::_collapse_section_recursive(Node *p_node) const {
+	if (!p_node) {
+		return;
+	}
+
+	p_node->editor_set_section_unfold(section, false);
+
+	for (int i = 0; i < p_node->get_child_count(); ++i) {
+		_collapse_section_recursive(p_node->get_child(i));
+	}
+}
+
 int EditorInspectorSection::_get_header_height() {
 	int header_height = theme_cache.bold_font->get_height(theme_cache.bold_font_size);
 	Ref<Texture2D> arrow = _get_arrow();
@@ -2324,6 +2416,13 @@ void EditorInspectorSection::_notification(int p_what) {
 
 				// - Arrow.
 				Ref<Texture2D> arrow = _get_arrow();
+				if (Object::cast_to<Node>(object) && object->editor_is_section_unfolded(section)) {
+					if (_is_unfolded_by_any_class()) {
+						arrow = get_editor_theme_icon(SNAME("GuiTreeThreeArrowsDown"));
+					} else if (_is_unfolded_by_same_class()) {
+						arrow = get_editor_theme_icon(SNAME("GuiTreeTwoArrowsDown"));
+					}
+				}
 				if (arrow.is_valid()) {
 					Point2 arrow_position;
 					if (rtl) {
@@ -2607,6 +2706,10 @@ void EditorInspectorSection::setup(const String &p_section, const String &p_labe
 	_test_unfold();
 
 	if (foldable) {
+		if (_should_auto_unfold(object->get_class())) {
+			object->editor_set_section_unfold(section, true);
+		}
+
 		if (object->editor_is_section_unfolded(section)) {
 			vbox->show();
 		} else {
@@ -2880,6 +2983,12 @@ void EditorInspectorSection::_update_popup() {
 	menu->add_icon_item(theme_cache.icon_paste, TTRC("Paste Section Values"), MENU_PASTE_SECTION);
 	menu->set_item_disabled(-1, EditorInspector::get_property_clipboard_type() != EditorInspector::PropertyClipboard::Type::SECTION);
 
+	menu->add_separator();
+	menu->add_check_item(TTRC("Auto Unfold for Nodes of the Same Class"), MENU_AUTO_UNFOLD_SAME_CLASS);
+	menu->add_check_item(TTRC("Auto Unfold for Nodes of Any Class"), MENU_AUTO_UNFOLD_ANY_CLASS);
+	menu->add_separator();
+	menu->add_item(TTRC("Collapse Section on All Nodes"), MENU_COLLAPSE_SECTION_ON_ALL_NODES);
+
 	if (can_revert) {
 		menu->add_separator();
 		menu->add_icon_item(theme_cache.icon_gui_revert, TTRC("Revert Value"), MENU_REVERT_VALUE);
@@ -2887,6 +2996,48 @@ void EditorInspectorSection::_update_popup() {
 	if (!doc_path.is_empty() && ScriptEditor::get_singleton() && EditorNode::get_singleton()) {
 		menu->add_separator();
 		menu->add_icon_item(theme_cache.help_icon, TTRC("Open Documentation"), MENU_OPEN_DOCUMENTATION);
+
+		menu->add_icon_item(theme_cache.icon_copy, TTRC("Copy Section Values"), MENU_COPY_VALUE);
+		menu->add_icon_item(theme_cache.icon_paste, TTRC("Paste Section Values"), MENU_PASTE_VALUE);
+	}
+
+	menu->set_item_disabled(MENU_PASTE_VALUE, EditorInspector::get_property_clipboard_type() != EditorInspector::PropertyClipboard::Type::SECTION);
+	int any_class_idx = menu->get_item_index(MENU_AUTO_UNFOLD_ANY_CLASS);
+	if (any_class_idx != -1 && EditorSettings::get_singleton()) {
+		PackedStringArray any_class_sections = EDITOR_GET("_interface/inspector/auto_unfold_any_class");
+		bool any_class_active = any_class_sections.has(section);
+		menu->set_item_checked(any_class_idx, any_class_active);
+
+		Dictionary same_class_dict = EDITOR_GET("_interface/inspector/auto_unfold_same_class");
+		bool same_class_active = false;
+		String class_name = object->get_class();
+		if (same_class_dict.has(class_name)) {
+			PackedStringArray class_sections = same_class_dict[class_name];
+			same_class_active = class_sections.has(section);
+		}
+		int same_class_idx = menu->get_item_index(MENU_AUTO_UNFOLD_SAME_CLASS);
+		menu->set_item_checked(same_class_idx, same_class_active);
+
+		if (any_class_active) {
+			menu->set_item_disabled(same_class_idx, true);
+			menu->set_item_tooltip(same_class_idx, TTR("This option is currently overridden by 'Auto Unfold Nodes of Any Class'."));
+		} else {
+			menu->set_item_disabled(same_class_idx, false);
+			menu->set_item_tooltip(same_class_idx, String());
+		}
+
+		int collapse_idx = menu->get_item_index(MENU_COLLAPSE_SECTION_ON_ALL_NODES);
+		if (collapse_idx != -1) {
+			bool is_auto_active = (any_class_active || same_class_active);
+
+			if (is_auto_active) {
+				menu->set_item_disabled(collapse_idx, true);
+				menu->set_item_tooltip(collapse_idx, TTR("Cannot Collapse while an Auto Unfold option is active."));
+			} else {
+				menu->set_item_disabled(collapse_idx, false);
+				menu->set_item_tooltip(collapse_idx, String());
+			}
+		}
 	}
 }
 
@@ -2959,6 +3110,24 @@ void EditorInspectorSection::menu_option(int p_option) {
 		case MENU_OPEN_DOCUMENTATION: {
 			ScriptEditor::get_singleton()->goto_help(doc_path);
 			EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
+		} break;
+		case MENU_AUTO_UNFOLD_ANY_CLASS:
+		case MENU_AUTO_UNFOLD_SAME_CLASS:
+			_toggle_auto_unfold(p_option);
+			break;
+		case MENU_COLLAPSE_SECTION_ON_ALL_NODES: {
+			if (!Object::cast_to<Node>(object)) {
+				break;
+			}
+
+			TypedArray<Node> open_roots = EditorInterface::get_singleton()->get_open_scene_roots();
+			for (int i = 0; i < open_roots.size(); ++i) {
+				Node *scene_root = Object::cast_to<Node>(open_roots[i]);
+				if (scene_root) {
+					_collapse_section_recursive(scene_root);
+					callable_mp(EditorInterface::get_singleton()->get_inspector(), &EditorInspector::update_tree).call_deferred();
+				}
+			}
 		} break;
 	}
 }

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -470,6 +470,9 @@ class EditorInspectorSection : public Container {
 		MENU_PASTE_SECTION,
 		MENU_REVERT_VALUE,
 		MENU_OPEN_DOCUMENTATION,
+		MENU_AUTO_UNFOLD_SAME_CLASS,
+		MENU_AUTO_UNFOLD_ANY_CLASS,
+		MENU_COLLAPSE_SECTION_ON_ALL_NODES,
 	};
 
 	String label;
@@ -510,6 +513,11 @@ class EditorInspectorSection : public Container {
 	int _get_header_height();
 	Ref<Texture2D> _get_arrow();
 	Ref<Texture2D> _get_checkbox();
+	bool _should_auto_unfold(const String &p_class_name) const;
+	void _toggle_auto_unfold(int p_id) const;
+	bool _is_unfolded_by_any_class() const;
+	bool _is_unfolded_by_same_class() const;
+	void _collapse_section_recursive(Node *p_node) const;
 
 	EditorInspector *_get_parent_inspector() const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
This PR addresses the need to reduce repetitive clicking when editing multiple nodes of the same type (e.g., mass-editing Transform properties of MeshInstance3D nodes). It allows users to automatically unfold specific property sections (like "Transform") when switching nodes. It's an attempt to address these proposals:

- https://github.com/godotengine/godot-proposals/issues/499
- https://github.com/godotengine/godot-proposals/issues/3676
- https://github.com/godotengine/godot-proposals/issues/9589
- https://github.com/godotengine/godot-proposals/issues/13781

### Features:
- Added two new toggle options in the inspector section context menu:
  - Auto Unfold for Nodes of the Same Class
  - Auto Unfold for Nodes of Any Class
- Added a 'Collapse Section on All Nodes' option.
- Introduced two new icons to indicate if a section was unfolded automatically: <img width="12" height="12" alt="GuiTreeTwoArrowsDown" src="https://github.com/user-attachments/assets/158bcc59-a20c-4c1c-97bf-96e51cb3fc7e" /> <img width="12" height="12" alt="GuiTreeThreeArrowsDown" src="https://github.com/user-attachments/assets/db46ba9f-3a89-4e8c-b5ad-63d8147efcc0" />
- The features are scoped to Node objects and remain hidden in the Remote Scene Tree to prevent cluttering non-local node contexts.
- Settings are stored in EditorSettings (hidden).

This video should give you an idea of how it works (sorry for the bad quality). 

https://github.com/user-attachments/assets/7cd0b30c-89e3-4cf1-ade2-c47fd51188a6

