### PR TITLE
renderer: Collapse resource tracker/usage vectors into `TrackedResource`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1184,12 +1184,10 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 	ERR_FAIL_COND_V_MSG(raytracing_list.active, ERR_INVALID_PARAMETER,
 			"Driver callback is forbidden during creation of a raytracing list.");
 
-	thread_local LocalVector<RDG::ResourceTracker *> trackers;
-	thread_local LocalVector<RDG::ResourceUsage> usages;
+	thread_local LocalVector<RDG::TrackedResource> tracked_resources;
 
 	uint32_t resource_count = p_resources.size();
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	tracked_resources.resize(resource_count);
 
 	if (resource_count > 0) {
 		for (uint32_t i = 0; i < p_resources.size(); i++) {
@@ -1203,8 +1201,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 					if (_buffer_make_mutable(buffer, cr.rid)) {
 						draw_graph.add_synchronization();
 					}
-					trackers[i] = buffer->draw_tracker;
-					usages[i] = (RDG::ResourceUsage)cr.usage;
+					tracked_resources[i] = { buffer->draw_tracker, (RDG::ResourceUsage)cr.usage };
 				} break;
 				case CALLBACK_RESOURCE_TYPE_TEXTURE: {
 					Texture *texture = texture_owner.get_or_null(cr.rid);
@@ -1214,8 +1211,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 					if (_texture_make_mutable(texture, cr.rid)) {
 						draw_graph.add_synchronization();
 					}
-					trackers[i] = texture->draw_tracker;
-					usages[i] = (RDG::ResourceUsage)cr.usage;
+					tracked_resources[i] = { texture->draw_tracker, (RDG::ResourceUsage)cr.usage };
 				} break;
 				default: {
 					CRASH_NOW_MSG("Invalid callback resource type.");
@@ -1224,7 +1220,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 		}
 	}
 
-	draw_graph.add_driver_callback(p_callback, p_userdata, trackers, usages);
+	draw_graph.add_driver_callback(p_callback, p_userdata, tracked_resources);
 
 	return OK;
 }
@@ -4365,8 +4361,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 
 	// Used for verification to make sure a uniform set does not use a framebuffer bound texture.
 	LocalVector<UniformSet::AttachableTexture> attachable_textures;
-	Vector<RDG::ResourceTracker *> draw_trackers;
-	Vector<RDG::ResourceUsage> draw_trackers_usage;
+	Vector<RDG::TrackedResource> draw_tracked_resources;
 	HashMap<RID, RDG::ResourceUsage> untracked_usage;
 	Vector<UniformSet::SharedTexture> shared_textures_to_update;
 	LocalVector<RID> pending_clear_textures;
@@ -4456,8 +4451,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (tracker != nullptr) {
-						draw_trackers.push_back(tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_SAMPLE);
+						draw_tracked_resources.push_back({ tracker, RDG::RESOURCE_USAGE_TEXTURE_SAMPLE });
 					} else {
 						untracked_usage[texture_id] = RDG::RESOURCE_USAGE_TEXTURE_SAMPLE;
 					}
@@ -4509,8 +4503,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (tracker != nullptr) {
-						draw_trackers.push_back(tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_SAMPLE);
+						draw_tracked_resources.push_back({ tracker, RDG::RESOURCE_USAGE_TEXTURE_SAMPLE });
 					} else {
 						untracked_usage[texture_id] = RDG::RESOURCE_USAGE_TEXTURE_SAMPLE;
 					}
@@ -4561,12 +4554,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (texture->draw_tracker != nullptr) {
-						draw_trackers.push_back(texture->draw_tracker);
-
 						if (set_uniform.writable) {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ_WRITE);
+							draw_tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ_WRITE });
 						} else {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ);
+							draw_tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ });
 						}
 					}
 
@@ -4596,12 +4587,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (buffer->draw_tracker != nullptr) {
-						draw_trackers.push_back(buffer->draw_tracker);
-
 						if (set_uniform.writable) {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ_WRITE);
+							draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ_WRITE });
 						} else {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ);
+							draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ });
 						}
 					} else {
 						untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ;
@@ -4629,8 +4618,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					ERR_FAIL_NULL_V_MSG(buffer, RID(), "SamplerBuffer (binding: " + itos(uniform.binding) + ", index " + itos(j + 1) + ") is not a valid texture buffer.");
 
 					if (buffer->draw_tracker != nullptr) {
-						draw_trackers.push_back(buffer->draw_tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ });
 					} else {
 						untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ;
 					}
@@ -4656,8 +4644,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 						"Uniform buffer supplied (binding: " + itos(uniform.binding) + ") size (" + itos(buffer->size) + ") is smaller than size of shader uniform: (" + itos(set_uniform.length) + ").");
 
 				if (buffer->draw_tracker != nullptr) {
-					draw_trackers.push_back(buffer->draw_tracker);
-					draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ);
+					draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ });
 				} else {
 					untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ;
 				}
@@ -4692,12 +4679,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 				}
 
 				if (buffer->draw_tracker != nullptr) {
-					draw_trackers.push_back(buffer->draw_tracker);
-
 					if (set_uniform.writable) {
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE });
 					} else {
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ });
 					}
 				} else {
 					untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ;
@@ -4742,9 +4727,8 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 				ERR_FAIL_NULL_V_MSG(accel, RID(), "Acceleration Structure supplied (binding: " + itos(uniform.binding) + ") is invalid.");
 
 				if (accel->draw_tracker != nullptr) {
-					draw_trackers.push_back(accel->draw_tracker);
 					// Acceleration structure is never going to be writable from raytracing shaders
-					draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ);
+					draw_tracked_resources.push_back({ accel->draw_tracker, RDG::RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ });
 				}
 
 				driver_uniform.ids.push_back(accel->driver_id);
@@ -4762,8 +4746,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 	uniform_set.driver_id = driver_uniform_set;
 	uniform_set.format = shader->set_formats[p_shader_set];
 	uniform_set.attachable_textures = attachable_textures;
-	uniform_set.draw_trackers = draw_trackers;
-	uniform_set.draw_trackers_usage = draw_trackers_usage;
+	uniform_set.draw_tracked_resources = draw_tracked_resources;
 	uniform_set.untracked_usage = untracked_usage;
 	uniform_set.shared_textures_to_update = shared_textures_to_update;
 	uniform_set.pending_clear_textures = pending_clear_textures;
@@ -5569,13 +5552,11 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 
 	thread_local LocalVector<RDG::AttachmentOperation> operations;
 	thread_local LocalVector<RDD::RenderPassClearValue> clear_values;
-	thread_local LocalVector<RDG::ResourceTracker *> resource_trackers;
-	thread_local LocalVector<RDG::ResourceUsage> resource_usages;
+	thread_local LocalVector<RDG::TrackedResource> tracked_resources;
 	BitField<RDD::PipelineStageBits> stages = {};
 	operations.resize(framebuffer->texture_ids.size());
 	clear_values.resize(framebuffer->texture_ids.size());
-	resource_trackers.clear();
-	resource_usages.clear();
+	tracked_resources.clear();
 	stages.clear();
 
 	uint32_t color_index = 0;
@@ -5597,8 +5578,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 		RDG::AttachmentOperation operation = RDG::ATTACHMENT_OPERATION_DEFAULT;
 		RDD::RenderPassClearValue clear_value;
 		if (framebuffer_key->vrs_attachment == i && (texture->usage_flags & TEXTURE_USAGE_VRS_ATTACHMENT_BIT)) {
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(_vrs_usage_from_method(framebuffer_key->vrs_method));
+			tracked_resources.push_back({ texture->draw_tracker, _vrs_usage_from_method(framebuffer_key->vrs_method) });
 			stages.set_flag(_vrs_stages_from_method(framebuffer_key->vrs_method));
 		} else if (texture->usage_flags & TEXTURE_USAGE_COLOR_ATTACHMENT_BIT) {
 			if (p_draw_flags.has_flag(DrawFlags(DRAW_CLEAR_COLOR_0 << color_index))) {
@@ -5609,8 +5589,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 				operation = RDG::ATTACHMENT_OPERATION_IGNORE;
 			}
 
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(RDG::RESOURCE_USAGE_ATTACHMENT_COLOR_READ_WRITE);
+			tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_ATTACHMENT_COLOR_READ_WRITE });
 			stages.set_flag(RDD::PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 			color_index++;
 		} else if (texture->usage_flags & (TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT)) {
@@ -5622,8 +5601,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 				operation = RDG::ATTACHMENT_OPERATION_IGNORE;
 			}
 
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(RDG::RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE);
+			tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE });
 			stages.set_flag(RDD::PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
 			stages.set_flag(RDD::PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
 		}
@@ -5633,7 +5611,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 	}
 
 	draw_graph.add_draw_list_begin(framebuffer->framebuffer_cache, Rect2i(viewport_offset, viewport_size), operations, clear_values, stages, p_breadcrumb);
-	draw_graph.add_draw_list_usages(resource_trackers, resource_usages);
+	draw_graph.add_draw_list_usages(tracked_resources);
 
 	// Mark textures as bound.
 	draw_list_bound_textures.clear();
@@ -6082,7 +6060,7 @@ void RenderingDevice::draw_list_draw(DrawListID p_list, bool p_use_indices, uint
 				_uniform_set_update_shared(uniform_set);
 				_uniform_set_update_clears(uniform_set);
 
-				draw_graph.add_draw_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+				draw_graph.add_draw_list_usages(uniform_set->draw_tracked_resources);
 				draw_list.state.sets[i].bound = true;
 
 				last_set_index = i;
@@ -6222,7 +6200,7 @@ void RenderingDevice::draw_list_draw_indirect(DrawListID p_list, bool p_use_indi
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_draw_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_draw_list_usages(uniform_set->draw_tracked_resources);
 
 			draw_list.state.sets[i].bound = true;
 		}
@@ -6584,7 +6562,7 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 			UniformSet *uniform_set = uniform_set_owner.get_or_null(raytracing_list.state.sets[i].uniform_set);
 			_uniform_set_update_shared(uniform_set);
 
-			draw_graph.add_raytracing_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_raytracing_list_usages(uniform_set->draw_tracked_resources);
 
 			raytracing_list.state.sets[i].bound = true;
 		}
@@ -6898,7 +6876,7 @@ void RenderingDevice::compute_list_dispatch(ComputeListID p_list, uint32_t p_x_g
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_compute_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_compute_list_usages(uniform_set->draw_tracked_resources);
 			compute_list.state.sets[i].bound = true;
 		}
 	}
@@ -7035,7 +7013,7 @@ void RenderingDevice::compute_list_dispatch_indirect(ComputeListID p_list, RID p
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_compute_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_compute_list_usages(uniform_set->draw_tracked_resources);
 			compute_list.state.sets[i].bound = true;
 		}
 	}
@@ -7528,8 +7506,7 @@ bool RenderingDevice::_uniform_set_make_mutable(UniformSet *p_uniform_set, RID p
 		return false;
 	} else {
 		// Uniform set has seen the resource but hasn't added its tracker yet.
-		p_uniform_set->draw_trackers.push_back(p_resource_tracker);
-		p_uniform_set->draw_trackers_usage.push_back(E->value);
+		p_uniform_set->draw_tracked_resources.push_back({ p_resource_tracker, E->value });
 		p_uniform_set->untracked_usage.remove(E);
 		return true;
 	}

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1205,12 +1205,10 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 	ERR_FAIL_COND_V_MSG(raytracing_list.active, ERR_INVALID_PARAMETER,
 			"Driver callback is forbidden during creation of a raytracing list.");
 
-	thread_local LocalVector<RDG::ResourceTracker *> trackers;
-	thread_local LocalVector<RDG::ResourceUsage> usages;
+	thread_local LocalVector<RDG::TrackedResource> tracked_resources;
 
 	uint32_t resource_count = p_resources.size();
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	tracked_resources.resize(resource_count);
 
 	if (resource_count > 0) {
 		for (uint32_t i = 0; i < p_resources.size(); i++) {
@@ -1224,8 +1222,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 					if (_buffer_make_mutable(buffer, cr.rid)) {
 						draw_graph.add_synchronization();
 					}
-					trackers[i] = buffer->draw_tracker;
-					usages[i] = (RDG::ResourceUsage)cr.usage;
+					tracked_resources[i] = { buffer->draw_tracker, (RDG::ResourceUsage)cr.usage };
 				} break;
 				case CALLBACK_RESOURCE_TYPE_TEXTURE: {
 					Texture *texture = texture_owner.get_or_null(cr.rid);
@@ -1235,8 +1232,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 					if (_texture_make_mutable(texture, cr.rid)) {
 						draw_graph.add_synchronization();
 					}
-					trackers[i] = texture->draw_tracker;
-					usages[i] = (RDG::ResourceUsage)cr.usage;
+					tracked_resources[i] = { texture->draw_tracker, (RDG::ResourceUsage)cr.usage };
 				} break;
 				default: {
 					CRASH_NOW_MSG("Invalid callback resource type.");
@@ -1245,7 +1241,7 @@ Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void 
 		}
 	}
 
-	draw_graph.add_driver_callback(p_callback, p_userdata, trackers, usages);
+	draw_graph.add_driver_callback(p_callback, p_userdata, tracked_resources);
 
 	return OK;
 }
@@ -4440,8 +4436,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 
 	// Used for verification to make sure a uniform set does not use a framebuffer bound texture.
 	LocalVector<UniformSet::AttachableTexture> attachable_textures;
-	Vector<RDG::ResourceTracker *> draw_trackers;
-	Vector<RDG::ResourceUsage> draw_trackers_usage;
+	Vector<RDG::TrackedResource> draw_tracked_resources;
 	HashMap<RID, RDG::ResourceUsage> untracked_usage;
 	Vector<UniformSet::SharedTexture> shared_textures_to_update;
 	LocalVector<RID> pending_clear_textures;
@@ -4531,8 +4526,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (tracker != nullptr) {
-						draw_trackers.push_back(tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_SAMPLE);
+						draw_tracked_resources.push_back({ tracker, RDG::RESOURCE_USAGE_TEXTURE_SAMPLE });
 					} else {
 						untracked_usage[texture_id] = RDG::RESOURCE_USAGE_TEXTURE_SAMPLE;
 					}
@@ -4584,8 +4578,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (tracker != nullptr) {
-						draw_trackers.push_back(tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_SAMPLE);
+						draw_tracked_resources.push_back({ tracker, RDG::RESOURCE_USAGE_TEXTURE_SAMPLE });
 					} else {
 						untracked_usage[texture_id] = RDG::RESOURCE_USAGE_TEXTURE_SAMPLE;
 					}
@@ -4636,12 +4629,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (texture->draw_tracker != nullptr) {
-						draw_trackers.push_back(texture->draw_tracker);
-
 						if (set_uniform.writable) {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ_WRITE);
+							draw_tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ_WRITE });
 						} else {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ);
+							draw_tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_IMAGE_READ });
 						}
 					}
 
@@ -4671,12 +4662,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					}
 
 					if (buffer->draw_tracker != nullptr) {
-						draw_trackers.push_back(buffer->draw_tracker);
-
 						if (set_uniform.writable) {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ_WRITE);
+							draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ_WRITE });
 						} else {
-							draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ);
+							draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ });
 						}
 					} else {
 						untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ;
@@ -4704,8 +4693,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					ERR_FAIL_NULL_V_MSG(buffer, RID(), "SamplerBuffer (binding: " + itos(uniform.binding) + ", index " + itos(j + 1) + ") is not a valid texture buffer.");
 
 					if (buffer->draw_tracker != nullptr) {
-						draw_trackers.push_back(buffer->draw_tracker);
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ });
 					} else {
 						untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_TEXTURE_BUFFER_READ;
 					}
@@ -4731,8 +4719,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 						"Uniform buffer supplied (binding: " + itos(uniform.binding) + ") size (" + itos(buffer->size) + ") is smaller than size of shader uniform: (" + itos(set_uniform.length) + ").");
 
 				if (buffer->draw_tracker != nullptr) {
-					draw_trackers.push_back(buffer->draw_tracker);
-					draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ);
+					draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ });
 				} else {
 					untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_UNIFORM_BUFFER_READ;
 				}
@@ -4771,12 +4758,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 				}
 
 				if (buffer->draw_tracker != nullptr) {
-					draw_trackers.push_back(buffer->draw_tracker);
-
 					if (set_uniform.writable) {
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE });
 					} else {
-						draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ);
+						draw_tracked_resources.push_back({ buffer->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ });
 					}
 				} else {
 					untracked_usage[buffer_id] = RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ;
@@ -4821,9 +4806,8 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 				ERR_FAIL_NULL_V_MSG(accel, RID(), "Acceleration Structure supplied (binding: " + itos(uniform.binding) + ") is invalid.");
 
 				if (accel->draw_tracker != nullptr) {
-					draw_trackers.push_back(accel->draw_tracker);
 					// Acceleration structure is never going to be writable from raytracing shaders
-					draw_trackers_usage.push_back(RDG::RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ);
+					draw_tracked_resources.push_back({ accel->draw_tracker, RDG::RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ });
 				}
 
 				driver_uniform.ids.push_back(accel->driver_id);
@@ -4841,8 +4825,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 	uniform_set.driver_id = driver_uniform_set;
 	uniform_set.format = shader->set_formats[p_shader_set];
 	uniform_set.attachable_textures = attachable_textures;
-	uniform_set.draw_trackers = draw_trackers;
-	uniform_set.draw_trackers_usage = draw_trackers_usage;
+	uniform_set.draw_tracked_resources = draw_tracked_resources;
 	uniform_set.untracked_usage = untracked_usage;
 	uniform_set.shared_textures_to_update = shared_textures_to_update;
 	uniform_set.pending_clear_textures = pending_clear_textures;
@@ -5648,13 +5631,11 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 
 	thread_local LocalVector<RDG::AttachmentOperation> operations;
 	thread_local LocalVector<RDD::RenderPassClearValue> clear_values;
-	thread_local LocalVector<RDG::ResourceTracker *> resource_trackers;
-	thread_local LocalVector<RDG::ResourceUsage> resource_usages;
+	thread_local LocalVector<RDG::TrackedResource> tracked_resources;
 	BitField<RDD::PipelineStageBits> stages = {};
 	operations.resize(framebuffer->texture_ids.size());
 	clear_values.resize(framebuffer->texture_ids.size());
-	resource_trackers.clear();
-	resource_usages.clear();
+	tracked_resources.clear();
 	stages.clear();
 
 	uint32_t color_index = 0;
@@ -5676,8 +5657,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 		RDG::AttachmentOperation operation = RDG::ATTACHMENT_OPERATION_DEFAULT;
 		RDD::RenderPassClearValue clear_value;
 		if (framebuffer_key->vrs_attachment == i && (texture->usage_flags & TEXTURE_USAGE_VRS_ATTACHMENT_BIT)) {
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(_vrs_usage_from_method(framebuffer_key->vrs_method));
+			tracked_resources.push_back({ texture->draw_tracker, _vrs_usage_from_method(framebuffer_key->vrs_method) });
 			stages.set_flag(_vrs_stages_from_method(framebuffer_key->vrs_method));
 		} else if (texture->usage_flags & TEXTURE_USAGE_COLOR_ATTACHMENT_BIT) {
 			if (p_draw_flags.has_flag(DrawFlags(DRAW_CLEAR_COLOR_0 << color_index))) {
@@ -5688,8 +5668,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 				operation = RDG::ATTACHMENT_OPERATION_IGNORE;
 			}
 
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(RDG::RESOURCE_USAGE_ATTACHMENT_COLOR_READ_WRITE);
+			tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_ATTACHMENT_COLOR_READ_WRITE });
 			stages.set_flag(RDD::PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 			color_index++;
 		} else if (texture->usage_flags & (TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT)) {
@@ -5701,8 +5680,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 				operation = RDG::ATTACHMENT_OPERATION_IGNORE;
 			}
 
-			resource_trackers.push_back(texture->draw_tracker);
-			resource_usages.push_back(RDG::RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE);
+			tracked_resources.push_back({ texture->draw_tracker, RDG::RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE });
 			stages.set_flag(RDD::PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
 			stages.set_flag(RDD::PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT);
 		}
@@ -5712,7 +5690,7 @@ RenderingDevice::DrawListID RenderingDevice::draw_list_begin(RID p_framebuffer, 
 	}
 
 	draw_graph.add_draw_list_begin(framebuffer->framebuffer_cache, Rect2i(viewport_offset, viewport_size), operations, clear_values, stages, p_breadcrumb);
-	draw_graph.add_draw_list_usages(resource_trackers, resource_usages);
+	draw_graph.add_draw_list_usages(tracked_resources);
 
 	// Mark textures as bound.
 	draw_list_bound_textures.clear();
@@ -6161,7 +6139,7 @@ void RenderingDevice::draw_list_draw(DrawListID p_list, bool p_use_indices, uint
 				_uniform_set_update_shared(uniform_set);
 				_uniform_set_update_clears(uniform_set);
 
-				draw_graph.add_draw_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+				draw_graph.add_draw_list_usages(uniform_set->draw_tracked_resources);
 				draw_list.state.sets[i].bound = true;
 
 				last_set_index = i;
@@ -6301,7 +6279,7 @@ void RenderingDevice::draw_list_draw_indirect(DrawListID p_list, bool p_use_indi
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_draw_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_draw_list_usages(uniform_set->draw_tracked_resources);
 
 			draw_list.state.sets[i].bound = true;
 		}
@@ -6663,7 +6641,7 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 			UniformSet *uniform_set = uniform_set_owner.get_or_null(raytracing_list.state.sets[i].uniform_set);
 			_uniform_set_update_shared(uniform_set);
 
-			draw_graph.add_raytracing_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_raytracing_list_usages(uniform_set->draw_tracked_resources);
 
 			raytracing_list.state.sets[i].bound = true;
 		}
@@ -6977,7 +6955,7 @@ void RenderingDevice::compute_list_dispatch(ComputeListID p_list, uint32_t p_x_g
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_compute_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_compute_list_usages(uniform_set->draw_tracked_resources);
 			compute_list.state.sets[i].bound = true;
 		}
 	}
@@ -7114,7 +7092,7 @@ void RenderingDevice::compute_list_dispatch_indirect(ComputeListID p_list, RID p
 			_uniform_set_update_shared(uniform_set);
 			_uniform_set_update_clears(uniform_set);
 
-			draw_graph.add_compute_list_usages(uniform_set->draw_trackers, uniform_set->draw_trackers_usage);
+			draw_graph.add_compute_list_usages(uniform_set->draw_tracked_resources);
 			compute_list.state.sets[i].bound = true;
 		}
 	}
@@ -7607,8 +7585,7 @@ bool RenderingDevice::_uniform_set_make_mutable(UniformSet *p_uniform_set, RID p
 		return false;
 	} else {
 		// Uniform set has seen the resource but hasn't added its tracker yet.
-		p_uniform_set->draw_trackers.push_back(p_resource_tracker);
-		p_uniform_set->draw_trackers_usage.push_back(E->value);
+		p_uniform_set->draw_tracked_resources.push_back({ p_resource_tracker, E->value });
 		p_uniform_set->untracked_usage.remove(E);
 		return true;
 	}

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1159,8 +1159,7 @@ private:
 		};
 
 		LocalVector<AttachableTexture> attachable_textures; // Used for validation.
-		Vector<RDG::ResourceTracker *> draw_trackers;
-		Vector<RDG::ResourceUsage> draw_trackers_usage;
+		Vector<RDG::TrackedResource> draw_tracked_resources;
 		HashMap<RID, RDG::ResourceUsage> untracked_usage;
 		LocalVector<SharedTexture> shared_textures_to_update;
 		LocalVector<RID> pending_clear_textures;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1164,8 +1164,7 @@ private:
 		};
 
 		LocalVector<AttachableTexture> attachable_textures; // Used for validation.
-		Vector<RDG::ResourceTracker *> draw_trackers;
-		Vector<RDG::ResourceUsage> draw_trackers_usage;
+		Vector<RDG::TrackedResource> draw_tracked_resources;
 		HashMap<RID, RDG::ResourceUsage> untracked_usage;
 		LocalVector<SharedTexture> shared_textures_to_update;
 		LocalVector<RID> pending_clear_textures;

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -363,7 +363,7 @@ RenderingDeviceGraph::RaytracingListInstruction *RenderingDeviceGraph::_allocate
 	return reinterpret_cast<RaytracingListInstruction *>(&raytracing_instruction_list.data[raytracing_list_data_offset]);
 }
 
-void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_trackers, ResourceUsage *p_resource_usages, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command) {
+void RenderingDeviceGraph::_add_command_to_graph(const TrackedResource *p_resources, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command) {
 	// Assign the next stages derived from the stages the command requires first.
 	r_command->next_stages = r_command->self_stages;
 
@@ -401,7 +401,7 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 	}
 
 	for (uint32_t i = 0; i < p_resource_count; i++) {
-		ResourceTracker *resource_tracker = p_resource_trackers[i];
+		ResourceTracker *resource_tracker = p_resources[i].tracker;
 		DEV_ASSERT(resource_tracker != nullptr);
 
 		resource_tracker->reset_if_outdated(tracking_frame);
@@ -411,13 +411,13 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 	}
 
 	for (uint32_t i = 0; i < p_resource_count; i++) {
-		ResourceTracker *resource_tracker = p_resource_trackers[i];
+		ResourceTracker *resource_tracker = p_resources[i].tracker;
 
 		const RDD::TextureSubresourceRange &subresources = resource_tracker->texture_subresources;
 		const Rect2i resource_tracker_rect(subresources.base_mipmap, subresources.base_layer, subresources.mipmap_count, subresources.layer_count);
 		Rect2i search_tracker_rect = resource_tracker_rect;
 
-		ResourceUsage new_resource_usage = p_resource_usages[i];
+		ResourceUsage new_resource_usage = p_resources[i].usage;
 		bool write_usage = _is_write_usage(new_resource_usage);
 		BitField<RDD::BarrierAccessBits> new_usage_access = _usage_to_access_bits(new_resource_usage);
 		bool is_resource_a_slice = resource_tracker->parent != nullptr;
@@ -429,7 +429,7 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 			if (resource_tracker->parent->command_index == p_command_index) {
 				DEV_ASSERT(resource_tracker->parent->usage_index != UINT32_MAX);
 
-				ERR_FAIL_COND_MSG(p_resource_usages[resource_tracker->parent->usage_index] != new_resource_usage, "Using a full texture and its slices at the same time with different usages is not allowed.");
+				ERR_FAIL_COND_MSG(p_resources[resource_tracker->parent->usage_index].usage != new_resource_usage, "Using a full texture and its slices at the same time with different usages is not allowed.");
 
 				continue;
 			}
@@ -1807,23 +1807,19 @@ void RenderingDeviceGraph::add_blas_build(RDD::AccelerationStructureID p_acceler
 	command->acceleration_structure = p_acceleration_structure;
 	command->scratch_buffer = p_scratch_buffer;
 
-	thread_local LocalVector<ResourceTracker *> trackers;
-	thread_local LocalVector<ResourceUsage> usages;
+	thread_local LocalVector<TrackedResource> resources;
 
 	// Sources and destination.
 	uint32_t resource_count = p_src_trackers.size() + 1;
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	resources.resize(resource_count);
 
 	for (uint32_t i = 0; i < p_src_trackers.size(); ++i) {
-		trackers[i] = p_src_trackers[i];
-		usages[i] = RESOURCE_USAGE_STORAGE_BUFFER_READ;
+		resources[i] = { p_src_trackers[i], RESOURCE_USAGE_STORAGE_BUFFER_READ };
 	}
 
-	trackers[resource_count - 1] = p_dst_tracker;
-	usages[resource_count - 1] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE;
+	resources[resource_count - 1] = { p_dst_tracker, RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE };
 
-	_add_command_to_graph(trackers.ptr(), usages.ptr(), usages.size(), command_index, command);
+	_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceleration_structure, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers) {
@@ -1837,23 +1833,19 @@ void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceler
 	command->instance_offset = p_instance_offset;
 	command->instance_count = p_instance_count;
 
-	thread_local LocalVector<ResourceTracker *> trackers;
-	thread_local LocalVector<ResourceUsage> usages;
+	thread_local LocalVector<TrackedResource> resources;
 
 	// Sources and destination.
 	uint32_t resource_count = p_src_trackers.size() + 1;
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	resources.resize(resource_count);
 
 	for (uint32_t i = 0; i < p_src_trackers.size(); ++i) {
-		trackers[i] = p_src_trackers[i];
-		usages[i] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ;
+		resources[i] = { p_src_trackers[i], RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ };
 	}
 
-	trackers[resource_count - 1] = p_dst_tracker;
-	usages[resource_count - 1] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE;
+	resources[resource_count - 1] = { p_dst_tracker, RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE };
 
-	_add_command_to_graph(trackers.ptr(), usages.ptr(), usages.size(), command_index, command);
+	_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_clear(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, uint32_t p_offset, uint32_t p_size) {
@@ -1876,7 +1868,8 @@ void RenderingDeviceGraph::add_buffer_clear(RDD::BufferID p_dst, ResourceTracker
 		usage = RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE;
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_copy(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, RDD::BufferCopyRegion p_region) {
@@ -1891,9 +1884,11 @@ void RenderingDeviceGraph::add_buffer_copy(RDD::BufferID p_src, ResourceTracker 
 	command->destination = p_dst;
 	command->region = p_region;
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-	_add_command_to_graph(trackers, usages, p_src_tracker != nullptr ? 2 : 1, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+		{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+	};
+	_add_command_to_graph(resources, p_src_tracker != nullptr ? 2 : 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_get_data(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, RDD::BufferCopyRegion p_region) {
@@ -1907,10 +1902,10 @@ void RenderingDeviceGraph::add_buffer_get_data(RDD::BufferID p_src, ResourceTrac
 	command->region = p_region;
 
 	if (p_src_tracker != nullptr) {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_FROM;
-		_add_command_to_graph(&p_src_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_src_tracker, RESOURCE_USAGE_COPY_FROM };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	} else {
-		_add_command_to_graph(nullptr, nullptr, 0, command_index, command);
+		_add_command_to_graph(nullptr, 0, command_index, command);
 	}
 }
 
@@ -1931,19 +1926,17 @@ void RenderingDeviceGraph::add_buffer_update(RDD::BufferID p_dst, ResourceTracke
 		buffer_copies[i] = p_buffer_copies[i];
 	}
 
-	ResourceUsage buffer_usage = RESOURCE_USAGE_COPY_TO;
-	_add_command_to_graph(&p_dst_tracker, &buffer_usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, RESOURCE_USAGE_COPY_TO };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
-void RenderingDeviceGraph::add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<ResourceTracker *> p_trackers, VectorView<RenderingDeviceGraph::ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
+void RenderingDeviceGraph::add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<TrackedResource> p_resources) {
 	int32_t command_index;
 	RecordedDriverCallbackCommand *command = static_cast<RecordedDriverCallbackCommand *>(_allocate_command(sizeof(RecordedDriverCallbackCommand), command_index));
 	command->type = RecordedCommand::TYPE_DRIVER_CALLBACK;
 	command->callback = p_callback;
 	command->userdata = p_userdata;
-	_add_command_to_graph((ResourceTracker **)p_trackers.ptr(), (ResourceUsage *)p_usages.ptr(), p_trackers.size(), command_index, command);
+	_add_command_to_graph(p_resources.ptr(), p_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_raytracing_list_begin() {
@@ -2000,8 +1993,7 @@ void RenderingDeviceGraph::add_raytracing_list_usage(ResourceTracker *p_tracker,
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->raytracing_list_index != raytracing_instruction_list.index) {
-		raytracing_instruction_list.command_trackers.push_back(p_tracker);
-		raytracing_instruction_list.command_tracker_usages.push_back(p_usage);
+		raytracing_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->raytracing_list_index = raytracing_instruction_list.index;
 		p_tracker->raytracing_list_usage = p_usage;
 	}
@@ -2012,11 +2004,9 @@ void RenderingDeviceGraph::add_raytracing_list_usage(ResourceTracker *p_tracker,
 #endif
 }
 
-void RenderingDeviceGraph::add_raytracing_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_raytracing_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_raytracing_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_raytracing_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2029,7 +2019,7 @@ void RenderingDeviceGraph::add_raytracing_list_end() {
 	command->self_stages = raytracing_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
 	memcpy(command->instruction_data(), raytracing_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(raytracing_instruction_list.command_trackers.ptr(), raytracing_instruction_list.command_tracker_usages.ptr(), raytracing_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(raytracing_instruction_list.command_resources.ptr(), raytracing_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_compute_list_begin(RDD::BreadcrumbMarker p_phase, uint32_t p_breadcrumb_data) {
@@ -2107,8 +2097,7 @@ void RenderingDeviceGraph::add_compute_list_usage(ResourceTracker *p_tracker, Re
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->compute_list_index != compute_instruction_list.index) {
-		compute_instruction_list.command_trackers.push_back(p_tracker);
-		compute_instruction_list.command_tracker_usages.push_back(p_usage);
+		compute_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->compute_list_index = compute_instruction_list.index;
 		p_tracker->compute_list_usage = p_usage;
 	}
@@ -2119,11 +2108,9 @@ void RenderingDeviceGraph::add_compute_list_usage(ResourceTracker *p_tracker, Re
 #endif
 }
 
-void RenderingDeviceGraph::add_compute_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_compute_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_compute_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_compute_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2136,7 +2123,7 @@ void RenderingDeviceGraph::add_compute_list_end() {
 	command->self_stages = compute_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
 	memcpy(command->instruction_data(), compute_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(compute_instruction_list.command_trackers.ptr(), compute_instruction_list.command_tracker_usages.ptr(), compute_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(compute_instruction_list.command_resources.ptr(), compute_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_draw_list_begin(FramebufferCache *p_framebuffer_cache, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb, bool p_split_cmd_buffer) {
@@ -2317,8 +2304,7 @@ void RenderingDeviceGraph::add_draw_list_usage(ResourceTracker *p_tracker, Resou
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->draw_list_index != draw_instruction_list.index) {
-		draw_instruction_list.command_trackers.push_back(p_tracker);
-		draw_instruction_list.command_tracker_usages.push_back(p_usage);
+		draw_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->draw_list_index = draw_instruction_list.index;
 		p_tracker->draw_list_usage = p_usage;
 	}
@@ -2329,11 +2315,9 @@ void RenderingDeviceGraph::add_draw_list_usage(ResourceTracker *p_tracker, Resou
 #endif
 }
 
-void RenderingDeviceGraph::add_draw_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_draw_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_draw_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_draw_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2398,7 +2382,7 @@ void RenderingDeviceGraph::add_draw_list_end() {
 	}
 
 	memcpy(command->instruction_data(), draw_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(draw_instruction_list.command_trackers.ptr(), draw_instruction_list.command_tracker_usages.ptr(), draw_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(draw_instruction_list.command_resources.ptr(), draw_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_clear_color(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, const Color &p_color, const RDD::TextureSubresourceRange &p_range) {
@@ -2427,7 +2411,8 @@ void RenderingDeviceGraph::add_texture_clear_color(RDD::TextureID p_dst, Resourc
 		}
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_clear_depth_stencil(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, float p_depth, uint8_t p_stencil, const RDD::TextureSubresourceRange &p_range) {
@@ -2452,7 +2437,8 @@ void RenderingDeviceGraph::add_texture_clear_depth_stencil(RDD::TextureID p_dst,
 		usage = RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE;
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_copy(RDD::TextureID p_src, ResourceTracker *p_src_tracker, RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, VectorView<RDD::TextureCopyRegion> p_texture_copy_regions) {
@@ -2473,9 +2459,11 @@ void RenderingDeviceGraph::add_texture_copy(RDD::TextureID p_src, ResourceTracke
 		texture_copy_regions[i] = p_texture_copy_regions[i];
 	}
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-	_add_command_to_graph(trackers, usages, 2, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+		{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+	};
+	_add_command_to_graph(resources, 2, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_get_data(RDD::TextureID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, VectorView<RDD::BufferTextureCopyRegion> p_buffer_texture_copy_regions, ResourceTracker *p_dst_tracker) {
@@ -2497,12 +2485,14 @@ void RenderingDeviceGraph::add_texture_get_data(RDD::TextureID p_src, ResourceTr
 
 	if (p_dst_tracker != nullptr) {
 		// Add the optional destination tracker if it was provided.
-		ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-		ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-		_add_command_to_graph(trackers, usages, 2, command_index, command);
+		TrackedResource resources[2] = {
+			{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+			{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+		};
+		_add_command_to_graph(resources, 2, command_index, command);
 	} else {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_FROM;
-		_add_command_to_graph(&p_src_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_src_tracker, RESOURCE_USAGE_COPY_FROM };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	}
 }
 
@@ -2521,9 +2511,11 @@ void RenderingDeviceGraph::add_texture_resolve(RDD::TextureID p_src, ResourceTra
 	command->dst_layer = p_dst_layer;
 	command->dst_mipmap = p_dst_mipmap;
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_RESOLVE_TO, RESOURCE_USAGE_RESOLVE_FROM };
-	_add_command_to_graph(trackers, usages, 2, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_RESOLVE_TO },
+		{ p_src_tracker, RESOURCE_USAGE_RESOLVE_FROM },
+	};
+	_add_command_to_graph(resources, 2, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_update(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, VectorView<RecordedBufferToTextureCopy> p_buffer_copies, VectorView<ResourceTracker *> p_buffer_trackers) {
@@ -2544,22 +2536,18 @@ void RenderingDeviceGraph::add_texture_update(RDD::TextureID p_dst, ResourceTrac
 
 	if (p_buffer_trackers.size() > 0) {
 		// Add the optional buffer trackers if they were provided.
-		thread_local LocalVector<ResourceTracker *> trackers;
-		thread_local LocalVector<ResourceUsage> usages;
-		trackers.clear();
-		usages.clear();
+		thread_local LocalVector<TrackedResource> resources;
+		resources.clear();
 		for (uint32_t i = 0; i < p_buffer_trackers.size(); i++) {
-			trackers.push_back(p_buffer_trackers[i]);
-			usages.push_back(RESOURCE_USAGE_COPY_FROM);
+			resources.push_back({ p_buffer_trackers[i], RESOURCE_USAGE_COPY_FROM });
 		}
 
-		trackers.push_back(p_dst_tracker);
-		usages.push_back(RESOURCE_USAGE_COPY_TO);
+		resources.push_back({ p_dst_tracker, RESOURCE_USAGE_COPY_TO });
 
-		_add_command_to_graph(trackers.ptr(), usages.ptr(), trackers.size(), command_index, command);
+		_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 	} else {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_TO;
-		_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_dst_tracker, RESOURCE_USAGE_COPY_TO };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	}
 }
 
@@ -2570,7 +2558,7 @@ void RenderingDeviceGraph::add_capture_timestamp(RDD::QueryPoolID p_query_pool, 
 	command->self_stages = 0;
 	command->pool = p_query_pool;
 	command->index = p_index;
-	_add_command_to_graph(nullptr, nullptr, 0, command_index, command);
+	_add_command_to_graph(nullptr, 0, command_index, command);
 }
 
 void RenderingDeviceGraph::add_synchronization() {

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -372,7 +372,7 @@ RenderingDeviceGraph::RaytracingListInstruction *RenderingDeviceGraph::_allocate
 	return reinterpret_cast<RaytracingListInstruction *>(&raytracing_instruction_list.data[raytracing_list_data_offset]);
 }
 
-void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_trackers, ResourceUsage *p_resource_usages, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command) {
+void RenderingDeviceGraph::_add_command_to_graph(const TrackedResource *p_resources, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command) {
 	// Assign the next stages derived from the stages the command requires first.
 	r_command->next_stages = r_command->self_stages;
 
@@ -410,7 +410,7 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 	}
 
 	for (uint32_t i = 0; i < p_resource_count; i++) {
-		ResourceTracker *resource_tracker = p_resource_trackers[i];
+		ResourceTracker *resource_tracker = p_resources[i].tracker;
 		DEV_ASSERT(resource_tracker != nullptr);
 
 		resource_tracker->reset_if_outdated(tracking_frame);
@@ -420,13 +420,13 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 	}
 
 	for (uint32_t i = 0; i < p_resource_count; i++) {
-		ResourceTracker *resource_tracker = p_resource_trackers[i];
+		ResourceTracker *resource_tracker = p_resources[i].tracker;
 
 		const RDD::TextureSubresourceRange &subresources = resource_tracker->texture_subresources;
 		const Rect2i resource_tracker_rect(subresources.base_mipmap, subresources.base_layer, subresources.mipmap_count, subresources.layer_count);
 		Rect2i search_tracker_rect = resource_tracker_rect;
 
-		ResourceUsage new_resource_usage = p_resource_usages[i];
+		ResourceUsage new_resource_usage = p_resources[i].usage;
 		bool write_usage = _is_write_usage(new_resource_usage);
 		BitField<RDD::BarrierAccessBits> new_usage_access = _usage_to_access_bits(new_resource_usage);
 		bool is_resource_a_slice = resource_tracker->parent != nullptr;
@@ -438,7 +438,7 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 			if (resource_tracker->parent->command_index == p_command_index) {
 				DEV_ASSERT(resource_tracker->parent->usage_index != UINT32_MAX);
 
-				ERR_FAIL_COND_MSG(p_resource_usages[resource_tracker->parent->usage_index] != new_resource_usage, "Using a full texture and its slices at the same time with different usages is not allowed.");
+				ERR_FAIL_COND_MSG(p_resources[resource_tracker->parent->usage_index].usage != new_resource_usage, "Using a full texture and its slices at the same time with different usages is not allowed.");
 
 				continue;
 			}
@@ -1818,23 +1818,19 @@ void RenderingDeviceGraph::add_blas_build(RDD::AccelerationStructureID p_acceler
 	command->acceleration_structure = p_acceleration_structure;
 	command->scratch_buffer = p_scratch_buffer;
 
-	thread_local LocalVector<ResourceTracker *> trackers;
-	thread_local LocalVector<ResourceUsage> usages;
+	thread_local LocalVector<TrackedResource> resources;
 
 	// Sources and destination.
 	uint32_t resource_count = p_src_trackers.size() + 1;
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	resources.resize(resource_count);
 
 	for (uint32_t i = 0; i < p_src_trackers.size(); ++i) {
-		trackers[i] = p_src_trackers[i];
-		usages[i] = RESOURCE_USAGE_STORAGE_BUFFER_READ;
+		resources[i] = { p_src_trackers[i], RESOURCE_USAGE_STORAGE_BUFFER_READ };
 	}
 
-	trackers[resource_count - 1] = p_dst_tracker;
-	usages[resource_count - 1] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE;
+	resources[resource_count - 1] = { p_dst_tracker, RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE };
 
-	_add_command_to_graph(trackers.ptr(), usages.ptr(), usages.size(), command_index, command);
+	_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceleration_structure, RDD::BufferID p_scratch_buffer, RDD::BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count, ResourceTracker *p_dst_tracker, VectorView<ResourceTracker *> p_src_trackers) {
@@ -1848,23 +1844,19 @@ void RenderingDeviceGraph::add_tlas_build(RDD::AccelerationStructureID p_acceler
 	command->instance_offset = p_instance_offset;
 	command->instance_count = p_instance_count;
 
-	thread_local LocalVector<ResourceTracker *> trackers;
-	thread_local LocalVector<ResourceUsage> usages;
+	thread_local LocalVector<TrackedResource> resources;
 
 	// Sources and destination.
 	uint32_t resource_count = p_src_trackers.size() + 1;
-	trackers.resize(resource_count);
-	usages.resize(resource_count);
+	resources.resize(resource_count);
 
 	for (uint32_t i = 0; i < p_src_trackers.size(); ++i) {
-		trackers[i] = p_src_trackers[i];
-		usages[i] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ;
+		resources[i] = { p_src_trackers[i], RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ };
 	}
 
-	trackers[resource_count - 1] = p_dst_tracker;
-	usages[resource_count - 1] = RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE;
+	resources[resource_count - 1] = { p_dst_tracker, RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE };
 
-	_add_command_to_graph(trackers.ptr(), usages.ptr(), usages.size(), command_index, command);
+	_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_clear(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, uint32_t p_offset, uint32_t p_size) {
@@ -1887,7 +1879,8 @@ void RenderingDeviceGraph::add_buffer_clear(RDD::BufferID p_dst, ResourceTracker
 		usage = RESOURCE_USAGE_STORAGE_BUFFER_READ_WRITE;
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_copy(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, RDD::BufferCopyRegion p_region) {
@@ -1902,9 +1895,11 @@ void RenderingDeviceGraph::add_buffer_copy(RDD::BufferID p_src, ResourceTracker 
 	command->destination = p_dst;
 	command->region = p_region;
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-	_add_command_to_graph(trackers, usages, p_src_tracker != nullptr ? 2 : 1, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+		{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+	};
+	_add_command_to_graph(resources, p_src_tracker != nullptr ? 2 : 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_buffer_get_data(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, RDD::BufferCopyRegion p_region) {
@@ -1918,10 +1913,10 @@ void RenderingDeviceGraph::add_buffer_get_data(RDD::BufferID p_src, ResourceTrac
 	command->region = p_region;
 
 	if (p_src_tracker != nullptr) {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_FROM;
-		_add_command_to_graph(&p_src_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_src_tracker, RESOURCE_USAGE_COPY_FROM };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	} else {
-		_add_command_to_graph(nullptr, nullptr, 0, command_index, command);
+		_add_command_to_graph(nullptr, 0, command_index, command);
 	}
 }
 
@@ -1942,19 +1937,17 @@ void RenderingDeviceGraph::add_buffer_update(RDD::BufferID p_dst, ResourceTracke
 		buffer_copies[i] = p_buffer_copies[i];
 	}
 
-	ResourceUsage buffer_usage = RESOURCE_USAGE_COPY_TO;
-	_add_command_to_graph(&p_dst_tracker, &buffer_usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, RESOURCE_USAGE_COPY_TO };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
-void RenderingDeviceGraph::add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<ResourceTracker *> p_trackers, VectorView<RenderingDeviceGraph::ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
+void RenderingDeviceGraph::add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<TrackedResource> p_resources) {
 	int32_t command_index;
 	RecordedDriverCallbackCommand *command = static_cast<RecordedDriverCallbackCommand *>(_allocate_command(sizeof(RecordedDriverCallbackCommand), command_index));
 	command->type = RecordedCommand::TYPE_DRIVER_CALLBACK;
 	command->callback = p_callback;
 	command->userdata = p_userdata;
-	_add_command_to_graph((ResourceTracker **)p_trackers.ptr(), (ResourceUsage *)p_usages.ptr(), p_trackers.size(), command_index, command);
+	_add_command_to_graph(p_resources.ptr(), p_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_raytracing_list_begin() {
@@ -2011,8 +2004,7 @@ void RenderingDeviceGraph::add_raytracing_list_usage(ResourceTracker *p_tracker,
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->raytracing_list_index != raytracing_instruction_list.index) {
-		raytracing_instruction_list.command_trackers.push_back(p_tracker);
-		raytracing_instruction_list.command_tracker_usages.push_back(p_usage);
+		raytracing_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->raytracing_list_index = raytracing_instruction_list.index;
 		p_tracker->raytracing_list_usage = p_usage;
 	}
@@ -2023,11 +2015,9 @@ void RenderingDeviceGraph::add_raytracing_list_usage(ResourceTracker *p_tracker,
 #endif
 }
 
-void RenderingDeviceGraph::add_raytracing_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_raytracing_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_raytracing_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_raytracing_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2040,7 +2030,7 @@ void RenderingDeviceGraph::add_raytracing_list_end() {
 	command->self_stages = raytracing_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
 	memcpy(command->instruction_data(), raytracing_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(raytracing_instruction_list.command_trackers.ptr(), raytracing_instruction_list.command_tracker_usages.ptr(), raytracing_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(raytracing_instruction_list.command_resources.ptr(), raytracing_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_compute_list_begin(RDD::BreadcrumbMarker p_phase, uint32_t p_breadcrumb_data) {
@@ -2118,8 +2108,7 @@ void RenderingDeviceGraph::add_compute_list_usage(ResourceTracker *p_tracker, Re
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->compute_list_index != compute_instruction_list.index) {
-		compute_instruction_list.command_trackers.push_back(p_tracker);
-		compute_instruction_list.command_tracker_usages.push_back(p_usage);
+		compute_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->compute_list_index = compute_instruction_list.index;
 		p_tracker->compute_list_usage = p_usage;
 	}
@@ -2130,11 +2119,9 @@ void RenderingDeviceGraph::add_compute_list_usage(ResourceTracker *p_tracker, Re
 #endif
 }
 
-void RenderingDeviceGraph::add_compute_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_compute_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_compute_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_compute_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2147,7 +2134,7 @@ void RenderingDeviceGraph::add_compute_list_end() {
 	command->self_stages = compute_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
 	memcpy(command->instruction_data(), compute_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(compute_instruction_list.command_trackers.ptr(), compute_instruction_list.command_tracker_usages.ptr(), compute_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(compute_instruction_list.command_resources.ptr(), compute_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_draw_list_begin(FramebufferCache *p_framebuffer_cache, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb, bool p_split_cmd_buffer) {
@@ -2330,8 +2317,7 @@ void RenderingDeviceGraph::add_draw_list_usage(ResourceTracker *p_tracker, Resou
 	p_tracker->reset_if_outdated(tracking_frame);
 
 	if (p_tracker->draw_list_index != draw_instruction_list.index) {
-		draw_instruction_list.command_trackers.push_back(p_tracker);
-		draw_instruction_list.command_tracker_usages.push_back(p_usage);
+		draw_instruction_list.command_resources.push_back({ p_tracker, p_usage });
 		p_tracker->draw_list_index = draw_instruction_list.index;
 		p_tracker->draw_list_usage = p_usage;
 	}
@@ -2342,11 +2328,9 @@ void RenderingDeviceGraph::add_draw_list_usage(ResourceTracker *p_tracker, Resou
 #endif
 }
 
-void RenderingDeviceGraph::add_draw_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages) {
-	DEV_ASSERT(p_trackers.size() == p_usages.size());
-
-	for (uint32_t i = 0; i < p_trackers.size(); i++) {
-		add_draw_list_usage(p_trackers[i], p_usages[i]);
+void RenderingDeviceGraph::add_draw_list_usages(VectorView<TrackedResource> p_resources) {
+	for (uint32_t i = 0; i < p_resources.size(); i++) {
+		add_draw_list_usage(p_resources[i].tracker, p_resources[i].usage);
 	}
 }
 
@@ -2416,7 +2400,7 @@ void RenderingDeviceGraph::add_draw_list_end() {
 	}
 
 	memcpy(command->instruction_data(), draw_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(draw_instruction_list.command_trackers.ptr(), draw_instruction_list.command_tracker_usages.ptr(), draw_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(draw_instruction_list.command_resources.ptr(), draw_instruction_list.command_resources.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_clear_color(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, const Color &p_color, const RDD::TextureSubresourceRange &p_range) {
@@ -2445,7 +2429,8 @@ void RenderingDeviceGraph::add_texture_clear_color(RDD::TextureID p_dst, Resourc
 		}
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_clear_depth_stencil(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, float p_depth, uint8_t p_stencil, const RDD::TextureSubresourceRange &p_range) {
@@ -2470,7 +2455,8 @@ void RenderingDeviceGraph::add_texture_clear_depth_stencil(RDD::TextureID p_dst,
 		usage = RESOURCE_USAGE_ATTACHMENT_DEPTH_STENCIL_READ_WRITE;
 	}
 
-	_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+	TrackedResource resource = { p_dst_tracker, usage };
+	_add_command_to_graph(&resource, 1, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_copy(RDD::TextureID p_src, ResourceTracker *p_src_tracker, RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, VectorView<RDD::TextureCopyRegion> p_texture_copy_regions) {
@@ -2491,9 +2477,11 @@ void RenderingDeviceGraph::add_texture_copy(RDD::TextureID p_src, ResourceTracke
 		texture_copy_regions[i] = p_texture_copy_regions[i];
 	}
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-	_add_command_to_graph(trackers, usages, 2, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+		{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+	};
+	_add_command_to_graph(resources, 2, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_get_data(RDD::TextureID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, VectorView<RDD::BufferTextureCopyRegion> p_buffer_texture_copy_regions, ResourceTracker *p_dst_tracker) {
@@ -2515,12 +2503,14 @@ void RenderingDeviceGraph::add_texture_get_data(RDD::TextureID p_src, ResourceTr
 
 	if (p_dst_tracker != nullptr) {
 		// Add the optional destination tracker if it was provided.
-		ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-		ResourceUsage usages[2] = { RESOURCE_USAGE_COPY_TO, RESOURCE_USAGE_COPY_FROM };
-		_add_command_to_graph(trackers, usages, 2, command_index, command);
+		TrackedResource resources[2] = {
+			{ p_dst_tracker, RESOURCE_USAGE_COPY_TO },
+			{ p_src_tracker, RESOURCE_USAGE_COPY_FROM },
+		};
+		_add_command_to_graph(resources, 2, command_index, command);
 	} else {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_FROM;
-		_add_command_to_graph(&p_src_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_src_tracker, RESOURCE_USAGE_COPY_FROM };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	}
 }
 
@@ -2539,9 +2529,11 @@ void RenderingDeviceGraph::add_texture_resolve(RDD::TextureID p_src, ResourceTra
 	command->dst_layer = p_dst_layer;
 	command->dst_mipmap = p_dst_mipmap;
 
-	ResourceTracker *trackers[2] = { p_dst_tracker, p_src_tracker };
-	ResourceUsage usages[2] = { RESOURCE_USAGE_RESOLVE_TO, RESOURCE_USAGE_RESOLVE_FROM };
-	_add_command_to_graph(trackers, usages, 2, command_index, command);
+	TrackedResource resources[2] = {
+		{ p_dst_tracker, RESOURCE_USAGE_RESOLVE_TO },
+		{ p_src_tracker, RESOURCE_USAGE_RESOLVE_FROM },
+	};
+	_add_command_to_graph(resources, 2, command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_update(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, VectorView<RecordedBufferToTextureCopy> p_buffer_copies, VectorView<ResourceTracker *> p_buffer_trackers) {
@@ -2562,22 +2554,18 @@ void RenderingDeviceGraph::add_texture_update(RDD::TextureID p_dst, ResourceTrac
 
 	if (p_buffer_trackers.size() > 0) {
 		// Add the optional buffer trackers if they were provided.
-		thread_local LocalVector<ResourceTracker *> trackers;
-		thread_local LocalVector<ResourceUsage> usages;
-		trackers.clear();
-		usages.clear();
+		thread_local LocalVector<TrackedResource> resources;
+		resources.clear();
 		for (uint32_t i = 0; i < p_buffer_trackers.size(); i++) {
-			trackers.push_back(p_buffer_trackers[i]);
-			usages.push_back(RESOURCE_USAGE_COPY_FROM);
+			resources.push_back({ p_buffer_trackers[i], RESOURCE_USAGE_COPY_FROM });
 		}
 
-		trackers.push_back(p_dst_tracker);
-		usages.push_back(RESOURCE_USAGE_COPY_TO);
+		resources.push_back({ p_dst_tracker, RESOURCE_USAGE_COPY_TO });
 
-		_add_command_to_graph(trackers.ptr(), usages.ptr(), trackers.size(), command_index, command);
+		_add_command_to_graph(resources.ptr(), resources.size(), command_index, command);
 	} else {
-		ResourceUsage usage = RESOURCE_USAGE_COPY_TO;
-		_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
+		TrackedResource resource = { p_dst_tracker, RESOURCE_USAGE_COPY_TO };
+		_add_command_to_graph(&resource, 1, command_index, command);
 	}
 }
 
@@ -2588,7 +2576,7 @@ void RenderingDeviceGraph::add_capture_timestamp(RDD::QueryPoolID p_query_pool, 
 	command->self_stages = 0;
 	command->pool = p_query_pool;
 	command->index = p_index;
-	_add_command_to_graph(nullptr, nullptr, 0, command_index, command);
+	_add_command_to_graph(nullptr, 0, command_index, command);
 }
 
 void RenderingDeviceGraph::add_synchronization() {

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -179,6 +179,13 @@ public:
 		RESOURCE_USAGE_MAX
 	};
 
+	struct ResourceTracker;
+
+	struct TrackedResource {
+		ResourceTracker *tracker;
+		ResourceUsage usage;
+	};
+
 	struct ResourceTracker {
 		uint32_t reference_count = 0;
 		int64_t command_frame = -1;
@@ -273,15 +280,13 @@ public:
 private:
 	struct InstructionList {
 		LocalVector<uint8_t> data;
-		LocalVector<ResourceTracker *> command_trackers;
-		LocalVector<ResourceUsage> command_tracker_usages;
+		LocalVector<TrackedResource> command_resources;
 		BitField<RDD::PipelineStageBits> stages = {};
 		int32_t index = 0;
 
 		void clear() {
 			data.clear();
-			command_trackers.clear();
-			command_tracker_usages.clear();
+			command_resources.clear();
 			stages.clear();
 		}
 	};
@@ -866,7 +871,7 @@ private:
 	ComputeListInstruction *_allocate_compute_list_instruction(uint32_t p_instruction_size);
 	void _check_discardable_attachment_dependency(ResourceTracker *p_resource_tracker, int32_t p_previous_command_index, int32_t p_command_index);
 	RaytracingListInstruction *_allocate_raytracing_list_instruction(uint32_t p_instruction_size);
-	void _add_command_to_graph(ResourceTracker **p_resource_trackers, ResourceUsage *p_resource_usages, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command);
+	void _add_command_to_graph(const TrackedResource *p_resources, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command);
 	void _add_texture_barrier_to_command(RDD::TextureID p_texture_id, BitField<RDD::BarrierAccessBits> p_src_access, BitField<RDD::BarrierAccessBits> p_dst_access, ResourceUsage p_prev_usage, ResourceUsage p_next_usage, RDD::TextureSubresourceRange p_subresources, LocalVector<RDD::TextureBarrier> &r_barrier_vector, int32_t &r_barrier_index, int32_t &r_barrier_count);
 #if USE_BUFFER_BARRIERS
 	void _add_buffer_barrier_to_command(RDD::BufferID p_buffer_id, BitField<RDD::BarrierAccessBits> p_src_access, BitField<RDD::BarrierAccessBits> p_dst_access, int32_t &r_barrier_index, int32_t &r_barrier_count);
@@ -900,7 +905,7 @@ public:
 	void add_buffer_copy(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, RDD::BufferCopyRegion p_region);
 	void add_buffer_get_data(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, RDD::BufferCopyRegion p_region);
 	void add_buffer_update(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, VectorView<RecordedBufferCopy> p_buffer_copies);
-	void add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<TrackedResource> p_resources);
 	void add_raytracing_list_begin();
 	void add_raytracing_list_bind_pipeline(RDD::RaytracingPipelineID p_pipeline);
 	void add_raytracing_list_bind_uniform_set(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
@@ -908,7 +913,7 @@ public:
 	void add_raytracing_list_trace_rays(const RDD::ShaderBindingTable &p_raygen_sbt, const RDD::ShaderBindingTable &p_miss_sbt, const RDD::ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth);
 	void add_raytracing_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_raytracing_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_raytracing_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_raytracing_list_usages(VectorView<TrackedResource> p_resources);
 	void add_raytracing_list_end();
 	void add_compute_list_begin(RDD::BreadcrumbMarker p_phase = RDD::BreadcrumbMarker::NONE, uint32_t p_breadcrumb_data = 0);
 	void add_compute_list_bind_pipeline(RDD::PipelineID p_pipeline);
@@ -919,7 +924,7 @@ public:
 	void add_compute_list_set_push_constant(RDD::ShaderID p_shader, const void *p_data, uint32_t p_data_size);
 	void add_compute_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_compute_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_compute_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_compute_list_usages(VectorView<TrackedResource> p_resources);
 	void add_compute_list_end();
 	void add_draw_list_begin(FramebufferCache *p_framebuffer_cache, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb = 0, bool p_split_cmd_buffer = false);
 	void add_draw_list_begin(RDD::RenderPassID p_render_pass, RDD::FramebufferID p_framebuffer, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb = 0, bool p_split_cmd_buffer = false);
@@ -942,7 +947,7 @@ public:
 	void add_draw_list_set_viewport(Rect2i p_rect);
 	void add_draw_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_draw_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_draw_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_draw_list_usages(VectorView<TrackedResource> p_resources);
 	void add_draw_list_end();
 	void add_texture_clear_color(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, const Color &p_color, const RDD::TextureSubresourceRange &p_range);
 	void add_texture_clear_depth_stencil(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, float p_depth, uint8_t p_stencil, const RDD::TextureSubresourceRange &p_range);

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -180,6 +180,13 @@ public:
 		RESOURCE_USAGE_MAX
 	};
 
+	struct ResourceTracker;
+
+	struct TrackedResource {
+		ResourceTracker *tracker;
+		ResourceUsage usage;
+	};
+
 	struct ResourceTracker {
 		uint32_t reference_count = 0;
 		int64_t command_frame = -1;
@@ -275,15 +282,13 @@ public:
 private:
 	struct InstructionList {
 		LocalVector<uint8_t> data;
-		LocalVector<ResourceTracker *> command_trackers;
-		LocalVector<ResourceUsage> command_tracker_usages;
+		LocalVector<TrackedResource> command_resources;
 		BitField<RDD::PipelineStageBits> stages = {};
 		int32_t index = 0;
 
 		void clear() {
 			data.clear();
-			command_trackers.clear();
-			command_tracker_usages.clear();
+			command_resources.clear();
 			stages.clear();
 		}
 	};
@@ -868,7 +873,7 @@ private:
 	ComputeListInstruction *_allocate_compute_list_instruction(uint32_t p_instruction_size);
 	void _check_discardable_attachment_dependency(ResourceTracker *p_resource_tracker, int32_t p_previous_command_index, int32_t p_command_index);
 	RaytracingListInstruction *_allocate_raytracing_list_instruction(uint32_t p_instruction_size);
-	void _add_command_to_graph(ResourceTracker **p_resource_trackers, ResourceUsage *p_resource_usages, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command);
+	void _add_command_to_graph(const TrackedResource *p_resources, uint32_t p_resource_count, int32_t p_command_index, RecordedCommand *r_command);
 	void _add_texture_barrier_to_command(RDD::TextureID p_texture_id, BitField<RDD::BarrierAccessBits> p_src_access, BitField<RDD::BarrierAccessBits> p_dst_access, ResourceUsage p_prev_usage, ResourceUsage p_next_usage, RDD::TextureSubresourceRange p_subresources, LocalVector<RDD::TextureBarrier> &r_barrier_vector, int32_t &r_barrier_index, int32_t &r_barrier_count);
 #if USE_BUFFER_BARRIERS
 	void _add_buffer_barrier_to_command(RDD::BufferID p_buffer_id, BitField<RDD::BarrierAccessBits> p_src_access, BitField<RDD::BarrierAccessBits> p_dst_access, int32_t &r_barrier_index, int32_t &r_barrier_count);
@@ -902,7 +907,7 @@ public:
 	void add_buffer_copy(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, RDD::BufferCopyRegion p_region);
 	void add_buffer_get_data(RDD::BufferID p_src, ResourceTracker *p_src_tracker, RDD::BufferID p_dst, RDD::BufferCopyRegion p_region);
 	void add_buffer_update(RDD::BufferID p_dst, ResourceTracker *p_dst_tracker, VectorView<RecordedBufferCopy> p_buffer_copies);
-	void add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_driver_callback(RDD::DriverCallback p_callback, void *p_userdata, VectorView<TrackedResource> p_resources);
 	void add_raytracing_list_begin();
 	void add_raytracing_list_bind_pipeline(RDD::RaytracingPipelineID p_pipeline);
 	void add_raytracing_list_bind_uniform_set(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
@@ -910,7 +915,7 @@ public:
 	void add_raytracing_list_trace_rays(const RDD::ShaderBindingTable &p_raygen_sbt, const RDD::ShaderBindingTable &p_miss_sbt, const RDD::ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth);
 	void add_raytracing_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_raytracing_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_raytracing_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_raytracing_list_usages(VectorView<TrackedResource> p_resources);
 	void add_raytracing_list_end();
 	void add_compute_list_begin(RDD::BreadcrumbMarker p_phase = RDD::BreadcrumbMarker::NONE, uint32_t p_breadcrumb_data = 0);
 	void add_compute_list_bind_pipeline(RDD::PipelineID p_pipeline);
@@ -921,7 +926,7 @@ public:
 	void add_compute_list_set_push_constant(RDD::ShaderID p_shader, const void *p_data, uint32_t p_data_size);
 	void add_compute_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_compute_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_compute_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_compute_list_usages(VectorView<TrackedResource> p_resources);
 	void add_compute_list_end();
 	void add_draw_list_begin(FramebufferCache *p_framebuffer_cache, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb = 0, bool p_split_cmd_buffer = false);
 	void add_draw_list_begin(RDD::RenderPassID p_render_pass, RDD::FramebufferID p_framebuffer, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, BitField<RDD::PipelineStageBits> p_stages, uint32_t p_breadcrumb = 0, bool p_split_cmd_buffer = false);
@@ -944,7 +949,7 @@ public:
 	void add_draw_list_set_viewport(Rect2i p_rect);
 	void add_draw_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_draw_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
-	void add_draw_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);
+	void add_draw_list_usages(VectorView<TrackedResource> p_resources);
 	void add_draw_list_end();
 	void add_texture_clear_color(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, const Color &p_color, const RDD::TextureSubresourceRange &p_range);
 	void add_texture_clear_depth_stencil(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, float p_depth, uint8_t p_stencil, const RDD::TextureSubresourceRange &p_range);


### PR DESCRIPTION
# Summary

Replace the in-sync command_trackers/command_tracker_usages and `UniformSet::draw_trackers/draw_trackers_usage` vector pairs with a single `TrackedResource { tracker, usage }` vector, and update the graph usage APIs (`add_*_usages`, `add_driver_callback`, `_add_command_to_graph`) accordingly.

Another benefit, given both vectors were read at the same time, is that the pair of values will be in contiguous locations in memory. Not likely to move any benchmark needles, but it is still an improvement.

# Motivation

I have been exploring an alternative synchronisation mechanism for Metal to use fences, which may track pipeline / render stages as a 3<sup>rd</sup> array. By introducing `TrackedResource`, I will be able to add the field to this rather than manage another vector that must be kept in sync.

----

<details>
<summary>🤖 AI disclosure</summary>

I used 🤖 to migrate my implementation from my long-running development branch to this branch. I wrote the code.

</summary>