### PR TITLE
[3.x] Add tooltips to exported variables

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -150,6 +150,9 @@ struct PropertyInfo {
 	StringName class_name; //for classes
 	PropertyHint hint;
 	String hint_string;
+#ifdef TOOLS_ENABLED
+	String tooltip;
+#endif
 	uint32_t usage;
 
 	_FORCE_INLINE_ PropertyInfo added_usage(int p_fl) const {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1768,7 +1768,7 @@ void EditorInspector::update_tree() {
 					if (doc_hint != String()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 					} else {
-						ep->set_tooltip(property_prefix + p.name);
+						ep->set_tooltip(property_prefix + p.name + "::" + p.tooltip);
 					}
 					ep->update_property();
 					ep->_update_pin_flags();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3728,6 +3728,28 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 			case GDScriptTokenizer::TK_CURSOR: {
 				tokenizer->advance();
 			} break;
+			case GDScriptTokenizer::TK_TOOLTIP: {
+				tokenizer->advance();
+#ifdef TOOLS_ENABLED
+				if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+					Variant constant = tokenizer->get_token_constant();
+					current_export.tooltip = constant;
+				}
+
+				// Handle multiline tooltips.
+				while (tokenizer->get_token(2) == GDScriptTokenizer::TK_TOOLTIP) {
+					tokenizer->advance(3);
+					if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+						Variant constant = tokenizer->get_token_constant();
+						current_export.tooltip += constant.operator String();
+					}
+				}
+#else
+				if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+					tokenizer->advance();
+				}
+#endif
+			} break;
 			case GDScriptTokenizer::TK_EOF:
 				p_class->end_line = tokenizer->get_token_line();
 			case GDScriptTokenizer::TK_ERROR: {
@@ -4925,6 +4947,13 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 					member._export = current_export;
 					current_export = PropertyInfo();
 				}
+
+#ifdef TOOLS_ENABLED
+				if (autoexport) {
+					member._export.tooltip = current_export.tooltip;
+					current_export.tooltip = "";
+				}
+#endif
 
 				bool onready = tokenizer->get_token(-1) == GDScriptTokenizer::TK_PR_ONREADY;
 

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -143,6 +143,7 @@ public:
 		TK_ERROR,
 		TK_EOF,
 		TK_CURSOR, //used for code completion
+		TK_TOOLTIP,
 		TK_MAX
 	};
 


### PR DESCRIPTION
This is basically a copy of #35716 but re-based on the latest commit in the 3.x branch. Saw that it had been stale for 131 day's and thought it might be worth giving this a shot to see if everything actually works, and it does.
<img width="910" height="394" alt="image" src="https://github.com/user-attachments/assets/4d759668-ac3f-47db-a14b-61c53dd48938" />

Can be tested with the same example the previous person gave:
```
## [b]Tooltips[/b] for exported variables. [br][img]icon.png[/img] [br]With [color=green]BBCode[/color] support. [br]Enjoy!
export var with_tooltip = 2
```

Closes #35716