### PR TITLE
Fix HTTPRequest slow downloads in non-threaded mode

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -552,7 +552,16 @@ void HTTPRequest::_notification(int p_what) {
 			if (use_threads.is_set()) {
 				return;
 			}
-			bool done = _update_connection();
+			bool done = false;
+			do {
+				const int downloaded_before = downloaded.get();
+				done = _update_connection();
+				// If no bytes arrived this iteration, the socket buffer is drained
+				// for this frame — don't spin further.
+				if (!done && downloaded.get() == downloaded_before) {
+					break;
+				}
+			} while (!done);
 			if (done) {
 				set_process_internal(false);
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

In non-threaded mode (`use_threads = false`), `_update_connection()` is called exactly once per `NOTIFICATION_INTERNAL_PROCESS`, and its `STATUS_BODY` case reads at most one chunk per call. Since the notification fires once per rendered frame, download throughput is capped at `download_chunk_size x frame_rate`, regardless of how fast the connection can actually deliver data. With the default 64 KiB chunk size at 60 fps, that ceiling is ~3.8 MB/s.

The threaded path is unaffected, because `_thread_func` already calls `_update_connection()` in a tight loop at OS speed.

This fix keeps the change on the caller side: in the non-threaded branch, loop `_update_connection()` until a read delivers no new bytes (socket buffer drained for this frame), then yield. `_update_connection()` itself — and the threaded path — are untouched. Using `downloaded` as the progress signal means the loop also exits immediately during `CONNECTING`/`REQUESTING`, where no body bytes move, so behavior in those states is unchanged.

- Closes #120425

## Additional information

Benchmark on the same machine as the issue (8 MB download, non-threaded, 60 fps):

| | before | after |
|---|---|---|
| download time | 2366 ms | 570 ms |

After the fix, non-threaded mode no longer reads just one chunk per frame, so an 8 MB download completes in ~570 ms instead of being held to the per-frame ceiling.

### Design note (being worked)

> [!NOTE]
> The commit in this PR is the simple drain loop without the budget described below — I'm keeping the budget as a separate step pending the discussion here.

There's a catch with draining each frame. The loop's rule is "keep reading until there's nothing left waiting, then let the frame finish." That's fine at normal speeds, but picture a firehose — a connection so fast that the moment you read a handful of data, more has already arrived. Then there's always something left, the loop never stops, and it reads the entire file in a single frame. The game freezes until the download finishes: I measured frames taking 75–215 ms (vs. the usual ~16 ms) while draining 256 MB over loopback.

This is a known tradeoff for reading from a socket on a single thread — the same "read until empty, but the source refills faster than you drain it" problem documented as edge-triggered *starvation* in the Linux [`epoll(7)`](https://man7.org/linux/man-pages/man7/epoll.7.html) man page. The standard fix is to cap the work done per loop, which is what I'm testing: a per-frame time budget that reads for up to a few milliseconds, then stops and resumes next frame. That bounds the freeze. The cost is that on a connection faster than the budget can drain, throughput scales with frame rate again — but at a far higher ceiling than the original one-chunk-per-frame, and without the stall, so realistic downloads still drain fully each frame. The open questions for maintainers: what the default budget should be, and whether to expose it as a property. Marked draft until that lands.

### AI Disclosure

I used AI assistance (Claude) throughout this work — the C++ analysis, the patch, and help drafting the issue and this PR. I did the investigation myself and built, benchmarked, and verified every version, but I want to be upfront that the patch is largely AI-written. If that's a blocker under your contribution policy, let me know and I'm glad to discuss.