### PR TITLE
Resize menu when search filter is applied.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -246,6 +246,10 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 	bool gutter_compact = theme_cache.gutter_compact;
 
 	for (int i = 0; i < items.size(); i++) {
+		if (!items[i].visible) {
+			continue;
+		}
+
 		_shape_item(i);
 
 		icon_max_w = MAX(_get_item_icon_size(i).width, icon_max_w);
@@ -1131,6 +1135,21 @@ void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();
+
+	if (is_wrapping_controls()) {
+		Size2 minsize = get_contents_minimum_size();
+		Size2 maxsize = get_max_size();
+		if (maxsize.height > 0) {
+			minsize.height = MIN(minsize.height, maxsize.height);
+		}
+		if (maxsize.width > 0) {
+			minsize.width = MIN(minsize.width, maxsize.width);
+		}
+		minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
+		set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
+		Size2i sz = get_size(); // Shrinkwraps to min size.
+		set_size(Vector2i(shrink_width ? 0 : sz.x, shrink_height ? 0 : sz.y));
+	}
 }
 
 void PopupMenu::_search_bar_focus_entered() {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120431

## Additional information

https://github.com/user-attachments/assets/a591ed27-e41c-4163-87db-64402693b2ec

Should it be a separate flag? I'm not sure if this is always a desired behavior.