### PR TITLE
Fix error on range step 0

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3576,6 +3576,14 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after call arguments.)*");
 	complete_extents(call);
 
+	if (call->function_name == SNAME("range") && call->arguments.size() == 3 && call->arguments[2]->type == Node::LITERAL) {
+		LiteralNode *step_node = static_cast<LiteralNode *>(call->arguments[2]);
+
+		if (double(step_node->value) == 0.0) {
+			push_error("The range() step argument must not be equal to 0.", step_node);
+		}
+	}
+
 	return call;
 }
 

--- a/modules/gdscript/tests/scripts/parser/errors/range_with_zero_step.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/range_with_zero_step.gd
@@ -1,0 +1,3 @@
+func test() -> void:
+	for i: int in range(1, 2, 0):
+		pass

--- a/modules/gdscript/tests/scripts/parser/errors/range_with_zero_step.out
+++ b/modules/gdscript/tests/scripts/parser/errors/range_with_zero_step.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The range() step argument must not be equal to 0.


### PR DESCRIPTION
The documentation say's that an error gets printed when using 0 as a step value, however currently that's not the case. This PR adds an error message and has a unit test for making certain the error prints correctly.

<img width="556" height="330" alt="image" src="https://github.com/user-attachments/assets/f32afcfd-db49-451f-b4ef-7ffee20f0e57" />

Fixes #20914 
Closes #36902