### PR TITLE
Fix input attachments triggering the texture type validation.

### DIFF
--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -453,7 +453,9 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						uniform.writable = false;
 					}
 
-					if (is_image) {
+					// Gather the texture type and format for runtime validation when creating uniform sets.
+					// We cannot enforce the type for input attachments since they do not indicate whether the texture is 2D or 2D array for multiview.
+					if (is_image && binding.descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
 						uniform.texture_type = _spv_image_dim_to_texture_type(binding.image.dim, binding.image.arrayed);
 						uniform.texture_format = _spv_image_format_to_data_format(binding.image.image_format);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Subpass inputs were returning `TEXTURE_TYPE_MAX` for the texture type and immediately failing the validation, causing 3D to not render on the mobile renderer. We cannot guess the texture type that is going to be used at this point, since both 2D and 2D array textures appear as `subpassInput` in GLSL. So the solution is to skip the validation.

## Additional information

Regression from #119342. Thanks to @stuartcarnie for finding it!
