### PR TITLE
Fix collision exclusion not waking up body

### DIFF
--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -909,6 +909,12 @@ void GodotPhysicsServer2D::body_add_collision_exception(RID p_body, RID p_body_b
 
 	body->add_exception(p_body_b);
 	body->wakeup();
+
+	GodotBody2D *body_b = body_owner.get_or_null(p_body_b);
+	if (!body_b) {
+		return;
+	}
+	body_b->wakeup();
 }
 
 void GodotPhysicsServer2D::body_remove_collision_exception(RID p_body, RID p_body_b) {
@@ -917,6 +923,12 @@ void GodotPhysicsServer2D::body_remove_collision_exception(RID p_body, RID p_bod
 
 	body->remove_exception(p_body_b);
 	body->wakeup();
+
+	GodotBody2D *body_b = body_owner.get_or_null(p_body_b);
+	if (!body_b) {
+		return;
+	}
+	body_b->wakeup();
 }
 
 void GodotPhysicsServer2D::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -864,6 +864,12 @@ void GodotPhysicsServer3D::body_add_collision_exception(RID p_body, RID p_body_b
 
 	body->add_exception(p_body_b);
 	body->wakeup();
+
+	GodotBody3D *body_b = body_owner.get_or_null(p_body_b);
+	if (!body_b) {
+		return;
+	}
+	body_b->wakeup();
 }
 
 void GodotPhysicsServer3D::body_remove_collision_exception(RID p_body, RID p_body_b) {
@@ -872,6 +878,12 @@ void GodotPhysicsServer3D::body_remove_collision_exception(RID p_body, RID p_bod
 
 	body->remove_exception(p_body_b);
 	body->wakeup();
+
+	GodotBody3D *body_b = body_owner.get_or_null(p_body_b);
+	if (!body_b) {
+		return;
+	}
+	body_b->wakeup();
 }
 
 void GodotPhysicsServer3D::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes [50527](https://github.com/godotengine/godot/issues/50527) for both 3D and 2D godot physics.

The issue is related to waking up only the body receiving the exception and not the target one, as shown in this [MRP](https://github.com/user-attachments/files/29130356/SleepExceptions.zip)

Before PR:

https://github.com/user-attachments/assets/856d1a27-9507-450a-a39e-8cfc555920ad

After PR:

https://github.com/user-attachments/assets/1f7c9b84-b8df-4bb9-83b7-e7366b36ff8d

## Additional information
Jolt has the old erroneous behaviour, since this PR fixes only the godot physics. Should another issue be opened for Jolt?