### PR TITLE
Remember and restore Asset Store search filters

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1786,7 +1786,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				if (saved_category < categories->get_item_count()) {
 					categories->select(saved_category);
 				}
-				
+
 				_search(current_page);
 			}
 		} break;

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1053,7 +1053,22 @@ void EditorAssetLibrary::_notification(int p_what) {
 #endif
 
 				if (initial_loading) {
-					_repository_changed(0); // Update when shown for the first time.
+					// Remember saved search state, excluding category, and restore it.
+					const String saved_filter = EditorSettings::get_singleton()->get_project_metadata("assetlib", "search_filter", String());
+					if (!saved_filter.is_empty()) {
+						filter->set_text(saved_filter);
+					}
+
+					current_page = EditorSettings::get_singleton()->get_project_metadata("assetlib", "search_page", 1);
+
+					const int saved_sort = EditorSettings::get_singleton()->get_project_metadata("assetlib", "search_sort", 0);
+					sort->select(saved_sort);
+
+					const int saved_source = EditorSettings::get_singleton()->get_project_metadata("assetlib", "search_source", 0);
+					if (saved_source < repository->get_item_count()) {
+						repository->select(saved_source);
+					}
+					_repository_changed(saved_source); // Update when shown for the first time.
 				}
 			}
 		} break;
@@ -1474,6 +1489,14 @@ void EditorAssetLibrary::_licenses_popup_hide() {
 	}
 }
 
+void EditorAssetLibrary::_save_search_state() {
+	EditorSettings::get_singleton()->set_project_metadata("assetlib", "search_filter", filter->get_text());
+	EditorSettings::get_singleton()->set_project_metadata("assetlib", "search_page", current_page);
+	EditorSettings::get_singleton()->set_project_metadata("assetlib", "search_sort", sort->get_selected());
+	EditorSettings::get_singleton()->set_project_metadata("assetlib", "search_category", categories->get_selected());
+	EditorSettings::get_singleton()->set_project_metadata("assetlib", "search_source", repository->get_selected());
+}
+
 void EditorAssetLibrary::_search(int p_page) {
 	ERR_FAIL_COND(p_page <= 0);
 
@@ -1511,6 +1534,10 @@ void EditorAssetLibrary::_search(int p_page) {
 	}
 
 	_api_request("search/query/" + args, REQUESTING_SEARCH);
+
+	if (!initial_loading) {
+		_save_search_state();
+	}
 }
 
 void EditorAssetLibrary::_request_current_config() {
@@ -1709,13 +1736,19 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 		case REQUESTING_CHECK: {
 			if (!templates_only) {
 				_api_request("tags/?featured_only=true", REQUESTING_TAGS, true);
+			} else {
+				if (initial_loading) {
+					_search(current_page);
+				}
 			}
 			_api_request("licenses/", REQUESTING_LICENSES, true);
 
 			filter->set_editable(true);
 			sort->set_disabled(false);
 
-			_search();
+			if (!initial_loading) {
+				_search();
+			}
 		} break;
 
 		case REQUESTING_TAGS: {
@@ -1745,6 +1778,16 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 				categories->add_item(name);
 				categories->set_item_metadata(-1, slug);
+			}
+
+			// Remember saved search category and restore it.
+			if (initial_loading) {
+				const int saved_category = EditorSettings::get_singleton()->get_project_metadata("assetlib", "search_category", 0);
+				if (saved_category < categories->get_item_count()) {
+					categories->select(saved_category);
+				}
+				
+				_search(current_page);
 			}
 		} break;
 

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -381,7 +381,7 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _save_search_state();
 	void _search(int p_page = 1);
-	
+
 	void _api_request(const String &p_request, RequestType p_request_type, bool p_is_parallel = false);
 	void _http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data, HTTPRequest *p_requester);
 	void _request_current_config();

--- a/editor/asset_library/asset_library_editor_plugin.h
+++ b/editor/asset_library/asset_library_editor_plugin.h
@@ -379,7 +379,9 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _manage_plugins();
 
+	void _save_search_state();
 	void _search(int p_page = 1);
+	
 	void _api_request(const String &p_request, RequestType p_request_type, bool p_is_parallel = false);
 	void _http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data, HTTPRequest *p_requester);
 	void _request_current_config();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15015

Lets the editor remember the Asset Store's search filters (search bar, current page, sorting, category and source) through project metadata as it's set, then restores the saved data on initial project load.