### PR TITLE
Add shell.nix for quick setup on nix-based systems

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  dlopenLibs = with pkgs; [
+    libx11 libxcursor libxinerama libxi libxrandr libxext libxkbcommon
+    wayland mesa libglvnd libdecor vulkan-loader
+    alsa-lib pulseaudio dbus fontconfig
+  ];
+in pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [ pkg-config scons wayland-scanner autoPatchelfHook ];
+
+  buildInputs = dlopenLibs ++ (with pkgs; [
+    freetype systemd
+    xcbutilcursor xcbutilwm xcbutilkeysyms xcbutilimage
+  ]);
+
+  shellHook = ''
+    export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath dlopenLibs}:$LD_LIBRARY_PATH"
+  '';
+}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Allows "plug-and-play" building and running on immutable systems like NixOS using nix-shell. User can just run `nix-shell` in cloned repo and all dependencies and env variables will be set