### PR TITLE
Add filtering by child and negating filters

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4209,7 +4209,7 @@ void SceneTreeDock::_filter_changed(const String &p_filter) {
 		filter->set_tooltip_text(warning);
 	} else {
 		filter->remove_theme_icon_override(SNAME("clear"));
-		filter->set_tooltip_text(TTR("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\")\nor group (if prefixed with \"group:\" or \"g:\"). Filtering is case-insensitive."));
+		filter->set_tooltip_text(TTR("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\"). Filtering is case-insensitive."));
 	}
 }
 
@@ -5053,7 +5053,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_accessibility_name(TTRC("Filter Nodes"));
-	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\")\nor group (if prefixed with \"group:\" or \"g:\"). Filtering is case-insensitive."));
+	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\"). Filtering is case-insensitive."));
 	filter_hbc->add_child(filter);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect(SceneStringName(text_changed), callable_mp(this, &SceneTreeDock::_filter_changed));

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4209,7 +4209,7 @@ void SceneTreeDock::_filter_changed(const String &p_filter) {
 		filter->set_tooltip_text(warning);
 	} else {
 		filter->remove_theme_icon_override(SNAME("clear"));
-		filter->set_tooltip_text(TTR("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\"). Filtering is case-insensitive."));
+		filter->set_tooltip_text(TTR("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\").\nPrefix with \"-\" to negate any filter term. Filtering is case-insensitive."));
 	}
 }
 
@@ -5053,7 +5053,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_accessibility_name(TTRC("Filter Nodes"));
-	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\"). Filtering is case-insensitive."));
+	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\"),\ngroup (if prefixed with \"group:\" or \"g:\"), or node type of their children (if prefixed with \"child:\" or \"c:\").\nPrefix with \"-\" to negate any filter term. Filtering is case-insensitive."));
 	filter_hbc->add_child(filter);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect(SceneStringName(text_changed), callable_mp(this, &SceneTreeDock::_filter_changed));

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1191,6 +1191,13 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 	for (int i = 0; i < p_terms.size(); i++) {
 		String term = p_terms[i];
 
+		// Handle negation prefix. Automatically negates any filter term.
+		bool negate = false;
+		if (term.begins_with("-") && term.length() > 1) {
+			negate = true;
+			term = term.substr(1);
+		}
+
 		bool matches = false;
 
 		// Recognize special filter.
@@ -1242,6 +1249,10 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 		} else {
 			// Default: filter by node name.
 			matches = p_item->get_text(0).to_lower().contains(term);
+		}
+
+		if (negate) {
+			matches = !matches;
 		}
 
 		if (!matches) {

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1189,7 +1189,9 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 	}
 
 	for (int i = 0; i < p_terms.size(); i++) {
-		const String &term = p_terms[i];
+		String term = p_terms[i];
+
+		bool matches = false;
 
 		// Recognize special filter.
 		if (term.contains_char(':') && !term.get_slicec(':', 0).is_empty()) {
@@ -1199,34 +1201,38 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 			if (parameter == "type" || parameter == "t") {
 				// Filter by Type.
 				Node *item_node = get_node(p_item->get_metadata(0));
-				if (!_node_matches_class_term(item_node, argument)) {
-					return false;
-				}
+				matches = _node_matches_class_term(item_node, argument);
 			} else if (parameter == "group" || parameter == "g") {
 				// Filter by Group.
 				Node *node = get_node(p_item->get_metadata(0));
 
 				if (argument.is_empty()) {
 					// When argument is empty, match all Nodes belonging to any exposed group.
-					if (node->get_persistent_group_count() == 0) {
-						return false;
-					}
+					matches = node->get_persistent_group_count() > 0;
 				} else {
 					List<Node::GroupInfo> group_info_list;
 					node->get_groups(&group_info_list);
 
-					bool term_in_groups = false;
 					for (const Node::GroupInfo &group_info : group_info_list) {
 						if (!group_info.persistent) {
 							continue; // Ignore internal groups.
 						}
 						if (String(group_info.name).to_lower().contains(argument)) {
-							term_in_groups = true;
+							matches = true;
 							break;
 						}
 					}
-					if (!term_in_groups) {
-						return false;
+				}
+			} else if (parameter == "child" || parameter == "c") {
+				// Filter by Child Node Type.
+				Node *item_node = get_node(p_item->get_metadata(0));
+				if (item_node) {
+					for (int child_idx = 0; child_idx < item_node->get_child_count(); child_idx++) {
+						Node *child = item_node->get_child(child_idx);
+						if (_node_matches_class_term(child, argument)) {
+							matches = true;
+							break;
+						}
 					}
 				}
 			} else if (filter_term_warning.is_empty()) {
@@ -1234,10 +1240,12 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 				continue;
 			}
 		} else {
-			// Default.
-			if (!p_item->get_text(0).to_lower().contains(term)) {
-				return false;
-			}
+			// Default: filter by node name.
+			matches = p_item->get_text(0).to_lower().contains(term);
+		}
+
+		if (!matches) {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Allows to filter scene tree by child
- Allows to invert filters by typing "-" before them (-t:Cam for every node that has not type that starts with Cam)

## Additional information

It currently also allows to negate names like -Net_ to hide every node with Net_, this is intended behaviour, but you can remove it if it's needed