### PR TITLE
Show C# [Tool] export XML <summary> as Inspector tooltips

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2118,6 +2118,15 @@ void GD_CLR_STDCALL CSharpScript::_add_property_default_values_callback(CSharpSc
 		p_script->exported_members_defval_cache[name] = value;
 	}
 }
+
+void GD_CLR_STDCALL CSharpScript::_add_property_doc_callback(CSharpScript *p_script, const String *p_class_name, const String *p_member, const String *p_summary) {
+	if (p_member->is_empty()) {
+		// Class-level summary.
+		p_script->class_doc_brief = *p_summary;
+		return;
+	}
+	p_script->member_docs[StringName(*p_member)] = *p_summary;
+}
 #endif
 
 bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_update) {
@@ -2148,6 +2157,8 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 #ifdef TOOLS_ENABLED
 		exported_members_cache.clear();
 		exported_members_defval_cache.clear();
+		member_docs.clear();
+		class_doc_brief = String();
 #endif
 
 		if (GDMonoCache::godot_api_cache_updated) {
@@ -2155,6 +2166,11 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 
 #ifdef TOOLS_ENABLED
 			GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyDefaultValues(this, &_add_property_default_values_callback);
+
+			// Tool scripts can surface their exported members' /// <summary> XML docs as Inspector tooltips.
+			if (is_tool() && GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyDocumentation) {
+				GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyDocumentation(this, &_add_property_doc_callback);
+			}
 #endif
 		}
 	}
@@ -2721,6 +2737,44 @@ Ref<Script> CSharpScript::get_base_script() const {
 StringName CSharpScript::get_global_name() const {
 	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
 }
+
+#ifdef TOOLS_ENABLED
+Vector<DocData::ClassDoc> CSharpScript::get_documentation() const {
+	Vector<DocData::ClassDoc> docs;
+
+	if (member_docs.is_empty() && class_doc_brief.is_empty()) {
+		// Nothing to document; behavior stays unchanged.
+		return docs;
+	}
+
+	DocData::ClassDoc doc;
+	// Must match the class name the inspector uses to look up property docs
+	// (see EditorInspector::update_tree, which reads get_doc_class_name()).
+	doc.name = get_doc_class_name();
+	doc.is_script_doc = true;
+	doc.script_path = get_path();
+
+	if (!class_doc_brief.is_empty()) {
+		doc.brief_description = class_doc_brief;
+		doc.description = class_doc_brief;
+	}
+
+	for (const KeyValue<StringName, String> &E : member_docs) {
+		// Only document members that are actually exported/known on this script.
+		if (!member_info.has(E.key)) {
+			continue;
+		}
+
+		DocData::PropertyDoc prop_doc;
+		prop_doc.name = E.key;
+		prop_doc.description = E.value;
+		doc.properties.push_back(prop_doc);
+	}
+
+	docs.push_back(doc);
+	return docs;
+}
+#endif // TOOLS_ENABLED
 
 void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 #ifdef TOOLS_ENABLED

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -204,11 +204,19 @@ private:
 
 	HashMap<StringName, PropertyInfo> member_info;
 
+#ifdef TOOLS_ENABLED
+	// Exported member name -> normalized /// <summary> text (Tool scripts only).
+	HashMap<StringName, String> member_docs;
+	// Class-level /// <summary> text (Tool scripts only).
+	String class_doc_brief;
+#endif
+
 	void _clear();
 
 	static void GD_CLR_STDCALL _add_property_info_list_callback(CSharpScript *p_script, const String *p_current_class_name, void *p_props, int32_t p_count);
 #ifdef TOOLS_ENABLED
 	static void GD_CLR_STDCALL _add_property_default_values_callback(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
+	static void GD_CLR_STDCALL _add_property_doc_callback(CSharpScript *p_script, const String *p_class_name, const String *p_member, const String *p_summary);
 #endif
 	bool _update_exports(PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
@@ -240,12 +248,8 @@ public:
 	void set_source_code(const String &p_code) override;
 
 #ifdef TOOLS_ENABLED
-	virtual StringName get_doc_class_name() const override { return StringName(); } // TODO
-	virtual Vector<DocData::ClassDoc> get_documentation() const override {
-		// TODO
-		Vector<DocData::ClassDoc> docs;
-		return docs;
-	}
+	virtual StringName get_doc_class_name() const override { return type_info.class_name; }
+	virtual Vector<DocData::ClassDoc> get_documentation() const override;
 	virtual String get_class_icon_path() const override {
 		return type_info.icon_path;
 	}
@@ -511,6 +515,9 @@ public:
 	}
 	String validate_path(const String &p_path) const override;
 	bool supports_builtin_mode() const override;
+#ifdef TOOLS_ENABLED
+	bool supports_documentation() const override { return true; }
+#endif
 	/* TODO? */ int find_function(const String &p_function, const String &p_code) const override {
 		return -1;
 	}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -6,6 +6,15 @@
 
     <!-- Determines if we should import Microsoft.NET.Sdk, if it wasn't already imported. -->
     <GodotSdkImportsMicrosoftNetSdk Condition=" '$(UsingMicrosoftNETSdk)' != 'true' ">true</GodotSdkImportsMicrosoftNetSdk>
+
+    <!--
+    Emit XML documentation next to the assembly (e.g. MyGame.xml beside MyGame.dll) so [Tool]
+    scripts can surface their /// <summary> text as Godot Inspector tooltips.
+    Opt out by setting GodotGenerateXmlDoc=false in the project.
+    -->
+    <GenerateDocumentationFile Condition=" '$(GenerateDocumentationFile)' == '' and '$(GodotGenerateXmlDoc)' != 'false' ">true</GenerateDocumentationFile>
+    <!-- Avoid turning "missing XML comment" into build warnings/noise. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -31,6 +31,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
+        public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, godot_string*, godot_string*, void>, void> ScriptManagerBridge_GetPropertyDocumentation;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> ScriptManagerBridge_CallStatic;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
@@ -75,6 +76,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_SwapGCHandleForType = &ScriptManagerBridge.SwapGCHandleForType,
                 ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,
                 ScriptManagerBridge_GetPropertyDefaultValues = &ScriptManagerBridge.GetPropertyDefaultValues,
+                ScriptManagerBridge_GetPropertyDocumentation = &ScriptManagerBridge.GetPropertyDocumentation,
                 ScriptManagerBridge_CallStatic = &ScriptManagerBridge.CallStatic,
                 CSharpInstanceBridge_Call = &CSharpInstanceBridge.Call,
                 CSharpInstanceBridge_Set = &CSharpInstanceBridge.Set,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -1009,6 +1009,67 @@ namespace Godot.Bridge
             }
         }
 
+        // Surfaces the /// <summary> XML documentation of exported members so the editor
+        // Inspector can show it as a tooltip/description. Only runs for [Tool] scripts.
+        // The callback receives (scriptPtr, className, memberName, summary); an empty
+        // memberName carries the class-level summary.
+        [UnmanagedCallersOnly]
+        internal static unsafe void GetPropertyDocumentation(IntPtr scriptPtr,
+            delegate* unmanaged<IntPtr, godot_string*, godot_string*, godot_string*, void> addDocFunc)
+        {
+            try
+            {
+                Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
+
+                // Requirement: only [Tool] scripts. Mirror the nesting/GodotTools rules used elsewhere.
+                bool isTool = scriptType.IsDefined(typeof(ToolAttribute), inherit: false)
+                    || (scriptType.IsNested && (scriptType.DeclaringType?.IsDefined(typeof(ToolAttribute), false) ?? false))
+                    || scriptType.Assembly.GetName().Name == "GodotTools";
+                if (!isTool)
+                    return;
+
+                using godot_string className =
+                    Marshaling.ConvertStringToNative(ReflectionUtils.ConstructTypeName(scriptType));
+
+                // Class-level summary (optional; used for the category tooltip / brief).
+                string? typeSummary = XmlDocumentationCache.GetTypeSummary(scriptType);
+                if (!string.IsNullOrEmpty(typeSummary))
+                {
+                    using godot_string emptyMember = Marshaling.ConvertStringToNative(string.Empty);
+                    using godot_string summaryNative = Marshaling.ConvertStringToNative(typeSummary);
+                    addDocFunc(scriptPtr, &className, &emptyMember, &summaryNative);
+                }
+
+                const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static
+                    | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+                for (Type? t = scriptType; t != null && typeof(GodotObject).IsAssignableFrom(t); t = t.BaseType)
+                {
+                    foreach (var field in t.GetFields(flags))
+                        EmitMemberSummary(scriptPtr, &className, field, field.Name, addDocFunc);
+                    foreach (var property in t.GetProperties(flags))
+                        EmitMemberSummary(scriptPtr, &className, property, property.Name, addDocFunc);
+                }
+            }
+            catch (Exception e)
+            {
+                // Requirement: never throw; on failure behavior stays unchanged (no docs).
+                ExceptionUtils.LogException(e);
+            }
+        }
+
+        private static unsafe void EmitMemberSummary(IntPtr scriptPtr, godot_string* className,
+            MemberInfo member, string memberName,
+            delegate* unmanaged<IntPtr, godot_string*, godot_string*, godot_string*, void> addDocFunc)
+        {
+            string? summary = XmlDocumentationCache.GetSummary(member);
+            if (string.IsNullOrEmpty(summary))
+                return;
+            using godot_string memberNative = Marshaling.ConvertStringToNative(memberName);
+            using godot_string summaryNative = Marshaling.ConvertStringToNative(summary);
+            addDocFunc(scriptPtr, className, &memberNative, &summaryNative);
+        }
+
         private static unsafe void GetPropertyInfoListForType(Type type, IntPtr scriptPtr,
             delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/XmlDocumentationCache.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/XmlDocumentationCache.cs
@@ -1,0 +1,175 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Text.RegularExpressions;
+using System.Xml;
+using Godot.NativeInterop;
+
+namespace Godot.Bridge
+{
+    /// <summary>
+    /// Lazily reads and caches the XML documentation file emitted next to a managed
+    /// assembly (e.g. MyGame.xml beside MyGame.dll), so the <c>/// &lt;summary&gt;</c>
+    /// text of exported members can be surfaced in the Godot Inspector. The result is
+    /// cached per assembly and invalidated when the XML file's last-write time changes.
+    /// </summary>
+    internal static class XmlDocumentationCache
+    {
+        private sealed class Entry
+        {
+            public DateTime WriteTimeUtc;
+            public Dictionary<string, string> Summaries = new(); // doc id ("P:Ns.T.Prop") -> summary
+        }
+
+        // Keyed weakly so assemblies stay collectible; a strong Dictionary<Assembly, ...>
+        // would pin the collectible load context and break hot-reload (see godot#78513).
+        private static readonly ConditionalWeakTable<Assembly, Entry> _byAssembly = new();
+        private static readonly object _lock = new();
+
+        public static string? GetSummary(MemberInfo member)
+            => GetSummaryById(member.DeclaringType?.Assembly, DocId(member));
+
+        public static string? GetTypeSummary(Type type)
+            => GetSummaryById(type.Assembly, "T:" + DocTypeName(type));
+
+        private static string? GetSummaryById(Assembly? asm, string? id)
+        {
+            if (asm == null || string.IsNullOrEmpty(id))
+                return null;
+
+            Entry entry = GetEntry(asm);
+            return entry.Summaries.TryGetValue(id, out string? summary) ? summary : null;
+        }
+
+        private static Entry GetEntry(Assembly asm)
+        {
+            string xmlPath = GetXmlPath(asm);
+
+            lock (_lock)
+            {
+                bool exists = xmlPath.Length != 0 && File.Exists(xmlPath);
+                DateTime writeTime = exists ? File.GetLastWriteTimeUtc(xmlPath) : DateTime.MinValue;
+
+                if (_byAssembly.TryGetValue(asm, out Entry? cached) && cached.WriteTimeUtc == writeTime)
+                    return cached; // Up to date (covers the "no file" -> MinValue case too).
+
+                var entry = new Entry { WriteTimeUtc = writeTime };
+                if (exists)
+                {
+                    try
+                    {
+                        Parse(xmlPath, entry.Summaries);
+                    }
+                    catch (Exception e)
+                    {
+                        // Invalid XML -> leave summaries empty, behavior stays unchanged.
+                        ExceptionUtils.LogException(e);
+                    }
+                }
+
+                _byAssembly.AddOrUpdate(asm, entry);
+                return entry;
+            }
+        }
+
+        // Resolves the path of the assembly's XML doc file (e.g. MyGame.xml).
+        // Godot loads project assemblies from memory (see GodotPlugins.PluginLoadContext),
+        // so Assembly.Location is empty; fall back to the load context's known on-disk path.
+        private static string GetXmlPath(Assembly asm)
+        {
+            if (asm.IsDynamic)
+                return string.Empty;
+
+            string? dir = null;
+            if (!string.IsNullOrEmpty(asm.Location))
+            {
+                dir = Path.GetDirectoryName(asm.Location);
+            }
+            else
+            {
+                AssemblyLoadContext? alc = AssemblyLoadContext.GetLoadContext(asm);
+                // PluginLoadContext exposes the on-disk path it loaded from. Read it via
+                // reflection to avoid a circular reference from GodotSharp to GodotPlugins.
+                // All assemblies in a plugin context share the same bin directory.
+                if (alc?.GetType().GetProperty("AssemblyLoadedPath")?.GetValue(alc) is string loadedPath
+                    && !string.IsNullOrEmpty(loadedPath))
+                {
+                    dir = Path.GetDirectoryName(loadedPath);
+                }
+            }
+
+            string? name = asm.GetName().Name;
+            if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name))
+                return string.Empty;
+
+            return Path.Combine(dir, name + ".xml");
+        }
+
+        private static void Parse(string xmlPath, Dictionary<string, string> into)
+        {
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+            using var reader = XmlReader.Create(xmlPath, settings);
+
+            string? currentMember = null;
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "member")
+                {
+                    currentMember = reader.GetAttribute("name");
+                }
+                else if (reader.NodeType == XmlNodeType.Element && reader.Name == "summary" && currentMember != null)
+                {
+                    string raw = reader.ReadInnerXml(); // May contain <see cref="..."/> etc.
+                    into[currentMember] = Normalize(raw);
+                }
+            }
+        }
+
+        // Collapse whitespace, drop tags, resolve <see cref="..."/> to its short name.
+        private static string Normalize(string xml)
+        {
+            // <see cref="T:Ns.Type.Member"/> -> Member ; <paramref name="x"/> -> x
+            xml = Regex.Replace(xml, "<see[^>]*cref=\"[A-Za-z]:(?<id>[^\"]+)\"[^>]*/?>",
+                m => ShortName(m.Groups["id"].Value));
+            xml = Regex.Replace(xml, "<(paramref|typeparamref)[^>]*name=\"(?<n>[^\"]+)\"[^>]*/?>",
+                m => m.Groups["n"].Value);
+            xml = Regex.Replace(xml, "<[^>]+>", string.Empty); // Strip any remaining tags.
+            xml = System.Net.WebUtility.HtmlDecode(xml);
+            xml = Regex.Replace(xml, "\\s+", " ").Trim(); // Normalize whitespace.
+            return xml;
+        }
+
+        private static string ShortName(string id)
+        {
+            int paren = id.IndexOf('(');
+            if (paren >= 0)
+                id = id[..paren];
+            int dot = id.LastIndexOf('.');
+            return dot >= 0 ? id[(dot + 1)..] : id;
+        }
+
+        // Build the XML doc member id used by the compiler.
+        private static string DocId(MemberInfo member)
+        {
+            if (member.DeclaringType == null)
+                return string.Empty;
+
+            string typeName = DocTypeName(member.DeclaringType);
+            return member.MemberType switch
+            {
+                MemberTypes.Field => "F:" + typeName + "." + member.Name,
+                MemberTypes.Property => "P:" + typeName + "." + member.Name,
+                _ => string.Empty,
+            };
+        }
+
+        // Namespace.Type, with the nested-type '+' separator replaced by '.' as the doc id format requires.
+        private static string DocTypeName(Type type)
+            => (type.FullName ?? type.Name).Replace('+', '.');
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Core\Bridge\PropertyInfo.cs" />
     <Compile Include="Core\Bridge\ScriptManagerBridge.cs" />
     <Compile Include="Core\Bridge\ScriptManagerBridge.types.cs" />
+    <Compile Include="Core\Bridge\XmlDocumentationCache.cs" />
     <Compile Include="Core\Callable.cs" />
     <Compile Include="Core\Color.cs" />
     <Compile Include="Core\Colors.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -72,6 +72,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, SwapGCHandleForType);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyInfoList);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyDefaultValues);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyDocumentation);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, CallStatic);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Call);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Set);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -70,6 +70,7 @@ struct godotsharp_property_def_val_pair {
 struct ManagedCallbacks {
 	using Callback_ScriptManagerBridge_GetPropertyInfoList_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *, void *p_props, int32_t p_count);
 	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
+	using Callback_ScriptManagerBridge_GetPropertyDocumentation_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *p_class_name, const String *p_member, const String *p_summary);
 
 	using FuncSignalAwaiter_SignalCallback = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Variant **, int32_t, bool *);
 	using FuncDelegateUtils_InvokeWithVariantArgs = void(GD_CLR_STDCALL *)(GCHandleIntPtr, void *, const Variant **, int32_t, const Variant *);
@@ -94,6 +95,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_SwapGCHandleForType = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr *, bool);
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
 	using FuncScriptManagerBridge_GetPropertyDefaultValues = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add);
+	using FuncScriptManagerBridge_GetPropertyDocumentation = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDocumentation_Add);
 	using FuncScriptManagerBridge_CallStatic = bool(GD_CLR_STDCALL *)(const CSharpScript *, const StringName *, const Variant **, int32_t, Callable::CallError *, Variant *);
 	using FuncCSharpInstanceBridge_Call = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant **, int32_t, Callable::CallError *, Variant *);
 	using FuncCSharpInstanceBridge_Set = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant *);
@@ -132,6 +134,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_SwapGCHandleForType ScriptManagerBridge_SwapGCHandleForType;
 	FuncScriptManagerBridge_GetPropertyInfoList ScriptManagerBridge_GetPropertyInfoList;
 	FuncScriptManagerBridge_GetPropertyDefaultValues ScriptManagerBridge_GetPropertyDefaultValues;
+	FuncScriptManagerBridge_GetPropertyDocumentation ScriptManagerBridge_GetPropertyDocumentation;
 	FuncScriptManagerBridge_CallStatic ScriptManagerBridge_CallStatic;
 	FuncCSharpInstanceBridge_Call CSharpInstanceBridge_Call;
 	FuncCSharpInstanceBridge_Set CSharpInstanceBridge_Set;


### PR DESCRIPTION
Rebased #120438

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/8269

This PR allows C# `[Tool]` and `[Export]` fields and properties to be described with XML documentation and be exposed in godot inspector as descriptions for custom fields for nodes. After this change, godot will read XML documentation generated by MSBuild

## Additional information

The implementation adds a managed callback from ScriptManagerBridge to collect XML documentation summaries, store them in CSharpScript and exposes them through `get_documentation()` / `get_doc_class_name()`. `CSharpLanguage::supports_documentation()` now returns true, so the summaries flow through the existing documentation pipeline (EditorFileSystem registration, Inspector tooltips, Script Editor help) - the same path GDScript uses, with no changes to editor_inspector.cpp or editor_help.cpp. It enables docs generation by default with opt-out through `GodotGenerateXmlDoc=false`, supresses `CS1591` warning to avoid warnings about incomplete XML comments, adds `XmlDocumentationCache` which lazily reads and caches the generated .xml file next to the assembly, invalidates cached documentation when the XML file write time changes, uses weak assembly-keyed caching to avoid pinning collectible load contexts during reloads, supports class and field/property summaries, only [Tool] classes, and only their exported members, falls back to unchanged behavior if documentation is missing, invalid or cannot be loaded.

**This was developed against Godot 4.6.3 as internal company's R&D engine mod. With the consent of the management board it is being published now so more people may use it.**