### PR TITLE
GDScript: Fix incorrect detection of base doc class name

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -62,6 +62,20 @@ String GDScriptDocGen::_get_class_name(const GDP::ClassNode &p_class) {
 	return full_name;
 }
 
+String GDScriptDocGen::_get_gdscript_name(const GDScript *p_script) {
+	if (p_script->local_name.is_empty()) {
+		// This is an outer unnamed class.
+		return _get_script_name(p_script->get_script_path());
+	} else {
+		// This is an inner or global outer class.
+		String name = p_script->local_name;
+		if (p_script->_owner) {
+			name = _get_gdscript_name(p_script->_owner) + "." + name;
+		}
+		return name;
+	}
+}
+
 void GDScriptDocGen::_doctype_from_gdtype(const GDType &p_gdtype, String &r_type, String &r_enum, bool p_is_return) {
 	if (!p_gdtype.is_hard_type()) {
 		r_type = "Variant";
@@ -336,27 +350,16 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 
 	doc.is_script_doc = true;
 
-	if (p_script->local_name == StringName()) {
-		// This is an outer unnamed class.
-		doc.name = _get_script_name(p_script->get_script_path());
-	} else {
-		// This is an inner or global outer class.
-		doc.name = p_script->local_name;
-		if (p_script->_owner) {
-			doc.name = p_script->_owner->doc.name + "." + doc.name;
-		}
-	}
+	doc.name = _get_gdscript_name(p_script);
 
 	doc.script_path = p_script->get_script_path();
 
 	if (p_script->base.is_valid() && p_script->base->is_valid()) {
-		if (!p_script->base->doc.name.is_empty()) {
-			doc.inherits = p_script->base->doc.name;
-		} else {
-			doc.inherits = p_script->base->get_instance_base_type();
-		}
-	} else if (p_script->native.is_valid()) {
-		doc.inherits = p_script->native->get_name();
+		// See GH-105926. Evaluate the doc name of the base class instead of using `p_script->base->doc.name`
+		// to avoid load/compile order issues in case of complex circular dependencies.
+		doc.inherits = _get_gdscript_name(p_script->base.ptr());
+	} else {
+		doc.inherits = p_script->get_instance_base_type();
 	}
 
 	doc.brief_description = p_class->doc_data.brief;

--- a/modules/gdscript/editor/gdscript_docgen.h
+++ b/modules/gdscript/editor/gdscript_docgen.h
@@ -40,8 +40,11 @@ class GDScriptDocGen {
 
 	static String _get_script_name(const String &p_path);
 	static String _get_class_name(const GDP::ClassNode &p_class);
+	static String _get_gdscript_name(const GDScript *p_script);
+
 	static void _doctype_from_gdtype(const GDType &p_gdtype, String &r_type, String &r_enum, bool p_is_return = false);
 	static String _docvalue_from_variant(const Variant &p_variant, int p_recursion_level = 1);
+
 	static void _generate_docs(GDScript *p_script, const GDP::ClassNode *p_class);
 
 public:


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #105926.

## Additional information

GDScript has a very complex loading/caching system, which is also used for dependency tracking. Under these circumstances, it's difficult to say whether the assumption "the base class must be compiled before the current class" is met. I previously assumed that circular dependencies were only possible in the analyzer, and that the compiler diligently avoided them by compiling each class separately (which is somewhat true). However, after briefly examining `GDScriptCache`, I'm no longer sure what guarantees are actually provided.

So, I'd prefer to stick with a simpler and less invasive solution to fix the bug for now. Since generating a doc name for a specific GDScript class is relatively reliable (deterministic, idempotent, and has little dependence on the cache system), I decided to fix it locally within `GDScriptDocGen`. I still believe that violating the assumption "the base class must be compiled before the current class" can lead to other, more serious bugs. But given the high complexity of the cache system and the lack of other issues clearly related to compilation order (as far as I know), I'd prefer not to touch `GDScriptCache` for now.

CC @Cykyrios