### PR TITLE
Fix error spam by assuring `Bone2D` length

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -321,9 +321,6 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 	if (!is_inside_tree()) {
 		return false; //may have been removed
 	}
-	if (!p_other_bone && length <= 0) {
-		return false;
-	}
 
 	Vector2 rel;
 	if (p_other_bone) {
@@ -465,6 +462,11 @@ bool Bone2D::get_autocalculate_length_and_angle() const {
 }
 
 void Bone2D::set_length(real_t p_length) {
+	if (p_length < 1) {
+		WARN_PRINT("Attempted to set Bone2D length to a value less than 1. Using minimum value of 1.");
+		p_length = 1;
+	}
+
 	length = p_length;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes [74266](https://github.com/godotengine/godot/issues/74266)

A Bone2D with a length <= 0 is not handled and spams errors while trying to render its polygon in the editor.

The length export range has a minimum of 1, but its not enforced in the setter function, so using a simple `set_length(0)` creates this situation:
<img width="744" height="392" alt="ErrorSpam" src="https://github.com/user-attachments/assets/9fd064f2-e1ef-4cd0-b428-b613179326d3" />

## Additional information

The length minimum value done in the export range is also not documented.
`p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("length"), PROPERTY_HINT_RANGE, "1, 1024, 1", PROPERTY_USAGE_DEFAULT));`

I limited the length to 1 like the export range does now, but (for its polygon rendering) it could also go without problems to a near-zero value of 1e-05 to avoid exactly 0. Should the export range be reduced to give that possibility?

I also added a Warning to not change the user's value silently without them knowing.
## Minimal reproduction project
A clearer minimal reproduction than the one in the issue:
[BoneLength.zip](https://github.com/user-attachments/files/29142299/BoneLength.zip)