### PR TITLE
Fix scene tree drag-n-drop regression on touchscreens

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6953,7 +6953,7 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 }
 
 bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (using_native_touch) {
+	if (using_native_touch && drag_touching) {
 		// Disable data drag & drop when touch dragging.
 		return false;
 	}
@@ -6962,7 +6962,7 @@ bool Tree::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
 }
 
 Variant Tree::get_drag_data(const Point2 &p_point) {
-	if (using_native_touch) {
+	if (using_native_touch && drag_touching) {
 		// Disable data drag & drop when touch dragging.
 		return Variant();
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/120452

It was a regression from https://github.com/godotengine/godot/pull/119507
