### PR TITLE
Optimize f0_Clear_Coat_To_Surface for Mobile

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1909,6 +1909,7 @@ void main() {
 		ambient_light *= cc_attenuation;
 		indirect_specular_light *= cc_attenuation;
 
+		// Clearcoat Layer
 		// We don't need a BRDF approximation for clearcoat, so we can use the fresnel directly.
 		indirect_specular_light += cc_specular_light * F;
 #endif

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -95,7 +95,11 @@ hvec3 f0_Clear_Coat_To_Surface(hvec3 f0) {
 	// Approximation of iorTof0(f0ToIor(f0), 1.5)
 	// This assumes that the clear coat layer has an IOR of 1.5
 	// see https://github.com/google/filament/blob/837b2715a05f4656d4f524bce50d1b23ff8f84c9/shaders/src/surface_material.fs#L54-L62
+#ifdef USING_MOBILE_RENDERER
+	return clamp(f0 * (f0 * half(0.526868) + half(0.529324)) - half(0.0482256), half(0.0), half(1.0));
+#else
 	return clamp(f0 * (f0 * (half(0.941892) - half(0.263008) * f0) + half(0.346479)) - half(0.0285998), half(0.0), half(1.0));
+#endif
 }
 
 void light_compute(hvec3 N, hvec3 L, hvec3 V, half A, hvec3 light_color, bool is_directional, half attenuation, hvec3 f0, half roughness, half metallic, half specular_amount, hvec3 albedo, inout half alpha, vec2 screen_uv, hvec3 energy_compensation,


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow up #111464
- Follow up #120458

## Additional information

As mobile rendering prioritizes maximum performance, using a lower-quality, more budget-friendly version of f0_Clear_Coat_To_Surface() is preferred.
