### PR TITLE
Skip callback on hole in the height map by detecting NaN vertex

### DIFF
--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1738,17 +1738,21 @@ _FORCE_INLINE_ bool _heightmap_cell_cull_segment(_HeightmapSegmentCullParams &p_
 	p_params.heightmap->_get_point(p_state.x, p_state.z, p_params.face->vertex[0]);
 	p_params.heightmap->_get_point(p_state.x + 1, p_state.z, p_params.face->vertex[1]);
 	p_params.heightmap->_get_point(p_state.x, p_state.z + 1, p_params.face->vertex[2]);
-	p_params.face->normal = Plane(p_params.face->vertex[0], p_params.face->vertex[1], p_params.face->vertex[2]).normal;
-	if (_heightmap_face_cull_segment(p_params)) {
-		return true;
+	if (p_params.face->vertex[0].is_finite() && p_params.face->vertex[1].is_finite() && p_params.face->vertex[2].is_finite()) {
+		p_params.face->normal = Plane(p_params.face->vertex[0], p_params.face->vertex[1], p_params.face->vertex[2]).normal;
+		if (_heightmap_face_cull_segment(p_params)) {
+			return true;
+		}
 	}
 
 	// Second triangle.
 	p_params.face->vertex[0] = p_params.face->vertex[1];
 	p_params.heightmap->_get_point(p_state.x + 1, p_state.z + 1, p_params.face->vertex[1]);
-	p_params.face->normal = Plane(p_params.face->vertex[0], p_params.face->vertex[1], p_params.face->vertex[2]).normal;
-	if (_heightmap_face_cull_segment(p_params)) {
-		return true;
+	if (p_params.face->vertex[0].is_finite() && p_params.face->vertex[1].is_finite() && p_params.face->vertex[2].is_finite()) {
+		p_params.face->normal = Plane(p_params.face->vertex[0], p_params.face->vertex[1], p_params.face->vertex[2]).normal;
+		if (_heightmap_face_cull_segment(p_params)) {
+			return true;
+		}
 	}
 
 	return false;
@@ -2048,17 +2052,21 @@ void GodotHeightMapShape3D::cull(const AABB &p_local_aabb, QueryCallback p_callb
 			_get_point(x, z, face.vertex[0]);
 			_get_point(x + 1, z, face.vertex[1]);
 			_get_point(x, z + 1, face.vertex[2]);
-			face.normal = Plane(face.vertex[0], face.vertex[1], face.vertex[2]).normal;
-			if (p_callback(p_userdata, &face)) {
-				return;
+			if (face.vertex[0].is_finite() && face.vertex[1].is_finite() && face.vertex[2].is_finite()) {
+				face.normal = Plane(face.vertex[0], face.vertex[1], face.vertex[2]).normal;
+				if (p_callback(p_userdata, &face)) {
+					return;
+				}
 			}
 
 			// Second triangle.
 			face.vertex[0] = face.vertex[1];
 			_get_point(x + 1, z + 1, face.vertex[1]);
-			face.normal = Plane(face.vertex[0], face.vertex[1], face.vertex[2]).normal;
-			if (p_callback(p_userdata, &face)) {
-				return;
+			if (face.vertex[0].is_finite() && face.vertex[1].is_finite() && face.vertex[2].is_finite()) {
+				face.normal = Plane(face.vertex[0], face.vertex[1], face.vertex[2]).normal;
+				if (p_callback(p_userdata, &face)) {
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120107

Add an `is_finite` check in `GodotShape` before normalizing NaN values, and skip the callback. This means that the attempt to generate collision surfaces for NaN vertices will be skipped, but it should be fine for hole behavior.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
