### PR TITLE
Allow reading multiple data chunks per frame in a single-threaded `HTTPRequest`

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -247,8 +247,8 @@
 			Maximum allowed size for response bodies. If the response body is compressed, this will be used as the maximum allowed size for the decompressed body.
 		</member>
 		<member name="download_chunk_size" type="int" setter="set_download_chunk_size" getter="get_download_chunk_size" default="65536">
-			The size of the buffer used and maximum bytes to read per iteration. See [member HTTPClient.read_chunk_size].
-			Set this to a lower value (e.g. 4096 for 4 KiB) when downloading small files to decrease memory usage at the cost of download speeds.
+			The size of the internal buffer and maximum bytes to read per iteration when processing response data.
+			Lowering this reduces memory usage, while increasing it reduces the number of read operations needed (see [member read_time_limit], which can negate the impact this has on download speed).
 		</member>
 		<member name="download_file" type="String" setter="set_download_file" getter="get_download_file" default="&quot;&quot;">
 			The file to download into. Will output any received file into it.
@@ -259,6 +259,11 @@
 		</member>
 		<member name="max_redirects" type="int" setter="set_max_redirects" getter="get_max_redirects" default="8">
 			Maximum number of allowed redirects.
+		</member>
+		<member name="read_time_limit" type="int" setter="set_read_time_limit" getter="get_read_time_limit" default="3300">
+			Maximum amount of time (in microseconds) this [HTTPRequest] may spend per frame reading buffered HTTP data, when [member use_threads] is [code]false[/code].
+			Higher values allow more buffered data to be processed each frame, improving download throughput at the cost of increased main thread usage.
+			One chunk read is guaranteed to happen, even if set to [code]0[/code] or another very low value.
 		</member>
 		<member name="timeout" type="float" setter="set_timeout" getter="get_timeout" default="0.0">
 			The duration to wait before a request times out, in seconds (independent of [member Engine.time_scale]). If [member timeout] is set to [code]0.0[/code], the request will never time out.

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -561,7 +561,26 @@ void HTTPRequest::_notification(int p_what) {
 			if (use_threads.is_set()) {
 				return;
 			}
-			bool done = _update_connection();
+
+			bool done = false;
+
+			if (read_time_limit_usec > 0) {
+				const int max_chunk_size = client->get_read_chunk_size();
+				const uint64_t start_usec = OS::get_singleton()->get_ticks_usec();
+				do {
+					const int downloaded_before = downloaded.get();
+					done = _update_connection();
+					if (downloaded.get() - downloaded_before < max_chunk_size) {
+						break;
+					}
+					if (OS::get_singleton()->get_ticks_usec() - start_usec >= read_time_limit_usec) {
+						break;
+					}
+				} while (!done);
+			} else {
+				done = _update_connection();
+			}
+
 			if (done) {
 				set_process_internal(false);
 			}
@@ -687,6 +706,15 @@ void HTTPRequest::set_tls_options(const Ref<TLSOptions> &p_options) {
 	tls_options = p_options;
 }
 
+void HTTPRequest::set_read_time_limit(int p_read_time_limit_usec) {
+	ERR_FAIL_COND_MSG(p_read_time_limit_usec < 0, "Read time limit must not be negative.");
+	read_time_limit_usec = (uint64_t)p_read_time_limit_usec;
+}
+
+int HTTPRequest::get_read_time_limit() const {
+	return (int)read_time_limit_usec;
+}
+
 void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("request", "url", "custom_headers", "method", "request_data"), &HTTPRequest::request, DEFVAL(PackedStringArray()), DEFVAL(HTTPClient::METHOD_GET), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("request_raw", "url", "custom_headers", "method", "request_data_raw"), &HTTPRequest::request_raw, DEFVAL(PackedStringArray()), DEFVAL(HTTPClient::METHOD_GET), DEFVAL(PackedByteArray()));
@@ -728,8 +756,12 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::set_http_proxy);
 	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::set_https_proxy);
 
+	ClassDB::bind_method(D_METHOD("set_read_time_limit", "time_limit_usec"), &HTTPRequest::set_read_time_limit);
+	ClassDB::bind_method(D_METHOD("get_read_time_limit"), &HTTPRequest::get_read_time_limit);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE_PATH), "set_download_file", "get_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216,suffix:B"), "set_download_chunk_size", "get_download_chunk_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "read_time_limit", PROPERTY_HINT_RANGE, U"0,1000000,suffix:µs"), "set_read_time_limit", "get_read_time_limit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_partial_download"), "set_keep_partial_download", "is_keeping_partial_download");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "append_to_download_file"), "set_append_to_download_file", "is_appending_to_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_threads"), "set_use_threads", "is_using_threads");

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -87,6 +87,9 @@ private:
 	bool keep_partial_download = false;
 	bool append_to_download_file = false;
 
+	// 3.3 milliseconds (roughly one fifth of a frame at 60 Hz).
+	uint64_t read_time_limit_usec = 3300;
+
 	Ref<StreamPeerGZIP> decompressor;
 	Ref<FileAccess> file;
 
@@ -154,6 +157,9 @@ public:
 
 	void set_download_chunk_size(int p_chunk_size);
 	int get_download_chunk_size() const;
+
+	void set_read_time_limit(int p_read_time_limit_usec);
+	int get_read_time_limit() const;
 
 	void set_body_size_limit(int p_bytes);
 	int get_body_size_limit() const;


### PR DESCRIPTION
## Problem(s) solved by this PR

- Closes #120425 

## Additional information

When `use_threads = false` on a `HTTPRequest,` incoming data gets processed on the main thread. Right now, only one chunk gets read per frame, which means throughput is effectively capped at `download_chunk_size * FPS`, which can be problematic (see the linked issue for more details)

This PR lets multiple chunks be processed within a single frame.

I also added a `read_time_limit` property that limits how much time can be spent reading data per frame (only applies when `use_threads = false`, it's not used otherwise). Without a limit like this, a fast connection could end up stalling the main for even seconds. At least one read still always happens per frame regardless of the limit.

Here is some data from a project running at 20 FPS, downloading a 16 MiB file on a simulated 10 MB/s network (localhost with a python server):
| `download_chunk_size` | 4 KB | 65 KB | 512 KB |
|--------|--------|--------|--------|
| 4.7.stable | 205 s | 13 s | 1.9 s |
| **This PR** | **1.85 s** | **1.85 s** | **1.85 s** |

## Author disclosure

I used Claude to discuss possible approaches, though honestly most of its suggestions were awful, and to review the changes for mistakes before pushing. 
All the code is mine.