### PR TITLE
Show categories inside sub-inspectors

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1874,7 +1874,14 @@ void EditorInspectorCategory::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			const Ref<StyleBox> &sb = theme_cache.background;
+			Ref<StyleBox> sb;
+			if (color_level == -1) {
+				sb = theme_cache.background;
+			} else if (color_level == 0) {
+				sb = theme_cache.sub_inspector_background;
+			} else {
+				sb = theme_cache.sub_inspector_color_background[color_level];
+			}
 
 			draw_style_box(sb, Rect2(Vector2(), get_size()));
 
@@ -1963,6 +1970,13 @@ void EditorInspectorCategory::set_doc_class_name(const String &p_name) {
 	doc_class_name = p_name;
 }
 
+void EditorInspectorCategory::set_color_level(int p_color_level) {
+	ERR_FAIL_COND(p_color_level < -1 || p_color_level > 16);
+	color_level = p_color_level;
+	update_minimum_size();
+	queue_redraw();
+}
+
 Size2 EditorInspectorCategory::get_minimum_size() const {
 	Size2 ms;
 	if (theme_cache.bold_font.is_valid()) {
@@ -1973,8 +1987,17 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	}
 	ms.height += theme_cache.vertical_separation;
 
-	if (theme_cache.background.is_valid()) {
-		ms.height += theme_cache.background->get_content_margin(SIDE_TOP) + theme_cache.background->get_content_margin(SIDE_BOTTOM);
+	Ref<StyleBox> bg;
+	if (color_level == -1) {
+		bg = theme_cache.background;
+	} else if (color_level == 0) {
+		bg = theme_cache.sub_inspector_background;
+	} else {
+		bg = theme_cache.sub_inspector_color_background[color_level];
+	}
+
+	if (bg.is_valid()) {
+		ms.height += bg->get_content_margin(SIDE_TOP) + bg->get_content_margin(SIDE_BOTTOM);
 	}
 
 	return ms;
@@ -3917,6 +3940,14 @@ void EditorInspector::initialize_category_theme(EditorInspectorCategory::ThemeCa
 	p_cache.icon_help = p_control->get_editor_theme_icon(SNAME("Help"));
 
 	p_cache.background = p_control->get_theme_stylebox(SNAME("bg"), SNAME("EditorInspectorCategory"));
+
+	if (p_control == parent_inspector) {
+		// Only initialize for the inspector, as stand-alone categories won't need it.
+		p_cache.sub_inspector_background = p_control->get_theme_stylebox("sub_inspector_category_bg", EditorStringName(EditorStyles));
+		for (int i = 0; i <= 16; i++) {
+			p_cache.sub_inspector_color_background[i] = p_control->get_theme_stylebox("sub_inspector_color_category_bg" + itos(i), EditorStringName(EditorStyles));
+		}
+	}
 }
 
 void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_cache, Control *p_control) {
@@ -4384,6 +4415,7 @@ void EditorInspector::update_tree() {
 			// Create an EditorInspectorCategory and add it to the inspector.
 			EditorInspectorCategory *category = memnew(EditorInspectorCategory);
 			category->set_property_info(p);
+			category->set_color_level(category_color_level);
 			main_vbox->add_child(category);
 			category_vbox = nullptr; // Reset.
 
@@ -5020,6 +5052,7 @@ void EditorInspector::update_tree() {
 
 	if (!current_favorites.is_empty()) {
 		favorites_section->show();
+		favorites_category->set_color_level(category_color_level);
 
 		// Organize the favorited properties in their sections, to keep context and differentiate from others with the same name.
 		bool is_localized = property_name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED;
@@ -5347,6 +5380,13 @@ void EditorInspector::set_show_categories(bool p_show_standard, bool p_show_cust
 	show_standard_categories = p_show_standard;
 	show_custom_categories = p_show_custom;
 	update_tree();
+}
+
+void EditorInspector::set_category_color_level(int p_color_level) {
+	if (category_color_level != p_color_level) {
+		category_color_level = p_color_level;
+		update_tree();
+	}
 }
 
 void EditorInspector::set_use_doc_hints(bool p_enable) {
@@ -6258,7 +6298,7 @@ EditorInspector::EditorInspector() {
 	base_vbox->add_child(favorites_section);
 	favorites_section->hide();
 
-	EditorInspectorCategory *favorites_category = memnew(EditorInspectorCategory);
+	favorites_category = memnew(EditorInspectorCategory);
 	favorites_category->set_as_favorite();
 	favorites_category->connect("unfavorite_all", callable_mp(this, &EditorInspector::_clear_current_favorites));
 	favorites_section->add_child(favorites_category);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -285,6 +285,8 @@ public:
 
 	virtual bool is_colored(ColorationMode p_mode) { return false; }
 
+	int get_sub_inspector_color_level() { return sub_inspector_color_level; }
+
 	void set_deletable(bool p_enable);
 	bool is_deletable() const;
 	void add_focusable(Control *p_control);
@@ -407,6 +409,8 @@ class EditorInspectorCategory : public Control {
 		Ref<Texture2D> icon_help;
 
 		Ref<StyleBox> background;
+		Ref<StyleBox> sub_inspector_background;
+		Ref<StyleBox> sub_inspector_color_background[17];
 	} theme_cache;
 
 	PropertyInfo info;
@@ -417,6 +421,7 @@ class EditorInspectorCategory : public Control {
 	PopupMenu *menu = nullptr;
 	bool is_favorite = false;
 	bool menu_icon_dirty = true;
+	int color_level = -1;
 
 	LocalVector<EditorProperty *> category_properties;
 
@@ -437,6 +442,7 @@ public:
 	void set_as_favorite();
 	void set_property_info(const PropertyInfo &p_info);
 	void set_doc_class_name(const String &p_name);
+	void set_color_level(int p_color_level);
 
 	void register_property(EditorProperty *p_property) { category_properties.push_back(p_property); }
 
@@ -765,6 +771,7 @@ private:
 	bool can_favorite = false;
 	PackedStringArray current_favorites;
 	VBoxContainer *favorites_section = nullptr;
+	EditorInspectorCategory *favorites_category = nullptr;
 	VBoxContainer *favorites_vbox = nullptr;
 	VBoxContainer *favorites_groups_vbox = nullptr;
 	HSeparator *favorites_separator = nullptr;
@@ -789,6 +796,7 @@ private:
 	LineEdit *search_box = nullptr;
 	bool show_standard_categories = false;
 	bool show_custom_categories = false;
+	int category_color_level = -1;
 	bool hide_script = true;
 	bool hide_metadata = true;
 	bool use_doc_hints = false;
@@ -924,6 +932,7 @@ public:
 	void set_autoclear(bool p_enable);
 
 	void set_show_categories(bool p_show_standard, bool p_show_custom);
+	void set_category_color_level(int p_color_level);
 	void set_use_doc_hints(bool p_enable);
 	void set_hide_script(bool p_hide);
 	void set_hide_metadata(bool p_hide);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3670,6 +3670,7 @@ void EditorPropertyResource::update_property() {
 			if (!sub_inspector) {
 				sub_inspector = memnew(EditorInspector);
 				sub_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+				sub_inspector->set_show_categories(true, true);
 				sub_inspector->set_use_doc_hints(true);
 
 				EditorInspector *parent_inspector = get_parent_inspector();
@@ -3718,6 +3719,7 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->edit(res.ptr());
 				_update_property_bg();
 			}
+			sub_inspector->set_category_color_level(get_sub_inspector_color_level());
 
 		} else if (sub_inspector) {
 			set_bottom_editor(nullptr);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2222,6 +2222,15 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
 
+			// EditorInspectorCategory when inside a sub-inspector.
+			p_theme->set_stylebox("sub_inspector_category_bg", EditorStringName(EditorStyles), category_bg);
+
+			// The same as above, but colored for nesting.
+			Ref<StyleBoxFlat> category_bg_color = category_bg->duplicate();
+			category_bg_color->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
+
+			p_theme->set_stylebox("sub_inspector_color_category_bg" + itos(i + 1), EditorStringName(EditorStyles), category_bg_color);
+
 			// Dictionary editor add item.
 			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
 			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2348,10 +2348,6 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// EditorProperty.
 
-		Ref<StyleBoxFlat> style_property_bg = p_config.base_style->duplicate();
-		style_property_bg->set_bg_color(p_config.highlight_color);
-		style_property_bg->set_border_width_all(0);
-
 		Ref<StyleBoxFlat> style_property_bg_selected = p_config.base_style->duplicate();
 		style_property_bg_selected->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.05));
 
@@ -2433,7 +2429,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
 
-		// Colored EditorProperty.
+		// Colored EditorProperty and EditorInspectorCategory.
 		for (int i = 0; i < 16; i++) {
 			Color si_base_color = p_config.accent_color;
 
@@ -2459,6 +2455,18 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			bg_color->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 			p_theme->set_stylebox("sub_inspector_property_bg" + itos(i + 1), EditorStringName(EditorStyles), bg_color);
+
+			// EditorInspectorCategory when inside a sub-inspector.
+			Ref<StyleBoxFlat> category_bg_sub = category_bg->duplicate();
+			category_bg_sub->set_content_margin_all(0);
+
+			p_theme->set_stylebox("sub_inspector_category_bg", EditorStringName(EditorStyles), category_bg_sub);
+
+			// The same as above, but colored for nesting.
+			Ref<StyleBoxFlat> category_bg_sub_color = category_bg_sub->duplicate();
+			category_bg_sub_color->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
+
+			p_theme->set_stylebox("sub_inspector_color_category_bg" + itos(i + 1), EditorStringName(EditorStyles), category_bg_sub_color);
 
 			// Dictionary editor add item.
 			// Expand to the left and right by 4px to compensate for the dictionary editor margins.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #116034.

## Additional information

Categories are now shown inside sub-inspectors, with a different look: thinner, and with the color accent of the sub-inspector level.
<img width="251" height="685" alt="Screenshot_20260619_181820" src="https://github.com/user-attachments/assets/6ed198fd-22cd-4f39-b789-6f97337492f2" />
