### PR TITLE
Add signals to ResourcePreloader, connect to ResourcePreloaderEditor

### DIFF
--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -248,7 +248,14 @@ void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column,
 }
 
 void ResourcePreloaderEditor::edit(ResourcePreloader *p_preloader) {
+	const Callable update_lib = callable_mp(this, &ResourcePreloaderEditor::_update_library);
+	if (preloader) {
+		preloader->disconnect("_resource_changed", update_lib);
+	}
 	preloader = p_preloader;
+	if (preloader) {
+		preloader->connect("_resource_changed", update_lib);
+	}
 	_update_library();
 }
 

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -92,12 +92,19 @@ void ResourcePreloader::add_resource(const StringName &p_name, const Ref<Resourc
 		add_resource(new_name, p_resource);
 	} else {
 		resources[p_name] = p_resource;
+#ifdef TOOLS_ENABLED
+		emit_signal("_resource_changed");
+#endif
 	}
 }
 
 void ResourcePreloader::remove_resource(const StringName &p_name) {
 	ERR_FAIL_COND(!resources.has(p_name));
-	resources.erase(p_name);
+	if (resources.erase(p_name)) {
+#ifdef TOOLS_ENABLED
+		emit_signal("_resource_changed");
+#endif
+	}
 }
 
 void ResourcePreloader::rename_resource(const StringName &p_from_name, const StringName &p_to_name) {
@@ -148,6 +155,10 @@ void ResourcePreloader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_list"), &ResourcePreloader::_get_resource_list);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "resources", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_resources", "_get_resources");
+
+#ifdef TOOLS_ENABLED
+	ADD_SIGNAL(MethodInfo("_resource_changed"));
+#endif
 }
 
 ResourcePreloader::ResourcePreloader() {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

By adding signals when adding/removing resources, we can allow the editor to dynamically update when the `ResourcePreloader` is updated through code.

Initially i tried making a `DirectoryResourcePreloader` tool to avoid editing resources by hand that i had sorted
into directories. E.g. `res://Resources/Cards`, `res://Resources/Encounters` and so on. I concluded that the editor could
not know that we had changed the resources from code and so `_update_library()` would never be run.

[directory-resource-preloader.zip](https://github.com/user-attachments/files/29150890/directory-resource-preloader.zip)

Failed with  `v4.6.3.stable.mono.nixpkgs [35e80b3a8]`

With commit changes:

[Βίντεο Οθόνης από 2026-06-19 22-54-33.webm](https://github.com/user-attachments/assets/acac54c6-a3dc-47d9-ac59-d2afbde17587)


## Additional information

At a glance, the `ResourcePreloader`'s simplicity does not scale very well with the editor, as every edit triggers a complete reconstruction. I lack context to know whether this is going to be problem worth looking into but a good-enough improvement can be achieved by adding "bulk edit" functions.
```gdscript
void add_resources(Dictionary<StringName, Resource> pairs);
void remove_resources(Array<StringName> names);
```
To keep the number of signals small, the proposed signals could then accept an `Array<StringName>` parameter, that is populated as needed.


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
