### PR TITLE
Fix `Abort on Reset` functionality in AnimationNodeOneShot

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -600,15 +600,15 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_proce
 	bool p_is_external_seeking = p_playback_info.is_external_seeking;
 
 	bool do_start = cur_request == ONE_SHOT_REQUEST_FIRE;
-
-	bool is_reset = Math::is_zero_approx(p_time) && p_seek && !p_is_external_seeking;
-	if (is_reset && cur_internal_active) {
-		do_start = true;
-	}
-
 	bool is_abort = cur_request == ONE_SHOT_REQUEST_ABORT;
-	if (is_reset && !do_start && (is_fading_out || (abort_on_reset && cur_active))) {
-		is_abort = true;
+	bool is_reset = Math::is_zero_approx(p_time) && p_seek && !p_is_external_seeking;
+	if (is_reset) {
+		if (!do_start && (is_fading_out || (abort_on_reset && cur_active))) {
+			is_abort = true;
+		}
+		if (cur_internal_active) {
+			do_start = true;
+		}
 	}
 
 	if (is_abort) {


### PR DESCRIPTION
It appears that the regression-targeting #115175 mishandled the fix, by assuming `!do_start` was equivalent to `cur_request != ONE_SHOT_REQUEST_FIRE`, and nullified `Abort on Reset` functionality entirely. If no one noticed, it's because I should have by now.

**Current master:**
> https://github.com/user-attachments/assets/a721d211-60ad-4f63-93f4-ee1b77cfd9d4

**Before 4.6 stable / with this PR:**
> https://github.com/user-attachments/assets/72fce0c1-ad37-42a7-a8bc-a522599f21b9

[MRP here](https://github.com/user-attachments/files/29159189/abort-on-reset-test.zip), use spacebar to arm idle oneshot. The problem that #115175 was targeting has also been tested to work.

cc @TokageItLab