### PR TITLE
EditorLanguage: Pass completion position explicitly

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -46,18 +46,29 @@
 class EditorLanguage {
 public:
 	/**
+	 * Zero based position in code.
+	 */
+	struct Position {
+		uint_fast32_t line;
+		uint_fast32_t column;
+
+		Position(uint_fast32_t p_line, uint_fast32_t p_column) : line(p_line), column(p_column) {}
+	};
+
+	/**
 	 * Called by the editor to request a list of `CodeCompletionOptions` from the language.
 	 *
 	 * The language MAY also calculate a hint for the call signature at the given position. See `r_call_hint` and `r_force` for more details.
 	 *
-	 * @param p_code The current content of the source fragment. Will always contain the special sentinel char 0xFFFF at the cursor position. The content might differ from the state on disk, the exact behavior in that case is up to the implementation.
+	 * @param p_code The current content of the source fragment. The content might differ from the state on disk, the exact behavior in that case is up to the implementation.
+	 * @param p_position The cursor position, where completion was requested.
 	 * @param p_path The path which identifies the source fragment. Implementations MAY support paths to builtin resources, or return an error for those.
 	 * @param p_owner If the source fragment is somehow tied to an object (e.g. the currently open scene) the editor will pass it to the language. Implementations MAY respect this in their analysis, e.g. for GDScript get node literals.
 	 * @param r_options The returned options. Can be empty.
 	 * @param r_force If `false` a non-empty signature hint will take priority over completion. If `true` completion will take priority. Might be removed in the future in favor of showing both.
 	 * @param r_call_hint The returned signature hint. Can be empty.
 	 */
-	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) { return ERR_UNAVAILABLE; }
+	virtual Error complete_code(const String &p_code, Position p_position, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) { return ERR_UNAVAILABLE; }
 
 	// Keep ScriptLanguageExtension::LookupResultType a subset of this.
 	struct LookupResult {
@@ -114,5 +125,23 @@ public:
 
 	virtual ~EditorLanguage() = default;
 };
+
+// Lives here for now, because the EditorLanguage adapter needs it and is located in core.
+namespace EditorStringUtils {
+/**
+ * Insert `p_what` at the given `p_position` of `p_str`.
+ */
+String insert(const Vector<String> &p_str, EditorLanguage::Position p_position, const String &p_what);
+
+/**
+ * Insert `p_what` at the given `p_position` of `p_str`.
+ */
+String insert(const String &p_str, EditorLanguage::Position p_position, const String &p_what);
+
+/**
+ * Find the char in the string. This methods must only be used if it is known that `p_chr` is in `p_str`.
+ */
+EditorLanguage::Position find_char(const String &p_str, char32_t p_chr);
+} //namespace EditorStringUtils
 
 #endif // TOOLS_ENABLED

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -271,8 +271,8 @@ private:
 		ScriptLanguageExtension *script_language = nullptr;
 
 	public:
-		virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override {
-			return script_language->complete_code(p_code, p_path, p_owner, r_options, r_force, r_call_hint);
+		virtual Error complete_code(const String &p_code, EditorLanguage::Position p_position, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override {
+			return script_language->complete_code(EditorStringUtils::insert(p_code, p_position, String::chr(0xFFFF)), p_path, p_owner, r_options, r_force, r_call_hint);
 		}
 
 		virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override {

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/editor_language.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
 #include "editor/editor_node.h"
@@ -1030,11 +1031,12 @@ void CodeTextEditor::_code_complete_timer_timeout() {
 
 void CodeTextEditor::_complete_request() {
 	List<ScriptLanguage::CodeCompletionOption> entries;
-	String ctext = text_editor->get_text_for_code_completion();
-	_code_complete_script(ctext, &entries);
+	EditorLanguage::Position pos(text_editor->get_caret_line(), text_editor->get_caret_column());
+	String ctext = text_editor->get_text();
+	_code_complete_script(ctext, pos, &entries);
 	bool forced = false;
 	if (code_complete_func) {
-		code_complete_func(code_complete_ud, ctext, &entries, forced);
+		code_complete_func(code_complete_ud, ctext, pos, &entries, forced);
 	}
 
 	for (const ScriptLanguage::CodeCompletionOption &e : entries) {

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/code_edit.h"
 #include "scene/gui/dialogs.h"
@@ -155,7 +156,7 @@ public:
 	FindReplaceBar();
 };
 
-typedef void (*CodeTextEditorCodeCompleteFunc)(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced);
+typedef void (*CodeTextEditorCodeCompleteFunc)(void *p_ud, const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced);
 
 class CodeTextEditor : public VBoxContainer {
 	GDCLASS(CodeTextEditor, VBoxContainer);
@@ -228,7 +229,7 @@ class CodeTextEditor : public VBoxContainer {
 protected:
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}
-	virtual void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options) {}
+	virtual void _code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options) {}
 
 	void _text_changed_idle_timeout();
 	void _code_complete_timer_timeout();

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "editor/gui/code_editor.h"
 #include "scene/gui/box_container.h"
 
@@ -260,7 +261,7 @@ protected:
 	VSplitContainer *editor_box = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
 
-	virtual void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) = 0;
+	virtual void _code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) = 0;
 	virtual bool _warning_clicked(const Variant &p_line);
 
 public:

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1144,12 +1144,12 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 	}
 }
 
-void ScriptTextEditor::_code_complete_scripts(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {
+void ScriptTextEditor::_code_complete_scripts(void *p_ud, const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {
 	ScriptTextEditor *ste = (ScriptTextEditor *)p_ud;
-	ste->_code_complete_script(p_code, r_options, r_force);
+	ste->_code_complete_script(p_code, p_position, r_options, r_force);
 }
 
-void ScriptTextEditor::_code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {
+void ScriptTextEditor::_code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {
 	if (color_panel->is_visible()) {
 		return;
 	}
@@ -1160,7 +1160,7 @@ void ScriptTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 		base = _find_node_for_script(base, base, script);
 	}
 	String hint;
-	Error err = script->get_language()->get_editor_language()->complete_code(p_code, script->get_path(), base, r_options, r_force, hint);
+	Error err = script->get_language()->get_editor_language()->complete_code(p_code, p_position, script->get_path(), base, r_options, r_force, hint);
 
 	if (err == OK) {
 		code_editor->get_text_editor()->set_code_hint(hint);

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "editor/gui/code_editor.h"
 #include "editor/script/script_editor_base.h"
 #include "editor/script/script_editor_plugin.h"
@@ -164,8 +165,8 @@ protected:
 	void _update_warnings();
 	void _update_errors();
 
-	static void _code_complete_scripts(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
-	virtual void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) override;
+	static void _code_complete_scripts(void *p_ud, const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
+	virtual void _code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) override;
 
 	void _set_theme_for_script();
 	void _show_errors_panel(bool p_show);

--- a/editor/script/string_utils.cpp
+++ b/editor/script/string_utils.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gdscript_editor_language.h                                            */
+/*  string_utils.cpp                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,40 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
 #include "core/object/editor_language.h"
+#include "core/string/string_builder.h"
+#include "core/string/ustring.h"
 
-class GDScriptEditorLanguage final : public EditorLanguage {
-	static GDScriptEditorLanguage *singleton;
+String EditorStringUtils::insert(const Vector<String> &p_str, EditorLanguage::Position p_position, const String &p_what) {
+	StringBuilder builder;
 
-public:
-	_FORCE_INLINE_ static GDScriptEditorLanguage *get_singleton() { return singleton; }
-
-	virtual Error complete_code(const String &p_code, Position p_position, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override;
-
-	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
-
-	GDScriptEditorLanguage() {
-		ERR_FAIL_COND(singleton != nullptr);
-		singleton = this;
-	}
-	~GDScriptEditorLanguage() {
-		if (singleton == this) {
-			singleton = nullptr;
+	for (uint_fast32_t i = 0; i < static_cast<uint_fast32_t>(p_str.size()); i++) {
+		if (i == p_position.line) {
+			builder += p_str[i].insert(p_position.column, p_what);
+		} else {
+			builder += p_str[i];
 		}
 	}
-};
+
+	return builder.as_string();
+}
+
+String EditorStringUtils::insert(const String &p_str, EditorLanguage::Position p_position, const String &p_what) {
+	return EditorStringUtils::insert(p_str.split("\n"), p_position, p_what);
+}
+
+EditorLanguage::Position EditorStringUtils::find_char(const String &p_str, char32_t p_chr) {
+	uint_fast32_t line = 0;
+	uint_fast32_t column = 0;
+	for (int i = 0; i < p_str.length(); i++) {
+		if (p_str[i] == p_chr) {
+			return EditorLanguage::Position(line, column);
+		} else if (p_str[i] == '\n') {
+			column = 0;
+			line += 1;
+		} else {
+			column += 1;
+		}
+	}
+	ERR_FAIL_V(EditorLanguage::Position(0, 0));
+}

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -1180,7 +1180,7 @@ static void _complete_include_paths(List<ScriptLanguage::CodeCompletionOption> *
 	_complete_include_paths_search(EditorFileSystem::get_singleton()->get_filesystem(), r_options);
 }
 
-void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options) {
+void ShaderTextEditor::_code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options) {
 	List<ScriptLanguage::CodeCompletionOption> pp_options;
 	List<ScriptLanguage::CodeCompletionOption> pp_defines;
 	ShaderPreprocessor preprocessor;
@@ -1190,7 +1190,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 	if (!complete_from_path.ends_with("/")) {
 		complete_from_path += "/";
 	}
-	preprocessor.preprocess(p_code, resource_path, code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
+	preprocessor.preprocess(EditorStringUtils::insert(p_code, p_position, String::chr(0xFFFF)), resource_path, code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
 	complete_from_path = String();
 	if (pp_options.size()) {
 		for (const ScriptLanguage::CodeCompletionOption &E : pp_options) {

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "editor/gui/code_editor.h"
 #include "editor/shader/shader_editor.h"
 #include "scene/gui/menu_button.h"
@@ -170,7 +171,7 @@ protected:
 	static void _bind_methods();
 	virtual void _load_theme_settings() override;
 
-	virtual void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options) override;
+	virtual void _code_complete_script(const String &p_code, EditorLanguage::Position p_position, List<ScriptLanguage::CodeCompletionOption> *r_options) override;
 
 public:
 	void set_block_shader_changed(bool p_block) { block_shader_changed = p_block; }

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -55,7 +55,7 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 	String source_code = gdscript->get_source_code();
 
 	GDScriptParser parser;
-	err = parser.parse(source_code, p_path, false);
+	err = parser.parse(source_code, p_path, GDScriptParser::EditorOptions::none());
 	ERR_FAIL_COND_V_MSG(err, err, "Failed to parse GDScript with GDScriptParser.");
 
 	GDScriptAnalyzer analyzer(&parser);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -522,7 +522,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 		GDScriptParser parser;
 		GDScriptAnalyzer analyzer(&parser);
-		Error err = parser.parse(source, path, false);
+		Error err = parser.parse(source, path, GDScriptParser::EditorOptions::none());
 
 		if (err == OK && analyzer.analyze() == OK) {
 			const GDScriptParser::ClassNode *c = parser.get_tree();
@@ -815,7 +815,7 @@ Error GDScript::reload(bool p_keep_state) {
 	if (!binary_tokens.is_empty()) {
 		err = parser.parse_binary(binary_tokens, path);
 	} else {
-		err = parser.parse(source, path, false);
+		err = parser.parse(source, path, GDScriptParser::EditorOptions::none());
 	}
 	if (err) {
 		if (EngineDebugger::is_active()) {
@@ -2732,7 +2732,7 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 	String source = f->get_as_utf8_string();
 
 	GDScriptParser parser;
-	err = parser.parse(source, p_path, false, false);
+	err = parser.parse(source, p_path, GDScriptParser::EditorOptions::none(), false);
 
 	const GDScriptParser::ClassNode *c = parser.get_tree();
 	if (!c) {
@@ -2782,7 +2782,7 @@ String GDScriptLanguage::_get_global_class_name(const String &p_path, String *r_
 							break;
 						}
 
-						if (OK != subparser.parse(subsource, subpath, false)) {
+						if (OK != subparser.parse(subsource, subpath, GDScriptParser::EditorOptions::none())) {
 							break;
 						}
 						path = subpath;

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -89,7 +89,7 @@ Error GDScriptParserRef::raise_status(Status p_new_status) {
 				} else {
 					String source = GDScriptCache::get_source_code(remapped_path);
 					source_hash = source.hash();
-					result = get_parser()->parse(source, path, false);
+					result = get_parser()->parse(source, path, GDScriptParser::EditorOptions::none());
 				}
 			} break;
 			case PARSED: {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -34,6 +34,8 @@
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
 
+#include "core/object/editor_language.h"
+
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"
 #include "editor/gdscript_editor_language.h"
@@ -156,7 +158,7 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 	GDScriptParser parser;
 	GDScriptAnalyzer analyzer(&parser);
 
-	Error err = parser.parse(p_script, p_path, false);
+	Error err = parser.parse(p_script, p_path, GDScriptParser::EditorOptions::none());
 	if (err == OK) {
 		err = analyzer.analyze();
 	}
@@ -3439,13 +3441,13 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	r_forced = r_result.size() > 0;
 }
 
-::Error GDScriptEditorLanguage::complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) {
+::Error GDScriptEditorLanguage::complete_code(const String &p_code, Position p_position, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) {
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 
 	GDScriptParser parser;
 	GDScriptAnalyzer analyzer(&parser);
 
-	parser.parse(p_code, p_path, true);
+	parser.parse(p_code, p_path, GDScriptParser::EditorOptions::completion(p_position.line, p_position.column));
 	analyzer.analyze();
 
 	r_forced = false;
@@ -4312,8 +4314,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		return OK;
 	}
 
+	// TODO: Pass position directly.
+	EditorLanguage::Position pos = EditorStringUtils::find_char(p_code, 0xFFFF);
 	GDScriptParser parser;
-	parser.parse(p_code, p_path, true);
+	parser.parse(p_code.remove_char(0xFFFF), p_path, GDScriptParser::EditorOptions::completion(pos.line, pos.column));
 
 	GDScriptParser::CompletionContext context = parser.get_completion_context();
 	context.base = p_owner;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -446,45 +446,23 @@ void GDScriptParser::set_last_completion_call_arg(int p_argument) {
 	completion_call_stack.back()->get().argument = p_argument;
 }
 
-Error GDScriptParser::parse(const String &p_source_code, const String &p_script_path, bool p_for_completion, bool p_parse_body) {
+Error GDScriptParser::parse(const String &p_source_code, const String &p_script_path, EditorOptions p_editor_options, bool p_parse_body) {
 	clear();
 
 	String source = p_source_code;
-	int cursor_line = -1;
-	int cursor_column = -1;
-	for_completion = p_for_completion;
 	parse_body = p_parse_body;
-
-	if (p_for_completion) {
-		// Remove cursor sentinel char.
-		const Vector<String> lines = p_source_code.split("\n");
-		cursor_line = 1;
-		cursor_column = 1;
-		for (int i = 0; i < lines.size(); i++) {
-			bool found = false;
-			const String &line = lines[i];
-			for (int j = 0; j < line.size(); j++) {
-				if (line[j] == char32_t(0xFFFF)) {
-					found = true;
-					break;
-				}
-				cursor_column++;
-			}
-			if (found) {
-				break;
-			}
-			cursor_line++;
-			cursor_column = 1;
-		}
-
-		source = source.replace_first(String::chr(0xFFFF), String());
-	}
 
 	GDScriptTokenizerText *text_tokenizer = memnew(GDScriptTokenizerText);
 	text_tokenizer->set_source_code(source);
 
 	tokenizer = text_tokenizer;
-	tokenizer->set_cursor_position(cursor_line, cursor_column);
+
+	for_completion = p_editor_options.for_completion;
+	if (for_completion) {
+		tokenizer->set_cursor_position(p_editor_options.line + 1, p_editor_options.column + 1);
+	} else {
+		tokenizer->set_cursor_position(-1, -1);
+	}
 
 	script_path = p_script_path.simplify_path();
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1648,7 +1648,33 @@ private:
 #endif // TOOLS_ENABLED
 
 public:
-	Error parse(const String &p_source_code, const String &p_script_path, bool p_for_completion, bool p_parse_body = true);
+	struct EditorOptions {
+	public:
+		bool for_completion;
+		uint_fast32_t line;
+		uint_fast32_t column;
+
+	private:
+		EditorOptions() = default;
+
+	public:
+		static EditorOptions completion(uint_fast32_t p_line, uint_fast32_t p_column) {
+			EditorOptions opt;
+			opt.for_completion = true;
+			opt.line = p_line;
+			opt.column = p_column;
+			return opt;
+		}
+		static EditorOptions none() {
+			EditorOptions opt;
+			opt.for_completion = false;
+			opt.line = 0;
+			opt.column = 0;
+			return opt;
+		}
+	};
+
+	Error parse(const String &p_source_code, const String &p_script_path, EditorOptions p_editor_options, bool p_parse_body = true);
 	Error parse_binary(const Vector<uint8_t> &p_binary, const String &p_script_path);
 	ClassNode *get_tree() const { return head; }
 	bool is_tool() const { return _is_tool; }

--- a/modules/gdscript/gdscript_resource_format.cpp
+++ b/modules/gdscript/gdscript_resource_format.cpp
@@ -85,7 +85,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 
 	GDScriptParser parser;
-	if (OK != parser.parse(source, p_path, false)) {
+	if (OK != parser.parse(source, p_path, GDScriptParser::EditorOptions::none())) {
 		return;
 	}
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -565,26 +565,6 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 	}
 }
 
-String ExtendGDScriptParser::get_text_for_completion(const LSP::Position &p_cursor) const {
-	String longthing;
-	int len = lines.size();
-	for (int i = 0; i < len; i++) {
-		if (i == p_cursor.line) {
-			longthing += lines[i].substr(0, p_cursor.character);
-			longthing += String::chr(0xFFFF); // Not unicode, represents the cursor.
-			longthing += lines[i].substr(p_cursor.character);
-		} else {
-			longthing += lines[i];
-		}
-
-		if (i != len - 1) {
-			longthing += "\n";
-		}
-	}
-
-	return longthing;
-}
-
 String ExtendGDScriptParser::get_text_for_lookup_symbol(const LSP::Position &p_cursor, const String &p_symbol, bool p_func_required) const {
 	String longthing;
 	int len = lines.size();
@@ -968,7 +948,7 @@ void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	path = p_path;
 	lines = p_code.split("\n");
 
-	parse_result = GDScriptParser::parse(p_code, p_path, false);
+	parse_result = GDScriptParser::parse(p_code, p_path, GDScriptParser::EditorOptions::none());
 	GDScriptAnalyzer analyzer(this);
 
 	if (parse_result == OK) {

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -137,7 +137,6 @@ public:
 
 	Error get_left_function_call(const LSP::Position &p_position, LSP::Position &r_func_pos, int &r_arg_index) const;
 
-	String get_text_for_completion(const LSP::Position &p_cursor) const;
 	String get_text_for_lookup_symbol(const LSP::Position &p_cursor, const String &p_symbol = "", bool p_func_required = false) const;
 	/**
 	 * Parses the symbol name at the given position. Returns that name and its full range.

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -638,8 +638,8 @@ void GDScriptWorkspace::completion(const LSP::CompletionParams &p_params, List<S
 			}
 		}
 
-		String code = parser->get_text_for_completion(p_params.position);
-		GDScriptEditorLanguage::get_singleton()->complete_code(code, path, current, r_options, forced, call_hint);
+		String code = String("\n").join(parser->get_lines());
+		GDScriptEditorLanguage::get_singleton()->complete_code(code, EditorLanguage::Position(p_params.position.line, p_params.position.character), path, current, r_options, forced, call_hint);
 	}
 }
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -545,7 +545,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	// Test parsing.
 	GDScriptParser parser;
 	if (tokenizer_mode == TOKENIZER_TEXT) {
-		err = parser.parse(script->get_source_code(), source_file, false);
+		err = parser.parse(script->get_source_code(), source_file, GDScriptParser::EditorOptions::none());
 	} else {
 		err = parser.parse_binary(script->get_binary_tokens_source(), source_file);
 	}

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -41,7 +41,9 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/object/editor_language.h"
 #include "core/object/script_language.h"
+#include "core/string/string_builder.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 #include "editor/settings/editor_settings.h"
@@ -110,11 +112,11 @@ static void test_directory(const String &p_dir) {
 			}
 
 			String code = acc->get_as_utf8_string();
-			// For ease of reading ➡ (0x27A1) acts as sentinel char instead of 0xFFFF in the files.
-			code = code.replace_first(String::chr(0x27A1), String::chr(0xFFFF));
-			// Require pointer sentinel char in scripts.
-			int location = code.find_char(0xFFFF);
-			CHECK(location != -1);
+
+			// ➡ (0x27A1) acts as cursor position indicator.
+			CHECK(code.contains_char(0x27A1));
+			EditorLanguage::Position cursor = EditorStringUtils::find_char(code, 0x27A1);
+			code = code.remove_char(0x27A1);
 
 			String res_path = ProjectSettings::get_singleton()->localize_path(path.path_join(next));
 
@@ -167,25 +169,24 @@ static void test_directory(const String &p_dir) {
 				// Remove the line which contains the sentinel char, to get a valid script.
 				Ref<GDScript> scr;
 				scr.instantiate();
-				int start = location;
-				int end = location;
-				for (; start >= 0; --start) {
-					if (code.get(start) == '\n') {
-						break;
+
+				StringBuilder new_code;
+				int line_iter = 0;
+				for (const String &code_line : code.split("\n")) {
+					if (static_cast<uint_fast32_t>(line_iter) != cursor.line) {
+						new_code += code_line;
+						new_code += "\n";
 					}
+					line_iter += 1;
 				}
-				for (; end < code.size(); ++end) {
-					if (code.get(end) == '\n') {
-						break;
-					}
-				}
-				scr->set_source_code(code.erase(start, end - start));
+
+				scr->set_source_code(new_code.as_string());
 				scr->reload();
 				scr->set_path(res_path);
 				owner->set_script(scr);
 			}
 
-			GDScriptEditorLanguage::get_singleton()->complete_code(code, res_path, owner, &options, forced, call_hint);
+			GDScriptEditorLanguage::get_singleton()->complete_code(code, cursor, res_path, owner, &options, forced, call_hint);
 			ERR_PRINT_ON;
 
 			String contains_excluded;

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -172,7 +172,7 @@ static void test_tokenizer_buffer(const Vector<uint8_t> &p_buffer, const Vector<
 
 static void test_parser(const String &p_code, const String &p_script_path, const Vector<String> &p_lines) {
 	GDScriptParser parser;
-	Error err = parser.parse(p_code, p_script_path, false);
+	Error err = parser.parse(p_code, p_script_path, GDScriptParser::EditorOptions::none());
 
 	if (err != OK) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
@@ -257,7 +257,7 @@ static void recursively_disassemble_functions(const Ref<GDScript> p_script, cons
 
 static void test_compiler(const String &p_code, const String &p_script_path, const Vector<String> &p_lines) {
 	GDScriptParser parser;
-	Error err = parser.parse(p_code, p_script_path, false);
+	Error err = parser.parse(p_code, p_script_path, GDScriptParser::EditorOptions::none());
 
 	if (err != OK) {
 		print_line("Error in parser:");

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -307,7 +307,7 @@ void assert_no_errors_in(const String &p_path) {
 	REQUIRE_MESSAGE(err == OK, vformat("Cannot read '%s'", p_path));
 
 	GDScriptParser parser;
-	err = parser.parse(source, p_path, true);
+	err = parser.parse(source, p_path, GDScriptParser::EditorOptions::none());
 	REQUIRE_MESSAGE(err == OK, vformat("Errors while parsing '%s'", p_path));
 
 	GDScriptAnalyzer analyzer(&parser);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related to https://github.com/godotengine/godot-proposals/issues/14566 (in addition to moving the functions I'm also interested in revisiting some of the API design).

## Additional information

At the moment the completion API relies on a special sentinel char `0xFFFF` to pass the cursor position to implementations. That's bad API design IMHO because it forces string operations even when not needed.

Best example is the GDScript stack:
In editor:
- concatenate code lines while inserting the sentinel char

In GDScript module:
- search `0xFFFF` in the code to extract cursor position
- replace `0xFFFF`with `""` because the parser uses the extracted position.

This PR changes the API so that the position is passed explicitly (using a new `EditorLanguage::Position` struct).

For `ScriptLanguageExtension` compat we insert the char in the adapter.

GDShader also inserts `0xFFFF` because the shader completion uses the sentinel char to produce a dedicated `CARET` token.

