### PR TITLE
Fix popup menus not following window on move

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -389,6 +389,32 @@ void MenuBar::_notification(int p_what) {
 				_open_popup(index);
 			}
 		} break;
+		case NOTIFICATION_WM_POSITION_CHANGED: {
+			if (active_menu == -1) {
+				break;
+			}
+			PopupMenu *pm = get_menu_popup(active_menu);
+			if (!pm->is_visible()) {
+				break;
+			}
+
+			Rect2 item_rect = _get_menu_item_rect(active_menu);
+			item_rect.position *= get_screen_transform().get_scale();
+			item_rect.size *= get_screen_transform().get_scale();
+
+			Rect2 rect = get_screen_rect();
+			rect.position.x += item_rect.position.x;
+			rect.position.y += rect.size.height;
+			if (get_viewport()->is_embedding_subwindows() && pm->get_force_native()) {
+				rect = get_viewport()->get_popup_base_transform_native().xform(rect);
+			}
+
+			pm->set_size(Size2(item_rect.size.x, 0));
+			if (is_layout_rtl()) {
+				rect.position.x += rect.size.width - pm->get_size().width;
+			}
+			pm->set_position(rect.position);
+		} break;
 	}
 }
 


### PR DESCRIPTION
When the editor window is moved while a menu (Scene, Project, etc.) is open, the popup stays at its original screen position instead of following the window.

MenuBar now handles NOTIFICATION_WM_POSITION_CHANGED by recalculating the open popup's position relative to the current window position. This mirrors the positioning logic in _open_popup() without toggling visibility.

Fixes MenuBar popups drifting on window move.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

AI was used to find the relevant functions and variables used as well as the commit name and description. All file changes were NOT performed by AI.

## What problem(s) does this PR solve?

- Closes #120473

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Tested with the following system setup:
Godot v4.8.dev (f964fa714) - Fedora Linux 44 (KDE Plasma Desktop Edition) on Wayland - X11 display driver, Multi-window, 1 monitor - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 3080 Ti (nvidia; 595.80) - AMD Ryzen 9 9950X3D 16-Core Processor (32 threads) - 60.42 GiB memory - PulseAudio (44100 Hz, Surround 7.1)
