### PR TITLE
Move `lookup_code` into `EditorLanguage`

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -59,6 +59,59 @@ public:
 	 */
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) { return ERR_UNAVAILABLE; }
 
+	// Keep ScriptLanguageExtension::LookupResultType a subset of this.
+	struct LookupResult {
+		enum class Type {
+			SCRIPT_LOCATION, // Use if none of the options below apply.
+			CLASS,
+			CLASS_CONSTANT,
+			CLASS_PROPERTY,
+			CLASS_METHOD,
+			CLASS_SIGNAL,
+			CLASS_ENUM,
+			CLASS_TBD_GLOBALSCOPE [[deprecated]], // Don't bind to ClassDB.
+			CLASS_ANNOTATION,
+			LOCAL_CONSTANT,
+			LOCAL_VARIABLE,
+		};
+
+		Type type;
+
+		// For `CLASS_*`.
+		String class_name;
+		String class_member;
+
+		// For `LOCAL_*`.
+		String description;
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
+
+		// For `LOCAL_*`.
+		String doc_type;
+		String enumeration;
+		bool is_bitfield = false;
+
+		// For `LOCAL_*`.
+		String value;
+
+		// `SCRIPT_LOCATION` and `LOCAL_*` must have, `CLASS_*` can have.
+		String script_path;
+		int location = -1;
+	};
+
+	/**
+	 * Called by the editor to lookup code at a given position.
+	 *
+	 * @param p_code The current content of the source fragment. Will always contain the special sentinel char 0xFFFF at the requested position. The content might differ from the state on disk, the exact behavior in that case is up to the implementation.
+	 * @param p_symbol The symbol under the cursor position. This parameter is unreliable (sometimes uses the user configured word separators) and will be removed in the future. New implementations should not use it and determine the symbol under the cursor on their own.
+	 * @param p_path The path which identifies the source fragment. Implementations MAY support paths to builtin resources, or return an error for those.
+	 * @param p_owner If the source fragment is somehow tied to an object (e.g. the currently open scene) the editor will pass it to the language. Implementations MAY respect this in their analysis, e.g. for GDScript get node literals.
+	 * @param r_result The returned `LookupResult`.
+	 */
+	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
+
 	virtual ~EditorLanguage() = default;
 };
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -369,51 +369,6 @@ public:
 		TypedArray<int> charac;
 	};
 
-	enum LookupResultType {
-		LOOKUP_RESULT_SCRIPT_LOCATION, // Use if none of the options below apply.
-		LOOKUP_RESULT_CLASS,
-		LOOKUP_RESULT_CLASS_CONSTANT,
-		LOOKUP_RESULT_CLASS_PROPERTY,
-		LOOKUP_RESULT_CLASS_METHOD,
-		LOOKUP_RESULT_CLASS_SIGNAL,
-		LOOKUP_RESULT_CLASS_ENUM,
-		LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE, // Deprecated.
-		LOOKUP_RESULT_CLASS_ANNOTATION,
-		LOOKUP_RESULT_LOCAL_CONSTANT,
-		LOOKUP_RESULT_LOCAL_VARIABLE,
-		LOOKUP_RESULT_MAX,
-	};
-
-	struct LookupResult {
-		LookupResultType type;
-
-		// For `CLASS_*`.
-		String class_name;
-		String class_member;
-
-		// For `LOCAL_*`.
-		String description;
-		bool is_deprecated = false;
-		String deprecated_message;
-		bool is_experimental = false;
-		String experimental_message;
-
-		// For `LOCAL_*`.
-		String doc_type;
-		String enumeration;
-		bool is_bitfield = false;
-
-		// For `LOCAL_*`.
-		String value;
-
-		// `SCRIPT_LOCATION` and `LOCAL_*` must have, `CLASS_*` can have.
-		Ref<Script> script;
-		String script_path;
-		int location = -1;
-	};
-
-	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
-
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -230,6 +230,22 @@ GDVIRTUAL_NATIVE_PTR(ScriptLanguageExtensionProfilingInfo)
 class ScriptLanguageExtension : public ScriptLanguage {
 	GDCLASS(ScriptLanguageExtension, ScriptLanguage)
 protected:
+	// See `EditorLanguage::LookupResult::Type`.
+	enum LookupResultType {
+		LOOKUP_RESULT_SCRIPT_LOCATION, // Use if none of the options below apply.
+		LOOKUP_RESULT_CLASS,
+		LOOKUP_RESULT_CLASS_CONSTANT,
+		LOOKUP_RESULT_CLASS_PROPERTY,
+		LOOKUP_RESULT_CLASS_METHOD,
+		LOOKUP_RESULT_CLASS_SIGNAL,
+		LOOKUP_RESULT_CLASS_ENUM,
+		LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE, // Deprecated.
+		LOOKUP_RESULT_CLASS_ANNOTATION,
+		LOOKUP_RESULT_LOCAL_CONSTANT,
+		LOOKUP_RESULT_LOCAL_VARIABLE,
+		LOOKUP_RESULT_MAX,
+	};
+
 	static void _bind_methods();
 
 public:
@@ -250,6 +266,10 @@ private:
 	public:
 		virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override {
 			return script_language->complete_code(p_code, p_path, p_owner, r_options, r_force, r_call_hint);
+		}
+
+		virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override {
+			return script_language->lookup_code(p_code, p_symbol, p_path, p_owner, r_result);
 		}
 
 		EditorAdapter(ScriptLanguageExtension *p_script_language) {
@@ -416,7 +436,8 @@ public:
 
 	GDVIRTUAL3RC_REQUIRED(Dictionary, _complete_code, const String &, const String &, Object *)
 
-	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) {
+#ifdef TOOLS_ENABLED
+	Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_complete_code, p_code, p_path, p_owner, ret);
 		if (!ret.has("result")) {
@@ -463,10 +484,12 @@ public:
 
 		return result;
 	}
+#endif // TOOLS_ENABLED
 
 	GDVIRTUAL4RC_REQUIRED(Dictionary, _lookup_code, const String &, const String &, const String &, Object *)
 
-	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override {
+#ifdef TOOLS_ENABLED
+	Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, EditorLanguage::LookupResult &r_result) {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_lookup_code, p_code, p_symbol, p_path, p_owner, ret);
 
@@ -474,7 +497,9 @@ public:
 		const Error result = Error(int(ret["result"]));
 
 		ERR_FAIL_COND_V(!ret.has("type"), ERR_UNAVAILABLE);
-		r_result.type = LookupResultType(int(ret["type"]));
+		int type = int(ret["type"]);
+		ERR_FAIL_INDEX_V(type, LOOKUP_RESULT_MAX, ERR_UNAVAILABLE);
+		r_result.type = EditorLanguage::LookupResult::Type(type);
 
 		r_result.class_name = ret.get("class_name", "");
 		r_result.class_member = ret.get("class_member", "");
@@ -491,12 +516,12 @@ public:
 
 		r_result.value = ret.get("value", "");
 
-		r_result.script = ret.get("script", Ref<Script>());
 		r_result.script_path = ret.get("script_path", "");
 		r_result.location = ret.get("location", -1);
 
 		return result;
 	}
+#endif // TOOLS_ENABLED
 
 	GDVIRTUAL3RC_REQUIRED(String, _auto_indent_code, const String &, int, int)
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1201,9 +1201,9 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		base = _find_node_for_script(base, base, script);
 	}
 
-	ScriptLanguage::LookupResult result;
+	EditorLanguage::LookupResult result;
 	String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(p_row, p_column);
-	Error lc_error = script->get_language()->lookup_code(code_text, p_symbol, script->get_path(), base, result);
+	Error lc_error = script->get_language()->get_editor_language()->lookup_code(code_text, p_symbol, script->get_path(), base, result);
 	if (ScriptServer::is_global_class(p_symbol)) {
 		EditorNode::get_singleton()->load_resource(ScriptServer::get_global_class_path(p_symbol));
 	} else if (p_symbol.is_resource_file() || p_symbol.begins_with("uid://")) {
@@ -1217,10 +1217,10 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 
 		if (!result.class_name.is_empty() && EditorHelp::get_doc_data()->class_list.has(result.class_name) && !EditorHelp::get_doc_data()->class_list[result.class_name].is_script_doc) {
 			switch (result.type) {
-				case ScriptLanguage::LOOKUP_RESULT_CLASS: {
+				case EditorLanguage::LookupResult::Type::CLASS: {
 					emit_signal(SNAME("go_to_help"), "class_name:" + result.class_name);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT: {
+				case EditorLanguage::LookupResult::Type::CLASS_CONSTANT: {
 					StringName cname = result.class_name;
 					while (ClassDB::class_exists(cname)) {
 						if (ClassDB::has_integer_constant(cname, result.class_member, true)) {
@@ -1231,7 +1231,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 					emit_signal(SNAME("go_to_help"), "class_constant:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY: {
+				case EditorLanguage::LookupResult::Type::CLASS_PROPERTY: {
 					StringName cname = result.class_name;
 					while (ClassDB::class_exists(cname)) {
 						if (ClassDB::has_property(cname, result.class_member, true)) {
@@ -1242,7 +1242,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 					emit_signal(SNAME("go_to_help"), "class_property:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD: {
+				case EditorLanguage::LookupResult::Type::CLASS_METHOD: {
 					StringName cname = result.class_name;
 					while (ClassDB::class_exists(cname)) {
 						if (ClassDB::has_method(cname, result.class_member, true)) {
@@ -1253,7 +1253,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 					emit_signal(SNAME("go_to_help"), "class_method:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_SIGNAL: {
+				case EditorLanguage::LookupResult::Type::CLASS_SIGNAL: {
 					StringName cname = result.class_name;
 					while (ClassDB::class_exists(cname)) {
 						if (ClassDB::has_signal(cname, result.class_member, true)) {
@@ -1264,7 +1264,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 					emit_signal(SNAME("go_to_help"), "class_signal:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM: {
+				case EditorLanguage::LookupResult::Type::CLASS_ENUM: {
 					StringName cname = result.class_name;
 					while (ClassDB::class_exists(cname)) {
 						if (ClassDB::has_enum(cname, result.class_member, true)) {
@@ -1275,22 +1275,24 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 					}
 					emit_signal(SNAME("go_to_help"), "class_enum:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_ANNOTATION: {
+				case EditorLanguage::LookupResult::Type::CLASS_ANNOTATION: {
 					emit_signal(SNAME("go_to_help"), "class_annotation:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE: { // Deprecated.
+					GODOT_PUSH_IGNORE_DEPRECATION()
+				case EditorLanguage::LookupResult::Type::CLASS_TBD_GLOBALSCOPE: { // Deprecated.
 					emit_signal(SNAME("go_to_help"), "class_global:" + result.class_name + ":" + result.class_member);
 				} break;
-				case ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION:
-				case ScriptLanguage::LOOKUP_RESULT_LOCAL_CONSTANT:
-				case ScriptLanguage::LOOKUP_RESULT_LOCAL_VARIABLE:
-				case ScriptLanguage::LOOKUP_RESULT_MAX: {
+					GODOT_POP_IGNORE_DEPRECATION()
+				case EditorLanguage::LookupResult::Type::SCRIPT_LOCATION:
+				case EditorLanguage::LookupResult::Type::LOCAL_CONSTANT:
+				case EditorLanguage::LookupResult::Type::LOCAL_VARIABLE: {
 					// Nothing to do.
 				} break;
 			}
 		} else if (result.location >= 0) {
-			if (result.script.is_valid()) {
-				emit_signal(SNAME("request_open_script_at_line"), result.script, result.location - 1);
+			if (!result.script_path.is_empty()) {
+				Ref<Script> scr = ResourceLoader::load(result.script_path);
+				emit_signal(SNAME("request_open_script_at_line"), scr, result.location - 1);
 			} else {
 				goto_line_centered(result.location - 1);
 			}
@@ -1320,9 +1322,9 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 		base = _find_node_for_script(base, base, script);
 	}
 
-	ScriptLanguage::LookupResult result;
+	EditorLanguage::LookupResult result;
 	String lc_text = code_editor->get_text_editor()->get_text_for_symbol_lookup();
-	Error lc_error = script->get_language()->lookup_code(lc_text, p_symbol, script->get_path(), base, result);
+	Error lc_error = script->get_language()->get_editor_language()->lookup_code(lc_text, p_symbol, script->get_path(), base, result);
 	bool is_singleton = ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton;
 	if (lc_error == OK || is_singleton || ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || p_symbol.begins_with("uid://")) {
 		text_edit->set_symbol_lookup_word_as_valid(true);
@@ -1355,16 +1357,16 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 		base = _find_node_for_script(base, base, script);
 	}
 
-	ScriptLanguage::LookupResult result;
+	EditorLanguage::LookupResult result;
 	String doc_symbol;
 	const String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(p_row, p_column);
-	const Error lc_error = script->get_language()->lookup_code(code_text, p_symbol, script->get_path(), base, result);
+	const Error lc_error = script->get_language()->get_editor_language()->lookup_code(code_text, p_symbol, script->get_path(), base, result);
 	if (lc_error == OK) {
 		switch (result.type) {
-			case ScriptLanguage::LOOKUP_RESULT_CLASS: {
+			case EditorLanguage::LookupResult::Type::CLASS: {
 				doc_symbol = "class|" + result.class_name + "|";
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT: {
+			case EditorLanguage::LookupResult::Type::CLASS_CONSTANT: {
 				StringName cname = result.class_name;
 				while (ClassDB::class_exists(cname)) {
 					if (ClassDB::has_integer_constant(cname, result.class_member, true)) {
@@ -1375,7 +1377,7 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				}
 				doc_symbol = "constant|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY: {
+			case EditorLanguage::LookupResult::Type::CLASS_PROPERTY: {
 				StringName cname = result.class_name;
 				while (ClassDB::class_exists(cname)) {
 					if (ClassDB::has_property(cname, result.class_member, true)) {
@@ -1386,7 +1388,7 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				}
 				doc_symbol = "property|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD: {
+			case EditorLanguage::LookupResult::Type::CLASS_METHOD: {
 				StringName cname = result.class_name;
 				while (ClassDB::class_exists(cname)) {
 					if (ClassDB::has_method(cname, result.class_member, true)) {
@@ -1397,7 +1399,7 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				}
 				doc_symbol = "method|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_SIGNAL: {
+			case EditorLanguage::LookupResult::Type::CLASS_SIGNAL: {
 				StringName cname = result.class_name;
 				while (ClassDB::class_exists(cname)) {
 					if (ClassDB::has_signal(cname, result.class_member, true)) {
@@ -1408,7 +1410,7 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				}
 				doc_symbol = "signal|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM: {
+			case EditorLanguage::LookupResult::Type::CLASS_ENUM: {
 				StringName cname = result.class_name;
 				while (ClassDB::class_exists(cname)) {
 					if (ClassDB::has_enum(cname, result.class_member, true)) {
@@ -1419,12 +1421,12 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				}
 				doc_symbol = "enum|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_ANNOTATION: {
+			case EditorLanguage::LookupResult::Type::CLASS_ANNOTATION: {
 				doc_symbol = "annotation|" + result.class_name + "|" + result.class_member;
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_LOCAL_CONSTANT:
-			case ScriptLanguage::LOOKUP_RESULT_LOCAL_VARIABLE: {
-				const String item_type = (result.type == ScriptLanguage::LOOKUP_RESULT_LOCAL_CONSTANT) ? "local_constant" : "local_variable";
+			case EditorLanguage::LookupResult::Type::LOCAL_CONSTANT:
+			case EditorLanguage::LookupResult::Type::LOCAL_VARIABLE: {
+				const String item_type = (result.type == EditorLanguage::LookupResult::Type::LOCAL_CONSTANT) ? "local_constant" : "local_variable";
 				Dictionary item_data;
 				item_data["description"] = result.description;
 				item_data["is_deprecated"] = result.is_deprecated;
@@ -1437,11 +1439,12 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 				item_data["value"] = result.value;
 				doc_symbol = item_type + "||" + p_symbol + "|" + JSON::stringify(item_data);
 			} break;
-			case ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION:
-			case ScriptLanguage::LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE: // Deprecated.
-			case ScriptLanguage::LOOKUP_RESULT_MAX: {
+				GODOT_PUSH_IGNORE_DEPRECATION()
+			case EditorLanguage::LookupResult::Type::SCRIPT_LOCATION:
+			case EditorLanguage::LookupResult::Type::CLASS_TBD_GLOBALSCOPE: {
 				// Nothing to do.
 			} break;
+				GODOT_POP_IGNORE_DEPRECATION()
 		}
 	}
 
@@ -2485,8 +2488,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 			if (base) {
 				base = _find_node_for_script(base, base, script);
 			}
-			ScriptLanguage::LookupResult result;
-			if (script->get_language()->lookup_code(tx->get_text_for_symbol_lookup(), word_at_pos, script->get_path(), base, result) == OK) {
+			EditorLanguage::LookupResult result;
+			if (script->get_language()->get_editor_language()->lookup_code(tx->get_text_for_symbol_lookup(), word_at_pos, script->get_path(), base, result) == OK) {
 				open_docs = true;
 			}
 		}

--- a/modules/gdscript/editor/gdscript_editor_language.h
+++ b/modules/gdscript/editor/gdscript_editor_language.h
@@ -40,6 +40,8 @@ public:
 
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override;
 
+	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
+
 	GDScriptEditorLanguage() {
 		ERR_FAIL_COND(singleton != nullptr);
 		singleton = this;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -598,9 +598,6 @@ public:
 	virtual bool can_inherit_from_file() const override { return true; }
 	virtual int find_function(const String &p_function, const String &p_code) const override;
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
-#ifdef TOOLS_ENABLED
-	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
-#endif
 	virtual String _get_indentation() const;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3942,7 +3942,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 
 #ifdef TOOLS_ENABLED
 
-static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, const String &p_symbol, GDScriptLanguage::LookupResult &r_result) {
+static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, const String &p_symbol, EditorLanguage::LookupResult &r_result) {
 	GDScriptParser::DataType base_type = p_base;
 
 	while (true) {
@@ -3971,26 +3971,26 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						String doc_enum_name;
 						GDScriptDocGen::doctype_from_gdtype(GDScriptAnalyzer::type_from_metatype(member.get_datatype()), doc_type_name, doc_enum_name);
 
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS;
 						r_result.class_name = doc_type_name;
 					} break;
 					case GDScriptParser::ClassNode::Member::CONSTANT:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 						break;
 					case GDScriptParser::ClassNode::Member::FUNCTION:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 						break;
 					case GDScriptParser::ClassNode::Member::SIGNAL:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_SIGNAL;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_SIGNAL;
 						break;
 					case GDScriptParser::ClassNode::Member::VARIABLE:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_PROPERTY;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_ENUM;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 						break;
 				}
 
@@ -4003,11 +4003,9 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.class_member = name;
 				}
 
-				Error err = OK;
-				r_result.script = GDScriptCache::get_shallow_script(base_type.script_path, err);
 				r_result.script_path = base_type.script_path;
 				r_result.location = member.get_line();
-				return err;
+				return OK;
 			} break;
 			case GDScriptParser::DataType::SCRIPT: {
 				const Ref<Script> scr = base_type.script_type;
@@ -4024,14 +4022,14 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				const int line = scr->get_member_line(name);
 				if (line >= 0) {
 					bool found_type = false;
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION;
+					r_result.type = EditorLanguage::LookupResult::Type::SCRIPT_LOCATION;
 					{
 						List<PropertyInfo> properties;
 						scr->get_script_property_list(&properties);
 						for (const PropertyInfo &property : properties) {
 							if (property.name == name && (property.usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
 								found_type = true;
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
+								r_result.type = EditorLanguage::LookupResult::Type::CLASS_PROPERTY;
 								r_result.class_name = scr->get_doc_class_name();
 								r_result.class_member = name;
 								break;
@@ -4044,7 +4042,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						for (const MethodInfo &method : methods) {
 							if (method.name == name) {
 								found_type = true;
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+								r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 								r_result.class_name = scr->get_doc_class_name();
 								r_result.class_member = name;
 								break;
@@ -4057,7 +4055,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						for (const MethodInfo &signal : signals) {
 							if (signal.name == name) {
 								found_type = true;
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_SIGNAL;
+								r_result.type = EditorLanguage::LookupResult::Type::CLASS_SIGNAL;
 								r_result.class_name = scr->get_doc_class_name();
 								r_result.class_member = name;
 								break;
@@ -4070,7 +4068,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							const Ref<GDScript> *subclass = gds->get_subclasses().getptr(name);
 							if (subclass != nullptr) {
 								found_type = true;
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+								r_result.type = EditorLanguage::LookupResult::Type::CLASS;
 								r_result.class_name = subclass->ptr()->get_doc_class_name();
 							}
 							// TODO: enums.
@@ -4081,13 +4079,12 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						scr->get_constants(&constants);
 						if (constants.has(name)) {
 							found_type = true;
-							r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+							r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 							r_result.class_name = scr->get_doc_class_name();
 							r_result.class_member = name;
 						}
 					}
 
-					r_result.script = scr;
 					r_result.script_path = base_type.script_path;
 					r_result.location = line;
 					return OK;
@@ -4108,7 +4105,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				ERR_FAIL_COND_V(!GDScriptAnalyzer::class_exists(class_name), ERR_BUG);
 
 				if (ClassDB::has_method(class_name, p_symbol, true)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+					r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4118,7 +4115,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				ClassDB::get_virtual_methods(class_name, &virtual_methods, true);
 				for (const MethodInfo &E : virtual_methods) {
 					if (E.name == p_symbol) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 						r_result.class_name = class_name;
 						r_result.class_member = p_symbol;
 						return OK;
@@ -4126,7 +4123,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				if (ClassDB::has_signal(class_name, p_symbol, true)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_SIGNAL;
+					r_result.type = EditorLanguage::LookupResult::Type::CLASS_SIGNAL;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4136,7 +4133,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				ClassDB::get_enum_list(class_name, &enums);
 				for (const StringName &E : enums) {
 					if (E == p_symbol) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_ENUM;
 						r_result.class_name = class_name;
 						r_result.class_member = p_symbol;
 						return OK;
@@ -4144,7 +4141,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				if (!String(ClassDB::get_integer_constant_enum(class_name, p_symbol, true)).is_empty()) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+					r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4154,7 +4151,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				ClassDB::get_integer_constant_list(class_name, &constants, true);
 				for (const String &E : constants) {
 					if (E == p_symbol) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 						r_result.class_name = class_name;
 						r_result.class_member = p_symbol;
 						return OK;
@@ -4168,7 +4165,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						return ERR_CANT_RESOLVE;
 					}
 
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
+					r_result.type = EditorLanguage::LookupResult::Type::CLASS_PROPERTY;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4184,21 +4181,21 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			case GDScriptParser::DataType::BUILTIN: {
 				if (base_type.is_meta_type) {
 					if (Variant::has_enum(base_type.builtin_type, p_symbol)) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_ENUM;
 						r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 						r_result.class_member = p_symbol;
 						return OK;
 					}
 
 					if (Variant::has_constant(base_type.builtin_type, p_symbol)) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 						r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 						r_result.class_member = p_symbol;
 						return OK;
 					}
 				} else {
 					if (Variant::has_member(base_type.builtin_type, p_symbol)) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_PROPERTY;
 						r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 						r_result.class_member = p_symbol;
 						return OK;
@@ -4206,7 +4203,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				if (Variant::has_builtin_method(base_type.builtin_type, p_symbol)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+					r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 					r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4222,7 +4219,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						GDScriptDocGen::doctype_from_gdtype(GDScriptAnalyzer::type_from_metatype(base_type), doc_type_name, doc_enum_name);
 
 						if (CoreConstants::is_global_enum(doc_enum_name)) {
-							r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+							r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 							r_result.class_name = "@GlobalScope";
 							r_result.class_member = p_symbol;
 							return OK;
@@ -4230,12 +4227,11 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							const int dot_pos = doc_enum_name.rfind_char('.');
 							if (dot_pos >= 0) {
 								Error err = OK;
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+								r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 								if (base_type.class_type != nullptr) {
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
 									r_result.class_name = doc_enum_name;
 									r_result.class_member = p_symbol;
-									r_result.script = GDScriptCache::get_shallow_script(base_type.script_path, err);
 									r_result.script_path = base_type.script_path;
 									const String enum_name = doc_enum_name.substr(dot_pos + 1);
 									if (base_type.class_type->has_member(enum_name)) {
@@ -4253,7 +4249,6 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
 									r_result.class_name = doc_enum_name;
 									r_result.class_member = p_symbol;
-									r_result.script = base_type.script_type;
 									r_result.script_path = base_type.script_path;
 									// TODO: Find a way to obtain enum value location for a script
 									r_result.location = base_type.script_type->get_member_line(doc_enum_name.substr(dot_pos + 1));
@@ -4265,7 +4260,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							}
 						}
 					} else if (Variant::has_builtin_method(Variant::DICTIONARY, p_symbol)) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_METHOD;
 						r_result.class_name = "Dictionary";
 						r_result.class_member = p_symbol;
 						return OK;
@@ -4278,7 +4273,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				if (base_type.is_meta_type) {
 					const String enum_name = "Variant." + p_symbol;
 					if (CoreConstants::is_global_enum(enum_name)) {
-						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+						r_result.type = EditorLanguage::LookupResult::Type::CLASS_ENUM;
 						r_result.class_name = "@GlobalScope";
 						r_result.class_member = enum_name;
 						return OK;
@@ -4297,22 +4292,22 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	return ERR_CANT_RESOLVE;
 }
 
-::Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) {
+::Error GDScriptEditorLanguage::lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) {
 	// Before parsing, try the usual stuff.
 	if (GDScriptAnalyzer::class_exists(p_symbol)) {
-		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+		r_result.type = LookupResult::Type::CLASS;
 		r_result.class_name = p_symbol;
 		return OK;
 	}
 
 	if (Variant::get_type_by_name(p_symbol) < Variant::VARIANT_MAX) {
-		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+		r_result.type = LookupResult::Type::CLASS;
 		r_result.class_name = p_symbol;
 		return OK;
 	}
 
 	if (p_symbol == "Variant") {
-		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+		r_result.type = LookupResult::Type::CLASS;
 		r_result.class_name = "Variant";
 		return OK;
 	}
@@ -4328,7 +4323,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		// Need special checks for `assert` and `preload` as they are technically
 		// keywords, so are not registered in `GDScriptUtilityFunctions`.
 		if (GDScriptUtilityFunctions::function_exists(p_symbol) || p_symbol == "assert" || p_symbol == "preload") {
-			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+			r_result.type = LookupResult::Type::CLASS_METHOD;
 			r_result.class_name = "@GDScript";
 			r_result.class_member = p_symbol;
 			return OK;
@@ -4344,7 +4339,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		bool success = false;
 		ClassDB::get_integer_constant(class_name, p_symbol, &success);
 		if (success) {
-			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+			r_result.type = LookupResult::Type::CLASS_CONSTANT;
 			r_result.class_name = class_name;
 			r_result.class_member = p_symbol;
 			return OK;
@@ -4354,7 +4349,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			ClassDB::get_enum_list(class_name, &enums, true);
 			for (const StringName &enum_name : enums) {
 				if (enum_name == p_symbol) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+					r_result.type = LookupResult::Type::CLASS_ENUM;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4375,7 +4370,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			ClassDB::get_enum_list(class_name, &enums, true);
 			for (const StringName &enum_name : enums) {
 				if (enum_name == p_symbol) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+					r_result.type = LookupResult::Type::CLASS_ENUM;
 					r_result.class_name = class_name;
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4435,7 +4430,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							case GDScriptParser::SuiteNode::Local::UNDEFINED:
 								return ERR_BUG;
 							case GDScriptParser::SuiteNode::Local::CONSTANT:
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_LOCAL_CONSTANT;
+								r_result.type = LookupResult::Type::LOCAL_CONSTANT;
 								r_result.description = local.constant->doc_data.description;
 								r_result.is_deprecated = local.constant->doc_data.is_deprecated;
 								r_result.deprecated_message = local.constant->doc_data.deprecated_message;
@@ -4446,7 +4441,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 								}
 								break;
 							case GDScriptParser::SuiteNode::Local::VARIABLE:
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_LOCAL_VARIABLE;
+								r_result.type = LookupResult::Type::LOCAL_VARIABLE;
 								r_result.description = local.variable->doc_data.description;
 								r_result.is_deprecated = local.variable->doc_data.is_deprecated;
 								r_result.deprecated_message = local.variable->doc_data.deprecated_message;
@@ -4459,17 +4454,15 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							case GDScriptParser::SuiteNode::Local::PARAMETER:
 							case GDScriptParser::SuiteNode::Local::FOR_VARIABLE:
 							case GDScriptParser::SuiteNode::Local::PATTERN_BIND:
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_LOCAL_VARIABLE;
+								r_result.type = LookupResult::Type::LOCAL_VARIABLE;
 								break;
 						}
 
 						GDScriptDocGen::doctype_from_gdtype(local.get_datatype(), r_result.doc_type, r_result.enumeration);
 
-						Error err = OK;
-						r_result.script = GDScriptCache::get_shallow_script(base_type.script_path, err);
 						r_result.script_path = base_type.script_path;
 						r_result.location = local.start_line;
-						return err;
+						return OK;
 					}
 					suite = suite->parent_block;
 				}
@@ -4490,9 +4483,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						}
 
 						if (FileAccess::exists(scr_path)) {
-							r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+							r_result.type = LookupResult::Type::CLASS;
 							r_result.class_name = p_symbol;
-							r_result.script = ResourceLoader::load(scr_path);
 							r_result.script_path = scr_path;
 							r_result.location = 0;
 							return OK;
@@ -4506,9 +4498,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					if (scr.is_null()) {
 						return ERR_BUG;
 					}
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+					r_result.type = LookupResult::Type::CLASS;
 					r_result.class_name = scr->get_doc_class_name();
-					r_result.script = scr;
 					r_result.script_path = scr_path;
 					r_result.location = 0;
 					return OK;
@@ -4521,10 +4512,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						const Object *obj = value;
 						if (obj) {
 							if (Object::cast_to<GDScriptNativeClass>(obj)) {
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+								r_result.type = LookupResult::Type::CLASS;
 								r_result.class_name = Object::cast_to<GDScriptNativeClass>(obj)->get_name();
 							} else {
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+								r_result.type = LookupResult::Type::CLASS;
 								r_result.class_name = obj->get_class();
 							}
 							return OK;
@@ -4533,28 +4524,28 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				if (p_symbol == "PI" || p_symbol == "TAU" || p_symbol == "INF" || p_symbol == "NAN") {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+					r_result.type = LookupResult::Type::CLASS_CONSTANT;
 					r_result.class_name = "@GDScript";
 					r_result.class_member = p_symbol;
 					return OK;
 				}
 
 				if (CoreConstants::is_global_enum(p_symbol)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
+					r_result.type = LookupResult::Type::CLASS_ENUM;
 					r_result.class_name = "@GlobalScope";
 					r_result.class_member = p_symbol;
 					return OK;
 				}
 
 				if (CoreConstants::is_global_constant(p_symbol)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+					r_result.type = LookupResult::Type::CLASS_CONSTANT;
 					r_result.class_name = "@GlobalScope";
 					r_result.class_member = p_symbol;
 					return OK;
 				}
 
 				if (Variant::has_utility_function(p_symbol)) {
-					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
+					r_result.type = LookupResult::Type::CLASS_METHOD;
 					r_result.class_name = "@GlobalScope";
 					r_result.class_member = p_symbol;
 					return OK;
@@ -4633,7 +4624,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		case GDScriptParser::COMPLETION_ANNOTATION: {
 			const String annotation_symbol = "@" + p_symbol.trim_prefix("@");
 			if (parser.annotation_exists(annotation_symbol)) {
-				r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ANNOTATION;
+				r_result.type = LookupResult::Type::CLASS_ANNOTATION;
 				r_result.class_name = "@GDScript";
 				r_result.class_member = annotation_symbol;
 				return OK;

--- a/modules/gdscript/gdscript_resource_format.cpp
+++ b/modules/gdscript/gdscript_resource_format.cpp
@@ -36,6 +36,10 @@
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
 
+#ifdef TOOLS_ENABLED
+#include "modules/gdscript/editor/gdscript_editor_language.h"
+#endif // TOOLS_ENABLED
+
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Error err;
 	bool ignoring = p_cache_mode == CACHE_MODE_IGNORE || p_cache_mode == CACHE_MODE_IGNORE_DEEP;
@@ -91,6 +95,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 }
 
 void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
+#ifdef TOOLS_ENABLED
 	Ref<GDScript> scr = ResourceLoader::load(p_path);
 	if (scr.is_null()) {
 		return;
@@ -113,13 +118,13 @@ void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSe
 		// Insert the "cursor" character, needed for the lookup to work.
 		const String source_with_cursor = source.insert(insert_idx + current.start_column, String::chr(0xFFFF));
 
-		ScriptLanguage::LookupResult result;
-		if (scr->get_language()->lookup_code(source_with_cursor, current.get_identifier(), p_path, nullptr, result) == OK) {
+		EditorLanguage::LookupResult result;
+		if (GDScriptEditorLanguage::get_singleton()->lookup_code(source_with_cursor, current.get_identifier(), p_path, nullptr, result) == OK) {
 			if (!result.class_name.is_empty() && ClassDB::class_exists(result.class_name)) {
 				r_classes->insert(result.class_name);
 			}
 
-			if (result.type == ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY) {
+			if (result.type == EditorLanguage::LookupResult::Type::CLASS_PROPERTY) {
 				PropertyInfo prop;
 				if (ClassDB::get_property_info(result.class_name, result.class_member, &prop)) {
 					if (!prop.class_name.is_empty() && ClassDB::class_exists(prop.class_name)) {
@@ -129,7 +134,7 @@ void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSe
 						r_classes->insert(prop.hint_string);
 					}
 				}
-			} else if (result.type == ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD) {
+			} else if (result.type == EditorLanguage::LookupResult::Type::CLASS_METHOD) {
 				MethodInfo met;
 				if (ClassDB::get_method_info(result.class_name, result.class_member, &met)) {
 					if (!met.return_val.class_name.is_empty() && ClassDB::class_exists(met.return_val.class_name)) {
@@ -144,6 +149,7 @@ void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSe
 
 		current = tokenizer.scan();
 	}
+#endif // TOOLS_ENABLED
 }
 
 Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -343,7 +343,7 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 				case LSP::SymbolKind::Function:
 					id = "class_method:" + symbol->native_class + ":" + symbol->name;
 					break;
-				default:
+				default: // Deprecated.
 					id = "class_global:" + symbol->native_class + ":" + symbol->name;
 					break;
 			}

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -38,6 +38,7 @@
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/editor_language.h"
 #include "core/object/script_language.h"
 #include "editor/doc/doc_tools.h"
 #include "editor/doc/editor_help.h"
@@ -667,17 +668,15 @@ const LSP::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const LSP::TextDocu
 				symbol = get_script_symbol(class_path);
 
 			} else {
-				ScriptLanguage::LookupResult ret;
+				EditorLanguage::LookupResult ret;
 				// TODO: `lookup_code` should already account for this. We might be able to simplify code here.
 				if (symbol_name == "new" && parser->get_lines()[p_doc_pos.position.line].remove_chars(" \t").contains("new(")) {
 					symbol_name = "_init";
 				}
-				if (OK == GDScriptLanguage::get_singleton()->lookup_code(parser->get_text_for_lookup_symbol(pos, symbol_name, p_func_required), symbol_name, path, nullptr, ret)) {
+				if (OK == GDScriptEditorLanguage::get_singleton()->lookup_code(parser->get_text_for_lookup_symbol(pos, symbol_name, p_func_required), symbol_name, path, nullptr, ret)) {
 					if (ret.location >= 0) {
 						String target_script_path = path;
-						if (ret.script.is_valid()) {
-							target_script_path = ret.script->get_path();
-						} else if (!ret.script_path.is_empty()) {
+						if (!ret.script_path.is_empty()) {
 							target_script_path = ret.script_path;
 						}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Part of https://github.com/godotengine/godot-proposals/issues/14566

## Additional information

Moves the `lookup_code` API and related structs to `EditorLanguage`. Compat is maintained through the adapter on `ScriptLanguageExtension`.

Also removes a `Script` member from `LookupResult` in favour of just using the path, to decouple the API further from the `Script` system.
