### PR TITLE
[Polygon2D] Add weight soft painting, spinbox strength selection and weight set mode.

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -326,6 +326,11 @@ void Polygon2DEditor::_select_mode(int p_mode) {
 	bone_scroll_main_vb->hide();
 	edit_uv_menu->hide();
 
+	bone_paint_strength_label->hide();
+	bone_paint_strength->hide();
+	bone_paint_radius_label->hide();
+	bone_paint_radius->hide();
+
 	switch (current_mode) {
 		case MODE_POINTS: {
 			action_buttons[ACTION_CREATE]->show();
@@ -363,6 +368,12 @@ void Polygon2DEditor::_select_mode(int p_mode) {
 			action_buttons[ACTION_CLEAR_WEIGHT]->show();
 			action_buttons[ACTION_SET_WEIGHT]->show();
 			_set_action(ACTION_PAINT_WEIGHT);
+
+			bone_paint_strength_label->show();
+			bone_paint_strength->show();
+			bone_paint_radius_label->show();
+			bone_paint_radius->show();
+			_select_paint_mode(PAINT_MODE_HARD);
 
 			bone_scroll_main_vb->show();
 			paint_toolbar->show();
@@ -1579,7 +1590,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	edit_uv_menu->get_popup()->add_item(TTR("Clear UV"), MENU_UV_CLEAR);
 	edit_uv_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Polygon2DEditor::_edit_menu_option));
 
-	Label *bone_paint_strength_label = memnew(Label(TTR("Strength:")));
+	bone_paint_strength_label = memnew(Label(TTR("Strength:")));
 	toolbar->add_child(bone_paint_strength_label);
 
 	bone_paint_strength = memnew(SpinBox);
@@ -1592,7 +1603,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	bone_paint_strength->set_accessibility_name(TTRC("Strength"));
 	bone_paint_strength->set_tooltip_text(TTR("By how much the brush changes the vertex weight."));
 
-	Label *bone_paint_radius_label = memnew(Label(TTR("Radius:")));
+	bone_paint_radius_label = memnew(Label(TTR("Radius:")));
 	toolbar->add_child(bone_paint_radius_label);
 
 	bone_paint_radius = memnew(SpinBox);

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -83,7 +83,9 @@ void Polygon2DEditor::_set_node(Node *p_polygon) {
 		_update_bone_list(node);
 		_update_available_modes();
 		if (current_mode == MODE_MAX) {
-			_select_mode(MODE_POINTS); // Initialize when opening the first time.
+			// Initialize when opening the first time.
+			_select_mode(MODE_POINTS);
+			_select_paint_mode(PAINT_MODE_HARD);
 		}
 		if (previous_node != node) {
 			_center_view_on_draw();
@@ -132,11 +134,9 @@ void Polygon2DEditor::_notification(int p_what) {
 			action_buttons[ACTION_SCALE]->set_button_icon(get_editor_theme_icon(SNAME("ToolScale")));
 			action_buttons[ACTION_ADD_POLYGON]->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			action_buttons[ACTION_REMOVE_POLYGON]->set_button_icon(get_editor_theme_icon(SNAME("Close")));
-			action_buttons[ACTION_PAINT_WEIGHT]->set_button_icon(get_editor_theme_icon(SNAME("Bucket")));
-			action_buttons[ACTION_CLEAR_WEIGHT]->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
-
-			b_snap_grid->set_button_icon(get_editor_theme_icon(SNAME("Grid")));
-			b_snap_enable->set_button_icon(get_editor_theme_icon(SNAME("SnapGrid")));
+			action_buttons[ACTION_PAINT_WEIGHT]->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			action_buttons[ACTION_CLEAR_WEIGHT]->set_button_icon(get_editor_theme_icon(SNAME("Close")));
+			action_buttons[ACTION_SET_WEIGHT]->set_button_icon(get_editor_theme_icon(SNAME("Paint")));
 
 			vscroll->set_anchors_and_offsets_preset(PRESET_RIGHT_WIDE);
 			hscroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
@@ -261,16 +261,71 @@ void Polygon2DEditor::_bone_paint_selected(int p_index) {
 	canvas->queue_redraw();
 }
 
+void Polygon2DEditor::_paint_bone_weight() {
+	Vector<float> painted_weights = node->get_bone_weights(bone_painting_bone);
+
+	int pc = painted_weights.size();
+	real_t amount = bone_paint_strength->get_value();
+	real_t radius = bone_paint_radius->get_value() * EDSCALE;
+
+	if (selected_action == ACTION_CLEAR_WEIGHT) {
+		amount = -amount;
+	}
+
+	float *w = painted_weights.ptrw();
+	const float *r = prev_weights.ptr();
+	const Vector2 *rv = editing_points.ptr();
+
+	Transform2D mtx;
+	mtx.columns[2] = -draw_offset * draw_zoom;
+	mtx.scale_basis(Vector2(draw_zoom, draw_zoom));
+
+	bool set = selected_action == ACTION_SET_WEIGHT;
+
+	if (current_paint_mode == PAINT_MODE_SOFT) {
+		real_t inner_radius = bone_paint_inner_radius->get_value() * EDSCALE;
+		float pinch = bone_paint_pinch->get_value();
+		float bubble = bone_paint_bubble->get_value();
+		bool track_min = selected_action == ACTION_CLEAR_WEIGHT;
+
+		float *extremes = bone_paint_stroke_extremes.ptrw();
+
+		for (int i = 0; i < pc; i++) {
+			Vector2 point_pos = mtx.xform(rv[i]);
+			float falloff = _get_soft_paint_easing(bone_paint_pos, point_pos, 1.0f, radius, inner_radius, pinch, bubble);
+			if (falloff <= 0.0f) {
+				continue;
+			}
+
+			float candidate = set ? Math::lerp(r[i], amount, falloff) : r[i] + amount * falloff;
+			candidate = CLAMP(candidate, 0.0f, 1.0f);
+
+			// Track the most extreme value reached at this vertex over the whole stroke,
+			// so passing through and back out doesn't erase the peak.
+			extremes[i] = track_min ? MIN(extremes[i], candidate) : MAX(extremes[i], candidate);
+			w[i] = extremes[i];
+		}
+	} else {
+		for (int i = 0; i < pc; i++) {
+			if (mtx.xform(rv[i]).distance_to(bone_paint_pos) < radius) {
+				w[i] = CLAMP(set ? amount : r[i] + amount, 0, 1);
+			}
+		}
+	}
+
+	node->set_bone_weights(bone_painting_bone, painted_weights);
+}
+
 void Polygon2DEditor::_select_mode(int p_mode) {
 	current_mode = Mode(p_mode);
 	mode_buttons[current_mode]->set_pressed(true);
 	for (int i = 0; i < ACTION_MAX; i++) {
 		action_buttons[i]->hide();
 	}
+	paint_toolbar->hide();
 	bone_scroll_main_vb->hide();
-	bone_paint_strength->hide();
-	bone_paint_radius->hide();
-	bone_paint_radius_label->hide();
+	edit_uv_menu->hide();
+
 	switch (current_mode) {
 		case MODE_POINTS: {
 			action_buttons[ACTION_CREATE]->show();
@@ -300,19 +355,45 @@ void Polygon2DEditor::_select_mode(int p_mode) {
 			action_buttons[ACTION_MOVE]->show();
 			action_buttons[ACTION_ROTATE]->show();
 			action_buttons[ACTION_SCALE]->show();
+			edit_uv_menu->show();
 			_set_action(ACTION_EDIT_POINT);
 		} break;
 		case MODE_BONES: {
 			action_buttons[ACTION_PAINT_WEIGHT]->show();
 			action_buttons[ACTION_CLEAR_WEIGHT]->show();
+			action_buttons[ACTION_SET_WEIGHT]->show();
 			_set_action(ACTION_PAINT_WEIGHT);
 
 			bone_scroll_main_vb->show();
-			bone_paint_strength->show();
-			bone_paint_radius->show();
-			bone_paint_radius_label->show();
+			paint_toolbar->show();
 			_update_bone_list(node);
 			bone_paint_pos = Vector2(-100000, -100000); // Send brush away when switching.
+		} break;
+		default:
+			break;
+	}
+	canvas->queue_redraw();
+}
+
+void Polygon2DEditor::_select_paint_mode(int p_mode) {
+	current_paint_mode = PaintMode(p_mode);
+	paint_mode_buttons[current_paint_mode]->set_pressed(true);
+
+	bone_paint_inner_radius_label->hide();
+	bone_paint_inner_radius->hide();
+	bone_paint_pinch_label->hide();
+	bone_paint_pinch->hide();
+	bone_paint_bubble_label->hide();
+	bone_paint_bubble->hide();
+
+	switch (current_paint_mode) {
+		case PAINT_MODE_SOFT: {
+			bone_paint_inner_radius_label->show();
+			bone_paint_inner_radius->show();
+			bone_paint_pinch_label->show();
+			bone_paint_pinch->show();
+			bone_paint_bubble_label->show();
+			bone_paint_bubble->show();
 		} break;
 		default:
 			break;
@@ -356,7 +437,25 @@ void Polygon2DEditor::_edit_menu_option(int p_option) {
 			undo_redo->add_undo_method(node, "set_uv", uvs);
 			undo_redo->commit_action();
 		} break;
-		case MENU_GRID_SETTINGS: {
+	}
+}
+
+void Polygon2DEditor::_grid_menu_option(int p_option) {
+	EditorSettings *settings = EditorSettings::get_singleton();
+	PopupMenu *menu = grid_menu->get_popup();
+	switch (p_option) {
+		case GRID_SHOW: {
+			snap_show_grid = !menu->is_item_checked(p_option);
+			menu->set_item_checked(p_option, snap_show_grid);
+			settings->set_project_metadata("polygon_2d_uv_editor", "show_grid", snap_show_grid);
+			canvas->queue_redraw();
+		} break;
+		case GRID_SNAP: {
+			use_snap = menu->is_item_checked(p_option);
+			menu->set_item_checked(p_option, use_snap);
+			settings->set_project_metadata("polygon_2d_uv_editor", "snap_enabled", use_snap);
+		} break;
+		case GRID_SETTINGS: {
 			grid_settings->popup_centered();
 		} break;
 	}
@@ -405,17 +504,6 @@ void Polygon2DEditor::_commit_action() {
 	undo_redo->add_do_method(CanvasItemEditor::get_singleton(), "update_viewport");
 	undo_redo->add_undo_method(CanvasItemEditor::get_singleton(), "update_viewport");
 	undo_redo->commit_action();
-}
-
-void Polygon2DEditor::_set_use_snap(bool p_use) {
-	use_snap = p_use;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_enabled", p_use);
-}
-
-void Polygon2DEditor::_set_show_grid(bool p_show) {
-	snap_show_grid = p_show;
-	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "show_grid", p_show);
-	canvas->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_off_x(real_t p_val) {
@@ -734,7 +822,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					}
 				}
 
-				if (current_action == ACTION_PAINT_WEIGHT || current_action == ACTION_CLEAR_WEIGHT) {
+				if (current_action == ACTION_PAINT_WEIGHT || current_action == ACTION_CLEAR_WEIGHT || current_action == ACTION_SET_WEIGHT) {
 					int bone_selected = -1;
 					for (int i = 0; i < bone_scroll_vb->get_child_count(); i++) {
 						CheckBox *c = Object::cast_to<CheckBox>(bone_scroll_vb->get_child(i));
@@ -748,6 +836,12 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 						prev_weights = node->get_bone_weights(bone_selected);
 						bone_painting = true;
 						bone_painting_bone = bone_selected;
+
+						bone_paint_stroke_extremes = prev_weights.duplicate();
+
+						bone_paint_pos = mb->get_position();
+						_paint_bone_weight();
+						canvas->queue_redraw();
 					}
 				}
 			} else {
@@ -918,7 +1012,8 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					}
 				} break;
 				case ACTION_PAINT_WEIGHT:
-				case ACTION_CLEAR_WEIGHT: {
+				case ACTION_CLEAR_WEIGHT:
+				case ACTION_SET_WEIGHT: {
 					bone_paint_pos = mm->get_position();
 				} break;
 				default: {
@@ -926,29 +1021,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 			}
 
 			if (bone_painting) {
-				Vector<float> painted_weights = node->get_bone_weights(bone_painting_bone);
-
-				{
-					int pc = painted_weights.size();
-					real_t amount = bone_paint_strength->get_value();
-					real_t radius = bone_paint_radius->get_value() * EDSCALE;
-
-					if (selected_action == ACTION_CLEAR_WEIGHT) {
-						amount = -amount;
-					}
-
-					float *w = painted_weights.ptrw();
-					const float *r = prev_weights.ptr();
-					const Vector2 *rv = editing_points.ptr();
-
-					for (int i = 0; i < pc; i++) {
-						if (mtx.xform(rv[i]).distance_to(bone_paint_pos) < radius) {
-							w[i] = CLAMP(r[i] + amount, 0, 1);
-						}
-					}
-				}
-
-				node->set_bone_weights(bone_painting_bone, painted_weights);
+				_paint_bone_weight();
 			}
 
 			canvas->queue_redraw();
@@ -956,7 +1029,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 		} else if (polygon_create.size()) {
 			create_to = mtx.affine_inverse().xform(mm->get_position());
 			canvas->queue_redraw();
-		} else if (selected_action == ACTION_PAINT_WEIGHT || selected_action == ACTION_CLEAR_WEIGHT) {
+		} else if (selected_action == ACTION_PAINT_WEIGHT || selected_action == ACTION_CLEAR_WEIGHT || selected_action == ACTION_SET_WEIGHT) {
 			bone_paint_pos = mm->get_position();
 			canvas->queue_redraw();
 		}
@@ -1062,6 +1135,33 @@ void Polygon2DEditor::_center_view_on_draw(bool p_enabled) {
 		// Ensure that the view is centered even if the canvas is redrawn multiple times in the frame.
 		get_tree()->connect("process_frame", callable_mp(this, &Polygon2DEditor::_center_view_on_draw).bind(false), CONNECT_ONE_SHOT);
 	}
+}
+
+real_t Polygon2DEditor::_get_soft_paint_easing(const Vector2 &p_brush_pos, const Vector2 &p_point_pos, real_t p_strength, real_t p_radius, real_t p_inner_radius, real_t p_pinch, real_t p_bubble) {
+	real_t dist = p_point_pos.distance_to(p_brush_pos);
+
+	if (dist <= p_inner_radius) {
+		return p_strength;
+	}
+
+	if (dist >= p_radius || p_radius <= p_inner_radius) {
+		return 0.0f;
+	}
+
+	const real_t t = (dist - p_inner_radius) / (p_radius - p_inner_radius);
+
+	// Simple smoothstep curve.
+	real_t weight = 1.0f - t * t * (3.0f - 2.0f * t);
+
+	// Pinch: Positive narrows/sharpens the peak. Negative flattens it.
+	real_t pinch_exponent = MAX(1.0f - p_pinch, 0.01f);
+	weight = Math::pow(weight, pinch_exponent);
+
+	// Bubble: additive bulge centered at t=0.5, zero at t=0 and t=1.
+	real_t bubble_curve = Math::sin(Math::PI * t);
+	weight += p_bubble * bubble_curve * weight;
+
+	return CLAMP(weight, 0.0f, 1.0f) * p_strength;
 }
 
 void Polygon2DEditor::_canvas_draw() {
@@ -1266,7 +1366,7 @@ void Polygon2DEditor::_canvas_draw() {
 		}
 	}
 
-	if (selected_action == ACTION_PAINT_WEIGHT || selected_action == ACTION_CLEAR_WEIGHT) {
+	if (selected_action == ACTION_PAINT_WEIGHT || selected_action == ACTION_CLEAR_WEIGHT || selected_action == ACTION_SET_WEIGHT) {
 		NodePath bone_path;
 		for (int i = 0; i < bone_scroll_vb->get_child_count(); i++) {
 			CheckBox *c = Object::cast_to<CheckBox>(bone_scroll_vb->get_child(i));
@@ -1320,7 +1420,34 @@ void Polygon2DEditor::_canvas_draw() {
 		}
 
 		//draw paint circle
-		canvas->draw_circle(bone_paint_pos, bone_paint_radius->get_value() * EDSCALE, Color(1, 1, 1, 0.1));
+		if (current_mode != MODE_BONES) {
+			canvas->draw_circle(bone_paint_pos, bone_paint_radius->get_value() * EDSCALE, Color(1, 1, 1, 0.1));
+		} else {
+			switch (current_paint_mode) {
+				case PAINT_MODE_SOFT: {
+					float radius = bone_paint_radius->get_value() * EDSCALE;
+					float inner_radius = bone_paint_inner_radius->get_value() * EDSCALE;
+					int circle_count = Math::ceil((radius - inner_radius) / (10 * EDSCALE)) * soft_painting_circle_count_per_10_rad;
+					float band_width = (radius - inner_radius) / circle_count;
+
+					// Using `draw_circle` causes visual artifacts due to point count mismatch.
+					canvas->draw_arc(bone_paint_pos, inner_radius / 2.0f, 0.0f, Math::TAU, soft_painting_circle_resolution, Color(1, 1, 1, 0.25), inner_radius, true);
+
+					for (int i = 0; i < circle_count; ++i) {
+						float dist_start = inner_radius + band_width * i;
+						float dist_mid = dist_start + band_width * 0.5f;
+						float weight = _get_soft_paint_easing(bone_paint_pos, bone_paint_pos + Vector2::RIGHT * dist_mid, 1.0f, radius, inner_radius, bone_paint_pinch->get_value(), bone_paint_bubble->get_value());
+
+						canvas->draw_arc(bone_paint_pos, dist_mid, 0.0f, Math::TAU, soft_painting_circle_resolution, Color(1, 1, 1, weight * 0.25), band_width, true);
+					}
+
+					canvas->draw_arc(bone_paint_pos, radius, 0.0f, Math::TAU, soft_painting_circle_resolution, Color(1, 0, 0, 0.1), band_width, true);
+				} break;
+				default: {
+					canvas->draw_circle(bone_paint_pos, bone_paint_radius->get_value() * EDSCALE, Color(1, 1, 1, 0.1));
+				} break;
+			}
+		}
 	}
 }
 
@@ -1402,6 +1529,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	action_buttons[ACTION_REMOVE_POLYGON]->set_tooltip_text(TTR("Remove a custom polygon. If none remain, custom polygon rendering is disabled."));
 	action_buttons[ACTION_PAINT_WEIGHT]->set_tooltip_text(TTR("Paint weights with specified intensity."));
 	action_buttons[ACTION_CLEAR_WEIGHT]->set_tooltip_text(TTR("Unpaint weights with specified intensity."));
+	action_buttons[ACTION_SET_WEIGHT]->set_tooltip_text(TTR("Set weights to specified intensity."));
 
 	action_buttons[ACTION_CREATE]->set_accessibility_name(TTRC("Create Polygon"));
 	action_buttons[ACTION_CREATE_INTERNAL]->set_accessibility_name(TTRC("Create Internal Vertex"));
@@ -1414,27 +1542,10 @@ Polygon2DEditor::Polygon2DEditor() {
 	action_buttons[ACTION_REMOVE_POLYGON]->set_accessibility_name(TTRC("Remove a custom polygon. If none remain, custom polygon rendering is disabled."));
 	action_buttons[ACTION_PAINT_WEIGHT]->set_accessibility_name(TTRC("Paint weights with specified intensity."));
 	action_buttons[ACTION_CLEAR_WEIGHT]->set_accessibility_name(TTRC("Unpaint weights with specified intensity."));
+	action_buttons[ACTION_SET_WEIGHT]->set_accessibility_name(TTRC("Set weights to specified intensity."));
 
-	bone_paint_strength = memnew(HSlider);
-	toolbar->add_child(bone_paint_strength);
-	bone_paint_strength->set_custom_minimum_size(Size2(75 * EDSCALE, 0));
-	bone_paint_strength->set_v_size_flags(SIZE_SHRINK_CENTER);
-	bone_paint_strength->set_min(0);
-	bone_paint_strength->set_max(1);
-	bone_paint_strength->set_step(0.01);
-	bone_paint_strength->set_value(0.5);
-	bone_paint_strength->set_accessibility_name(TTRC("Strength"));
-
-	bone_paint_radius_label = memnew(Label(TTR("Radius:")));
-	toolbar->add_child(bone_paint_radius_label);
-	bone_paint_radius = memnew(SpinBox);
-	toolbar->add_child(bone_paint_radius);
-
-	bone_paint_radius->set_min(1);
-	bone_paint_radius->set_max(100);
-	bone_paint_radius->set_step(1);
-	bone_paint_radius->set_value(32);
-	bone_paint_radius->set_accessibility_name(TTRC("Radius:"));
+	paint_toolbar = memnew(HBoxContainer);
+	edit_vbox->add_child(paint_toolbar);
 
 	HSplitContainer *uv_main_hsc = memnew(HSplitContainer);
 	edit_vbox->add_child(uv_main_hsc);
@@ -1457,40 +1568,108 @@ Polygon2DEditor::Polygon2DEditor() {
 	toolbar->add_child(space);
 	space->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	edit_menu = memnew(MenuButton);
-	toolbar->add_child(edit_menu);
-	edit_menu->set_flat(false);
-	edit_menu->set_theme_type_variation("FlatMenuButton");
-	edit_menu->set_text(TTR("Edit"));
-	edit_menu->get_popup()->add_item(TTR("Copy Polygon to UV"), MENU_POLYGON_TO_UV);
-	edit_menu->get_popup()->add_item(TTR("Copy UV to Polygon"), MENU_UV_TO_POLYGON);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_item(TTR("Clear UV"), MENU_UV_CLEAR);
-	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_item(TTR("Grid Settings"), MENU_GRID_SETTINGS);
-	edit_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Polygon2DEditor::_edit_menu_option));
+	edit_uv_menu = memnew(MenuButton);
+	toolbar->add_child(edit_uv_menu);
+	edit_uv_menu->set_flat(false);
+	edit_uv_menu->set_theme_type_variation("FlatMenuButton");
+	edit_uv_menu->set_text(TTR("Edit"));
+	edit_uv_menu->get_popup()->add_item(TTR("Copy Polygon to UV"), MENU_POLYGON_TO_UV);
+	edit_uv_menu->get_popup()->add_item(TTR("Copy UV to Polygon"), MENU_UV_TO_POLYGON);
+	edit_uv_menu->get_popup()->add_separator();
+	edit_uv_menu->get_popup()->add_item(TTR("Clear UV"), MENU_UV_CLEAR);
+	edit_uv_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Polygon2DEditor::_edit_menu_option));
+
+	Label *bone_paint_strength_label = memnew(Label(TTR("Strength:")));
+	toolbar->add_child(bone_paint_strength_label);
+
+	bone_paint_strength = memnew(SpinBox);
+	toolbar->add_child(bone_paint_strength);
+	bone_paint_strength->set_v_size_flags(SIZE_SHRINK_CENTER);
+	bone_paint_strength->set_min(0);
+	bone_paint_strength->set_max(1);
+	bone_paint_strength->set_step(0.01);
+	bone_paint_strength->set_value(0.5);
+	bone_paint_strength->set_accessibility_name(TTRC("Strength"));
+	bone_paint_strength->set_tooltip_text(TTR("By how much the brush changes the vertex weight."));
+
+	Label *bone_paint_radius_label = memnew(Label(TTR("Radius:")));
+	toolbar->add_child(bone_paint_radius_label);
+
+	bone_paint_radius = memnew(SpinBox);
+	toolbar->add_child(bone_paint_radius);
+	bone_paint_radius->set_min(1);
+	bone_paint_radius->set_max(100);
+	bone_paint_radius->set_step(1);
+	bone_paint_radius->set_value(32);
+	bone_paint_radius->set_accessibility_name(TTRC("Radius:"));
+	bone_paint_radius->set_tooltip_text(TTR("The size of the weight painting brush."));
 
 	toolbar->add_child(memnew(VSeparator));
 
-	b_snap_enable = memnew(Button);
-	b_snap_enable->set_theme_type_variation(SceneStringName(FlatButton));
-	toolbar->add_child(b_snap_enable);
-	b_snap_enable->set_text(TTR("Snap"));
-	b_snap_enable->set_focus_mode(FOCUS_ACCESSIBILITY);
-	b_snap_enable->set_toggle_mode(true);
-	b_snap_enable->set_pressed(use_snap);
-	b_snap_enable->set_tooltip_text(TTR("Enable Snap"));
-	b_snap_enable->connect(SceneStringName(toggled), callable_mp(this, &Polygon2DEditor::_set_use_snap));
+	grid_menu = memnew(MenuButton);
+	toolbar->add_child(grid_menu);
+	grid_menu->set_flat(false);
+	grid_menu->set_theme_type_variation("FlatMenuButton");
+	grid_menu->set_text(TTR("Grid"));
+	grid_menu->get_popup()->add_check_item(TTR("Show Grid"), GRID_SHOW);
+	grid_menu->get_popup()->add_check_item(TTR("Enable Snap"), GRID_SNAP);
+	grid_menu->get_popup()->add_item(TTR("Grid Settings"), GRID_SETTINGS);
+	grid_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Polygon2DEditor::_grid_menu_option));
 
-	b_snap_grid = memnew(Button);
-	b_snap_grid->set_theme_type_variation(SceneStringName(FlatButton));
-	toolbar->add_child(b_snap_grid);
-	b_snap_grid->set_text(TTR("Grid"));
-	b_snap_grid->set_focus_mode(FOCUS_ACCESSIBILITY);
-	b_snap_grid->set_toggle_mode(true);
-	b_snap_grid->set_pressed(snap_show_grid);
-	b_snap_grid->set_tooltip_text(TTR("Show Grid"));
-	b_snap_grid->connect(SceneStringName(toggled), callable_mp(this, &Polygon2DEditor::_set_show_grid));
+	for (int i = 0; i < PAINT_MODE_MAX; i++) {
+		paint_mode_buttons[i] = memnew(Button);
+		paint_toolbar->add_child(paint_mode_buttons[i]);
+		paint_mode_buttons[i]->set_toggle_mode(true);
+		paint_mode_buttons[i]->set_button_group(mode_button_group);
+		paint_mode_buttons[i]->connect(SceneStringName(pressed), callable_mp(this, &Polygon2DEditor::_select_paint_mode).bind(i));
+	}
+
+	paint_mode_buttons[PAINT_MODE_HARD]->set_text(TTR("Hard"));
+	paint_mode_buttons[PAINT_MODE_SOFT]->set_text(TTR("Soft"));
+
+	paint_mode_buttons[PAINT_MODE_HARD]->set_tooltip_text(TTR("All vertices inside the brush are painted equally."));
+	paint_mode_buttons[PAINT_MODE_SOFT]->set_tooltip_text(TTR("Vertices inside the brush are painted based on the distance from the brush's center."));
+
+	paint_mode_buttons[PAINT_MODE_HARD]->set_accessibility_name(TTRC("Hard Brush"));
+	paint_mode_buttons[PAINT_MODE_SOFT]->set_accessibility_name(TTRC("Soft Brush"));
+
+	paint_toolbar->add_child(memnew(VSeparator));
+
+	bone_paint_inner_radius_label = memnew(Label(TTR("Inner Rad.:")));
+	paint_toolbar->add_child(bone_paint_inner_radius_label);
+
+	bone_paint_inner_radius = memnew(SpinBox);
+	paint_toolbar->add_child(bone_paint_inner_radius);
+	bone_paint_inner_radius->set_min(0);
+	bone_paint_inner_radius->set_max(100);
+	bone_paint_inner_radius->set_step(1);
+	bone_paint_inner_radius->set_value(0);
+	bone_paint_inner_radius->set_accessibility_name(TTRC("Inner Rad.:"));
+	bone_paint_inner_radius->set_tooltip_text(TTR("The size of the inner portion of the soft weight painting brush where vertices are painted at max strength."));
+
+	bone_paint_pinch_label = memnew(Label(TTR("Pinch:")));
+	paint_toolbar->add_child(bone_paint_pinch_label);
+
+	bone_paint_pinch = memnew(SpinBox);
+	paint_toolbar->add_child(bone_paint_pinch);
+	bone_paint_pinch->set_min(-1);
+	bone_paint_pinch->set_max(1);
+	bone_paint_pinch->set_step(0.01);
+	bone_paint_pinch->set_value(0);
+	bone_paint_pinch->set_accessibility_name(TTRC("Pinch:"));
+	bone_paint_pinch->set_tooltip_text(TTR("Modifies the curve near the center / inner radius. Positive, narrows the curve. Negative, flattens the curve."));
+
+	bone_paint_bubble_label = memnew(Label(TTR("Bubble:")));
+	paint_toolbar->add_child(bone_paint_bubble_label);
+
+	bone_paint_bubble = memnew(SpinBox);
+	paint_toolbar->add_child(bone_paint_bubble);
+	bone_paint_bubble->set_min(-1);
+	bone_paint_bubble->set_max(1);
+	bone_paint_bubble->set_step(0.01);
+	bone_paint_bubble->set_value(0);
+	bone_paint_bubble->set_accessibility_name(TTRC("Bubble:"));
+	bone_paint_bubble->set_tooltip_text(TTR("Additive bulge halfway in the brush's radius. Doesn't affect brush borders. Positive inflates the curve, negative deflates the curve."));
 
 	grid_settings = memnew(AcceptDialog);
 	grid_settings->set_title(TTR("Configure Grid:"));

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -52,7 +52,6 @@
 #include "scene/gui/panel.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
-#include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/view_panner.h"

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -290,25 +290,38 @@ void Polygon2DEditor::_paint_bone_weight() {
 		float *extremes = bone_paint_stroke_extremes.ptrw();
 
 		for (int i = 0; i < pc; i++) {
+			if (mtx.xform(rv[i]).distance_to(bone_paint_pos) >= radius) {
+				continue;
+			}
+
 			Vector2 point_pos = mtx.xform(rv[i]);
 			float falloff = _get_soft_paint_easing(bone_paint_pos, point_pos, 1.0f, radius, inner_radius, pinch, bubble);
+
+			if (set) {
+				// Soft Set ignores the previous weight and sets it to a new value between
+				// 0 and 'amount', but tracks the highest value it ever reached.
+				extremes[i] = MAX(extremes[i], falloff);
+				w[i] = CLAMP(Math::lerp(0, (float)amount, extremes[i]), 0.0f, 1.0f);
+				continue;
+			}
+
 			if (falloff <= 0.0f) {
 				continue;
 			}
 
-			float candidate = set ? Math::lerp(r[i], (float)amount, falloff) : r[i] + amount * falloff;
-			candidate = CLAMP(candidate, 0.0f, 1.0f);
-
 			// Track the most extreme value reached at this vertex over the whole stroke,
 			// so passing through and back out doesn't erase the peak.
+			float candidate = CLAMP(set ? Math::lerp(r[i], (float)amount, falloff) : r[i] + amount * falloff, 0.0f, 1.0f);
 			extremes[i] = track_min ? MIN(extremes[i], candidate) : MAX(extremes[i], candidate);
 			w[i] = extremes[i];
 		}
 	} else {
 		for (int i = 0; i < pc; i++) {
-			if (mtx.xform(rv[i]).distance_to(bone_paint_pos) < radius) {
-				w[i] = CLAMP(set ? amount : r[i] + amount, 0, 1);
+			if (mtx.xform(rv[i]).distance_to(bone_paint_pos) >= radius) {
+				continue;
 			}
+
+			w[i] = CLAMP(set ? amount : r[i] + amount, 0, 1);
 		}
 	}
 
@@ -847,7 +860,12 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 						bone_painting = true;
 						bone_painting_bone = bone_selected;
 
-						bone_paint_stroke_extremes = prev_weights.duplicate();
+						if (current_paint_mode == PAINT_MODE_SOFT && current_action == ACTION_SET_WEIGHT) {
+							bone_paint_stroke_extremes.resize(prev_weights.size());
+							bone_paint_stroke_extremes.fill(0.0f);
+						} else {
+							bone_paint_stroke_extremes = prev_weights.duplicate();
+						}
 
 						bone_paint_pos = mb->get_position();
 						_paint_bone_weight();

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -296,7 +296,7 @@ void Polygon2DEditor::_paint_bone_weight() {
 				continue;
 			}
 
-			float candidate = set ? Math::lerp(r[i], amount, falloff) : r[i] + amount * falloff;
+			float candidate = set ? Math::lerp(r[i], (float)amount, falloff) : r[i] + amount * falloff;
 			candidate = CLAMP(candidate, 0.0f, 1.0f);
 
 			// Track the most extreme value reached at this vertex over the whole stroke,

--- a/editor/scene/2d/polygon_2d_editor_plugin.h
+++ b/editor/scene/2d/polygon_2d_editor_plugin.h
@@ -55,7 +55,12 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 		MENU_POLYGON_TO_UV,
 		MENU_UV_TO_POLYGON,
 		MENU_UV_CLEAR,
-		MENU_GRID_SETTINGS,
+	};
+
+	enum {
+		GRID_SHOW,
+		GRID_SNAP,
+		GRID_SETTINGS,
 	};
 
 	enum Mode {
@@ -63,7 +68,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 		MODE_POLYGONS,
 		MODE_UV,
 		MODE_BONES,
-		MODE_MAX
+		MODE_MAX,
 	};
 
 	enum Action {
@@ -78,8 +83,18 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 		ACTION_REMOVE_POLYGON,
 		ACTION_PAINT_WEIGHT,
 		ACTION_CLEAR_WEIGHT,
-		ACTION_MAX
+		ACTION_SET_WEIGHT,
+		ACTION_MAX,
 	};
+
+	enum PaintMode {
+		PAINT_MODE_HARD,
+		PAINT_MODE_SOFT,
+		PAINT_MODE_MAX,
+	};
+
+	static constexpr int soft_painting_circle_count_per_10_rad = 3;
+	static constexpr int soft_painting_circle_resolution = 32;
 
 	Polygon2D *node = nullptr;
 	Polygon2D *previous_node = nullptr;
@@ -89,9 +104,8 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Button *mode_buttons[MODE_MAX];
 	Action selected_action = ACTION_CREATE;
 	Button *action_buttons[ACTION_MAX];
-	Button *b_snap_enable = nullptr;
-	Button *b_snap_grid = nullptr;
-	MenuButton *edit_menu = nullptr;
+	MenuButton *edit_uv_menu = nullptr;
+	MenuButton *grid_menu = nullptr;
 
 	Control *canvas = nullptr;
 	Panel *canvas_background = nullptr;
@@ -111,14 +125,24 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	ScrollContainer *bone_scroll = nullptr;
 	VBoxContainer *bone_scroll_vb = nullptr;
 	Button *sync_bones = nullptr;
-	HSlider *bone_paint_strength = nullptr;
-	SpinBox *bone_paint_radius = nullptr;
-	Label *bone_paint_radius_label = nullptr;
 	bool bone_painting = false;
 	int bone_painting_bone = 0;
 	Vector<float> prev_weights;
+	Vector<float> bone_paint_stroke_extremes;
 	Vector2 bone_paint_pos;
 	AcceptDialog *grid_settings = nullptr;
+
+	HBoxContainer *paint_toolbar = nullptr;
+	Button *paint_mode_buttons[PAINT_MODE_MAX];
+	PaintMode current_paint_mode = PAINT_MODE_MAX; // Uninitialized.
+	SpinBox *bone_paint_strength = nullptr;
+	SpinBox *bone_paint_radius = nullptr;
+	Label *bone_paint_inner_radius_label = nullptr;
+	SpinBox *bone_paint_inner_radius = nullptr;
+	Label *bone_paint_pinch_label = nullptr;
+	SpinBox *bone_paint_pinch = nullptr;
+	Label *bone_paint_bubble_label = nullptr;
+	SpinBox *bone_paint_bubble = nullptr;
 
 	void _sync_bones();
 	void _update_bone_list(const Polygon2D *p_for_node);
@@ -148,10 +172,13 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Vector2 snap_step;
 
 	void _edit_menu_option(int p_option);
+	void _grid_menu_option(int p_option);
 
 	void _cancel_editing();
 	void _update_polygon_editing_state();
 	void _update_available_modes();
+
+	real_t _get_soft_paint_easing(const Vector2 &p_brush_pos, const Vector2 &p_point_pos, real_t p_strength, real_t p_radius, real_t p_inner_radius, real_t p_pinch, real_t p_bubble);
 
 	void _center_view();
 	void _update_zoom_and_pan(bool p_zoom_at_center);
@@ -168,7 +195,9 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	void _set_snap_step_y(real_t p_val);
 
 	void _select_mode(int p_mode);
+	void _select_paint_mode(int p_mode);
 	void _bone_paint_selected(int p_index);
+	void _paint_bone_weight();
 
 	int _get_polygon_count() const override;
 

--- a/editor/scene/2d/polygon_2d_editor_plugin.h
+++ b/editor/scene/2d/polygon_2d_editor_plugin.h
@@ -135,7 +135,9 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	HBoxContainer *paint_toolbar = nullptr;
 	Button *paint_mode_buttons[PAINT_MODE_MAX];
 	PaintMode current_paint_mode = PAINT_MODE_MAX; // Uninitialized.
+	Label *bone_paint_strength_label = nullptr;
 	SpinBox *bone_paint_strength = nullptr;
+	Label *bone_paint_radius_label = nullptr;
 	SpinBox *bone_paint_radius = nullptr;
 	Label *bone_paint_inner_radius_label = nullptr;
 	SpinBox *bone_paint_inner_radius = nullptr;


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/15061

This is my first PR so if I missed something, please let me know!

This PR adds new features to the Polygon2D Polygon edit panel based on 
commonly found features in other weight-painting software.

- Swapped the strength slider for a spinbox, allowing for more granular control.
- Added the ability to set vertices to a specific weight instead of only relying on 
adding and subtracting.
- Changed the icons for adding and subtracting weights to a 'plus' and 'minus' 
as the old 'paint bucket' and 'brush' didn't visually explain the features. If there 
was a way to get an 'equal' icon added for the weight-setting, it'd be nice, but 
without it, I've used a 'brush' icon.

Before:
<img width="600" height="448" alt="add-sub-old" src="https://github.com/user-attachments/assets/32bdaeeb-0c1c-4e07-8dde-3314d30b4e15" />

After:
<img width="600" height="452" alt="add-remove-set" src="https://github.com/user-attachments/assets/c79086ae-2cf3-487e-97ac-efa5a5fe2e16" />

---

- Moved 'Grid', 'Snap' and 'Grid Settings' to a new 'Grid' submenu.
- Since the 'Edit' submenu only contains 'UV'-related options, I moved it to the 
'UV' selection mode.

Before:
<img width="600" height="448" alt="submenu-old" src="https://github.com/user-attachments/assets/7c241b95-725c-4ff7-9fc6-ca0ba0d1da0d" />

After:
<img width="600" height="400" alt="submenus" src="https://github.com/user-attachments/assets/f6a82e64-172e-49b3-b257-49d1bddc8d78" />

---

- While for polygon/vertex mode, not acknowledging clicking without moving is 
normal behavior, for paint mode, it is expected that rapidly clicking causes painting 
even if the mouse isn't moving. That issue is now fixed.

Before:
<img width="600" height="448" alt="no-move-paint-old" src="https://github.com/user-attachments/assets/3dc6d802-8140-464f-a3b4-28a44769c2bd" />

After:
<img width="600" height="448" alt="no-move-paint" src="https://github.com/user-attachments/assets/288a980a-e7b7-4c45-b4d3-7f817ca65bd3" />

---

- Added soft weight painting, using 3DS Max's soft selection algorithm as inspiration.
- Includes 'Inner Radius' (if inside, set to max strength), 'Pinch' (narrows/extends peak) 
and 'Bubble' (flat addition to middle).
- Cursor reflects modification to variables, visualizing brush curve.
- Slight changes to painting behavior only in soft painting. Vertices in soft paint remembers 
the highest/lowest value they were at during a single brush stroke. This means that a 
vertex starting outside the brush, then being painted over, will not revert to 0 if it leaves 
the brush during the stroke.

<img width="600" height="448" alt="soft-paint" src="https://github.com/user-attachments/assets/847e49c9-f212-4fbb-ab45-922c31afaae3" />
