### PR TITLE
Autocompletion: Respect negated type narrowing

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2446,13 +2446,23 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 			}
 		}
 
-		if (suite->parent_if && suite->parent_if->condition && suite->parent_if->condition->type == GDScriptParser::Node::TYPE_TEST) {
+		if (suite->parent_if && suite->parent_if->condition) {
 			// Operator `is` used, check if identifier is in there! this helps resolve in blocks that are (if (identifier is value)): which are very common..
 			// Super dirty hack, but very useful.
 			// Credit: Zylann.
 			// TODO: this could be hacked to detect AND-ed conditions too...
-			const GDScriptParser::TypeTestNode *type_test = static_cast<const GDScriptParser::TypeTestNode *>(suite->parent_if->condition);
-			if (type_test->operand && type_test->test_type && type_test->operand->type == GDScriptParser::Node::IDENTIFIER && static_cast<const GDScriptParser::IdentifierNode *>(type_test->operand)->name == p_identifier->name && static_cast<const GDScriptParser::IdentifierNode *>(type_test->operand)->source == p_identifier->source) {
+
+			const GDScriptParser::TypeTestNode *type_test = nullptr;
+			if (suite->parent_if->true_block == suite && suite->parent_if->condition->type == GDScriptParser::Node::TYPE_TEST) {
+				type_test = static_cast<const GDScriptParser::TypeTestNode *>(suite->parent_if->condition);
+			} else if (suite->parent_if->false_block == suite && suite->parent_if->condition->type == GDScriptParser::Node::UNARY_OPERATOR) {
+				GDScriptParser::UnaryOpNode *op = static_cast<GDScriptParser::UnaryOpNode *>(suite->parent_if->condition);
+				if (op->operation == GDScriptParser::UnaryOpNode::OP_LOGIC_NOT && op->operand->type == GDScriptParser::Node::TYPE_TEST) {
+					type_test = static_cast<const GDScriptParser::TypeTestNode *>(op->operand);
+				}
+			}
+
+			if (type_test && type_test->operand && type_test->test_type && type_test->operand->type == GDScriptParser::Node::IDENTIFIER && static_cast<const GDScriptParser::IdentifierNode *>(type_test->operand)->name == p_identifier->name && static_cast<const GDScriptParser::IdentifierNode *>(type_test->operand)->source == p_identifier->source) {
 				// Bingo.
 				GDScriptParser::CompletionContext c = p_context;
 				c.current_line = type_test->operand->start_line;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2394,6 +2394,7 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 	} else if (match(GDScriptTokenizer::Token::ELSE)) {
 		consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "else".)");
 		n_if->false_block = parse_suite(R"("else" block)");
+		n_if->false_block->parent_if = n_if;
 	}
 	complete_extents(n_if);
 

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/negated_else.cfg
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/negated_else.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    { "display": "position" },
+    { "display": "device" },
+]

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/negated_else.gd
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/negated_else.gd
@@ -1,0 +1,5 @@
+func test(ev: InputEvent):
+	if ev is not InputEventMouse:
+		pass
+	else:
+		ev.➡

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/negated_if.cfg
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/negated_if.cfg
@@ -1,0 +1,7 @@
+[output]
+include=[
+    { "display": "device" },
+]
+exclude=[
+    { "display": "position" },
+]

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/negated_if.gd
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/negated_if.gd
@@ -1,0 +1,3 @@
+func test(ev: InputEvent):
+	if ev is not InputEventMouse:
+		ev.➡

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/normal_else.cfg
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/normal_else.cfg
@@ -1,0 +1,7 @@
+[output]
+include=[
+    { "display": "device" },
+]
+exclude=[
+    { "display": "position" },
+]

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/normal_else.gd
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/normal_else.gd
@@ -1,0 +1,5 @@
+func test(ev: InputEvent):
+	if ev is InputEventMouse:
+		pass
+	else:
+		ev.➡

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/normal_if.cfg
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/normal_if.cfg
@@ -1,0 +1,5 @@
+[output]
+include=[
+    { "display": "position" },
+    { "display": "device" },
+]

--- a/modules/gdscript/tests/scripts/completion/type_narrowing/normal_if.gd
+++ b/modules/gdscript/tests/scripts/completion/type_narrowing/normal_if.gd
@@ -1,0 +1,3 @@
+func test(ev: InputEvent):
+	if ev is InputEventMouse:
+		ev.➡


### PR DESCRIPTION
Autocompletion at the moment is able to detect type narrowing under this condition:

```gdscript
if e is A:
    e. # suggest props of A
```

This PR extends this feature to also account for negated conditions:

```gdscript
if e is not A:
    pass
else:
    e. # suggest props of A
```

What this is **not**:
- smartcasting in the analyzer -> inference does still not work, the code is marked as unsafe as well
