### PR TITLE
Add translation helper lines when moving objects in the 3D viewport

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -447,6 +447,9 @@
 		<member name="editors/3d/manipulator_gizmo_size" type="int" setter="" getter="">
 			Size of the default gizmo for moving, rotating, and scaling 3D nodes.
 		</member>
+		<member name="editors/3d/manipulator_show_translation_preview" type="bool" setter="" getter="">
+			If [code]true[/code], displays a preview line from the original to the current position while translating objects in the 3D viewport.
+		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
 			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.
 			When 3-button mouse emulation mode is enabled, the pan, zoom and orbit modifiers can always be used in the 3D editor viewport, even when not holding down any mouse button.

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -1550,6 +1550,7 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 			} else {
 				//handle plane translate
 				_edit.mode = TRANSFORM_TRANSLATE;
+				_save_drag_start_positions();
 				_compute_edit(p_screenpos);
 				_edit.plane = TransformPlane(TRANSFORM_X_AXIS + col_axis + (is_plane_translate ? 3 : 0));
 			}
@@ -3082,6 +3083,22 @@ void Node3DEditorViewport::_freelook_speed_scaled() {
 	surface->queue_redraw();
 }
 
+void Node3DEditorViewport::_save_drag_start_positions() {
+	_drag_start_positions.clear();
+
+	if (!bool(EDITOR_GET("editors/3d/manipulator_show_translation_preview"))) {
+		return;
+	}
+
+	TypedArray<Node> selected_nodes = editor_selection->get_selected_nodes();
+	for (int i = 0; i < selected_nodes.size(); i++) {
+		Node3D *node = Object::cast_to<Node3D>(selected_nodes[i]);
+		if (node) {
+			_drag_start_positions[node->get_instance_id()] = node->get_global_position();
+		}
+	}
+}
+
 bool Node3DEditorViewport::_is_nav_modifier_pressed(const String &p_name) {
 	return _is_shortcut_empty(p_name) || Input::get_singleton()->is_action_pressed(p_name);
 }
@@ -4083,6 +4100,61 @@ void Node3DEditorViewport::_draw() {
 			float alpha = occluded ? occluded_alpha : 1.0f;
 			surface->draw_circle(screen_pos, circle_radius + outline_width, Color(0, 0, 0, 0.6 * alpha), true, -1.0, true);
 			surface->draw_circle(screen_pos, circle_radius, Color(0, 1, 0, alpha), true, -1.0, true);
+		}
+	}
+
+	if (_edit.mode == TRANSFORM_TRANSLATE && !_drag_start_positions.is_empty()) {
+		Color line_color = Color(1.0, 1.0, 1.0, 0.8);
+
+		for (const KeyValue<ObjectID, Vector3> &E : _drag_start_positions) {
+			Object *obj = ObjectDB::get_instance(E.key);
+			Node3D *node = Object::cast_to<Node3D>(obj);
+
+			if (!node) {
+				continue;
+			}
+
+			Vector3 start_pos = E.value;
+			Vector3 current_pos = node->get_global_position();
+
+			if (start_pos.is_equal_approx(current_pos) ||
+					camera->is_position_behind(start_pos) ||
+					camera->is_position_behind(current_pos)) {
+				continue;
+			}
+
+			Color current_line_color = line_color;
+			Vector3 delta = (current_pos - start_pos).abs();
+
+			bool locked_x = (delta.y <= CMP_EPSILON && delta.z <= CMP_EPSILON);
+			bool locked_y = (delta.x <= CMP_EPSILON && delta.z <= CMP_EPSILON);
+			bool locked_z = (delta.x <= CMP_EPSILON && delta.y <= CMP_EPSILON);
+
+			if (locked_x) {
+				current_line_color = get_theme_color(SNAME("axis_x_color"), SNAME("Editor"));
+			} else if (locked_y) {
+				current_line_color = get_theme_color(SNAME("axis_y_color"), SNAME("Editor"));
+			} else if (locked_z) {
+				current_line_color = get_theme_color(SNAME("axis_z_color"), SNAME("Editor"));
+			}
+
+			Vector2 screen_pos_start = camera->unproject_position(start_pos);
+			Vector2 screen_pos_current = camera->unproject_position(current_pos);
+
+			RenderingServer::get_singleton()->canvas_item_add_line(
+					ci,
+					screen_pos_start,
+					screen_pos_current,
+					current_line_color,
+					4.0 * EDSCALE,
+					true);
+
+			RenderingServer::get_singleton()->canvas_item_add_circle(
+					ci,
+					screen_pos_start,
+					5 * EDSCALE,
+					current_line_color,
+					true);
 		}
 	}
 
@@ -6121,6 +6193,10 @@ void Node3DEditorViewport::begin_transform(TransformMode p_mode, bool instant) {
 		_edit.children_original_globals.clear();
 
 		_edit.mode = p_mode;
+		if (p_mode == TRANSFORM_TRANSLATE) {
+			_save_drag_start_positions();
+		}
+
 		_compute_edit(_edit.mouse_pos);
 		_edit.instant = instant;
 		_edit.initial_click_vector = Vector3();
@@ -6617,6 +6693,7 @@ void Node3DEditorViewport::finish_transform() {
 	_edit.rotation_angle = 0.0;
 	_edit.gizmo_initiated = false;
 	_edit.children_original_globals.clear();
+	_drag_start_positions.clear();
 	spatial_editor->set_local_coords_enabled(_edit.original_local);
 	spatial_editor->update_transform_gizmo();
 	surface->queue_redraw();

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -435,6 +435,9 @@ private:
 	void _freelook_changed();
 	void _freelook_speed_scaled();
 
+	HashMap<ObjectID, Vector3> _drag_start_positions;
+	void _save_drag_start_positions();
+
 	real_t zoom_indicator_delay;
 	int zoom_failed_attempts_count = 0;
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -995,6 +995,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d/freelook/freelook_speed_zoom_link", false);
 
 	// 3D: Manipulator
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "editors/3d/manipulator_show_translation_preview", true, "");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_size", 80, "16,160,1");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_FLAGS, "editors/3d/show_gizmo_during_rotation", 2, "Global,Local");


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Closes proposal https://github.com/godotengine/godot-proposals/issues/14876


https://github.com/user-attachments/assets/ebbc0807-235b-4c31-99d4-f49a20bb8d67



## Additional information
This PR implements a visual QoL feature for the 3D editor viewport. When translating objects, a preview line is drawn from the object's original starting position to its current position. This helps users visualize movement distance and direction.

**Key features:**
* Draws a 2D line via RenderingServer from the unprojected start to the current 3D position.
* Automatically switches to the respective axis color (red, green, blue) when movement is locked to a specific axis.
* Multi-selection handling.
* Frustum culling to prevent unprojection problems when objects are moved behind the camera.
* Added a new toggle in Editor Settings (`editors/3d/manipulator/show_translation_preview`) to enable/disable the feature (enabled by default).

## Use of AI
AI was used to develop this logic to determine whether a translation can be considered locked to an axis:

```
bool locked_x = (delta.y <= CMP_EPSILON && delta.z <= CMP_EPSILON);
bool locked_y = (delta.x <= CMP_EPSILON && delta.z <= CMP_EPSILON);
bool locked_z = (delta.x <= CMP_EPSILON && delta.y <= CMP_EPSILON);
```