### PR TITLE
GraphEdit: Fix dragged connection preview thicker than settled connections

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -3212,7 +3212,11 @@ GraphEdit::GraphEdit() {
 
 	dragged_connection_line = memnew(Line2D);
 	dragged_connection_line->set_texture_mode(Line2D::LINE_TEXTURE_STRETCH);
-	dragged_connection_line->set_use_parent_material(true);
+	// NOT use_parent_material: the drag draw assigns its own per-line ShaderMaterial
+	// (see _update_top_connection_layer) whose `line_width` param matches the line's
+	// geometric width, so the rim/AA shader softens the edges exactly like an
+	// established connection. Inheriting the parent material left the param
+	// mismatched, rendering the drag preview visibly thicker than the settled wire.
 	top_connection_layer->add_child(dragged_connection_line);
 
 	h_scrollbar = memnew(HScrollBar);


### PR DESCRIPTION
The dragged connection line is created with `use_parent_material(true)`, so it ignores the per-line `ShaderMaterial` that `_update_top_connection_layer()` assigns it and renders against the parent material instead. The connection shader's rim/AA is then sized for the wrong width, so the drag preview draws visibly thicker than established connections.

Established connection lines are created at runtime in `connect_node()` and keep their own material — only the constructor-built `dragged_connection_line` was swept into the recent change making internal children use their parent's material. Dropping `use_parent_material` on it restores its own correctly-configured material, matching connections.

Before/After screenshots to follow.
