### PR TITLE
Fix issues in some `Container` types related to maximum size

### DIFF
--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -72,7 +72,7 @@ void FlowContainer::_resort() {
 			continue;
 		}
 
-		Size2i child_msc = child->get_combined_minimum_size();
+		Size2i child_msc = child->get_bound_minimum_size();
 		Size2i child_max_size = child->get_combined_maximum_size();
 
 		if (vertical) { /* VERTICAL */

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -184,7 +184,7 @@ void GraphNode::_resort() {
 			continue;
 		}
 
-		Size2i size = child->get_combined_minimum_size() + (slot_table[i].draw_stylebox ? sb_slot->get_minimum_size() : Size2());
+		Size2i size = child->get_bound_minimum_size() + (slot_table[i].draw_stylebox ? sb_slot->get_minimum_size() : Size2());
 		Size2 max_size = child->get_combined_maximum_size();
 
 		stretch_min += size.height;
@@ -192,9 +192,6 @@ void GraphNode::_resort() {
 		_MinSizeCache msc;
 		msc.min_size = size.height;
 		msc.max_size = max_size.height >= 0 ? int(max_size.height) + (slot_table[i].draw_stylebox ? sb_slot->get_minimum_size().height : 0) : -1;
-		if (msc.max_size >= 0 && msc.max_size < msc.min_size) {
-			msc.min_size = msc.max_size;
-		}
 		msc.will_stretch = child->get_v_size_flags().has_flag(SIZE_EXPAND);
 		msc.final_size = msc.min_size;
 		min_size_cache[child] = msc;
@@ -296,7 +293,9 @@ void GraphNode::_resort() {
 		int height = to_y_pos - from_y_pos;
 		float margin = sb_panel->get_margin(SIDE_LEFT) + (slot_table[i].draw_stylebox ? sb_slot->get_margin(SIDE_LEFT) : 0);
 		float final_width = width - (slot_table[i].draw_stylebox ? sb_slot->get_minimum_size().x : 0);
-		Rect2 rect(margin, from_y_pos, final_width, height);
+		float final_height = height - (slot_table[i].draw_stylebox ? sb_slot->get_minimum_size().y : 0);
+		float final_y_pos = from_y_pos + (slot_table[i].draw_stylebox ? sb_slot->get_margin(SIDE_TOP) : 0);
+		Rect2 rect(margin, final_y_pos, final_width, final_height);
 		fit_child_in_rect(child, rect);
 
 		slot_y_cache.push_back(child->get_rect().position.y + child->get_rect().size.height * 0.5);
@@ -711,6 +710,8 @@ void GraphNode::_notification(int p_what) {
 							Rect2 child_rect = child->get_rect();
 							child_rect.position.x = sb_panel->get_margin(SIDE_LEFT);
 							child_rect.size.width = width;
+							child_rect.position.y -= sb_slot->get_margin(SIDE_TOP);
+							child_rect.size.height += sb_slot->get_margin(SIDE_TOP) + sb_slot->get_margin(SIDE_BOTTOM);
 							draw_style_box(sb_slot, child_rect);
 						}
 					}

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -63,7 +63,7 @@ void GridContainer::_resort() {
 		if (is_propagating_maximum_size()) {
 			c->set_parent_maximum_size_cache(combined_max_size);
 		}
-		Size2i ms = c->get_combined_minimum_size();
+		Size2i ms = c->get_bound_minimum_size();
 		Size2 max_size = c->get_combined_maximum_size();
 		if (col_minw.has(col)) {
 			col_minw[col] = MAX(col_minw[col], ms.width);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120498
- Closes #120499 

| Scenario | Before (4.7.stable) | After (with PR) |
| -- | -- | -- |
| `GraphNode` with "slot" `StyleBox` | <img width="288" height="170" alt="Image" src="https://github.com/user-attachments/assets/ae3c9c4c-6221-4446-87f6-2cbf295ef11c" /> | <img width="292" height="174" alt="image" src="https://github.com/user-attachments/assets/fd988044-e5b8-44c4-895d-661d36ee5ff7" /> |
| `GraphNode` with "slot" `StyleBox` and a child with max size < min size | <img width="121" height="324" alt="Image" src="https://github.com/user-attachments/assets/486aefe2-ecbe-4dc6-bdeb-22604753e3f8" /> | <img width="130" height="322" alt="image" src="https://github.com/user-attachments/assets/000d0c34-9aa8-42d3-87cd-d84be770098b" /> |
| FlowContainer` with a child with max size < min size | <img width="214" height="139" alt="Image" src="https://github.com/user-attachments/assets/4ac82189-a9fe-43ac-b4e8-0c32195303b4" /> | <img width="233" height="131" alt="image" src="https://github.com/user-attachments/assets/d2047d52-9e58-4c78-83ea-598a4db0f336" /> |
| `GridContainer` with a child with max height < min height (top left) & one with max width < min width (top center) | <img width="229" height="215" alt="Image" src="https://github.com/user-attachments/assets/bdbcaf1f-e366-4da9-a3c5-84c7cc595cfd" /> | <img width="178" height="144" alt="image" src="https://github.com/user-attachments/assets/05f968cd-fb11-4f7a-94cf-dcc0e859cdd5" /> |

## Additional information

I left the two commits separate since they fix different things, but imho both belong in the same PR, as we need both to fix the "`GraphNode` with "slot" `StyleBox` and a child with max size < min size" scenario. 
Let me know if I should squash since they're fairly small. Or, let me know if I need to split the PRs, in case one but not the other gets flagged for cherry-picking to 4.7.1.
