### PR TITLE
Add editor setting to change how scene previews are drawn in inspector

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1193,6 +1193,11 @@
 		<member name="interface/inspector/resources_to_open_in_new_inspector" type="PackedStringArray" setter="" getter="">
 			List of resources that should always be opened in a new inspector view, even if [member interface/inspector/open_resources_in_current_inspector] is [code]true[/code].
 		</member>
+		<member name="interface/inspector/scene_preview_mode" type="int" setter="" getter="">
+			Controls how scene previews are drawn in resource pickers.
+			- [b]Thumbnail:[/b] Only a thumbnail of the scene is shown.
+			- [b]Name:[/b] Only the name of the scene resource is shown.
+		</member>
 		<member name="interface/inspector/show_low_level_opentype_features" type="bool" setter="" getter="">
 			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
 		</member>

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -117,7 +117,10 @@ void EditorResourcePicker::_update_resource() {
 			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name);
 
 			// Preview will override the above, so called at the end.
-			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, callable_mp(this, &EditorResourcePicker::_update_resource_preview).bind(edited_resource->get_instance_id()));
+			const ScenePreviewMode preview_mode = (ScenePreviewMode)EDITOR_GET("interface/inspector/scene_preview_mode").operator int();
+			if (Ref<PackedScene>(edited_resource).is_null() || preview_mode == ScenePreviewMode::MODE_THUMBNAIL) {
+				EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, callable_mp(this, &EditorResourcePicker::_update_resource_preview).bind(edited_resource->get_instance_id()));
+			}
 		}
 	} else if (edited_resource.is_valid()) {
 		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -44,6 +44,13 @@ class TreeItem;
 class EditorResourcePicker : public HBoxContainer {
 	GDCLASS(EditorResourcePicker, HBoxContainer);
 
+public:
+	enum ScenePreviewMode {
+		MODE_THUMBNAIL,
+		MODE_NAME,
+	};
+
+private:
 	String base_type;
 	Ref<Resource> edited_resource;
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -51,6 +51,7 @@
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/inspector/editor_property_name_processor.h"
+#include "editor/inspector/editor_resource_picker.h"
 #include "editor/project_manager/engine_update_label.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "editor/translations/editor_translation.h"
@@ -603,6 +604,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_mode", (int32_t)ColorPicker::MODE_RGB, "RGB,HSV,RAW,OKHSL")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle") // `SHAPE_NONE` is 4.
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/color_picker_show_intensity", true, "");
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/scene_preview_mode", (int32_t)EditorResourcePicker::MODE_THUMBNAIL, "Thumbnail,Name")
 
 	// Theme
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_ENUM, "interface/theme/follow_system_theme", false, "")


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4757

## What problem(s) does this PR solve?

Scene thumbnails in the inspector can take up a lot of space and are often not useful currently due to how they're generated. Even when the thumbnails are improved by https://github.com/godotengine/godot/pull/112060, some scenes don't have a visual element that would be captured in a thumbnail (game logic components, complex audio setups, temporary vfx), and so it's useful to have the option to show a scene's name instead of a thumbnail. 

## Additional information

This PR uses an enum for the setting rather than a toggle to keep the door open for other options, like [this comment](https://github.com/godotengine/godot-proposals/issues/4757#issuecomment-1730170705) from the proposal suggesting the thumbnail *and* name could be drawn together.

---

Thumbnail mode (current/default behavior):
<img width="400" alt="thumbnail_mode" src="https://github.com/user-attachments/assets/eb7d2a17-89a3-466c-a67a-2c020f036d4f" />

Name mode:
<img width="400" alt="name_mode" src="https://github.com/user-attachments/assets/1bfdca17-b762-423c-9eb6-4962d6ed8a5b" />

