### PR TITLE
[DRAFT] Add non-allocating versions of `PhysicsDirectSpaceState[2D|3D]` query methods

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -69,10 +69,19 @@
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
 				[code]position[/code]: The intersection point.
 				[code]face_index[/code]: The face index at the intersection point.
-				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[b]Note:[/b] This value is only valid if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
+			</description>
+		</method>
+		<method name="intersect_ray_no_alloc">
+			<return type="bool" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
+			<param index="1" name="result" type="PhysicsRayQueryResult3D" />
+			<description>
+				Intersects a ray in a given space. Ray position and other parameters are defined through [PhysicsRayQueryParameters3D]. If an intersection occurs, this method returns true and writes the intersection information into the [PhysicsRayQueryResult3D] object passed in [code skip-lint]result[/code].
+				If the ray did not intersect anything, false is returned instead.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsRayQueryResult3D.xml
+++ b/doc/classes/PhysicsRayQueryResult3D.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsRayQueryResult3D" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Stores the result of a ray intersection query.
+	</brief_description>
+	<description>
+		This object contains the intersection information produced by [method PhysicsDirectSpaceState3D.intersect_ray_no_alloc].
+		After calling [method PhysicsDirectSpaceState3D.intersect_ray_no_alloc], the fields of this object will be populated with the hit information if the ray intersects a shape. If no intersection occurred, the values remain unchanged from the previous state.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="collider" type="Object" setter="set_collider" getter="get_collider">
+			The colliding object.
+		</member>
+		<member name="collider_id" type="int" setter="set_collider_id" getter="get_collider_id" default="0">
+			The colliding object's ID.
+		</member>
+		<member name="face_index" type="int" setter="set_face_index" getter="get_face_index" default="-1">
+			The face index at the intersection point.
+			[b]Note:[/b] This value is only valid if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+		</member>
+		<member name="normal" type="Vector3" setter="set_normal" getter="get_normal" default="Vector3(0, 0, 0)">
+			The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
+		</member>
+		<member name="position" type="Vector3" setter="set_position" getter="get_position" default="Vector3(0, 0, 0)">
+			The intersection point.
+		</member>
+		<member name="rid" type="RID" setter="set_rid" getter="get_rid" default="RID()">
+			The intersecting object's [RID].
+		</member>
+		<member name="shape" type="int" setter="set_shape" getter="get_shape" default="0">
+			The shape index of the colliding shape.
+		</member>
+	</members>
+</class>

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -238,6 +238,39 @@ void PhysicsRayQueryParameters3D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
+void PhysicsRayQueryResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &PhysicsRayQueryResult3D::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsRayQueryResult3D::get_position);
+
+	ClassDB::bind_method(D_METHOD("set_normal", "normal"), &PhysicsRayQueryResult3D::set_normal);
+	ClassDB::bind_method(D_METHOD("get_normal"), &PhysicsRayQueryResult3D::get_normal);
+
+	ClassDB::bind_method(D_METHOD("set_rid", "rid"), &PhysicsRayQueryResult3D::set_rid);
+	ClassDB::bind_method(D_METHOD("get_rid"), &PhysicsRayQueryResult3D::get_rid);
+
+	ClassDB::bind_method(D_METHOD("set_collider_id", "collider_id"), &PhysicsRayQueryResult3D::set_collider_id);
+	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsRayQueryResult3D::get_collider_id);
+
+	ClassDB::bind_method(D_METHOD("set_collider", "collider"), &PhysicsRayQueryResult3D::set_collider);
+	ClassDB::bind_method(D_METHOD("get_collider"), &PhysicsRayQueryResult3D::get_collider);
+
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsRayQueryResult3D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsRayQueryResult3D::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_face_index", "face_index"), &PhysicsRayQueryResult3D::set_face_index);
+	ClassDB::bind_method(D_METHOD("get_face_index"), &PhysicsRayQueryResult3D::get_face_index);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "normal"), "set_normal", "get_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "rid"), "set_rid", "get_rid");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_id"), "set_collider_id", "get_collider_id");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider"), "set_collider", "get_collider");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shape"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "face_index"), "set_face_index", "get_face_index");
+}
+
+///////////////////////////////////////////////////////
+
 Ref<PhysicsRayQueryParameters3D> PhysicsRayQueryParameters3D::create(Vector3 p_from, Vector3 p_to, uint32_t p_mask, const TypedArray<RID> &p_exclude) {
 	Ref<PhysicsRayQueryParameters3D> params;
 	params.instantiate();
@@ -383,6 +416,13 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	return d;
 }
 
+bool PhysicsDirectSpaceState3D::_intersect_ray_no_alloc(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, RequiredParam<PhysicsRayQueryResult3D> rp_ray_result) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, false);
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_result, rp_ray_result, false);
+
+	return intersect_ray(p_ray_query->get_parameters(), *p_ray_result->get_result_ptr());
+}
+
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results) {
 	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
 
@@ -488,6 +528,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
+	ClassDB::bind_method(D_METHOD("intersect_ray_no_alloc", "parameters", "result"), &PhysicsDirectSpaceState3D::_intersect_ray_no_alloc);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -119,6 +119,7 @@ public:
 };
 
 class PhysicsRayQueryParameters3D;
+class PhysicsRayQueryResult3D;
 class PhysicsPointQueryParameters3D;
 class PhysicsShapeQueryParameters3D;
 
@@ -127,6 +128,7 @@ class PhysicsDirectSpaceState3D : public Object {
 
 private:
 	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query);
+	bool _intersect_ray_no_alloc(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, RequiredParam<PhysicsRayQueryResult3D> rp_ray_result);
 	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
@@ -867,6 +869,39 @@ public:
 
 	void set_exclude(const TypedArray<RID> &p_exclude);
 	TypedArray<RID> get_exclude() const;
+};
+
+class PhysicsRayQueryResult3D : public RefCounted {
+	GDCLASS(PhysicsRayQueryResult3D, RefCounted);
+
+	PhysicsDirectSpaceState3D::RayResult result;
+
+protected:
+	static void _bind_methods();
+
+public:
+	PhysicsDirectSpaceState3D::RayResult *get_result_ptr() { return &result; }
+
+	void set_position(const Vector3 &p_position) { result.position = p_position; }
+	const Vector3 &get_position() const { return result.position; }
+
+	void set_normal(const Vector3 &p_normal) { result.normal = p_normal; }
+	const Vector3 &get_normal() const { return result.normal; }
+
+	void set_rid(const RID &p_rid) { result.rid = p_rid; }
+	RID get_rid() const { return result.rid; }
+
+	void set_collider_id(ObjectID p_collider_id) { result.collider_id = p_collider_id; }
+	ObjectID get_collider_id() const { return result.collider_id; }
+
+	void set_collider(Object *p_collider) { result.collider = p_collider; }
+	Object *get_collider() const { return result.collider; }
+
+	void set_shape(int p_shape) { result.shape = p_shape; }
+	int get_shape() const { return result.shape; }
+
+	void set_face_index(int p_face_index) { result.face_index = p_face_index; }
+	int get_face_index() const { return result.face_index; }
 };
 
 class PhysicsPointQueryParameters3D : public RefCounted {

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -346,6 +346,7 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count");
 
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
+	GDREGISTER_CLASS(PhysicsRayQueryResult3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsTestMotionParameters3D);


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

*While looking for related PRs I noticed some recent ones that attempted to do something very similar, but they were entirely AI generated, so I feel the need to say that I do not and will never submit AI generated code for review.*

## What problem(s) does this PR solve?

- Slow raycasts due to dictionary creation overhead in all languages
- Related #112433 #113970 

## Additional information

This PR adds a non-allocating version of intersect_ray to `PhysicsDirectSpaceState3D` by registering a new RefCounted type: `PhysicsRayQueryResult3D`, and adding `PhysicsDirectSpaceState3D.intersect_ray_no_alloc(params: PhysicsRayQueryParameters3D, result: PhysicsRayQueryResult3D)`. This gives an alternate raycasting path with very good performance on all supported languages, without requiring waiting for native structs or custom variants to come to GDScript.

This PR is very similar in spirit to #113970 (and the same motivation applies) except it adds the non-allocating version alongside the existing implementation to avoid breaking changes. 

~I've run some [preliminary benchmarks](https://github.com/godotengine/godot/pull/112433#issuecomment-4759798217)  on the non-allocating version using a raycasting rope simulation in a custom 4.5.1 build with the same changes~ More accurate isolated benchmarks below.

## TODO:

- [x] Add `get_result_ptr()` to result type, avoid calling setters manually in `_intersect_ray_no_alloc`
- [x] Add documentation with doctools
- [x] Add tests
- [x] Microbenchmarks
- [ ] Add equivalent API for the rest of PhysicsDirectSpaceState3D/2D (shape casts, get_rest_info, etc.)
- [ ] Refactor once naming is agreed on
