### PR TITLE
Proper Wayland support/detection

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -856,6 +856,25 @@ bool EditorNode::_is_project_data_missing() {
 	return false;
 }
 
+#ifdef WAYLAND_ENABLED
+static ObjectID xwayland_btn_id;
+
+static void _xwayland_timer_tick() {
+	Button *btn = ObjectDB::get_instance<Button>(xwayland_btn_id);
+	if (!btn) {
+		return;
+	}
+	int remaining = (int)btn->get_meta(SNAME("xwayland_timeout")) - 1;
+	btn->set_meta(SNAME("xwayland_timeout"), remaining);
+	if (remaining <= 0) {
+		btn->set_text(TTR("I know what I am doing"));
+		btn->set_disabled(false);
+	} else {
+		btn->set_text(vformat(TTR("I know what I am doing (%ds)"), remaining));
+	}
+}
+#endif
+
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -1043,6 +1062,37 @@ void EditorNode::_notification(int p_what) {
 			if (Engine::get_singleton()->is_recovery_mode_hint()) {
 				EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Editor functionality has been restricted."), EditorToaster::SEVERITY_WARNING);
 			}
+
+#ifdef WAYLAND_ENABLED
+			if (DisplayServer::get_singleton()->get_name() == "X11" && OS::get_singleton()->has_environment("WAYLAND_DISPLAY")) {
+				if (!EditorSettings::get_singleton()->has_setting("interface/editor/xwayland_warning_dismissed") || !(bool)EditorSettings::get_singleton()->get_setting("interface/editor/xwayland_warning_dismissed")) {
+					AcceptDialog *xwayland_dlg = memnew(AcceptDialog);
+					xwayland_dlg->set_title(TTR("Xwayland Detected"));
+					xwayland_dlg->set_text(TTR("You are running Godot under XWayland. You really shouldn't do this.\n\nLaunch Godot with the native Wayland display server instead.\n\nSeriously."));
+					xwayland_dlg->set_autowrap(true);
+					xwayland_dlg->set_min_size(Vector2i(500, 0));
+					xwayland_dlg->set_unparent_when_invisible(true);
+
+					xwayland_dlg->set_ok_button_text(TTR("Close Godot"));
+					xwayland_dlg->connect(SceneStringName(confirmed), callable_mp(get_tree(), &SceneTree::quit).bind(0), CONNECT_DEFERRED);
+
+					Button *reckless_btn = xwayland_dlg->add_button(TTR("I know what I am doing (10s)"), false, "reckless");
+					reckless_btn->set_meta(SNAME("xwayland_timeout"), 10);
+					reckless_btn->set_disabled(true);
+					reckless_btn->connect(SceneStringName(pressed), callable_mp(EditorSettings::get_singleton(), &EditorSettings::set_setting).bind("interface/editor/xwayland_warning_dismissed", true));
+					reckless_btn->connect(SceneStringName(pressed), callable_mp((Window *)xwayland_dlg, &Window::hide));
+
+					xwayland_btn_id = reckless_btn->get_instance_id();
+
+					for (int i = 1; i <= 10; i++) {
+						get_tree()->create_timer(i, false)->connect(SNAME("timeout"), callable_mp_static(&_xwayland_timer_tick));
+					}
+
+					add_child(xwayland_dlg);
+					xwayland_dlg->popup_centered();
+				}
+			}
+#endif
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -86,6 +86,25 @@ constexpr int GODOT4_CONFIG_VERSION = 5;
 
 ProjectManager *ProjectManager::singleton = nullptr;
 
+#ifdef WAYLAND_ENABLED
+static ObjectID xwayland_btn_id;
+
+static void _xwayland_timer_tick() {
+	Button *btn = ObjectDB::get_instance<Button>(xwayland_btn_id);
+	if (!btn) {
+		return;
+	}
+	int remaining = (int)btn->get_meta(SNAME("xwayland_timeout")) - 1;
+	btn->set_meta(SNAME("xwayland_timeout"), remaining);
+	if (remaining <= 0) {
+		btn->set_text(TTR("I know what I am doing"));
+		btn->set_disabled(false);
+	} else {
+		btn->set_text(vformat(TTR("I know what I am doing (%ds)"), remaining));
+	}
+}
+#endif
+
 // Notifications.
 
 void ProjectManager::_notification(int p_what) {
@@ -112,6 +131,37 @@ void ProjectManager::_notification(int p_what) {
 			_select_main_view(MAIN_VIEW_PROJECTS);
 			_update_list_placeholder();
 			_titlebar_resized();
+
+#ifdef WAYLAND_ENABLED
+			if (DisplayServer::get_singleton()->get_name() == "X11" && OS::get_singleton()->has_environment("WAYLAND_DISPLAY")) {
+				if (!EditorSettings::get_singleton()->has_setting("interface/editor/xwayland_warning_dismissed") || !(bool)EditorSettings::get_singleton()->get_setting("interface/editor/xwayland_warning_dismissed")) {
+					AcceptDialog *xwayland_dlg = memnew(AcceptDialog);
+					xwayland_dlg->set_title(TTR("Xwayland Detected"));
+					xwayland_dlg->set_text(TTR("You are running Godot under XWayland. You really shouldn't do this.\n\nLaunch Godot with the native Wayland display server instead.\n\nSeriously."));
+					xwayland_dlg->set_autowrap(true);
+					xwayland_dlg->set_min_size(Vector2i(500, 0));
+					xwayland_dlg->set_unparent_when_invisible(true);
+
+					xwayland_dlg->set_ok_button_text(TTR("Close Godot"));
+					xwayland_dlg->connect(SceneStringName(confirmed), callable_mp(get_tree(), &SceneTree::quit).bind(0), CONNECT_DEFERRED);
+
+					Button *reckless_btn = xwayland_dlg->add_button(TTR("I know what I am doing (10s)"), false, "reckless");
+					reckless_btn->set_meta(SNAME("xwayland_timeout"), 10);
+					reckless_btn->set_disabled(true);
+					reckless_btn->connect(SceneStringName(pressed), callable_mp(EditorSettings::get_singleton(), &EditorSettings::set_setting).bind("interface/editor/xwayland_warning_dismissed", true));
+					reckless_btn->connect(SceneStringName(pressed), callable_mp((Window *)xwayland_dlg, &Window::hide));
+
+					xwayland_btn_id = reckless_btn->get_instance_id();
+
+					for (int i = 1; i <= 10; i++) {
+						get_tree()->create_timer(i, false)->connect(SNAME("timeout"), callable_mp_static(&_xwayland_timer_tick));
+					}
+
+					add_child(xwayland_dlg);
+					xwayland_dlg->popup_centered();
+				}
+			}
+#endif
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1181,8 +1181,6 @@ void GameView::_notification(int p_what) {
 				embed_size_mode = (EmbedSizeMode)(int)EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_size_mode", SIZE_MODE_FIXED);
 				_update_embed_menu_options();
 
-				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
-				EditorRunBar::get_singleton()->connect("stop_pressed", callable_mp(this, &GameView::_stop_pressed));
 				EditorRun::instance_starting_callback = _instance_starting_static;
 				EditorRun::instance_rq_screenshot_callback = _instance_rq_screenshot_static;
 
@@ -1193,6 +1191,9 @@ void GameView::_notification(int p_what) {
 				// Embedding not available.
 				embedding_hb->hide();
 			}
+
+			EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
+			EditorRunBar::get_singleton()->connect("stop_pressed", callable_mp(this, &GameView::_stop_pressed));
 
 			_update_ui();
 		} break;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -509,6 +509,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/use_embedded_menu", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/use_native_file_dialogs", false, "", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
+	if (DisplayServer::get_singleton()->get_name() == "Wayland") {
+		props["interface/editor/appearance/expand_to_title"].hide_from_editor = true;
+	}
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/appearance/max_sticky_tree_items", 6, "0,16")
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/fonts/main_font_size", 14, "8,48,1")
@@ -1111,6 +1114,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #endif
 	int default_game_embed_mode = OS::get_singleton()->has_feature("xr_editor") ? -1 : 0;
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/game_embed_mode", default_game_embed_mode, game_embed_mode_hints);
+	if (DisplayServer::get_singleton()->get_name() == "Wayland") {
+		props["run/window_placement/game_embed_mode"].hide_from_editor = true;
+	}
 
 	// Auto save
 	_initial_set("run/auto_save/save_before_running", true, true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -115,6 +115,11 @@
 #include "tests/test_main.h"
 #endif
 
+#ifdef WAYLAND_ENABLED
+#include <dlfcn.h>
+#include <wayland-client.h>
+#endif
+
 #ifdef TOOLS_ENABLED
 #include "editor/debugger/debug_adapter/debug_adapter_server.h"
 #include "editor/debugger/editor_debugger_node.h"
@@ -208,6 +213,34 @@ static int text_driver_idx = -1;
 static int audio_driver_idx = -1;
 
 // Engine config/tools
+
+#ifdef WAYLAND_ENABLED
+static bool _is_wayland_available() {
+	void *lib = dlopen("libwayland-client.so.0", RTLD_LAZY | RTLD_LOCAL);
+	if (!lib) {
+		lib = dlopen("libwayland-client.so", RTLD_LAZY | RTLD_LOCAL);
+		if (!lib) {
+			return false;
+		}
+	}
+	using ConnectFunc = wl_display *(*)(const char *);
+	using DisconnectFunc = void (*)(wl_display *);
+	ConnectFunc wl_display_connect_fn = (ConnectFunc)dlsym(lib, "wl_display_connect");
+	DisconnectFunc wl_display_disconnect_fn = (DisconnectFunc)dlsym(lib, "wl_display_disconnect");
+	if (!wl_display_connect_fn || !wl_display_disconnect_fn) {
+		dlclose(lib);
+		return false;
+	}
+	wl_display *d = wl_display_connect_fn(nullptr);
+	if (d) {
+		wl_display_disconnect_fn(d);
+		dlclose(lib);
+		return true;
+	}
+	dlclose(lib);
+	return false;
+}
+#endif
 
 static AccessibilityServerEnums::AccessibilityMode accessibility_mode = AccessibilityServerEnums::AccessibilityMode::ACCESSIBILITY_AUTO;
 static String accessibility_driver_name;
@@ -3139,7 +3172,13 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 					if (display_driver.is_empty()) {
 						if (prefer_wayland) {
+#ifdef WAYLAND_ENABLED
+							if (_is_wayland_available()) {
+								display_driver = "wayland";
+							}
+#else
 							display_driver = "wayland";
+#endif
 						} else {
 							display_driver = "default";
 						}
@@ -3243,6 +3282,14 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 		if (display_driver.is_empty()) {
 			display_driver = GLOBAL_GET("display/display_server/driver");
+		}
+
+		if (display_driver.is_empty() || display_driver == "default") {
+#ifdef WAYLAND_ENABLED
+			if (_is_wayland_available()) {
+				display_driver = "wayland";
+			}
+#endif
 		}
 
 		int display_driver_idx = -1;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -302,7 +302,6 @@ bool DisplayServerWayland::has_feature(DisplayServerEnums::Feature p_feature) co
 		case DisplayServerEnums::FEATURE_WINDOW_DRAG:
 		case DisplayServerEnums::FEATURE_CLIPBOARD_PRIMARY:
 		case DisplayServerEnums::FEATURE_SUBWINDOWS:
-		case DisplayServerEnums::FEATURE_WINDOW_EMBEDDING:
 		case DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS:
 		case DisplayServerEnums::FEATURE_HDR_OUTPUT: {
 			return true;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -289,7 +289,6 @@ bool DisplayServerWayland::has_feature(DisplayServerEnums::Feature p_feature) co
 #endif
 		case DisplayServerEnums::FEATURE_TOUCHSCREEN:
 		case DisplayServerEnums::FEATURE_MOUSE:
-		case DisplayServerEnums::FEATURE_MOUSE_WARP:
 		case DisplayServerEnums::FEATURE_CLIPBOARD:
 		case DisplayServerEnums::FEATURE_CURSOR_SHAPE:
 		case DisplayServerEnums::FEATURE_CUSTOM_CURSOR_SHAPE:
@@ -305,6 +304,11 @@ bool DisplayServerWayland::has_feature(DisplayServerEnums::Feature p_feature) co
 		case DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS:
 		case DisplayServerEnums::FEATURE_HDR_OUTPUT: {
 			return true;
+		} break;
+		// This is a dead code (Nothing checks it)
+		// But I prefer to keep functionality so just added proper check
+		case DisplayServerEnums::FEATURE_MOUSE_WARP: {
+			return wayland_thread.is_pointer_warp_supported();
 		} break;
 
 		//case DisplayServerEnums::FEATURE_NATIVE_DIALOG:

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -2502,6 +2502,8 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 
 	show_window(DisplayServerEnums::MAIN_WINDOW_ID);
 
+	process_events();
+
 	if (!windows.has(DisplayServerEnums::MAIN_WINDOW_ID) || !windows[DisplayServerEnums::MAIN_WINDOW_ID].visible) {
 		ERR_PRINT("Could not map the main window.");
 		r_error = ERR_CANT_CREATE;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -5417,6 +5417,10 @@ void WaylandThread::pointer_set_hint(const Point2i &p_hint) {
 	}
 }
 
+bool WaylandThread::is_pointer_warp_supported() const {
+	return registry.wp_pointer_warp != nullptr;
+}
+
 void WaylandThread::pointer_warp(const Point2i &p_to) {
 	// NOTE: This is for compositors that don't support the pointer-warp protocol.
 	// It's hacked together and not guaranteed to work.

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1321,6 +1321,7 @@ public:
 	void pointer_set_constraint(PointerConstraint p_constraint);
 	void pointer_set_hint(const Point2i &p_hint);
 	void pointer_warp(const Point2i &p_to);
+	bool is_pointer_warp_supported() const;
 	PointerConstraint pointer_get_constraint() const;
 	DisplayServerEnums::WindowID pointer_get_pointed_window_id() const;
 	DisplayServerEnums::WindowID pointer_get_last_pointed_window_id() const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Launching a game on Linux Wayland is almost impossible in non-tab mode now because of someone who enabled window embedding on Wayland, editor almost fully freezes after launch.

## Additional information

After some weir actions I figured out that when you launch in separate window editor starts to freeze because treats Godot's window and game window as one (this works perfectly on DMs with embedding support). Cause of this is auto using XWayland on launch, this causes Godot to think this is X11 env, making whole `platform/linuxbsd/wayland/display_server_wayland.cpp` dead/useless code.

#### So this PR adds

- Runtime Wayland detection (dlopen/dlsym)
- Hide unsupported settings (expand_to_title and game_embed_mode)
- Signal connection fix (play_pressed/stop_pressed)
- XWayland warning

Fixes #119243 
Fixes #102580 