### PR TITLE
`UDPServer/TCPServer.listen()`: change `port` parameter from `uint16_t` to `int64_t`

### DIFF
--- a/core/io/tcp_server.compat.inc
+++ b/core/io/tcp_server.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tcp_server.h                                                          */
+/*  tcp_server.compat.inc                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,25 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
-#include "core/io/ip_address.h"
-#include "core/io/socket_server.h"
-#include "core/io/stream_peer_tcp.h"
-
-class TCPServer : public SocketServer {
-	GDCLASS(TCPServer, SocketServer);
-
-protected:
-	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
-	Error _listen_bind_compat_120522(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
-	static void _bind_compatibility_methods();
-#endif // DISABLE_DEPRECATED
 
-public:
-	Error listen(int64_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
-	int get_local_port() const;
-	Ref<StreamPeerTCP> take_connection();
-	Ref<StreamPeerSocket> take_socket_connection() override { return take_connection(); }
-};
+#include "core/object/class_db.h"
+
+Error TCPServer::_listen_bind_compat_120522(uint16_t p_port, const IPAddress &p_bind_address) {
+	return listen(p_port, p_bind_address);
+}
+
+void TCPServer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("listen", "port", "bind_address"), &TCPServer::_listen_bind_compat_120522, DEFVAL("*"));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/tcp_server.cpp
+++ b/core/io/tcp_server.cpp
@@ -38,9 +38,10 @@ void TCPServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("take_connection"), &TCPServer::take_connection);
 }
 
-Error TCPServer::listen(uint16_t p_port, const IPAddress &p_bind_address) {
+Error TCPServer::listen(int64_t p_port, const IPAddress &p_bind_address) {
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
+	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't listen on port %d. The port number must be between 0 and 65535 (inclusive).", p_port));
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
 
 	Error err;

--- a/core/io/tcp_server.cpp
+++ b/core/io/tcp_server.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "tcp_server.h"
+#include "tcp_server.compat.inc"
 
 #include "core/object/class_db.h"
 

--- a/core/io/tcp_server.h
+++ b/core/io/tcp_server.h
@@ -41,7 +41,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error listen(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
+	Error listen(int64_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
 	int get_local_port() const;
 	Ref<StreamPeerTCP> take_connection();
 	Ref<StreamPeerSocket> take_socket_connection() override { return take_connection(); }

--- a/core/io/udp_server.compat.inc
+++ b/core/io/udp_server.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tcp_server.h                                                          */
+/*  udp_server.compat.inc                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,25 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
-#include "core/io/ip_address.h"
-#include "core/io/socket_server.h"
-#include "core/io/stream_peer_tcp.h"
-
-class TCPServer : public SocketServer {
-	GDCLASS(TCPServer, SocketServer);
-
-protected:
-	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
-	Error _listen_bind_compat_120522(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
-	static void _bind_compatibility_methods();
-#endif // DISABLE_DEPRECATED
 
-public:
-	Error listen(int64_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
-	int get_local_port() const;
-	Ref<StreamPeerTCP> take_connection();
-	Ref<StreamPeerSocket> take_socket_connection() override { return take_connection(); }
-};
+#include "core/object/class_db.h"
+
+Error UDPServer::_listen_bind_compat_120522(uint16_t p_port, const IPAddress &p_bind_address) {
+	return listen(p_port, p_bind_address);
+}
+
+void UDPServer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("listen", "port", "bind_address"), &UDPServer::_listen_bind_compat_120522, DEFVAL("*"));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -99,9 +99,10 @@ Error UDPServer::poll() {
 	return OK;
 }
 
-Error UDPServer::listen(uint16_t p_port, const IPAddress &p_bind_address) {
+Error UDPServer::listen(int64_t p_port, const IPAddress &p_bind_address) {
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
+	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't listen on port %d. The port number must be between 0 and 65535 (inclusive).", p_port));
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
 
 	Error err;

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "udp_server.h"
+#include "udp_server.compat.inc"
 
 #include "core/object/class_db.h"
 

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -64,7 +64,7 @@ protected:
 
 public:
 	void remove_peer(IPAddress p_ip, int p_port);
-	Error listen(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
+	Error listen(int64_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
 	Error poll();
 	int get_local_port() const;
 	bool is_listening() const;

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -62,6 +62,11 @@ protected:
 	Ref<NetSocket> _sock;
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _listen_bind_compat_120522(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	void remove_peer(IPAddress p_ip, int p_port);
 	Error listen(int64_t p_port, const IPAddress &p_bind_address = IPAddress("*"));

--- a/misc/extension_api_validation/4.7-stable/GH-120522.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-120522.txt
@@ -1,0 +1,7 @@
+GH-120522
+--------------
+
+Validate extension JSON: Error: Field 'classes/TCPServer/methods/listen/arguments/0': meta changed value in new API, from "uint16" to "int64".
+Validate extension JSON: Error: Field 'classes/UDPServer/methods/listen/arguments/0': meta changed value in new API, from "uint16" to "int64".
+
+Changed the "port" parameter type in TCPServer.listen() and UDPServer.listen() from uint16_t to int64_t. Now it checks if it lies in the range 0-65535, and returns an error if not.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120521 

## Additional information

Changed the parameter type of `port` to `int64_t` (a 64-bit signed integer, the same type as `int` in GDScript).
Performs a check if the value is in the range 0-65535 (inclusive).