### PR TITLE
Improve OGG-Vorbis playback performance with cache

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -411,6 +411,12 @@ AudioStreamPlaybackOggVorbis::~AudioStreamPlaybackOggVorbis() {
 }
 
 Ref<AudioStreamPlayback> AudioStreamOggVorbis::instantiate_playback() {
+	for (const Ref<AudioStreamPlaybackOggVorbis> &playback : playback_cache) {
+		if (playback->get_reference_count() == 1) {
+			return playback;
+		}
+	}
+
 	Ref<AudioStreamPlaybackOggVorbis> ovs;
 
 	ERR_FAIL_COND_V(packet_sequence.is_null(), nullptr);
@@ -422,6 +428,7 @@ Ref<AudioStreamPlayback> AudioStreamOggVorbis::instantiate_playback() {
 	ovs->active = false;
 	ovs->loops = 0;
 	if (ovs->_alloc_vorbis()) {
+		playback_cache.push_back(ovs);
 		return ovs;
 	}
 	// Failed to allocate data structures.

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/local_vector.h"
 #include "core/variant/variant.h"
 #include "servers/audio/audio_stream.h"
 
@@ -134,6 +135,8 @@ class AudioStreamOggVorbis : public AudioStream {
 	int beat_count = 0;
 	int bar_beats = 4;
 	Dictionary tags;
+
+	LocalVector<Ref<AudioStreamPlaybackOggVorbis>> playback_cache;
 
 protected:
 	static void _bind_methods();

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -161,6 +161,7 @@ void AudioStreamPlaybackResampled::begin_resample() {
 	//mix buffer
 	_mix_internal(internal_buffer + 4, INTERNAL_BUFFER_LEN);
 	mix_offset = 0;
+	internal_buffer_end = -1;
 }
 
 int AudioStreamPlaybackResampled::_mix_internal(AudioFrame *p_buffer, int p_frames) {


### PR DESCRIPTION
- Added a cache list to prevent re-allocating memory for a playback stream on every call to 'instantiate_playback()'
- Also fix a possible bug revealed by the cache which misses a line setting 'internal_buffer_end' back to -1 when begin_resample() is called

IMPORTANT: I am not certain that this doesn't break other sound file types, or that it doesn't cause some weird edge-case bug. But, the changes are very small and I had a very extreme use case in which this had a large performance benefit.

## What problem(s) does this PR solve?

Back when I first wrote this code, it was mainly because I was playing short files very frequently as part of a weapon firing sound layer system, layering up to 20+ simultaneous streams and playing 50+ sounds per second. I would track when a sound would complete, then re-use it, otherwise I would make more to ensure the sound can layer over itself. There was a noticeable performance impact to my project that I felt was excessive, despite my optimization attempts. My frame rate would dip significantly only while playing sounds, and was proportional to how many sounds I was starting. I tracked it down to the allocation call being pretty heavy, done here:

https://github.com/godotengine/godot/blob/f964fa714f503bd063b96f6194eb3e45355c1084/modules/vorbis/audio_stream_ogg_vorbis.cpp#L424-L426

So, I wrote a simple cache to keep stream objects around internally. They are basically generic containers that can be used with any sound input, so they only need to be allocated once and can be safely re-used any time. This basically made sound playback a rounding error, a very big performance benefit. But this caused a new problem: every even-numbered play would seem to fail and do nothing. Odd-numbered calls would successfully play, and Even-numbered calls would always fail. I am certain that my changes to ogg-vorbis streams did not create it, but instead revealed the bug's presence.

I was searching for issues about audio streams failing to re-play the same audio. I believe I found an issue in the past, but now I can't locate it again to reference here. This had me very puzzled for a long time, and I tracked it to being a potential general bug that was fixed by resetting the `internal_buffer_end` value to `-1` in this method:

https://github.com/godotengine/godot/blob/f964fa714f503bd063b96f6194eb3e45355c1084/servers/audio/audio_stream.cpp#L155-L164

It seems like this is supposed to support reusing stream, but it just didn't initialize correctly and would think it instantly finished, and then set this value to `-1`, which caused every odd-numbered play to succeed, here:

https://github.com/godotengine/godot/blob/f964fa714f503bd063b96f6194eb3e45355c1084/servers/audio/audio_stream.cpp#L224-L230

I believe this is a current bug, which my PR will also fix. However, I do not remember if I was able to produce it prior to my changes. I think it may only be possible when re-using a stream that has already finished playing before.

## Additional information

I do not have performance measurements to provide, though you can just look at the code and tell that skipping a several millisecond allocation has benefits. It has been a long while since I first wrote this, and I never tested other sound file types. But it worked great for my extreme use case and I wanted to see if it could be added as a general performance boost. The only downside is that it can keep a bunch of streams around if a game plays like 100 sounds at once and then averages only a couple streams at a time from then on. Those extra allocations will be cycled around but could possibly be culled to an upper bound, like say 50 streams may be kept, and anything extra will be culled optimistically when the reference count is 1.

I think there's more testing and improvements to be made, I just wanted to go ahead and make the PR to see. I would really like to get some feedback on this, and I would not be opposed to extending this to the other audio stream types that could benefit from a cache as well.
