### PR TITLE
Change `HTTPRequest::_get_redirect_headers()` return type from `Error` to `void`

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -231,7 +231,7 @@ bool HTTPRequest::_is_method_safe() const {
 	return (method == HTTPClient::METHOD_GET || method == HTTPClient::METHOD_HEAD || method == HTTPClient::METHOD_OPTIONS || method == HTTPClient::METHOD_TRACE);
 }
 
-Error HTTPRequest::_get_redirect_headers(Vector<String> *r_headers) {
+void HTTPRequest::_get_redirect_headers(Vector<String> *r_headers) {
 	for (const String &E : headers) {
 		const String h = E.to_lower();
 		// We strip content headers when changing a redirect to GET.
@@ -239,7 +239,6 @@ Error HTTPRequest::_get_redirect_headers(Vector<String> *r_headers) {
 			r_headers->push_back(E);
 		}
 	}
-	return OK;
 }
 
 bool HTTPRequest::_is_automatic_redirect() const {

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -105,7 +105,7 @@ private:
 
 	bool _is_content_header(const String &p_header) const;
 	bool _is_method_safe() const;
-	Error _get_redirect_headers(Vector<String> *r_headers);
+	void _get_redirect_headers(Vector<String> *r_headers);
 	bool _is_automatic_redirect() const;
 
 	bool _handle_response(bool *ret_value);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Unnesecary code in the `HTTPRequest::_get_redirect_headers()` function.

## Additional information

Removes an unnecessary `Error` return value from `HTTPReqiest_get_redirect_headers()`. The function cannot fail and always returns `OK`. The return value is not used by any caller.
