### PR TITLE
[macOS] reinitialize input device on device switch

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -82,9 +82,9 @@ class AudioDriverCoreAudio : public AudioDriver {
 			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
 			void *inClientData);
 
-	static OSStatus input_sample_rate_cb(AudioObjectID inObjectID, 
-		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, 
-		void *inClientData);
+	static OSStatus input_sample_rate_cb(AudioObjectID inObjectID,
+			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
+			void *inClientData);
 #endif
 
 	static OSStatus output_callback(void *inRefCon,

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -32,6 +32,7 @@
 
 #ifdef COREAUDIO_ENABLED
 
+#include "core/templates/safe_refcount.h"
 #include "servers/audio/audio_server.h"
 
 #import <AudioUnit/AudioUnit.h>
@@ -62,8 +63,16 @@ class AudioDriverCoreAudio : public AudioDriver {
 	unsigned int buffer_size = 0;
 
 #ifdef MACOS_ENABLED
+	AudioDeviceID input_device_id = 0;
+	SafeFlag input_reconfig_pending;
+	Mutex input_reconfig_mutex;
+	bool input_running = false;
+
 	PackedStringArray _get_device_list(bool capture = false);
 	void _set_device(const String &output_device, bool capture = false);
+
+	void _set_input_sample_rate_listener(AudioDeviceID device_id, bool add);
+	void _reconfigure_input_device();
 
 	static OSStatus input_device_address_cb(AudioObjectID inObjectID,
 			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
@@ -72,6 +81,10 @@ class AudioDriverCoreAudio : public AudioDriver {
 	static OSStatus output_device_address_cb(AudioObjectID inObjectID,
 			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
 			void *inClientData);
+
+	static OSStatus input_sample_rate_cb(AudioObjectID inObjectID, 
+		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, 
+		void *inClientData);
 #endif
 
 	static OSStatus output_callback(void *inRefCon,

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -69,6 +69,16 @@ OSStatus AudioDriverCoreAudio::output_device_address_cb(AudioObjectID inObjectID
 	return noErr;
 }
 
+OSStatus AudioDriverCoreAudio::input_sample_rate_cb(AudioObjectID inObjectID, 
+		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, 
+		void *inClientData) {
+	AudioDriverCoreAudio *driver = static_cast<AudioDriverCoreAudio *>(inClientData);
+
+	driver->_reconfigure_input_device();
+
+	return noErr;
+}
+
 // Switch to kAudioObjectPropertyElementMain everywhere to remove deprecated warnings.
 #if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED < 120000) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED < 150000)
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
@@ -237,6 +247,13 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 	if (!ad->active) {
 		return 0;
 	}
+
+#ifdef MACOS_ENABLED
+	// skip audio render while reconfiguring input device
+	if (ad->input_reconfig_pending.is_set()) {
+		return 0;
+	}
+#endif
 
 	ad->lock();
 	ad->start_counting_ticks();
@@ -418,7 +435,11 @@ Error AudioDriverCoreAudio::init_input_device() {
 	AudioStreamBasicDescription strdesc;
 	memset(&strdesc, 0, sizeof(strdesc));
 	size = sizeof(strdesc);
+#ifdef MACOS_ENABLED
+	result = AudioUnitGetProperty(input_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, kInputBus, &strdesc, &size);
+#else
 	result = AudioUnitGetProperty(input_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, kInputBus, &strdesc, &size);
+#endif
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
 	switch (strdesc.mChannelsPerFrame) {
@@ -477,7 +498,12 @@ Error AudioDriverCoreAudio::init_input_device() {
 	result = AudioUnitInitialize(input_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	print_verbose("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz");
+#ifdef MACOS_ENABLED
+	input_device_id = device_id;
+	_set_input_sample_rate_listener(input_device_id, true);
+#endif
+
+	print_verbose("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz, input device channels: " + itos(capture_channels));
 	print_verbose("CoreAudio: input audio buffer frames: " + itos(capture_buffer_frames) + " calculated latency: " + itos(capture_buffer_frames * 1000 / capture_mix_rate) + "ms");
 
 	return OK;
@@ -500,6 +526,9 @@ void AudioDriverCoreAudio::finish_input_device() {
 		}
 
 #ifdef MACOS_ENABLED
+		_set_input_sample_rate_listener(input_device_id, false);
+		input_device_id = 0;
+
 		AudioObjectPropertyAddress prop;
 		prop.mSelector = kAudioHardwarePropertyDefaultInputDevice;
 		prop.mScope = kAudioObjectPropertyScopeGlobal;
@@ -530,6 +559,11 @@ Error AudioDriverCoreAudio::input_start() {
 	if (result != noErr) {
 		ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));
 	}
+#ifdef MACOS_ENABLED
+	else {
+		input_running = true;
+	}
+#endif
 
 	return OK;
 }
@@ -540,12 +574,125 @@ Error AudioDriverCoreAudio::input_stop() {
 		if (result != noErr) {
 			ERR_PRINT("AudioOutputUnitStop failed, code: " + itos(result));
 		}
+#ifdef MACOS_ENABLED
+		else {
+			input_running = false;
+		}
+#endif
 	}
 
 	return OK;
 }
 
 #ifdef MACOS_ENABLED
+
+void AudioDriverCoreAudio::_set_input_sample_rate_listener(AudioDeviceID device_id, bool add) {
+    if (device_id == 0) {
+		return;
+	}
+
+	AudioObjectPropertyAddress property_sr = { kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain };
+
+	OSStatus result;
+	if (add) {
+		result = AudioObjectAddPropertyListener(device_id, &property_sr, &input_sample_rate_cb, this);
+	} else {
+		result = AudioObjectRemovePropertyListener(device_id, &property_sr, &input_sample_rate_cb, this);
+	}
+	if (result != noErr) {
+		String action = add ? "Add" : "Remove";
+		ERR_PRINT("AudioObject " + action + " PropertyListener failed, code: " + itos(result));
+	}
+}
+
+void AudioDriverCoreAudio::_reconfigure_input_device() {
+	MutexLock reconfig_lock(input_reconfig_mutex);
+
+	input_reconfig_pending.set();
+
+	bool was_running = input_running;
+	if (was_running) {
+		OSStatus result = AudioOutputUnitStop(input_unit);
+		if (result != noErr) {
+			ERR_PRINT("AudioOutputUnitStop failed, code: " + itos(result));
+		}
+	}
+
+	lock();
+
+	OSStatus result = AudioUnitUninitialize(input_unit);
+	if (result != noErr) {
+		ERR_PRINT("AudioUnitUninitialize failed, code: " + itos(result));
+	}
+
+	// update existing device_id, if changed
+	AudioDeviceID device_id = input_device_id;
+	UInt32 dev_id_size = sizeof(AudioDeviceID);
+	result = AudioUnitGetProperty(input_unit, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &device_id, &dev_id_size);
+	if (result == noErr && device_id != input_device_id) {
+		_set_input_sample_rate_listener(input_device_id, false);
+		_set_input_sample_rate_listener(device_id, true);
+		input_device_id = device_id;
+	}
+
+	// update actual input channels
+	AudioStreamBasicDescription strdesc;
+	memset(&strdesc, 0, sizeof(strdesc));
+	UInt32 size = sizeof(strdesc);
+	result = AudioUnitGetProperty(input_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, kInputBus, &strdesc, &size);
+	if (result == noErr) {
+		capture_channels = (strdesc.mChannelsPerFrame == 1) ? 1 : 2;
+	}
+
+	// update actual mix rate
+	double hw_mix_rate;
+	UInt32 hw_mix_rate_size = sizeof(hw_mix_rate);
+	AudioObjectPropertyAddress property_sr = { kAudioDevicePropertyNominalSampleRate, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain };
+	result = AudioObjectGetPropertyData(device_id, &property_sr, 0, nullptr, &hw_mix_rate_size, &hw_mix_rate);
+	if (result == noErr) {
+		capture_mix_rate = hw_mix_rate;
+	}
+
+	// update capture channels count
+	memset(&strdesc, 0, sizeof(strdesc));
+	strdesc.mFormatID = kAudioFormatLinearPCM;
+	strdesc.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+	strdesc.mChannelsPerFrame = capture_channels;
+	strdesc.mSampleRate = capture_mix_rate;
+	strdesc.mFramesPerPacket = 1;
+	strdesc.mBitsPerChannel = 16;
+	strdesc.mBytesPerFrame = strdesc.mBitsPerChannel * strdesc.mChannelsPerFrame / 8;
+	strdesc.mBytesPerPacket = strdesc.mBytesPerFrame * strdesc.mFramesPerPacket;
+
+	result = AudioUnitSetProperty(input_unit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, kInputBus, &strdesc, sizeof(strdesc));
+	if (result != noErr) {
+		ERR_PRINT("AudioUnitSetProperty (StreamFormat) failed, code: " + itos(result));
+	}
+	
+
+	// update capture buffer size
+	uint32_t latency = Engine::get_singleton()->get_audio_output_latency();
+	capture_buffer_frames = Math::closest_power_of_2(latency * (uint32_t)capture_mix_rate / (uint32_t)1000);
+	buffer_size = capture_buffer_frames * capture_channels;
+
+	result = AudioUnitInitialize(input_unit);
+	if (result != noErr) {
+		ERR_PRINT("AudioUnitInitialize failed, code: " + itos(result));
+	}
+
+	input_buffer_init(capture_buffer_frames);
+
+	if (was_running) {
+		result = AudioOutputUnitStart(input_unit);
+		if (result != noErr) {
+			ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));
+		}
+	}
+
+	print_verbose("CoreAudio: input device reinitialized; input sampling rate: " + itos(capture_mix_rate) + " Hz, input device channels: " + itos(capture_channels));
+	input_reconfig_pending.clear();
+	unlock();
+}
 
 PackedStringArray AudioDriverCoreAudio::_get_device_list(bool input) {
 	PackedStringArray list;
@@ -684,9 +831,9 @@ void AudioDriverCoreAudio::_set_device(const String &output_device, bool input) 
 		ERR_FAIL_COND(result != noErr);
 
 		if (input) {
+			// Reinitialize input device, also
 			// Reset audio input to keep synchronization.
-			input_position = 0;
-			input_size = 0;
+			_reconfigure_input_device();
 		}
 	}
 }

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -69,8 +69,8 @@ OSStatus AudioDriverCoreAudio::output_device_address_cb(AudioObjectID inObjectID
 	return noErr;
 }
 
-OSStatus AudioDriverCoreAudio::input_sample_rate_cb(AudioObjectID inObjectID, 
-		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses, 
+OSStatus AudioDriverCoreAudio::input_sample_rate_cb(AudioObjectID inObjectID,
+		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
 		void *inClientData) {
 	AudioDriverCoreAudio *driver = static_cast<AudioDriverCoreAudio *>(inClientData);
 
@@ -587,7 +587,7 @@ Error AudioDriverCoreAudio::input_stop() {
 #ifdef MACOS_ENABLED
 
 void AudioDriverCoreAudio::_set_input_sample_rate_listener(AudioDeviceID device_id, bool add) {
-    if (device_id == 0) {
+	if (device_id == 0) {
 		return;
 	}
 
@@ -668,7 +668,6 @@ void AudioDriverCoreAudio::_reconfigure_input_device() {
 	if (result != noErr) {
 		ERR_PRINT("AudioUnitSetProperty (StreamFormat) failed, code: " + itos(result));
 	}
-	
 
 	// update capture buffer size
 	uint32_t latency = Engine::get_singleton()->get_audio_output_latency();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Original problem was, that when you start Godot app and your default input device is 16khz (most bt earphones), AudioUnit is set to 16khz and then switching to different input in runtime causes robovoice glitch. Otherwise if you run with builtin mac microphone (44100), and then try to switch to bluetooth mic, you just get -10863 (kAudioUnitErr_CannotDoInCurrentContext) because AudioUnit was already initialized with mixrate different to real device. So, this patch is trying to fix this problem by reinitializing input device on SampleRate changes

- I believe it fixes: https://github.com/godotengine/godot/issues/106397

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

fix uses almost exact code as in init_input_device, but triggered with SampleRate change. Also it's failsafe, so in worst scenario if something went bad, audio driver will stick to last saved params and worst you get is robovoice (what is already the case)

Also i assume problem was partly fixed in https://github.com/godotengine/godot/pull/88628 but they did not refresh actual sample rate on changes, so it fixed the problem only partly

_Bugsquad edit: Rewrite of https://github.com/godotengine/godot/pull/120518_

### EDIT/P.S.
If you're testing this, check the following scenarios (which previously caused problems):

- Set your device's default input/output device to a wireless headset (any BT headset with a microphone will work)
- Launch the app
- Record/listen to your voice
- Switch the input device to the MacBook's microphone (while app running, your app should support runtime device switch)
- Without this edit, you would hear robovoice. If the fix works, you will hear your recording without artifacts.

----
- Set your device's default input/output device to the built-in microphone and built-in speakers (a BT headset must be connected)
- Launch the app
- Record/listen to your voice
- Switch the input device to the headset's microphone (while app running, your app should support runtime device switch)
- Without this edit, you would see error -10863 (in earlier versions of Godot, you might see -50). If the fix works, the device will switch, and you will hear your recording without artifacts.