### PR TITLE
LSP: Adjust outgoing paths to match client symlink

### DIFF
--- a/modules/gdscript/doc_classes/GDScriptWorkspace.xml
+++ b/modules/gdscript/doc_classes/GDScriptWorkspace.xml
@@ -30,14 +30,14 @@
 				Returns the interface of the script in a machine-readable format.
 			</description>
 		</method>
-		<method name="get_file_path">
+		<method name="get_file_path" deprecated="">
 			<return type="String" />
 			<param index="0" name="uri" type="String" />
 			<description>
 				Converts a URI to a file path.
 			</description>
 		</method>
-		<method name="get_file_uri" qualifiers="const">
+		<method name="get_file_uri" qualifiers="const" deprecated="">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
 			<description>

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -33,7 +33,6 @@
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
 #include "gdscript_language_protocol.h"
-#include "gdscript_workspace.h"
 
 LSP::Position GodotPosition::to_lsp() const {
 	LSP::Position res;
@@ -138,7 +137,7 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 				if (exists) {
 					String value = const_val;
 					LSP::DocumentLink link;
-					link.target = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(scr_path);
+					link.target = GDScriptLanguageProtocol::get_singleton()->get_file_uri(scr_path);
 					link.range = GodotRange(GodotPosition(token.start_line, token.start_column), GodotPosition(token.end_line, token.end_column)).to_lsp();
 					document_links.push_back(link);
 				}
@@ -717,7 +716,7 @@ String ExtendGDScriptParser::get_symbol_name_under_position(const LSP::Position 
 }
 
 String ExtendGDScriptParser::get_uri() const {
-	return GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(path);
+	return GDScriptLanguageProtocol::get_singleton()->get_file_uri(path);
 }
 
 const LSP::DocumentSymbol *ExtendGDScriptParser::search_symbol_defined_at_line(int p_line, const LSP::DocumentSymbol &p_parent, const String &p_symbol_name) const {

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -33,6 +33,7 @@
 #include "godot_lsp.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -40,6 +41,7 @@
 #include "editor/doc/editor_help.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
 
 #define LSP_CLIENT_V(m_ret_val) \
@@ -219,13 +221,19 @@ Variant GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 		// since it might lead to unexpected behavior, like wrong warnings about duplicate class names.
 
 		String root;
+		String cannonical_root; // Absolute path to workspace as known by the client.
+
 		Variant root_uri_var = p_params["rootUri"];
 		Variant root_var = p_params.get("rootPath", Variant());
 		if (root_uri_var.is_string()) {
-			root = get_workspace()->get_file_path(root_uri_var);
+			cannonical_root = decode_file_uri(root_uri_var);
+			root = get_file_path(root_uri_var);
 		} else if (root_var.is_string()) {
+			cannonical_root = root_var;
 			root = root_var;
 		}
+
+		client->cannonical_root = cannonical_root;
 
 		if (ProjectSettings::get_singleton()->localize_path(root) != "res://") {
 			LSP::ShowMessageParams params{
@@ -404,6 +412,105 @@ bool GDScriptLanguageProtocol::is_goto_native_symbols_enabled() const {
 	return bool(_EDITOR_GET("network/language_server/show_native_symbols_in_editor"));
 }
 
+String GDScriptLanguageProtocol::decode_file_uri(const String &p_uri) const {
+	int port;
+	String scheme;
+	String host;
+	String encoded_path;
+	String fragment;
+
+	// Don't use the returned error, the result isn't OK for URIs that are not valid web URLs.
+	p_uri.parse_url(scheme, host, port, encoded_path, fragment);
+
+	// TODO: Make the parsing RFC-3986 compliant.
+	ERR_FAIL_COND_V_MSG(scheme != "file" && scheme != "file:" && scheme != "file://", String(), "LSP: The language server only supports the file protocol: " + p_uri);
+
+	// Treat host like authority for now and ignore the port. It's an edge case for invalid file URI's anyway.
+	ERR_FAIL_COND_V_MSG(host != "" && host != "localhost", String(), "LSP: The language server does not support nonlocal files: " + p_uri);
+
+	// If query or fragment are present, the URI is not a valid file URI as per RFC-8089.
+	// We currently don't handle the query and it will be part of the path. However,
+	// this should not be a problem for a correct file URI.
+	ERR_FAIL_COND_V_MSG(fragment != "", String(), "LSP: Received malformed file URI: " + p_uri);
+
+	return encoded_path.uri_file_decode().simplify_path();
+}
+
+String GDScriptLanguageProtocol::get_file_path(const String &p_uri) {
+	String canonical_res = ProjectSettings::get_singleton()->get_resource_path();
+	String simple_path = decode_file_uri(p_uri);
+
+	// First try known paths that point to res://, to reduce file system interaction.
+	bool res_adjusted = false;
+	for (const String &res_path : absolute_res_paths) {
+		if (simple_path.begins_with(res_path)) {
+			res_adjusted = true;
+			simple_path = "res://" + simple_path.substr(res_path.size());
+			break;
+		}
+	}
+
+	// Traverse the path and compare each directory with res://
+	if (!res_adjusted) {
+		Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+
+		int offset = 0;
+		while (offset <= simple_path.length()) {
+			offset = simple_path.find_char('/', offset);
+			if (offset == -1) {
+				offset = simple_path.length();
+			}
+
+			String part = simple_path.substr(0, offset);
+
+			if (!part.is_empty()) {
+				bool is_equal = dir->is_equivalent(canonical_res, part);
+
+				if (is_equal) {
+					absolute_res_paths.insert(part);
+					res_adjusted = true;
+					simple_path = "res://" + simple_path.substr(offset + 1);
+					break;
+				}
+			}
+
+			offset += 1;
+		}
+
+		// Could not resolve the path to the project.
+		if (!res_adjusted) {
+			return simple_path;
+		}
+	}
+
+	// Resolve the file inside of the project using EditorFileSystem.
+	EditorFileSystemDirectory *editor_dir;
+	int file_idx;
+	editor_dir = EditorFileSystem::get_singleton()->find_file(simple_path, &file_idx);
+	if (editor_dir) {
+		return editor_dir->get_file_path(file_idx);
+	}
+
+	return simple_path;
+}
+
+String GDScriptLanguageProtocol::get_file_uri(const String &p_path) const {
+	LSP_CLIENT_V(String());
+
+	// Just in case a uid:// or something odd makes its way here.
+	const String res_path = ProjectSettings::get_singleton()->localize_path(ProjectSettings::get_singleton()->globalize_path(p_path));
+
+	const String client_path = client->cannonical_root.path_join(res_path.lstrip("res://"));
+
+	LocalVector<String> encoded_parts;
+	for (const String &part : client_path.lstrip("/").split("/")) {
+		encoded_parts.push_back(part.uri_encode());
+	}
+
+	// Always return file URI's with authority part (encoding drive letters with leading slash), to maintain compat with RFC-1738 which required it.
+	return "file:///" + String("/").join(Vector<String>(encoded_parts));
+}
+
 ExtendGDScriptParser *GDScriptLanguageProtocol::LSPeer::parse_script(const String &p_path) {
 	remove_cached_parser(p_path);
 
@@ -477,7 +584,7 @@ void GDScriptLanguageProtocol::lsp_did_open(const Dictionary &p_params) {
 		document.text = "";
 	}
 
-	String path = get_workspace()->get_file_path(document.uri);
+	String path = get_file_path(document.uri);
 
 	/// An open notification must not be sent more than once without a corresponding close notification send before.
 	ERR_FAIL_COND_MSG(client->managed_files.has(path), "LSP: Client is opening already opened file.");
@@ -494,7 +601,7 @@ void GDScriptLanguageProtocol::lsp_did_change(const Dictionary &p_params) {
 	LSP::TextDocumentIdentifier identifier;
 	identifier.load(p_params["textDocument"]);
 
-	String path = get_workspace()->get_file_path(identifier.uri);
+	String path = get_file_path(identifier.uri);
 	LSP::TextDocumentItem *document = client->managed_files.getptr(path);
 
 	/// Before a client can change a text document it must claim ownership of its content using the textDocument/didOpen notification.
@@ -524,7 +631,7 @@ void GDScriptLanguageProtocol::lsp_did_close(const Dictionary &p_params) {
 	LSP::TextDocumentIdentifier identifier;
 	identifier.load(p_params["textDocument"]);
 
-	String path = get_workspace()->get_file_path(identifier.uri);
+	String path = get_file_path(identifier.uri);
 	bool was_opened = client->managed_files.erase(path);
 
 	client->remove_cached_parser(path);
@@ -622,7 +729,7 @@ Array GDScriptLanguageProtocol::lsp_completion(const Dictionary &p_params) {
 void GDScriptLanguageProtocol::resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list) {
 	LSP_CLIENT;
 
-	String path = workspace->get_file_path(p_doc_pos.textDocument.uri);
+	String path = get_file_path(p_doc_pos.textDocument.uri);
 
 	const ExtendGDScriptParser *parser = get_parse_result(path);
 	if (!parser) {

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -71,6 +71,14 @@ private:
 		Error send_data();
 
 		/**
+		 * Filepath to the workspace as the client indicated it.
+		 *
+		 * Since incoming paths are normalized for symlinks, when returning paths we need to use this path
+		 * to prevent path mismatches on the client side.
+		 */
+		String cannonical_root;
+
+		/**
 		 * Represents how the server should behave towards this client in certain situations.
 		 * This gets derived from client capabilities so the configured behavior is guaranteed to be supported by the client.
 		 */
@@ -113,6 +121,9 @@ private:
 	Ref<GDScriptTextDocument> text_document;
 	Ref<GDScriptWorkspace> workspace;
 
+	// Absolute paths that are known to point to res://
+	HashSet<String> absolute_res_paths;
+
 	Error on_client_connected();
 	void on_client_disconnected(const int &p_client_id);
 
@@ -144,6 +155,19 @@ public:
 
 	bool is_smart_resolve_enabled() const;
 	bool is_goto_native_symbols_enabled() const;
+
+	/**
+	 * Extracts a file path from a file URI.
+	 *
+	 * LSP limitations apply (e.g. only local files).
+	 */
+	String decode_file_uri(const String &p_uri) const;
+
+	/**
+	 * Transforms a file URI into a `res://` adjusted file path.
+	 */
+	String get_file_path(const String &p_uri);
+	String get_file_uri(const String &p_path) const;
 
 	// Text Document Synchronization
 	void lsp_did_open(const Dictionary &p_params);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -85,7 +85,7 @@ void GDScriptTextDocument::willSaveWaitUntil(const Variant &p_param) {
 	LSP::TextDocumentIdentifier doc;
 	doc.load(dict["textDocument"]);
 
-	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(doc.uri);
 	Ref<Script> scr = ResourceLoader::load(path);
 	if (scr.is_valid()) {
 		ScriptEditor::get_singleton()->clear_docs_from_script(scr);
@@ -98,7 +98,7 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 	doc.load(dict["textDocument"]);
 	String text = dict["text"];
 
-	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(doc.uri);
 	Ref<GDScript> scr = ResourceLoader::load(path);
 	if (scr.is_valid() && (scr->load_source_code(path) == OK)) {
 		if (scr->is_tool()) {
@@ -145,7 +145,7 @@ Variant GDScriptTextDocument::nativeSymbol(const Dictionary &p_params) {
 Array GDScriptTextDocument::documentSymbol(const Dictionary &p_params) {
 	Dictionary params = p_params["textDocument"];
 	String uri = params["uri"];
-	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(uri);
 	Array arr;
 
 	ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
@@ -163,7 +163,7 @@ Array GDScriptTextDocument::documentHighlight(const Dictionary &p_params) {
 
 	const LSP::DocumentSymbol *symbol = GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_symbol(params);
 	if (symbol) {
-		String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(params.textDocument.uri);
+		String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(params.textDocument.uri);
 		Vector<LSP::Location> usages = GDScriptLanguageProtocol::get_singleton()->get_workspace()->find_usages_in_file(*symbol, path);
 
 		for (const LSP::Location &usage : usages) {
@@ -399,7 +399,7 @@ Array GDScriptTextDocument::find_symbols(const LSP::TextDocumentPositionParams &
 		location.uri = symbol->uri;
 		if (!location.uri.is_empty()) {
 			location.range = symbol->selectionRange;
-			const String &path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(symbol->uri);
+			const String &path = GDScriptLanguageProtocol::get_singleton()->get_file_path(symbol->uri);
 			if (file_checker->file_exists(path)) {
 				arr.push_back(location.to_json());
 			}

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -35,27 +35,28 @@
 #include "../gdscript_parser.h"
 #include "gdscript_language_protocol.h"
 
-#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "editor/doc/doc_tools.h"
 #include "editor/doc/editor_help.h"
 #include "editor/editor_node.h"
-#include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
 
 void GDScriptWorkspace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_new_signal", "obj", "function", "args"), &GDScriptWorkspace::apply_new_signal);
-	ClassDB::bind_method(D_METHOD("get_file_path", "uri"), &GDScriptWorkspace::get_file_path);
-	ClassDB::bind_method(D_METHOD("get_file_uri", "path"), &GDScriptWorkspace::get_file_uri);
 	ClassDB::bind_method(D_METHOD("generate_script_api", "path"), &GDScriptWorkspace::generate_script_api);
 
 #ifndef DISABLE_DEPRECATED
+	GODOT_PUSH_IGNORE_DEPRECATION();
+	ClassDB::bind_method(D_METHOD("get_file_path", "uri"), &GDScriptWorkspace::get_file_path);
+	ClassDB::bind_method(D_METHOD("get_file_uri", "path"), &GDScriptWorkspace::get_file_uri);
 	ClassDB::bind_method(D_METHOD("didDeleteFiles", "params"), &GDScriptWorkspace::didDeleteFiles);
 	ClassDB::bind_method(D_METHOD("parse_script", "path", "content"), &GDScriptWorkspace::parse_script);
 	ClassDB::bind_method(D_METHOD("parse_local_script", "path"), &GDScriptWorkspace::parse_local_script);
 	ClassDB::bind_method(D_METHOD("publish_diagnostics", "path"), &GDScriptWorkspace::publish_diagnostics);
+	GODOT_POP_IGNORE_DEPRECATION();
 #endif
 }
 
@@ -103,7 +104,7 @@ void GDScriptWorkspace::apply_new_signal(Object *obj, String function, PackedStr
 
 	text_edit.newText = function_body;
 
-	String uri = get_file_uri(scr->get_path());
+	String uri = GDScriptLanguageProtocol::get_singleton()->get_file_uri(scr->get_path());
 
 	LSP::ApplyWorkspaceEditParams params;
 	params.edit.add_edit(uri, text_edit);
@@ -421,7 +422,7 @@ bool GDScriptWorkspace::can_rename(const LSP::TextDocumentPositionParams &p_doc_
 		return false;
 	}
 
-	String path = get_file_path(p_doc_pos.textDocument.uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(p_doc_pos.textDocument.uri);
 	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
 	if (parser) {
 		_ALLOW_DISCARD_ parser->get_symbol_name_under_position(p_doc_pos.position, r_range);
@@ -447,7 +448,7 @@ Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::Document
 				LSP::TextDocumentPositionParams params;
 
 				LSP::TextDocumentIdentifier text_doc;
-				text_doc.uri = get_file_uri(p_file_path);
+				text_doc.uri = GDScriptLanguageProtocol::get_singleton()->get_file_uri(p_file_path);
 
 				params.textDocument = text_doc;
 				params.position.line = i;
@@ -501,92 +502,11 @@ Vector<LSP::Location> GDScriptWorkspace::find_all_usages(const LSP::DocumentSymb
 }
 
 String GDScriptWorkspace::get_file_path(const String &p_uri) {
-	int port;
-	String scheme;
-	String host;
-	String encoded_path;
-	String fragment;
-
-	// Don't use the returned error, the result isn't OK for URIs that are not valid web URLs.
-	p_uri.parse_url(scheme, host, port, encoded_path, fragment);
-
-	// TODO: Make the parsing RFC-3986 compliant.
-	ERR_FAIL_COND_V_MSG(scheme != "file" && scheme != "file:" && scheme != "file://", String(), "LSP: The language server only supports the file protocol: " + p_uri);
-
-	// Treat host like authority for now and ignore the port. It's an edge case for invalid file URI's anyway.
-	ERR_FAIL_COND_V_MSG(host != "" && host != "localhost", String(), "LSP: The language server does not support nonlocal files: " + p_uri);
-
-	// If query or fragment are present, the URI is not a valid file URI as per RFC-8089.
-	// We currently don't handle the query and it will be part of the path. However,
-	// this should not be a problem for a correct file URI.
-	ERR_FAIL_COND_V_MSG(fragment != "", String(), "LSP: Received malformed file URI: " + p_uri);
-
-	String canonical_res = ProjectSettings::get_singleton()->get_resource_path();
-	String simple_path = encoded_path.uri_file_decode().simplify_path();
-
-	// First try known paths that point to res://, to reduce file system interaction.
-	bool res_adjusted = false;
-	for (const String &res_path : absolute_res_paths) {
-		if (simple_path.begins_with(res_path)) {
-			res_adjusted = true;
-			simple_path = "res://" + simple_path.substr(res_path.size());
-			break;
-		}
-	}
-
-	// Traverse the path and compare each directory with res://
-	if (!res_adjusted) {
-		Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-
-		int offset = 0;
-		while (offset <= simple_path.length()) {
-			offset = simple_path.find_char('/', offset);
-			if (offset == -1) {
-				offset = simple_path.length();
-			}
-
-			String part = simple_path.substr(0, offset);
-
-			if (!part.is_empty()) {
-				bool is_equal = dir->is_equivalent(canonical_res, part);
-
-				if (is_equal) {
-					absolute_res_paths.insert(part);
-					res_adjusted = true;
-					simple_path = "res://" + simple_path.substr(offset + 1);
-					break;
-				}
-			}
-
-			offset += 1;
-		}
-
-		// Could not resolve the path to the project.
-		if (!res_adjusted) {
-			return simple_path;
-		}
-	}
-
-	// Resolve the file inside of the project using EditorFileSystem.
-	EditorFileSystemDirectory *editor_dir;
-	int file_idx;
-	editor_dir = EditorFileSystem::get_singleton()->find_file(simple_path, &file_idx);
-	if (editor_dir) {
-		return editor_dir->get_file_path(file_idx);
-	}
-
-	return simple_path;
+	return GDScriptLanguageProtocol::get_singleton()->get_file_path(p_uri);
 }
 
 String GDScriptWorkspace::get_file_uri(const String &p_path) const {
-	String path = ProjectSettings::get_singleton()->globalize_path(p_path).lstrip("/");
-	LocalVector<String> encoded_parts;
-	for (const String &part : path.split("/")) {
-		encoded_parts.push_back(part.uri_encode());
-	}
-
-	// Always return file URI's with authority part (encoding drive letters with leading slash), to maintain compat with RFC-1738 which required it.
-	return "file:///" + String("/").join(Vector<String>(encoded_parts));
+	return GDScriptLanguageProtocol::get_singleton()->get_file_uri(p_path);
 }
 
 void GDScriptWorkspace::publish_diagnostics(const String &p_path) {
@@ -602,12 +522,12 @@ void GDScriptWorkspace::publish_diagnostics(const String &p_path) {
 		}
 	}
 	params["diagnostics"] = errors;
-	params["uri"] = get_file_uri(p_path);
+	params["uri"] = GDScriptLanguageProtocol::get_singleton()->get_file_uri(p_path);
 	GDScriptLanguageProtocol::get_singleton()->notify_client("textDocument/publishDiagnostics", params);
 }
 
 void GDScriptWorkspace::completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options) {
-	String path = get_file_path(p_params.textDocument.uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(p_params.textDocument.uri);
 	String call_hint;
 	bool forced = false;
 
@@ -645,7 +565,7 @@ void GDScriptWorkspace::completion(const LSP::CompletionParams &p_params, List<S
 const LSP::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const LSP::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name, bool p_func_required) {
 	const LSP::DocumentSymbol *symbol = nullptr;
 
-	String path = get_file_path(p_doc_pos.textDocument.uri);
+	String path = GDScriptLanguageProtocol::get_singleton()->get_file_path(p_doc_pos.textDocument.uri);
 
 	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
 	if (parser) {
@@ -733,7 +653,7 @@ const LSP::DocumentSymbol *GDScriptWorkspace::resolve_native_symbol(const LSP::N
 }
 
 void GDScriptWorkspace::resolve_document_links(const String &p_uri, List<LSP::DocumentLink> &r_list) {
-	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(get_file_path(p_uri));
+	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(GDScriptLanguageProtocol::get_singleton()->get_file_path(p_uri));
 	if (parser && parser->parse_result == Error::OK) {
 		const List<LSP::DocumentLink> &links = parser->get_document_links();
 		for (const LSP::DocumentLink &E : links) {
@@ -753,7 +673,7 @@ Dictionary GDScriptWorkspace::generate_script_api(const String &p_path) {
 }
 
 Error GDScriptWorkspace::resolve_signature(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::SignatureHelp &r_signature) {
-	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(get_file_path(p_doc_pos.textDocument.uri));
+	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(GDScriptLanguageProtocol::get_singleton()->get_file_path(p_doc_pos.textDocument.uri));
 	if (parser) {
 		LSP::TextDocumentPositionParams text_pos;
 		text_pos.textDocument = p_doc_pos.textDocument;

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -57,9 +57,6 @@ protected:
 	bool initialized = false;
 	HashMap<StringName, LSP::DocumentSymbol> native_symbols;
 
-	// Absolute paths that are known to point to res://
-	HashSet<String> absolute_res_paths;
-
 	const LSP::DocumentSymbol *get_native_symbol(const String &p_class, const String &p_member = "") const;
 	const LSP::DocumentSymbol *get_script_symbol(const String &p_path) const;
 	const LSP::DocumentSymbol *get_parameter_symbol(const LSP::DocumentSymbol *p_parent, const String &symbol_identifier);
@@ -80,8 +77,10 @@ public:
 public:
 	Error initialize();
 
-	String get_file_path(const String &p_uri);
-	String get_file_uri(const String &p_path) const;
+#ifndef DISABLE_DEPRECATED
+	String get_file_path [[deprecated]] (const String &p_uri);
+	String get_file_uri [[deprecated]] (const String &p_path) const;
+#endif // !DISABLE_DEPRECATED
 
 	void publish_diagnostics(const String &p_path);
 	void completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options);

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/config/project_settings.h"
 #ifdef TOOLS_ENABLED
 
 #ifndef GDSCRIPT_NO_LSP
@@ -54,6 +55,7 @@ public:
 	static void setup_client() {
 		GDScriptLanguageProtocol *proto = GDScriptLanguageProtocol::get_singleton();
 		Ref<GDScriptLanguageProtocol::LSPeer> peer = memnew(GDScriptLanguageProtocol::LSPeer);
+		peer->cannonical_root = ProjectSettings::get_singleton()->get_resource_path();
 		proto->clients.insert(proto->next_client_id, peer);
 		proto->latest_client_id = proto->next_client_id;
 		proto->next_client_id++;
@@ -334,12 +336,11 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		EditorFileSystem *efs = memnew(EditorFileSystem);
 		GDScriptLanguageProtocol *proto = initialize(root);
 		REQUIRE(proto);
-		Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
 
 		{
 			String path = "res://lsp/local_variables.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			SUBCASE("Can get correct ranges for public variables") {
 				Vector<InlineTestData> test_data = filter_ref_towards(all_test_data, "member");
@@ -358,7 +359,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for indented variables") {
 			String path = "res://lsp/indentation.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -366,7 +367,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for scopes") {
 			String path = "res://lsp/scopes.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -374,7 +375,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for lambda") {
 			String path = "res://lsp/lambdas.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -382,7 +383,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for inner class") {
 			String path = "res://lsp/class.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -390,7 +391,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for inner class") {
 			String path = "res://lsp/enums.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -398,7 +399,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for shadowing & shadowed variables") {
 			String path = "res://lsp/shadowing_initializer.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}
@@ -406,7 +407,7 @@ TEST_SUITE("[Modules][GDScript][LSP][Editor]") {
 		SUBCASE("Can get correct ranges for properties and getter/setter") {
 			String path = "res://lsp/properties.gd";
 			assert_no_errors_in(path);
-			String uri = workspace->get_file_uri(path);
+			String uri = proto->get_file_uri(path);
 			Vector<InlineTestData> all_test_data = read_tests(path);
 			test_resolve_symbols(uri, all_test_data, all_test_data);
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Hypothetical fix for https://github.com/GDQuest/zed-gdscript/issues/69 (Zed behaves differently for symlinks on Linux, so will need testing from the reporter on Windows)

## Additional information

Till now we did transform incoming paths to account for symlinks. However we did not transform the paths we returned to the client to match the location at which the client is opened. This PR fixes that.

The diff looks worse than it is, since I moved functions between classes. (For convenient client access. I'm planning to move all LSP functions into `GDScriptLanguageProtocol` in the future.)

> [!NOTE]
> 
> **LLM Disclosure**: Copilot was used to rewrite the calls to the moved functions, since no programmatic re-factoring functionally could cover that.