### PR TITLE
Add Warning for MultiMeshInstance2D/3D when MultiMesh resource is null

### DIFF
--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -96,6 +96,7 @@ void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 		_refresh_interpolated();
 	}
 	queue_redraw();
+	update_configuration_warnings();
 }
 
 Ref<MultiMesh> MultiMeshInstance2D::get_multimesh() const {
@@ -232,8 +233,13 @@ void MultiMeshInstance2D::navmesh_parse_source_geometry(const Ref<NavigationPoly
 }
 #endif // NAVIGATION_2D_DISABLED
 
-MultiMeshInstance2D::MultiMeshInstance2D() {
+PackedStringArray MultiMeshInstance2D::get_configuration_warnings() const{
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+	if (multimesh.is_null()) {
+		warnings.push_back(RTR("MultiMeshInstance2D requires a MultiMesh to render anything. Please add a MultiMesh resource for it!"));
+	}
+	return warnings;
 }
 
-MultiMeshInstance2D::~MultiMeshInstance2D() {
+MultiMeshInstance2D::MultiMeshInstance2D() {
 }

--- a/scene/2d/multimesh_instance_2d.h
+++ b/scene/2d/multimesh_instance_2d.h
@@ -71,6 +71,6 @@ public:
 	static void navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
 #endif // NAVIGATION_2D_DISABLED
 
+	virtual PackedStringArray get_configuration_warnings() const override;
 	MultiMeshInstance2D();
-	~MultiMeshInstance2D();
 };

--- a/scene/3d/multimesh_instance_3d.cpp
+++ b/scene/3d/multimesh_instance_3d.cpp
@@ -74,6 +74,7 @@ void MultiMeshInstance3D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	} else {
 		set_base(RID());
 	}
+	update_configuration_warnings();
 }
 
 Ref<MultiMesh> MultiMeshInstance3D::get_multimesh() const {
@@ -145,8 +146,13 @@ void MultiMeshInstance3D::navmesh_parse_source_geometry(const Ref<NavigationMesh
 }
 #endif // NAVIGATION_3D_DISABLED
 
-MultiMeshInstance3D::MultiMeshInstance3D() {
+PackedStringArray MultiMeshInstance3D::get_configuration_warnings() const {
+	PackedStringArray warnings = GeometryInstance3D::get_configuration_warnings();
+	if (multimesh.is_null()) {
+		warnings.push_back(RTR("MultiMeshInstance3D requires a MultiMesh to render anything. Please add a MultiMesh resource for it!"));
+	}
+	return warnings;
 }
 
-MultiMeshInstance3D::~MultiMeshInstance3D() {
+MultiMeshInstance3D::MultiMeshInstance3D() {
 }

--- a/scene/3d/multimesh_instance_3d.h
+++ b/scene/3d/multimesh_instance_3d.h
@@ -69,7 +69,7 @@ public:
 	static void navmesh_parse_init();
 	static void navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_node);
 #endif // NAVIGATION_3D_DISABLED
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	MultiMeshInstance3D();
-	~MultiMeshInstance3D();
 };


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes [15053](https://github.com/godotengine/godot-proposals/issues/15053)

## Additional information
Follow up of https://github.com/godotengine/godot/pull/116956, code was based on the same pr for this implementation.
Adds the ability for MultiMeshInstance2D/3D to warn the user if the MultiMesh resource is not assigned (multimesh = null). Just like the MeshInstance2D/3D already do for their Mesh resource since Godot 4.7. Made for consistency and usability.
No AI involvement in the researching, referencing, set up nor code of this pr.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
