### PR TITLE
[Metal] Make shader cache thread safe.

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1044,6 +1044,7 @@ void RenderingDeviceDriverMetal::framebuffer_free(FramebufferID p_framebuffer) {
 #pragma mark - Shader
 
 void RenderingDeviceDriverMetal::shader_cache_free_entry(const SHA256Digest &key) {
+	MutexLock lock(_shader_cache_mutex);
 	if (ShaderCacheEntry **pentry = _shader_cache.getptr(key); pentry != nullptr) {
 		ShaderCacheEntry *entry = *pentry;
 		_shader_cache.erase(key);
@@ -1116,6 +1117,8 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 	PipelineType pipeline_type = PIPELINE_TYPE_RASTERIZATION;
 	Vector<uint8_t> decompressed_code;
 	for (uint32_t shader_index = 0; shader_index < shaders.size(); shader_index++) {
+		MutexLock lock(_shader_cache_mutex);
+
 		const RenderingShaderContainer::Shader &shader = shaders[shader_index];
 		const RSCM::StageData &shader_data = mtl_shaders[shader_index];
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -177,6 +177,7 @@ protected:
 	 * To prevent unbounded growth of the cache, cache entries are automatically freed when
 	 * there are no more references to the MDLibrary associated with the cache entry.
 	 */
+	Mutex _shader_cache_mutex;
 	HashMap<SHA256Digest, ShaderCacheEntry *> _shader_cache;
 	void shader_cache_free_entry(const SHA256Digest &key);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120504

## Additional information

Seems like `shader_create_from_container` is now called from multiple threads and might overwrite cache map. 

_Edit: Regression from https://github.com/godotengine/godot/pull/119123_