### PR TITLE
Unify collection hint string parsing

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -48,6 +48,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
 #include "scene/main/scene_tree.h"
+#include "scene/property_utils.h"
 
 bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
@@ -892,31 +893,7 @@ void EditorPropertyArray::_add_element() {
 
 void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint_string) {
 	array_type = p_array_type;
-
-	// The format of p_hint_string is:
-	// subType/subTypeHint:nextSubtype ... etc.
-	if (!p_hint_string.is_empty()) {
-		int hint_subtype_separator = p_hint_string.find_char(':');
-		if (hint_subtype_separator >= 0) {
-			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
-			int slash_pos = subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
-				subtype_string = subtype_string.substr(0, slash_pos);
-			}
-
-			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1);
-			subtype = Variant::Type(subtype_string.to_int());
-		} else {
-			subtype = Variant::get_type_by_name(p_hint_string);
-
-			if (subtype == Variant::VARIANT_MAX) {
-				subtype = Variant::OBJECT;
-				subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				subtype_hint_string = p_hint_string;
-			}
-		}
-	}
+	PropertyUtils::parse_array_hint_string(p_hint_string, subtype, subtype_hint, &subtype_hint_string);
 }
 
 void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_event) {
@@ -1195,62 +1172,15 @@ void EditorPropertyDictionary::_change_type_menu(int p_index) {
 }
 
 void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_string) {
-	PackedStringArray types = p_hint_string.split(";", true, 1);
-	if (types.size() > 0 && !types[0].is_empty()) {
-		String key = types[0];
-		int hint_key_subtype_separator = key.find_char(':');
-		if (hint_key_subtype_separator >= 0) {
-			String key_subtype_string = key.substr(0, hint_key_subtype_separator);
-			int slash_pos = key_subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				key_subtype_hint = PropertyHint(key_subtype_string.substr(slash_pos + 1).to_int());
-				key_subtype_string = key_subtype_string.substr(0, slash_pos);
-			}
+	PropertyUtils::parse_dictionary_hint_string(p_hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
 
-			key_subtype_hint_string = key.substr(hint_key_subtype_separator + 1);
-			key_subtype = Variant::Type(key_subtype_string.to_int());
-		} else {
-			key_subtype = Variant::get_type_by_name(key);
+	Variant new_key = object->get_new_item_key();
+	VariantInternal::initialize(&new_key, key_subtype);
+	object->set_new_item_key(new_key);
 
-			if (key_subtype == Variant::VARIANT_MAX) {
-				key_subtype = Variant::OBJECT;
-				key_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				key_subtype_hint_string = key;
-			}
-		}
-
-		Variant new_key = object->get_new_item_key();
-		VariantInternal::initialize(&new_key, key_subtype);
-		object->set_new_item_key(new_key);
-	}
-
-	if (types.size() > 1 && !types[1].is_empty()) {
-		String value = types[1];
-		int hint_value_subtype_separator = value.find_char(':');
-		if (hint_value_subtype_separator >= 0) {
-			String value_subtype_string = value.substr(0, hint_value_subtype_separator);
-			int slash_pos = value_subtype_string.find_char('/');
-			if (slash_pos >= 0) {
-				value_subtype_hint = PropertyHint(value_subtype_string.substr(slash_pos + 1).to_int());
-				value_subtype_string = value_subtype_string.substr(0, slash_pos);
-			}
-
-			value_subtype_hint_string = value.substr(hint_value_subtype_separator + 1);
-			value_subtype = Variant::Type(value_subtype_string.to_int());
-		} else {
-			value_subtype = Variant::get_type_by_name(value);
-
-			if (value_subtype == Variant::VARIANT_MAX) {
-				value_subtype = Variant::OBJECT;
-				value_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
-				value_subtype_hint_string = value;
-			}
-		}
-
-		Variant new_value = object->get_new_item_value();
-		VariantInternal::initialize(&new_value, value_subtype);
-		object->set_new_item_value(new_value);
-	}
+	Variant new_value = object->get_new_item_value();
+	VariantInternal::initialize(&new_value, value_subtype);
+	object->set_new_item_value(new_value);
 }
 
 void EditorPropertyDictionary::set_preview_value(bool p_preview_value) {

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -317,3 +317,67 @@ Ref<Script> PropertyUtils::get_custom_type_script(const Object *p_object) {
 	}
 	return ResourceLoader::load(custom_script);
 }
+
+void PropertyUtils::parse_array_hint_string(const String &p_hint_string, Variant::Type &r_subtype, PropertyHint &r_subtype_hint, String *r_subtype_hint_string) {
+	r_subtype = Variant::NIL;
+	r_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_subtype_hint_string) {
+		*r_subtype_hint_string = String();
+	}
+
+	if (p_hint_string.is_empty()) {
+		return;
+	}
+
+	// The format of p_hint_string is:
+	// subType/subTypeHint:nextSubtype ... etc.
+	int hint_subtype_separator = p_hint_string.find_char(':');
+	if (hint_subtype_separator >= 0) {
+		String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
+		int slash_pos = subtype_string.find_char('/');
+		if (slash_pos >= 0) {
+			r_subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1).to_int());
+			subtype_string = subtype_string.substr(0, slash_pos);
+		}
+
+		if (r_subtype_hint_string) {
+			*r_subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1);
+		}
+		r_subtype = Variant::Type(subtype_string.to_int());
+	} else {
+		r_subtype = Variant::get_type_by_name(p_hint_string);
+
+		if (r_subtype == Variant::VARIANT_MAX) {
+			r_subtype = Variant::OBJECT;
+			r_subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+			if (r_subtype_hint_string) {
+				*r_subtype_hint_string = p_hint_string;
+			}
+		}
+	}
+}
+
+void PropertyUtils::parse_dictionary_hint_string(const String &p_hint_string, Variant::Type &r_key_subtype, PropertyHint &r_key_subtype_hint, Variant::Type &r_value_subtype, PropertyHint &r_value_subtype_hint, String *r_key_subtype_hint_string, String *r_value_subtype_hint_string) {
+	r_key_subtype = Variant::NIL;
+	r_key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_key_subtype_hint_string) {
+		*r_key_subtype_hint_string = String();
+	}
+	r_value_subtype = Variant::NIL;
+	r_value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	if (r_value_subtype_hint_string) {
+		*r_value_subtype_hint_string = String();
+	}
+	if (p_hint_string.is_empty()) {
+		return;
+	}
+
+	// Missing ; separator is treated as key only.
+	int key_value_separator = p_hint_string.find_char(';');
+	String key_hint_string = p_hint_string.substr(0, key_value_separator);
+	parse_array_hint_string(key_hint_string, r_key_subtype, r_key_subtype_hint, r_key_subtype_hint_string);
+	if (key_value_separator >= 0) {
+		String value_hint_string = p_hint_string.substr(key_value_separator + 1);
+		parse_array_hint_string(value_hint_string, r_value_subtype, r_value_subtype_hint, r_value_subtype_hint_string);
+	}
+}

--- a/scene/property_utils.h
+++ b/scene/property_utils.h
@@ -48,4 +48,7 @@ public:
 
 	static void assign_custom_type_script(Object *p_object, const Ref<Script> &p_script);
 	static Ref<Script> get_custom_type_script(const Object *p_object);
+
+	static void parse_array_hint_string(const String &p_hint_string, Variant::Type &r_subtype, PropertyHint &r_subtype_hint, String *r_subtype_hint_string = nullptr);
+	static void parse_dictionary_hint_string(const String &p_hint_string, Variant::Type &r_key_subtype, PropertyHint &r_key_subtype_hint, Variant::Type &r_value_subtype, PropertyHint &r_value_subtype_hint, String *r_key_subtype_hint_string = nullptr, String *r_value_subtype_hint_string = nullptr);
 };

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -973,80 +973,54 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				value = missing_resource_properties[E.name];
 			}
 		} else if (E.type == Variant::ARRAY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int hint_subtype_separator = E.hint_string.find_char(':');
-			if (hint_subtype_separator >= 0) {
-				String subtype_string = E.hint_string.substr(0, hint_subtype_separator);
-				int slash_pos = subtype_string.find_char('/');
-				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (slash_pos >= 0) {
-					subtype_hint = PropertyHint(subtype_string.get_slicec('/', 1).to_int());
-					subtype_string = subtype_string.substr(0, slash_pos);
-				}
-				Variant::Type subtype = Variant::Type(subtype_string.to_int());
-
-				if (subtype == Variant::OBJECT && subtype_hint == PROPERTY_HINT_NODE_TYPE) {
-					use_deferred_node_path_bit = true;
-					Array array = value;
-					Array new_array;
-					for (int i = 0; i < array.size(); i++) {
-						Variant elem = array[i];
-						if (elem.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(elem)) {
-								new_array.push_back(p_node->get_path_to(n));
-								continue;
-							}
+			Variant::Type subtype;
+			PropertyHint subtype_hint;
+			PropertyUtils::parse_array_hint_string(E.hint_string, subtype, subtype_hint);
+			if (subtype == Variant::OBJECT && subtype_hint == PROPERTY_HINT_NODE_TYPE) {
+				use_deferred_node_path_bit = true;
+				Array array = value;
+				Array new_array;
+				for (int i = 0; i < array.size(); i++) {
+					Variant elem = array[i];
+					if (elem.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(elem)) {
+							new_array.push_back(p_node->get_path_to(n));
+							continue;
 						}
-						new_array.push_back(elem);
 					}
-					value = new_array;
+					new_array.push_back(elem);
 				}
+				value = new_array;
 			}
 		} else if (E.type == Variant::DICTIONARY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int key_value_separator = E.hint_string.find_char(';');
-			if (key_value_separator >= 0) {
-				int key_subtype_separator = E.hint_string.find_char(':');
-				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
-				int key_slash_pos = key_subtype_string.find_char('/');
-				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (key_slash_pos >= 0) {
-					key_subtype_hint = PropertyHint(key_subtype_string.get_slicec('/', 1).to_int());
-					key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
-				}
-				Variant::Type key_subtype = Variant::Type(key_subtype_string.to_int());
-				bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			Variant::Type key_subtype;
+			PropertyHint key_subtype_hint;
+			Variant::Type value_subtype;
+			PropertyHint value_subtype_hint;
+			PropertyUtils::parse_dictionary_hint_string(E.hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint);
 
-				int value_subtype_separator = E.hint_string.find_char(':', key_value_separator) - (key_value_separator + 1);
-				String value_subtype_string = E.hint_string.substr(key_value_separator + 1, value_subtype_separator);
-				int value_slash_pos = value_subtype_string.find_char('/');
-				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (value_slash_pos >= 0) {
-					value_subtype_hint = PropertyHint(value_subtype_string.get_slicec('/', 1).to_int());
-					value_subtype_string = value_subtype_string.substr(0, value_slash_pos);
-				}
-				Variant::Type value_subtype = Variant::Type(value_subtype_string.to_int());
-				bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
-
-				if (convert_key || convert_value) {
-					use_deferred_node_path_bit = true;
-					Dictionary dict = value;
-					Dictionary new_dict;
-					for (const KeyValue<Variant, Variant> &kv : dict) {
-						Variant new_key = kv.key;
-						if (convert_key && new_key.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_key)) {
-								new_key = p_node->get_path_to(n);
-							}
+			bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			if (convert_key || convert_value) {
+				use_deferred_node_path_bit = true;
+				Dictionary dict = value;
+				Dictionary new_dict;
+				for (const KeyValue<Variant, Variant> &kv : dict) {
+					Variant new_key = kv.key;
+					if (convert_key && new_key.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_key)) {
+							new_key = p_node->get_path_to(n);
 						}
-						Variant new_value = kv.value;
-						if (convert_value && new_value.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_value)) {
-								new_value = p_node->get_path_to(n);
-							}
-						}
-						new_dict[new_key] = new_value;
 					}
-					value = new_dict;
+					Variant new_value = kv.value;
+					if (convert_value && new_value.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_value)) {
+							new_value = p_node->get_path_to(n);
+						}
+					}
+					new_dict[new_key] = new_value;
 				}
+				value = new_dict;
 			}
 		}
 

--- a/tests/scene/test_property_utils.cpp
+++ b/tests/scene/test_property_utils.cpp
@@ -1,0 +1,399 @@
+/**************************************************************************/
+/*  test_property_utils.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_property_utils)
+
+#include "scene/property_utils.h"
+
+namespace TestPropertyUtils {
+
+TEST_CASE("[PropertyUtils] Empty Array Hint") {
+	String hint_string;
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::NIL);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Type Only Array Hint") {
+	String hint_string = vformat("%d:", Variant::INT);
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Type String Array Hint") {
+	String hint_string = "int";
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Object Type Array Hint") {
+	String hint_string = "Texture";
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::OBJECT);
+	CHECK(subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(subtype_hint_string == "Texture");
+}
+
+TEST_CASE("[PropertyUtils] Type And Hint Array Hint") {
+	String hint_string = vformat("%d/%d:", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Array Hint") {
+	String hint_string = vformat("%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type subtype;
+	PropertyHint subtype_hint;
+	String subtype_hint_string;
+	PropertyUtils::parse_array_hint_string(hint_string, subtype, subtype_hint, &subtype_hint_string);
+
+	CHECK(subtype == Variant::INT);
+	CHECK(subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(subtype_hint_string == "One,Two,Three");
+}
+
+TEST_CASE("[PropertyUtils] Empty Dictionary Hint") {
+	String hint_string;
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type Only Dictionary Hint") {
+	String hint_string = vformat("%d:;", Variant::INT);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type String Dictionary Hint") {
+	String hint_string = "int";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Object Type Dictionary Hint") {
+	String hint_string = "Texture";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::OBJECT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(key_subtype_hint_string == "Texture");
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key Type And Hint Dictionary Hint") {
+	String hint_string = vformat("%d/%d:;", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Key Dictionary Hint") {
+	String hint_string = vformat("%d/%d:%s;", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == "One,Two,Three");
+	CHECK(value_subtype == Variant::NIL);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Type Only Dictionary Hint") {
+	String hint_string = vformat(";%d:", Variant::INT);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Type String Dictionary Hint") {
+	String hint_string = ";int";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Value Object Type Dictionary Hint") {
+	String hint_string = ";Texture";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::OBJECT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(value_subtype_hint_string == "Texture");
+}
+
+TEST_CASE("[PropertyUtils] Value Type And Hint Dictionary Hint") {
+	String hint_string = vformat(";%d/%d:", Variant::INT, PROPERTY_HINT_ENUM);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Value Dictionary Hint") {
+	String hint_string = vformat(";%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::NIL);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::INT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(value_subtype_hint_string == "One,Two,Three");
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type Only Dictionary Hint") {
+	String hint_string = vformat("%d:;%d:", Variant::INT, Variant::STRING);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type Strings Dictionary Hint") {
+	String hint_string = "int;float";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::FLOAT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_NONE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Object Type Dictionary Hint") {
+	String hint_string = "Texture;Texture2D";
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::OBJECT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(key_subtype_hint_string == "Texture");
+	CHECK(value_subtype == Variant::OBJECT);
+	CHECK(value_subtype_hint == PROPERTY_HINT_RESOURCE_TYPE);
+	CHECK(value_subtype_hint_string == "Texture2D");
+}
+
+TEST_CASE("[PropertyUtils] Key And Value Type And Hint Dictionary Hint") {
+	String hint_string = vformat("%d/%d:;%d/%d:", Variant::INT, PROPERTY_HINT_ENUM, Variant::STRING, PROPERTY_HINT_FILE);
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == String());
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_FILE);
+	CHECK(value_subtype_hint_string == String());
+}
+
+TEST_CASE("[PropertyUtils] Complete Key And Value Dictionary Hint") {
+	String hint_string = vformat("%d/%d:%s;%d/%d:%s", Variant::INT, PROPERTY_HINT_ENUM, "One,Two,Three", Variant::STRING, PROPERTY_HINT_FILE, "*.png");
+	Variant::Type key_subtype;
+	PropertyHint key_subtype_hint;
+	String key_subtype_hint_string;
+	Variant::Type value_subtype;
+	PropertyHint value_subtype_hint;
+	String value_subtype_hint_string;
+	PropertyUtils::parse_dictionary_hint_string(hint_string, key_subtype, key_subtype_hint, value_subtype, value_subtype_hint, &key_subtype_hint_string, &value_subtype_hint_string);
+
+	CHECK(key_subtype == Variant::INT);
+	CHECK(key_subtype_hint == PROPERTY_HINT_ENUM);
+	CHECK(key_subtype_hint_string == "One,Two,Three");
+	CHECK(value_subtype == Variant::STRING);
+	CHECK(value_subtype_hint == PROPERTY_HINT_FILE);
+	CHECK(value_subtype_hint_string == "*.png");
+}
+
+} //namespace TestPropertyUtils


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Code cleanup to centralize parsing of collection type from hint strings. Most of this is from #112632, this PR splits off a smaller portion for easier review.

Partial overlap with #118987 on updating the editor property parsing.

Also adds test cases around collection hint string parsing to ensure everything's consistent.

## Additional information

There is some minor behavior differences but they still result in the same overall behavior

- `PackedScene` and missing `:` in array hints. `PackedScene` ignored this case before, but handling it now shouldn't cause any issues since `PackedScene` will ignore this case since no hint strings parsed that way will have the node subtype hint.
- `PackedScene` and missing ';' treats the dictionary hint string as only setting the type for the key. This means `PackedScene` does `Node` <-> `NodePath` conversions during pack and instantiate for an extra case, but otherwise functions the same. This is only possible for properties defined via `_get_property_list()` and looked fine from a basic scene save/load testing. So technically, this fixes a missing edge case since the inspector supported this hint string format, but not scene save/load.
- `EditorPropertyDictionary` always assigns the new item types. Previously, it skipped type assignment for empty hint strings which defaults the item types to `Nil`. Now parsing will return `Nil`, then it will set the types as `Nil`.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
