### PR TITLE
Add `get_slot_count()`, `get_slot_input_port()`, and `get_slot_output_port()` to `GraphNode`.

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -228,7 +228,7 @@
 				Ports can be further customized using [param color_left]/[param color_right] and [param custom_icon_left]/[param custom_icon_right]. The color parameter adds a tint to the icon. The custom icon can be used to override the default port dot.
 				Additionally, [param draw_stylebox] can be used to enable or disable drawing of the background stylebox for each slot. See [theme_item slot].
 				Individual properties can also be set using one of the [code]set_slot_*[/code] methods.
-				[b]Note:[/b] This method only sets properties of the slot. To create the slot itself, add a [Control]-derived child to the [GraphNode].
+				[b]Note:[/b] This method only sets properties of the slot. To create the slot itself, add a [Control]-derived child to the GraphNode.
 			</description>
 		</method>
 		<method name="set_slot_color_left">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -5,9 +5,9 @@
 	</brief_description>
 	<description>
 		[GraphNode] allows to create nodes for a [GraphEdit] graph with customizable content based on its child controls. [GraphNode] is derived from [Container] and it is responsible for placing its children on screen. This works similar to [VBoxContainer]. Children, in turn, provide [GraphNode] with so-called slots, each of which can have a connection port on either side.
-		Each [GraphNode] slot is defined by its index and can provide the node with up to two ports: one on the left, and one on the right. By convention the left port is also referred to as the [b]input port[/b] and the right port is referred to as the [b]output port[/b]. Each port can be enabled and configured individually, using different type and color. The type is an arbitrary value that you can define using your own considerations. The parent [GraphEdit] will receive this information on each connect and disconnect request.
+		Each [GraphNode] slot is defined by a [Control]-derived child of the [GraphNode]. It has an index and can provide the node with up to two ports: one on the left, and one on the right. By convention the left port is also referred to as the [b]input port[/b] and the right port is referred to as the [b]output port[/b]. Each port can be enabled and configured individually, using different type and color. The type is an arbitrary value that you can define using your own considerations. The parent [GraphEdit] will receive this information on each connect and disconnect request.
 		Slots can be configured in the Inspector dock once you add at least one child [Control]. The properties are grouped by each slot's index in the "Slot" section.
-		[b]Note:[/b] While GraphNode is set up using slots and slot indices, connections are made between the ports which are enabled. Because of that [GraphEdit] uses the port's index and not the slot's index. You can use [method get_input_port_slot] and [method get_output_port_slot] to get the slot index from the port index.
+		[b]Note:[/b] While GraphNode is set up using slots and slot indices, connections are made between the ports which are enabled. Because of that [GraphEdit] uses the port's index and not the slot's index. You can use [method get_input_port_slot] and [method get_output_port_slot] to get the slot index from the port index, and [method get_slot_input_port] and [method get_slot_output_port] to get the port index from the slot index.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -116,6 +116,14 @@
 				Returns the right (output) [Color] of the slot with the given [param slot_index].
 			</description>
 		</method>
+		<method name="get_slot_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of slots.
+				[b]Note:[/b] Slots are defined by [Control]-derived children of the [GraphNode]. [method set_slot] method only sets properties of a slot.
+				[b]Note:[/b] Slot count is updated in a deferred call, which means adding/removing a child does not have an immediate effect on result of this function. Only after deferred functions are called slot count will be updated.
+			</description>
+		</method>
 		<method name="get_slot_custom_icon_left" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="slot_index" type="int" />
@@ -130,6 +138,14 @@
 				Returns the right (output) custom [Texture2D] of the slot with the given [param slot_index].
 			</description>
 		</method>
+		<method name="get_slot_input_port">
+			<return type="int" />
+			<param index="0" name="slot_index" type="int" />
+			<description>
+				Returns index of the input port associated with given [param slot_index].
+				Returns -1 if slot has no input port.
+			</description>
+		</method>
 		<method name="get_slot_metadata_left" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="slot_index" type="int" />
@@ -142,6 +158,14 @@
 			<param index="0" name="slot_index" type="int" />
 			<description>
 				Returns the right (output) metadata of the slot with the given [param slot_index].
+			</description>
+		</method>
+		<method name="get_slot_output_port">
+			<return type="int" />
+			<param index="0" name="slot_index" type="int" />
+			<description>
+				Returns index of the output port associated with given [param slot_index].
+				Returns -1 if slot has no output port.
 			</description>
 		</method>
 		<method name="get_slot_type_left" qualifiers="const">
@@ -204,7 +228,7 @@
 				Ports can be further customized using [param color_left]/[param color_right] and [param custom_icon_left]/[param custom_icon_right]. The color parameter adds a tint to the icon. The custom icon can be used to override the default port dot.
 				Additionally, [param draw_stylebox] can be used to enable or disable drawing of the background stylebox for each slot. See [theme_item slot].
 				Individual properties can also be set using one of the [code]set_slot_*[/code] methods.
-				[b]Note:[/b] This method only sets properties of the slot. To create the slot itself, add a [Control]-derived child to the GraphNode.
+				[b]Note:[/b] This method only sets properties of the slot. To create the slot itself, add a [Control]-derived child to the [GraphNode].
 			</description>
 		</method>
 		<method name="set_slot_color_left">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -120,8 +120,8 @@
 			<return type="int" />
 			<description>
 				Returns the number of slots.
-				[b]Note:[/b] Slots are defined by [Control]-derived children of the [GraphNode]. [method set_slot] method only sets properties of a slot.
-				[b]Note:[/b] Slot count is updated in a deferred call, which means adding/removing a child does not have an immediate effect on result of this function. Only after deferred functions are called slot count will be updated.
+				[b]Note:[/b] Slots are defined by [Control]-derived children of the [GraphNode]. [method set_slot] only sets properties of a slot.
+				[b]Note:[/b] The slot count is updated in a deferred call, which means adding/removing a child does not have an immediate effect on the returned value of this function. The slot count is only updated after deferred functions are called.
 			</description>
 		</method>
 		<method name="get_slot_custom_icon_left" qualifiers="const">
@@ -142,8 +142,8 @@
 			<return type="int" />
 			<param index="0" name="slot_index" type="int" />
 			<description>
-				Returns index of the input port associated with given [param slot_index].
-				Returns -1 if slot has no input port.
+				Returns the index of the input port associated with the given [param slot_index].
+				Returns [code]-1[/code] if the slot has no input port.
 			</description>
 		</method>
 		<method name="get_slot_metadata_left" qualifiers="const">
@@ -164,8 +164,8 @@
 			<return type="int" />
 			<param index="0" name="slot_index" type="int" />
 			<description>
-				Returns index of the output port associated with given [param slot_index].
-				Returns -1 if slot has no output port.
+				Returns the index of the output port associated with the given [param slot_index].
+				Returns [code]-1[/code] if the slot has no output port.
 			</description>
 		</method>
 		<method name="get_slot_type_left" qualifiers="const">

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -1046,6 +1046,7 @@ void GraphNode::_port_pos_update() {
 
 	left_port_cache.clear();
 	right_port_cache.clear();
+	slot_port_cache.clear();
 
 	slot_count = 0; // Reset the slot count, which is the index of the current slot.
 
@@ -1069,14 +1070,20 @@ void GraphNode::_port_pos_update() {
 				port_y = child->get_position().y + size.height * 0.5; // The y centor is calculated from the class object position.
 			}
 
+			SlotCache slot_cache;
+
 			if (slot.enable_left) {
+				slot_cache.left_port_index = left_port_cache.size();
 				PortCache port_cache_left{ Point2i(edgeofs, port_y), slot_count, slot.type_left, slot.color_left };
 				left_port_cache.push_back(port_cache_left);
 			}
 			if (slot.enable_right) {
+				slot_cache.right_port_index = right_port_cache.size();
 				PortCache port_cache_right{ Point2i(get_size().width - edgeofs, port_y), slot_count, slot.type_right, slot.color_right };
 				right_port_cache.push_back(port_cache_right);
 			}
+
+			slot_port_cache.push_back(slot_cache);
 		}
 		vertical_ofs += size.height + separation; // Add the height of the child and the separation to the vertical offset.
 		slot_count++; // Go to the next slot
@@ -1177,6 +1184,28 @@ int GraphNode::get_output_port_slot(int p_port_idx) {
 
 	ERR_FAIL_INDEX_V(p_port_idx, right_port_cache.size(), -1);
 	return right_port_cache[p_port_idx].slot_index;
+}
+
+int GraphNode::get_slot_count() const {
+	return slot_count;
+}
+
+int GraphNode::get_slot_input_port(int p_slot_index) {
+	if (port_pos_dirty) {
+		_port_pos_update();
+	}
+
+	ERR_FAIL_INDEX_V(p_slot_index, slot_port_cache.size(), -1);
+	return slot_port_cache[p_slot_index].left_port_index;
+}
+
+int GraphNode::get_slot_output_port(int p_slot_index) {
+	if (port_pos_dirty) {
+		_port_pos_update();
+	}
+
+	ERR_FAIL_INDEX_V(p_slot_index, slot_port_cache.size(), -1);
+	return slot_port_cache[p_slot_index].right_port_index;
 }
 
 String GraphNode::get_accessibility_container_name(const Node *p_node) const {
@@ -1323,6 +1352,10 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_output_port_type", "port_idx"), &GraphNode::get_output_port_type);
 	ClassDB::bind_method(D_METHOD("get_output_port_color", "port_idx"), &GraphNode::get_output_port_color);
 	ClassDB::bind_method(D_METHOD("get_output_port_slot", "port_idx"), &GraphNode::get_output_port_slot);
+
+	ClassDB::bind_method(D_METHOD("get_slot_count"), &GraphNode::get_slot_count);
+	ClassDB::bind_method(D_METHOD("get_slot_input_port", "slot_index"), &GraphNode::get_slot_input_port);
+	ClassDB::bind_method(D_METHOD("get_slot_output_port", "slot_index"), &GraphNode::get_slot_output_port);
 
 	GDVIRTUAL_BIND(_draw_port, "slot_index", "position", "left", "color")
 

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -62,6 +62,11 @@ class GraphNode : public GraphElement {
 		Color color;
 	};
 
+	struct SlotCache {
+		int left_port_index = -1;
+		int right_port_index = -1;
+	};
+
 	struct _MinSizeCache {
 		int min_size = 0;
 		int max_size = -1;
@@ -87,6 +92,7 @@ class GraphNode : public GraphElement {
 
 	HashMap<int, Slot> slot_table;
 	Vector<int> slot_y_cache;
+	Vector<SlotCache> slot_port_cache;
 
 	Control::FocusMode slots_focus_mode = Control::FOCUS_ACCESSIBILITY;
 	int slot_count = 0;
@@ -192,6 +198,10 @@ public:
 	int get_output_port_type(int p_port_idx);
 	Color get_output_port_color(int p_port_idx);
 	int get_output_port_slot(int p_port_idx);
+
+	int get_slot_count() const;
+	int get_slot_input_port(int p_slot_index);
+	int get_slot_output_port(int p_slot_index);
 
 	void set_slots_focus_mode(Control::FocusMode p_focus_mode);
 	Control::FocusMode get_slots_focus_mode() const;

--- a/tests/scene/test_graph_node.cpp
+++ b/tests/scene/test_graph_node.cpp
@@ -34,7 +34,10 @@ TEST_FORCE_LINK(test_graph_node)
 
 #ifndef ADVANCED_GUI_DISABLED
 
+#include "core/object/message_queue.h"
 #include "scene/gui/graph_node.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
 
 namespace TestGraphNode {
 
@@ -53,6 +56,153 @@ TEST_CASE("[GraphNode][SceneTree]") {
 
 		memdelete(test_child);
 		memdelete(test_node);
+	}
+
+	SUBCASE("[GraphNode] Graph Node with no children should report no slots.") {
+		// Setup.
+		GraphNode *graph_node = memnew(GraphNode);
+		graph_node->set_name("Graph Node");
+
+		Window *root = SceneTree::get_singleton()->get_root();
+		root->add_child(graph_node);
+
+		// Test.
+		MessageQueue::get_singleton()->flush();
+		CHECK(graph_node->get_slot_count() == 0);
+
+		memdelete(graph_node);
+	}
+
+	SUBCASE("[GraphNode] Graph Node with no children should report no slots, even if slot properties were defined.") {
+		// Setup.
+		GraphNode *graph_node = memnew(GraphNode);
+		graph_node->set_name("Graph Node");
+
+		Window *root = SceneTree::get_singleton()->get_root();
+		root->add_child(graph_node);
+
+		// Test.
+		graph_node->set_slot(0, true, 0, Color(1, 0, 0, 1), true, 1, Color(0, 0, 1, 1));
+		graph_node->set_slot(2, true, 0, Color(0, 1, 0, 1), true, 1, Color(1, 1, 1, 1));
+		MessageQueue::get_singleton()->flush();
+		CHECK(graph_node->get_slot_count() == 0);
+
+		memdelete(graph_node);
+	}
+
+	SUBCASE("[GraphNode] Graph Node should properly count slots.") {
+		// Setup.
+		GraphNode *graph_node = memnew(GraphNode);
+		graph_node->set_name("Graph Node");
+
+		Window *root = SceneTree::get_singleton()->get_root();
+		root->add_child(graph_node);
+
+		// Test adding and removing children.
+		// Need to flush deferred functions, as that's when slots are updated.
+		int expected_slot_count = 0;
+		CHECK(graph_node->get_slot_count() == expected_slot_count);
+
+		Vector<Node *> test_children;
+		for (int i = 0; i < 5; ++i) {
+			Control *slot = memnew(Control);
+			graph_node->add_child(slot);
+			test_children.push_back(slot);
+			expected_slot_count++;
+
+			MessageQueue::get_singleton()->flush();
+			CHECK(graph_node->get_slot_count() == expected_slot_count);
+
+			if ((i & 1) == 0) {
+				Node *not_a_slot = memnew(Node);
+				graph_node->add_child(not_a_slot);
+				test_children.push_back(not_a_slot);
+
+				MessageQueue::get_singleton()->flush();
+				CHECK(graph_node->get_slot_count() == expected_slot_count);
+			}
+		}
+
+		for (Node *test_child : test_children) {
+			Control *c = Object::cast_to<Control>(test_child);
+			if (c) {
+				expected_slot_count--;
+			}
+			graph_node->remove_child(test_child);
+			memdelete(test_child);
+			MessageQueue::get_singleton()->flush();
+			CHECK(graph_node->get_slot_count() == expected_slot_count);
+		}
+
+		// Cleanup.
+		memdelete(graph_node);
+	}
+
+	SUBCASE("[GraphNode] Graph Node should properly report ports for slots.") {
+		// Setup.
+		GraphNode *graph_node = memnew(GraphNode);
+		graph_node->set_name("Graph Node");
+
+		Window *root = SceneTree::get_singleton()->get_root();
+		root->add_child(graph_node);
+
+		Vector<Control *> test_children;
+		for (int i = 0; i < 6; ++i) {
+			Control *slot = memnew(Control);
+			graph_node->add_child(slot);
+			test_children.push_back(slot);
+		}
+
+		MessageQueue::get_singleton()->flush();
+
+		graph_node->set_slot(0, true, 0, Color(1, 0, 0, 1), true, 1, Color(0, 0, 1, 1));
+		graph_node->set_slot(1, true, 0, Color(1, 0, 0, 1), false, 1, Color(0, 0, 1, 1));
+		graph_node->set_slot(2, false, 0, Color(1, 0, 0, 1), true, 1, Color(0, 0, 1, 1));
+		graph_node->set_slot(3, false, 0, Color(1, 0, 0, 1), false, 1, Color(0, 0, 1, 1));
+		// Slot 4 left undefined.
+		graph_node->set_slot(5, true, 0, Color(1, 0, 0, 1), true, 1, Color(0, 0, 1, 1));
+		graph_node->set_slot(6, true, 0, Color(1, 0, 0, 1), true, 1, Color(0, 0, 1, 1));
+
+		// Test.
+		CHECK(graph_node->get_slot_count() == 6);
+
+		CHECK(graph_node->get_slot_input_port(0) == 0);
+		CHECK(graph_node->get_slot_input_port(1) == 1);
+		CHECK(graph_node->get_slot_input_port(2) == -1);
+		CHECK(graph_node->get_slot_input_port(3) == -1);
+		CHECK(graph_node->get_slot_input_port(4) == -1);
+		CHECK(graph_node->get_slot_input_port(5) == 2);
+
+		CHECK(graph_node->get_slot_output_port(0) == 0);
+		CHECK(graph_node->get_slot_output_port(1) == -1);
+		CHECK(graph_node->get_slot_output_port(2) == 1);
+		CHECK(graph_node->get_slot_output_port(3) == -1);
+		CHECK(graph_node->get_slot_output_port(4) == -1);
+		CHECK(graph_node->get_slot_output_port(5) == 2);
+
+		graph_node->set_slot_enabled_left(5, false);
+		CHECK(graph_node->get_slot_input_port(5) == -1);
+		CHECK(graph_node->get_slot_output_port(5) == 2);
+
+		graph_node->set_slot_enabled_right(5, false);
+		CHECK(graph_node->get_slot_input_port(5) == -1);
+		CHECK(graph_node->get_slot_output_port(5) == -1);
+
+		graph_node->set_slot_enabled_right(4, true);
+		graph_node->set_slot_enabled_left(5, true);
+		graph_node->set_slot_enabled_right(5, true);
+		CHECK(graph_node->get_slot_input_port(4) == -1);
+		CHECK(graph_node->get_slot_input_port(5) == 2);
+		CHECK(graph_node->get_slot_output_port(4) == 2);
+		CHECK(graph_node->get_slot_output_port(5) == 3);
+
+		// Cleanup.
+		for (Node *test_child : test_children) {
+			graph_node->remove_child(test_child);
+			memdelete(test_child);
+		}
+
+		memdelete(graph_node);
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- This PR adds `get_slot_count()`, `get_slot_input_port()` and `get_slot_output_port()` to `GraphNode`.
- Those are symmetric to already existing `get_input_port_count()`, `get_input_port_slot()`, `get_output_port_count()` and `get_output_port_slot()`.
- It closes https://github.com/godotengine/godot-proposals/issues/8243

## Additional information

- Original proposal suggested adding `get_input_slot_count()` and `get_output_slot_count()`, but slots are not input or output.  
  There is only one kind of slot. Therefore just one `get_slot_count()` function was added.
- In proposal discussion it was suggested that `get_child_count()` is sufficient, but it is not.  
  Only `Control` derived children are counted as slots.
- Naming of `get_slot_input_port()` and `get_slot_output_port()` is not as suggested in the proposal, but instead it is kept consistent with already existing functions `get_input_port_slot()` and `get_output_port_slot()`.
- `slot_port_cache` is added in `GraphNode` instead of extending `slot_y_cache` because `slot_y_cache` is updated at a different time.  
  `slot_port_cache` is updated together with `left_port_cache` and `right_port_cache`.
- Code was tested manually and using provided unit tests.