### PR TITLE
Fix crash in `Tree::_get_item_focus_rect`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5160,7 +5160,10 @@ void Tree::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			drag_touching = false;
+			if (!is_visible()) {
+				drag_touching = false;
+				popup_editor->hide();
+			}
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
@@ -5642,7 +5645,7 @@ void Tree::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			if (popup_edited_item != nullptr) {
+			if (popup_edited_item != nullptr && popup_editor->is_visible()) {
 				Rect2 rect = _get_item_focus_rect(popup_edited_item);
 
 				popup_editor->set_position(get_screen_position() + rect.position);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes an intermittent crash I was seeing in my project when making a Tree node visible that has row select mode.
- Occurs when `selected_col` is -1.

## Additional information

lldb backtrace of the crash:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x10411b358)
  * frame #0: 0x000000010411b358 godot.macos.editor.dev.arm64`CowData<TreeItem::Cell>::get(this=0x00000077fc7f8778, p_index=-1) const at cowdata.h:197:3
    frame #1: 0x00000001040d9bd0 godot.macos.editor.dev.arm64`Vector<TreeItem::Cell>::operator[](this=0x00000077fc7f8770, p_index=-1) const at vector.h:144:75
    frame #2: 0x00000001040ff238 godot.macos.editor.dev.arm64`Tree::_get_item_focus_rect(this=0x000000780474dc10, p_item=0x00000077fc7f8610) const at tree.cpp:4663:10
    frame #3: 0x0000000104106ae4 godot.macos.editor.dev.arm64`Tree::_notification(this=0x000000780474dc10, p_what=2000) at tree.cpp:5646:18
    frame #4: 0x0000000102aae6d0 godot.macos.editor.dev.arm64`Tree::_notification_forwardv(this=0x000000780474dc10, p_notification=2000) at tree.h:470:2
    frame #5: 0x00000001063fb060 godot.macos.editor.dev.arm64`Object::_notification_forward(this=0x000000780474dc10, p_notification=2000) at object.cpp:910:2
    frame #6: 0x00000001000185ec godot.macos.editor.dev.arm64`Object::notification(this=0x000000780474dc10, p_notification=2000, p_reversed=false) at object.h:725:4
    frame #7: 0x0000000103adf170 godot.macos.editor.dev.arm64`SceneTree::flush_transform_notifications(this=0x0000007802e53210) at scene_tree.cpp:209:9
    frame #8: 0x0000000103ae2540 godot.macos.editor.dev.arm64`SceneTree::process(this=0x0000007802e53210, p_time=0.0069439999999999997) at scene_tree.cpp:717:2
    frame #9: 0x00000001000d8848 godot.macos.editor.dev.arm64`Main::iteration() at main.cpp:5058:44
    frame #10: 0x000000010000cc98 godot.macos.editor.dev.arm64`invocation function for block in OS_MacOS_NSApp::start_main(.block_descriptor=0x00000077f9f61900, observer=0x0000007802754a00, activity=32) at os_macos.mm:1157:12
    frame #11: 0x0000000183f2e4a4 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 36
    frame #12: 0x0000000183f2e39c CoreFoundation`__CFRunLoopDoObservers + 648
    frame #13: 0x0000000183f2da28 CoreFoundation`__CFRunLoopRun + 940
    frame #14: 0x0000000184006ba4 CoreFoundation`_CFRunLoopRunSpecificWithOptions + 532
    frame #15: 0x00000001912135a4 HIToolbox`RunCurrentEventLoopInMode + 320
    frame #16: 0x000000019121692c HIToolbox`ReceiveNextEventCommon + 488
    frame #17: 0x0000000191398f8c HIToolbox`_BlockUntilNextEventMatchingListInMode + 48
    frame #18: 0x0000000188727924 AppKit`_DPSBlockUntilNextEventMatchingListInMode + 292
    frame #19: 0x00000001883e38fc AppKit`_DPSNextEvent + 580
    frame #20: 0x0000000188b5d17c AppKit`-[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 780
    frame #21: 0x0000000188b5cc9c AppKit`-[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:] + 244
    frame #22: 0x00000001883d6a4c AppKit`-[NSApplication run] + 396
    frame #23: 0x000000010000c968 godot.macos.editor.dev.arm64`OS_MacOS_NSApp::run(this=0x000000011071b370) at os_macos.mm:1108:2
    frame #24: 0x00000001000b92dc godot.macos.editor.dev.arm64`main(argc=5, argv=0x000000016fdff110) at godot_main_macos.mm:132:6
    frame #25: 0x0000000183a9c914 dyld`start + 6700
```

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
