### PR TITLE
Metal: Fix data race when loading shader containers

### DIFF
--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -641,8 +641,8 @@ static const char *SHADER_STAGE_NAMES[] = {
 	"comp", // RDC::SHADER_STAGE_COMPUTE
 };
 
-void ShaderCacheEntry::notify_free() const {
-	owner.shader_cache_free_entry(key);
+void ShaderCacheEntry::notify_free() {
+	owner.shader_cache_free_entry(this);
 }
 
 #pragma mark - MDLibrary

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -889,7 +889,7 @@ struct ShaderCacheEntry {
 	std::weak_ptr<MDLibrary> library;
 
 	/// Notify the cache that this entry is no longer needed.
-	void notify_free() const;
+	void notify_free();
 
 	ShaderCacheEntry(RenderingDeviceDriverMetal &p_owner, SHA256Digest p_key) :
 			owner(p_owner), key(p_key) {

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1043,13 +1043,34 @@ void RenderingDeviceDriverMetal::framebuffer_free(FramebufferID p_framebuffer) {
 
 #pragma mark - Shader
 
-void RenderingDeviceDriverMetal::shader_cache_free_entry(const SHA256Digest &key) {
-	if (ShaderCacheEntry **pentry = _shader_cache.getptr(key); pentry != nullptr) {
-		ShaderCacheEntry *entry = *pentry;
-		_shader_cache.erase(key);
-		entry->library.reset();
-		memdelete(entry);
+void RenderingDeviceDriverMetal::shader_cache_free_entry(ShaderCacheEntry *p_entry) {
+	MutexLock lock(_shader_cache_lock);
+	// Only remove the map slot if it still refers to this exact entry. A concurrent
+	// creation for the same hash may have replaced it, in which case that newer entry
+	// (and its library) must be left untouched.
+	if (ShaderCacheEntry **pentry = _shader_cache.getptr(p_entry->key); pentry != nullptr && *pentry == p_entry) {
+		_shader_cache.erase(p_entry->key);
 	}
+	memdelete(p_entry);
+}
+
+std::optional<std::shared_ptr<MDLibrary>> RenderingDeviceDriverMetal::shader_cache_get_library(const SHA256Digest &key) {
+	MutexLock lock(_shader_cache_lock);
+
+	if (ShaderCacheEntry **p = _shader_cache.getptr(key); p != nullptr) {
+		if (std::shared_ptr<MDLibrary> lib = (*p)->library.lock()) {
+			return lib;
+		}
+		// Library was released; remove stale cache entry and recreate.
+		_shader_cache.erase(key);
+	}
+
+	return std::nullopt;
+}
+
+void RenderingDeviceDriverMetal::shader_cache_set_entry(const SHA256Digest &key, ShaderCacheEntry *p_entry) {
+	MutexLock lock(_shader_cache_lock);
+	_shader_cache[key] = p_entry;
 }
 
 template <typename T, typename U>
@@ -1122,14 +1143,9 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 		if (shader.shader_stage == RDD::ShaderStage::SHADER_STAGE_COMPUTE) {
 			pipeline_type = PIPELINE_TYPE_COMPUTE;
 		}
-
-		if (ShaderCacheEntry **p = _shader_cache.getptr(shader_data.hash); p != nullptr) {
-			if (std::shared_ptr<MDLibrary> lib = (*p)->library.lock()) {
-				libraries[shader.shader_stage] = lib;
-				continue;
-			}
-			// Library was released; remove stale cache entry and recreate.
-			_shader_cache.erase(shader_data.hash);
+		if (std::optional<std::shared_ptr<MDLibrary>> lib = shader_cache_get_library(shader_data.hash); lib) {
+			libraries[shader.shader_stage] = std::move(*lib);
+			continue;
 		}
 
 		if (shader.code_decompressed_size > 0) {
@@ -1167,7 +1183,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 			library = MDLibrary::create(cd, device, source.get(), options.get(), _shader_load_strategy);
 		}
 
-		_shader_cache[shader_data.hash] = cd;
+		shader_cache_set_entry(shader_data.hash, cd);
 		libraries[shader.shader_stage] = library;
 	}
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -36,6 +36,7 @@
 
 #include <Metal/Metal.hpp>
 
+#include <optional>
 #include <variant>
 
 class RenderingShaderContainerFormatMetal;
@@ -178,7 +179,10 @@ protected:
 	 * there are no more references to the MDLibrary associated with the cache entry.
 	 */
 	HashMap<SHA256Digest, ShaderCacheEntry *> _shader_cache;
-	void shader_cache_free_entry(const SHA256Digest &key);
+	Mutex _shader_cache_lock;
+	void shader_cache_free_entry(ShaderCacheEntry *p_entry);
+	std::optional<std::shared_ptr<MDLibrary>> shader_cache_get_library(const SHA256Digest &key);
+	void shader_cache_set_entry(const SHA256Digest &key, ShaderCacheEntry *p_entry);
 
 public:
 	virtual Error initialize(uint32_t p_device_index, uint32_t p_frame_count) override = 0;


### PR DESCRIPTION
Closes #120504

Protects the `_shader_cache` member with a `Mutex` to avoid the data race. Further, we hold the lock as briefly as possible and only accessing `_shader_cache` via member functions. This should maximise the parallelism of `shader_create_from_container`, as creating libraries from source can take some time to compile when the `LAZY` strategy is not used.

Ran the editor under TSAN in Xcode and reproduced the data race:

<details>
<summary>Data race</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=46747)
  Write of size 4 at 0x000123559818 by thread T20:
    #0 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_insert_element(unsigned int, HashMapElement<SHA256Digest, ShaderCacheEntry*>*) <null> (Godot:arm64+0x1065ea7a4)
    #1 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_insert(SHA256Digest const&, ShaderCacheEntry* const&, unsigned int, bool) <null> (Godot:arm64+0x1065ea1f4)
    #2 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::operator[](SHA256Digest const&) <null> (Godot:arm64+0x1065bf8cc)
    #3 RenderingDeviceDriverMetal::shader_create_from_container(Ref<RenderingShaderContainer> const&, Vector<RenderingDeviceDriver::ImmutableSampler> const&) <null> (Godot:arm64+0x1065bdf78)
    #4 RenderingDevice::shader_create_from_bytecode_with_samplers(Vector<unsigned char> const&, RID, Vector<RenderingDevice::Uniform> const&) <null> (Godot:arm64+0x108f62904)
    #5 ShaderRD::_load_variant_from_cache(unsigned int, ShaderRD::CompileData) <null> (Godot:arm64+0x108dac010)
    #6 WorkerThreadPool::GroupUserData<ShaderRD, void (ShaderRD::*)(unsigned int, ShaderRD::CompileData), ShaderRD::CompileData>::callback_indexed(unsigned int) <null> (Godot:arm64+0x108db7ca8)
    #7 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) <null> (Godot:arm64+0x100fe0850)
    #8 WorkerThreadPool::_thread_function(void*) <null> (Godot:arm64+0x100fe1dfc)
    #9 Thread::thread_callback(void*) <null> (Godot:arm64+0x1016fac14)

  Previous read of size 4 at 0x000123559818 by thread T15:
    #0 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_lookup_idx_unchecked(SHA256Digest const&, unsigned int, unsigned int&) const <null> (Godot:arm64+0x1065e7640)
    #1 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_lookup_idx(SHA256Digest const&, unsigned int&) const <null> (Godot:arm64+0x1065e74fc)
    #2 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::getptr(SHA256Digest const&) <null> (Godot:arm64+0x1065bc0ec)
    #3 RenderingDeviceDriverMetal::shader_create_from_container(Ref<RenderingShaderContainer> const&, Vector<RenderingDeviceDriver::ImmutableSampler> const&) <null> (Godot:arm64+0x1065bd3a8)
    #4 RenderingDevice::shader_create_from_bytecode_with_samplers(Vector<unsigned char> const&, RID, Vector<RenderingDevice::Uniform> const&) <null> (Godot:arm64+0x108f62904)
    #5 ShaderRD::_load_variant_from_cache(unsigned int, ShaderRD::CompileData) <null> (Godot:arm64+0x108dac010)
    #6 WorkerThreadPool::GroupUserData<ShaderRD, void (ShaderRD::*)(unsigned int, ShaderRD::CompileData), ShaderRD::CompileData>::callback_indexed(unsigned int) <null> (Godot:arm64+0x108db7ca8)
    #7 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) <null> (Godot:arm64+0x100fe0850)
    #8 WorkerThreadPool::_thread_function(void*) <null> (Godot:arm64+0x100fe1dfc)
    #9 Thread::thread_callback(void*) <null> (Godot:arm64+0x1016fac14)

  Location is heap block of size 1572 at 0x000123559400 allocated by thread T11:
    #0 calloc <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x67edc)
    #1 void* Memory::alloc_static<true>(unsigned long, bool) <null> (Godot:arm64+0x100ffac40)
    #2 Memory::alloc_static_zeroed(unsigned long, bool) <null> (Godot:arm64+0x1065db7b0)
    #3 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_resize_and_rehash(unsigned int) <null> (Godot:arm64+0x1065ea348)
    #4 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_insert(SHA256Digest const&, ShaderCacheEntry* const&, unsigned int, bool) <null> (Godot:arm64+0x1065ea030)
    #5 HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::operator[](SHA256Digest const&) <null> (Godot:arm64+0x1065bf8cc)
    #6 RenderingDeviceDriverMetal::shader_create_from_container(Ref<RenderingShaderContainer> const&, Vector<RenderingDeviceDriver::ImmutableSampler> const&) <null> (Godot:arm64+0x1065bdf78)
    #7 RenderingDevice::shader_create_from_bytecode_with_samplers(Vector<unsigned char> const&, RID, Vector<RenderingDevice::Uniform> const&) <null> (Godot:arm64+0x108f62904)
    #8 ShaderRD::_load_variant_from_cache(unsigned int, ShaderRD::CompileData) <null> (Godot:arm64+0x108dac010)
    #9 WorkerThreadPool::GroupUserData<ShaderRD, void (ShaderRD::*)(unsigned int, ShaderRD::CompileData), ShaderRD::CompileData>::callback_indexed(unsigned int) <null> (Godot:arm64+0x108db7ca8)
    #10 WorkerThreadPool::_process_task(WorkerThreadPool::Task*) <null> (Godot:arm64+0x100fe0850)
    #11 WorkerThreadPool::_thread_function(void*) <null> (Godot:arm64+0x100fe1dfc)
    #12 Thread::thread_callback(void*) <null> (Godot:arm64+0x1016fac14)

  Thread T20 (tid=3752905, running) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33acc)
    #1 Thread::start(void (*)(void*), void*, Thread::Settings const&) <null> (Godot:arm64+0x1016fb040)
    #2 WorkerThreadPool::init(int, float) <null> (Godot:arm64+0x100fe7ce4)
    #3 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x100013088)
    #4 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x10000d36c)
    #5 -[GodotApplicationDelegate applicationDidFinishLaunching:] <null> (Godot:arm64+0x106276ee4)
    #6 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ <null> (CoreFoundation:arm64e+0x729b8)
    #7 main <null> (Godot:arm64+0x106286d48)

  Thread T15 (tid=3752900, running) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33acc)
    #1 Thread::start(void (*)(void*), void*, Thread::Settings const&) <null> (Godot:arm64+0x1016fb040)
    #2 WorkerThreadPool::init(int, float) <null> (Godot:arm64+0x100fe7ce4)
    #3 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x100013088)
    #4 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x10000d36c)
    #5 -[GodotApplicationDelegate applicationDidFinishLaunching:] <null> (Godot:arm64+0x106276ee4)
    #6 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ <null> (CoreFoundation:arm64e+0x729b8)
    #7 main <null> (Godot:arm64+0x106286d48)

  Thread T11 (tid=3752896, running) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33acc)
    #1 Thread::start(void (*)(void*), void*, Thread::Settings const&) <null> (Godot:arm64+0x1016fb040)
    #2 WorkerThreadPool::init(int, float) <null> (Godot:arm64+0x100fe7ce4)
    #3 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x100013088)
    #4 Main::setup(char const*, int, char**, bool) <null> (Godot:arm64+0x10000d36c)
    #5 -[GodotApplicationDelegate applicationDidFinishLaunching:] <null> (Godot:arm64+0x106276ee4)
    #6 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ <null> (CoreFoundation:arm64e+0x729b8)
    #7 main <null> (Godot:arm64+0x106286d48)

SUMMARY: ThreadSanitizer: data race (/Volumes/Data/projects/games/godot/xcode/main/Debug/Godot.app/Contents/MacOS/Godot:arm64+0x1065ea7a4) in HashMap<SHA256Digest, ShaderCacheEntry*, HashMapHasherDefault, HashMapComparatorDefault<SHA256Digest, void>, DefaultTypedAllocator<HashMapElement<SHA256Digest, ShaderCacheEntry*>>>::_insert_element(unsigned int, HashMapElement<SHA256Digest, ShaderCacheEntry*>*)+0x1d8
==================
```

</summary>