### PR TITLE
Fix use-after-free crash in `TileSetAtlasSourceEditor`

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -607,6 +607,7 @@ void TileSetAtlasSourceEditor::_update_atlas_source_inspector() {
 
 void TileSetAtlasSourceEditor::_update_tile_inspector() {
 	// Update visibility.
+	tile_inspector->edit(nullptr);
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
 		if (!selection.is_empty()) {
 			tile_proxy_object.instantiate(this);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120542

## Additional information
This happened because a new `tile_proxy_object` was instantiated, which immediately destroyed the old one. However, the tile_inspector still held a pointer to that old object. When the new object was being processed, it was attempted to clean up and separate signals from the object that was already inactive, which caused a crash.

I added `tile_inspector->edit(nullptr);` right before the proxy object gets overwritten. This forces the inspector to let go of the old object and clean up before the object actually gets wiped from memory.