### PR TITLE
Editor: Clear `EditorHelpBit` cache when changing locale

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4421,6 +4421,11 @@ void EditorHelpBit::_bind_methods() {
 
 void EditorHelpBit::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED:
+			if (!current_symbol.is_empty()) {
+				parse_symbol(current_symbol, current_prologue);
+			}
+			break;
 		case NOTIFICATION_THEME_CHANGED:
 			content->begin_bulk_theme_override();
 
@@ -4436,6 +4441,17 @@ void EditorHelpBit::_notification(int p_what) {
 			_update_labels();
 			break;
 	}
+}
+
+void EditorHelpBit::clear_cache() {
+	doc_class_cache.clear();
+	doc_enum_cache.clear();
+	doc_constant_cache.clear();
+	doc_property_cache.clear();
+	doc_theme_item_cache.clear();
+	doc_method_cache.clear();
+	doc_signal_cache.clear();
+	doc_annotation_cache.clear();
 }
 
 String EditorHelpBit::get_as_plain_text(const String &p_symbol, const String &p_prologue) {
@@ -4683,11 +4699,15 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 		item_data = JSON::parse_string(slices[3]);
 	}
 
+	current_symbol = p_symbol;
+	current_prologue = p_prologue;
+
 	symbol_doc_link = String();
 	symbol_class_name = class_name;
 	symbol_type = String();
 	symbol_name = item_name;
 	symbol_hint = SYMBOL_HINT_NONE;
+
 	help_data = HelpData();
 
 	if (item_type == "class") {
@@ -4851,6 +4871,9 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 }
 
 void EditorHelpBit::set_custom_text(const String &p_type, const String &p_name, const String &p_description) {
+	current_symbol = String();
+	current_prologue = String();
+
 	symbol_doc_link = String();
 	symbol_class_name = String();
 	symbol_type = p_type;
@@ -4884,7 +4907,12 @@ void EditorHelpBit::update_content_height() {
 	content->set_custom_minimum_size(Size2(content->get_custom_minimum_size().x, CLAMP(content_height, content_min_height, content_max_height)));
 }
 
-EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_allow_selection, bool p_in_tooltip) {
+EditorHelpBit::EditorHelpBit(
+		const String &p_symbol,
+		const String &p_prologue,
+		bool p_use_class_prefix,
+		bool p_allow_selection,
+		bool p_in_tooltip) {
 	add_theme_constant_override("separation", 0);
 
 	title = memnew(RichTextLabel);
@@ -5010,7 +5038,12 @@ void EditorHelpBitTooltip::_notification(int p_what) {
 	}
 }
 
-Control *EditorHelpBitTooltip::make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_shortcut) {
+Control *EditorHelpBitTooltip::make_tooltip(
+		Control *p_target,
+		const String &p_symbol,
+		const String &p_prologue,
+		bool p_use_class_prefix,
+		bool p_shortcut) {
 	ERR_FAIL_NULL_V(p_target, _make_invisible_control());
 
 	// Show the custom tooltip only if it is not already visible.
@@ -5201,7 +5234,7 @@ void EditorHelpHighlighter::highlight(RichTextLabel *p_rich_text_label, Language
 	}
 }
 
-void EditorHelpHighlighter::reset_cache() {
+void EditorHelpHighlighter::clear_cache() {
 	const Color text_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
 
 #ifdef MODULE_GDSCRIPT_ENABLED

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -323,6 +323,9 @@ class EditorHelpBit : public VBoxContainer {
 
 	bool use_class_prefix = false;
 
+	String current_symbol;
+	String current_prologue;
+
 	String symbol_doc_link;
 	String symbol_class_name;
 	String symbol_type;
@@ -354,6 +357,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static void clear_cache();
 	static String get_as_plain_text(const String &p_symbol, const String &p_prologue = String());
 
 	void parse_symbol(const String &p_symbol, const String &p_prologue = String());
@@ -362,7 +366,12 @@ public:
 	void set_content_height_limits(float p_min, float p_max);
 	void update_content_height();
 
-	EditorHelpBit(const String &p_symbol = String(), const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_allow_selection = true, bool p_in_tooltip = false);
+	EditorHelpBit(
+			const String &p_symbol = String(),
+			const String &p_prologue = String(),
+			bool p_use_class_prefix = false,
+			bool p_allow_selection = true,
+			bool p_in_tooltip = false);
 };
 
 // Standard tooltips do not allow you to hover over them.
@@ -388,7 +397,12 @@ protected:
 
 public:
 	// The returned control is an orphan node, which is to make the standard tooltip invisible.
-	[[nodiscard]] static Control *make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_shortcut = false);
+	[[nodiscard]] static Control *make_tooltip(
+			Control *p_target,
+			const String &p_symbol,
+			const String &p_prologue = String(),
+			bool p_use_class_prefix = false,
+			bool p_shortcut = false);
 
 	void popup_under_position(const Point2 &p_point);
 
@@ -426,7 +440,7 @@ public:
 	static EditorHelpHighlighter *get_singleton();
 
 	void highlight(RichTextLabel *p_rich_text_label, Language p_language, const String &p_source, bool p_use_cache);
-	void reset_cache();
+	void clear_cache();
 
 	EditorHelpHighlighter();
 	virtual ~EditorHelpHighlighter();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -698,8 +698,7 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 #if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 		if (EditorHelpHighlighter::get_singleton()) {
 			// Update syntax colors.
-			EditorHelpHighlighter::free_singleton();
-			EditorHelpHighlighter::create_singleton();
+			EditorHelpHighlighter::get_singleton()->clear_cache();
 		}
 #endif
 	}
@@ -761,6 +760,7 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 	editor_dock_manager->update_tab_styles();
 	editor_dock_manager->update_docks_menu();
 	editor_dock_manager->set_tab_icon_max_width(theme->get_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
+
 #ifdef ANDROID_ENABLED
 	DisplayServer::get_singleton()->window_set_color(theme->get_color(SNAME("background"), EditorStringName(Editor)));
 #endif
@@ -873,6 +873,8 @@ void EditorNode::_notification(int p_what) {
 				// TRANSLATORS: The placeholder is the rendering method that has overridden the default one.
 				renderer->set_item_text(0, vformat(TTR("%s (Overridden)"), _to_rendering_method_display_name(current_renderer_os)));
 			}
+
+			EditorHelpBit::clear_cache();
 		} break;
 
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -1166,11 +1168,6 @@ void EditorNode::_notification(int p_what) {
 				DisplayServer::get_singleton()->screen_set_keep_on(EDITOR_GET("interface/editor/display/keep_screen_on"));
 			}
 
-#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme/highlighting")) {
-				EditorHelpHighlighter::get_singleton()->reset_cache();
-			}
-#endif
 #ifdef ANDROID_ENABLED
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen/touch_actions_panel")) {
 				_touch_actions_panel_mode_changed();

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -656,6 +656,11 @@ void CreateDialog::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			// Update `EditorHelpBit` in case it contains custom text.
+			_update_search();
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 			search_options->add_theme_constant_override("icon_max_width", icon_width);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -123,6 +123,8 @@ void ProjectManager::_notification(int p_what) {
 			empty_list_message->set_text(vformat("[center][b]%s[/b] %s[/center]", line1, line2));
 
 			_titlebar_resized();
+
+			EditorHelpBit::clear_cache();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -308,6 +310,11 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			asset_library->add_theme_style_override(SceneStringName(panel), memnew(StyleBoxEmpty));
 		}
 	}
+
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+	EditorHelpHighlighter::get_singleton()->clear_cache();
+#endif
+
 #ifdef ANDROID_ENABLED
 	DisplayServer::get_singleton()->window_set_color(theme->get_color("background", EditorStringName(Editor)));
 #endif

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -745,7 +745,11 @@ void EditorBuildProfileManager::_notification(int p_what) {
 				edited.instantiate();
 				_update_edited_profile();
 			}
+		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			// Update `EditorHelpBit` in case it contains custom text.
+			_class_list_item_selected();
 		} break;
 	}
 }

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -358,6 +358,11 @@ void EditorFeatureProfileManager::_notification(int p_what) {
 			_update_profile_list(current_profile);
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			// Update `EditorHelpBit` in case it contains custom text.
+			_class_list_item_selected();
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			// Make sure that the icons are correctly adjusted if the theme's lightness was switched.
 			_update_selected_profile();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120190.
- Supersedes #117324.

## Additional information

_None._
