### PR TITLE
Fix `HTTPRequest.has_header` match logic

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -76,34 +76,29 @@ Error HTTPRequest::_parse_url(const String &p_url) {
 }
 
 bool HTTPRequest::has_header(const PackedStringArray &p_headers, const String &p_header_name) {
-	bool exists = false;
-
 	String lower_case_header_name = p_header_name.to_lower();
-	for (int i = 0; i < p_headers.size() && !exists; i++) {
-		String sanitized = p_headers[i].strip_edges().to_lower();
-		if (sanitized.begins_with(lower_case_header_name)) {
-			exists = true;
-		}
-	}
-
-	return exists;
-}
-
-String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const String &p_header_name) {
-	String value = "";
-
-	String lowwer_case_header_name = p_header_name.to_lower();
-	for (int i = 0; i < p_headers.size(); i++) {
-		if (p_headers[i].find_char(':') > 0) {
-			Vector<String> parts = p_headers[i].split(":", false, 1);
-			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
-				value = parts[1].strip_edges();
-				break;
+	for (const String &header : p_headers) {
+		if (header.find_char(':') > 0) {
+			Vector<String> parts = header.split(":", false, 1);
+			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lower_case_header_name) {
+				return true;
 			}
 		}
 	}
+	return false;
+}
 
-	return value;
+String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const String &p_header_name) {
+	String lower_case_header_name = p_header_name.to_lower();
+	for (const String &header : p_headers) {
+		if (header.find_char(':') > 0) {
+			Vector<String> parts = header.split(":", false, 1);
+			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lower_case_header_name) {
+				return parts[1].strip_edges();
+			}
+		}
+	}
+	return String();
 }
 
 Error HTTPRequest::request(const String &p_url, const Vector<String> &p_custom_headers, HTTPClient::Method p_method, const String &p_request_data) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes the private function `HTTPRequest::has_header()`.

The current implementation is wrong, because it checks if the line starts with the header, when it instead should check if it matches with the entire text before ":" :

https://github.com/godotengine/godot/blob/d569fcf207aea355ea9d0822255ad490945f5572/scene/main/http_request.cpp#L81-L87

So, if the line is for example "Content-Length: 123", then `has_header(list, "Content")` will return `true`, when it should return `false`.

I simply copied the code from the function below `get_header_value`, which is implemented correctly:

https://github.com/godotengine/godot/blob/d569fcf207aea355ea9d0822255ad490945f5572/scene/main/http_request.cpp#L95-L104

## Additional information

I also made some cleanups:

- Fixed a typo ("lowwer_case_header_name" --> "lower_case_header_name")
- Return early instead of keeping track of an additional variable
- Change the `for (int i = 0; i < p_headers.size(); i++)` loop to a `for (const String &header : p_headers)` loop (suggested by AThousandShips)

I also applied this to the neighboring function `get_header_value`, because the change is too small to put in a separate PR, and as mentioned earlier, the code is almost identical. If that's not OK, I can revert it, but I think that it makes the code cleaner and more bug-proof (`has_header` used a messy break statement `&& !exists` instead of `break;`, which is easy to miss)

This is not a breaking change, as this function is not exposed.