### PR TITLE
Fix scene tab titles not updating on language change

### DIFF
--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -78,7 +78,7 @@ void EditorSceneTabs::_notification(int p_what) {
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			_scene_tabs_resized();
+			_update_tab_titles();
 		} break;
 	}
 }


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120553

## Additional information
With fix:

https://github.com/user-attachments/assets/40493a79-f8d1-4fb4-8547-391ee63b909b

As I don't have that much experience with the Godot code I have some doubts of which _notification() to target, but for me it made sense for the change to be here.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
