### PR TITLE
Fix RDG treating intersecting read-only slices as self dependency.

### DIFF
--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -406,6 +406,13 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 
 		resource_tracker->reset_if_outdated(tracking_frame);
 
+		resource_tracker->command_index = p_command_index;
+		resource_tracker->usage_index = i;
+	}
+
+	for (uint32_t i = 0; i < p_resource_count; i++) {
+		ResourceTracker *resource_tracker = p_resource_trackers[i];
+
 		const RDD::TextureSubresourceRange &subresources = resource_tracker->texture_subresources;
 		const Rect2i resource_tracker_rect(subresources.base_mipmap, subresources.base_layer, subresources.mipmap_count, subresources.layer_count);
 		Rect2i search_tracker_rect = resource_tracker_rect;
@@ -417,6 +424,15 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 		if (is_resource_a_slice) {
 			// This resource depends on a parent resource.
 			resource_tracker->parent->reset_if_outdated(tracking_frame);
+
+			// Quit early if the parent is already in this command.
+			if (resource_tracker->parent->command_index == p_command_index) {
+				DEV_ASSERT(resource_tracker->parent->usage_index != UINT32_MAX);
+
+				ERR_FAIL_COND_MSG(p_resource_usages[resource_tracker->parent->usage_index] != new_resource_usage, "Using a full texture and its slices at the same time with different usages is not allowed.");
+
+				continue;
+			}
 
 			if (resource_tracker->texture_slice_command_index != p_command_index) {
 				// Indicate this slice has been used by this command.

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -182,6 +182,8 @@ public:
 	struct ResourceTracker {
 		uint32_t reference_count = 0;
 		int64_t command_frame = -1;
+		int32_t command_index = -1;
+		uint32_t usage_index = UINT32_MAX;
 		BitField<RDD::PipelineStageBits> previous_frame_stages = {};
 		BitField<RDD::PipelineStageBits> current_frame_stages = {};
 		int32_t read_full_command_list_index = -1;
@@ -213,6 +215,8 @@ public:
 		_FORCE_INLINE_ void reset_if_outdated(int64_t new_command_frame) {
 			if (new_command_frame != command_frame) {
 				command_frame = new_command_frame;
+				command_index = -1;
+				usage_index = UINT32_MAX;
 				previous_frame_stages = current_frame_stages;
 				current_frame_stages.clear();
 				read_full_command_list_index = -1;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120516

Allows parent textures and slices with the same usages to exist in the same command. RDG previously did not account for this behavior and it caused a lot of self dependency checks to trigger due to layout transitions being considered as write usage.

The scenario specifically happens with the following configuration:

- Slice view into the first layer used in an early draw call. Usage is `TEXTURE_SAMPLE`.
- Full texture used in a later draw call. Usage is still `TEXTURE_SAMPLE`.

This happens in a draw list so it's a single command.

## Additional information

Regression from #119342. No GPU validation errors on D3D12 or Vulkan with the PR.

