### PR TITLE
OpenGL: Emulate multiview when it's not supported

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1548,6 +1548,7 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 	scene_state.data.camera_visible_layers = p_render_data->camera_visible_layers;
 
 	if (p_render_data->view_count > 1) {
+		scene_state.multiview_data.view_index = 0;
 		for (uint32_t v = 0; v < p_render_data->view_count; v++) {
 			projection = correction * p_render_data->view_projection[v];
 			GLES3::MaterialStorage::store_camera(projection, scene_state.multiview_data.projection_matrix_view[v]);
@@ -2653,7 +2654,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	scene_state.reset_gl_state();
 
-	GLuint motion_vectors_fbo = rt ? rt->overridden.velocity_fbo : 0;
+	GLuint motion_vectors_fbo = (rt && !rb->emulate_multiview) ? rt->overridden.velocity_fbo : 0;
 	if (motion_vectors_fbo != 0 && enough_vertex_attribs_for_motion_vectors) {
 		RENDER_TIMESTAMP("Motion Vectors Pass");
 		glBindFramebuffer(GL_FRAMEBUFFER, motion_vectors_fbo);
@@ -2687,243 +2688,269 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		scene_state.prev_data_state = 2;
 	}
 
-	GLuint fbo = 0;
-	if (is_reflection_probe && GLES3::LightStorage::get_singleton()->reflection_probe_has_atlas_index(render_data.reflection_probe)) {
-		fbo = GLES3::LightStorage::get_singleton()->reflection_probe_instance_get_framebuffer(render_data.reflection_probe, render_data.reflection_probe_pass);
-	} else {
-		rb->set_apply_environment_effects_in_post(apply_environment_effects_in_post);
-		rb->set_apply_canvas_bg_exposure(apply_canvas_bg_exposure);
-		fbo = rb->get_render_fbo();
-	}
+	// When the GPU doesn't support multiview, we emulate it by rendering the
+	// scene once per view into each layer of the texture array. Otherwise this
+	// loop runs a single time and GPU multiview renders all views at once.
+	const uint32_t eye_passes = rb->emulate_multiview ? rb->view_count : 1;
 
-	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-	glViewport(0, 0, rb->internal_size.x, rb->internal_size.y);
+	for (uint32_t eye = 0; eye < eye_passes; eye++) {
+		if (rb->emulate_multiview && eye > 0) {
+			// Change the view_index and re-upload the multiview UBO.
+			scene_state.multiview_data.view_index = eye;
+			_update_scene_ubo(scene_state.multiview_buffer, SCENE_MULTIVIEW_UNIFORM_LOCATION, sizeof(SceneState::MultiviewUBO), &scene_state.multiview_data, "Multiview UBO");
 
-	// If SSAO is enabled, we definitely need the depth buffer.
-	if (ssao_enabled) {
-		scene_state.used_depth_texture = true;
-	}
+			if (!flip_y) {
+				// Re-establish the winding order, which was changed at the end
+				// of the previous loop.
+				glFrontFace(GL_CW);
+			}
+		}
 
-	// Do depth prepass if it's explicitly enabled
-	bool use_depth_prepass = config->use_depth_prepass;
+		// Each view clears and renders into its own texture-array layer.
+		fb_cleared = false;
 
-	// Forcibly enable depth prepass if opaque stencil writes are used.
-	use_depth_prepass = use_depth_prepass || scene_state.used_opaque_stencil;
+		GLuint fbo = 0;
+		if (is_reflection_probe && GLES3::LightStorage::get_singleton()->reflection_probe_has_atlas_index(render_data.reflection_probe)) {
+			fbo = GLES3::LightStorage::get_singleton()->reflection_probe_instance_get_framebuffer(render_data.reflection_probe, render_data.reflection_probe_pass);
+		} else {
+			rb->set_apply_environment_effects_in_post(apply_environment_effects_in_post);
+			rb->set_apply_canvas_bg_exposure(apply_canvas_bg_exposure);
+			fbo = rb->get_render_fbo(rb->emulate_multiview ? (int)eye : -1);
+		}
 
-	// Don't do depth prepass we are rendering overdraw
-	use_depth_prepass = use_depth_prepass && get_debug_draw_mode() != RSE::VIEWPORT_DEBUG_DRAW_OVERDRAW;
+		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+		glViewport(0, 0, rb->internal_size.x, rb->internal_size.y);
 
-	if (use_depth_prepass) {
-		RENDER_TIMESTAMP("Depth Prepass");
-		//pre z pass
+		// If SSAO is enabled, we definitely need the depth buffer.
+		if (ssao_enabled) {
+			scene_state.used_depth_texture = true;
+		}
+
+		// Do depth prepass if it's explicitly enabled
+		bool use_depth_prepass = config->use_depth_prepass;
+
+		// Forcibly enable depth prepass if opaque stencil writes are used.
+		use_depth_prepass = use_depth_prepass || scene_state.used_opaque_stencil;
+
+		// Don't do depth prepass we are rendering overdraw
+		use_depth_prepass = use_depth_prepass && get_debug_draw_mode() != RSE::VIEWPORT_DEBUG_DRAW_OVERDRAW;
+
+		if (use_depth_prepass) {
+			RENDER_TIMESTAMP("Depth Prepass");
+			//pre z pass
+
+			if (render_data.render_region != Rect2i()) {
+				glViewport(render_data.render_region.position.x, render_data.render_region.position.y, render_data.render_region.size.width, render_data.render_region.size.height);
+			}
+
+			scene_state.enable_gl_depth_test(true);
+			scene_state.enable_gl_depth_draw(true);
+			scene_state.enable_gl_blend(false);
+			scene_state.set_gl_depth_func(GL_GEQUAL);
+			scene_state.enable_gl_scissor_test(false);
+			scene_state.enable_gl_stencil_test(false);
+
+			glColorMask(0, 0, 0, 0);
+			RasterizerUtilGLES3::clear_depth(0.0);
+			RasterizerUtilGLES3::clear_stencil(0);
+			glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+			// Some desktop GL implementations fall apart when using Multiview with GL_NONE.
+			GLuint db = p_camera_data->view_count > 1 ? GL_COLOR_ATTACHMENT0 : GL_NONE;
+			glDrawBuffers(1, &db);
+
+			uint64_t spec_constant = SceneShaderGLES3::DISABLE_FOG | SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL |
+					SceneShaderGLES3::DISABLE_LIGHTMAP | SceneShaderGLES3::DISABLE_LIGHT_OMNI |
+					SceneShaderGLES3::DISABLE_LIGHT_SPOT | SceneShaderGLES3::DISABLE_LIGHT_AREA;
+
+			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant, use_wireframe);
+			_render_list_template<PASS_MODE_DEPTH>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
+
+			glColorMask(1, 1, 1, 1);
+
+			fb_cleared = true;
+			scene_state.used_depth_prepass = true;
+		} else {
+			scene_state.used_depth_prepass = false;
+		}
+
+		glBlendEquation(GL_FUNC_ADD);
+		if (render_data.transparent_bg) {
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+			scene_state.enable_gl_blend(true);
+		} else {
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+			scene_state.enable_gl_blend(false);
+		}
+		scene_state.current_blend_mode = GLES3::SceneShaderData::BLEND_MODE_MIX;
+
+		scene_state.enable_gl_scissor_test(false);
+		scene_state.enable_gl_depth_test(true);
+		scene_state.enable_gl_depth_draw(true);
+		scene_state.set_gl_depth_func(GL_GEQUAL);
+
+		{
+			GLuint db = GL_COLOR_ATTACHMENT0;
+			glDrawBuffers(1, &db);
+		}
+
+		scene_state.enable_gl_stencil_test(false);
+
+		if (!fb_cleared) {
+			RasterizerUtilGLES3::clear_depth(0.0);
+			RasterizerUtilGLES3::clear_stencil(0);
+			glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+		}
+
+		// Need to clear framebuffer unless:
+		// a) We explicitly request not to (i.e. ENV_BG_KEEP).
+		// b) We are rendering to a non-intermediate framebuffer with ENV_BG_CANVAS (shared between 2D and 3D).
+		if (!keep_color && (!draw_canvas || (rt && fbo != rt->fbo))) {
+			clear_color.a = render_data.transparent_bg ? 0.0f : 1.0f;
+			glClearBufferfv(GL_COLOR, 0, clear_color.components);
+		}
+		if ((keep_color || draw_canvas) && rt && fbo != rt->fbo) {
+			// Need to copy our current contents to our intermediate/MSAA buffer
+			GLES3::CopyEffects *copy_effects = GLES3::CopyEffects::get_singleton();
+
+			scene_state.enable_gl_depth_test(false);
+			scene_state.enable_gl_depth_draw(false);
+
+			glActiveTexture(GL_TEXTURE0);
+			glBindTexture(rt->view_count > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D, rt->color);
+
+			if (apply_canvas_bg_exposure) {
+				copy_effects->copy_with_exposure(tonemap_ubo.exposure, render_data.luminance_multiplier);
+			} else {
+				copy_effects->copy_screen(render_data.luminance_multiplier);
+			}
+
+			scene_state.enable_gl_depth_test(true);
+			scene_state.enable_gl_depth_draw(true);
+		}
+
+		RENDER_TIMESTAMP("Render Opaque Pass");
+		uint64_t spec_constant_base_flags = 0;
 
 		if (render_data.render_region != Rect2i()) {
 			glViewport(render_data.render_region.position.x, render_data.render_region.position.y, render_data.render_region.size.width, render_data.render_region.size.height);
 		}
 
-		scene_state.enable_gl_depth_test(true);
-		scene_state.enable_gl_depth_draw(true);
-		scene_state.enable_gl_blend(false);
-		scene_state.set_gl_depth_func(GL_GEQUAL);
-		scene_state.enable_gl_scissor_test(false);
+		{
+			// Specialization Constants that apply for entire rendering pass.
+			if (render_data.directional_light_count == 0) {
+				spec_constant_base_flags |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
+			}
+
+			if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment))) {
+				spec_constant_base_flags |= SceneShaderGLES3::DISABLE_FOG;
+			}
+
+			if (render_data.environment.is_valid() && environment_get_fog_mode(render_data.environment) == RSE::EnvironmentFogMode::ENV_FOG_MODE_DEPTH) {
+				spec_constant_base_flags |= SceneShaderGLES3::USE_DEPTH_FOG;
+			}
+
+			if (!apply_environment_effects_in_post) {
+				spec_constant_base_flags |= SceneShaderGLES3::APPLY_TONEMAPPING;
+			}
+		}
+
+		if (draw_feed && camera_feed_id > -1) {
+			RENDER_TIMESTAMP("Render Camera feed");
+
+			scene_state.enable_gl_depth_draw(false);
+			scene_state.enable_gl_depth_test(false);
+			scene_state.enable_gl_blend(false);
+			scene_state.set_gl_cull_mode(RSE::CULL_MODE_BACK);
+
+			Ref<CameraFeed> feed = CameraServer::get_singleton()->get_feed_by_id(camera_feed_id);
+
+			if (feed.is_valid()) {
+				RID camera_YCBCR = feed->get_texture(CameraServer::FEED_YCBCR_IMAGE);
+				GLES3::TextureStorage::get_singleton()->texture_bind(camera_YCBCR, 0);
+
+				GLES3::FeedEffects *feed_effects = GLES3::FeedEffects::get_singleton();
+				feed_effects->draw();
+			}
+			scene_state.enable_gl_depth_draw(true);
+			scene_state.enable_gl_depth_test(true);
+			scene_state.enable_gl_blend(true);
+		}
+
+		// Render Opaque Objects.
+		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
+
+		_render_list_template<PASS_MODE_COLOR>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
+
+		scene_state.enable_gl_depth_draw(false);
 		scene_state.enable_gl_stencil_test(false);
 
-		glColorMask(0, 0, 0, 0);
-		RasterizerUtilGLES3::clear_depth(0.0);
-		RasterizerUtilGLES3::clear_stencil(0);
-		glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		// Some desktop GL implementations fall apart when using Multiview with GL_NONE.
-		GLuint db = p_camera_data->view_count > 1 ? GL_COLOR_ATTACHMENT0 : GL_NONE;
-		glDrawBuffers(1, &db);
+		if (draw_sky || draw_sky_fog_only) {
+			RENDER_TIMESTAMP("Render Sky");
 
-		uint64_t spec_constant = SceneShaderGLES3::DISABLE_FOG | SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL |
-				SceneShaderGLES3::DISABLE_LIGHTMAP | SceneShaderGLES3::DISABLE_LIGHT_OMNI |
-				SceneShaderGLES3::DISABLE_LIGHT_SPOT | SceneShaderGLES3::DISABLE_LIGHT_AREA;
+			scene_state.enable_gl_depth_test(true);
+			scene_state.set_gl_depth_func(GL_GEQUAL);
+			scene_state.enable_gl_blend(false);
+			scene_state.set_gl_cull_mode(RSE::CULL_MODE_BACK);
 
-		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant, use_wireframe);
-		_render_list_template<PASS_MODE_DEPTH>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
+			Transform3D transform = render_data.cam_transform;
+			Projection projection = render_data.cam_projection;
 
-		glColorMask(1, 1, 1, 1);
-
-		fb_cleared = true;
-		scene_state.used_depth_prepass = true;
-	} else {
-		scene_state.used_depth_prepass = false;
-	}
-
-	glBlendEquation(GL_FUNC_ADD);
-	if (render_data.transparent_bg) {
-		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		scene_state.enable_gl_blend(true);
-	} else {
-		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
-		scene_state.enable_gl_blend(false);
-	}
-	scene_state.current_blend_mode = GLES3::SceneShaderData::BLEND_MODE_MIX;
-
-	scene_state.enable_gl_scissor_test(false);
-	scene_state.enable_gl_depth_test(true);
-	scene_state.enable_gl_depth_draw(true);
-	scene_state.set_gl_depth_func(GL_GEQUAL);
-
-	{
-		GLuint db = GL_COLOR_ATTACHMENT0;
-		glDrawBuffers(1, &db);
-	}
-
-	scene_state.enable_gl_stencil_test(false);
-
-	if (!fb_cleared) {
-		RasterizerUtilGLES3::clear_depth(0.0);
-		RasterizerUtilGLES3::clear_stencil(0);
-		glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-	}
-
-	// Need to clear framebuffer unless:
-	// a) We explicitly request not to (i.e. ENV_BG_KEEP).
-	// b) We are rendering to a non-intermediate framebuffer with ENV_BG_CANVAS (shared between 2D and 3D).
-	if (!keep_color && (!draw_canvas || (rt && fbo != rt->fbo))) {
-		clear_color.a = render_data.transparent_bg ? 0.0f : 1.0f;
-		glClearBufferfv(GL_COLOR, 0, clear_color.components);
-	}
-	if ((keep_color || draw_canvas) && rt && fbo != rt->fbo) {
-		// Need to copy our current contents to our intermediate/MSAA buffer
-		GLES3::CopyEffects *copy_effects = GLES3::CopyEffects::get_singleton();
-
-		scene_state.enable_gl_depth_test(false);
-		scene_state.enable_gl_depth_draw(false);
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(rt->view_count > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D, rt->color);
-
-		if (apply_canvas_bg_exposure) {
-			copy_effects->copy_with_exposure(tonemap_ubo.exposure, render_data.luminance_multiplier);
-		} else {
-			copy_effects->copy_screen(render_data.luminance_multiplier);
+			_draw_sky(render_data.environment, projection, transform, sky_energy_multiplier, render_data.luminance_multiplier, p_camera_data->view_count > 1, flip_y, apply_environment_effects_in_post);
 		}
 
-		scene_state.enable_gl_depth_test(true);
-		scene_state.enable_gl_depth_draw(true);
-	}
+		if (scene_state.used_screen_texture || scene_state.used_depth_texture) {
+			rb->check_backbuffer(scene_state.used_screen_texture, scene_state.used_depth_texture);
+			Size2i size = rb->get_internal_size();
+			GLuint backbuffer_fbo = rb->get_backbuffer_fbo();
+			GLuint backbuffer = rb->get_backbuffer();
+			GLuint backbuffer_depth = rb->get_backbuffer_depth();
 
-	RENDER_TIMESTAMP("Render Opaque Pass");
-	uint64_t spec_constant_base_flags = 0;
-
-	if (render_data.render_region != Rect2i()) {
-		glViewport(render_data.render_region.position.x, render_data.render_region.position.y, render_data.render_region.size.width, render_data.render_region.size.height);
-	}
-
-	{
-		// Specialization Constants that apply for entire rendering pass.
-		if (render_data.directional_light_count == 0) {
-			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
-		}
-
-		if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment))) {
-			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_FOG;
-		}
-
-		if (render_data.environment.is_valid() && environment_get_fog_mode(render_data.environment) == RSE::EnvironmentFogMode::ENV_FOG_MODE_DEPTH) {
-			spec_constant_base_flags |= SceneShaderGLES3::USE_DEPTH_FOG;
-		}
-
-		if (!apply_environment_effects_in_post) {
-			spec_constant_base_flags |= SceneShaderGLES3::APPLY_TONEMAPPING;
-		}
-	}
-
-	if (draw_feed && camera_feed_id > -1) {
-		RENDER_TIMESTAMP("Render Camera feed");
-
-		scene_state.enable_gl_depth_draw(false);
-		scene_state.enable_gl_depth_test(false);
-		scene_state.enable_gl_blend(false);
-		scene_state.set_gl_cull_mode(RSE::CULL_MODE_BACK);
-
-		Ref<CameraFeed> feed = CameraServer::get_singleton()->get_feed_by_id(camera_feed_id);
-
-		if (feed.is_valid()) {
-			RID camera_YCBCR = feed->get_texture(CameraServer::FEED_YCBCR_IMAGE);
-			GLES3::TextureStorage::get_singleton()->texture_bind(camera_YCBCR, 0);
-
-			GLES3::FeedEffects *feed_effects = GLES3::FeedEffects::get_singleton();
-			feed_effects->draw();
-		}
-		scene_state.enable_gl_depth_draw(true);
-		scene_state.enable_gl_depth_test(true);
-		scene_state.enable_gl_blend(true);
-	}
-
-	// Render Opaque Objects.
-	RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
-
-	_render_list_template<PASS_MODE_COLOR>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
-
-	scene_state.enable_gl_depth_draw(false);
-	scene_state.enable_gl_stencil_test(false);
-
-	if (draw_sky || draw_sky_fog_only) {
-		RENDER_TIMESTAMP("Render Sky");
-
-		scene_state.enable_gl_depth_test(true);
-		scene_state.set_gl_depth_func(GL_GEQUAL);
-		scene_state.enable_gl_blend(false);
-		scene_state.set_gl_cull_mode(RSE::CULL_MODE_BACK);
-
-		Transform3D transform = render_data.cam_transform;
-		Projection projection = render_data.cam_projection;
-
-		_draw_sky(render_data.environment, projection, transform, sky_energy_multiplier, render_data.luminance_multiplier, p_camera_data->view_count > 1, flip_y, apply_environment_effects_in_post);
-	}
-
-	if (scene_state.used_screen_texture || scene_state.used_depth_texture) {
-		rb->check_backbuffer(scene_state.used_screen_texture, scene_state.used_depth_texture);
-		Size2i size = rb->get_internal_size();
-		GLuint backbuffer_fbo = rb->get_backbuffer_fbo();
-		GLuint backbuffer = rb->get_backbuffer();
-		GLuint backbuffer_depth = rb->get_backbuffer_depth();
-
-		if (backbuffer_fbo != 0) {
-			glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
-			glReadBuffer(GL_COLOR_ATTACHMENT0);
-			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, backbuffer_fbo);
-			if (scene_state.used_screen_texture) {
-				glBlitFramebuffer(0, 0, size.x, size.y,
-						0, 0, size.x, size.y,
-						GL_COLOR_BUFFER_BIT, GL_NEAREST);
-				glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 6);
-				glBindTexture(GL_TEXTURE_2D, backbuffer);
+			if (rb->emulate_multiview) {
+				rb->attach_backbuffer_layer(eye);
 			}
-			if (scene_state.used_depth_texture) {
-				glBlitFramebuffer(0, 0, size.x, size.y,
-						0, 0, size.x, size.y,
-						GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
-				glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 7);
-				glBindTexture(GL_TEXTURE_2D, backbuffer_depth);
+
+			if (backbuffer_fbo != 0) {
+				glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+				glReadBuffer(GL_COLOR_ATTACHMENT0);
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, backbuffer_fbo);
+				if (scene_state.used_screen_texture) {
+					glBlitFramebuffer(0, 0, size.x, size.y,
+							0, 0, size.x, size.y,
+							GL_COLOR_BUFFER_BIT, GL_NEAREST);
+					glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 6);
+					glBindTexture(GL_TEXTURE_2D, backbuffer);
+				}
+				if (scene_state.used_depth_texture) {
+					glBlitFramebuffer(0, 0, size.x, size.y,
+							0, 0, size.x, size.y,
+							GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
+					glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 7);
+					glBindTexture(GL_TEXTURE_2D, backbuffer_depth);
+				}
 			}
+
+			// Bound framebuffer may have changed, so change it back
+			glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 		}
 
-		// Bound framebuffer may have changed, so change it back
-		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-	}
+		RENDER_TIMESTAMP("Render 3D Transparent Pass");
+		scene_state.enable_gl_blend(true);
 
-	RENDER_TIMESTAMP("Render 3D Transparent Pass");
-	scene_state.enable_gl_blend(true);
+		//Render transparent pass
+		RenderListParameters render_list_params_alpha(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
 
-	//Render transparent pass
-	RenderListParameters render_list_params_alpha(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
+		_render_list_template<PASS_MODE_COLOR_TRANSPARENT>(&render_list_params_alpha, &render_data, 0, render_list[RENDER_LIST_ALPHA].elements.size(), true);
 
-	_render_list_template<PASS_MODE_COLOR_TRANSPARENT>(&render_list_params_alpha, &render_data, 0, render_list[RENDER_LIST_ALPHA].elements.size(), true);
+		scene_state.enable_gl_stencil_test(false);
 
-	scene_state.enable_gl_stencil_test(false);
+		if (!flip_y) {
+			// Restore the default winding order.
+			glFrontFace(GL_CCW);
+		}
 
-	if (!flip_y) {
-		// Restore the default winding order.
-		glFrontFace(GL_CCW);
-	}
-
-	if (!is_reflection_probe && rb.is_valid()) {
-		_render_buffers_debug_draw(rb, p_shadow_atlas, fbo);
+		if (!is_reflection_probe && rb.is_valid()) {
+			_render_buffers_debug_draw(rb, p_shadow_atlas, fbo);
+		}
 	}
 
 	// Reset stuff that may trip up the next process.

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -459,6 +459,10 @@ private:
 			float projection_matrix_view[RendererSceneRender::MAX_RENDER_VIEWS][16];
 			float inv_projection_matrix_view[RendererSceneRender::MAX_RENDER_VIEWS][16];
 			float eye_offset[RendererSceneRender::MAX_RENDER_VIEWS][4];
+			// Current view being rendered. Used when emulating multiview by
+			// rendering once per view (when the GPU doesn't support multiview).
+			uint32_t view_index = 0;
+			uint32_t pad[3];
 		};
 		static_assert(sizeof(MultiviewUBO) % 16 == 0, "Multiview UBO size must be a multiple of 16 bytes");
 		static_assert(sizeof(MultiviewUBO) < 16384, "MultiviewUBO size must be 16384 bytes or smaller");

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -200,15 +200,19 @@ void ShaderGLES3::_build_variant_code(StringBuilder &builder, uint32_t p_variant
 	// Insert multiview extension loading, because it needs to appear before
 	// any non-preprocessor code (like the "precision highp..." lines below).
 	builder.append("#ifdef USE_MULTIVIEW\n");
-	builder.append("#if defined(GL_OVR_multiview2)\n");
-	builder.append("#extension GL_OVR_multiview2 : require\n");
-	builder.append("#elif defined(GL_OVR_multiview)\n");
-	builder.append("#extension GL_OVR_multiview : require\n");
-	builder.append("#endif\n");
-	if (p_stage_type == StageType::STAGE_TYPE_VERTEX) {
-		builder.append("layout(num_views=2) in;\n");
+	if (GLES3::Config::get_singleton()->multiview_supported) {
+		builder.append("#if defined(GL_OVR_multiview2)\n");
+		builder.append("#extension GL_OVR_multiview2 : require\n");
+		builder.append("#elif defined(GL_OVR_multiview)\n");
+		builder.append("#extension GL_OVR_multiview : require\n");
+		builder.append("#endif\n");
+		if (p_stage_type == StageType::STAGE_TYPE_VERTEX) {
+			builder.append("layout(num_views=2) in;\n");
+		}
+		builder.append("#define ViewIndex gl_ViewID_OVR\n");
+	} else {
+		builder.append("#define EMULATE_MULTIVIEW\n");
 	}
-	builder.append("#define ViewIndex gl_ViewID_OVR\n");
 	builder.append("#define MAX_VIEWS 2\n");
 	builder.append("#else\n");
 	builder.append("#define ViewIndex uint(0)\n");

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -480,12 +480,20 @@ struct MultiviewData {
 	highp mat4 projection_matrix_view[MAX_VIEWS];
 	highp mat4 inv_projection_matrix_view[MAX_VIEWS];
 	highp vec4 eye_offset[MAX_VIEWS];
+	highp uint view_index;
+	highp uint pad0;
+	highp uint pad1;
+	highp uint pad2;
 };
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
 }
 multiview_data_block;
+
+#ifdef EMULATE_MULTIVIEW
+#define ViewIndex (multiview_data_block.data.view_index)
+#endif
 
 #ifdef RENDER_MOTION_VECTORS
 layout(std140) uniform PrevMultiviewDataBlock { // ubo:14
@@ -1226,12 +1234,20 @@ struct MultiviewData {
 	highp mat4 projection_matrix_view[MAX_VIEWS];
 	highp mat4 inv_projection_matrix_view[MAX_VIEWS];
 	highp vec4 eye_offset[MAX_VIEWS];
+	highp uint view_index;
+	highp uint pad0;
+	highp uint pad1;
+	highp uint pad2;
 };
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
 }
 multiview_data_block;
+
+#ifdef EMULATE_MULTIVIEW
+#define ViewIndex (multiview_data_block.data.view_index)
+#endif
 #endif
 
 uniform highp mat4 world_transform;

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -123,8 +123,16 @@ layout(std140) uniform MultiviewData { // ubo:12
 	highp mat4 projection_matrix_view[MAX_VIEWS];
 	highp mat4 inv_projection_matrix_view[MAX_VIEWS];
 	highp vec4 eye_offset[MAX_VIEWS];
+	highp uint view_index;
+	highp uint pad0;
+	highp uint pad1;
+	highp uint pad2;
 }
 multiview_data;
+
+#ifdef EMULATE_MULTIVIEW
+#define ViewIndex (multiview_data.view_index)
+#endif
 #endif
 
 layout(location = 0) out vec4 frag_color;

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -137,7 +137,8 @@ void RenderSceneBuffersGLES3::configure(const RenderSceneBuffersConfiguration *p
 	msaa3d.mode = p_config->get_msaa_3d();
 	//screen_space_aa = p_config->get_screen_space_aa();
 	//use_debanding = p_config->get_use_debanding();
-	view_count = config->multiview_supported ? p_config->get_view_count() : 1;
+	view_count = p_config->get_view_count();
+	emulate_multiview = view_count > 1 && !config->multiview_supported;
 
 	bool use_multiview = view_count > 1;
 
@@ -177,6 +178,9 @@ void RenderSceneBuffersGLES3::configure(const RenderSceneBuffersConfiguration *p
 		msaa3d.mode = RSE::VIEWPORT_MSAA_DISABLED;
 	} else if (use_multiview && msaa3d.mode != RSE::VIEWPORT_MSAA_DISABLED && !config->msaa_multiview_supported && !config->rt_msaa_multiview_supported) {
 		WARN_PRINT_ONCE("Multiview MSAA is not supported on this device.");
+		msaa3d.mode = RSE::VIEWPORT_MSAA_DISABLED;
+	} else if (emulate_multiview && msaa3d.mode != RSE::VIEWPORT_MSAA_DISABLED) {
+		WARN_PRINT_ONCE("MSAA is not supported when emulating multiview.");
 		msaa3d.mode = RSE::VIEWPORT_MSAA_DISABLED;
 	}
 
@@ -247,7 +251,12 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 		glBindFramebuffer(GL_FRAMEBUFFER, internal3d.fbo);
 
 #ifndef IOS_ENABLED
-		if (use_multiview) {
+		if (emulate_multiview) {
+			// Attach the first layer now so the FBO is complete.
+			// Layer per eye is attached in RasterizerSceneGLES3::render_scene().
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, internal3d.color, 0, 0);
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, internal3d.depth, 0, 0);
+		} else if (use_multiview) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, internal3d.color, 0, 0, view_count);
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, internal3d.depth, 0, 0, view_count);
 		} else {
@@ -471,8 +480,8 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 
 	glBindFramebuffer(GL_FRAMEBUFFER, backbuffer3d.fbo);
 
-	bool use_multiview = view_count > 1 && GLES3::Config::get_singleton()->multiview_supported;
-	GLenum texture_target = use_multiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+	bool use_array = view_count > 1 && (GLES3::Config::get_singleton()->multiview_supported || emulate_multiview);
+	GLenum texture_target = use_array ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 	GLenum depth_format = GL_DEPTH24_STENCIL8;
 	uint32_t depth_format_size = 4;
 
@@ -480,7 +489,7 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		glGenTextures(1, &backbuffer3d.color);
 		glBindTexture(texture_target, backbuffer3d.color);
 
-		if (use_multiview) {
+		if (use_array) {
 			glTexImage3D(texture_target, 0, color_internal_format, internal_size.x, internal_size.y, view_count, 0, color_format, color_type, nullptr);
 		} else {
 			glTexImage2D(texture_target, 0, color_internal_format, internal_size.x, internal_size.y, 0, color_format, color_type, nullptr);
@@ -494,7 +503,9 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		GLES3::Utilities::get_singleton()->texture_allocated_data(backbuffer3d.color, internal_size.x * internal_size.y * view_count * color_format_size, "3D Back buffer color texture");
 
 #ifndef IOS_ENABLED
-		if (use_multiview) {
+		if (emulate_multiview) {
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, backbuffer3d.color, 0, 0);
+		} else if (use_array) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, backbuffer3d.color, 0, 0, view_count);
 		} else {
 #else
@@ -508,7 +519,7 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		glGenTextures(1, &backbuffer3d.depth);
 		glBindTexture(texture_target, backbuffer3d.depth);
 
-		if (use_multiview) {
+		if (use_array) {
 			glTexImage3D(texture_target, 0, depth_format, internal_size.x, internal_size.y, view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 		} else {
 			glTexImage2D(texture_target, 0, depth_format, internal_size.x, internal_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
@@ -522,7 +533,9 @@ void RenderSceneBuffersGLES3::check_backbuffer(bool p_need_color, bool p_need_de
 		GLES3::Utilities::get_singleton()->texture_allocated_data(backbuffer3d.depth, internal_size.x * internal_size.y * view_count * depth_format_size, "3D back buffer depth texture");
 
 #ifndef IOS_ENABLED
-		if (use_multiview) {
+		if (emulate_multiview) {
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, backbuffer3d.depth, 0, 0);
+		} else if (use_array) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, backbuffer3d.depth, 0, 0, view_count);
 		} else {
 #else
@@ -636,11 +649,43 @@ void RenderSceneBuffersGLES3::free_render_buffer_data() {
 	_clear_glow_buffers();
 }
 
-GLuint RenderSceneBuffersGLES3::get_render_fbo() {
+void RenderSceneBuffersGLES3::attach_backbuffer_layer(uint32_t p_view) {
+	glBindFramebuffer(GL_FRAMEBUFFER, backbuffer3d.fbo);
+	if (backbuffer3d.color != 0) {
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, backbuffer3d.color, 0, p_view);
+	}
+	if (backbuffer3d.depth != 0) {
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, backbuffer3d.depth, 0, p_view);
+	}
+}
+
+GLuint RenderSceneBuffersGLES3::get_render_fbo(int p_view) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLuint rt_fbo = 0;
 
 	_check_render_buffers();
+
+	if (emulate_multiview && p_view >= 0) {
+		GLuint color = 0;
+		GLuint depth = 0;
+		bool depth_has_stencil = true;
+		if (internal3d.fbo != 0) {
+			rt_fbo = internal3d.fbo;
+			color = internal3d.color;
+			depth = internal3d.depth;
+		} else {
+			rt_fbo = texture_storage->render_target_get_fbo(render_target);
+			color = texture_storage->render_target_get_color(render_target);
+			depth = texture_storage->render_target_get_depth(render_target);
+			depth_has_stencil = texture_storage->render_target_get_depth_has_stencil(render_target);
+		}
+
+		glBindFramebuffer(GL_FRAMEBUFFER, rt_fbo);
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, color, 0, p_view);
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, depth_has_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT, depth, 0, p_view);
+
+		return rt_fbo;
+	}
 
 	if (msaa3d.check_fbo_cache) {
 		GLuint color = texture_storage->render_target_get_color(render_target);

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -49,6 +49,7 @@ public:
 	//bool use_taa = false;
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
+	bool emulate_multiview = false;
 	bool apply_environment_effects_in_post = false;
 	bool apply_canvas_bg_exposure = false;
 
@@ -115,7 +116,9 @@ public:
 	void check_backbuffer(bool p_need_color, bool p_need_depth); // Check if we need to initialize our backbuffer.
 	void check_glow_buffers(); // Check if we need to initialize our glow buffers.
 
-	GLuint get_render_fbo();
+	GLuint get_render_fbo(int p_view = -1);
+	void attach_backbuffer_layer(uint32_t p_view);
+
 	GLuint get_msaa3d_fbo() {
 		_check_render_buffers();
 		return msaa3d.fbo;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2549,7 +2549,9 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 		return;
 	}
 
+#ifndef IOS_ENABLED
 	Config *config = Config::get_singleton();
+#endif
 
 	if (rt->hdr) {
 		rt->color_internal_format = GL_RGBA16F;
@@ -2577,8 +2579,8 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 
 	{
 		Texture *texture;
-		bool use_multiview = rt->view_count > 1 && config->multiview_supported;
-		GLenum texture_target = use_multiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+		bool use_array = rt->view_count > 1;
+		GLenum texture_target = use_array ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 
 		/* Front FBO */
 
@@ -2599,7 +2601,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			glGenTextures(1, &rt->color);
 			glBindTexture(texture_target, rt->color);
 
-			if (use_multiview) {
+			if (use_array) {
 				glTexImage3D(texture_target, 0, rt->color_internal_format, rt->size.x, rt->size.y, rt->view_count, 0, rt->color_format, rt->color_type, nullptr);
 			} else {
 				glTexImage2D(texture_target, 0, rt->color_internal_format, rt->size.x, rt->size.y, 0, rt->color_format, rt->color_type, nullptr);
@@ -2611,7 +2613,11 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			GLES3::Utilities::get_singleton()->texture_allocated_data(rt->color, rt->size.x * rt->size.y * rt->view_count * rt->color_format_size, "Render target color texture");
 		}
 #ifndef IOS_ENABLED
-		if (use_multiview) {
+		if (use_array && !config->multiview_supported) {
+			// Attach the first layer now so the FBO is complete.
+			// Layer per eye is attached in RasterizerSceneGLES3::render_scene().
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rt->color, 0, 0);
+		} else if (use_array) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rt->color, 0, 0, rt->view_count);
 		} else {
 #else
@@ -2631,7 +2637,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			glGenTextures(1, &rt->depth);
 			glBindTexture(texture_target, rt->depth);
 
-			if (use_multiview) {
+			if (use_array) {
 				glTexImage3D(texture_target, 0, GL_DEPTH24_STENCIL8, rt->size.x, rt->size.y, rt->view_count, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 			} else {
 				glTexImage2D(texture_target, 0, GL_DEPTH24_STENCIL8, rt->size.x, rt->size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
@@ -2648,7 +2654,9 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 		}
 
 #ifndef IOS_ENABLED
-		if (use_multiview) {
+		if (use_array && !config->multiview_supported) {
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, rt->depth_has_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT, rt->depth, 0, 0);
+		} else if (use_array) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, rt->depth_has_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT, rt->depth, 0, 0, rt->view_count);
 		} else {
 #else
@@ -2685,7 +2693,7 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			texture->format = rt->image_format;
 			texture->real_format = rt->image_format;
 			texture->target = texture_target;
-			if (rt->view_count > 1 && config->multiview_supported) {
+			if (rt->view_count > 1) {
 				texture->type = Texture::TYPE_LAYERED;
 				texture->layers = rt->view_count;
 			} else {
@@ -2725,7 +2733,9 @@ void TextureStorage::_update_render_target_velocity(RenderTarget *rt) {
 	glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 #ifndef IOS_ENABLED
-	if (view_count > 1) {
+	if (view_count > 1 && !GLES3::Config::get_singleton()->multiview_supported) {
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, velocity_texture_id, 0, 0);
+	} else if (view_count > 1) {
 		glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, velocity_texture_id, 0, 0, view_count);
 	} else {
 #else
@@ -2742,7 +2752,9 @@ void TextureStorage::_update_render_target_velocity(RenderTarget *rt) {
 	glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 #ifndef IOS_ENABLED
-	if (view_count > 1) {
+	if (view_count > 1 && !GLES3::Config::get_singleton()->multiview_supported) {
+		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, velocity_depth_texture_id, 0, 0);
+	} else if (view_count > 1) {
 		glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, velocity_depth_texture_id, 0, 0, view_count);
 	} else {
 #else

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -295,11 +295,6 @@ bool WebXRInterfaceJS::initialize() {
 			return false;
 		}
 
-		if (session_mode == "immersive-vr" && !GLES3::Config::get_singleton()->multiview_supported) {
-			emit_signal("session_failed", "Stereo rendering in Godot requires multiview, but this web browser doesn't support it.");
-			return false;
-		}
-
 		if (requested_reference_space_types.is_empty()) {
 			emit_signal("session_failed", "No reference spaces were requested.");
 			return false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Since Godot 4, stereo XR rendering has required multiview. This isn't a problem on Vulkan (multiview is a core part of the spec), but on OpenGL it's an optional extension. The extension is supported on all desktop platforms and many mobile ones too - the primary place where support is spotty is with WebXR

What this means is that Godot 4 with WebXR won't work on headsets/platforms that don't support multiview, which includes: visionOS, Android XR and Pico headsets. (Less importantly, this also includes Google Cardboard.)

_(Note: Godot 3 actually works fine on those platforms because it doesn't need multiview)_

**With this PR, WebXR starts working on Android XR, Pico, and visionOS!** (Less importantly, it also fixes Google Cardboard.)

~~Unfortunately, it still doesn't work on Pico and visionOS. On Pico, it looks like it's because of an incomplete implementation of WebXR Layers. On visionOS, I'm not sure what's going wrong - I haven't tried to figure out how to access the debug console on that platform yet.~~

**UPDATE (2026-09-19):** Rebasing on https://github.com/godotengine/godot/pull/123642 gets WebXR working out-of-the-box on Pico and visionOS too

## Additional Information

This PR will "emulate" multiview when it isn't supported by rendering everything twice: once for each eye.

The changes are fully self-contained in the OpenGL renderer, and kept as minimal as possible by still using texture arrays, just rendering to one layer at a time.

Unfortunately, it is slower than it needs to be, because there will likely be an extra blit somewhere to copy from the texture array into two textures or a side-by-side texture. That could be in #123642 , the WebXR Layers polyfill, or the browser itself. A deeper change (that would break compatibility with existing `XRInterface`'s) could be made that would avoid the extra blit, but I didn't go that way.

~~Marking as DRAFT because I don't necessarily expect this to be merged - I've proposed adding functionality like this multiple times, including before the release of Godot 4.0-stable, and it was shot down. :-) This PR is mainly a way to share what this could look like for discussion~~

**UPDATE (2026-09-22):** Given that the XR team is open to this change now, and https://github.com/godotengine/godot/pull/123642 is merged, I'm taking this out of DRAFT

(FYI, the diff is easier to read using `git diff -w` because the majority of the changes in `rasterizer_scene_gles3.cpp` are just an extra level of indentation.)

**AI disclosure:** Claude code was used to take the first pass at these changes (per my fairly detailed instructions), but I reviewed it, and then iterated on it quite a bit after that. I was the original author of [multiview support in the OpenGL renderer](https://github.com/godotengine/godot/pull/65334), and this is basically indistinguishable from what I would have written by hand.