### PR TITLE
GLTF: handle importing/exporting initial blend shape weights on nodes

### DIFF
--- a/doc/classes/ImporterMeshInstance3D.xml
+++ b/doc/classes/ImporterMeshInstance3D.xml
@@ -6,6 +6,36 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="find_blend_shape_by_name">
+			<return type="int" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the index of the blend shape with the given [param name]. Returns [code]-1[/code] if no blend shape with this name exists, including when [member mesh] is [code]null[/code].
+			</description>
+		</method>
+		<method name="get_blend_shape_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of blend shapes available. Produces an error if [member mesh] is [code]null[/code].
+			</description>
+		</method>
+		<method name="get_blend_shape_value" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="blend_shape_idx" type="int" />
+			<description>
+				Returns the value of the blend shape at the given [param blend_shape_idx]. Returns [code]0.0[/code] and produces an error if [member mesh] is [code]null[/code] or doesn't have a blend shape at that index.
+			</description>
+		</method>
+		<method name="set_blend_shape_value">
+			<return type="void" />
+			<param index="0" name="blend_shape_idx" type="int" />
+			<param index="1" name="value" type="float" />
+			<description>
+				Sets the value of the blend shape at [param blend_shape_idx] to [param value]. Produces an error if [member mesh] is [code]null[/code] or doesn't have a blend shape at that index.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
 		</member>

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2849,6 +2849,9 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 			if (mesh.is_valid()) {
 				_copy_meta(importer_mesh.ptr(), mesh.ptr());
 				mesh_node->set_mesh(mesh);
+				for (int i = 0; i < mesh->get_blend_shape_count(); i++) {
+					mesh_node->set_blend_shape_value(i, src_mesh_node->get_blend_shape_value(i));
+				}
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
 					mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
 				}

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -86,6 +86,9 @@
 		<member name="visible" type="bool" setter="set_visible" getter="get_visible" default="true">
 			If [code]true[/code], the GLTF node is visible. If [code]false[/code], the GLTF node is not visible. This is converted to the [member Node3D.visible] property in the Godot scene, and is exported to [code]KHR_node_visibility[/code] when [code]false[/code].
 		</member>
+		<member name="weights" type="PackedFloat32Array" setter="set_weights" getter="get_weights" default="PackedFloat32Array()">
+			If this glTF node is a mesh with blend shapes, the weights of the blend shapes for this glTF node.
+		</member>
 		<member name="xform" type="Transform3D" setter="set_xform" getter="get_xform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			The transform of the glTF node relative to its parent. This property is usually unused since the position, rotation, and scale properties are preferred.
 		</member>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -429,6 +429,9 @@ Error GLTFDocument::_serialize_nodes(Ref<GLTFState> p_state) {
 		} else {
 			node["matrix"] = _xform_to_array(gltf_node->transform);
 		}
+		if (!gltf_node->weights.is_empty()) {
+			node["weights"] = gltf_node->weights;
+		}
 		if (gltf_node->children.size()) {
 			Array children;
 			for (int j = 0; j < gltf_node->children.size(); j++) {
@@ -591,6 +594,9 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 			if (n.has("scale")) {
 				node->set_scale(_arr_to_vec3(n["scale"]));
 			}
+		}
+		if (n.has("weights")) {
+			node->set_weights(n["weights"]);
 		}
 		node->set_additional_data("GODOT_rest_transform", node->transform);
 
@@ -4147,6 +4153,15 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 		return mi;
 	}
 	mi->set_mesh(import_mesh);
+	if (!gltf_node->weights.is_empty()) {
+		for (int i = 0; i < gltf_node->weights.size(); i++) {
+			mi->set_blend_shape_value(i, gltf_node->weights[i]);
+		}
+	} else if (!mesh->get_blend_weights().is_empty()) {
+		for (int i = 0; i < mesh->get_blend_weights().size(); i++) {
+			mi->set_blend_shape_value(i, mesh->get_blend_weights()[i]);
+		}
+	}
 	import_mesh->merge_meta_from(*mesh);
 	return mi;
 }
@@ -4541,6 +4556,10 @@ void GLTFDocument::_convert_mesh_instance_to_gltf(MeshInstance3D *p_scene_parent
 	GLTFMeshIndex gltf_mesh_index = _convert_mesh_to_gltf(p_state, p_scene_parent);
 	if (gltf_mesh_index != -1) {
 		p_gltf_node->mesh = gltf_mesh_index;
+		p_gltf_node->weights.resize(p_scene_parent->get_blend_shape_count());
+		for (int i = 0; i < p_scene_parent->get_blend_shape_count(); i++) {
+			p_gltf_node->weights.write[i] = p_scene_parent->get_blend_shape_value(i);
+		}
 	}
 }
 

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -57,6 +57,8 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rotation", "rotation"), &GLTFNode::set_rotation);
 	ClassDB::bind_method(D_METHOD("get_scale"), &GLTFNode::get_scale);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &GLTFNode::set_scale);
+	ClassDB::bind_method(D_METHOD("get_weights"), &GLTFNode::get_weights);
+	ClassDB::bind_method(D_METHOD("set_weights", "weights"), &GLTFNode::set_weights);
 	ClassDB::bind_method(D_METHOD("get_children"), &GLTFNode::get_children);
 	ClassDB::bind_method(D_METHOD("set_children", "children"), &GLTFNode::set_children);
 	ClassDB::bind_method(D_METHOD("append_child_index", "child_index"), &GLTFNode::append_child_index);
@@ -79,6 +81,7 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "weights"), "set_weights", "get_weights"); // Vector<float>
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light"), "set_light", "get_light"); // GLTFLightIndex
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "get_visible"); // bool
@@ -169,6 +172,14 @@ Vector3 GLTFNode::get_scale() {
 
 void GLTFNode::set_scale(const Vector3 &p_scale) {
 	transform.basis = transform.basis.orthonormalized() * Basis::from_scale(p_scale);
+}
+
+Vector<float> GLTFNode::get_weights() {
+	return weights;
+}
+
+void GLTFNode::set_weights(const Vector<float> &p_weights) {
+	weights = p_weights;
 }
 
 Vector<int> GLTFNode::get_children() {

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -52,6 +52,7 @@ private:
 	bool joint = false;
 	bool visible = true;
 	Vector<int> children;
+	Vector<float> weights;
 	GLTFLightIndex light = -1;
 	Dictionary additional_data;
 
@@ -94,6 +95,9 @@ public:
 
 	Vector3 get_scale();
 	void set_scale(const Vector3 &p_scale);
+
+	Vector<float> get_weights();
+	void set_weights(const Vector<float> &p_blend_shape_weights);
 
 	Vector<int> get_children();
 	void set_children(const Vector<int> &p_children);

--- a/scene/3d/importer_mesh_instance_3d.cpp
+++ b/scene/3d/importer_mesh_instance_3d.cpp
@@ -35,6 +35,7 @@
 
 void ImporterMeshInstance3D::set_mesh(const Ref<ImporterMesh> &p_mesh) {
 	mesh = p_mesh;
+	blend_shape_values.resize_initialized(mesh->get_blend_shape_count());
 }
 Ref<ImporterMesh> ImporterMeshInstance3D::get_mesh() const {
 	return mesh;
@@ -45,6 +46,44 @@ void ImporterMeshInstance3D::set_skin(const Ref<Skin> &p_skin) {
 }
 Ref<Skin> ImporterMeshInstance3D::get_skin() const {
 	return skin;
+}
+
+int ImporterMeshInstance3D::get_blend_shape_count() const {
+	if (mesh.is_null()) {
+		return 0;
+	}
+	return mesh->get_blend_shape_count();
+}
+
+int ImporterMeshInstance3D::find_blend_shape_by_name(const StringName &p_name) {
+	if (mesh.is_null()) {
+		return -1;
+	}
+	for (int i = 0; i < mesh->get_blend_shape_count(); i++) {
+		if (mesh->get_blend_shape_name(i) == p_name) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+float ImporterMeshInstance3D::get_blend_shape_value(int p_blend_shape) const {
+	ERR_FAIL_COND_V(mesh.is_null(), 0.0);
+	ERR_FAIL_INDEX_V(p_blend_shape, (int)mesh->get_blend_shape_count(), 0);
+	// ImporterMesh doesn't emit changed signals, so we just assume the value is 0.0 if it hasn't been set yet.
+	if (p_blend_shape >= (int)blend_shape_values.size()) {
+		return 0.0;
+	}
+	return blend_shape_values[p_blend_shape];
+}
+
+void ImporterMeshInstance3D::set_blend_shape_value(int p_blend_shape, float p_value) {
+	ERR_FAIL_COND(mesh.is_null());
+	if ((int)blend_shape_values.size() != mesh->get_blend_shape_count()) {
+		blend_shape_values.resize_initialized(mesh->get_blend_shape_count());
+	}
+	ERR_FAIL_INDEX(p_blend_shape, (int)blend_shape_values.size());
+	blend_shape_values[p_blend_shape] = p_value;
 }
 
 void ImporterMeshInstance3D::set_surface_material(int p_idx, const Ref<Material> &p_material) {
@@ -161,6 +200,11 @@ void ImporterMeshInstance3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_visibility_range_fade_mode", "mode"), &ImporterMeshInstance3D::set_visibility_range_fade_mode);
 	ClassDB::bind_method(D_METHOD("get_visibility_range_fade_mode"), &ImporterMeshInstance3D::get_visibility_range_fade_mode);
+
+	ClassDB::bind_method(D_METHOD("get_blend_shape_count"), &ImporterMeshInstance3D::get_blend_shape_count);
+	ClassDB::bind_method(D_METHOD("find_blend_shape_by_name", "name"), &ImporterMeshInstance3D::find_blend_shape_by_name);
+	ClassDB::bind_method(D_METHOD("get_blend_shape_value", "blend_shape_idx"), &ImporterMeshInstance3D::get_blend_shape_value);
+	ClassDB::bind_method(D_METHOD("set_blend_shape_value", "blend_shape_idx", "value"), &ImporterMeshInstance3D::set_blend_shape_value);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, ImporterMesh::get_class_static()), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, Skin::get_class_static()), "set_skin", "get_skin");

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -50,6 +50,7 @@ class ImporterMeshInstance3D : public Node3D {
 	float visibility_range_begin_margin = 0.0;
 	float visibility_range_end_margin = 0.0;
 	GeometryInstance3D::VisibilityRangeFadeMode visibility_range_fade_mode = GeometryInstance3D::VISIBILITY_RANGE_FADE_DISABLED;
+	LocalVector<float> blend_shape_values;
 
 protected:
 	static void _bind_methods();
@@ -60,6 +61,11 @@ public:
 
 	void set_skin(const Ref<Skin> &p_skin);
 	Ref<Skin> get_skin() const;
+
+	int get_blend_shape_count() const;
+	int find_blend_shape_by_name(const StringName &p_name);
+	float get_blend_shape_value(int p_blend_shape) const;
+	void set_blend_shape_value(int p_blend_shape, float p_value);
 
 	void set_surface_material(int p_idx, const Ref<Material> &p_material);
 	Ref<Material> get_surface_material(int p_idx) const;


### PR DESCRIPTION
GLTFDocument currently does nothing with the [`weights`](https://github.com/KhronosGroup/glTF/blob/5382af51376ef5bae767b42e9b2202b3cab9a1b4/specification/2.0/schema/node.schema.json#L74) property on imported nodes, and it does not export them either.

According to the spec, these weights override any weights found on the mesh object:


> When an instantiated mesh has morph targets, it MUST use morph weights specified with the node.weights property. When the latter is undefined, mesh.weights property MUST be used instead. When both of these fields are undefined, the mesh is instantiated in a non-morphed state (i.e., with all morph weights set to zeros).


This PR adds support for both parsing and exporting those weights on mesh nodes.

This required extending the ImporterMeshInstance3D class so that the weights on these nodes can be recorded.  