### PR TITLE
Replace `{project}` with `-r` in VS Code

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1263,7 +1263,7 @@ String EditorSettings::_guess_exec_args_for_extenal_editor(const String &p_path)
 	} else if (editor == "geany" || editor == "kate") {
 		new_exec_flags = "{file} --line {line} --column {col}";
 	} else if (editor == "code" || editor == "visual studio code" || editor == "codium" || editor == "vscodium") {
-		new_exec_flags = "{project} --goto {file}:{line}:{col}";
+		new_exec_flags = "--reuse-window --goto {file}:{line}:{col}";
 	}
 
 	return new_exec_flags;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Prevents session overwriting

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

If I forget to open the project workspace and click on a script inside Godot, my last VS Code session is not restored.

### Steps to reproduce
- Follow this [tutorial](https://docs.godotengine.org/en/stable/tutorials/editor/external_editor.html)
- Open the project workspace in VS Code
- Open a few files so they are saved in the session history
- Close the window
- Open Godot and open a script

This bypasses the restore behavior, causing all history from the last session to be lost.

Replacing `{project}` with `--reuse-window` eliminates the risk of losing the session:
- If no VS Code window is open: The script opens in a new window without a workspace
- If the window with the project workspace is already open: It will be reused
- If the project workspace window is not open, but another VS Code window is: That open window will be used instead

I'm using the [flatpak](https://github.com/flathub/org.godotengine.Godot) version of Godot with these editor settings:
- **Exec Path:** `flatpak-spawn`
- **Exec Flags:** `--host code --reuse-window --goto {file}:{line}:{col}`