### PR TITLE
Add basic unit tests for Button

### DIFF
--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_button)
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
+#include "tests/signal_watcher.h"
 
 namespace TestButton {
 
@@ -60,6 +61,106 @@ TEST_CASE("[SceneTree][Button] is_hovered()") {
 	// Simulate mouse exiting the button.
 	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(150, 150), MouseButtonMask::NONE, Key::NONE);
 	CHECK(button->is_hovered() == false);
+
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] Click emits the pressed signal") {
+	// Create new button instance.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Set up button's size and position.
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Watch the button's interaction signals.
+	SIGNAL_WATCH(button, "pressed");
+	SIGNAL_WATCH(button, "button_down");
+	SIGNAL_WATCH(button, "button_up");
+
+	// These signals carry no arguments.
+	Array empty_args = { {} };
+
+	// Simulate mouse entering the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(35, 35), MouseButtonMask::NONE, Key::NONE);
+
+	// Pressing the mouse should fire "button_down" but not "pressed".
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(35, 35), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+	SIGNAL_CHECK("button_down", empty_args);
+	SIGNAL_CHECK_FALSE("pressed");
+
+	// Releasing the mouse should fire "pressed" and "button_up".
+	SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(35, 35), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+	SIGNAL_CHECK("pressed", empty_args);
+	SIGNAL_CHECK("button_up", empty_args);
+
+	SIGNAL_UNWATCH(button, "pressed");
+	SIGNAL_UNWATCH(button, "button_down");
+	SIGNAL_UNWATCH(button, "button_up");
+
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] Disabled button ignores clicks") {
+	// Create new button instance.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Set up button's size and position.
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Disable the button.
+	button->set_disabled(true);
+	CHECK(button->is_disabled());
+
+	// Watch the button's pressed signal.
+	SIGNAL_WATCH(button, "pressed");
+
+	// Simulate a full click on the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(35, 35), MouseButtonMask::NONE, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(35, 35), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(35, 35), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+	// A disabled button should not emit "pressed".
+	SIGNAL_CHECK_FALSE("pressed");
+
+	SIGNAL_UNWATCH(button, "pressed");
+
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] Toggle mode latches the pressed state") {
+	// Create new button instance.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Watch the button's toggled signal.
+	SIGNAL_WATCH(button, "toggled");
+
+	// Without toggle mode, set_pressed() should be ignored.
+	button->set_pressed(true);
+	CHECK_FALSE(button->is_pressed());
+	SIGNAL_CHECK_FALSE("toggled");
+
+	// Enable toggle mode.
+	button->set_toggle_mode(true);
+
+	// Button should now stay pressed and emit "toggled".
+	button->set_pressed(true);
+	CHECK(button->is_pressed());
+	SIGNAL_CHECK("toggled", { { true } });
+
+	// Button should stay unpressed and emit "toggled" again.
+	button->set_pressed(false);
+	CHECK_FALSE(button->is_pressed());
+	SIGNAL_CHECK("toggled", { { false } });
+
+	SIGNAL_UNWATCH(button, "toggled");
 
 	memdelete(button);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- part of issue: https://github.com/godotengine/godot/issues/43440
- adding on to unit test: https://github.com/godotengine/godot/pull/93381
- revisiting my old PR attempt a year ago https://github.com/godotengine/godot/pull/102947 now that I have more experience

## Additional information

- This PR improves unit test coverage for the `Button` control (and the `BaseButton` interaction logic it inherits).
- Adds 3 new test cases
- **Click emits the pressed signal** -- verifies the full mouse-click flow and signal emission: `button_down` fires on press, and `pressed` and `button_up` on release.
- **Disabled button ignores clicks** -- verifies that a button with  `disabled = true` drops input and never emits `pressed`.
- **Toggle mode keeps the pressed state** -- verifies that `set_pressed()` has no effect outside toggle mode, and that in toggle mode the button keeps its state and emits `toggled` with the new value.

## AI Disclosure
- I used Claude Opus 4.8 to explain the Button and BaseButton source code to me to help understand the existing codebase and architecture. The implementation and unit tests were written, reviewed, and validated by me, and I understand the resulting code and behavior well enough to explain and maintain it independently.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
