### PR TITLE
Implement script equivalents for locking and selection grouping nodes

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -272,6 +272,20 @@
 				Returns [code]true[/code] if the 3D editor currently has snapping mode enabled, and [code]false[/code] otherwise.
 			</description>
 		</method>
+		<method name="is_node_locked" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Returns [code]true[/code] if the specified [param node] is locked. See [method set_node_locked]
+			</description>
+		</method>
+		<method name="is_node_selection_grouped" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Returns [code]true[/code] if the specified [param node] is in a selection group with its children. See [method set_node_selection_grouped]
+			</description>
+		</method>
 		<method name="is_object_edited" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
@@ -501,6 +515,25 @@
 			<param index="0" name="name" type="String" />
 			<description>
 				Sets the editor's current main screen to the one specified in [param name]. [param name] must match the title of the tab in question exactly (e.g. [code]2D[/code], [code]3D[/code], [code skip-lint]Script[/code], [code]Game[/code], or [code]Asset Store[/code] for default tabs).
+			</description>
+		</method>
+		<method name="set_node_locked">
+			<return type="void" />
+			<param index="0" name="node" type="Node" />
+			<param index="1" name="locked" type="bool" />
+			<description>
+				If [param locked] is [code]true[/code], the node can no longer be moved or selected through the editor viewport.
+				[b]Note:[/b] This method is only relevant for [CanvasItem] and [Node3D] based nodes.
+			</description>
+		</method>
+		<method name="set_node_selection_grouped">
+			<return type="void" />
+			<param index="0" name="node" type="Node" />
+			<param index="1" name="grouped" type="bool" />
+			<description>
+				If [param grouped] is [code]true[/code], the node will form a selection group with its children. A selection group will cause the parent to be selected when any of its children are clicked in the editor viewport.
+				[b]Note:[/b] This method is only relevant for [CanvasItem] and [Node3D] based nodes.
+				[b]Note:[/b] 2D nodes are unable to form selection groups with 3D nodes, and vice versa.
 			</description>
 		</method>
 		<method name="set_object_edited">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -712,6 +712,34 @@ void EditorInterface::reload_scene_from_path(const String &scene_path) {
 	EditorNode::get_singleton()->reload_scene(scene_path);
 }
 
+void EditorInterface::set_node_locked(Node *p_node, bool p_locked) {
+	ERR_FAIL_NULL_MSG(p_node, "Cannot lock a null node.");
+	if (p_locked) {
+		p_node->set_meta("_edit_lock_", true);
+	} else if (p_node->has_meta("_edit_lock_")) {
+		p_node->remove_meta("_edit_lock_");
+	}
+}
+
+bool EditorInterface::is_node_locked(Node *p_node) const {
+	ERR_FAIL_NULL_V_MSG(p_node, false, "Cannot get the locked status of a null node.");
+	return p_node->has_meta("_edit_lock_");
+}
+
+void EditorInterface::set_node_selection_grouped(Node *p_node, bool p_grouped) {
+	ERR_FAIL_NULL_MSG(p_node, "Cannot create a selection group for a null node.");
+	if (p_grouped) {
+		p_node->set_meta("_edit_group_", true);
+	} else if (p_node->has_meta("_edit_group_")) {
+		p_node->remove_meta("_edit_group_");
+	}
+}
+
+bool EditorInterface::is_node_selection_grouped(Node *p_node) const {
+	ERR_FAIL_NULL_V_MSG(p_node, false, "Cannot get the selection grouped status of a null node.");
+	return p_node->has_meta("_edit_group_");
+}
+
 void EditorInterface::set_object_edited(Object *p_object, bool p_edited) {
 	ERR_FAIL_NULL_MSG(p_object, "Cannot change edited status on a null object.");
 	p_object->set_edited(p_edited);
@@ -920,6 +948,11 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath", "set_inherited"), &EditorInterface::open_scene_from_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
+
+	ClassDB::bind_method(D_METHOD("set_node_locked", "node", "locked"), &EditorInterface::set_node_locked);
+	ClassDB::bind_method(D_METHOD("is_node_locked", "node"), &EditorInterface::is_node_locked);
+	ClassDB::bind_method(D_METHOD("set_node_selection_grouped", "node", "grouped"), &EditorInterface::set_node_selection_grouped);
+	ClassDB::bind_method(D_METHOD("is_node_selection_grouped", "node"), &EditorInterface::is_node_selection_grouped);
 
 	ClassDB::bind_method(D_METHOD("set_object_edited", "object", "edited"), &EditorInterface::set_object_edited);
 	ClassDB::bind_method(D_METHOD("is_object_edited", "object"), &EditorInterface::is_object_edited);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -174,6 +174,11 @@ public:
 	void open_scene_from_path(const String &scene_path, bool p_set_inherited = false);
 	void reload_scene_from_path(const String &scene_path);
 
+	void set_node_locked(Node *p_node, bool p_locked);
+	bool is_node_locked(Node *p_node) const;
+	void set_node_selection_grouped(Node *p_node, bool p_grouped);
+	bool is_node_selection_grouped(Node *p_node) const;
+
 	void set_object_edited(Object *p_object, bool p_edited);
 	bool is_object_edited(Object *p_object) const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/3046

This provides a script equivalent for locking nodes which, as far as I'm aware, is only intuitively possible with the button on the viewport toolbar. This PR also adds a script equivalent for the other toolbar button, selection grouping, as they have related uses. 

I was inspired to make this PR after I kept trying to move collision objects around... only to realize a few minutes later that I accidentally moved the collision shape instead. The methods are usable for plugins and tool scripts, and they would find their use for something like loading and creating nodes with many accidentally selectable children.

## Additional information

I opted to put the methods inside of `EditorInterface` instead of `Node` like in the proposal. I believe they are better suited there, as these methods are only relevant for `CanvasItem` and `Node3D` based nodes (and since it's related to editor buttons and functionality). 
