### PR TITLE
Small joypad touchpad API fixes

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -806,13 +806,13 @@ Vector2 Input::get_joy_touchpad_finger_position(int p_device, int p_finger, int 
 	_THREAD_SAFE_METHOD_
 	const TouchpadInfo *touch = joy_touch.getptr(p_device);
 	if (touch == nullptr) {
-		return Vector2();
+		return Vector2(-1, -1);
 	}
 
 	uint16_t index = p_finger | (p_touchpad << 8);
 	const TouchpadFingerInfo *finger_info = touch->finger_info.getptr(index);
 	if (finger_info == nullptr) {
-		return Vector2();
+		return Vector2(-1, -1);
 	}
 
 	return finger_info->position;
@@ -822,13 +822,13 @@ float Input::get_joy_touchpad_finger_pressure(int p_device, int p_finger, int p_
 	_THREAD_SAFE_METHOD_
 	const TouchpadInfo *touch = joy_touch.getptr(p_device);
 	if (touch == nullptr) {
-		return 0.0f;
+		return -1.0f;
 	}
 
 	uint16_t index = p_finger | (p_touchpad << 8);
 	const TouchpadFingerInfo *finger_info = touch->finger_info.getptr(index);
 	if (finger_info == nullptr) {
-		return 0.0f;
+		return -1.0f;
 	}
 
 	return finger_info->pressure;
@@ -1888,7 +1888,7 @@ void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, con
 	motion->gamepad_motion->ProcessMotion(gyro_degrees.x, gyro_degrees.y, gyro_degrees.z, accel_g.x, accel_g.y, accel_g.z, delta_time);
 }
 
-void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure) {
+void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure, bool p_pressed) {
 	_THREAD_SAFE_METHOD_
 
 	if (_should_ignore_joypad_events()) {
@@ -1897,7 +1897,7 @@ void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vecto
 
 	TouchpadInfo &touch = joy_touch[p_device];
 	uint16_t index = p_finger | (p_touchpad << 8);
-	if (p_pressure > 0.0) {
+	if (p_pressed) {
 		touch.finger_info[index] = TouchpadFingerInfo{ p_position, p_pressure };
 	} else {
 		touch.finger_info.erase(index);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -399,10 +399,6 @@ public:
 	Vector3 get_magnetometer() const;
 	Vector3 get_gyroscope() const;
 
-	Vector2 get_joy_touchpad_finger_position(int p_device, int p_finger, int p_touchpad = 0) const;
-	float get_joy_touchpad_finger_pressure(int p_device, int p_finger, int p_touchpad = 0) const;
-	PackedInt32Array get_joy_touchpad_fingers(int p_device, int p_touchpad = 0) const;
-
 	int get_joy_num_touchpads(int p_device) const;
 
 	Point2 get_mouse_position() const;
@@ -448,6 +444,10 @@ public:
 
 	void set_joy_motion_sensors_rate(int p_device, float p_rate);
 
+	Vector2 get_joy_touchpad_finger_position(int p_device, int p_finger, int p_touchpad = 0) const;
+	float get_joy_touchpad_finger_pressure(int p_device, int p_finger, int p_touchpad = 0) const;
+	PackedInt32Array get_joy_touchpad_fingers(int p_device, int p_touchpad = 0) const;
+
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	void stop_joy_vibration(int p_device);
 	void vibrate_handheld(int p_duration_ms = 500, float p_amplitude = -1.0);
@@ -477,7 +477,7 @@ public:
 	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
 	void joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, const Vector3 &p_gyroscope);
-	void joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure);
+	void joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure, bool p_pressed);
 
 	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);
 	void remove_joy_mapping(const String &p_guid);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -231,8 +231,8 @@
 			<param index="1" name="finger" type="int" />
 			<param index="2" name="touchpad" type="int" default="0" />
 			<description>
-				Returns the position of the specified finger on the specified touchpad on the joypad. The X and Y values are in the range from [code]0.0[/code] to [code]1.0[/code], with [code](0.0, 0.0)[/code] representing the top-left corner of the touchpad and [code](1.0, 1.0)[/code] representing the bottom-right corner.
-				If the joypad doesn't have the specified touchpad or the specified finger is not currently touching the touchpad, this method returns [constant Vector2.ZERO].
+				Returns the position of the specified finger on the specified touchpad on the joypad. The X and Y values, if the specified finger is touching the specified touchpad, are in the range from [code]0.0[/code] to [code]1.0[/code], with [code](0.0, 0.0)[/code] representing the top-left corner of the touchpad and [code](1.0, 1.0)[/code] representing the bottom-right corner.
+				If the joypad doesn't have the specified touchpad or the specified finger is not currently touching the touchpad, this method returns [code]Vector2(-1.0, -1.0)[/code].
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
 		</method>
@@ -242,8 +242,8 @@
 			<param index="1" name="finger" type="int" />
 			<param index="2" name="touchpad" type="int" default="0" />
 			<description>
-				Returns the pressure of the specified finger on the specified touchpad on the joypad. The return value is in the range from [code]0.0[/code] to [code]1.0[/code].
-				If the joypad doesn't have the specified touchpad or the specified finger is not currently touching the touchpad, this method returns [code]0.0[/code].
+				Returns the pressure of the specified finger on the specified touchpad on the joypad. The return value, if the specified finger is touching the specified touchpad, is in the range from [code]0.0[/code] to [code]1.0[/code].
+				If the joypad doesn't have the specified touchpad or the specified finger is not currently touching the touchpad, this method returns [code]-1.0[/code].
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
 		</method>

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -289,7 +289,8 @@ void JoypadSDL::process_events() {
 							sdl_event.gtouchpad.touchpad,
 							sdl_event.gtouchpad.finger,
 							Vector2(sdl_event.gtouchpad.x, sdl_event.gtouchpad.y),
-							sdl_event.gtouchpad.pressure);
+							sdl_event.gtouchpad.pressure,
+							sdl_event.type != SDL_EVENT_GAMEPAD_TOUCHPAD_UP);
 					break;
 			}
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR modifies the joypad touchpad API to return negative values if the requested finger and/or touchpad don't exist, so they don't overlap with real position values when the finger and touchpad do exist, as well as tracking presses/releases separately from the pressure parameter.
See this discussion for more details: https://github.com/godotengine/godot/pull/111714#issuecomment-4624833563