### PR TITLE
Add joypad touchpad events (`InputEventJoypadTouchpadTouch` and `InputEventJoypadTouchpadDrag`)

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -802,6 +802,15 @@ Vector3 Input::get_gyroscope() const {
 	return gyroscope;
 }
 
+static uint16_t _combine_joy_touch_id(int p_finger, int p_touchpad) {
+	return p_finger | (p_touchpad << 8);
+}
+
+static void _uncombine_joy_touch_id(uint16_t p_touch_id, int &r_finger, int &r_touchpad) {
+	r_touchpad = p_touch_id >> 8;
+	r_finger = p_touch_id & 0xFF;
+}
+
 Vector2 Input::get_joy_touchpad_finger_position(int p_device, int p_finger, int p_touchpad) const {
 	_THREAD_SAFE_METHOD_
 	const TouchpadInfo *touch = joy_touch.getptr(p_device);
@@ -809,7 +818,7 @@ Vector2 Input::get_joy_touchpad_finger_position(int p_device, int p_finger, int 
 		return Vector2(-1, -1);
 	}
 
-	uint16_t index = p_finger | (p_touchpad << 8);
+	uint16_t index = _combine_joy_touch_id(p_finger, p_touchpad);
 	const TouchpadFingerInfo *finger_info = touch->finger_info.getptr(index);
 	if (finger_info == nullptr) {
 		return Vector2(-1, -1);
@@ -825,7 +834,7 @@ float Input::get_joy_touchpad_finger_pressure(int p_device, int p_finger, int p_
 		return -1.0f;
 	}
 
-	uint16_t index = p_finger | (p_touchpad << 8);
+	uint16_t index = _combine_joy_touch_id(p_finger, p_touchpad);
 	const TouchpadFingerInfo *finger_info = touch->finger_info.getptr(index);
 	if (finger_info == nullptr) {
 		return -1.0f;
@@ -843,9 +852,10 @@ PackedInt32Array Input::get_joy_touchpad_fingers(int p_device, int p_touchpad) c
 
 	PackedInt32Array result;
 	for (const KeyValue<uint16_t, TouchpadFingerInfo> &index : touch->finger_info) {
-		int touchpad = index.key >> 8;
+		int finger, touchpad;
+		_uncombine_joy_touch_id(index.key, finger, touchpad);
 		if (touchpad == p_touchpad) {
-			result.append(index.key & 0xFF);
+			result.append(finger);
 		}
 	}
 	return result;
@@ -1052,6 +1062,39 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 
 	if (jm.is_valid()) {
 		set_joy_axis(jm->get_device(), jm->get_axis(), jm->get_axis_value());
+	}
+
+	Ref<InputEventJoypadTouchpadTouch> jtt = p_event;
+
+	if (jtt.is_valid()) {
+		if (joy_touch.has(jtt->get_device())) {
+			TouchpadInfo &touch = joy_touch[jtt->get_device()];
+			uint16_t index = _combine_joy_touch_id(jtt->get_finger_id(), jtt->get_touchpad_id());
+			if (jtt->is_pressed()) {
+				TouchpadFingerInfo finger_info;
+				finger_info.position = jtt->get_position();
+				finger_info.pressure = jtt->get_pressure();
+				finger_info.last_timestamp = OS::get_singleton()->get_ticks_msec();
+				touch.finger_info[index] = finger_info;
+			} else {
+				touch.finger_info.erase(index);
+			}
+		}
+	}
+
+	Ref<InputEventJoypadTouchpadDrag> jtd = p_event;
+
+	if (jtd.is_valid()) {
+		if (joy_touch.has(jtd->get_device())) {
+			TouchpadInfo &touch = joy_touch[jtd->get_device()];
+			uint16_t index = _combine_joy_touch_id(jtd->get_finger_id(), jtd->get_touchpad_id());
+			if (touch.finger_info.has(index)) {
+				TouchpadFingerInfo &finger_info = touch.finger_info[index];
+				finger_info.position = jtd->get_position();
+				finger_info.pressure = jtd->get_pressure();
+				finger_info.last_timestamp = OS::get_singleton()->get_ticks_msec();
+			}
+		}
 	}
 
 	Ref<InputEventGesture> ge = p_event;
@@ -1896,11 +1939,37 @@ void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vecto
 	}
 
 	TouchpadInfo &touch = joy_touch[p_device];
-	uint16_t index = p_finger | (p_touchpad << 8);
-	if (p_pressed) {
-		touch.finger_info[index] = TouchpadFingerInfo{ p_position, p_pressure };
-	} else {
-		touch.finger_info.erase(index);
+	uint16_t index = _combine_joy_touch_id(p_finger, p_touchpad);
+
+	if (p_pressed != touch.finger_info.has(index)) {
+		Ref<InputEventJoypadTouchpadTouch> ievent;
+		ievent.instantiate();
+		ievent->set_device(p_device);
+		ievent->set_touchpad_id(p_touchpad);
+		ievent->set_finger_id(p_finger);
+		ievent->set_position(p_position);
+		ievent->set_pressure(p_pressure);
+		ievent->set_pressed(p_pressed);
+
+		parse_input_event(ievent);
+	} else if (p_pressed) {
+		// Must exist since here p_pressed == touch.finger_info.has(index) and p_pressed is true
+		TouchpadFingerInfo &finger_info = touch.finger_info[index];
+		uint64_t new_timestamp = OS::get_singleton()->get_ticks_msec();
+		float delta_time = (new_timestamp - finger_info.last_timestamp) / 1000.0f;
+		Vector2 velocity = (p_position - finger_info.position) / delta_time;
+
+		Ref<InputEventJoypadTouchpadDrag> ievent;
+		ievent.instantiate();
+		ievent->set_device(p_device);
+		ievent->set_touchpad_id(p_touchpad);
+		ievent->set_finger_id(p_finger);
+		ievent->set_position(p_position);
+		ievent->set_relative(p_position - finger_info.position);
+		ievent->set_velocity(velocity);
+		ievent->set_pressure(p_pressure);
+
+		parse_input_event(ievent);
 	}
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -196,7 +196,8 @@ private:
 
 	struct TouchpadFingerInfo {
 		Vector2 position;
-		float pressure;
+		float pressure = 0.0f;
+		uint64_t last_timestamp = 0;
 	};
 
 	struct TouchpadInfo {

--- a/core/input/input_enums.h
+++ b/core/input/input_enums.h
@@ -46,6 +46,8 @@ enum class InputEventType {
 	MIDI,
 	SHORTCUT,
 	ACTION,
+	JOY_TOUCHPAD_TOUCH,
+	JOY_TOUCHPAD_DRAG,
 	MAX,
 };
 

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1348,6 +1348,233 @@ void InputEventJoypadButton::_bind_methods() {
 
 ///////////////////////////////////
 
+void InputEventJoypadTouchpadTouch::set_pressed(bool p_pressed) {
+	pressed = p_pressed;
+}
+
+void InputEventJoypadTouchpadTouch::set_touchpad_id(int p_touchpad_id) {
+	touchpad_id = p_touchpad_id;
+}
+
+int InputEventJoypadTouchpadTouch::get_touchpad_id() const {
+	return touchpad_id;
+}
+
+void InputEventJoypadTouchpadTouch::set_finger_id(int p_finger_id) {
+	finger_id = p_finger_id;
+}
+
+int InputEventJoypadTouchpadTouch::get_finger_id() const {
+	return finger_id;
+}
+
+void InputEventJoypadTouchpadTouch::set_position(const Vector2 &p_position) {
+	position = p_position;
+}
+
+Vector2 InputEventJoypadTouchpadTouch::get_position() const {
+	return position;
+}
+
+void InputEventJoypadTouchpadTouch::set_pressure(float p_pressure) {
+	pressure = p_pressure;
+}
+
+float InputEventJoypadTouchpadTouch::get_pressure() const {
+	return pressure;
+}
+
+bool InputEventJoypadTouchpadTouch::action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const {
+	Ref<InputEventJoypadTouchpadTouch> jtt = p_event;
+	if (jtt.is_null()) {
+		return false;
+	}
+
+	bool match = touchpad_id == jtt->touchpad_id && finger_id == jtt->finger_id;
+	if (match) {
+		bool jtt_pressed = jtt->is_pressed();
+		if (r_pressed != nullptr) {
+			*r_pressed = jtt_pressed;
+		}
+		if (r_strength != nullptr) {
+			*r_strength = pressure;
+		}
+		if (r_raw_strength != nullptr) {
+			*r_raw_strength = pressure;
+		}
+	}
+
+	return match;
+}
+
+bool InputEventJoypadTouchpadTouch::is_match(const Ref<InputEvent> &p_event, bool p_exact_match) const {
+	Ref<InputEventJoypadTouchpadTouch> jtt = p_event;
+	if (jtt.is_null()) {
+		return false;
+	}
+
+	return touchpad_id == jtt->touchpad_id && finger_id == jtt->finger_id;
+}
+
+String InputEventJoypadTouchpadTouch::as_text() const {
+	String text = vformat(RTR("Joypad Touchpad %d Finger %d Touch, Position: (%.2f, %.2f)"), touchpad_id, finger_id, position.x, position.y);
+	if (pressure != 0) {
+		text += ", " + RTR("Pressure:") + " " + String(Variant(pressure));
+	}
+	return text;
+}
+
+String InputEventJoypadTouchpadTouch::_to_string() {
+	String p = is_pressed() ? "true" : "false";
+	return vformat("InputEventJoypadTouchpadTouch: touchpad_id=%d, finger_id=%d, pressed=%s, pressure=%.2f, position=(%.2f, %.2f)", touchpad_id, finger_id, p, pressure, position.x, position.y);
+}
+
+void InputEventJoypadTouchpadTouch::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_touchpad_id", "touchpad_id"), &InputEventJoypadTouchpadTouch::set_touchpad_id);
+	ClassDB::bind_method(D_METHOD("get_touchpad_id"), &InputEventJoypadTouchpadTouch::get_touchpad_id);
+
+	ClassDB::bind_method(D_METHOD("set_finger_id", "finger_id"), &InputEventJoypadTouchpadTouch::set_finger_id);
+	ClassDB::bind_method(D_METHOD("get_finger_id"), &InputEventJoypadTouchpadTouch::get_finger_id);
+
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventJoypadTouchpadTouch::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"), &InputEventJoypadTouchpadTouch::get_position);
+
+	ClassDB::bind_method(D_METHOD("set_pressure", "pressure"), &InputEventJoypadTouchpadTouch::set_pressure);
+	ClassDB::bind_method(D_METHOD("get_pressure"), &InputEventJoypadTouchpadTouch::get_pressure);
+
+	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventJoypadTouchpadTouch::set_pressed);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "touchpad_id"), "set_touchpad_id", "get_touchpad_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "finger_id"), "set_finger_id", "get_finger_id");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure"), "set_pressure", "get_pressure");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
+}
+
+///////////////////////////////////
+
+void InputEventJoypadTouchpadDrag::set_touchpad_id(int p_touchpad_id) {
+	touchpad_id = p_touchpad_id;
+}
+
+int InputEventJoypadTouchpadDrag::get_touchpad_id() const {
+	return touchpad_id;
+}
+
+void InputEventJoypadTouchpadDrag::set_finger_id(int p_finger_id) {
+	finger_id = p_finger_id;
+}
+
+int InputEventJoypadTouchpadDrag::get_finger_id() const {
+	return finger_id;
+}
+
+void InputEventJoypadTouchpadDrag::set_position(const Vector2 &p_position) {
+	position = p_position;
+}
+
+Vector2 InputEventJoypadTouchpadDrag::get_position() const {
+	return position;
+}
+
+void InputEventJoypadTouchpadDrag::set_relative(const Vector2 &p_relative) {
+	relative = p_relative;
+}
+
+Vector2 InputEventJoypadTouchpadDrag::get_relative() const {
+	return relative;
+}
+
+void InputEventJoypadTouchpadDrag::set_velocity(const Vector2 &p_velocity) {
+	velocity = p_velocity;
+}
+
+Vector2 InputEventJoypadTouchpadDrag::get_velocity() const {
+	return velocity;
+}
+
+void InputEventJoypadTouchpadDrag::set_pressure(float p_pressure) {
+	pressure = p_pressure;
+}
+
+float InputEventJoypadTouchpadDrag::get_pressure() const {
+	return pressure;
+}
+
+bool InputEventJoypadTouchpadDrag::action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const {
+	Ref<InputEventJoypadTouchpadDrag> jtd = p_event;
+	if (jtd.is_null()) {
+		return false;
+	}
+
+	bool match = touchpad_id == jtd->touchpad_id && finger_id == jtd->finger_id;
+	if (match) {
+		bool jtd_pressed = jtd->is_pressed();
+		if (r_pressed != nullptr) {
+			*r_pressed = jtd_pressed;
+		}
+		if (r_strength != nullptr) {
+			*r_strength = pressure;
+		}
+		if (r_raw_strength != nullptr) {
+			*r_raw_strength = pressure;
+		}
+	}
+
+	return match;
+}
+
+bool InputEventJoypadTouchpadDrag::is_match(const Ref<InputEvent> &p_event, bool p_exact_match) const {
+	Ref<InputEventJoypadTouchpadDrag> jtd = p_event;
+	if (jtd.is_null()) {
+		return false;
+	}
+
+	return touchpad_id == jtd->touchpad_id && finger_id == jtd->finger_id;
+}
+
+String InputEventJoypadTouchpadDrag::as_text() const {
+	String text = vformat(RTR("Joypad Touchpad %d Finger %d Drag, Position: (%s)"), touchpad_id, finger_id, String(position));
+	if (pressure != 0) {
+		text += ", " + RTR("Pressure:") + " " + String(Variant(pressure));
+	}
+	return text;
+}
+
+String InputEventJoypadTouchpadDrag::_to_string() {
+	return vformat("InputEventJoypadTouchpadDrag: touchpad_id=%d, finger_id=%d, pressure=%.2f, position=(%s), relative=(%s), velocity=(%s)",
+			touchpad_id, finger_id, pressure, String(position), String(relative), String(velocity));
+}
+
+void InputEventJoypadTouchpadDrag::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_touchpad_id", "touchpad_id"), &InputEventJoypadTouchpadDrag::set_touchpad_id);
+	ClassDB::bind_method(D_METHOD("get_touchpad_id"), &InputEventJoypadTouchpadDrag::get_touchpad_id);
+
+	ClassDB::bind_method(D_METHOD("set_finger_id", "finger_id"), &InputEventJoypadTouchpadDrag::set_finger_id);
+	ClassDB::bind_method(D_METHOD("get_finger_id"), &InputEventJoypadTouchpadDrag::get_finger_id);
+
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventJoypadTouchpadDrag::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"), &InputEventJoypadTouchpadDrag::get_position);
+
+	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventJoypadTouchpadDrag::set_relative);
+	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventJoypadTouchpadDrag::get_relative);
+
+	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &InputEventJoypadTouchpadDrag::set_velocity);
+	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventJoypadTouchpadDrag::get_velocity);
+
+	ClassDB::bind_method(D_METHOD("set_pressure", "pressure"), &InputEventJoypadTouchpadDrag::set_pressure);
+	ClassDB::bind_method(D_METHOD("get_pressure"), &InputEventJoypadTouchpadDrag::get_pressure);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "touchpad_id"), "set_touchpad_id", "get_touchpad_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "finger_id"), "set_finger_id", "get_finger_id");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure"), "set_pressure", "get_pressure");
+}
+
+///////////////////////////////////
+
 void InputEventScreenTouch::set_index(int p_index) {
 	index = p_index;
 }

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -368,6 +368,86 @@ public:
 	InputEventType get_type() const final override { return InputEventType::JOY_BUTTON; }
 };
 
+class InputEventJoypadTouchpadTouch : public InputEvent {
+	GDCLASS(InputEventJoypadTouchpadTouch, InputEvent);
+
+	int touchpad_id = 0;
+	int finger_id = 0;
+	Vector2 position;
+	float pressure = 0; //0 to 1
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_pressed(bool p_pressed);
+
+	void set_touchpad_id(int p_touchpad_id);
+	int get_touchpad_id() const;
+
+	void set_finger_id(int finger_id);
+	int get_finger_id() const;
+
+	void set_position(const Vector2 &p_position);
+	Vector2 get_position() const;
+
+	void set_pressure(float p_pressure);
+	float get_pressure() const;
+
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
+
+	virtual bool is_action_type() const override { return true; }
+
+	virtual String as_text() const override;
+	virtual String _to_string() override;
+
+	InputEventType get_type() const final override { return InputEventType::JOY_TOUCHPAD_TOUCH; }
+};
+
+class InputEventJoypadTouchpadDrag : public InputEvent {
+	GDCLASS(InputEventJoypadTouchpadDrag, InputEvent);
+
+	int touchpad_id = 0;
+	int finger_id = 0;
+	Vector2 position;
+	Vector2 relative;
+	Vector2 velocity;
+	float pressure = 0; //0 to 1
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_touchpad_id(int p_touchpad_id);
+	int get_touchpad_id() const;
+
+	void set_finger_id(int finger_id);
+	int get_finger_id() const;
+
+	void set_position(const Vector2 &p_position);
+	Vector2 get_position() const;
+
+	void set_relative(const Vector2 &p_relative);
+	Vector2 get_relative() const;
+
+	void set_velocity(const Vector2 &p_velocity);
+	Vector2 get_velocity() const;
+
+	void set_pressure(float p_pressure);
+	float get_pressure() const;
+
+	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const override;
+	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
+
+	virtual bool is_action_type() const override { return true; }
+
+	virtual String as_text() const override;
+	virtual String _to_string() override;
+
+	InputEventType get_type() const final override { return InputEventType::JOY_TOUCHPAD_DRAG; }
+};
+
 class InputEventScreenTouch : public InputEventFromWindow {
 	GDCLASS(InputEventScreenTouch, InputEventFromWindow);
 	int index = 0;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -198,6 +198,8 @@ void register_core_types() {
 	GDREGISTER_CLASS(InputEventMouseMotion);
 	GDREGISTER_CLASS(InputEventJoypadButton);
 	GDREGISTER_CLASS(InputEventJoypadMotion);
+	GDREGISTER_CLASS(InputEventJoypadTouchpadTouch);
+	GDREGISTER_CLASS(InputEventJoypadTouchpadDrag);
 	GDREGISTER_CLASS(InputEventScreenDrag);
 	GDREGISTER_CLASS(InputEventScreenTouch);
 	GDREGISTER_CLASS(InputEventAction);

--- a/doc/classes/InputEventJoypadTouchpadDrag.xml
+++ b/doc/classes/InputEventJoypadTouchpadDrag.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InputEventJoypadTouchpadDrag" inherits="InputEvent" api_type="core" experimental="" keywords="gamepad, controller" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Represents a gamepad touchpad drag event.
+	</brief_description>
+	<description>
+		Stores information about gamepad touchpad drag events.
+	</description>
+	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+	</tutorials>
+	<members>
+		<member name="finger_id" type="int" setter="set_finger_id" getter="get_finger_id" default="0">
+			The touch finger index in the case of a multi-touch event. One index for each finger.
+		</member>
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
+			The touch position. The X and Y values are in the range from [code]0.0[/code] to [code]1.0[/code], with [code](0.0, 0.0)[/code] representing the top-left corner of the touchpad and [code](1.0, 1.0)[/code] representing the bottom-right corner.
+		</member>
+		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
+			The touch pressure in the range from [code]0.0[/code] to [code]1.0[/code].
+		</member>
+		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
+			The drag position relative to the previous position (position at the last frame).
+		</member>
+		<member name="touchpad_id" type="int" setter="set_touchpad_id" getter="get_touchpad_id" default="0">
+			The touchpad index.
+		</member>
+		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
+			The drag velocity.
+		</member>
+	</members>
+</class>

--- a/doc/classes/InputEventJoypadTouchpadTouch.xml
+++ b/doc/classes/InputEventJoypadTouchpadTouch.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InputEventJoypadTouchpadTouch" inherits="InputEvent" api_type="core" experimental="" keywords="gamepad, controller" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Represents a gamepad touchpad touch event.
+	</brief_description>
+	<description>
+		Stores information about gamepad touchpad multi-touch press/release input events. Supports touch press, touch release, and [member finger_id] for multi-touch count and order.
+	</description>
+	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+	</tutorials>
+	<members>
+		<member name="finger_id" type="int" setter="set_finger_id" getter="get_finger_id" default="0">
+			The touch finger index in the case of a multi-touch event. One index for each finger.
+		</member>
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
+			The touch position. The X and Y values are in the range from [code]0.0[/code] to [code]1.0[/code], with [code](0.0, 0.0)[/code] representing the top-left corner of the touchpad and [code](1.0, 1.0)[/code] representing the bottom-right corner.
+		</member>
+		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
+			If [code]true[/code], the touch's state is pressed. If [code]false[/code], the touch's state is released.
+		</member>
+		<member name="pressure" type="float" setter="set_pressure" getter="get_pressure" default="0.0">
+			The touch pressure in the range from [code]0.0[/code] to [code]1.0[/code].
+		</member>
+		<member name="touchpad_id" type="int" setter="set_touchpad_id" getter="get_touchpad_id" default="0">
+			The touchpad index.
+		</member>
+	</members>
+</class>


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR adds joypad touchpad events: `InputEventJoypadTouchpadTouch` and `InputEventJoypadTouchpadDrag`.
They're done similarly to already existing and `InputEventScreenTouch` and `InputEventScreenDrag` events, since both represent finger touches and movement across a touch-supported surface, if that makes sense.

I think these events would allow the users to use the touchpads more easily and more intuitively. I've created several code examples that use these events, and these examples describe the usage scenarios mentioned in https://github.com/godotengine/godot-proposals/issues/14481
These examples will later be used in joypad touchpad tutorial.

<details>
<summary>Swipe example</summary>

```gdscript
var track_fingers: Dictionary[int, Vector2]

func _input(event: InputEvent) -> void:
	if event is InputEventJoypadTouchpadTouch:
		if event.pressed and event.finger_id not in track_fingers:
			track_fingers[event.finger_id] = event.position
		elif not event.pressed:
			track_fingers.erase(event.finger_id)
	if event is InputEventJoypadTouchpadDrag:
		if event.finger_id in track_fingers:
			var distance: Vector2 = event.position - track_fingers[event.finger_id]
			var reacted := true
			if distance.x > 0.5:
				print("Moved right")
			elif distance.x < -0.5:
				print("Moved left")
			elif distance.y > 0.5:
				print("Moved down")
			elif distance.y < -0.5:
				print("Moved up")
			else:
				reacted = false
			if reacted:
				track_fingers[event.finger_id] = event.position
```

https://github.com/user-attachments/assets/09c45906-413b-45b9-a440-e31964db214d

</details>

<details>
<summary>Rotation/scale example</summary>

```gdscript
@onready var icon: Sprite2D = $Icon

var track_fingers: Array[int] = []
var last_distance := Vector2.ZERO
var rotating := false
func _input(event: InputEvent) -> void:
	if event is InputEventJoypadTouchpadTouch:
		# Track the fingers here for ease of use
		if event.pressed and event.finger_id not in track_fingers:
			track_fingers.append(event.finger_id)
		elif not event.pressed and event.finger_id in track_fingers:
			track_fingers.erase(event.finger_id)
			
		# Only apply transformations if both fingers are touching the touchpad
		if 0 in track_fingers and 1 in track_fingers:
			rotating = true
			last_distance = get_current_distance()
		else:
			rotating = false
			
	elif event is InputEventJoypadTouchpadDrag:
		if rotating:
			var new_distance := get_current_distance()
			var angle_delta := new_distance.angle() - last_distance.angle()
			var scale_delta := new_distance.length() / last_distance.length()
			last_distance = new_distance
			
			icon.rotation += angle_delta
			icon.scale *= scale_delta
				
func get_current_distance() -> Vector2:
	var pos1 := Input.get_joy_touchpad_finger_position(0, 0)
	var pos2 := Input.get_joy_touchpad_finger_position(0, 1)
	var distance := pos2 - pos1
	distance.y /= 2 # PS Touchpad is about half the size vertically
	return distance
```

https://github.com/user-attachments/assets/6f2ca213-638c-4402-92fa-cf2474ca2287

</details>

<details>
<summary>Trackpad example</summary>

```gdscript
@onready var icon: Sprite2D = $Icon

func _input(event: InputEvent) -> void:
	if event is InputEventJoypadTouchpadDrag:
		var distance: Vector2 = event.relative * 1000
		distance.y /= 2 # PS Touchpad is about half the size vertically
		icon.position += event.relative * 1000
```

https://github.com/user-attachments/assets/ec4d7173-a15b-4097-942c-268a98ae54b2

</details>

TODO:
- [ ] Accumulating events?

## Additional information

- Requires https://github.com/godotengine/godot/pull/120578 to be merged first.