### PR TITLE
Fix GraphNode caches missing ports when a parent Node is invisible

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -1051,7 +1051,7 @@ void GraphNode::_port_pos_update() {
 	slot_count = 0; // Reset the slot count, which is the index of the current slot.
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *child = as_sortable_control(get_child(i, false), SortableVisibilityMode::VISIBLE_IN_TREE);
+		Control *child = as_sortable_control(get_child(i, false), SortableVisibilityMode::VISIBLE);
 		if (!child) {
 			continue;
 		}


### PR DESCRIPTION
Update GraphNode's `left_port_cache` and `right_port_cache` on `VISIBLE` nodes, not just `VISIBLE_IN_TREE`.

## Motivation
A project I'm working on using `GraphEdit` would not be able to traverse `GraphNode`s while the `GraphEdit` wasn't visible, only when tabbing into the `GraphEdit` to make it visible

## What problem(s) does this PR solve?
- When attempting to get port information on a GraphNode via functions like `get_input_port_count()` or `get_input_port_type(port)` while the GraphNode or any of it's parents is not visible. You would error out as `left_port_cache` and `right_port_cache` was cleared all previously valid ports
- This allows traversal/evaluation of `GraphEdit`s while the `GraphEdit` (or any of their parent) is not visible

## Testing
- Tested for regression on the issue fixed in #97763 
- Tested a script editor implementation that I've previously failed to traverse due to this issue

## Additional information
- As someone using Godot mostly in-engine, I am not very familiar with the engine code itself.
- I have not found any open issues or discussions regarding this. Likely as GraphEdit is a rather niche component and subject to change
- Looked at #97763 which previously set it from `IGNORE` to `VISIBLE_IN_TREE`.
My assumption is that there was no particular reason they have used `VISIBLE_IN_TREE`, but using `IGNORE` is likely incorrect due to the difference between ports and slots
- Received guidance from `sarcen` (thank you)