### PR TITLE
Avoid zero division for `normalize()` in PrimitiveMesh

### DIFF
--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -1116,7 +1116,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 
 	thisrow = 0;
 	prevrow = 0;
-	const real_t side_normal_y = (bottom_radius - top_radius) / height;
+	const real_t side_normal_y = Math::is_zero_approx(height) ? 0 : (bottom_radius - top_radius) / height;
 	for (j = 0; j <= (rings + 1); j++) {
 		v = j;
 		v /= (rings + 1);
@@ -1989,7 +1989,7 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 	int i, j, prevrow, thisrow, point;
 	float x, y, z;
 
-	float scale = height / radius * (is_hemisphere ? 1.0 : 0.5);
+	float scale = Math::is_zero_approx(radius) ? 0 : height / radius * (is_hemisphere ? 1.0 : 0.5);
 
 	// Only used if we calculate UV2
 	float circumference = radius * Math::TAU;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120107
- Context https://github.com/godotengine/godot/issues/120107#issuecomment-4775579878

Add a fallback for division by zero in values that may be normalized by PrimitiveMesh. Since the inspector prevents these values from becoming 0 due to the 0.001 limit, this zero-div/NaN.normalize() case was only encountered when set radius/height by the user script.

The behavior when radius (or height for cylinder) is 0 will change before and after this PR. However, before this PR, when a sphere with a radius of 0 was present, NaN vertex was passed directly to the Rendering/Physics server, so it is wrong way. For the cylinder, the calculation of the normal vector relative to a side with zero thickness would be improved, but in any case, this will not result in a visible change.

I assume these cases are niche, but it will be fixed by this PR.