### PR TITLE
Alternative calculation of coverage for Shadow Map atlas quadrant selection

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3517,7 +3517,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 				Transform3D cam_xf = p_camera_data->main_transform;
 				float zn = p_camera_data->main_projection.get_z_near();
-				Plane p(-cam_xf.basis.get_column(2), cam_xf.origin + cam_xf.basis.get_column(2) * -zn); //camera near plane
+				Transform3D view_matrix = cam_xf.affine_inverse();//Q: is it necessary to use affine_inverse() rather than inverse()?
 
 				// near plane half width and height
 				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
@@ -3532,15 +3532,14 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						if (!p_camera_data->is_orthogonal) {
-							//if using perspetive, map them to near plane
-							for (int j = 0; j < 2; j++) {
-								if (p.distance_to(points[j]) < 0) {
-									points[j].z = -zn; //small hack to keep size constant when hitting the screen
-								}
-
-								p.intersects_segment(cam_xf.origin, points[j], &points[j]); //map to plane
-							}
+						for (int j=0; j < 2; j++){
+							points[j] = view_matrix.xform(points[j]);
+							if (points[j].z > -zn){//alternative hack
+								points[j].z = -zn;
+							}//projection on the screen
+							points[j].x = points[j].x * (-zn / points[j].z);
+							points[j].y = points[j].y * (-zn / points[j].z);
+							points[j].z = -zn;
 						}
 
 						float screen_diameter = points[0].distance_to(points[1]) * 2;
@@ -3560,15 +3559,14 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							base + cam_xf.basis.get_column(0) * w
 						};
 
-						if (!p_camera_data->is_orthogonal) {
-							//if using perspetive, map them to near plane
-							for (int j = 0; j < 2; j++) {
-								if (p.distance_to(points[j]) < 0) {
-									points[j].z = -zn; //small hack to keep size constant when hitting the screen
-								}
-
-								p.intersects_segment(cam_xf.origin, points[j], &points[j]); //map to plane
+						for (int j=0; j < 2; j++){
+							points[j] = view_matrix.xform(points[j]);
+							if (points[j].z > -zn){
+								points[j].z = -zn;
 							}
+							points[j].x = points[j].x * (-zn / points[j].z);
+							points[j].y = points[j].y * (-zn / points[j].z);
+							points[j].z = -zn;
 						}
 
 						float screen_diameter = points[0].distance_to(points[1]) * 2;
@@ -3585,15 +3583,14 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						if (!p_camera_data->is_orthogonal) {
-							//if using perspetive, map them to near plane
-							for (int j = 0; j < 2; j++) {
-								if (p.distance_to(points[j]) < 0) {
-									points[j].z = -zn; //small hack to keep size constant when hitting the screen
-								}
-
-								p.intersects_segment(cam_xf.origin, points[j], &points[j]); //map to plane
+						for (int j=0; j < 2; j++){
+							points[j] = view_matrix.xform(points[j]);
+							if (points[j].z > -zn){
+								points[j].z = -zn;
 							}
+							points[j].x = points[j].x * (-zn / points[j].z);
+							points[j].y = points[j].y * (-zn / points[j].z);
+							points[j].z = -zn;
 						}
 
 						float screen_diameter = points[0].distance_to(points[1]) * 2;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3498,7 +3498,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		}
 
 		// Positional Shadows
-		
+
 		Transform3D cam_xf = p_camera_data->main_transform; //taken out of the 'for' loop in 'compute coverage', 
 		float zn = p_camera_data->main_projection.get_z_near(); //so as not to calculate for each light source
 		Transform3D view_matrix = cam_xf.affine_inverse(); //Q: is it necessary to use affine_inverse() rather than inverse()?
@@ -3532,9 +3532,9 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						for (int j=0; j < 2; j++) {
+						for (int j = 0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn){//alternative hack
+							if (points[j].z > -zn) { //alternative hack
 								points[j].z = -zn;
 							}//projection on the screen
 							points[j].x = points[j].x * (-zn / points[j].z);
@@ -3559,9 +3559,9 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							base + cam_xf.basis.get_column(0) * w
 						};
 
-						for (int j=0; j < 2; j++) {
+						for (int j = 0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn){
+							if (points[j].z > -zn) {
 								points[j].z = -zn;
 							}
 							points[j].x = points[j].x * (-zn / points[j].z);
@@ -3583,9 +3583,9 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						for (int j=0; j < 2; j++) {
+						for (int j = 0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn){
+							if (points[j].z > -zn) {
 								points[j].z = -zn;
 							}
 							points[j].x = points[j].x * (-zn / points[j].z);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3498,11 +3498,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		}
 
 		// Positional Shadows
-
-		Transform3D cam_xf = p_camera_data->main_transform; //taken out of the 'for' loop in 'compute coverage', 
-		float zn = p_camera_data->main_projection.get_z_near(); //so as not to calculate for each light source
-		Transform3D view_matrix = cam_xf.affine_inverse(); //Q: is it necessary to use affine_inverse() rather than inverse()?
-		
+		float zn = p_camera_data->main_projection.get_z_near();
 		for (uint32_t i = 0; i < (uint32_t)scene_cull_result.lights.size(); i++) {
 			Instance *ins = scene_cull_result.lights[i];
 
@@ -3515,86 +3511,89 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			if (!RSG::light_storage->light_instance_is_shadow_visible_at_position(light->instance, camera_position)) {
 				continue;
 			}
-
 			float coverage = 0.f;
-
 			{ //compute coverage
 				// near plane half width and height
 				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
-
 				switch (RSG::light_storage->light_get_type(ins->base)) {
 					case RSE::LIGHT_OMNI: {
 						float radius = RSG::light_storage->light_get_param(ins->base, RSE::LIGHT_PARAM_RANGE);
-
-						//get two points parallel to near plane
-						Vector3 points[2] = {
-							ins->transform.origin,
-							ins->transform.origin + cam_xf.basis.get_column(0) * radius
-						};
-
-						for (int j = 0; j < 2; j++) {
-							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn) { //alternative hack
-								points[j].z = -zn;
-							}//projection on the screen
-							points[j].x = points[j].x * (-zn / points[j].z);
-							points[j].y = points[j].y * (-zn / points[j].z);
-							points[j].z = -zn;
+						if (!p_camera_data->is_orthogonal) {
+							float dist_to_cam = ins->transform.origin.distance_to(camera_position);
+							if (dist_to_cam <= (radius + zn)) {
+								float dist_factor = 1.0f - (dist_to_cam / (radius + zn + 0.001f));
+								coverage = 1.0f + dist_factor;
+							} else {
+								float screen_radius = (radius * zn / dist_to_cam);
+								float coverage_x = screen_radius / vp_half_extents.x;
+								float coverage_y = screen_radius / vp_half_extents.y;
+								//coverage = coverage_x * coverage_y; //Total coverage as part of the screen area
+								//coverage = MAX(coverage_x, coverage_y); //max
+								coverage = (coverage_x + coverage_y) * 0.5f;
+							}
+						} else {
+							float coverage_x = radius / vp_half_extents.x;
+							float coverage_y = radius / vp_half_extents.y;
+							coverage = (coverage_x + coverage_y) * 0.5f;
 						}
-
-						float screen_diameter = points[0].distance_to(points[1]) * 2;
-						coverage = screen_diameter / (vp_half_extents.x + vp_half_extents.y);
 					} break;
 					case RSE::LIGHT_SPOT: {
 						float radius = RSG::light_storage->light_get_param(ins->base, RSE::LIGHT_PARAM_RANGE);
 						float angle = RSG::light_storage->light_get_param(ins->base, RSE::LIGHT_PARAM_SPOT_ANGLE);
-
-						float w = radius * Math::sin(Math::deg_to_rad(angle));
-						float d = radius * Math::cos(Math::deg_to_rad(angle));
-
-						Vector3 base = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * d;
-
-						Vector3 points[2] = {
-							base,
-							base + cam_xf.basis.get_column(0) * w
-						};
-
-						for (int j = 0; j < 2; j++) {
-							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn) {
-								points[j].z = -zn;
+						float angle_rad = Math::deg_to_rad(angle);
+						if (!p_camera_data->is_orthogonal) {
+							Vector3 sphere_coord;
+							float sphere_radius;
+							if (angle_rad <= Math::PI / 4.0) { // <=45
+								sphere_radius = radius / (2.0 * Math::cos(angle_rad));
+								sphere_coord = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * sphere_radius;
+							} else { // >45
+								angle_rad = MIN(1.53589f, angle_rad); // 1.53589f is about 88 degrees
+								sphere_radius = radius * Math::sin(angle_rad);
+								sphere_coord = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * (radius * Math::cos(angle_rad));
 							}
-							points[j].x = points[j].x * (-zn / points[j].z);
-							points[j].y = points[j].y * (-zn / points[j].z);
-							points[j].z = -zn;
+							float dist_to_cam = sphere_coord.distance_to(camera_position);
+							if (dist_to_cam <= (sphere_radius + zn)) {
+								float dist_factor = 1.0f - (dist_to_cam / (sphere_radius + zn + 0.001f));
+								coverage = 1.0f + dist_factor;
+							} else {
+								float screen_radius = (sphere_radius * zn / dist_to_cam);
+								float coverage_x = screen_radius / vp_half_extents.x;
+								float coverage_y = screen_radius / vp_half_extents.y;
+								coverage = (coverage_x + coverage_y) * 0.5f;
+							}
+						} else { //is_orthogonal
+							float sphere_radius;
+							if (angle_rad <= Math::PI / 4.0) { // <=45
+								sphere_radius = radius / (2.0 * Math::cos(angle_rad));
+							} else { // >45
+								angle_rad = MIN(Math::PI / 2.0f, angle_rad); //90 degrees-to secure the calculation of the sin
+								sphere_radius = radius * Math::sin(angle_rad);
+							}
+							float coverage_x = sphere_radius / vp_half_extents.x;
+							float coverage_y = sphere_radius / vp_half_extents.y;
+							coverage = (coverage_x + coverage_y) * 0.5f;
 						}
-
-						float screen_diameter = points[0].distance_to(points[1]) * 2;
-						coverage = screen_diameter / (vp_half_extents.x + vp_half_extents.y);
-
 					} break;
 					case RSE::LIGHT_AREA: {
 						float diagonal = RSG::light_storage->light_area_get_size(ins->base).length();
 						float radius = RSG::light_storage->light_get_param(ins->base, RSE::LIGHT_PARAM_RANGE) + diagonal;
-
-						//get two points parallel to near plane
-						Vector3 points[2] = {
-							ins->transform.origin,
-							ins->transform.origin + cam_xf.basis.get_column(0) * radius
-						};
-
-						for (int j = 0; j < 2; j++) {
-							points[j] = view_matrix.xform(points[j]);
-							if (points[j].z > -zn) {
-								points[j].z = -zn;
+						if (!p_camera_data->is_orthogonal) {
+							float dist_to_cam = ins->transform.origin.distance_to(camera_position);
+							if (dist_to_cam <= (radius + zn)) {
+								float dist_factor = 1.0f - (dist_to_cam / (radius + zn + 0.0001f));
+								coverage = 1.0f + dist_factor;
+							} else {
+								float screen_radius = (radius * zn / dist_to_cam);
+								float coverage_x = screen_radius / vp_half_extents.x;
+								float coverage_y = screen_radius / vp_half_extents.y;
+								coverage = (coverage_x + coverage_y) * 0.5f;
 							}
-							points[j].x = points[j].x * (-zn / points[j].z);
-							points[j].y = points[j].y * (-zn / points[j].z);
-							points[j].z = -zn;
+						} else { // Orthogonal
+							float coverage_x = radius / vp_half_extents.x;
+							float coverage_y = radius / vp_half_extents.y;
+							coverage = (coverage_x + coverage_y) * 0.5f;
 						}
-
-						float screen_diameter = points[0].distance_to(points[1]) * 2;
-						coverage = screen_diameter / (vp_half_extents.x + vp_half_extents.y);
 					} break;
 					default: {
 						ERR_PRINT("Invalid Light Type");

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3499,9 +3499,9 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 		// Positional Shadows
 		
-		Transform3D cam_xf = p_camera_data->main_transform;//taken out of the 'for' loop in 'compute coverage', 
-		float zn = p_camera_data->main_projection.get_z_near();//so as not to calculate for each light source
-		Transform3D view_matrix = cam_xf.affine_inverse();//Q: is it necessary to use affine_inverse() rather than inverse()?
+		Transform3D cam_xf = p_camera_data->main_transform; //taken out of the 'for' loop in 'compute coverage', 
+		float zn = p_camera_data->main_projection.get_z_near(); //so as not to calculate for each light source
+		Transform3D view_matrix = cam_xf.affine_inverse(); //Q: is it necessary to use affine_inverse() rather than inverse()?
 		
 		for (uint32_t i = 0; i < (uint32_t)scene_cull_result.lights.size(); i++) {
 			Instance *ins = scene_cull_result.lights[i];
@@ -3532,7 +3532,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						for (int j=0; j < 2; j++){
+						for (int j=0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
 							if (points[j].z > -zn){//alternative hack
 								points[j].z = -zn;
@@ -3559,7 +3559,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							base + cam_xf.basis.get_column(0) * w
 						};
 
-						for (int j=0; j < 2; j++){
+						for (int j=0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
 							if (points[j].z > -zn){
 								points[j].z = -zn;
@@ -3583,7 +3583,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
-						for (int j=0; j < 2; j++){
+						for (int j=0; j < 2; j++) {
 							points[j] = view_matrix.xform(points[j]);
 							if (points[j].z > -zn){
 								points[j].z = -zn;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3498,6 +3498,11 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		}
 
 		// Positional Shadows
+		
+		Transform3D cam_xf = p_camera_data->main_transform;//taken out of the 'for' loop in 'compute coverage', 
+		float zn = p_camera_data->main_projection.get_z_near();//so as not to calculate for each light source
+		Transform3D view_matrix = cam_xf.affine_inverse();//Q: is it necessary to use affine_inverse() rather than inverse()?
+		
 		for (uint32_t i = 0; i < (uint32_t)scene_cull_result.lights.size(); i++) {
 			Instance *ins = scene_cull_result.lights[i];
 
@@ -3514,11 +3519,6 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			float coverage = 0.f;
 
 			{ //compute coverage
-
-				Transform3D cam_xf = p_camera_data->main_transform;
-				float zn = p_camera_data->main_projection.get_z_near();
-				Transform3D view_matrix = cam_xf.affine_inverse();//Q: is it necessary to use affine_inverse() rather than inverse()?
-
 				// near plane half width and height
 				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Should close https://github.com/godotengine/godot/issues/80064, 
- Close https://github.com/godotengine/godot/issues/85327

## Additional information
The calculation assumes that the camera is facing each light source (lights behind the camera are cut off by the "light_instance_is_shadow_visible_at_position" check). Also, calculations beyond the boundaries of the "for" cycle were previously performed for each light source that casts a shadow into the camera. Compiled and tested  with a change in the version 4.6.3 code, everything worked fine on windows. 
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

- *Bugsquad edit: See also https://github.com/godotengine/godot/pull/120743.*
