### PR TITLE
Fix `StringName` temporary loss in macOS export plugin, potentially leading to crashes.

### DIFF
--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1841,7 +1841,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 			if (appnames.is_empty()) {
 				domain->set_locale_override(lang);
-				const String &name = domain->translate(project_name, String());
+				String name = domain->translate(project_name, String());
 				if (name != project_name) {
 					f->store_line("CFBundleDisplayName = \"" + name.xml_escape(true) + "\";");
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a potential crash & build error on `master`, where a temporary `StringName` is referenced as a `String`, leading to a dangling pointer.

Regression from https://github.com/godotengine/godot/pull/118856.