### PR TITLE
[Editor] Use `EditorHelpBitTooltip` for `CreateDialog` tree tooltips.

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3530,9 +3530,15 @@ EditorHelp::EditorHelp() {
 
 #define HANDLE_DOC(m_string) ((is_native ? DTR(m_string) : (m_string)).strip_edges())
 
-EditorHelpBit::HelpData EditorHelpBit::_get_class_help_data(const StringName &p_class_name) {
-	if (doc_class_cache.has(p_class_name)) {
-		return doc_class_cache[p_class_name];
+EditorHelpBit::HelpData EditorHelpBit::_get_class_help_data(const StringName &p_class_name, bool p_use_brief_description) {
+	if (p_use_brief_description) {
+		if (doc_class_brief_cache.has(p_class_name)) {
+			return doc_class_brief_cache[p_class_name];
+		}
+	} else {
+		if (doc_class_cache.has(p_class_name)) {
+			return doc_class_cache[p_class_name];
+		}
 	}
 
 	HelpData result;
@@ -3548,7 +3554,7 @@ EditorHelpBit::HelpData EditorHelpBit::_get_class_help_data(const StringName &p_
 		if (!brief_description.is_empty()) {
 			result.description += "[b]" + brief_description + "[/b]";
 		}
-		if (!long_description.is_empty()) {
+		if (!long_description.is_empty() && !p_use_brief_description) {
 			if (!result.description.is_empty()) {
 				result.description += '\n';
 			}
@@ -3570,7 +3576,11 @@ EditorHelpBit::HelpData EditorHelpBit::_get_class_help_data(const StringName &p_
 		}
 
 		if (is_native) {
-			doc_class_cache[p_class_name] = result;
+			if (p_use_brief_description) {
+				doc_class_brief_cache[p_class_name] = result;
+			} else {
+				doc_class_cache[p_class_name] = result;
+			}
 		}
 	}
 
@@ -4454,7 +4464,7 @@ String EditorHelpBit::get_as_plain_text(const String &p_symbol, const String &p_
 	HelpData new_help_data = HelpData();
 
 	if (item_type == "class") {
-		new_help_data = _get_class_help_data(class_name);
+		new_help_data = _get_class_help_data(class_name, false);
 	} else if (item_type == "enum") {
 		new_help_data = _get_enum_help_data(class_name, item_name);
 	} else if (item_type == "constant") {
@@ -4695,7 +4705,7 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 		symbol_type = TTR("Class");
 		symbol_name = class_name;
 		symbol_hint = SYMBOL_HINT_INHERITANCE;
-		help_data = _get_class_help_data(class_name);
+		help_data = _get_class_help_data(class_name, use_brief_description);
 	} else if (item_type == "enum") {
 		symbol_doc_link = vformat("$%s.%s", class_name, item_name);
 		symbol_type = TTR("Enumeration");
@@ -4884,7 +4894,7 @@ void EditorHelpBit::update_content_height() {
 	content->set_custom_minimum_size(Size2(content->get_custom_minimum_size().x, CLAMP(content_height, content_min_height, content_max_height)));
 }
 
-EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_allow_selection, bool p_in_tooltip) {
+EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_allow_selection, bool p_in_tooltip, bool p_use_brief_description) {
 	add_theme_constant_override("separation", 0);
 
 	title = memnew(RichTextLabel);
@@ -4913,6 +4923,7 @@ EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, b
 	add_child(content);
 
 	use_class_prefix = p_use_class_prefix;
+	use_brief_description = p_use_brief_description;
 
 	if (!p_symbol.is_empty()) {
 		parse_symbol(p_symbol, p_prologue);
@@ -5010,7 +5021,7 @@ void EditorHelpBitTooltip::_notification(int p_what) {
 	}
 }
 
-Control *EditorHelpBitTooltip::make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_shortcut) {
+Control *EditorHelpBitTooltip::make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_shortcut, bool p_use_brief_description) {
 	ERR_FAIL_NULL_V(p_target, _make_invisible_control());
 
 	// Show the custom tooltip only if it is not already visible.
@@ -5020,7 +5031,7 @@ Control *EditorHelpBitTooltip::make_tooltip(Control *p_target, const String &p_s
 		return _make_invisible_control();
 	}
 
-	EditorHelpBit *help_bit = memnew(EditorHelpBit(p_symbol, p_prologue, p_use_class_prefix, false, true));
+	EditorHelpBit *help_bit = memnew(EditorHelpBit(p_symbol, p_prologue, p_use_class_prefix, false, true, p_use_brief_description));
 
 	EditorHelpBitTooltip *tooltip = memnew(EditorHelpBitTooltip(p_target, p_shortcut));
 	help_bit->connect("request_hide", callable_mp(static_cast<Node *>(tooltip), &Node::queue_free));

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -310,6 +310,7 @@ class EditorHelpBit : public VBoxContainer {
 	};
 
 	inline static HashMap<StringName, HelpData> doc_class_cache;
+	inline static HashMap<StringName, HelpData> doc_class_brief_cache;
 	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_enum_cache;
 	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_constant_cache;
 	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_property_cache;
@@ -322,6 +323,7 @@ class EditorHelpBit : public VBoxContainer {
 	RichTextLabel *content = nullptr;
 
 	bool use_class_prefix = false;
+	bool use_brief_description = false;
 
 	String symbol_doc_link;
 	String symbol_class_name;
@@ -334,7 +336,7 @@ class EditorHelpBit : public VBoxContainer {
 	float content_min_height = 0.0;
 	float content_max_height = 0.0;
 
-	static HelpData _get_class_help_data(const StringName &p_class_name);
+	static HelpData _get_class_help_data(const StringName &p_class_name, bool p_use_brief_description);
 	static HelpData _get_enum_help_data(const StringName &p_class_name, const StringName &p_enum_name);
 	static HelpData _get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name);
 	static HelpData _get_property_help_data(const StringName &p_class_name, const StringName &p_property_name);
@@ -362,7 +364,7 @@ public:
 	void set_content_height_limits(float p_min, float p_max);
 	void update_content_height();
 
-	EditorHelpBit(const String &p_symbol = String(), const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_allow_selection = true, bool p_in_tooltip = false);
+	EditorHelpBit(const String &p_symbol = String(), const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_allow_selection = true, bool p_in_tooltip = false, bool p_use_brief_description = false);
 };
 
 // Standard tooltips do not allow you to hover over them.
@@ -388,7 +390,7 @@ protected:
 
 public:
 	// The returned control is an orphan node, which is to make the standard tooltip invisible.
-	[[nodiscard]] static Control *make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_shortcut = false);
+	[[nodiscard]] static Control *make_tooltip(Control *p_target, const String &p_symbol, const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_shortcut = false, bool p_use_brief_description = false);
 
 	void popup_under_position(const Point2 &p_point);
 

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -47,6 +47,13 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/tree.h"
 
+class CreateDialogTree : public Tree {
+public:
+	virtual Control *make_custom_tooltip(const String &p_text) const override {
+		return EditorHelpBitTooltip::make_tooltip(const_cast<CreateDialogTree *>(this), "class|" + p_text + "|", String(), false, false, true);
+	}
+};
+
 void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
 	_fill_type_list();
 
@@ -482,8 +489,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		r_item->set_collapsed(should_collapse);
 	}
 
-	const String &description = DTR(class_doc ? class_doc->value.brief_description : "");
-	r_item->set_tooltip_text(0, description);
+	r_item->set_tooltip_text(0, p_type);
 
 	if (p_type_category == TypeCategory::OTHER_TYPE && !script_type) {
 		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;
@@ -1075,7 +1081,7 @@ CreateDialog::CreateDialog() {
 	filter_popup->set_hide_on_checkable_item_selection(false);
 	filter_popup->connect(SceneStringName(id_pressed), callable_mp(this, &CreateDialog::_type_filter_toggled).bind(true));
 
-	search_options = memnew(Tree);
+	search_options = memnew(CreateDialogTree);
 	search_box->set_forward_control(search_options);
 	search_options->set_accessibility_name(TTRC("Matches:"));
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -37,6 +37,7 @@ class EditorHelpBit;
 class FilterLineEdit;
 class ItemList;
 class Tree;
+class CreateDialogTree;
 class TreeItem;
 
 class HBoxContainer;
@@ -66,7 +67,7 @@ class CreateDialog : public ConfirmationDialog {
 	bool types_enabled[TYPE_MAX];
 
 	FilterLineEdit *search_box = nullptr;
-	Tree *search_options = nullptr;
+	CreateDialogTree *search_options = nullptr;
 
 	String base_type;
 	bool is_base_type_node = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/102010

## Additional information

Replaces plain text tooltip with `EditorHelpBitTooltip` with brief description only.

<img width="1029" height="417" alt="Screenshot 2026-06-23 at 22 11 13" src="https://github.com/user-attachments/assets/07e423f8-4446-491a-9990-d924d4d1144d" />
