### PR TITLE
Fix translate being used as a reference, leading to a possible crash, in apple editor export

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2076,7 +2076,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 
 			if (appnames.is_empty()) {
 				domain->set_locale_override(lang);
-				const String &name = domain->translate(project_name, String());
+				String name = domain->translate(project_name, String());
 				if (name != project_name) {
 					f->store_line("CFBundleDisplayName = \"" + name.xml_escape(true) + "\";");
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a potential crash & build error on master, where a temporary StringName is referenced as a String, leading to a dangling pointer.

Regression from https://github.com/godotengine/godot/pull/118856. Analogous to https://github.com/godotengine/godot/pull/120584.

## Additional information

Identified by @AThousandShips, thanks!
