### PR TITLE
[Asset Store][Editor Main Plugins] Rename Asset Store shortcut key

### DIFF
--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -266,7 +266,7 @@ void EditorMainScreen::add_main_plugin(EditorPlugin *p_editor) {
 	tb->set_name(p_editor->get_plugin_name());
 	tb->set_text(p_editor->get_plugin_name());
 
-	Ref<Shortcut> shortcut = EditorSettings::get_singleton()->get_shortcut("editor/editor_" + p_editor->get_plugin_name().to_lower());
+	Ref<Shortcut> shortcut = EditorSettings::get_singleton()->get_shortcut("editor/editor_" + p_editor->get_plugin_name().to_lower().replace_char(' ', '_'));
 	if (shortcut.is_valid()) {
 		tb->set_shortcut(shortcut);
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -425,7 +425,7 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 			editor_main_screen->select(EditorMainScreen::EDITOR_GAME);
 		} else if (ED_IS_SHORTCUT("editor/editor_help", p_event)) {
 			emit_signal(SNAME("request_help_search"), "");
-		} else if (ED_IS_SHORTCUT("editor/editor_assetlib", p_event) && AssetLibraryEditorPlugin::is_available()) {
+		} else if (ED_IS_SHORTCUT("editor/editor_asset_store", p_event) && AssetLibraryEditorPlugin::is_available()) {
 			editor_main_screen->select(EditorMainScreen::EDITOR_ASSETLIB);
 		} else if (ED_IS_SHORTCUT("editor/editor_next", p_event)) {
 			editor_main_screen->select_next();
@@ -9010,13 +9010,13 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/editor_3d", TTRC("Open 3D Workspace"), KeyModifierMask::CTRL | Key::F2);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_script", TTRC("Open Script Editor"), KeyModifierMask::CTRL | Key::F3);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_game", TTRC("Open Game View"), KeyModifierMask::CTRL | Key::F4);
-	ED_SHORTCUT_AND_COMMAND("editor/editor_assetlib", TTRC("Open Asset Store"), KeyModifierMask::CTRL | Key::F5);
+	ED_SHORTCUT_AND_COMMAND("editor/editor_asset_store", TTRC("Open Asset Store"), KeyModifierMask::CTRL | Key::F5);
 
 	ED_SHORTCUT_OVERRIDE("editor/editor_2d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_1);
 	ED_SHORTCUT_OVERRIDE("editor/editor_3d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_2);
 	ED_SHORTCUT_OVERRIDE("editor/editor_script", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_3);
 	ED_SHORTCUT_OVERRIDE("editor/editor_game", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_4);
-	ED_SHORTCUT_OVERRIDE("editor/editor_assetlib", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_5);
+	ED_SHORTCUT_OVERRIDE("editor/editor_asset_store", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_5);
 
 	ED_SHORTCUT_AND_COMMAND("editor/editor_next", TTRC("Open the next Editor"));
 	ED_SHORTCUT_AND_COMMAND("editor/editor_prev", TTRC("Open the previous Editor"));

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1330,6 +1330,9 @@ void EditorSettings::_handle_setting_compatibility() {
 	_rename_setting("interface/editor/update_continuously", "interface/editor/display/update_continuously");
 	_rename_setting("interface/editor/collapse_main_menu", "interface/editor/appearance/collapse_main_menu");
 	_rename_setting("asset_library/use_threads", "asset_store/use_threads");
+
+	// Handle renamed shortcuts.
+	_rename_shortcut("editor/editor_assetlib", "editor/editor_asset_store");
 }
 
 void EditorSettings::_rename_setting(const String &p_old_name, const String &p_new_name) {
@@ -1342,6 +1345,16 @@ void EditorSettings::_rename_setting(const String &p_old_name, const String &p_n
 		ProjectSettings::get_singleton()->set_editor_setting_override(p_old_name, Variant());
 	}
 	compat_map[p_old_name] = p_new_name;
+}
+
+void EditorSettings::_rename_shortcut(const String &p_old_path, const String &p_new_path) {
+	if (!shortcuts.has(p_old_path)) {
+		return;
+	}
+	if (!shortcuts.has(p_new_path)) {
+		shortcuts[p_new_path] = shortcuts[p_old_path];
+	}
+	shortcuts.erase(p_old_path);
 }
 #endif
 

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -128,6 +128,7 @@ private:
 	HashMap<String, String> compat_map;
 	void _handle_setting_compatibility();
 	void _rename_setting(const String &p_old_name, const String &p_new_name);
+	void _rename_shortcut(const String &p_old_path, const String &p_new_path);
 #endif
 
 	// Bind helpers.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Since the shortcut keys for editor main screen plugins use the plugin name, the lookup to show the tooltip for the Asset Store button was failing; instead of "asset store" it was expecting "assetlib". Per discussion in the contributors chat, the fix for now is just to rename the shortcut key.

Validated that the tooltip now shows (and that remapping still works). Also added a unit test with a minimal plugin for avoiding any future regressions.

- Closes #120557

## Screenshot

<img width="1917" height="1029" alt="image" src="https://github.com/user-attachments/assets/aadcc5e1-d761-430b-a2b6-addc7c9f3a54" />
