### PR TITLE
Fix private enum constants being visible in documentation

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1688,18 +1688,17 @@ void EditorHelp::_update_doc() {
 		Vector<DocData::ConstantDoc> constants;
 
 		for (const DocData::ConstantDoc &constant : cd.constants) {
+			// Ignore undocumented private.
+			const bool is_documented = constant.is_deprecated || constant.is_experimental || !constant.description.strip_edges().is_empty();
+			if (!is_documented && constant.name.begins_with("_")) {
+				continue;
+			}
 			if (!constant.enumeration.is_empty()) {
 				if (!enums.has(constant.enumeration)) {
 					enums[constant.enumeration] = Vector<DocData::ConstantDoc>();
 				}
-
 				enums[constant.enumeration].push_back(constant);
 			} else {
-				// Ignore undocumented private.
-				const bool is_documented = constant.is_deprecated || constant.is_experimental || !constant.description.strip_edges().is_empty();
-				if (!is_documented && constant.name.begins_with("_")) {
-					continue;
-				}
 				constants.push_back(constant);
 			}
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120535 

## Additional information

Private enum constants were not being filtered from the documentation. I moved the `is_documented && begins_with("_")` check so that it also filters enums like in the example below.

This is an example based on the original issue.
```
class_name Sample
extends Node

enum Rounding { FLOOR, ROUND, CEIL }

const _CONST_ENUM_ROUNDING := Rounding.ROUND
const CONST_ENUM_ROUNDING := Rounding.ROUND
```

Before: 
Both enums listed
<img width="292" height="104" alt="image" src="https://github.com/user-attachments/assets/eb228b99-3e19-4c49-ae6d-b1c3169a6263" />

After:
Only the public enum is listed
<img width="286" height="70" alt="image" src="https://github.com/user-attachments/assets/a9013c66-c896-4e68-bf48-2c694a8199aa" />
