### PR TITLE
Fix exclusive window focus handling

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3139,7 +3139,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 
 		gui.currently_dragged_subwindow = click_on_window;
 
-		if (!click_on_window && gui.subwindow_focused) {
+		if (!click_on_window && gui.subwindow_focused && !gui.subwindow_focused->is_exclusive()) {
 			// No window found and clicked, remove focus.
 			_sub_window_grab_focus(nullptr);
 		}

--- a/tests/scene/test_window.cpp
+++ b/tests/scene/test_window.cpp
@@ -91,6 +91,26 @@ TEST_CASE("[SceneTree][Window]") {
 		memdelete(c);
 		memdelete(w);
 	}
+
+	SUBCASE("Exclusive window doesn't lose focus on background mouse press") {
+		Window *w = memnew(Window);
+		root->add_child(w);
+
+		w->set_transient(true);
+		w->set_exclusive(true);
+
+		w->set_size(Size2i(100, 100));
+		w->set_position(Point2i(0, 0));
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(50, 50), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(w->has_focus());
+
+		// When root window is clicked, focus should stay on window node because window node is exclusive.
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(500, 500), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(w->has_focus());
+
+		memdelete(w);
+	}
 }
 
 } // namespace TestWindow


### PR DESCRIPTION
Fixes #81370 by adding check to verify that window is not `Exclusive` before removing focus.

Also, adds a test to check issue #81370. Verifies that if a Window is `Exclusive`, the ancestral Window does not receive input.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #81370

### Technical Overview

- This PR fixes the issue above by verifying that the focused Window is not exclusive before removing the focus. It does this by adding `!gui.subwindow_focused->is_exclusive()` as @rsubtil suggested, when checking if it can remove the focus.
- Added a test that adds a Window child to the root (Window) and sets `Exclusive` and `Transient` to true in the child Window's flags. When the child Window is clicked, it checks that it was focused. Then it checks again after the mouse is clicked on the root node. The child Window should stay focused the whole time, because the `Exclusive` flag is set to true.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->