### PR TITLE
Hide `High Quality Mode` import setting when compress mode is not `VRAM Compressed`

### DIFF
--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -120,7 +120,8 @@ String ResourceImporterLayeredTexture::get_resource_type() const {
 
 bool ResourceImporterLayeredTexture::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	if (p_option == "compress/high_quality_mode") {
-		return bool(p_options["compress/high_quality"]);
+		int compress_mode = int(p_options["compress/mode"]);
+		return compress_mode == COMPRESS_VRAM_COMPRESSED && bool(p_options["compress/high_quality"]);
 	}
 	if (p_option == "compress/lossy_quality" && p_options.has("compress/mode")) {
 		return int(p_options["compress/mode"]) == COMPRESS_LOSSY;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -181,7 +181,9 @@ String ResourceImporterTexture::get_resource_type() const {
 
 bool ResourceImporterTexture::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	if (p_option == "compress/high_quality_mode") {
-		return bool(p_options["compress/high_quality"]);
+		int compress_mode = int(p_options["compress/mode"]);
+		return compress_mode == COMPRESS_VRAM_COMPRESSED && bool(p_options["compress/high_quality"]);
+
 	} else if (p_option == "compress/high_quality" || p_option == "compress/hdr_compression") {
 		int compress_mode = int(p_options["compress/mode"]);
 		if (compress_mode != COMPRESS_VRAM_COMPRESSED) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Related to #115003

The `High Quality Mode` import setting would show up even if the current compress mode was not `VRAM Compressed`.

Before:
<img width="624" height="165" alt="before" src="https://github.com/user-attachments/assets/c1314c79-24ea-4fce-981a-7c6388fc7739" />

After:
<img width="628" height="129" alt="after" src="https://github.com/user-attachments/assets/e687f967-a631-48b9-9b52-8e0dc38af0be" />
