### PR TITLE
Vulkan: Don't let VMA enforce maxMemoryAllocationCount

### DIFF
--- a/thirdparty/vulkan/vk_mem_alloc.cpp
+++ b/thirdparty/vulkan/vk_mem_alloc.cpp
@@ -5,13 +5,6 @@
 #endif
 #endif
 
-// AMD integrated GPUs report a low VkPhysicalDeviceLimits::maxMemoryAllocationCount
-// (typically 4096). VMA 3.3.0 changed VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
-// to default to 1, which makes VMA itself fail allocations with VK_ERROR_TOO_MANY_OBJECTS
-// once that count is reached, instead of forwarding the request to the driver. This
-// regressed content-heavy projects that ran fine on 4.6 (VMA 3.1.0, where the default was
-// 0) on those GPUs. Restore the previous behavior and let the driver decide.
-// See https://github.com/godotengine/godot/issues/120534
 #define VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT 0
 
 #include "vk_mem_alloc.h"

--- a/thirdparty/vulkan/vk_mem_alloc.cpp
+++ b/thirdparty/vulkan/vk_mem_alloc.cpp
@@ -4,4 +4,14 @@
 #define _DEBUG
 #endif
 #endif
+
+// AMD integrated GPUs report a low VkPhysicalDeviceLimits::maxMemoryAllocationCount
+// (typically 4096). VMA 3.3.0 changed VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
+// to default to 1, which makes VMA itself fail allocations with VK_ERROR_TOO_MANY_OBJECTS
+// once that count is reached, instead of forwarding the request to the driver. This
+// regressed content-heavy projects that ran fine on 4.6 (VMA 3.1.0, where the default was
+// 0) on those GPUs. Restore the previous behavior and let the driver decide.
+// See https://github.com/godotengine/godot/issues/120534
+#define VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT 0
+
 #include "vk_mem_alloc.h"


### PR DESCRIPTION
## Bug

Godot 4.7 crashes on load in Forward+/Mobile (Vulkan) on AMD **integrated** GPUs (Ryzen APUs / "AMD Radeon Graphics") for content-heavy projects, with a flood of `VkResult error -10` on `buffer_create` / `texture_create`. `-10` is `VK_ERROR_TOO_MANY_OBJECTS`. Regression from 4.6; does not affect NVIDIA, AMD discrete, or D3D12. Fixes #120534.

## Root cause

The 4.7 VMA update (3.1.0 to 3.3.0, 805c9d4b18) pulled in upstream VMA commit [`89d3a6a`](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/89d3a6a5ea35d140fe865ed493c89bde777c6a07), which **changed the default of `VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT` from `0` to `1`**. With it on, VMA returns `VK_ERROR_TOO_MANY_OBJECTS` itself the moment the live `VkDeviceMemory` count reaches `maxMemoryAllocationCount`, instead of forwarding the allocation to the driver:

```c
#if VMA_DEBUG_DONT_EXCEED_MAX_MEMORY_ALLOCATION_COUNT
    if (prevDeviceMemoryCount >= m_PhysicalDeviceProperties.limits.maxMemoryAllocationCount)
        return VK_ERROR_TOO_MANY_OBJECTS;
#endif
```

AMD iGPUs report a low `maxMemoryAllocationCount` (typically 4096); content-heavy projects cross it during load. On 4.6 (VMA 3.1.0, macro `= 0`) VMA forwarded these and the driver serviced them; on 4.7 it refuses them, so resource creation fails and the project crashes. This is **not** a Godot-side leak; RenderingDevice RID counts stay flat and small (verified with a probe build), and the renderer already made >4096 distinct allocations on these GPUs before 4.7, which the driver tolerated.

## Fix

Define the macro back to `0` in `vk_mem_alloc.cpp`. One line, keeps the rest of the 3.3.0 update.

## Possible follow-up

This restores 4.6 behavior, which relies on the driver accepting more than the reported limit. The spec-clean follow-up is to reduce the *number* of distinct device allocations on low-limit GPUs (larger sub-allocated blocks for small buffers/images); that is a bigger change than this regression warrants.

## Testing

Reporter confirmed a VMA-reverted build no longer crashes; a build with only this one-line change is linked from the issue for confirmation.
