### PR TITLE
BoneAttachment3D: Don't save overridden `transform`

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -60,6 +60,14 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "external_skeleton" && !use_external_skeleton) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
+
+	// Don't save overridden `transform` to reduce VCS diffs.
+	// BoneAttachment3D's transform is set dynamically,
+	// so we don't need to store its actual `transform` property
+	// to have it function the same way between editor and runtime.
+	if (p_property.name == "transform" && !override_pose && bone_idx >= 0 && const_cast<BoneAttachment3D *>(this)->get_skeleton()) {
+		p_property.usage &= ~PROPERTY_USAGE_STORAGE;
+	}
 }
 
 PackedStringArray BoneAttachment3D::get_configuration_warnings() const {


### PR DESCRIPTION
Closes [godot-proposals/#15065](https://github.com/godotengine/godot-proposals/issues/15065).

With this PR, any BoneAttachment3D meeting the following conditions will not have its `transform` property saved to the scene file.
- `override_pose` disabled.
- `bone_idx` greater than `-1`.
- Valid skeleton.

Currently testing in my production fork.
Doesn't seem to have any adverse effects when loading primary or instanced scene, in editor or in game.