### PR TITLE
Add global option to Copy/ConvertTransformModifier for reference bone

### DIFF
--- a/doc/classes/ConvertTransformModifier3D.xml
+++ b/doc/classes/ConvertTransformModifier3D.xml
@@ -14,7 +14,7 @@
 		- Extract reference pose absolutely and add it to the apply bone's pose.
 		[b]Not Relative + Not Additive:[/b]
 		- Extract reference pose absolutely and the apply bone's pose is replaced with it.
-		[b]Note:[/b] The relative option is only available when [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
+		[b]Note:[/b] The relative and global options are only available when [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
 		[b]Note:[/b] If there is a rotation greater than [code]180[/code] degrees with constrained axes, flipping may occur.
 	</description>
 	<tutorials>
@@ -83,6 +83,13 @@
 				Returns [code]true[/code] if the additive option is enabled in the setting at [param index].
 			</description>
 		</method>
+		<method name="is_global" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns [code]true[/code] if the global option is enabled in the setting at [param index].
+			</description>
+		</method>
 		<method name="is_relative" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
@@ -96,8 +103,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets additive option in the setting at [param index] to [param enabled]. This mainly affects the process of applying transform to the [method BoneConstraint3D.set_apply_bone].
-				If sets [param enabled] to [code]true[/code], the processed transform is added to the pose of the current apply bone.
-				If sets [param enabled] to [code]false[/code], the pose of the current apply bone is replaced with the processed transform. However, if set [method set_relative] to [code]true[/code], the transform is relative to rest.
+				If [param enabled] is [code]true[/code], the processed transform is added to the pose of the current apply bone.
+				If [param enabled] is [code]false[/code], the pose of the current apply bone is replaced with the processed transform. However, if set [method set_relative] to [code]true[/code], the transform is relative to rest.
 			</description>
 		</method>
 		<method name="set_apply_axis">
@@ -130,6 +137,17 @@
 			<param index="1" name="transform_mode" type="int" enum="ConvertTransformModifier3D.TransformMode" />
 			<description>
 				Sets the operation of the remapping destination transform.
+			</description>
+		</method>
+		<method name="set_global">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets the global option in the setting at [param index] to [param enabled].
+				If [param enabled] is [code]true[/code], the global pose of the reference bone is used as the remapping source.
+				If [param enabled] is [code]false[/code], the local pose of the reference bone is used as the remapping source.
+				[b]Note:[/b] If the parent of the reference bone has a non-uniform scale, the reference bone is sheared as seen from global space. Since the local pose cannot bring in the shear, the scale may not be applied as intended.
 			</description>
 		</method>
 		<method name="set_reference_axis">
@@ -170,8 +188,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets relative option in the setting at [param index] to [param enabled].
-				If sets [param enabled] to [code]true[/code], the extracted and applying transform is relative to the rest.
-				If sets [param enabled] to [code]false[/code], the extracted transform is absolute.
+				If [param enabled] is [code]true[/code], the extracted and applying transform is relative to the rest.
+				If [param enabled] is [code]false[/code], the extracted transform is absolute.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CopyTransformModifier3D.xml
+++ b/doc/classes/CopyTransformModifier3D.xml
@@ -14,7 +14,7 @@
 		- Extract reference pose absolutely and add it to the apply bone's pose.
 		[b]Not Relative + Not Additive:[/b]
 		- Extract reference pose absolutely and the apply bone's pose is replaced with it.
-		[b]Note:[/b] The relative option is only available when [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
+		[b]Note:[/b] The relative and global options are only available when [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -89,6 +89,13 @@
 				Returns [code]true[/code] if the invert flags has the flag for the Z-axis in the setting at [param index]. See also [method set_invert_flags].
 			</description>
 		</method>
+		<method name="is_global" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns [code]true[/code] if the global option is enabled in the setting at [param index].
+			</description>
+		</method>
 		<method name="is_position_copying" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
@@ -123,8 +130,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets additive option in the setting at [param index] to [param enabled]. This mainly affects the process of applying transform to the [method BoneConstraint3D.set_apply_bone].
-				If sets [param enabled] to [code]true[/code], the processed transform is added to the pose of the current apply bone.
-				If sets [param enabled] to [code]false[/code], the pose of the current apply bone is replaced with the processed transform. However, if set [method set_relative] to [code]true[/code], the transform is relative to rest.
+				If [param enabled] is [code]true[/code], the processed transform is added to the pose of the current apply bone.
+				If [param enabled] is [code]false[/code], the pose of the current apply bone is replaced with the processed transform. However, if set [method set_relative] to [code]true[/code], the transform is relative to rest.
 			</description>
 		</method>
 		<method name="set_axis_flags">
@@ -140,7 +147,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the X-axis will be copied.
+				If [param enabled] is [code]true[/code], the X-axis will be copied.
 			</description>
 		</method>
 		<method name="set_axis_x_inverted">
@@ -148,7 +155,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the X-axis will be inverted.
+				If [param enabled] is [code]true[/code], the X-axis will be inverted.
 			</description>
 		</method>
 		<method name="set_axis_y_enabled">
@@ -156,7 +163,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the Y-axis will be copied.
+				If [param enabled] is [code]true[/code], the Y-axis will be copied.
 			</description>
 		</method>
 		<method name="set_axis_y_inverted">
@@ -164,7 +171,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the Y-axis will be inverted.
+				If [param enabled] is [code]true[/code], the Y-axis will be inverted.
 			</description>
 		</method>
 		<method name="set_axis_z_enabled">
@@ -172,7 +179,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the Z-axis will be copied.
+				If [param enabled] is [code]true[/code], the Z-axis will be copied.
 			</description>
 		</method>
 		<method name="set_axis_z_inverted">
@@ -180,7 +187,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the Z-axis will be inverted.
+				If [param enabled] is [code]true[/code], the Z-axis will be inverted.
 			</description>
 		</method>
 		<method name="set_copy_flags">
@@ -197,7 +204,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the position will be copied.
+				If [param enabled] is [code]true[/code], the position will be copied.
 			</description>
 		</method>
 		<method name="set_copy_rotation">
@@ -205,7 +212,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the rotation will be copied.
+				If [param enabled] is [code]true[/code], the rotation will be copied.
 			</description>
 		</method>
 		<method name="set_copy_scale">
@@ -213,7 +220,18 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], the scale will be copied.
+				If [param enabled] is [code]true[/code], the scale will be copied.
+			</description>
+		</method>
+		<method name="set_global">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets the global option in the setting at [param index] to [param enabled].
+				If [param enabled] is [code]true[/code], the global pose of the reference bone is extracted and applied so that the global pose of the apply bone coincides with it.
+				If [param enabled] is [code]false[/code], the local pose of the reference bone is extracted and applied to the local pose of the apply bone.
+				[b]Note:[/b] If the parent of the reference bone has a non-uniform scale, the reference bone is sheared as seen from global space. Since the local pose cannot bring in the shear, the scale may not be applied as intended.
 			</description>
 		</method>
 		<method name="set_invert_flags">
@@ -232,8 +250,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets relative option in the setting at [param index] to [param enabled].
-				If sets [param enabled] to [code]true[/code], the extracted and applying transform is relative to the rest.
-				If sets [param enabled] to [code]false[/code], the extracted transform is absolute.
+				If [param enabled] is [code]true[/code], the extracted and applying transform is relative to the rest.
+				If [param enabled] is [code]false[/code], the extracted transform is absolute.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/convert_transform_modifier_3d.cpp
+++ b/scene/3d/convert_transform_modifier_3d.cpp
@@ -69,6 +69,8 @@ bool ConvertTransformModifier3D::_set(const StringName &p_path, const Variant &p
 			} else {
 				return false;
 			}
+		} else if (where == "global") {
+			set_global(which, p_value);
 		} else if (where == "relative") {
 			set_relative(which, p_value);
 		} else if (where == "additive") {
@@ -113,6 +115,8 @@ bool ConvertTransformModifier3D::_get(const StringName &p_path, Variant &r_ret) 
 			} else {
 				return false;
 			}
+		} else if (where == "global") {
+			r_ret = is_global(which);
 		} else if (where == "relative") {
 			r_ret = is_relative(which);
 		} else if (where == "additive") {
@@ -158,6 +162,7 @@ void ConvertTransformModifier3D::_get_property_list(List<PropertyInfo> *p_list) 
 		props.push_back(PropertyInfo(Variant::FLOAT, path + "reference/range_min", PROPERTY_HINT_RANGE, hint_reference_range));
 		props.push_back(PropertyInfo(Variant::FLOAT, path + "reference/range_max", PROPERTY_HINT_RANGE, hint_reference_range));
 
+		props.push_back(PropertyInfo(Variant::BOOL, path + "global"));
 		props.push_back(PropertyInfo(Variant::BOOL, path + "relative"));
 		props.push_back(PropertyInfo(Variant::BOOL, path + "additive"));
 	}
@@ -172,8 +177,10 @@ void ConvertTransformModifier3D::_validate_dynamic_prop(PropertyInfo &p_property
 	PackedStringArray split = p_property.name.split("/");
 	if (split.size() > 2 && split[0] == "settings") {
 		int which = split[1].to_int();
-		if (split[2].begins_with("relative") && get_reference_type(which) != REFERENCE_TYPE_BONE) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+		if (get_reference_type(which) != REFERENCE_TYPE_BONE) {
+			if (split[2].begins_with("global") || split[2].begins_with("relative")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
 		}
 	}
 }
@@ -280,6 +287,18 @@ float ConvertTransformModifier3D::get_reference_range_max(int p_index) const {
 	return setting->reference_range_max;
 }
 
+void ConvertTransformModifier3D::set_global(int p_index, bool p_enabled) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
+	setting->global = p_enabled;
+}
+
+bool ConvertTransformModifier3D::is_global(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
+	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
+	return setting->is_global();
+}
+
 void ConvertTransformModifier3D::set_relative(int p_index, bool p_enabled) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
@@ -323,6 +342,8 @@ void ConvertTransformModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_reference_range_max", "index", "range_max"), &ConvertTransformModifier3D::set_reference_range_max);
 	ClassDB::bind_method(D_METHOD("get_reference_range_max", "index"), &ConvertTransformModifier3D::get_reference_range_max);
 
+	ClassDB::bind_method(D_METHOD("set_global", "index", "enabled"), &ConvertTransformModifier3D::set_global);
+	ClassDB::bind_method(D_METHOD("is_global", "index"), &ConvertTransformModifier3D::is_global);
 	ClassDB::bind_method(D_METHOD("set_relative", "index", "enabled"), &ConvertTransformModifier3D::set_relative);
 	ClassDB::bind_method(D_METHOD("is_relative", "index"), &ConvertTransformModifier3D::is_relative);
 	ClassDB::bind_method(D_METHOD("set_additive", "index", "enabled"), &ConvertTransformModifier3D::set_additive);
@@ -337,12 +358,31 @@ void ConvertTransformModifier3D::_bind_methods() {
 
 void ConvertTransformModifier3D::_process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
 	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
-	Transform3D destination = p_skeleton->get_bone_pose(p_reference_bone);
+	Transform3D destination;
+	Transform3D to_apply_space;
+	bool is_global = setting->is_global();
+	if (is_global) {
+		Transform3D apply_parent_global_pose;
+		int apply_parent = p_skeleton->get_bone_parent(p_apply_bone);
+		if (apply_parent >= 0) {
+			apply_parent_global_pose = p_skeleton->get_bone_global_pose(apply_parent);
+		}
+		to_apply_space = apply_parent_global_pose.affine_inverse();
+		destination = to_apply_space * p_skeleton->get_bone_global_pose(p_reference_bone);
+	} else {
+		destination = p_skeleton->get_bone_pose(p_reference_bone);
+	}
 	if (setting->is_relative()) {
-		Vector3 scl_relative = destination.basis.get_scale() / p_skeleton->get_bone_rest(p_reference_bone).basis.get_scale();
-		destination.basis = p_skeleton->get_bone_rest(p_reference_bone).basis.get_rotation_quaternion().inverse() * destination.basis.get_rotation_quaternion();
+		Transform3D reference_rest;
+		if (is_global) {
+			reference_rest = to_apply_space * p_skeleton->get_bone_global_rest(p_reference_bone);
+		} else {
+			reference_rest = p_skeleton->get_bone_rest(p_reference_bone);
+		}
+		Vector3 scl_relative = destination.basis.get_scale() / reference_rest.basis.get_scale();
+		destination.basis = reference_rest.basis.get_rotation_quaternion().inverse() * destination.basis.get_rotation_quaternion();
 		destination.basis.scale_local(scl_relative);
-		destination.origin = destination.origin - p_skeleton->get_bone_rest(p_reference_bone).origin;
+		destination.origin = destination.origin - reference_rest.origin;
 	}
 	_process_convert(p_index, p_skeleton, p_apply_bone, destination, p_amount);
 }

--- a/scene/3d/convert_transform_modifier_3d.h
+++ b/scene/3d/convert_transform_modifier_3d.h
@@ -53,8 +53,16 @@ public:
 		float reference_range_min = 0.0;
 		float reference_range_max = 0.0;
 
+		bool global = false;
 		bool relative = true;
 		bool additive = false;
+
+		bool is_global() {
+			if (reference_type == REFERENCE_TYPE_NODE) {
+				return false;
+			}
+			return global;
+		}
 
 		bool is_relative() {
 			if (reference_type == REFERENCE_TYPE_NODE) {
@@ -95,6 +103,9 @@ public:
 	float get_reference_range_min(int p_index) const;
 	void set_reference_range_max(int p_index, float p_range_max);
 	float get_reference_range_max(int p_index) const;
+
+	void set_global(int p_index, bool p_enabled);
+	bool is_global(int p_index) const;
 
 	void set_relative(int p_index, bool p_enabled);
 	bool is_relative(int p_index) const;

--- a/scene/3d/copy_transform_modifier_3d.cpp
+++ b/scene/3d/copy_transform_modifier_3d.cpp
@@ -46,6 +46,8 @@ bool CopyTransformModifier3D::_set(const StringName &p_path, const Variant &p_va
 			set_axis_flags(which, static_cast<BitField<AxisFlag>>((int)p_value));
 		} else if (what == "invert") {
 			set_invert_flags(which, static_cast<BitField<AxisFlag>>((int)p_value));
+		} else if (what == "global") {
+			set_global(which, p_value);
 		} else if (what == "relative") {
 			set_relative(which, p_value);
 		} else if (what == "additive") {
@@ -71,6 +73,8 @@ bool CopyTransformModifier3D::_get(const StringName &p_path, Variant &r_ret) con
 			r_ret = (int)get_axis_flags(which);
 		} else if (what == "invert") {
 			r_ret = (int)get_invert_flags(which);
+		} else if (what == "global") {
+			r_ret = is_global(which);
 		} else if (what == "relative") {
 			r_ret = is_relative(which);
 		} else if (what == "additive") {
@@ -92,6 +96,7 @@ void CopyTransformModifier3D::_get_property_list(List<PropertyInfo> *p_list) con
 		props.push_back(PropertyInfo(Variant::INT, path + "copy", PROPERTY_HINT_FLAGS, "Position,Rotation,Scale"));
 		props.push_back(PropertyInfo(Variant::INT, path + "axes", PROPERTY_HINT_FLAGS, "X,Y,Z"));
 		props.push_back(PropertyInfo(Variant::INT, path + "invert", PROPERTY_HINT_FLAGS, "X,Y,Z"));
+		props.push_back(PropertyInfo(Variant::BOOL, path + "global"));
 		props.push_back(PropertyInfo(Variant::BOOL, path + "relative"));
 		props.push_back(PropertyInfo(Variant::BOOL, path + "additive"));
 	}
@@ -106,8 +111,10 @@ void CopyTransformModifier3D::_validate_dynamic_prop(PropertyInfo &p_property) c
 	PackedStringArray split = p_property.name.split("/");
 	if (split.size() > 2 && split[0] == "settings") {
 		int which = split[1].to_int();
-		if (split[2].begins_with("relative") && get_reference_type(which) != REFERENCE_TYPE_BONE) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+		if (get_reference_type(which) != REFERENCE_TYPE_BONE) {
+			if (split[2].begins_with("global") || split[2].begins_with("relative")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
 		}
 	}
 }
@@ -299,6 +306,18 @@ bool CopyTransformModifier3D::is_axis_z_inverted(int p_index) const {
 	return setting->invert_flags.has_flag(AXIS_FLAG_Z);
 }
 
+void CopyTransformModifier3D::set_global(int p_index, bool p_enabled) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
+	setting->global = p_enabled;
+}
+
+bool CopyTransformModifier3D::is_global(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
+	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
+	return setting->is_global();
+}
+
 void CopyTransformModifier3D::set_relative(int p_index, bool p_enabled) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
@@ -352,6 +371,8 @@ void CopyTransformModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_axis_z_inverted", "index", "enabled"), &CopyTransformModifier3D::set_axis_z_inverted);
 	ClassDB::bind_method(D_METHOD("is_axis_z_inverted", "index"), &CopyTransformModifier3D::is_axis_z_inverted);
 
+	ClassDB::bind_method(D_METHOD("set_global", "index", "enabled"), &CopyTransformModifier3D::set_global);
+	ClassDB::bind_method(D_METHOD("is_global", "index"), &CopyTransformModifier3D::is_global);
 	ClassDB::bind_method(D_METHOD("set_relative", "index", "enabled"), &CopyTransformModifier3D::set_relative);
 	ClassDB::bind_method(D_METHOD("is_relative", "index"), &CopyTransformModifier3D::is_relative);
 	ClassDB::bind_method(D_METHOD("set_additive", "index", "enabled"), &CopyTransformModifier3D::set_additive);
@@ -372,12 +393,31 @@ void CopyTransformModifier3D::_bind_methods() {
 
 void CopyTransformModifier3D::_process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
 	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
-	Transform3D destination = p_skeleton->get_bone_pose(p_reference_bone);
+	Transform3D destination;
+	Transform3D to_apply_space;
+	bool is_global = setting->is_global();
+	if (is_global) {
+		Transform3D apply_parent_global_pose;
+		int apply_parent = p_skeleton->get_bone_parent(p_apply_bone);
+		if (apply_parent >= 0) {
+			apply_parent_global_pose = p_skeleton->get_bone_global_pose(apply_parent);
+		}
+		to_apply_space = apply_parent_global_pose.affine_inverse();
+		destination = to_apply_space * p_skeleton->get_bone_global_pose(p_reference_bone);
+	} else {
+		destination = p_skeleton->get_bone_pose(p_reference_bone);
+	}
 	if (setting->is_relative()) {
-		Vector3 scl_relative = destination.basis.get_scale() / p_skeleton->get_bone_rest(p_reference_bone).basis.get_scale();
-		destination.basis = p_skeleton->get_bone_rest(p_reference_bone).basis.get_rotation_quaternion().inverse() * destination.basis.get_rotation_quaternion();
+		Transform3D reference_rest;
+		if (is_global) {
+			reference_rest = to_apply_space * p_skeleton->get_bone_global_rest(p_reference_bone);
+		} else {
+			reference_rest = p_skeleton->get_bone_rest(p_reference_bone);
+		}
+		Vector3 scl_relative = destination.basis.get_scale() / reference_rest.basis.get_scale();
+		destination.basis = reference_rest.basis.get_rotation_quaternion().inverse() * destination.basis.get_rotation_quaternion();
 		destination.basis.scale_local(scl_relative);
-		destination.origin = destination.origin - p_skeleton->get_bone_rest(p_reference_bone).origin;
+		destination.origin = destination.origin - reference_rest.origin;
 	}
 	_process_copy(p_index, p_skeleton, p_apply_bone, destination, p_amount);
 }

--- a/scene/3d/copy_transform_modifier_3d.h
+++ b/scene/3d/copy_transform_modifier_3d.h
@@ -55,8 +55,16 @@ public:
 		BitField<AxisFlag> axis_flags = AXIS_FLAG_ALL;
 		BitField<AxisFlag> invert_flags = 0;
 
+		bool global = false;
 		bool relative = true;
 		bool additive = false;
+
+		bool is_global() {
+			if (reference_type == REFERENCE_TYPE_NODE) {
+				return false;
+			}
+			return global;
+		}
 
 		bool is_relative() {
 			if (reference_type == REFERENCE_TYPE_NODE) {
@@ -109,6 +117,9 @@ public:
 	bool is_axis_y_inverted(int p_index) const;
 	void set_axis_z_inverted(int p_index, bool p_enabled);
 	bool is_axis_z_inverted(int p_index) const;
+
+	void set_global(int p_index, bool p_enabled);
+	bool is_global(int p_index) const;
 
 	void set_relative(int p_index, bool p_enabled);
 	bool is_relative(int p_index) const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/4190
- Another approach (but not conflict) with #120609

Add a global option when the target mode is set to “bone” in the Copy/ConvertTransformModifier.

This enables compatibility with models in which "skinned bone groups" and "bones with parent-child relationships" are completely separated.

As explained in #120609, scaling can be difficult when bones have parent-child relationships.

In environments that do not support `skin_scale`, when you want to adjust thickness via scaling, an approach is sometimes taken that uses constraints to separate "skinned bone groups" from "bone groups with parent-child relationships" like:

<img width="154" height="208" alt="image" src="https://github.com/user-attachments/assets/20937eab-0905-49de-af03-56d4ffbcae15" />

Adding this option enables that approach and allows models to be ported to external applications that utilize it.

The basic visual behavior of this approach is nearly identical to that of `skin_scale`.

Compared to `skin_scale`, the disadvantage of adopting this approach is that, similar to when using `cancel bone`, it requires modifying the bone and skinning structure.

The advantages, from a maintainer’s perspective, are that it is less invasive to the core than the `skin_scale` method; from a user’s perspective, it allows for extracting `bone_scale` from skinned bones and using `ConvertTransformModifier` to synchronize the positions of child bones. However, since the `ConvertTransformModifier` currently supports only a single axis, this is limited to cases where the axis from parent to child matches one of the basis axes.

The following video shows a comparison with the "cancel bone" method, including changes in length:

https://github.com/user-attachments/assets/4e991ba5-dfec-4b7e-ab4b-aee83a6bb7c7

https://github.com/user-attachments/assets/f15ef850-c3b5-46e8-bf89-e64bc5399c86

[cancel-bone.zip](https://github.com/user-attachments/files/29295727/cancel-bone.zip) (needs this PR for demonstration)

While both look the same, the "copy global pose" approach modifies length via position, not scale, so making IK available.

<img width="538" height="414" alt="image" src="https://github.com/user-attachments/assets/22ea9900-d5e0-4140-8e78-7fd58afafb5b" />

