### PR TITLE
Fix semantic inconsistencies in DisplayServer cursor shape mappings for x11 and Wayland

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -686,8 +686,8 @@ private:
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR, //DisplayServerEnums::CURSOR_CROSS
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_WAIT, //DisplayServerEnums::CURSOR_WAIT
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_PROGRESS, //DisplayServerEnums::CURSOR_BUSY
-		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRAB, //DisplayServerEnums::CURSOR_DRAG
-		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRABBING, //DisplayServerEnums::CURSOR_CAN_DROP
+		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRABBING, //DisplayServerEnums::CURSOR_DRAG
+		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRAB, //DisplayServerEnums::CURSOR_CAN_DROP
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NO_DROP, //DisplayServerEnums::CURSOR_FORBIDDEN
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NS_RESIZE, //DisplayServerEnums::CURSOR_VSIZE
 		wp_cursor_shape_device_v1_shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_EW_RESIZE, //DisplayServerEnums::CURSOR_HSIZE

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -7308,23 +7308,23 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 
 	for (int i = 0; i < DisplayServerEnums::CURSOR_MAX; i++) {
 		static const char *cursor_file[] = {
-			"left_ptr",
-			"xterm",
-			"hand2",
-			"cross",
-			"watch",
-			"left_ptr_watch",
-			"fleur",
-			"dnd-move",
-			"crossed_circle",
-			"v_double_arrow",
-			"h_double_arrow",
-			"size_bdiag",
-			"size_fdiag",
-			"move",
-			"row_resize",
-			"col_resize",
-			"question_arrow"
+			"left_ptr", // CURSOR_ARROW
+			"xterm", // CURSOR_IBEAM
+			"hand2", // CURSOR_POINTING_HAND
+			"cross", // CURSOR_CROSS
+			"watch", // CURSOR_WAIT
+			"left_ptr_watch", // CURSOR_BUSY
+			"move", // CURSOR_DRAG
+			"dnd-move", // CURSOR_CAN_DROP
+			"forbidden", // CURSOR_FORBIDDEN
+			"v_double_arrow", // CURSOR_VSIZE
+			"h_double_arrow", // CURSOR_HSIZE
+			"size_bdiag", // CURSOR_BDIAGSIZE
+			"size_fdiag", // CURSOR_FDIAGSIZE
+			"fleur", // CURSOR_MOVE
+			"row_resize", // CURSOR_VSPLIT
+			"col_resize", // CURSOR_HSPLIT
+			"question_arrow" // CURSOR_HELP
 		};
 
 		cursor_img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
@@ -7351,7 +7351,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 					fallback = "hand1";
 					break;
 				case DisplayServerEnums::CURSOR_FORBIDDEN:
-					fallback = "forbidden";
+					fallback = "crossed_circle";
 					break;
 				case DisplayServerEnums::CURSOR_VSIZE:
 					fallback = "ns-resize";


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/120428

## Information

As discussed in the PR, the cursor mapping for both X11 and Wayland contains inconsistencies, this being due to a mismatch between cursor names and their visual appearance.

This fixes the mapping of the cursor's visual interpretation based on the KDE Plasma Breeze Light theme, which is used as a reference baseline. Due to the lack of a strict semantic standard for cursor appearance across X11 themes and Wayland compositors, this mapping reflects a best-effort heuristic based on the said cursor theme.

Given that the issue stems from inconsistent cursor enum translations across backend-specific implementations, this PR aligns both backends with the intended cursor role definitions in the shared abstraction layer.

## About GenAI usage
No generative AI was used