### PR TITLE
[3.x] Fix new CI compiler warnings

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -3231,6 +3231,8 @@ void Image::fix_alpha_edges() {
 	const int alpha_threshold = 20;
 	const int max_dist = 0x7FFFFFFF;
 
+	uint8_t closest_color[3]{};
+
 	for (int i = 0; i < height; i++) {
 		for (int j = 0; j < width; j++) {
 			const uint8_t *rptr = &srcptr[(i * width + j) * 4];
@@ -3241,7 +3243,6 @@ void Image::fix_alpha_edges() {
 			}
 
 			int closest_dist = max_dist;
-			uint8_t closest_color[3];
 
 			int from_x = MAX(0, j - max_radius);
 			int to_x = MIN(width - 1, j + max_radius);

--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -433,12 +433,13 @@ MessageQueue::~MessageQueue() {
 					args[i].~Variant();
 				}
 			}
-			message->~Message();
 
 			read_pos += sizeof(Message);
 			if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
 				read_pos += sizeof(Variant) * message->args;
 			}
+
+			message->~Message();
 		}
 
 	} // for which

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -48,11 +48,11 @@ class MessageQueue {
 	};
 
 	struct Message {
-		ObjectID instance_id;
+		ObjectID instance_id = 0;
 		StringName target;
-		int16_t type;
+		int16_t type = 0;
 		union {
-			int16_t notification;
+			int16_t notification = 0;
 			int16_t args;
 		};
 	};

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1311,10 +1311,10 @@ public:
 			return ERR_FILE_BAD_PATH;
 		}
 
-		Error err = OK;
+		Error error = OK;
 
-		FileAccess *fa_pack = FileAccess::open(p_path, FileAccess::WRITE, &err);
-		ERR_FAIL_COND_V_MSG(err != OK, ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
+		FileAccess *fa_pack = FileAccess::open(p_path, FileAccess::WRITE, &error);
+		ERR_FAIL_COND_V_MSG(error != OK, ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
 
 		AppxPackager packager;
 		packager.init(fa_pack);
@@ -1385,9 +1385,9 @@ public:
 
 			print_line("ADDING: " + path);
 
-			err = packager.add_file(path, data.ptr(), data.size(), template_file_no++, template_files_amount, _should_compress_asset(path, data));
-			if (err != OK) {
-				return err;
+			error = packager.add_file(path, data.ptr(), data.size(), template_file_no++, template_files_amount, _should_compress_asset(path, data));
+			if (error != OK) {
+				return error;
 			}
 
 			ret = unzGoToNextFile(pkg);
@@ -1430,9 +1430,9 @@ public:
 			print_line(itos(i) + " param: " + cl[i]);
 		}
 
-		err = packager.add_file("__cl__.cl", clf.ptr(), clf.size(), -1, -1, false);
-		if (err != OK) {
-			return err;
+		error = packager.add_file("__cl__.cl", clf.ptr(), clf.size(), -1, -1, false);
+		if (error != OK) {
+			return error;
 		}
 
 		if (ep.step("Adding project files...", 3)) {
@@ -1442,7 +1442,7 @@ public:
 		EditorNode::progress_add_task("project_files", "Project Files", 100);
 		packager.set_progress_task("project_files");
 
-		err = export_project_files(p_preset, save_appx_file, &packager, copy_shared_objects);
+		error = export_project_files(p_preset, save_appx_file, &packager, copy_shared_objects);
 
 		EditorNode::progress_end_task("project_files");
 

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -76,9 +76,9 @@ private:
 		bool last_buttons[MAX_JOY_BUTTONS];
 		DWORD last_pad;
 
-		LPDIRECTINPUTDEVICE8 di_joy;
+		LPDIRECTINPUTDEVICE8 di_joy = nullptr;
 		List<LONG> joy_axis;
-		GUID guid;
+		GUID guid{};
 
 		dinput_gamepad() {
 			id = -1;

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -76,6 +76,20 @@
 
 void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long fftFrameSize, long osamp, float sampleRate, float *indata, float *outdata,int stride) {
 
+	// Workaround compiler warning.
+	// error: 'void* memset(void*, int, size_t)' specified bound between 18446744065119617024 and
+	// 18446744073709551608 exceeds maximum object size 9223372036854775807
+	// [-Werror=stringop-overflow=]
+
+	// Any negative values become very high numbers.
+	unsigned long fftFrameSize_ul = fftFrameSize;
+	if (fftFrameSize_ul > MAX_FRAME_LENGTH)
+	{
+		ERR_PRINT_ONCE("Invalid FFT frame size for PitchShift. This is a bug, please report.");
+		return;
+	}
+	// May not be necessary, but makes it easier to prevent warnings later with memset.
+	fftFrameSize = fftFrameSize_ul;
 
 	/*
 		Routine smbPitchShift(). See top of file for explanation

--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -38,34 +38,22 @@ class SMBPitchShift {
 		MAX_FRAME_LENGTH = 8192
 	};
 
-	float gInFIFO[MAX_FRAME_LENGTH];
-	float gOutFIFO[MAX_FRAME_LENGTH];
-	float gFFTworksp[2 * MAX_FRAME_LENGTH];
-	float gLastPhase[MAX_FRAME_LENGTH / 2 + 1];
-	float gSumPhase[MAX_FRAME_LENGTH / 2 + 1];
-	float gOutputAccum[2 * MAX_FRAME_LENGTH];
-	float gAnaFreq[MAX_FRAME_LENGTH];
-	float gAnaMagn[MAX_FRAME_LENGTH];
-	float gSynFreq[MAX_FRAME_LENGTH];
-	float gSynMagn[MAX_FRAME_LENGTH];
-	long gRover;
+	float gInFIFO[MAX_FRAME_LENGTH]{};
+	float gOutFIFO[MAX_FRAME_LENGTH]{};
+	float gFFTworksp[2 * MAX_FRAME_LENGTH]{};
+	float gLastPhase[MAX_FRAME_LENGTH / 2 + 1]{};
+	float gSumPhase[MAX_FRAME_LENGTH / 2 + 1]{};
+	float gOutputAccum[2 * MAX_FRAME_LENGTH]{};
+	float gAnaFreq[MAX_FRAME_LENGTH]{};
+	float gAnaMagn[MAX_FRAME_LENGTH]{};
+	float gSynFreq[MAX_FRAME_LENGTH]{};
+	float gSynMagn[MAX_FRAME_LENGTH]{};
+	long gRover = 0;
 
 	void smbFft(float *fftBuffer, long fftFrameSize, long sign);
 
 public:
 	void PitchShift(float pitchShift, long numSampsToProcess, long fftFrameSize, long osamp, float sampleRate, float *indata, float *outdata, int stride);
-
-	SMBPitchShift() {
-		gRover = 0;
-		memset(gInFIFO, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gOutFIFO, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gFFTworksp, 0, 2 * MAX_FRAME_LENGTH * sizeof(float));
-		memset(gLastPhase, 0, (MAX_FRAME_LENGTH / 2 + 1) * sizeof(float));
-		memset(gSumPhase, 0, (MAX_FRAME_LENGTH / 2 + 1) * sizeof(float));
-		memset(gOutputAccum, 0, 2 * MAX_FRAME_LENGTH * sizeof(float));
-		memset(gAnaFreq, 0, MAX_FRAME_LENGTH * sizeof(float));
-		memset(gAnaMagn, 0, MAX_FRAME_LENGTH * sizeof(float));
-	}
 };
 
 class AudioEffectPitchShift;
@@ -75,7 +63,7 @@ class AudioEffectPitchShiftInstance : public AudioEffectInstance {
 	friend class AudioEffectPitchShift;
 	Ref<AudioEffectPitchShift> base;
 
-	int fft_size;
+	int fft_size = 0;
 	SMBPitchShift shift_l;
 	SMBPitchShift shift_r;
 
@@ -89,7 +77,7 @@ class AudioEffectPitchShift : public AudioEffect {
 public:
 	friend class AudioEffectPitchShiftInstance;
 
-	enum FFT_Size {
+	enum FFT_Size : uint32_t {
 		FFT_SIZE_256,
 		FFT_SIZE_512,
 		FFT_SIZE_1024,


### PR DESCRIPTION
Presumably something has changed in the build system (e.g. compiler version) that now picks more warnings where it didn't before.

* uninitialized data - `dinput_gamepad`
* memset overrun - `AudioEffectPitchShift`
* uninitialized data - `MessageQueue` - the object data was being accessed after calling the destructor
* uninitialized data - `Image::fix_alpha_edges`
* shadowed variable - UWP export

## What problem(s) does this PR solve?

Fixes build warning as errors due to uninitialized data and shadowed variables.

## Additional information

* The code using `dinput_gamepad` members still looks unsafe (e.g. no NULL checks for `di_joy`) but that is outside the scope of fixing the CI so others can get PRs to pass CI.
* The rename to `error` isn't perfect, but I don't have a windows machine here so I'm flying blind :grin: . An alternative would have been to rename the `err`s in the nested blocks, but difficult to do blind.
* Some of these may represent actual bugs, if there is a possibility of using without assignment. Others may be false positives (they cannot in practice be used without assignment).
* `closest_color` is moved outside the loop, to prevent zeroing in a hot loop. It is important that it is initialized with *something* to avoid the warning. However it could be a genuine bug if it is read before the first genuine write.

I can also see some of these have come up in 4.x before, e.g. #105744 . I'll see if any of the 4.x versions can be used as reference.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
