### PR TITLE
CI: Fix API validation of removed dummy methods

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -10,6 +10,7 @@ sources:
   - .github/{actions/*,workflows}/*.yml
   - "**/{SConstruct,SCsub,*.py}"
   - "**/*.{h,hpp,hh,hxx,c,cpp,cc,cxx,m,mm,inc,glsl}"
+  - misc/extension_api_validation/**
   - modules/mono/**/*.{cs,csproj,sln,props,targets}
   - platform/android/java/{gradle*,**/*.{jar,java,kt,gradle}}
   - platform/web/{package{,-lock}.json,js/**/*.js}

--- a/misc/extension_api_validation/4.7-stable/GH-114533.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-114533.txt
@@ -1,0 +1,7 @@
+GH-114533
+--------------
+Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/codeLens
+Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/colorPresentation
+Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/foldingRange
+
+Removed dummy endpoints from an unstable interface. Compatibility methods deliberately excluded.


### PR DESCRIPTION
- Followup to #114533

Despite being dummy methods with no real likelyhood of being accessed, the API still needs to be properly suppressed in CI. This fixes that, restoring proper functionality to our GHA