### PR TITLE
Properly show negative `ObjectID` properties

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1666,8 +1666,8 @@ void EditorPropertyObjectID::update_property() {
 
 	const ObjectID id = _get_object_id();
 	if (id.is_valid()) {
-		edit->set_text(type + ": " + uitos(id));
-		edit->set_tooltip_text(type + ": " + uitos(id));
+		edit->set_text(type + ": " + itos(id));
+		edit->set_tooltip_text(type + ": " + itos(id));
 		edit->set_disabled(false);
 		edit->set_button_icon(EditorNode::get_singleton()->get_class_icon(type));
 	} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #96378.

## Additional information

`ObjectID`s of `RefCounted` objects use their first bit to flag themselves as such. This means that their ID will show as a negative value. This PR fixes `EditorPropertyObjectID` assuming that they're always positive.