### PR TITLE
Avoid full project list reload in `ProjectList::_scan_finished()`

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -673,17 +673,37 @@ void ProjectList::_scan_finished() {
 		scan_progress->hide();
 	}
 
-	for (const String &E : scan_data->found_projects) {
-		add_project(E, false);
+	bool edited = false;
+
+	for (const String &path : scan_data->found_projects) {
+		bool already_exists = false;
+		for (const Item &p : _projects) {
+			if (p.path == path) {
+				already_exists = true;
+				break;
+			}
+		}
+		if (already_exists) {
+			continue;
+		}
+
+		add_project(path, false);
+		_projects.push_back(load_project_data(path, false));
+		_create_project_item_control(_projects.size() - 1);
+		edited = true;
 	}
 	memdelete(scan_data);
 	scan_data = nullptr;
 
-	save_config();
+	set_v_scroll(0);
 
-	if (ProjectManager::get_singleton()->is_initialized()) {
-		update_project_list();
+	if (!edited) {
+		return;
 	}
+
+	save_config();
+	sort_projects();
+	emit_signal(SNAME(SIGNAL_LIST_CHANGED));
 }
 
 // Initialization & loading.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Not optimal performance in `ProjectList::_scan_finished()` (called when a scan in the Project Manager finishes).

## Additional information

Avoids the expensive `update_project_list()` call:

https://github.com/godotengine/godot/blob/d3a5a85866fb4115b058506425d1d4e7f39dd194/editor/project_manager/project_list.cpp#L932-L934

In my testing (50 projects, the scan folder contained 7 projects), this reduced the runtime of `ProjectList::_scan_finished()` from **120 to 45** miliseconds (with 35 being the cost of hiding the Window). I also tested another scenario, 1000 projects, adding another 1000 using the scan, it improved from 4000 ms to 2000 ms (as it doesn't need to process the otehr ones).

I've also tried a HashSet to replace this chunk of code:

```cpp
bool already_exists = false;
for (const Item &p : _projects) {
	if (p.path == path) {
		already_exists = true;
		break;
	}
}
if (already_exists) {
	continue;
}
```

but it's slower (even in extreme scenarios). The check is needed to prevent a crash.

The performance diffrence is visible without a profiler.

No AI was used.

Related: https://github.com/godotengine/godot/pull/120958