### PR TITLE
Wayland: Improve pointer constraining 

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -509,12 +509,6 @@ void DisplayServerWayland::_mouse_update_mode() {
 
 	wayland_thread.pointer_set_constraint(constraint);
 
-	if (wanted_mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED) {
-		WindowData *pointed_win = windows.getptr(wayland_thread.pointer_get_pointed_window_id());
-		ERR_FAIL_NULL(pointed_win);
-		wayland_thread.pointer_set_hint(pointed_win->rect.size / 2);
-	}
-
 	mouse_mode = wanted_mouse_mode;
 }
 
@@ -1943,7 +1937,8 @@ void DisplayServerWayland::try_suspend() {
 void DisplayServerWayland::process_events() {
 	wayland_thread.mutex.lock();
 
-	wayland_thread.keyboard_echo_keys();
+	// Some behavior depends on the progress of the main thread.
+	wayland_thread.main_loop_callback();
 
 	while (wayland_thread.has_message()) {
 		Ref<WaylandThread::Message> msg = wayland_thread.pop_message();

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -401,7 +401,6 @@ void WaylandThread::_set_current_seat(struct wl_seat *p_seat) {
 	seat_state_unlock_pointer(new_state);
 
 	wl_seat_current = p_seat;
-	pointer_set_constraint(pointer_constraint);
 }
 
 void WaylandThread::_window_hover(DisplayServerEnums::WindowID p_window_id) {
@@ -2110,6 +2109,19 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 	}
 
 	if (ws != nullptr) {
+		if (hover_changed && pd.pointed_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+			// We update the constraint only on enter.
+
+			wayland_thread->seat_state_unlock_pointer(ss);
+			if (wayland_thread->pointer_constraint == PointerConstraint::LOCKED) {
+				wayland_thread->seat_state_lock_pointer(ss, ws->wl_surface);
+				// Godot always expects a centered pointer when locked.
+				wayland_thread->seat_state_set_hint(ss, ws->rect.size.x / 2, ws->rect.size.y / 2);
+			} else if (wayland_thread->pointer_constraint == PointerConstraint::CONFINED) {
+				wayland_thread->seat_state_confine_pointer(ss, ws->wl_surface);
+			}
+		}
+
 		double scale = window_state_get_scale_factor(ws);
 
 		wayland_thread->_set_current_seat(ss->wl_seat);
@@ -2869,6 +2881,28 @@ void WaylandThread::_wl_data_source_on_dnd_finished(void *data, struct wl_data_s
 }
 
 void WaylandThread::_wl_data_source_on_action(void *data, struct wl_data_source *wl_data_source, uint32_t dnd_action) {
+}
+
+void WaylandThread::_zwp_locked_pointer_v1_on_locked(void *data, struct zwp_locked_pointer_v1 *zwp_locked_pointer_v1) {
+	SeatState *ss = (SeatState *)data;
+	ERR_FAIL_NULL(ss);
+
+	ss->pointer_locked = true;
+
+	// Maybe by the time we lock the legacy constraint warp has already been
+	// committed. Let's give it a shot.
+	if (ss->constraint_warp_committed) {
+		PointerConstraint old_constraint = ss->wayland_thread->pointer_constraint;
+		ss->wayland_thread->pointer_set_constraint(PointerConstraint::NONE);
+		ss->wayland_thread->pointer_set_constraint(old_constraint);
+
+		ss->pointer_locked = false;
+		ss->constraint_warping = false;
+		ss->constraint_warp_committed = false;
+	}
+}
+
+void WaylandThread::_zwp_locked_pointer_v1_on_unlocked(void *data, struct zwp_locked_pointer_v1 *zwp_locked_pointer_v1) {
 }
 
 void WaylandThread::_wp_color_manager_on_supported_intent(void *data, struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t render_intent) {
@@ -4113,10 +4147,13 @@ void WaylandThread::seat_state_unlock_pointer(SeatState *p_ss) {
 		zwp_confined_pointer_v1_destroy(p_ss->wp_confined_pointer);
 		p_ss->wp_confined_pointer = nullptr;
 	}
+
+	p_ss->pointer_locked = false;
 }
 
-void WaylandThread::seat_state_lock_pointer(SeatState *p_ss) {
+void WaylandThread::seat_state_lock_pointer(SeatState *p_ss, struct wl_surface *p_surface) {
 	ERR_FAIL_NULL(p_ss);
+	ERR_FAIL_NULL(p_surface);
 
 	if (p_ss->wl_pointer == nullptr) {
 		WARN_PRINT("Can't lock - no pointer?");
@@ -4128,15 +4165,12 @@ void WaylandThread::seat_state_lock_pointer(SeatState *p_ss) {
 		return;
 	}
 
-	if (p_ss->wp_locked_pointer == nullptr) {
-		struct wl_surface *locked_surface = window_get_wl_surface(p_ss->pointer_data.last_pointed_id);
-		if (locked_surface == nullptr) {
-			locked_surface = window_get_wl_surface(DisplayServerEnums::MAIN_WINDOW_ID);
-		}
-		ERR_FAIL_NULL(locked_surface);
+	p_ss->pointer_locked = false;
 
-		p_ss->wp_locked_pointer = zwp_pointer_constraints_v1_lock_pointer(registry.wp_pointer_constraints, locked_surface, p_ss->wl_pointer, nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
-	}
+	// We always set a listener that tracks the locking status. This is useful as
+	// this constraint might be reused for the legacy warp hack.
+	p_ss->wp_locked_pointer = zwp_pointer_constraints_v1_lock_pointer(registry.wp_pointer_constraints, p_surface, p_ss->wl_pointer, nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+	zwp_locked_pointer_v1_add_listener(p_ss->wp_locked_pointer, &zwp_locked_pointer_v1_listener, p_ss);
 }
 
 void WaylandThread::seat_state_set_hint(SeatState *p_ss, int p_x, int p_y) {
@@ -4162,8 +4196,9 @@ void WaylandThread::seat_state_warp_pointer(SeatState *p_ss, int p_x, int p_y) {
 	wp_pointer_warp_v1_warp_pointer(registry.wp_pointer_warp, surface, p_ss->wl_pointer, wl_fixed_from_int(p_x), wl_fixed_from_int(p_y), p_ss->pointer_enter_serial);
 }
 
-void WaylandThread::seat_state_confine_pointer(SeatState *p_ss) {
+void WaylandThread::seat_state_confine_pointer(SeatState *p_ss, struct wl_surface *p_surface) {
 	ERR_FAIL_NULL(p_ss);
+	ERR_FAIL_NULL(p_surface);
 
 	if (p_ss->wl_pointer == nullptr) {
 		return;
@@ -4174,10 +4209,7 @@ void WaylandThread::seat_state_confine_pointer(SeatState *p_ss) {
 	}
 
 	if (p_ss->wp_confined_pointer == nullptr) {
-		struct wl_surface *confined_surface = window_get_wl_surface(p_ss->pointer_data.last_pointed_id);
-		ERR_FAIL_NULL(confined_surface);
-
-		p_ss->wp_confined_pointer = zwp_pointer_constraints_v1_confine_pointer(registry.wp_pointer_constraints, confined_surface, p_ss->wl_pointer, nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+		p_ss->wp_confined_pointer = zwp_pointer_constraints_v1_confine_pointer(registry.wp_pointer_constraints, p_surface, p_ss->wl_pointer, nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
 	}
 }
 
@@ -5378,19 +5410,22 @@ DisplayServerEnums::WindowID WaylandThread::pointer_get_last_pointed_window_id()
 }
 
 void WaylandThread::pointer_set_constraint(PointerConstraint p_constraint) {
+	pointer_constraint = p_constraint;
+
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+	ERR_FAIL_NULL(ss);
 
-	if (ss) {
+	WindowState *ws = window_get_state(ss->pointer_data.pointed_id);
+	if (ws) {
 		seat_state_unlock_pointer(ss);
-
-		if (p_constraint == PointerConstraint::LOCKED) {
-			seat_state_lock_pointer(ss);
-		} else if (p_constraint == PointerConstraint::CONFINED) {
-			seat_state_confine_pointer(ss);
+		if (pointer_constraint == PointerConstraint::LOCKED) {
+			seat_state_lock_pointer(ss, ws->wl_surface);
+			// Godot always expects a centered pointer when locked.
+			seat_state_set_hint(ss, ws->rect.size.x / 2, ws->rect.size.y / 2);
+		} else if (pointer_constraint == PointerConstraint::CONFINED) {
+			seat_state_confine_pointer(ss, ws->wl_surface);
 		}
 	}
-
-	pointer_constraint = p_constraint;
 }
 
 void WaylandThread::pointer_set_hint(const Point2i &p_hint) {
@@ -5418,19 +5453,6 @@ void WaylandThread::pointer_set_hint(const Point2i &p_hint) {
 }
 
 void WaylandThread::pointer_warp(const Point2i &p_to) {
-	// NOTE: This is for compositors that don't support the pointer-warp protocol.
-	// It's hacked together and not guaranteed to work.
-	if (registry.wp_pointer_warp == nullptr) {
-		PointerConstraint old_constraint = pointer_get_constraint();
-
-		pointer_set_constraint(PointerConstraint::LOCKED);
-		pointer_set_hint(p_to);
-
-		pointer_set_constraint(old_constraint);
-
-		return;
-	}
-
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 	if (!ss) {
 		return;
@@ -5438,6 +5460,35 @@ void WaylandThread::pointer_warp(const Point2i &p_to) {
 
 	WindowState *ws = window_get_state(ss->pointer_data.pointed_id);
 	if (!ws) {
+		return;
+	}
+
+	// NOTE: This is for compositors that don't support the pointer-warp protocol.
+	// It's hacked together and not guaranteed to work.
+	if (registry.wp_pointer_warp == nullptr) {
+		if (ss->constraint_warping) {
+			return;
+		}
+
+		if (!ss->wp_locked_pointer) {
+			seat_state_unlock_pointer(ss);
+			seat_state_lock_pointer(ss, ws->wl_surface);
+		}
+
+		pointer_set_hint(p_to);
+
+		ss->constraint_warping = true;
+		ss->constraint_warp_committed = false;
+
+		if (!ss->wp_locked_pointer) {
+			seat_state_unlock_pointer(ss);
+			seat_state_lock_pointer(ss, ws->wl_surface);
+		}
+
+		pointer_set_hint(p_to);
+
+		// Gotta wait a frame... Not ideal but, y'know.
+
 		return;
 	}
 
@@ -6132,6 +6183,32 @@ bool WaylandThread::window_is_suspended(DisplayServerEnums::WindowID p_window_id
 
 bool WaylandThread::is_fifo_available() const {
 	return registry.wp_fifo_manager_name != 0;
+}
+
+void WaylandThread::main_loop_callback() {
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+
+	if (ss) {
+		seat_state_echo_keys(ss);
+
+		// We need to wait a commit before "finalizing" the "legacy warp" hack. This
+		// callback is called *after* a commit, but we don't know when the warp
+		// request has been made, so we first wait one commit, then "finalize" on the
+		// next. Additionally, we also wait for the pointer to be locked, as otherwise
+		// it's not guaranteed for the position hint to even be acknowledged, AFAICT.
+		if (ss->constraint_warping && ss->pointer_locked) {
+			if (ss->constraint_warp_committed) {
+				PointerConstraint old_constraint = pointer_constraint;
+				pointer_set_constraint(PointerConstraint::NONE);
+				pointer_set_constraint(old_constraint);
+
+				ss->constraint_warping = false;
+				ss->constraint_warp_committed = false;
+			} else {
+				ss->constraint_warp_committed = true;
+			}
+		}
+	}
 }
 
 bool WaylandThread::is_suspended() const {

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -508,6 +508,11 @@ public:
 		struct zwp_locked_pointer_v1 *wp_locked_pointer = nullptr;
 		struct zwp_confined_pointer_v1 *wp_confined_pointer = nullptr;
 
+		bool pointer_locked = false;
+
+		bool constraint_warping = false;
+		bool constraint_warp_committed = false;
+
 		struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch = nullptr;
 
 		// NOTE: According to the wp_pointer_gestures protocol specification, there
@@ -824,6 +829,9 @@ private:
 	static void _xdg_popup_on_repositioned(void *data, struct xdg_popup *xdg_popup, uint32_t token);
 
 	// wayland-protocols event handlers.
+	static void _zwp_locked_pointer_v1_on_locked(void *data, struct zwp_locked_pointer_v1 *zwp_locked_pointer_v1);
+	static void _zwp_locked_pointer_v1_on_unlocked(void *data, struct zwp_locked_pointer_v1 *zwp_locked_pointer_v1);
+
 	static void _wp_color_manager_on_supported_intent(void *data, struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t render_intent);
 	static void _wp_color_manager_on_supported_feature(void *data, struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t feature);
 	static void _wp_color_manager_on_supported_tf_named(void *data, struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t tf);
@@ -1027,6 +1035,11 @@ private:
 	};
 
 	// wayland-protocols event listeners.
+	static constexpr struct zwp_locked_pointer_v1_listener zwp_locked_pointer_v1_listener{
+		.locked = _zwp_locked_pointer_v1_on_locked,
+		.unlocked = _zwp_locked_pointer_v1_on_unlocked,
+	};
+
 	static constexpr struct wp_color_manager_v1_listener wp_color_manager_listener = {
 		.supported_intent = _wp_color_manager_on_supported_intent,
 		.supported_feature = _wp_color_manager_on_supported_feature,
@@ -1246,10 +1259,10 @@ public:
 	static EmbeddingCompositorState *godot_embedding_compositor_get_state(struct godot_embedding_compositor *p_compositor);
 
 	void seat_state_unlock_pointer(SeatState *p_ss);
-	void seat_state_lock_pointer(SeatState *p_ss);
+	void seat_state_lock_pointer(SeatState *p_ss, struct wl_surface *p_surface);
 	void seat_state_set_hint(SeatState *p_ss, int p_x, int p_y);
 	void seat_state_warp_pointer(SeatState *p_ss, int p_x, int p_y);
-	void seat_state_confine_pointer(SeatState *p_ss);
+	void seat_state_confine_pointer(SeatState *p_ss, struct wl_surface *p_surface);
 
 	static void seat_state_update_cursor(SeatState *p_ss);
 
@@ -1368,6 +1381,8 @@ public:
 	bool get_reset_frame();
 	bool wait_frame_suspend_ms(int p_timeout);
 	bool is_fifo_available() const;
+
+	void main_loop_callback();
 
 	uint64_t window_get_last_frame_time(DisplayServerEnums::WindowID p_window_id) const;
 	bool window_is_suspended(DisplayServerEnums::WindowID p_window_id) const;


### PR DESCRIPTION
~~Fixes 116232.~~ Update: Fix got moved into #120831.
Fixes #114044. (on compliant compositors, see below)

## What problem(s) does this PR solve?

This patch improves the QoL of various pointer constraining related operations ("mouse mode") like locking and confining. They both would often not fire or print errors. This has hopefully been fixed, although compositors have various quirks across the line.


## Additional information

Mouse mode handling is now "deferred" like on Windows. This means that it will now wait for the pointer to enter a surface and only then apply the constraint.

"Legacy" warping (the old constraint-based hack) is hopefully more consistent now. As per spec, we wait a frame (surface commit to be precise) before actually "finishing" the warp procedure. This means that the cursor will be in the wrong place for one frame in certain situations but it's an unavoidable side-effect of this hack. The correct solution will always be the new pointer warp protocol. Coverage is still limited, but as of now KWin and Mutter support it so hopefully the majority of users are already covered right now.

~~Lastly, we remove the "workaround" done for constranining on embedded games (surface redirection). It actually relied on a few broken implementations (sway, kwin), broke the majority of compositors and caused crashes without extra tracking logic. Overall it's not a huge loss as it was not possible to work around confinement on these faulty implementations anyway.~~ Update: incorporated in #120831.

---

I've sat on this for a long time as I really wanted to test on *all* compositors, but unfortunately my emulation-based approach is giving me issues due to QEMU's mouse emulation. Sorry for that. I'm looking into a bare-metal custom liveCD solution as nothing else worked.

In the meantime in particular I've thoroughly tested legacy warping on sway, niri, and weston (which crashed before and still crashes now, I have absolutely no idea why it does that). No warping regressions on KWin.

I've tested constraining less but I couldn't find particular regressions, outside of the broken compositors (sway and KWin) and can confirm that niri for example now constrains properly! :D

A good benchmark for compositors is the Weston demo `weston-constraints`, which tests exactly that. Also see the following for some research done by @mahkoh https://gitlab.freedesktop.org/wayland/wayland-protocols/-/work_items/287#note_3167468

This isn't the testing I wanted to do but as the "big ones" (KWin, mutter) support native warping, we should be fine hopefully. Still an improvement, I think.