### PR TITLE
Fix `MeshLibrary` editor not properly handling read-only libs

### DIFF
--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -173,6 +173,12 @@ void MeshLibraryEditor::edit(const Ref<MeshLibrary> &p_mesh_library) {
 		// Avoid updating multiple times at once.
 		mesh_library->connect_changed(callable_mp(update_items_delay, &Timer::start).bind(UPDATE_ITEMS_DELAY_TIMEOUT));
 		_update_mesh_items();
+
+		bool read_only = EditorNode::get_singleton()->is_resource_read_only(mesh_library);
+		add_item->set_disabled(read_only);
+		remove_item->set_disabled(read_only);
+		import_scene->set_disabled(read_only);
+		inspector->set_read_only(read_only);
 	}
 }
 


### PR DESCRIPTION
Before, one could use the `MeshLibrary` editor to "edit" read-only `MeshLibrary` resources (e. g. glb files exported as libraries). Those edits wouldn't last, and be reset once the resource was opened again. Now editing of those are properly disabled.

**ATTENTION:** If this PR is cherry-picked, #120672 will need to be too.