### PR TITLE
Use a 2-pixel outline in Viewport and Viewport-related editor icons

### DIFF
--- a/editor/icons/SubViewport.svg
+++ b/editor/icons/SubViewport.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="none" stroke="#e0e0e0" stroke-width="1.25"><rect width="12.75" height="10.75" x="1.625" y="2.625" rx="1.5"/><rect width="6.75" height="6.75" x="4.625" y="4.625" rx="1.5"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12" height="10" x="2" y="3" fill="none" stroke="#e0e0e0" stroke-width="2" rx="1.5" ry="1.5"/><rect width="4" height="4" x="6" y="6" fill="none" stroke="#e0e0e0" stroke-width="2" rx="1.5" ry="1.5"/></svg>

--- a/editor/icons/SubViewportContainer.svg
+++ b/editor/icons/SubViewportContainer.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="none" stroke="#8eef97"><rect width="12" height="12" x="2" y="2" stroke-width="2" rx="1"/><rect width="6.75" height="6.75" x="4.625" y="4.625" stroke-width="1.25" rx="1.5"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12" height="12" x="2" y="2" fill="none" stroke="#8eef97" stroke-width="2" rx="1"/><rect width="4" height="4" x="6" y="6" fill="none" stroke="#8eef97" stroke-width="2" rx="1.5" ry="1.5"/></svg>

--- a/editor/icons/Viewport.svg
+++ b/editor/icons/Viewport.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12.75" height="10.75" x="1.625" y="2.625" fill="none" stroke="gray" stroke-width="1.25" rx="1.5"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12" height="10" x="2" y="3" fill="none" stroke="gray" stroke-width="2" rx="1.425" ry="1.425"/></svg>

--- a/editor/icons/ViewportTexture.svg
+++ b/editor/icons/ViewportTexture.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12.75" height="10.75" x="1.625" y="2.625" fill="none" stroke="#e0e0e0" stroke-width="1.25" rx="1.5"/><path fill="#e0e0e0" d="M9 6v1H8v1H6v1H5v1H4v1h8V9h-1V7h-1V6z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12" height="10" x="2" y="3" fill="none" stroke="#e0e0e0" stroke-width="2" rx="1.5" ry="1.5"/><path fill="#e0e0e0" d="M9 6v1H8v1H6v1H5v1H4v1h8V9h-1V7h-1V6z"/></svg>


### PR DESCRIPTION
This is more visually consistent with other editor icons.

- See https://github.com/godotengine/godot/pull/74573#pullrequestreview-4576294834
and https://github.com/godotengine/godot-proposals/issues/15077.

## Preview

Before | After
-|-
<img width="245" height="138" alt="Image" src="https://github.com/user-attachments/assets/ba6d0986-9772-46d3-a403-50c2a6d1b88a" /> | <img width="245" height="138" alt="Image" src="https://github.com/user-attachments/assets/fbc02c51-2137-487c-98c2-a1256026df0b" />