### PR TITLE
Improve documentation on `_input_event` 2d and 3d

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -16,7 +16,9 @@
 			<param index="1" name="event" type="InputEvent" />
 			<param index="2" name="shape_idx" type="int" />
 			<description>
-				Accepts unhandled [InputEvent]s. [param shape_idx] is the child index of the clicked [Shape2D]. Connect to [signal input_event] to easily pick up these events.
+				Detects unhandled mouse and touch [InputEvent]s through [param event] when they happen while hovering over the object. Gesture events are not detected. [param viewport] is the [Viewport] that the event originated in (for viewports other than the main one to be detected, [member Viewport.physics_object_picking] needs to be set to [code]true[/code]). [param shape_idx] is the index of the detected shape from [PhysicsServer2D].
+				See also [method Node._unhandled_input], [method shape_find_owner], and [method shape_owner_get_owner].
+				[b]Note:[/b] [InputEventScreenDrag] events are triggered if the drag events started while hovering the object, or when the object is in the path of the drag event.
 				[b]Note:[/b] [method _input_event] requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
@@ -263,7 +265,7 @@
 			<param index="1" name="event" type="InputEvent" />
 			<param index="2" name="shape_idx" type="int" />
 			<description>
-				Emitted when an input event occurs. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. See [method _input_event] for details.
+				Emitted when an unhandled input event occurs. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. See [method _input_event] for details.
 			</description>
 		</signal>
 		<signal name="mouse_entered">

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -18,7 +18,9 @@
 			<param index="3" name="normal" type="Vector3" />
 			<param index="4" name="shape_idx" type="int" />
 			<description>
-				Receives unhandled [InputEvent]s. [param event_position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point. Connect to the [signal input_event] signal to easily pick up these events.
+				Detects unhandled mouse and touch [InputEvent]s through [param event] when they happen while hovering over the object. Gesture events are not detected. [param camera] is the [Camera3D] that the event originated in (for cameras inside viewports other than the main one to be detected, the parent [member Viewport.physics_object_picking] needs to be set to [code]true[/code]). [param event_position] is the position hit by a raycast from the camera to the mouse, in global space. [param normal] is the normal vector of the surface at that point in world space. [param shape_idx] is the index of the detected shape from [PhysicsServer3D].
+				See also [method Node._unhandled_input], [method shape_find_owner], and [method shape_owner_get_owner].
+				[b]Note:[/b] [InputEventScreenDrag] events are triggered if the drag events started while hovering the object, or when the object is in the path of the drag event.
 				[b]Note:[/b] [method _input_event] requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
@@ -211,7 +213,7 @@
 			<param index="3" name="normal" type="Vector3" />
 			<param index="4" name="shape_idx" type="int" />
 			<description>
-				Emitted when the object receives an unhandled [InputEvent]. [param event_position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point.
+				Emitted when an unhandled input event occurs. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. See [method _input_event] for details.
 			</description>
 		</signal>
 		<signal name="mouse_entered">


### PR DESCRIPTION
The old description for `_input_event` provided no near enough information about those methods and signals considering how much it actually can do, or does in general.

So I delved into the source code and tested behaviors in general to see how it actually worked, and I might still be missing something.

It might be worth mentioning also about https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-input-devices-pointing-emulate-mouse-from-touch but I am not exactly sure how to phrase it.