### PR TITLE
avoid running 'GetVolumeInformationW' on network drives

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -143,6 +143,11 @@ void DirAccessWindows::_update_drives() {
 			String drive = String::chr('A' + i) + ':';
 			String path = drive + '\\';
 			String label;
+			UINT type = GetDriveTypeW((LPCWSTR)(path).utf16().get_data());
+			if (type == DRIVE_REMOTE) {
+				drives.push_back(DriveInfo{ drive, "[network]" });
+				continue;
+			}
 			char16_t wlabel[4096];
 			if (GetVolumeInformationW((LPCWSTR)(path).utf16().get_data(), (LPWSTR)wlabel, 4096, nullptr, nullptr, nullptr, nullptr, 0)) {
 				label = String::utf16(wlabel);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120649

## Additional information

checks whether a drive is a network drive before querying it with GetVolumeInformationW, which I have noticed hangs for about 8 seconds on disconnected network drives.

I don't know that this is the best way to resolve this, but it is a way.

I tested by launching godot editor with and without this change and without it it hangs for ~30 seconds and with it it opens right away
