### PR TITLE
Fix "Remove" button in `MeshLibrary` editor being enabled when it shouldn't

### DIFF
--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -176,7 +176,9 @@ void MeshLibraryEditor::edit(const Ref<MeshLibrary> &p_mesh_library) {
 
 		bool read_only = EditorNode::get_singleton()->is_resource_read_only(mesh_library);
 		add_item->set_disabled(read_only);
-		remove_item->set_disabled(read_only);
+		if (read_only) {
+			remove_item->set_disabled(true);
+		}
 		import_scene->set_disabled(read_only);
 		inspector->set_read_only(read_only);
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes regression from #120655.

## Additional information

If that PR is cherry-picked, this one will need to be as well.