### PR TITLE
Hide pagination in the asset store when there are no assets to list

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -2091,6 +2091,17 @@ void EditorAssetLibrary::_set_library_message(const String &p_message) {
 	library_message_button->hide();
 
 	library_message_box->show();
+
+	// Remove pagination, as an error message is being shown and there are no assets to list.
+	// Pagination is recreated when the next search is performed.
+	if (asset_top_page) {
+		memdelete(asset_top_page);
+		asset_top_page = nullptr;
+	}
+	if (asset_bottom_page) {
+		memdelete(asset_bottom_page);
+		asset_bottom_page = nullptr;
+	}
 }
 
 void EditorAssetLibrary::_set_library_message_with_action(const String &p_message, const String &p_action_text, const Callable &p_action) {


### PR DESCRIPTION
This occurs when an error is being displayed, e.g. due to the lack of search results or when the asset store is unreachable.

Performing another search recreates the nodes that were hidden, so the pagination will correctly show up again if there are results.

## Preview

Before | After
-|-
<img width="1351" height="324" alt="Image" src="https://github.com/user-attachments/assets/209ed03b-07a3-453f-9cb3-9ce7ff055848" /> | <img width="1351" height="324" alt="Image" src="https://github.com/user-attachments/assets/b08ab183-47df-4bf7-a9ca-ee1254ee080a" />

Website for comparison:

<img width="940" height="268" alt="Image" src="https://github.com/user-attachments/assets/4dcea7b8-2ae0-41a0-be8a-c1e88459e456" />

