### PR TITLE
Increase the default size of the editor About dialog

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3985,7 +3985,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			OS::get_singleton()->shell_open("https://godotengine.org/community");
 		} break;
 		case HELP_ABOUT: {
-			about->popup_centered(Size2(780, 500) * EDSCALE);
+			// The default width is chosen to allow for several developer names per column, as well as unwrapped license texts.
+			// The default height is chosen to show the first developer names (to give a hint that the list can be scrolled).
+			about->popup_centered(Size2(985, 545) * EDSCALE);
 		} break;
 		case HELP_SUPPORT_GODOT_DEVELOPMENT: {
 			OS::get_singleton()->shell_open("https://fund.godotengine.org/?ref=help_menu");

--- a/editor/gui/editor_about.cpp
+++ b/editor/gui/editor_about.cpp
@@ -254,6 +254,7 @@ EditorAbout::EditorAbout() {
 		ScrollContainer *sc = memnew(ScrollContainer);
 		sc->set_name(TTRC("Authors"));
 		sc->set_v_size_flags(Control::SIZE_EXPAND);
+		sc->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 		tc->add_child(sc);
 
 		VBoxContainer *vb = memnew(VBoxContainer);
@@ -272,6 +273,7 @@ EditorAbout::EditorAbout() {
 		ScrollContainer *sc = memnew(ScrollContainer);
 		sc->set_name(TTRC("Donors"));
 		sc->set_v_size_flags(Control::SIZE_EXPAND);
+		sc->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 		tc->add_child(sc);
 
 		VBoxContainer *vb = memnew(VBoxContainer);


### PR DESCRIPTION
This has several benefits:

- Author names are now displayed on two columns instead of just one (as originally intended).
- Author/donor names are slightly visible at the top of each list. Combined with scroll hints (which are now enabled for these lists), this signals to user they can scroll to view a list of authors/donors.
- License texts are now displayed without word wrapping.

## Preview

Before | After
-|-
<img width="780" height="500" alt="Image" src="https://github.com/user-attachments/assets/e8142f18-3153-4b89-b288-44d5a8d16d49" /> | <img width="985" height="545" alt="Image" src="https://github.com/user-attachments/assets/cde984ce-48aa-4e1f-9fc3-517eab001abc" />

Before | After
-|-
<img width="780" height="500" alt="Image" src="https://github.com/user-attachments/assets/c1878907-fc27-4937-974b-20de56daff1c" /> | <img width="985" height="545" alt="Image" src="https://github.com/user-attachments/assets/f9ef796a-093b-473d-906a-6792a1cf4a34" />

Before | After
-|-
<img width="780" height="500" alt="Image" src="https://github.com/user-attachments/assets/09509e91-72b7-419e-838f-3b073bc8d317" /> | <img width="985" height="545" alt="Image" src="https://github.com/user-attachments/assets/347623b8-e6ce-4e02-afc3-d32a611d7ed2" />

Before | After
-|-
<img width="780" height="500" alt="Image" src="https://github.com/user-attachments/assets/efb71af2-c1fd-4d9f-a6ff-89616e41eed0" /> | <img width="985" height="545" alt="Image" src="https://github.com/user-attachments/assets/2538b6f5-a51b-4110-a970-a5bce3764015" />

Before | After
-|-
<img width="780" height="500" alt="Image" src="https://github.com/user-attachments/assets/57d99642-5ddb-430b-abf0-913a7afe88f0" /> | <img width="985" height="545" alt="Image" src="https://github.com/user-attachments/assets/f3e44f91-505e-4ffb-8c27-fdbeabfa4fc7" />


