### PR TITLE
Fix wrong pointer in compatibility_test_init null check

### DIFF
--- a/tests/compatibility_test/src/compat_checker.c
+++ b/tests/compatibility_test/src/compat_checker.c
@@ -218,7 +218,7 @@ GDExtensionBool __attribute__((visibility("default"))) compatibility_test_init(G
 	string_name_destructor = variant_get_ptr_destructor(GDEXTENSION_VARIANT_TYPE_STRING_NAME);
 
 	string_name_new_with_latin1_chars = (GDExtensionInterfaceStringNameNewWithLatin1Chars)p_get_proc_address("string_name_new_with_latin1_chars");
-	if (classdb_get_method_bind == NULL) {
+	if (string_name_new_with_latin1_chars == NULL) {
 		fprintf(stderr, "Failed to load interface method `string_name_new_with_latin1_chars`\n");
 		return false;
 	}


### PR DESCRIPTION
compat_checker.c contains a series of proc-address lookups, each of which retrieves and validates a function pointer. The lookup for string_name_new_with_latin1_chars checks the wrong pointer; it tests the previously assigned classdb_get_method_bind rather than string_name_new_with_latin1_chars.

If string_name_new_with_latin1_chars ever failed to resolve, init would still return success and the extension would later dereference a null pointer in startup_func. This would crash instead of printing the intended "Failed to load interface method" error. This fix aligns the check with the five sibling checks in the same function, each of which validates its own just-assigned pointer.
