### PR TITLE
Fix node collections not getting preserved by placeholder script

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -870,11 +870,28 @@ void PlaceHolderScriptInstance::property_set_fallback(const StringName &p_name, 
 		}
 		if (!found) {
 			PropertyHint hint = PROPERTY_HINT_NONE;
+			String hint_string;
 			const Object *obj = p_value.get_validated_object();
+			// Temporary hint so Nodes are converted to NodePaths when PackedScene is saved
 			if (obj && obj->is_class("Node")) {
 				hint = PROPERTY_HINT_NODE_TYPE;
+			} else if (p_value.get_type() == Variant::ARRAY) {
+				Array array = p_value;
+				if (array.get_typed_builtin() == Variant::OBJECT && ClassDB::is_parent_class(array.get_typed_class_name(), "Node")) {
+					hint = PROPERTY_HINT_TYPE_STRING;
+					hint_string = vformat("%d/%d:Node", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE);
+				}
+			} else if (p_value.get_type() == Variant::DICTIONARY) {
+				Dictionary dict = p_value;
+				bool is_key_node = dict.get_typed_key_builtin() == Variant::OBJECT && ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
+				bool is_value_node = dict.get_typed_value_builtin() == Variant::OBJECT && ClassDB::is_parent_class(dict.get_typed_value_class_name(), "Node");
+				if (is_key_node || is_value_node) {
+					hint = PROPERTY_HINT_TYPE_STRING;
+					String node_hint_string = vformat("%d/%d:Node", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE);
+					hint_string = (is_key_node ? node_hint_string : "") + ";" + (is_value_node ? node_hint_string : "");
+				}
 			}
-			properties.push_back(PropertyInfo(p_value.get_type(), p_name, hint, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE));
+			properties.push_back(PropertyInfo(p_value.get_type(), p_name, hint, hint_string, PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE));
 		}
 	}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -676,8 +676,16 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 			bool valid;
 			Array array = base->get(dnp.property, &valid);
-			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			array = array.duplicate();
+			if (!valid && base->get_script_instance() && base->get_script_instance()->is_placeholder()) {
+				// Fallback handling could be enabled, so still try to set the property even if its definition is missing.
+				// Collection type is the minimum to ensure node collection interactions with scene packing
+				// and node duplication are preserved.
+				array = Array();
+				array.set_typed(Variant::OBJECT, "Node", Variant());
+			} else {
+				ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
+				array = array.duplicate();
+			}
 
 			array.resize(paths.size());
 			for (int i = 0; i < array.size(); i++) {
@@ -689,8 +697,21 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 			bool valid;
 			Dictionary dict = base->get(dnp.property, &valid);
-			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
-			dict = dict.duplicate();
+			if (!valid && base->get_script_instance() && base->get_script_instance()->is_placeholder()) {
+				// Fallback handling could be enabled, so still try to set the property even if its definition is missing.
+				// Collection type is the minimum to ensure node collection interactions with scene packing
+				// and node duplication are preserved. Since the dictionary could be of Node and NodePath, need to
+				// rely on types set in _parse_node() to know what was originally a Node.
+				dict = Dictionary();
+				bool is_key_node = paths.get_typed_key_builtin() == Variant::NODE_PATH;
+				bool is_value_node = paths.get_typed_value_builtin() == Variant::NODE_PATH;
+				dict.set_typed(is_key_node ? Variant::OBJECT : Variant::NIL, is_key_node ? "Node" : "", Variant(),
+						is_value_node ? Variant::OBJECT : Variant::NIL, is_value_node ? "Node" : "", Variant());
+			} else {
+				ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, base->get_name()));
+				dict = dict.duplicate();
+			}
+
 			bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
 					ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
 			bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
@@ -1005,6 +1026,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			int key_value_separator = E.hint_string.find_char(';');
 			if (key_value_separator >= 0) {
 				int key_subtype_separator = E.hint_string.find_char(':');
+				if (key_subtype_separator > key_value_separator) {
+					key_subtype_separator = key_value_separator;
+				}
 				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
 				int key_slash_pos = key_subtype_string.find_char('/');
 				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
@@ -1030,6 +1054,10 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 					use_deferred_node_path_bit = true;
 					Dictionary dict = value;
 					Dictionary new_dict;
+					// Set types as a hint to help instantiate recover from missing properties
+					new_dict.set_typed(convert_key ? Variant::NODE_PATH : Variant::NIL, "", Variant(),
+							convert_value ? Variant::NODE_PATH : Variant::NIL, "", Variant());
+
 					for (const KeyValue<Variant, Variant> &kv : dict) {
 						Variant new_key = kv.key;
 						if (convert_key && new_key.get_type() == Variant::OBJECT) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #97190
- Closes #96715
- Closes #117291
- Supersedes #97864 

## Additional information

At it's core, the problem is that properties can exist in the `PackedScene` file, but the script that the property came from has some issue that doesn't allow it to provide the property definition. For properties that aren't node collections, data isn't lost because `set` is always called, so the property data is just saved via `PlaceholderScriptInstance::property_set_fallback`.  Node collections have an issue since their `set` requires `get` to succeed, which cannot happen to handle the temporarily missing property definitions.

From what I could tell, the call to `get` isn't explicitly needed since the result overwritten entirely in the conversion process. It's an artifact from when conversion was handled per element, but that was changed to be converting the whole collection in #77735.  However, it is implicitly needed to set collection types for other features around node collections. To fully remove the need for valid `get` would require #112632, so this change only does enough to get these properties saved in the placeholder.

This change does make `tscn` and `scn` slightly bigger in order to make sure enough information in the file to recover dictionaries correctly. Without the extra type information, it's impossible to tell whether the key, value, or both were originally nodes since the hint string is missing.

### Related Issues

I did test against #97153 and it looks like the script is removed and no script instance created, so no regression.

There's a similar, but broader issue that occurs with C# tool scripts that this change does not address. If a C# tool script had been compiled previously, but needs a recompile so the editor is aware of new property definitions, then all new properties will have their data lost after recompile and save. See #109698

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
