### PR TITLE
ConnectDialog: Update method tree when opening method popup

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -214,7 +214,6 @@ void ConnectDialog::_tree_node_selected() {
 
 	cdbinds->update_base_node_relative(current);
 
-	_update_method_tree();
 	_update_warning_label();
 	_update_ok_enabled();
 }
@@ -462,6 +461,7 @@ void ConnectDialog::_open_method_popup() {
 	method_popup->popup_centered();
 	method_search->clear();
 	method_search->grab_focus();
+	_update_method_tree();
 }
 
 /*

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -159,7 +159,6 @@ private:
 	void _method_check_button_pressed(const CheckButton *p_button);
 	void _open_method_popup();
 
-	void _unbind_count_changed(double p_count);
 	void _add_bind();
 	void _remove_bind(const String &p_bind);
 	void _advanced_pressed();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120667 

Instead of updating the tree after every change, now it just happens when opening the popup (and by the popup itself when filters change). This removes the responsibility of every code that changes something to call this function.

## Additional information

Removed `_unbind_count_changed`, since it's defined in the header file, but not implemented/used.