### PR TITLE
Fix closed Curve3D first/last point missing in/out control point

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -2286,10 +2286,10 @@ Vector<RBMap<real_t, Vector3>> Curve3D::_tessellate_even_length(int p_max_stages
 }
 
 bool Curve3D::_filter_property(const String &p_name, int p_index) const {
-	if (p_index == 0) {
+	if (!closed && p_index == 0) {
 		return p_name != "in";
 	}
-	if (p_index == get_point_count() - 1) {
+	if (!closed && p_index == get_point_count() - 1) {
 		return p_name != "out";
 	}
 	return true;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes #120681.

## Additional information

Regression from #92282. `Curve3D` had a different condition in the removed `_get_property_list` than `Curve`/`Curve2D`, this was overlooked in the new `Curve3D::_filter_property`.

https://github.com/godotengine/godot/blob/20b44c9575f3d638d1861813003768155fb0fe9a/scene/resources/curve.cpp#L2451-L2467
