### PR TITLE
[3.x] Fix `safe_unproject_position()`

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -484,8 +484,9 @@ bool Camera::safe_unproject_position(const Vector3 &p_pos, Point2 &r_result) con
 
 	// Here we return false and let the calling routine handle this error condition.
 	if (Math::absf(p.d) < CMP_EPSILON) {
-		// Bodge some kind of result at infinity from the viewport center.
-		r_result = Point2();
+		// Establish the viewport center as our baseline
+		Point2 center = viewport_size * 0.5f;
+		r_result = center;
 
 		// The viewport size here is irrelevant, we just want a high number
 		// (representing infinity) but not actually close to infinity to prevent
@@ -493,14 +494,17 @@ bool Camera::safe_unproject_position(const Vector3 &p_pos, Point2 &r_result) con
 		// Suffice is for them to be WAY off the main viewport.
 		const float SOME_HIGH_VALUE = 100000.0f;
 		if (p.normal.x > 0) {
-			r_result.x = SOME_HIGH_VALUE;
+			r_result.x += SOME_HIGH_VALUE;
 		} else if (p.normal.x < 0) {
-			r_result.x = -SOME_HIGH_VALUE;
+			r_result.x -= SOME_HIGH_VALUE;
 		}
+
+		// +y is down in 2D viewport,
+		// whereas in 3D, +y is up, so we need to flip here.
 		if (p.normal.y > 0) {
-			r_result.y = SOME_HIGH_VALUE;
+			r_result.y -= SOME_HIGH_VALUE;
 		} else if (p.normal.y < 0) {
-			r_result.y = -SOME_HIGH_VALUE;
+			r_result.y += SOME_HIGH_VALUE;
 		}
 
 		return false;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
* fixes returning center of the viewport (instead of top left) when the 3D position is at the origin
* +y is up in 3D but down in 2D, so the Y polarity needs flipping in the recovery branch

## Additional information
While working on improving #96063 I came up with a couple of fixes that need to be backported to 3.x.
They are for the recovery branch (which is incredibly rare to occur) but definitely worth fixing.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
