### PR TITLE
Add `add_apple_embedded_platform_spm_package` method to `EditorExportPlugin`

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -312,6 +312,16 @@
 				Adds a static library from the given [param path] to the Apple embedded platform project.
 			</description>
 		</method>
+		<method name="add_apple_embedded_platform_spm_package">
+			<return type="void" />
+			<param index="0" name="url" type="String" />
+			<param index="1" name="version" type="String" />
+			<param index="2" name="products" type="PackedStringArray" />
+			<description>
+				Adds a Swift Package Manager package to the Apple embedded platform's Xcode project. The [param url] is the URL of the package, [param version] is the version requirement (e.g. "1.0.0"), and [param products] is an array of product names to include from the package.
+				[b]Note:[/b] Only supported on iOS and visionOS.
+			</description>
+		</method>
 		<method name="add_file">
 			<return type="void" />
 			<param index="0" name="path" type="String" />

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1659,14 +1659,36 @@ Error EditorExportPlatformAppleEmbedded::_export_apple_embedded_plugins(const Re
 		pbx_id.low_bits = 0;
 
 		HashMap<String, PluginConfigAppleEmbedded::SPMPackage> unique_packages;
+
+		// Collect from .gdip plugin configs
 		for (int i = 0; i < enabled_plugins.size(); i++) {
 			for (const PluginConfigAppleEmbedded::SPMPackage &package : enabled_plugins[i].spm_packages) {
 				if (!unique_packages.has(package.url)) {
 					unique_packages[package.url] = package;
 				} else {
 					for (const String &product : package.products) {
-						if (unique_packages[package.url].products.find(product) == -1) {
+						if (!unique_packages[package.url].products.has(product)) {
 							unique_packages[package.url].products.push_back(product);
+						}
+					}
+				}
+			}
+		}
+
+		// Also collect from EditorExportPlugins (added using add_apple_embedded_platform_spm_package() method)
+		Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
+		for (int i = 0; i < export_plugins.size(); i++) {
+			for (const EditorExportPlugin::AppleEmbeddedSPMPackage &ep_package : export_plugins[i]->get_apple_embedded_platform_spm_packages()) {
+				if (!unique_packages.has(ep_package.url)) {
+					PluginConfigAppleEmbedded::SPMPackage package;
+					package.url = ep_package.url;
+					package.version = ep_package.version;
+					package.products = ep_package.products;
+					unique_packages[ep_package.url] = package;
+				} else {
+					for (const String &product : ep_package.products) {
+						if (!unique_packages[ep_package.url].products.has(product)) {
+							unique_packages[ep_package.url].products.push_back(product);
 						}
 					}
 				}

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -127,6 +127,20 @@ String EditorExportPlugin::get_apple_embedded_platform_cpp_code() const {
 	return apple_embedded_platform_cpp_code;
 }
 
+void EditorExportPlugin::add_apple_embedded_platform_spm_package(const String &p_url, const String &p_version, const PackedStringArray &p_products) {
+	AppleEmbeddedSPMPackage package;
+	package.url = p_url;
+	package.version = p_version;
+	for (const String &product : p_products) {
+		package.products.push_back(product);
+	}
+	apple_embedded_platform_spm_packages.push_back(package);
+}
+
+Vector<EditorExportPlugin::AppleEmbeddedSPMPackage> EditorExportPlugin::get_apple_embedded_platform_spm_packages() const {
+	return apple_embedded_platform_spm_packages;
+}
+
 void EditorExportPlugin::add_macos_plugin_file(const String &p_path) {
 	macos_plugin_files.push_back(p_path);
 }
@@ -356,6 +370,7 @@ void EditorExportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_apple_embedded_platform_linker_flags", "flags"), &EditorExportPlugin::add_apple_embedded_platform_linker_flags);
 	ClassDB::bind_method(D_METHOD("add_apple_embedded_platform_bundle_file", "path"), &EditorExportPlugin::add_apple_embedded_platform_bundle_file);
 	ClassDB::bind_method(D_METHOD("add_apple_embedded_platform_cpp_code", "code"), &EditorExportPlugin::add_apple_embedded_platform_cpp_code);
+	ClassDB::bind_method(D_METHOD("add_apple_embedded_platform_spm_package", "url", "version", "products"), &EditorExportPlugin::add_apple_embedded_platform_spm_package);
 
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("add_ios_project_static_lib", "path"), &EditorExportPlugin::add_apple_embedded_platform_project_static_lib);

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -43,6 +43,15 @@ class EditorExportPlugin : public RefCounted {
 	friend class EditorExportPlatform;
 	friend class EditorExportPreset;
 
+public:
+	// Data for an SPM dependency, collected via add_apple_embedded_platform_spm_package() during export
+	struct AppleEmbeddedSPMPackage {
+		String url;
+		String version;
+		Vector<String> products;
+	};
+
+private:
 	String export_base_path;
 	Ref<EditorExportPreset> export_preset;
 
@@ -62,6 +71,7 @@ class EditorExportPlugin : public RefCounted {
 	String apple_embedded_platform_linker_flags;
 	Vector<String> apple_embedded_platform_bundle_files;
 	String apple_embedded_platform_cpp_code;
+	Vector<AppleEmbeddedSPMPackage> apple_embedded_platform_spm_packages;
 
 	Vector<String> macos_plugin_files;
 
@@ -78,6 +88,7 @@ class EditorExportPlugin : public RefCounted {
 		apple_embedded_platform_plist_content = "";
 		apple_embedded_platform_linker_flags = "";
 		apple_embedded_platform_cpp_code = "";
+		apple_embedded_platform_spm_packages.clear();
 		macos_plugin_files.clear();
 	}
 
@@ -106,6 +117,7 @@ protected:
 	void add_apple_embedded_platform_linker_flags(const String &p_flags);
 	void add_apple_embedded_platform_bundle_file(const String &p_path);
 	void add_apple_embedded_platform_cpp_code(const String &p_code);
+	void add_apple_embedded_platform_spm_package(const String &p_url, const String &p_version, const PackedStringArray &p_products);
 	void add_macos_plugin_file(const String &p_path);
 
 	void skip();
@@ -192,6 +204,7 @@ public:
 	String get_apple_embedded_platform_linker_flags() const;
 	Vector<String> get_apple_embedded_platform_bundle_files() const;
 	String get_apple_embedded_platform_cpp_code() const;
+	Vector<AppleEmbeddedSPMPackage> get_apple_embedded_platform_spm_packages() const;
 	const Vector<String> &get_macos_plugin_files() const;
 	Variant get_option(const StringName &p_name) const;
 };


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/15079

## Notes:

**(1)** Kept the `PluginConfigAppleEmbedded::SPMPackage` and `EditorExportPlugin::AppleEmbeddedSPMPackage` struct duplication because the coupling required to remove it would be worse than the duplication itself.

The two structs live at different architectural layers:

- `PluginConfigAppleEmbedded::SPMPackage` belongs to the config-file parsing layer: it's a data record produced by reading a `.gdip` file and is Apple-platform-specific by definition.
- `EditorExportPlugin::AppleEmbeddedSPMPackage` belongs to the export plugin API layer: it's the public interface a cross-platform plugin class exposes to GDScript and C++ callers.

Any deduplication strategy has to bridge those two layers, and all the options have worse properties than the current 3-line field-copy:

**Option A** - `editor_export_plugin.h` includes `plugin_config_apple_embedded.h`
This pulls a platform-specific header (`plugin_config_apple_embedded`, which itself includes `core/io/config_file.h`, `core/string/ustring.h` etc. and carries Apple semantics in its name and constants) into a generic class that Android and desktop plugins also subclass. Every non-Apple export plugin would now silently carry Apple config-parsing baggage.

**Option B** - `plugin_config_apple_embedded.h` includes `editor_export_plugin.h`
Config file parser would need to know about the export plugin API, GDCLASS machinery, RefCounted, and the rest of the editor export system. That's a much heavier include for a struct that currently only needs `core/io/config_file.h`.

**Option C** - a shared third header (e.g., `editor/export/apple_embedded_export_types.h`)
This avoids the bad dependency directions, but the payoff doesn't justify a new file, in my opinion. The shared content would be a 5-line struct. Both files would gain an include, and the conversion site in `_export_apple_embedded_plugins` would go away, but we would have traded one boilerplate location for one new file that future contributors have to discover and remember exists.

