### PR TITLE
Fix crash in spriteframes editor

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2042,7 +2042,7 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 	}
 
 	bool show_node_edit = false;
-	if (selected->has_method("get_sprite_frames")) {
+	if (selected && selected->has_method("get_sprite_frames")) {
 		if (frames != selected->call("get_sprite_frames")) {
 			_remove_sprite_node();
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a regression from #108767

The spriteframes editor crashes when trying to open with no node selected in the scene tree. To reproduce, create a `Spriteframes` resource in the filesystem dock.
## Additional information

Readding the null check removed in that PR fixes the issue.