### PR TITLE
Add Action InputName for BaseButton to deprecate TouchScreenButton.

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -44,6 +44,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="action" type="StringName" setter="set_action" getter="get_action" default="&amp;&quot;&quot;">
+			The button's input action. Input actions can be handled with [InputEventAction].
+		</member>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
 			Determines when the button is considered clicked.
 		</member>

--- a/doc/classes/TouchScreenButton.xml
+++ b/doc/classes/TouchScreenButton.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TouchScreenButton" inherits="Node2D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="TouchScreenButton" inherits="Node2D" api_type="core" deprecated="Use [BaseButton] derived nodes instead. They supersede this class for all intents and purposes." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Button for touch screen devices for gameplay use.
 	</brief_description>
 	<description>
-		TouchScreenButton allows you to create on-screen buttons for touch devices. It's intended for gameplay use, such as a unit you have to touch to move. Unlike [Button], TouchScreenButton supports multitouch out of the box. Several TouchScreenButtons can be pressed at the same time with touch input.
+		TouchScreenButton allows you to create on-screen buttons for touch devices. It's intended for gameplay use, such as a unit you have to touch to move. [Button] and TouchScreenButton support multitouch out of the box. Several TouchScreenButtons can be pressed at the same time with touch input.
 		This node inherits from [Node2D]. Unlike with [Control] nodes, you cannot set anchors on it. If you want to create menus or user interfaces, you may want to use [Button] nodes instead. To make button nodes react to touch events, you can enable [member ProjectSettings.input_devices/pointing/emulate_mouse_from_touch] in the Project Settings.
 		You can configure TouchScreenButton to be visible only on touch devices, helping you develop your game both for desktop and mobile devices.
 	</description>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -31,10 +31,13 @@
 #include "base_button.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/string/string_name.h"
 #include "scene/gui/label.h"
 #include "scene/main/timer.h"
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
@@ -203,6 +206,7 @@ void BaseButton::_notification(int p_what) {
 			if (status.pressed_down_with_focus) {
 				status.pressed_down_with_focus = false;
 				emit_signal(SNAME("button_up"));
+				_action_release();
 			}
 		} break;
 
@@ -247,6 +251,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		if (!status.pressed_down_with_focus) {
 			status.pressed_down_with_focus = true;
 			emit_signal(SNAME("button_down"));
+			_action_press();
 		}
 	}
 
@@ -281,10 +286,35 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		if (status.pressed_down_with_focus) {
 			status.pressed_down_with_focus = false;
 			emit_signal(SNAME("button_up"));
+			_action_release();
 		}
 	}
 
 	queue_redraw();
+}
+
+void BaseButton::_action_press() {
+	if (action == StringName()) {
+		return;
+	}
+	Input::get_singleton()->action_press(action);
+	Ref<InputEventAction> iea;
+	iea.instantiate();
+	iea->set_action(action);
+	iea->set_pressed(true);
+	get_viewport()->push_input(iea, true);
+}
+
+void BaseButton::_action_release() {
+	if (action == StringName()) {
+		return;
+	}
+	Input::get_singleton()->action_release(action);
+	Ref<InputEventAction> iea;
+	iea.instantiate();
+	iea->set_action(action);
+	iea->set_pressed(false);
+	get_viewport()->push_input(iea, true);
 }
 
 void BaseButton::pressed() {
@@ -308,6 +338,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 		if (status.pressed_down_with_focus) {
 			status.pressed_down_with_focus = false;
 			emit_signal(SNAME("button_up"));
+			_action_release();
 		}
 	}
 	queue_accessibility_update();
@@ -554,6 +585,14 @@ Control *BaseButton::make_custom_tooltip(const String &p_text) const {
 	return label;
 }
 
+void BaseButton::set_action(const StringName &p_action) {
+	action = p_action;
+}
+
+StringName BaseButton::get_action() const {
+	return action;
+}
+
 void BaseButton::set_button_group(const Ref<ButtonGroup> &p_group) {
 	if (button_group.is_valid()) {
 		button_group->buttons.erase(this);
@@ -612,6 +651,9 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shortcut", "shortcut"), &BaseButton::set_shortcut);
 	ClassDB::bind_method(D_METHOD("get_shortcut"), &BaseButton::get_shortcut);
 
+	ClassDB::bind_method(D_METHOD("set_action", "action"), &BaseButton::set_action);
+	ClassDB::bind_method(D_METHOD("get_action"), &BaseButton::get_action);
+
 	ClassDB::bind_method(D_METHOD("set_button_group", "button_group"), &BaseButton::set_button_group);
 	ClassDB::bind_method(D_METHOD("get_button_group"), &BaseButton::get_button_group);
 
@@ -629,6 +671,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action", PROPERTY_HINT_INPUT_NAME, "show_builtin,loose_mode"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "button_group", PROPERTY_HINT_RESOURCE_TYPE, ButtonGroup::get_class_static()), "set_button_group", "get_button_group");
 
 	ADD_GROUP("Shortcut", "");

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -70,6 +70,7 @@ private:
 		int touch_index = -1;
 	} status;
 
+	StringName action;
 	Ref<ButtonGroup> button_group;
 
 	void _unpress_group();
@@ -77,6 +78,9 @@ private:
 	void _toggled(bool p_pressed);
 
 	void on_action_event(Ref<InputEvent> p_event);
+
+	void _action_press();
+	void _action_release();
 
 	Timer *shortcut_feedback_timer = nullptr;
 	bool in_shortcut_feedback = false;
@@ -142,6 +146,9 @@ public:
 	Ref<Shortcut> get_shortcut() const;
 
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
+
+	void set_action(const StringName &p_action);
+	StringName get_action() const;
 
 	void set_button_group(const Ref<ButtonGroup> &p_group);
 	Ref<ButtonGroup> get_button_group() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/3976

## Additional information

The Multitouch Support for `BaseButton` #110893 was the first step to depreciate the `TouchScreenButton`. This is a follow up PR to implement the remaining Action InputName to include all features from `TouchScreenButton` into the `BaseButton`.