### PR TITLE
Extend the selection highlight of rows in the animation libraries dialog

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -1012,6 +1012,7 @@ AnimationLibraryEditor::AnimationLibraryEditor() {
 	tree->set_hide_root(true);
 	tree->set_hide_folding(false);
 	tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
+	tree->set_select_mode(Tree::SELECT_ROW);
 	mc->add_child(tree);
 	tree->connect("item_edited", callable_mp(this, &AnimationLibraryEditor::_item_renamed));
 	tree->connect("button_clicked", callable_mp(this, &AnimationLibraryEditor::_button_pressed));


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes: https://github.com/godotengine/godot-proposals/issues/7142

| Before | After |
|--------|--------|
| <img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/6c13969b-2189-4485-9709-8385416bc976" /> | <img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/a3f36a34-a392-4383-a493-11d285024dc1" /> | 

## Additional information

Didn't see anything break after the change.