### PR TITLE
Fix sticky Ctrl/Cmd grid snap in 3D editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2291,16 +2291,6 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	}
 }
 
-void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(p_event.is_null());
-
-	if (!is_visible_in_tree()) {
-		return;
-	}
-
-	snap_key_enabled = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
-}
-
 void Node3DEditor::_sun_environ_settings_pressed() {
 	Vector2 pos = sun_environ_settings->get_screen_position() + sun_environ_settings->get_size();
 	sun_environ_popup->set_position(pos - Vector2(sun_environ_popup->get_contents_minimum_size().width / 2, 0));
@@ -3686,7 +3676,6 @@ Node3DEditor::Node3DEditor() {
 
 	selected = nullptr;
 
-	set_process_shortcut_input(true);
 	add_to_group(SceneStringName(_spatial_editor_group));
 
 	current_hover_gizmo_handle = -1;
@@ -4012,6 +4001,11 @@ void Node3DEditor::set_local_coords_enabled(bool on) const {
 
 bool Node3DEditor::is_preserve_children_transform_enabled() const {
 	return tool_option_button[Node3DEditor::TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->is_pressed();
+}
+
+bool Node3DEditor::is_snap_enabled() const {
+	const bool snap_key_down = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
+	return snap_enabled != snap_key_down;
 }
 
 bool Node3DEditor::is_vertex_snap_use_collision() const {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -224,7 +224,6 @@ private:
 	ConfirmationDialog *settings_dialog = nullptr;
 
 	bool snap_enabled = false;
-	bool snap_key_enabled = false;
 	bool vertex_snap_origin_mode = false;
 	bool vertex_snap_use_collision = false;
 	EditorSpinSlider *snap_translate = nullptr;
@@ -388,8 +387,6 @@ private:
 
 protected:
 	void _notification(int p_what);
-	//void _gui_input(InputEvent p_event);
-	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	static void _bind_methods();
 
@@ -411,7 +408,7 @@ public:
 	bool are_local_coords_enabled() const;
 	void set_local_coords_enabled(bool on) const;
 	bool is_preserve_children_transform_enabled() const;
-	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
+	bool is_snap_enabled() const;
 	bool is_vertex_snap_origin_mode() const { return vertex_snap_origin_mode; }
 	bool is_vertex_snap_use_collision() const;
 	real_t get_translate_snap() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Ctrl/Cmd toggles grid snapping in the 3D editor while held during object manipulation. In certain situations the toggle gets stuck (the key is treated as held even after it is released) until any key press refreshes the state.

- Closes #115616
- Closes #115368 
- Closes #59687 

## Additional information

The root cause is that the snap key state was cached and updated in `Node3DEditor::shortcut_input`, which was not called for the key release event in some cases. Cases I've tested:
- [macOS] **Cmd+Tab out of Godot:** if you hold Cmd+Tab until the macOS animations finish, the Cmd release doesn't reach Godot
- [macOS/Windows] **Ctrl/Cmd+S to save and releasing Ctrl/Cmd while the save progress dialog is up:** input events aren't forwarded to Godot windows while the save is in progress.
- [macOS/Windows] **Holding Ctrl/Cmd, opening project settings, releasing Ctrl/Cmd:** the release event is sent to the project settings window, never reaching `Node3DEditor`

The solution is to query the Ctrl/Cmd state directly from `Input` (which appears to always have the correct pressed state). `CanvasItemEditor` already does the same for snapping, so this looks like the correct approach. I also checked the original PR that implemented snapping with Ctrl/Cmd #16890 - there was no specific reason to cache the value.

ℹ️ I have tested the changes on macOS and on Windows 11 (via Parallels).

_AI assistance was used for codebase exploration, code reviewing and stylistic text editing. No generated code was used in the PR_