### PR TITLE
Fix crash when closing all script editor tabs

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3629,7 +3629,7 @@ void ScriptEditor::_history_back() {
 
 void ScriptEditor::_roll_back_to_pre_tab() {
 	Control *tselected = tab_container->get_current_tab_control();
-	if (history[history_pos].control != tselected) {
+	if (history_pos == -1 || history[history_pos].control != tselected) {
 		return;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120688 

## Additional information

`_roll_back_to_pre_tab()` is called for every closed tab after clicking "Close All". If `history_pos` is 0, then `history_pos` is set to -1 at the end of the function. The next closed tab tries `history[history_pos]` and crashes because of the negative index.

Added a `history_pos == -1` early return at the start of the function to fix this.
