### PR TITLE
Fix dialog title when adding animation inside the animation library editor

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -56,6 +56,7 @@ void AnimationLibraryEditor::set_animation_mixer(Object *p_mixer) {
 
 void AnimationLibraryEditor::_add_library() {
 	add_library_name->set_text("");
+	add_library_dialog->set_title(TTRC("Library Name:"));
 	add_library_dialog->popup_centered();
 	add_library_name->grab_focus();
 	adding_animation = false;
@@ -547,6 +548,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 		switch (p_id) {
 			case LIB_BUTTON_ADD: {
 				add_library_name->set_text("");
+				add_library_dialog->set_title(TTRC("Animation Name:"));
 				add_library_dialog->popup_centered();
 				add_library_name->grab_focus();
 				adding_animation = true;
@@ -969,7 +971,6 @@ AnimationLibraryEditor::AnimationLibraryEditor() {
 	file_dialog->connect("files_selected", callable_mp(this, &AnimationLibraryEditor::_load_files));
 
 	add_library_dialog = memnew(ConfirmationDialog);
-	add_library_dialog->set_title(TTRC("Library Name:"));
 
 	VBoxContainer *dialog_vb = memnew(VBoxContainer);
 	add_library_name = memnew(LineEdit);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120692

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
The dialog title was hardcoded to "Library Name:" at creation time. I changed it to set the correct title depending on the context before displaying the dialog.