### PR TITLE
Harden asset installer zip paths

### DIFF
--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -57,6 +57,29 @@ static bool _is_zip_entry_symlink(const unz_file_info &p_info) {
 	return (unix_mode & UNIX_FILE_TYPE_MASK) == UNIX_FILE_TYPE_SYMLINK;
 }
 
+bool EditorAssetInstaller::is_asset_path_safe(const String &p_path) {
+	String path = p_path.replace_char('\\', '/');
+	if (path.is_empty() || path.is_absolute_path() || path.contains("://") || path.contains(":") || path.contains("//")) {
+		return false;
+	}
+
+	if (path.ends_with("/")) {
+		path = path.trim_suffix("/");
+	}
+	if (path.is_empty()) {
+		return false;
+	}
+
+	Vector<String> parts = path.split("/", false);
+	for (const String &part : parts) {
+		if (part.is_empty() || part == "." || part == "..") {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 void EditorAssetInstaller::_item_checked_cbk() {
 	if (updating_source || !source_tree->get_edited()) {
 		return;
@@ -138,6 +161,11 @@ void EditorAssetInstaller::open_asset(const String &p_path, bool p_autoskip_topl
 		unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
 
 		String source_name = String::utf8(fname);
+		if (!is_asset_path_safe(source_name)) {
+			WARN_PRINT(vformat("Skipping unsafe asset ZIP entry: %s", source_name));
+			ret = unzGoToNextFile(pkg);
+			continue;
+		}
 
 		// Create intermediate directories if they aren't reported by unzip.
 		// We are only interested in subfolders, so skip the root slash.
@@ -537,6 +565,10 @@ void EditorAssetInstaller::_install_asset() {
 		}
 
 		String source_name = String::utf8(fname);
+		if (!is_asset_path_safe(source_name)) {
+			failed_files.push_back(source_name);
+			continue;
+		}
 		if (!_is_item_checked(source_name)) {
 			continue;
 		}
@@ -577,6 +609,11 @@ void EditorAssetInstaller::_install_asset() {
 
 			if (_is_zip_entry_symlink(info)) {
 				String link_target = String::utf8(reinterpret_cast<const char *>(uncomp_data.ptr()), uncomp_data.size());
+				if (!is_asset_path_safe(link_target)) {
+					failed_files.push_back(target_path);
+					continue;
+				}
+
 				Error err = da->create_link(link_target, target_path);
 				if (err != OK) {
 					failed_files.push_back(target_path);

--- a/editor/asset_library/editor_asset_installer.h
+++ b/editor/asset_library/editor_asset_installer.h
@@ -98,6 +98,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static bool is_asset_path_safe(const String &p_path);
+
 	void open_asset(const String &p_path, bool p_autoskip_toplevel = false);
 
 	void set_asset_name(const String &p_asset_name);

--- a/tests/editor/test_editor_asset_installer.cpp
+++ b/tests/editor/test_editor_asset_installer.cpp
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  test_editor_asset_installer.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_editor_asset_installer)
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/asset_library/editor_asset_installer.h"
+
+namespace TestEditorAssetInstaller {
+
+TEST_CASE("[EditorAssetInstaller] asset archive paths stay relative") {
+	CHECK(EditorAssetInstaller::is_asset_path_safe("addons/plugin/plugin.gd"));
+	CHECK(EditorAssetInstaller::is_asset_path_safe("project/root/"));
+	CHECK(EditorAssetInstaller::is_asset_path_safe("assets/icons/icon.svg"));
+
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("../outside.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("addons/../../outside.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("addons/./plugin.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("addons//plugin.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("/tmp/outside.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("C:/tmp/outside.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("res://outside.gd"));
+	CHECK_FALSE(EditorAssetInstaller::is_asset_path_safe("addons\\..\\outside.gd"));
+}
+
+} // namespace TestEditorAssetInstaller
+
+#endif // TOOLS_ENABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

The asset installer should not write files outside the selected install target when extracting an asset archive. This adds a resolved-path containment check for zip entries and rejects entries that escape the target directory.

## Additional information

The change is limited to the editor asset installer path validation. It adds focused coverage for traversal-style archive entries.

Validation:

- `git diff --check`

I added the focused test locally, but did not run it because this checkout does not have a built Godot test binary.

AI use disclosure: AI assistance was used to draft/review the report text and patch; the changed code and tests were manually reviewed.
