### PR TITLE
Add unit tests for Timer autostart and paused behavior

### DIFF
--- a/tests/scene/test_timer.cpp
+++ b/tests/scene/test_timer.cpp
@@ -206,4 +206,40 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 	memdelete(test_timer);
 }
 
+TEST_CASE("[SceneTree][Timer] Check Timer Autostart behavior") {
+	Timer *test_timer = memnew(Timer);
+
+	SUBCASE("Timer starts automatically when added to scene if autostart is enabled") {
+		test_timer->set_autostart(true);
+		SceneTree::get_singleton()->get_root()->add_child(test_timer);
+
+		CHECK_FALSE(test_timer->is_stopped());
+		CHECK(test_timer->get_time_left() > 0.0);
+	}
+
+	memdelete(test_timer);
+}
+
+TEST_CASE("[SceneTree][Timer] Check Paused Timer behavior") {
+	Timer *test_timer = memnew(Timer);
+	SceneTree::get_singleton()->get_root()->add_child(test_timer);
+
+	SUBCASE("Paused Timer doesn't process time and time left remains unchanged") {
+		test_timer->set_wait_time(2.0);
+		test_timer->start();
+		test_timer->set_paused(true);
+
+		// Simulate passing time
+		SceneTree::get_singleton()->process(1.0);
+
+		CHECK(Math::is_equal_approx(test_timer->get_time_left(), 2.0));
+
+		test_timer->set_paused(false);
+		SceneTree::get_singleton()->process(1.0);
+		CHECK(Math::is_equal_approx(test_timer->get_time_left(), 1.0));
+	}
+
+	memdelete(test_timer);
+}
+
 } // namespace TestTimer


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related #43440
- Supersedes #97794

## Additional information

This PR supersedes #97794, resolving the rebase merge conflicts and applying all reviewer feedback from the previous attempt (using tabs, removing redundant comments, and utilizing the `SUBCASE` macro as summarized by @madebydavid and originally requested by @Mickeon).

*Note on AI Usage:* AI was used as a tutor to understand how the Doctest `SUBCASE` macro works and to help figure out the specific compilation and testing command-line workflow for the engine.

**Local Testing Output:**
```text
./godot.linuxbsd.editor.x86_64 --test --tc="*Timer*"
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  6 |  6 passed | 0 failed | 1372 skipped
[doctest] assertions: 31 | 31 passed | 0 failed |
[doctest] Status: SUCCESS!