### PR TITLE
Fix manually-created BlendSpace2D triangles dropped on load which is reported here #120616

### DIFF
--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -371,8 +371,36 @@ void AnimationNodeBlendSpace2D::_set_triangles(const Vector<int> &p_triangles) {
 		return;
 	}
 	ERR_FAIL_COND(p_triangles.size() % 3 != 0);
+
+	triangles.clear();
 	for (int i = 0; i < p_triangles.size(); i += 3) {
-		add_triangle(p_triangles[i + 0], p_triangles[i + 1], p_triangles[i + 2]);
+		BlendTriangle t;
+		t.points[0] = p_triangles[i + 0];
+		t.points[1] = p_triangles[i + 1];
+		t.points[2] = p_triangles[i + 2];
+
+		SortArray<int> sort;
+		sort.sort(t.points, 3);
+
+		bool already_exists = false;
+		for (int j = 0; j < triangles.size(); j++) {
+			bool all_equal = true;
+			for (int k = 0; k < 3; k++) {
+				if (triangles[j].points[k] != t.points[k]) {
+					all_equal = false;
+					break;
+				}
+			}
+			if (all_equal) {
+				already_exists = true;
+				break;
+			}
+		}
+		if (already_exists) {
+			continue;
+		}
+
+		triangles.push_back(t);
 	}
 }
 


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120616

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->



## Cause
Blend point properties (`blend_point_*/node|pos|name`) are serialized through
`_get_property_list()`. `Object` emits the override's properties *after* the
ClassDB-registered ones, and `triangles` is a ClassDB property — so `triangles`
is written (and therefore deserialized) *before* any blend point exists.
On load, `_set_triangles()` ran while `blend_points_used == 0`, so every
`add_triangle()` call tripped `ERR_FAIL_INDEX(p_x, blend_points_used)` and was
discarded. The now-empty triangle list was written back on the next save,
permanently wiping the manual triangles.
This is a regression from #110369, which moved blend point serialization out of
the property registration that previously came *before* `triangles`. 

_Used AI to analyze the regression._

## Fix
`_set_triangles()` now stores the triangle indices directly instead of routing
through `add_triangle()`, so loading no longer depends on the blend points
being deserialized first. The indices become valid once the blend points
finish loading. The sort and duplicate-rejection that `add_triangle()`
performed are preserved.
Because the fix makes loading order-independent, it also **recovers projects
already saved with the broken ordering** rather than only preventing new
breakage.
## Testing
- Disable auto-triangulation, create triangles manually, save, reopen → triangles persist, no errors.
- A project saved by an affected build now loads its triangles correctly.