### PR TITLE
Fix orthographic camera directional shadow culling

### DIFF
--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -147,15 +147,20 @@ bool RenderingLightCuller::_prepare_light(const RendererSceneCull::Instance &p_i
 		Plane boundary_planes[5];
 		{
 			constexpr const int MAX_PLANES = 5;
+			// Orthogonal cameras have fixed max shadow distance, determined by the camera far plane.
+			// That must be accounted for, or else GH-120457 happens.
+			// For perspective cameras, shadow far must also never be further than the camera far plane (otherwise things break).
+			float camera_far = data.camera_projection.get_z_far();
+			float shadow_far = data.camera_projection.is_orthogonal() ? camera_far : MIN(lsource.range, camera_far);
 			real_t plane_distances[MAX_PLANES] = {
 				data.camera_projection.get_z_near(),
-				lsource.cascade_splits[0] * lsource.range,
-				lsource.cascade_splits[1] * lsource.range,
-				lsource.cascade_splits[2] * lsource.range,
-				lsource.range,
+				lsource.cascade_splits[0] * shadow_far,
+				lsource.cascade_splits[1] * shadow_far,
+				lsource.cascade_splits[2] * shadow_far,
+				shadow_far,
 			};
-			//If not 4 cascades, replace last used cascade plane distance with max shadow range (shadow far plane distance).
-			plane_distances[used_planes - 1] = lsource.range;
+			// If not 4 cascades, replace last used cascade plane distance with max shadow range (shadow far plane distance).
+			plane_distances[used_planes - 1] = shadow_far;
 #ifdef LIGHT_CULLER_DEBUG_LOGGING
 			if (is_logging()) {
 				print_line("cascade split planes (first " + itos(used_planes) + " used): " +


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes #120457

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR pins the max shadow distance of orthogonal cameras to the camera's far plane, restoring the behaviour from versions before 4.7.

As an extra I also fixed some broken shadow behaviour for projective cameras when the max shadow distance was larger than the camera far, while I was at it. There seems to be no issue opened about this, but the behaviour was still broken.

https://github.com/user-attachments/assets/9be82d4b-b59d-4965-acc2-12ee9a24a799

