### PR TITLE
GDShader: Add implicit conversion of `bool` constants to `float`, `int`, and `uint`

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4265,6 +4265,21 @@ bool ShaderLanguage::convert_constant(ConstantNode *p_constant, DataType p_to_ty
 			p_value->sint = p_constant->values[0].uint;
 		}
 		return true;
+	} else if (p_constant->datatype == TYPE_BOOL && p_to_type == TYPE_FLOAT) {
+		if (p_value) {
+			p_value->real = p_constant->values[0].boolean ? 1.0f : 0.0f;
+		}
+		return true;
+	} else if (p_constant->datatype == TYPE_BOOL && p_to_type == TYPE_UINT) {
+		if (p_value) {
+			p_value->uint = p_constant->values[0].boolean ? 1U : 0U;
+		}
+		return true;
+	} else if (p_constant->datatype == TYPE_BOOL && p_to_type == TYPE_INT) {
+		if (p_value) {
+			p_value->sint = p_constant->values[0].boolean ? 1 : 0;
+		}
+		return true;
 	} else {
 		return false;
 	}
@@ -4295,6 +4310,7 @@ bool ShaderLanguage::is_float_type(DataType p_type) {
 		}
 	}
 }
+
 bool ShaderLanguage::is_sampler_type(DataType p_type) {
 	return p_type > TYPE_MAT4 && p_type < TYPE_STRUCT;
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120673

## Additional information

This PR adds support for implicit conversion of `bool` constants to `float`, `int`, and `uint` during constant conversion.
Currently, the shader compiler rejects boolean literals in constructors unless they are explicitly cast, which breaks valid GLSL cases like `vec3(false)`

Boolean constant values are now treated as:
- `false → 0`
- `true → 1`

This allows expressions such as:
```glsl
const vec3 v = vec3(false);
const ivec4 i = ivec4(true);
const uvec2 u = uvec2(false);

vec3 v2 = vec3(false);
ivec4 i2 = ivec4(true);
uvec2 u2 = uvec2(false);
```

## Testing 

Tested locally with the following scenarios:

1. `vec3(true)` -  evaluates to `vec3(1.0f, 1.0f, 1.0f)` (pass)
2. `vec4(false, true, false, true)` - evaluates to `vec4(0.0f, 1.0f, 0.0f, 1.0f )`  (pass)
3.  `vec3 v = vec3(1 + true);` - throws compile error (expected)
4. `const float arr[] = {true};`  - throws compile error (expected)
5. `float x = false;` - throws compile error (expected, variables need explicit cast)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
