### PR TITLE
X11: Don't sleep the input events when exiting

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4691,8 +4691,10 @@ bool DisplayServerX11::_wait_for_events(int timeout_seconds, int timeout_microse
 
 void DisplayServerX11::_poll_events() {
 	while (!events_thread_done.is_set()) {
-		// Wait with a shorter timeout from the events thread to avoid delayed inputs.
-		_wait_for_events(0, 1000);
+		if (!exiting) {
+			// Wait with a shorter timeout from the events thread to avoid delayed inputs.
+			_wait_for_events(0, 1000);
+		}
 
 		// Process events from the queue.
 		{
@@ -7468,6 +7470,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 }
 
 DisplayServerX11::~DisplayServerX11() {
+	exiting = true;
+
 	// Send owned clipboard data to clipboard manager before exit.
 	Window x11_main_window = windows[DisplayServerEnums::MAIN_WINDOW_ID].x11_window;
 	_clipboard_transfer_ownership(XA_PRIMARY, x11_main_window);

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -331,6 +331,7 @@ class DisplayServerX11 : public DisplayServer {
 	bool xshaped_ext_ok = true;
 	bool xwayland = false;
 	bool kde5_embed_workaround = false; // Workaround embedded game visibility on KDE 5 (GH-102043).
+	bool exiting = false; // Workaround to prevent sleeping input events when exiting (GH-63460).
 
 	struct Property {
 		unsigned char *data;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #63460.

## Additional information

This is Mk. II of #106233.
It adds a new `exiting` boolean which is used when exiting in X11 to prevent sleeping input events.

This PR has been made with 100% human meat.