### PR TITLE
X11: prevent premature closing of popup menu

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4840,6 +4840,12 @@ bool DisplayServerX11::mouse_process_popups() {
 				if (((mask & Button1Mask) || (mask & Button2Mask) || (mask & Button3Mask) || (mask & Button4Mask) || (mask & Button5Mask))) {
 					List<DisplayServerEnums::WindowID>::Element *C = nullptr;
 					List<DisplayServerEnums::WindowID>::Element *E = popup_list.back();
+					
+					//Prevent engine from false closing popup menu
+					if(last_mouse_monitor_mask == 0){
+						last_mouse_monitor_mask = mask;
+					}
+					
 					// Find top popup to close.
 					while (E) {
 						// Popup window area.

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4840,12 +4840,12 @@ bool DisplayServerX11::mouse_process_popups() {
 				if (((mask & Button1Mask) || (mask & Button2Mask) || (mask & Button3Mask) || (mask & Button4Mask) || (mask & Button5Mask))) {
 					List<DisplayServerEnums::WindowID>::Element *C = nullptr;
 					List<DisplayServerEnums::WindowID>::Element *E = popup_list.back();
-					
+
 					// Prevent premature closing of popup menu.
-					if(last_mouse_monitor_mask == 0){
+					if (last_mouse_monitor_mask == 0) {
 						last_mouse_monitor_mask = mask;
 					}
-					
+
 					// Find top popup to close.
 					while (E) {
 						// Popup window area.

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4841,7 +4841,7 @@ bool DisplayServerX11::mouse_process_popups() {
 					List<DisplayServerEnums::WindowID>::Element *C = nullptr;
 					List<DisplayServerEnums::WindowID>::Element *E = popup_list.back();
 					
-					//Prevent engine from false closing popup menu
+					// Prevent premature closing of popup menu.
 					if(last_mouse_monitor_mask == 0){
 						last_mouse_monitor_mask = mask;
 					}


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120636

## Additional information

Just added small if statement that checks if last_mouse_monitor_mask is zero and if that's true, it sets value of current mask which prevents false close window event

AI was used only to ask some details about X11, it didn't write any code

Test before fix: https://youtu.be/e50zRwaa2ro

Test after fix: https://youtu.be/pTh8O7c3oLU