### PR TITLE
Do not serialize export options that do not have the `PROPERTY_USAGE_STORAGE` flag

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -110,7 +110,7 @@ void EditorExport::_save() {
 			PropertyInfo *prop = preset->properties.getptr(E.key);
 			if (prop && prop->usage & PROPERTY_USAGE_SECRET) {
 				credentials->set_value(option_section, E.key, E.value);
-			} else {
+			} else if (prop && prop->usage & PROPERTY_USAGE_STORAGE) {
 				config->set_value(option_section, E.key, E.value);
 			}
 		}

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -108,9 +108,9 @@ void EditorExport::_save() {
 
 		for (const KeyValue<StringName, Variant> &E : preset->values) {
 			PropertyInfo *prop = preset->properties.getptr(E.key);
-			if (prop && prop->usage & PROPERTY_USAGE_SECRET) {
+			if (prop && prop->usage & PROPERTY_USAGE_SECRET && prop->usage & PROPERTY_USAGE_STORAGE) {
 				credentials->set_value(option_section, E.key, E.value);
-			} else {
+			} else if (prop && prop->usage & PROPERTY_USAGE_STORAGE) {
 				config->set_value(option_section, E.key, E.value);
 			}
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120720

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This commit adds a check if a property has the storage flag present, only if that's present it will serialize it.