### PR TITLE
Android: Fix EditorSettings not instantiated error when running game

### DIFF
--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -549,9 +549,11 @@ JNIEXPORT jobjectArray JNICALL Java_org_godotengine_godot_GodotLib_getRendererIn
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getEditorSetting(JNIEnv *env, jclass clazz, jstring p_setting_key) {
 	String editor_setting_value = "";
 #ifdef TOOLS_ENABLED
-	String godot_setting_key = jstring_to_string(p_setting_key, env);
-	Variant editor_setting = EDITOR_GET(godot_setting_key);
-	editor_setting_value = (editor_setting.get_type() == Variant::NIL) ? "" : editor_setting;
+	if (EditorSettings::get_singleton() != nullptr) {
+		String godot_setting_key = jstring_to_string(p_setting_key, env);
+		Variant editor_setting = EDITOR_GET(godot_setting_key);
+		editor_setting_value = (editor_setting.get_type() == Variant::NIL) ? "" : editor_setting;
+	}
 #else
 	WARN_PRINT("Access to the Editor Settings in only available on Editor builds");
 #endif


### PR DESCRIPTION
Add null check in getEditorSetting JNI call to match setEditorSetting. Fixes error when game runner process calls getEditorSetting before EditorSettings is initialized.

Add null check in getEditorSetting JNI call

Adds a null check for `EditorSettings::get_singleton()` in `getEditorSetting` to match the existing pattern in `setEditorSetting`.

When the game runner process (GodotGame) starts, it calls `getEditorSetting` for various touchscreen settings before `EditorSettings` is instantiated, causing the error during PIE:

