### PR TITLE
GDScript: Display warnings and errors in editor tooltip

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1499,6 +1499,9 @@
 		<member name="text_editor/appearance/whitespace/line_spacing" type="int" setter="" getter="">
 			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying fewer lines on screen. Negative values allow for even more compact text, but may look broken with certain fonts.
 		</member>
+		<member name="text_editor/behavior/diagnostics/enable_tooltips" type="bool" setter="" getter="">
+			If [code]true[/code], warning and error messages will appear in tooltips when hovering over code.
+		</member>
 		<member name="text_editor/behavior/documentation/enable_tooltips" type="bool" setter="" getter="">
 			If [code]true[/code], documentation tooltips will appear when hovering over a symbol.
 		</member>

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -5080,7 +5080,8 @@ Control *EditorHelpBitTooltip::make_tooltip(
 		const String &p_symbol,
 		const String &p_prologue,
 		bool p_use_class_prefix,
-		bool p_shortcut) {
+		bool p_shortcut,
+		const String &p_diagnostics) {
 	ERR_FAIL_NULL_V(p_target, _make_invisible_control());
 
 	// Show the custom tooltip only if it is not already visible.
@@ -5090,14 +5091,26 @@ Control *EditorHelpBitTooltip::make_tooltip(
 		return _make_invisible_control();
 	}
 
-	EditorHelpBit *help_bit = memnew(EditorHelpBit(p_symbol, p_prologue, p_use_class_prefix, false, true));
-
 	EditorHelpBitTooltip *tooltip = memnew(EditorHelpBitTooltip(p_target, p_shortcut));
-	help_bit->connect("request_hide", callable_mp(static_cast<Node *>(tooltip), &Node::queue_free));
-	tooltip->add_child(help_bit);
+
+	bool has_diagnostics = !p_diagnostics.is_empty();
+	bool has_doc_tooltip = !p_symbol.is_empty() || !p_prologue.is_empty();
+
+	if (has_diagnostics) {
+		tooltip->diagnostics_label->set_text(p_diagnostics);
+	} else {
+		tooltip->diagnostics_label->hide();
+	}
+
+	if (has_doc_tooltip) {
+		EditorHelpBit *help_bit = memnew(EditorHelpBit(p_symbol, p_prologue, p_use_class_prefix, false, true));
+		help_bit->connect("request_hide", callable_mp(static_cast<Node *>(tooltip), &Node::queue_free));
+		tooltip->vbox->add_child(help_bit);
+		help_bit->update_content_height();
+	}
+
 	p_target->add_child(tooltip);
 
-	help_bit->update_content_height();
 	if (tooltip->is_shortcut_pressed()) {
 		tooltip->_shortcut_pressed(p_target);
 	} else {
@@ -5158,6 +5171,19 @@ EditorHelpBitTooltip::EditorHelpBitTooltip(Control *p_target, bool p_shortcut) {
 	_is_shortcut_pressed = p_shortcut;
 
 	set_theme_type_variation("TooltipPanel");
+
+	diagnostics_label = memnew(RichTextLabel);
+	diagnostics_label->set_theme_type_variation("EditorHelpBitTooltipTitle");
+	diagnostics_label->set_custom_minimum_size(Size2(640 * EDSCALE, 0)); // GH-93031. Set the minimum width even if `fit_content` is true.
+	diagnostics_label->set_fit_content(true);
+	diagnostics_label->set_selection_enabled(true);
+	diagnostics_label->set_context_menu_enabled(false);
+	diagnostics_label->set_use_bbcode(true);
+
+	vbox = memnew(VBoxContainer);
+	vbox->add_child(diagnostics_label);
+
+	add_child(vbox);
 
 	timer = memnew(Timer);
 	timer->set_wait_time(0.25);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -381,6 +381,9 @@ class EditorHelpBitTooltip : public PopupPanel {
 
 	static bool _is_tooltip_visible;
 
+	RichTextLabel *diagnostics_label;
+	VBoxContainer *vbox;
+
 	Timer *timer = nullptr;
 	uint64_t _enter_tree_time = 0;
 	bool _is_mouse_inside_tooltip = false;
@@ -402,7 +405,8 @@ public:
 			const String &p_symbol,
 			const String &p_prologue = String(),
 			bool p_use_class_prefix = false,
-			bool p_shortcut = false);
+			bool p_shortcut = false,
+			const String &p_diagnostics = String());
 
 	void popup_under_position(const Point2 &p_point);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -682,6 +682,9 @@ void ScriptTextEditor::_inline_object_handle_click(const Dictionary &p_info, con
 	inline_color_start = p_info["column"];
 	inline_color_end = p_info["color_end"];
 
+	// Reset tooltip hover timer.
+	hover_tooltip_timer->stop();
+
 	_update_color_constructor_options();
 	inline_color_options->select(p_info["color_mode"]);
 
@@ -1382,12 +1385,57 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 }
 
 void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, int p_column, bool p_shortcut) {
-	if (!EDITOR_GET("text_editor/behavior/documentation/enable_tooltips").booleanize()) {
+	bool enable_docs = EDITOR_GET("text_editor/behavior/documentation/enable_tooltips").booleanize();
+	bool enable_diagnostics = EDITOR_GET("text_editor/behavior/diagnostics/enable_tooltips").booleanize();
+
+	String diagnostic_strings_concatenated;
+	if (enable_diagnostics) {
+		// Look for any errors that include this location.
+		PackedStringArray error_strings;
+		for (const EditorLanguage::ScriptError &e : errors) {
+			if (_is_line_col_in_range(p_row + 1, p_column + 1, e.start_line, e.start_column, e.end_line, e.end_column)) {
+				error_strings.append(e.message);
+			}
+		}
+
+		// Look for any warnings that include this location.
+		PackedStringArray warning_strings;
+		for (const EditorLanguage::Warning &w : warnings) {
+			if (_is_line_col_in_range(p_row + 1, p_column + 1, w.start_line, w.start_column, w.end_line, w.end_column)) {
+				warning_strings.append(vformat("%s: %s", w.string_code, w.message));
+			}
+		}
+
+		if (!error_strings.is_empty()) {
+			const Color error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			diagnostic_strings_concatenated += vformat("[color=%s]", error_color.to_html());
+			diagnostic_strings_concatenated += String("\n").join(error_strings).replace("[", "[lb]");
+			diagnostic_strings_concatenated += "[/color]";
+		}
+		if (!error_strings.is_empty() && !warning_strings.is_empty()) {
+			diagnostic_strings_concatenated += "\n";
+		}
+		if (!warning_strings.is_empty()) {
+			const Color warning_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+			diagnostic_strings_concatenated += vformat("[color=%s]", warning_color.to_html());
+			diagnostic_strings_concatenated += String("\n").join(warning_strings).replace("[", "[lb]");
+			diagnostic_strings_concatenated += "[/color]";
+		}
+	}
+
+	// If documentation tooltips aren't enabled, there's no need to process the rest of the method.
+	// We can just pop up the tooltip with the diagnostics, if they are enabled (if not, we don't need
+	// to do anything at all).
+	if (!enable_docs || p_symbol.is_empty()) {
+		if (enable_diagnostics) {
+			Control *tmp = EditorHelpBitTooltip::make_tooltip(code_editor->get_text_editor(), String(), String(), true, p_shortcut, diagnostic_strings_concatenated);
+			memdelete(tmp);
+		}
 		return;
 	}
 
 	if (p_symbol.begins_with("res://") || p_symbol.begins_with("uid://")) {
-		Control *tmp = EditorHelpBitTooltip::make_tooltip(code_editor->get_text_editor(), "resource||" + p_symbol);
+		Control *tmp = EditorHelpBitTooltip::make_tooltip(code_editor->get_text_editor(), "resource||" + p_symbol, String(), false, false, diagnostic_strings_concatenated);
 		memdelete(tmp);
 		return;
 	}
@@ -1499,8 +1547,8 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 		debug_value = TTR("Current value: ") + debug_value.replace("[", "[lb]");
 	}
 
-	if (!doc_symbol.is_empty() || !debug_value.is_empty()) {
-		Control *tmp = EditorHelpBitTooltip::make_tooltip(code_editor->get_text_editor(), doc_symbol, debug_value, true, p_shortcut);
+	if (!doc_symbol.is_empty() || !debug_value.is_empty() || !diagnostic_strings_concatenated.is_empty()) {
+		Control *tmp = EditorHelpBitTooltip::make_tooltip(code_editor->get_text_editor(), doc_symbol, debug_value, true, p_shortcut, diagnostic_strings_concatenated);
 		memdelete(tmp);
 	}
 }
@@ -1891,8 +1939,16 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	code_editor->toggle_inline_comment(delimiter);
 }
 
+void ScriptTextEditor::_apply_project_settings() {
+	hover_tooltip_timer->set_wait_time(GLOBAL_GET_CACHED(double, "gui/timers/tooltip_delay_sec"));
+}
+
 void ScriptTextEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			_apply_project_settings();
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ScriptTextEditor::_apply_project_settings));
+		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (is_ready() && is_visible_in_tree()) {
 				_update_errors();
@@ -1918,6 +1974,9 @@ void ScriptTextEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_DRAG_END: {
 			drag_info_label->hide();
+		} break;
+		case NOTIFICATION_MOUSE_EXIT: {
+			hover_tooltip_timer->stop();
 		} break;
 	}
 }
@@ -2419,6 +2478,7 @@ void ScriptTextEditor::_assign_dragged_export_variables() {
 void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 	Ref<InputEventMouseButton> mb = p_ev;
 	Ref<InputEventKey> k = p_ev;
+	Ref<InputEventMouseMotion> mm = p_ev;
 	Point2 local_pos;
 	bool create_menu = false;
 
@@ -2430,6 +2490,22 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 		tx->adjust_viewport_to_caret(0);
 		local_pos = tx->get_caret_draw_pos(0);
 		create_menu = true;
+	} else if (mm.is_valid() && p_ev->get_device() != InputEvent::DEVICE_ID_EMULATION) {
+		Vector2i mpos = mm->get_position();
+		if (tx->is_layout_rtl()) {
+			mpos.x = tx->get_size().x - mpos.x;
+		}
+
+		Point2i last_hover_tooltip_pos = hover_tooltip_pos;
+		hover_tooltip_pos = tx->get_line_column_at_pos(mpos, false, false);
+		if (hover_tooltip_pos != last_hover_tooltip_pos) {
+			hover_tooltip_timer->start();
+		}
+	}
+
+	// Matching behavior in CodeEdit::gui_input (see GH-121311)
+	if (k.is_valid() && k->is_pressed() && k->get_keycode() != Key::CTRL && k->get_keycode() != Key::ALT && k->get_keycode() != Key::SHIFT && k->get_keycode() != Key::META && k->get_keycode() != Key::CAPSLOCK) {
+		hover_tooltip_timer->stop();
 	}
 
 	if (create_menu) {
@@ -2617,7 +2693,6 @@ void ScriptTextEditor::register_editor() {
 void ScriptTextEditor::_enable_code_editor() {
 	code_editor->connect("show_errors_panel", callable_mp(this, &ScriptTextEditor::_show_errors_panel));
 	code_editor->get_text_editor()->connect("symbol_lookup", callable_mp(this, &ScriptTextEditor::_lookup_symbol));
-	code_editor->get_text_editor()->connect("symbol_hovered", callable_mp(this, &ScriptTextEditor::_show_symbol_tooltip).bind(false));
 	code_editor->get_text_editor()->connect("symbol_validate", callable_mp(this, &ScriptTextEditor::_validate_symbol));
 	code_editor->get_text_editor()->connect("gutter_added", callable_mp(this, &ScriptTextEditor::_update_gutter_indexes));
 	code_editor->get_text_editor()->connect("gutter_removed", callable_mp(this, &ScriptTextEditor::_update_gutter_indexes));
@@ -2634,6 +2709,20 @@ void ScriptTextEditor::_enable_code_editor() {
 	add_child(quick_open);
 
 	add_child(connection_info_dialog);
+}
+
+void ScriptTextEditor::_on_hover_tooltip_timer_timeout() {
+	CodeEdit *ce = code_editor->get_text_editor();
+	const String word = ce->get_lookup_word(hover_tooltip_pos.y, hover_tooltip_pos.x);
+	const int line = hover_tooltip_pos.y;
+	const int column = hover_tooltip_pos.x;
+
+	bool is_mouse_over_code_completion_popup = ce->get_code_completion_selected_index() != -1 && ce->get_code_completion_rect().has_point(get_local_mouse_position());
+	if (line < 0 || column < 0 || Input::get_singleton()->is_anything_pressed() || is_mouse_over_code_completion_popup) {
+		return;
+	}
+
+	_show_symbol_tooltip(word, line, column, false);
 }
 
 ScriptTextEditor::ScriptTextEditor() {
@@ -2678,8 +2767,6 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->add_child(drag_info_label);
 	drag_info_label->hide();
 
-	code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
-
 	inline_color_popup = memnew(PopupPanel);
 	add_child(inline_color_popup);
 
@@ -2698,6 +2785,14 @@ ScriptTextEditor::ScriptTextEditor() {
 	inline_color_picker->get_slider_container()->add_sibling(inline_color_options);
 
 	connection_info_dialog = memnew(ConnectionInfoDialog);
+
+	// ScriptTextEditor uses its own timer instead of the CodeEdit symbol_hovered signal
+	// so that it can detect hovering over non-symbols for the purposes of warning/error tooltips.
+	hover_tooltip_timer = memnew(Timer);
+	hover_tooltip_timer->set_wait_time(0.5);
+	hover_tooltip_timer->set_one_shot(true);
+	hover_tooltip_timer->connect("timeout", callable_mp(this, &ScriptTextEditor::_on_hover_tooltip_timer_timeout));
+	add_child(hover_tooltip_timer, false, INTERNAL_MODE_FRONT);
 
 	update_settings();
 	set_process_shortcut_input(true);

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -139,6 +139,16 @@ class ScriptTextEditor : public CodeEditorBase {
 	String _get_dropped_resource_as_exported_member(const Ref<Resource> &p_resource, const Vector<ObjectID> &p_script_instance_obj_ids);
 	void _assign_dragged_export_variables();
 
+	Timer *hover_tooltip_timer = nullptr;
+	Point2i hover_tooltip_pos;
+	void _on_hover_tooltip_timer_timeout();
+	void _apply_project_settings();
+	static bool _is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
+		// TODO: Duplicate of logic from TextEdit::_is_line_col_in_range, minus the include_edges logic.
+		// At some point, this function should probably be unified.
+		return (p_line >= p_from_line && p_line <= p_to_line && (p_line > p_from_line || p_column >= p_from_column) && (p_line < p_to_line || p_column <= p_to_column));
+	}
+
 	static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource);
 
 protected:

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -870,6 +870,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);
 	_initial_set("text_editor/behavior/files/drop_preload_resources_as_uid", true, true);
 
+	// Behavior: Diagnostics
+	_initial_set("text_editor/behavior/diagnostics/enable_tooltips", true, true);
+
 	// Behavior: Documentation
 	_initial_set("text_editor/behavior/documentation/enable_tooltips", true, true);
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -537,6 +537,8 @@ public:
 	void confirm_code_completion(bool p_replace = false);
 	void cancel_code_completion();
 
+	Rect2i get_code_completion_rect() const { return code_completion_rect; }
+
 	/* Line length guidelines */
 	void set_line_length_guidelines(TypedArray<int> p_guideline_columns);
 	TypedArray<int> get_line_length_guidelines() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Along with https://github.com/godotengine/godot/pull/119588:
  - Closes https://github.com/godotengine/godot-proposals/issues/1005
  - Closes https://github.com/godotengine/godot-proposals/issues/13105

## Additional information

With this PR, when a user hovers their cursor over a portion of code causing a warning or error, the tooltip that appears will provide the warning/error text.

https://github.com/user-attachments/assets/caabfb91-716d-4aa9-acaa-e675f629a0e0 