### PR TITLE
Add `get_fft` method to `AudioEffectSpectrumAnalyzerInstance`

### DIFF
--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -13,6 +13,12 @@
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<methods>
+		<method name="get_fft" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns the result of the last FFT performed. The higher the index, the higher the frequency it represents. The [code]x[/code] components of the return value represent the left stereo channel, and [code]y[/code] represent the right channel.
+			</description>
+		</method>
 		<method name="get_magnitude_for_frequency_range" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="from_hz" type="float" />

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -13,6 +13,13 @@
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<methods>
+		<method name="get_fft" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns the result of the last FFT performed. The higher the index, the higher the frequency it represents. The [code]x[/code] components of the return value represent the left stereo channel, and [code]y[/code] represent the right channel.
+				[b]Note:[/b] This function should not be called from audio thread.
+			</description>
+		</method>
 		<method name="get_magnitude_for_frequency_range" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="from_hz" type="float" />

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -151,6 +151,7 @@ void AudioEffectSpectrumAnalyzerInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_magnitude_for_frequency_range", "from_hz", "to_hz", "mode"), &AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range, DEFVAL(MAGNITUDE_MAX));
 	BIND_ENUM_CONSTANT(MAGNITUDE_AVERAGE);
 	BIND_ENUM_CONSTANT(MAGNITUDE_MAX);
+	ClassDB::bind_method(D_METHOD("get_fft"), &AudioEffectSpectrumAnalyzerInstance::get_fft);
 }
 
 Vector2 AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode) const {
@@ -187,6 +188,19 @@ Vector2 AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range(f
 
 		return max;
 	}
+}
+
+PackedVector2Array AudioEffectSpectrumAnalyzerInstance::get_fft() const {
+	int fft_index = fft_pos;
+	const AudioFrame *last_fft = fft_history[fft_index].ptr();
+
+	PackedVector2Array ret;
+	ret.resize(fft_size);
+	for (int i = 0; i < fft_size; i++) {
+		ret.write[i] = Vector2(last_fft[i].left, last_fft[i].right);
+	}
+
+	return ret;
 }
 
 Ref<AudioEffectInstance> AudioEffectSpectrumAnalyzer::instantiate() {

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -149,6 +149,7 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 
 void AudioEffectSpectrumAnalyzerInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_magnitude_for_frequency_range", "from_hz", "to_hz", "mode"), &AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range, DEFVAL(MAGNITUDE_MAX));
+	ClassDB::bind_method(D_METHOD("get_fft"), &AudioEffectSpectrumAnalyzerInstance::get_fft);
 	BIND_ENUM_CONSTANT(MAGNITUDE_AVERAGE);
 	BIND_ENUM_CONSTANT(MAGNITUDE_MAX);
 }
@@ -187,6 +188,20 @@ Vector2 AudioEffectSpectrumAnalyzerInstance::get_magnitude_for_frequency_range(f
 
 		return max;
 	}
+}
+
+Vector<Vector2> AudioEffectSpectrumAnalyzerInstance::get_fft() const {
+	int fft_index = fft_pos;
+	const AudioFrame *last_fft = fft_history[fft_index].ptr();
+
+	Vector<Vector2> ret;
+	ret.resize_uninitialized(fft_size);
+	Vector2 *retw = ret.ptrw();
+	for (int i = 0; i < fft_size; i++) {
+		retw[i] = Vector2(last_fft[i].left, last_fft[i].right);
+	}
+
+	return ret;
 }
 
 Ref<AudioEffectInstance> AudioEffectSpectrumAnalyzer::instantiate() {

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.h
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.h
@@ -61,6 +61,7 @@ protected:
 public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 	Vector2 get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode = MAGNITUDE_MAX) const;
+	PackedVector2Array get_fft() const;
 };
 
 VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzerInstance::MagnitudeMode)

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.h
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.h
@@ -61,6 +61,7 @@ protected:
 public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 	Vector2 get_magnitude_for_frequency_range(float p_begin, float p_end, MagnitudeMode p_mode = MAGNITUDE_MAX) const;
+	Vector<Vector2> get_fft() const;
 };
 
 VARIANT_ENUM_CAST(AudioEffectSpectrumAnalyzerInstance::MagnitudeMode)


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/5910
- Addresses https://github.com/godotengine/godot-proposals/issues/13395 (read below)

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR adds the method `get_fft()` to `AudioEffectSpectrumAnalyzerInstance` which returns the entire last FFT array.
The currect workflow of having to loop through the entire spectrum and getting thousands of magnitudes via `get_magnitude_for_frequency_range()` is not ideal. One of the main reasons is that the returned data does not accurately reflect actual FFT results (the average or maximum magnitude within a certain frequency range is calculated instead).
Internally, the data we want already exists in `fft_history`, so this PR is basically exposing part of it.

Regarding the proposal this PR simply "addresses", the proposal seems to ask for the entire FFT buffer (`fft_history`). I don't think it's super necessary, I don't know exactly how to implement (2D array), and I think this could be reconstructed with the method implemented by this PR.

Would appreciate someone checking the code, making sure nothing important was missed. Functionally, this works and I have tested it.
I personally have reasons to want this implement, since I have an audio visualizer made in Godot. This new method runs faster than looping with `get_magnitude_for_frequency_range()`.