### PR TITLE
Fix double free of `custom_ci` RID in `Tree` destructor.

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -7668,7 +7668,6 @@ Tree::~Tree() {
 	RenderingServer::get_singleton()->free_rid(content_ci);
 	RenderingServer::get_singleton()->free_rid(custom_ci);
 	RenderingServer::get_singleton()->free_rid(header_ci);
-	RenderingServer::get_singleton()->free_rid(custom_ci);
 	RenderingServer::get_singleton()->free_rid(stylebox_ci);
 	RenderingServer::get_singleton()->free_rid(last_sticky_ci);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes a double-free of `custom_ci` (the first free being two lines above.)

## Additional information

`custom_ci` was introduced in https://github.com/godotengine/godot/commit/251af31089845b1e4da6201abb0880cbf7da10f1 with an accidental RID leak. The author added more functionality and fixed the leak with https://github.com/godotengine/godot/commit/92ecfbae8348992680d60a627219bdb0d3fd35f7; however, the leak was simultaneously fixed by a separate author in https://github.com/godotengine/godot/commit/0bca265a8118eca70639e5d107f9e8ded2c20751. Unfortunately these two changes merged cleanly and resulted in a double-free that nobody noticed.

Bug tracked down and fixed with Claude, fix verified by me.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
