### PR TITLE
Add lifetime constraint to `StringName` -> `String` conversion, avoiding footguns

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -125,12 +125,12 @@ public:
 		return (void *)_data;
 	}
 
-	_FORCE_INLINE_ const String &string() const {
+	_FORCE_INLINE_ const String &string() const _LIFETIME_BOUND_ {
 		static const String EMPTY;
 		return _data ? _data->name : EMPTY;
 	}
 
-	_FORCE_INLINE_ operator const String &() const {
+	_FORCE_INLINE_ operator const String &() const _LIFETIME_BOUND_ {
 		return string();
 	}
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -62,6 +62,12 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #define GD_HAS_FEATURE(m_feature) 0
 #endif
 
+#if defined(__has_cpp_attribute)
+#define GD_HAS_CPP_ATTRIBUTE(m_feature) __has_cpp_attribute(m_feature)
+#else
+#define GD_HAS_CPP_ATTRIBUTE(m_feature) 0
+#endif
+
 #if (GD_HAS_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)) && !defined(ASAN_ENABLED)
 #error Address sanitizer was enabled without defining `ASAN_ENABLED`
 #endif
@@ -125,6 +131,18 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 // we can prevent the warning in specific cases by preceding the call with a cast.
 #ifndef _ALLOW_DISCARD_
 #define _ALLOW_DISCARD_ (void)
+#endif
+
+#if GD_HAS_CPP_ATTRIBUTE(clang::lifetimebound)
+#define _LIFETIME_BOUND_ [[clang::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(gnu::lifetimebound)
+#define _LIFETIME_BOUND_ [[gnu::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(msvc::lifetimebound)
+#define _LIFETIME_BOUND_ [[msvc::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(lifetimebound)
+#define _LIFETIME_BOUND_ [[lifetimebound]]
+#else
+#define _LIFETIME_BOUND_
 #endif
 
 // Make room for our constexpr's below by overriding potential system-specific macros.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Identifies footguns like https://github.com/godotengine/godot/pull/120584 and https://github.com/godotengine/godot/pull/120591
- Follow-up to https://github.com/godotengine/godot/pull/118856

## Additional information

Implements a rust-like lifetime check for `StringName::operator const String &`, which specifies that the returned reference depends on the lifetime of the `StringName` callee via [`[[clang::lifetimebound]]`](https://clang.llvm.org/docs/AttributeReference.html#lifetimebound). This is supposedly mature in clang. MSVC has a similar attribute, but it's MSVC 2022+.

I have confirmed that this would have caught https://github.com/godotengine/godot/pull/120584 reliably.

The new attribute is added via `_LIFETIME_BOUND_`, which can (and should!) be used for similar functions, such as `span()` and `ptr()`, to get similar safety guarantees.