### PR TITLE
Fix compiling `core/profiling` files with Perfetto profiler

### DIFF
--- a/core/profiling/profiling.cpp
+++ b/core/profiling/profiling.cpp
@@ -99,7 +99,7 @@ const StringInternData *_intern_name(const StringName &p_name) {
 
 	_data = TracyInternTable::string_allocator.alloc();
 	_data->name = p_name;
-	_data->name_utf8 = p_name.operator String().utf8();
+	_data->name_utf8 = p_name.string().utf8();
 
 	_data->next = TracyInternTable::string_table[idx];
 	_data->prev = nullptr;

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -144,7 +144,7 @@ struct PerfettoScriptTracer {
 
 	PerfettoScriptTracer(const StringName &p_file, const StringName &p_function, const StringName &p_name, int p_line, bool p_system_call) : name(p_name), is_system_call(p_system_call) {
 		if (is_system_call || !__tracing_system_call.erase(name)) {
-			TRACE_EVENT_BEGIN("godot_scripting", perfetto::DynamicString(p_name.operator String().utf8().get_data()), "source file", p_file.operator String().utf8().get_data(), "line number", p_line);
+			TRACE_EVENT_BEGIN("godot_scripting", perfetto::DynamicString(p_name.string().utf8().get_data()), "source file", p_file.string().utf8().get_data(), "line number", p_line);
 			tracing = true;
 		}
 


### PR DESCRIPTION
Refined #118856

I didn't look in any other places for the `operator String()`, I only came across it myself in core/profiling.

- Bugsquad edit: Includes https://github.com/godotengine/godot/pull/120668