### PR TITLE
Fix project settings margins in editor modern theme

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -624,7 +624,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderActionEditor");
 	main_vbox->add_child(mc);
 
 	// Action Editor Tree

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2045,17 +2045,6 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("NoBorderHorizontalBottom", "NoBorderHorizontal");
 			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottom", margin);
 
-			margin *= 2;
-
-			// Used in nested containers.
-			p_theme->set_type_variation("NoBorderHorizontalWide", "MarginContainer");
-			p_theme->set_constant("margin_left", "NoBorderHorizontalWide", margin);
-			p_theme->set_constant("margin_right", "NoBorderHorizontalWide", margin);
-
-			// Same as above, including the bottom.
-			p_theme->set_type_variation("NoBorderHorizontalBottomWide", "NoBorderHorizontalWide");
-			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottomWide", margin);
-
 			// Used in the asset library. Specifically, the ("bg", "AssetLib") stylebox.
 
 			margin = -p_config.base_margin * EDSCALE;
@@ -2099,6 +2088,19 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("NoBorderHorizontalWindow", "MarginContainer");
 			p_theme->set_constant("margin_left", "NoBorderHorizontalWindow", margin);
 			p_theme->set_constant("margin_right", "NoBorderHorizontalWindow", margin);
+
+			// Used in nested containers.
+			p_theme->set_type_variation("NoBorderHorizontalWide", "MarginContainer");
+			p_theme->set_constant("margin_left", "NoBorderHorizontalWide", margin);
+			p_theme->set_constant("margin_right", "NoBorderHorizontalWide", margin);
+
+			// Same as above, including the bottom.
+			p_theme->set_type_variation("NoBorderHorizontalBottomWide", "NoBorderHorizontalWide");
+			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottomWide", 2 * -bottom_panel_margin);
+
+			// Used in the action map editor.
+			p_theme->set_type_variation("NoBorderActionEditor", "NoBorderHorizontalWide");
+			p_theme->set_constant("margin_bottom", "NoBorderActionEditor", -bottom_panel_margin);
 		}
 
 		// Buttons in material previews.


### PR DESCRIPTION
_Bugsquad edit:_ If this is cherry-picked, #120865 must be as well.

## What problem(s) does this PR solve?

- Closes #120735 

## Additional information

I found the cause to be the theme type variations "NoBorderHorizontalWide" and "NoBorderHorizontalBottomWide", introduced in [[da561cd](https://github.com/godotengine/godot/commit/da561cd619711453c00a6d2eabe6048f76f62daa)] to be used inside the action_map_editor, localization_editor and globals autoload/shader/groups editors (that all have this behaviour).

The negative PanelContainers margins used do not match the ProjectSettingsEditor AcceptDialog, so i moved them to use the right ones.
I also added "NoBorderActionEditor" to fix the action_map_editor with the right bottom margin.

Before:
<img width="1144" height="189" alt="CutActions0" src="https://github.com/user-attachments/assets/a113828f-4c9c-4fd7-b715-0523dd6020c2" />
<img width="1149" height="195" alt="CutAutoloads0" src="https://github.com/user-attachments/assets/b15ac21b-466e-415e-aa3a-571932a4a203" />

After:
<img width="1141" height="196" alt="UncutActions0" src="https://github.com/user-attachments/assets/f92707b6-9e09-4769-a50e-b6e1c2d2dd8b" />
<img width="1142" height="198" alt="UncutAutoloads0" src="https://github.com/user-attachments/assets/f8c1f8a2-1ff8-454b-bf30-f3db79c8ab6f" />
