### PR TITLE
Fix enum constants incorrectly shown in documentation Enumerations section

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1693,7 +1693,7 @@ void EditorHelp::_update_doc() {
 			if (!is_documented && constant.name.begins_with("_")) {
 				continue;
 			}
-			if (!constant.enumeration.is_empty()) {
+			if (!constant.enumeration.is_empty() && !constant.enumeration.contains(".")) {
 				if (!enums.has(constant.enumeration)) {
 					enums[constant.enumeration] = Vector<DocData::ConstantDoc>();
 				}
@@ -1728,16 +1728,6 @@ void EditorHelp::_update_doc() {
 			bool is_first_enum = true;
 			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
 				String key = E.key;
-				if ((key.get_slice_count(".") > 1) && (key.get_slicec('.', 0) == edited_class)) {
-					key = key.get_slicec('.', 1);
-				}
-				if (cd.enums.has(key)) {
-					const bool is_documented = cd.enums[key].is_deprecated || cd.enums[key].is_experimental || !cd.enums[key].description.strip_edges().is_empty();
-					if (!is_documented && cd.is_script_doc && E.key.begins_with("_")) {
-						continue;
-					}
-				}
-
 				class_desc->add_newline();
 				if (is_first_enum) {
 					is_first_enum = false;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120734

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

I will use this enum in examples below `Shape{Circle, Square}`.

https://github.com/godotengine/godot/blob/d7c45b19ccf6ddadc73d1c8423cd2848f59de437/editor/doc/editor_help.cpp#L1687

This dictionary was holding enums like `Shape` and constants like `const a = Shape.Circle` which lead to weird behavior.
I added a filter based on if the constant has a ".", so that it only contains actual enum members.

I also deleted the private filtering logic which is now done before, and deleted the "." slicing section which is unnecessary now.

This also fixes some other issues with the previous logic, like the code below not generating any documentation for `a` at all.
```gdscript
class_name example
class InnerA:
	enum Shape { Square, Circle }

const a := InnerA.Shape.Circle
```


