### PR TITLE
Fix Skeleton2D crash and physics multi-thread deadlock

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -843,4 +843,7 @@ Skeleton2D::Skeleton2D() {
 Skeleton2D::~Skeleton2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free_rid(skeleton);
+	if (modification_stack.is_valid()) {
+		callable_mp(modification_stack.ptr(), &SkeletonModificationStack2D::set_skeleton).call_deferred((Object *)nullptr);
+	}
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120552

### Problem 1: Critical Crash (Segmentation Fault)
When a `Skeleton2D` node is freed or during scene reloading, `SkeletonModificationStack2D` can retain a dangling pointer to the deleted skeleton. Accessing this unvalidated pointer during subsequent frames or physics updates leads to random memory corruption and immediate segmentation faults.

### Problem 2: Multi-threaded Physics Deadlock & Mutex Starvation
To fix the crash, simply nullifying or cleaning up the pointer synchronously inside the destruction/notification phase introduced an even worse issue when multi-threaded physics was enabled. 
1. If the pointer was modified synchronously, it risked racing with the physics thread or mutating state while tree/physics locks were held.
2. If left unhandled, the physics thread would constantly hit `ERR_FAIL_COND_MSG` at a very high frequency (e.g., 60Hz to 480Hz+). This slammed the global log/print mutex, causing massive thread starvation that completely froze the main thread, resulting in an unrecoverable deadlock.

---

## Solution

This PR solves both issues elegantly by decoupling the cleanup phase:

**Deferred Pointer Nullification (The Core Fix):**
Inside the `Skeleton2D` cleanup logic, instead of synchronously forcing `modification_stack->set_skeleton(nullptr)`, we now use `callable_mp` to defer this execution:
```cpp
if (modification_stack.is_valid()) {
    callable_mp(modification_stack.ptr(), &SkeletonModificationStack2D::set_skeleton).call_deferred((Object*)nullptr);
}