### PR TITLE
Fix error when saving a modified script that you're about to close

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4207,7 +4207,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	erase_tab_confirm->set_flag(Window::FLAG_RESIZE_DISABLED, true);
 	erase_tab_confirm->set_ok_button_text(TTRC("Save"));
 	erase_tab_confirm->add_button(TTRC("Discard"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "discard");
-	erase_tab_confirm->connect(SceneStringName(confirmed), callable_mp(this, &ScriptEditor::_close_current_tab).bind(true, true));
+	erase_tab_confirm->connect(SceneStringName(confirmed), callable_mp(this, &ScriptEditor::_close_current_tab).bind(true));
 	erase_tab_confirm->connect("custom_action", callable_mp(this, &ScriptEditor::_close_discard_current_tab));
 	add_child(erase_tab_confirm);
 


### PR DESCRIPTION
If you try to close an modified script and then confirm to save, the following error will appear:
```
ERROR: core/object/object.cpp:1310 - Error calling from signal 'confirmed' to callable: 'ScriptEditor::ScriptEditor::_close_current_tab': Method expected 1 argument(s), but called with 2.
```
It's simply because the connection binds one more argument than it should, probably because someone forget to update it while modifying the function.