### PR TITLE
Make `ptr()` and `span()` lifetime-bound across `CowData` types, and fix lifetime violations with callers

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -147,7 +147,8 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 // but we don't want to make it noisy by printing lots of file & line info (because it's already
 // been printing by a preceding _err_print_error).
 void _err_print_error_asap(const String &p_error, ErrorHandlerType p_type) {
-	const char *err_details = p_error.utf8().get_data();
+	const CharString err_details_str = p_error.utf8();
+	const char *err_details = err_details_str.get_data();
 
 	if (!CoreGlobals::print_ready) {
 		_err_print_fallback(nullptr, nullptr, 0, err_details, p_type, false);

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2401,7 +2401,7 @@ bool Image::is_empty() const {
 	return (data.is_empty());
 }
 
-Vector<uint8_t> Image::get_data() const {
+const Vector<uint8_t> &Image::get_data() const {
 	return data;
 }
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -379,7 +379,7 @@ public:
 	// Returns true when the image is empty (0,0) in size.
 	bool is_empty() const;
 
-	Vector<uint8_t> get_data() const;
+	const Vector<uint8_t> &get_data() const _LIFETIME_BOUND_;
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -593,7 +593,7 @@ void StreamPeerBuffer::set_data_array(const Vector<uint8_t> &p_data) {
 	pointer = 0;
 }
 
-Vector<uint8_t> StreamPeerBuffer::get_data_array() const {
+const Vector<uint8_t> &StreamPeerBuffer::get_data_array() const {
 	return data;
 }
 

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -140,7 +140,7 @@ public:
 	void resize(int p_size);
 
 	void set_data_array(const Vector<uint8_t> &p_data);
-	Vector<uint8_t> get_data_array() const;
+	const Vector<uint8_t> &get_data_array() const _LIFETIME_BOUND_;
 
 	void clear();
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -173,9 +173,9 @@ class [[nodiscard]] CharStringT {
 	static constexpr T _null = 0;
 
 public:
-	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ const T *get_data() const { return size() ? ptr() : &_null; }
+	_FORCE_INLINE_ T *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
+	_FORCE_INLINE_ const T *get_data() const _LIFETIME_BOUND_ { return size() ? ptr() : &_null; }
 
 	// Returns the number of characters in the buffer, including the terminating NUL character.
 	// In most cases, length() should be used instead.
@@ -184,8 +184,8 @@ public:
 	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
-	_FORCE_INLINE_ operator Span<T>() const { return Span(ptr(), length()); }
-	_FORCE_INLINE_ Span<T> span() const { return Span(ptr(), length()); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return Span(ptr(), length()); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(ptr(), length()); }
 
 	/// Resizes the string. The given size must include the null terminator.
 	/// New characters are not initialized, and should be set by the caller.
@@ -293,9 +293,9 @@ public:
 		npos = -1 ///<for "some" compatibility with std::string (npos is a huge value in std::string)
 	};
 
-	_FORCE_INLINE_ char32_t *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ const char32_t *get_data() const { return size() ? ptr() : &_null; }
+	_FORCE_INLINE_ char32_t *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char32_t *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
+	_FORCE_INLINE_ const char32_t *get_data() const _LIFETIME_BOUND_ { return size() ? ptr() : &_null; }
 
 	// Returns the number of characters in the buffer, including the terminating NUL character.
 	// In most cases, length() should be used instead.
@@ -304,8 +304,8 @@ public:
 	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
-	_FORCE_INLINE_ operator Span<char32_t>() const { return Span(ptr(), length()); }
-	_FORCE_INLINE_ Span<char32_t> span() const { return Span(ptr(), length()); }
+	_FORCE_INLINE_ operator Span<char32_t>() const _LIFETIME_BOUND_ { return Span(ptr(), length()); }
+	_FORCE_INLINE_ Span<char32_t> span() const _LIFETIME_BOUND_ { return Span(ptr(), length()); }
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -161,13 +161,13 @@ public:
 		p_from._ptr = nullptr;
 	}
 
-	_FORCE_INLINE_ T *ptrw() {
+	_FORCE_INLINE_ T *ptrw() _LIFETIME_BOUND_ {
 		// If forking fails, we can only crash.
 		CRASH_COND(_copy_on_write());
 		return _ptr;
 	}
 
-	_FORCE_INLINE_ const T *ptr() const {
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ {
 		return _ptr;
 	}
 
@@ -213,8 +213,8 @@ public:
 	Error insert(Size p_pos, T &&p_val);
 	Error push_back(T &&p_val);
 
-	_FORCE_INLINE_ operator Span<T>() const { return Span<T>(ptr(), size()); }
-	_FORCE_INLINE_ Span<T> span() const { return operator Span<T>(); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return Span<T>(ptr(), size()); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return operator Span<T>(); }
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData() { _unref(); }

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -125,11 +125,11 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ constexpr T *ptr() { return (T *)(_data); }
-	_FORCE_INLINE_ constexpr const T *ptr() const { return (const T *)(_data); }
+	_FORCE_INLINE_ constexpr T *ptr() _LIFETIME_BOUND_ { return (T *)(_data); }
+	_FORCE_INLINE_ constexpr const T *ptr() const _LIFETIME_BOUND_ { return (const T *)(_data); }
 
-	_FORCE_INLINE_ constexpr operator Span<T>() const { return Span<T>(ptr(), size()); }
-	_FORCE_INLINE_ constexpr Span<T> span() const { return operator Span<T>(); }
+	_FORCE_INLINE_ constexpr operator Span<T>() const _LIFETIME_BOUND_ { return Span<T>(ptr(), size()); }
+	_FORCE_INLINE_ constexpr Span<T> span() const _LIFETIME_BOUND_ { return operator Span<T>(); }
 
 	_FORCE_INLINE_ constexpr uint32_t size() const { return _size; }
 	_FORCE_INLINE_ constexpr bool is_empty() const { return !_size; }

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -71,12 +71,12 @@ private:
 	}
 
 public:
-	_FORCE_INLINE_ T *ptr() { return data; }
-	_FORCE_INLINE_ const T *ptr() const { return data; }
+	_FORCE_INLINE_ T *ptr() _LIFETIME_BOUND_ { return data; }
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ { return data; }
 	_FORCE_INLINE_ U size() const { return count; }
 
-	_FORCE_INLINE_ Span<T> span() const { return Span(data, count); }
-	_FORCE_INLINE_ operator Span<T>() const { return span(); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(data, count); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
 	// Must take a copy instead of a reference (see GH-31736).
 	_FORCE_INLINE_ void push_back(T p_elem) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -87,13 +87,13 @@ public:
 
 	void reverse();
 
-	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ T *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
 	_FORCE_INLINE_ Size size() const { return _cowdata.size(); }
 	_FORCE_INLINE_ USize capacity() const { return _cowdata.capacity(); }
 
-	_FORCE_INLINE_ operator Span<T>() const { return _cowdata.span(); }
-	_FORCE_INLINE_ Span<T> span() const { return _cowdata.span(); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return _cowdata.span(); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return _cowdata.span(); }
 
 	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -190,8 +190,8 @@ public:
 	bool is_read_only() const;
 	static Array create_read_only();
 
-	Span<Variant> span() const;
-	operator Span<Variant>() const {
+	Span<Variant> span() const _LIFETIME_BOUND_;
+	operator Span<Variant>() const _LIFETIME_BOUND_ {
 		return this->span();
 	}
 

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -261,7 +261,9 @@ Error AudioDriverPulseAudio::init_output_device() {
 	attr.maxlength = (uint32_t)-1;
 	attr.minreq = (uint32_t)-1;
 
-	const char *dev = output_device_name == "Default" ? nullptr : output_device_name.utf8().get_data();
+	CharString output_device_name_nondefault = output_device_name == "Default" ? CharString() : output_device_name.utf8();
+	const char *dev = output_device_name_nondefault.ptr(); // nullptr on CharString()
+
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_playback(pa_str, dev, &attr, flags, nullptr, nullptr);
 	ERR_FAIL_COND_V(error_code < 0, ERR_CANT_OPEN);
@@ -752,7 +754,9 @@ Error AudioDriverPulseAudio::init_input_device() {
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
-	const char *dev = input_device_name == "Default" ? nullptr : input_device_name.utf8().get_data();
+	CharString output_device_name_nondefault = output_device_name == "Default" ? CharString() : output_device_name.utf8();
+	const char *dev = output_device_name_nondefault.ptr(); // nullptr on CharString()
+
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_record(pa_rec_str, dev, &attr, flags);
 	if (error_code < 0) {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -580,8 +580,9 @@ NodePath Polygon2D::get_bone_path(int p_index) const {
 	return bone_weights[p_index].path;
 }
 
-Vector<float> Polygon2D::get_bone_weights(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, bone_weights.size(), Vector<float>());
+const Vector<float> &Polygon2D::get_bone_weights(int p_index) const {
+	static const Vector<float> EMPTY;
+	ERR_FAIL_INDEX_V(p_index, bone_weights.size(), EMPTY);
 	return bone_weights[p_index].weights;
 }
 

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -146,7 +146,7 @@ public:
 	void add_bone(const NodePath &p_path = NodePath(), const Vector<float> &p_weights = Vector<float>());
 	int get_bone_count() const;
 	NodePath get_bone_path(int p_index) const;
-	Vector<float> get_bone_weights(int p_index) const;
+	const Vector<float> &get_bone_weights(int p_index) const _LIFETIME_BOUND_;
 	void erase_bone(int p_idx);
 	void clear_bones();
 	void set_bone_weights(int p_index, const Vector<float> &p_weights);

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -91,7 +91,7 @@ void NavigationPolygon::set_vertices(const Vector<Vector2> &p_vertices) {
 	rect_cache_dirty = true;
 }
 
-Vector<Vector2> NavigationPolygon::get_vertices() const {
+const Vector<Vector2> &NavigationPolygon::get_vertices() const {
 	RWLockRead read_lock(rwlock);
 	return vertices;
 }

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -100,7 +100,7 @@ public:
 	StringName source_geometry_group_name = "navigation_polygon_source_geometry_group";
 
 	void set_vertices(const Vector<Vector2> &p_vertices);
-	Vector<Vector2> get_vertices() const;
+	const Vector<Vector2> &get_vertices() const _LIFETIME_BOUND_;
 
 	void add_polygon(const Vector<int> &p_polygon);
 	int get_polygon_count() const;

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -80,39 +80,53 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 	material = p_mesh->surface_get_material(p_surface);
 
 	const Vector3 *vr = varray.ptr();
+	Vector<Vector3> vector_nr;
+	Vector<real_t> vector_ta;
+	Vector<Vector2> vector_uv;
+	Vector<Vector2> vector_uv2;
+	Vector<Color> vector_col;
+	Vector<int> vector_bo;
+	Vector<float> vector_we;
 
 	const Vector3 *nr = nullptr;
 	if (arrays[Mesh::ARRAY_NORMAL].get_type() != Variant::NIL) {
-		nr = arrays[Mesh::ARRAY_NORMAL].operator Vector<Vector3>().ptr();
+		vector_nr = arrays[Mesh::ARRAY_NORMAL].operator Vector<Vector3>();
+		nr = vector_nr.ptr();
 	}
 
 	const real_t *ta = nullptr;
 	if (arrays[Mesh::ARRAY_TANGENT].get_type() != Variant::NIL) {
-		ta = arrays[Mesh::ARRAY_TANGENT].operator Vector<real_t>().ptr();
+		vector_ta = arrays[Mesh::ARRAY_TANGENT].operator Vector<real_t>();
+		ta = vector_ta.ptr();
 	}
 
 	const Vector2 *uv = nullptr;
 	if (arrays[Mesh::ARRAY_TEX_UV].get_type() != Variant::NIL) {
-		uv = arrays[Mesh::ARRAY_TEX_UV].operator Vector<Vector2>().ptr();
+		vector_uv = arrays[Mesh::ARRAY_TEX_UV].operator Vector<Vector2>();
+		uv = vector_uv.ptr();
 	}
 	const Vector2 *uv2 = nullptr;
 	if (arrays[Mesh::ARRAY_TEX_UV2].get_type() != Variant::NIL) {
-		uv2 = arrays[Mesh::ARRAY_TEX_UV2].operator Vector<Vector2>().ptr();
+		vector_uv2 = arrays[Mesh::ARRAY_TEX_UV2].operator Vector<Vector2>();
+		uv2 = vector_uv2.ptr();
 	}
 
 	const Color *col = nullptr;
 	if (arrays[Mesh::ARRAY_COLOR].get_type() != Variant::NIL) {
-		col = arrays[Mesh::ARRAY_COLOR].operator Vector<Color>().ptr();
+		vector_col = arrays[Mesh::ARRAY_COLOR].operator Vector<Color>();
+		col = vector_col.ptr();
 	}
 
 	const int *bo = nullptr;
 	if (arrays[Mesh::ARRAY_BONES].get_type() != Variant::NIL) {
-		bo = arrays[Mesh::ARRAY_BONES].operator Vector<int>().ptr();
+		vector_bo = arrays[Mesh::ARRAY_BONES].operator Vector<int>();
+		bo = vector_bo.ptr();
 	}
 
 	const float *we = nullptr;
 	if (arrays[Mesh::ARRAY_WEIGHTS].get_type() != Variant::NIL) {
-		we = arrays[Mesh::ARRAY_WEIGHTS].operator Vector<float>().ptr();
+		vector_we = arrays[Mesh::ARRAY_WEIGHTS].operator Vector<float>();
+		we = vector_we.ptr();
 	}
 
 	vertices.resize(vcount);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up of https://github.com/godotengine/godot/pull/120732

Fixes pointer lifetime bugs by informing the compiler of lifetime violations, which can lead to crashes in certain circumstances.
