### PR TITLE
Fix mouse filter being ignored in game view select

### DIFF
--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -1069,6 +1069,13 @@ void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_n
 	xform = (xform * ci->get_transform()).affine_inverse();
 	const real_t local_grab_distance = xform.basis_xform(Vector2(sel_2d_grab_dist, 0)).length() / view_2d_zoom;
 	if (ci->_edit_is_selected_on_click(xform.xform(pos), local_grab_distance)) {
+		if (Object::cast_to<Control>(ci)) {
+			Control *control = Object::cast_to<Control>(ci);
+			if (control->get_mouse_filter_with_override() != Control::MOUSE_FILTER_STOP) {
+				return;
+			}
+		}
+
 		SelectResult res;
 		res.item = ci;
 		res.order = ci->get_effective_z_index() + ci->get_canvas_layer();
@@ -1143,6 +1150,13 @@ void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_
 	}
 
 	if (selected) {
+		if (Object::cast_to<Control>(ci)) {
+			Control *control = Object::cast_to<Control>(ci);
+			if (control->get_mouse_filter_with_override() != Control::MOUSE_FILTER_STOP) {
+				return;
+			}
+		}
+
 		SelectResult res;
 		res.item = ci;
 		res.order = ci->get_effective_z_index() + ci->get_canvas_layer();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119649

## Additional information
This means that the game view 2D remote scene tree select will only select controls with `mouse_filter` set to Stop.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
