### PR TITLE
Remove `GDExtensionConstPtr` in favor of `GDExtensionPtr<const T>`

### DIFF
--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -122,7 +122,7 @@ GDExtensionManager::LoadStatus GDExtensionManager::load_extension(const String &
 	return load_extension_with_loader(p_path, loader);
 }
 
-GDExtensionManager::LoadStatus GDExtensionManager::load_extension_from_function(const String &p_path, GDExtensionConstPtr<const GDExtensionInitializationFunction> p_init_func) {
+GDExtensionManager::LoadStatus GDExtensionManager::load_extension_from_function(const String &p_path, GDExtensionPtr<const GDExtensionInitializationFunction> p_init_func) {
 	Ref<GDExtensionFunctionLoader> func_loader;
 	func_loader.instantiate();
 	func_loader->set_initialization_function((GDExtensionInitializationFunction)*p_init_func.data);

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -69,7 +69,7 @@ private:
 
 public:
 	LoadStatus load_extension(const String &p_path);
-	LoadStatus load_extension_from_function(const String &p_path, GDExtensionConstPtr<const GDExtensionInitializationFunction> p_init_func);
+	LoadStatus load_extension_from_function(const String &p_path, GDExtensionPtr<const GDExtensionInitializationFunction> p_init_func);
 	LoadStatus load_extension_with_loader(const String &p_path, const Ref<GDExtensionLoader> &p_loader);
 	LoadStatus reload_extension(const String &p_path);
 	LoadStatus unload_extension(const String &p_path);

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -56,7 +56,7 @@ GodotInstance::~GodotInstance() {
 bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
 	print_verbose("Godot Instance initialization");
 	GDExtensionManager *gdextension_manager = GDExtensionManager::get_singleton();
-	GDExtensionConstPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
+	GDExtensionPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
 	GDExtensionManager::LoadStatus status = gdextension_manager->load_extension_from_function("libgodot://main", ptr);
 	return status == GDExtensionManager::LoadStatus::LOAD_STATUS_OK;
 }

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -79,10 +79,10 @@ protected:
 
 public:
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
-	GDVIRTUAL2R(Error, _get_packet, GDExtensionConstPtr<const uint8_t *>, GDExtensionPtr<int>);
+	GDVIRTUAL2R(Error, _get_packet, GDExtensionPtr<const uint8_t *>, GDExtensionPtr<int>);
 
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	GDVIRTUAL2R(Error, _put_packet, GDExtensionConstPtr<const uint8_t>, int);
+	GDVIRTUAL2R(Error, _put_packet, GDExtensionPtr<const uint8_t>, int);
 
 	EXBIND0RC(int, get_available_packet_count);
 	EXBIND0RC(int, get_max_packet_size);

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -102,10 +102,10 @@ protected:
 
 public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) override;
-	GDVIRTUAL3R(Error, _put_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _put_data, GDExtensionPtr<const uint8_t>, int, GDExtensionPtr<int>);
 
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
-	GDVIRTUAL3R(Error, _put_partial_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _put_partial_data, GDExtensionPtr<const uint8_t>, int, GDExtensionPtr<int>);
 
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
 	GDVIRTUAL3R(Error, _get_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>);

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -36,97 +36,41 @@
 #include "core/variant/variant_caster.h"
 #include "core/variant/variant_internal.h"
 
+// Metafunction for pointee name. Specialized in GDVIRTUAL_NATIVE_PTR; takes into account const; falls back to "void".
 template <typename T>
-struct GDExtensionConstPtr {
-	const T *data = nullptr;
-	GDExtensionConstPtr(const T *p_assign) { data = p_assign; }
-	static const char *get_name() { return "const void"; }
-	operator const T *() const { return data; }
-	operator Variant() const { return uint64_t(data); }
+struct GDExtensionPtrName {
+	static const char *get() { return "void"; }
 };
-
 template <typename T>
-struct GDExtensionPtr {
-	T *data = nullptr;
-	GDExtensionPtr(T *p_assign) { data = p_assign; }
-	static const char *get_name() { return "void"; }
-	operator T *() const { return data; }
-	operator Variant() const { return uint64_t(data); }
+struct GDExtensionPtrName<const T> {
+	static const char *get() {
+		static const CharString name = (String("const ") + GDExtensionPtrName<T>::get()).utf8();
+		return name.get_data();
+	}
+};
+template <typename T>
+struct GDExtensionPtrName<T *> {
+	static const char *get() {
+		static const CharString name = (String(GDExtensionPtrName<T>::get()) + " *").utf8();
+		return name.get_data();
+	}
 };
 
 #define GDVIRTUAL_NATIVE_PTR(m_type) \
 	template <> \
-	struct GDExtensionConstPtr<const m_type> { \
-		const m_type *data = nullptr; \
-		GDExtensionConstPtr() {} \
-		GDExtensionConstPtr(const m_type *p_assign) { \
-			data = p_assign; \
-		} \
-		static const char *get_name() { \
-			return "const " #m_type; \
-		} \
-		operator const m_type *() const { \
-			return data; \
-		} \
-		operator Variant() const { \
-			return uint64_t(data); \
-		} \
-	}; \
-	template <> \
-	struct VariantCaster<GDExtensionConstPtr<const m_type>> { \
-		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) { \
-			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t()); \
-		} \
-	}; \
-	template <> \
-	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> { \
-		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) { \
-			return *reinterpret_cast<const GDExtensionConstPtr<const m_type> *>(VariantInternal::get_int(v)); \
-		} \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) { \
-			*VariantInternal::get_int(v) = uint64_t(p_value.data); \
-		} \
-	}; \
-	template <> \
-	struct GDExtensionPtr<m_type> { \
-		m_type *data = nullptr; \
-		GDExtensionPtr() {} \
-		GDExtensionPtr(m_type *p_assign) { \
-			data = p_assign; \
-		} \
-		static const char *get_name() { \
-			return #m_type; \
-		} \
-		operator m_type *() const { \
-			return data; \
-		} \
-		operator Variant() const { \
-			return uint64_t(data); \
-		} \
-	}; \
-	template <> \
-	struct VariantCaster<GDExtensionPtr<m_type>> { \
-		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) { \
-			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t()); \
-		} \
-	}; \
-	template <> \
-	struct VariantInternalAccessor<GDExtensionPtr<m_type>> { \
-		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) { \
-			return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v)); \
-		} \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) { \
-			*VariantInternal::get_int(v) = uint64_t(p_value.data); \
-		} \
+	struct GDExtensionPtrName<m_type> { \
+		static const char *get() { return #m_type; } \
 	};
 
+// Raw pointer passed across the GDExtension boundary. T can be const-qualified to map to `const MyClass*`.
 template <typename T>
-struct GetTypeInfo<GDExtensionConstPtr<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::INT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_INT_IS_POINTER, GDExtensionConstPtr<T>::get_name());
-	}
+struct GDExtensionPtr {
+	T *data = nullptr;
+	GDExtensionPtr() {}
+	GDExtensionPtr(T *p_assign) { data = p_assign; }
+	static const char *get_name() { return GDExtensionPtrName<T>::get(); }
+	operator T *() const { return data; }
+	operator Variant() const { return uint64_t(data); }
 };
 
 template <typename T>
@@ -139,27 +83,33 @@ struct GetTypeInfo<GDExtensionPtr<T>> {
 };
 
 template <typename T>
-struct PtrToArg<GDExtensionConstPtr<T>> {
-	_FORCE_INLINE_ static GDExtensionConstPtr<T> convert(const void *p_ptr) {
-		return GDExtensionConstPtr<T>(reinterpret_cast<const T *>(p_ptr));
-	}
-	typedef const T *EncodeT;
-	_FORCE_INLINE_ static void encode(GDExtensionConstPtr<T> p_val, void *p_ptr) {
-		*((const T **)p_ptr) = p_val.data;
-	}
-};
-template <typename T>
-struct PtrToArg<GDExtensionPtr<T>> {
-	_FORCE_INLINE_ static GDExtensionPtr<T> convert(const void *p_ptr) {
-		return GDExtensionPtr<T>(reinterpret_cast<const T *>(p_ptr));
-	}
-	typedef T *EncodeT;
-	_FORCE_INLINE_ static void encode(GDExtensionPtr<T> p_val, void *p_ptr) {
-		*((T **)p_ptr) = p_val.data;
+struct VariantCaster<GDExtensionPtr<T>> {
+	static _FORCE_INLINE_ GDExtensionPtr<T> cast(const Variant &p_variant) {
+		return GDExtensionPtr<T>(reinterpret_cast<T *>(p_variant.operator uint64_t()));
 	}
 };
 
-GDVIRTUAL_NATIVE_PTR(void)
+template <typename T>
+struct VariantInternalAccessor<GDExtensionPtr<T>> {
+	static _FORCE_INLINE_ const GDExtensionPtr<T> &get(const Variant *v) {
+		return *reinterpret_cast<const GDExtensionPtr<T> *>(VariantInternal::get_int(v));
+	}
+	static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<T> &p_value) {
+		*VariantInternal::get_int(v) = uint64_t(p_value.data);
+	}
+};
+
+template <typename T>
+struct PtrToArg<GDExtensionPtr<T>> {
+	_FORCE_INLINE_ static GDExtensionPtr<T> convert(const void *p_ptr) {
+		return GDExtensionPtr<T>(static_cast<T *>(const_cast<void *>(p_ptr)));
+	}
+	typedef T *EncodeT;
+	_FORCE_INLINE_ static void encode(GDExtensionPtr<T> p_val, void *p_ptr) {
+		*static_cast<T **>(p_ptr) = p_val.data;
+	}
+};
+
 GDVIRTUAL_NATIVE_PTR(AudioFrame)
 GDVIRTUAL_NATIVE_PTR(bool)
 GDVIRTUAL_NATIVE_PTR(char)
@@ -167,7 +117,6 @@ GDVIRTUAL_NATIVE_PTR(char16_t)
 GDVIRTUAL_NATIVE_PTR(char32_t)
 GDVIRTUAL_NATIVE_PTR(wchar_t)
 GDVIRTUAL_NATIVE_PTR(uint8_t)
-GDVIRTUAL_NATIVE_PTR(uint8_t *)
 GDVIRTUAL_NATIVE_PTR(int8_t)
 GDVIRTUAL_NATIVE_PTR(uint16_t)
 GDVIRTUAL_NATIVE_PTR(int16_t)

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -41,9 +41,6 @@
 class RefCounted;
 
 template <typename T>
-struct GDExtensionConstPtr;
-
-template <typename T>
 struct GDExtensionPtr;
 
 class VariantInternal {
@@ -561,10 +558,6 @@ public:
 	template <typename T>
 	_FORCE_INLINE_ static Variant make(const T &v) {
 		return Variant(v);
-	}
-	template <typename T>
-	_FORCE_INLINE_ static Variant make(const GDExtensionConstPtr<T> &v) {
-		return v.operator Variant();
 	}
 	template <typename T>
 	_FORCE_INLINE_ static Variant make(const GDExtensionPtr<T> &v) {

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -13,7 +13,7 @@
 	<methods>
 		<method name="_process" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="src_buffer" type="const void*" />
+			<param index="0" name="src_buffer" type="const AudioFrame*" />
 			<param index="1" name="r_dst_buffer" type="AudioFrame*" />
 			<param index="2" name="frame_count" type="int" />
 			<description>

--- a/doc/classes/MovieWriter.xml
+++ b/doc/classes/MovieWriter.xml
@@ -68,7 +68,7 @@
 		<method name="_write_frame" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="frame_image" type="Image" />
-			<param index="1" name="audio_frame_block" type="const void*" />
+			<param index="1" name="audio_frame_block" type="const int32_t*" />
 			<description>
 				Called at the end of every rendered frame. The [param frame_image] and [param audio_frame_block] function arguments should be written to.
 			</description>

--- a/misc/extension_api_validation/4.7-stable/GH-120749.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-120749.txt
@@ -1,0 +1,7 @@
+GH-120749
+---------
+
+Validate extension JSON: Error: Field 'classes/AudioEffectInstance/methods/_process/arguments/0': type changed value in new API, from "const void*" to "const AudioFrame*".
+Validate extension JSON: Error: Field 'classes/MovieWriter/methods/_write_frame/arguments/1': type changed value in new API, from "const void*" to "const int32_t*".
+
+Removing `GDExtensionConstPtr<T>` in favor of `GDExtensionPtr<const T>` fixed the pointee type name of these virtual method arguments.

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -375,7 +375,7 @@ void OpenXRExtensionWrapper::on_state_exiting() {
 bool OpenXRExtensionWrapper::on_event_polled(const XrEventDataBuffer &p_event) {
 	bool event_polled;
 
-	if (GDVIRTUAL_CALL(_on_event_polled, GDExtensionConstPtr<void>(&p_event), event_polled)) {
+	if (GDVIRTUAL_CALL(_on_event_polled, GDExtensionPtr<const void>(&p_event), event_polled)) {
 		return event_polled;
 	}
 
@@ -385,7 +385,7 @@ bool OpenXRExtensionWrapper::on_event_polled(const XrEventDataBuffer &p_event) {
 void *OpenXRExtensionWrapper::set_viewport_composition_layer_and_get_next_pointer(const XrCompositionLayerBaseHeader *p_layer, const Dictionary &p_property_values, void *p_next_pointer) {
 	uint64_t pointer = 0;
 
-	if (GDVIRTUAL_CALL(_set_viewport_composition_layer_and_get_next_pointer, GDExtensionConstPtr<void>(p_layer), p_property_values, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+	if (GDVIRTUAL_CALL(_set_viewport_composition_layer_and_get_next_pointer, GDExtensionPtr<const void>(p_layer), p_property_values, GDExtensionPtr<void>(p_next_pointer), pointer)) {
 		return reinterpret_cast<void *>(pointer);
 	}
 
@@ -393,7 +393,7 @@ void *OpenXRExtensionWrapper::set_viewport_composition_layer_and_get_next_pointe
 }
 
 void OpenXRExtensionWrapper::on_viewport_composition_layer_destroyed(const XrCompositionLayerBaseHeader *p_layer) {
-	GDVIRTUAL_CALL(_on_viewport_composition_layer_destroyed, GDExtensionConstPtr<void>(p_layer));
+	GDVIRTUAL_CALL(_on_viewport_composition_layer_destroyed, GDExtensionPtr<const void>(p_layer));
 }
 
 void OpenXRExtensionWrapper::get_viewport_composition_layer_extension_properties(List<PropertyInfo> *p_property_list) {

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -191,8 +191,8 @@ public:
 	virtual Dictionary get_viewport_composition_layer_extension_property_defaults(); // Get the default values for the additional property definitions for OpenXRCompositionLayer.
 	virtual void *set_android_surface_swapchain_create_info_and_get_next_pointer(const Dictionary &p_property_values, void *p_next_pointer);
 
-	GDVIRTUAL3R(uint64_t, _set_viewport_composition_layer_and_get_next_pointer, GDExtensionConstPtr<void>, Dictionary, GDExtensionPtr<void>);
-	GDVIRTUAL1(_on_viewport_composition_layer_destroyed, GDExtensionConstPtr<void>);
+	GDVIRTUAL3R(uint64_t, _set_viewport_composition_layer_and_get_next_pointer, GDExtensionPtr<const void>, Dictionary, GDExtensionPtr<void>);
+	GDVIRTUAL1(_on_viewport_composition_layer_destroyed, GDExtensionPtr<const void>);
 	GDVIRTUAL0R(TypedArray<Dictionary>, _get_viewport_composition_layer_extension_properties);
 	GDVIRTUAL0R(Dictionary, _get_viewport_composition_layer_extension_property_defaults);
 	GDVIRTUAL2R(uint64_t, _set_android_surface_swapchain_create_info_and_get_next_pointer, Dictionary, GDExtensionPtr<void>);
@@ -201,7 +201,7 @@ public:
 	// Should return true if the event was handled, false otherwise.
 	virtual bool on_event_polled(const XrEventDataBuffer &event);
 
-	GDVIRTUAL1R(bool, _on_event_polled, GDExtensionConstPtr<void>);
+	GDVIRTUAL1R(bool, _on_event_polled, GDExtensionPtr<const void>);
 
 	OpenXRExtensionWrapper();
 	virtual ~OpenXRExtensionWrapper() override;

--- a/modules/openxr/openxr_api_extension.cpp
+++ b/modules/openxr/openxr_api_extension.cpp
@@ -133,7 +133,7 @@ uint64_t OpenXRAPIExtension::get_session() {
 	return (uint64_t)OpenXRAPI::get_singleton()->get_session();
 }
 
-Transform3D OpenXRAPIExtension::transform_from_pose(GDExtensionConstPtr<const void> p_pose) {
+Transform3D OpenXRAPIExtension::transform_from_pose(GDExtensionPtr<const void> p_pose) {
 	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), Transform3D());
 	return OpenXRAPI::get_singleton()->transform_from_pose(*(XrPosef *)p_pose.data);
 }
@@ -213,7 +213,7 @@ bool OpenXRAPIExtension::is_running() {
 	return OpenXRAPI::get_singleton()->is_running();
 }
 
-void OpenXRAPIExtension::set_custom_play_space(GDExtensionConstPtr<const void> p_custom_space) {
+void OpenXRAPIExtension::set_custom_play_space(GDExtensionPtr<const void> p_custom_space) {
 	ERR_FAIL_NULL(OpenXRAPI::get_singleton());
 	OpenXRAPI::get_singleton()->set_custom_play_space(*(XrSpace *)p_custom_space.data);
 }

--- a/modules/openxr/openxr_api_extension.h
+++ b/modules/openxr/openxr_api_extension.h
@@ -62,7 +62,7 @@ public:
 	uint64_t get_session();
 
 	// Helper method to convert an XrPosef to a Transform3D.
-	Transform3D transform_from_pose(GDExtensionConstPtr<const void> p_pose);
+	Transform3D transform_from_pose(GDExtensionPtr<const void> p_pose);
 
 	bool xr_result(uint64_t p_result, const String &p_format, const Array &p_args = Array());
 
@@ -83,7 +83,7 @@ public:
 	bool is_initialized();
 	bool is_running();
 
-	void set_custom_play_space(GDExtensionConstPtr<const void> p_custom_space);
+	void set_custom_play_space(GDExtensionPtr<const void> p_custom_space);
 	uint64_t get_play_space();
 	int64_t get_predicted_display_time();
 	int64_t get_next_frame_time();

--- a/modules/webrtc/webrtc_data_channel_extension.h
+++ b/modules/webrtc/webrtc_data_channel_extension.h
@@ -68,8 +68,8 @@ public:
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 
 	/** GDExtension **/
-	GDVIRTUAL2R(Error, _get_packet, GDExtensionConstPtr<const uint8_t *>, GDExtensionPtr<int>);
-	GDVIRTUAL2R(Error, _put_packet, GDExtensionConstPtr<const uint8_t>, int);
+	GDVIRTUAL2R(Error, _get_packet, GDExtensionPtr<const uint8_t *>, GDExtensionPtr<int>);
+	GDVIRTUAL2R(Error, _put_packet, GDExtensionPtr<const uint8_t>, int);
 
 	WebRTCDataChannelExtension() {}
 };

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -107,11 +107,11 @@ protected:
 public:
 	/* PacketPeer extension */
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
-	GDVIRTUAL2R(Error, _get_packet, GDExtensionConstPtr<const uint8_t *>, GDExtensionPtr<int>);
+	GDVIRTUAL2R(Error, _get_packet, GDExtensionPtr<const uint8_t *>, GDExtensionPtr<int>);
 	GDVIRTUAL0R(PackedByteArray, _get_packet_script); // For GDScript.
 
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	GDVIRTUAL2R(Error, _put_packet, GDExtensionConstPtr<const uint8_t>, int);
+	GDVIRTUAL2R(Error, _put_packet, GDExtensionPtr<const uint8_t>, int);
 	GDVIRTUAL1R(Error, _put_packet_script, PackedByteArray); // For GDScript.
 
 	EXBIND0RC(int, get_available_packet_count);

--- a/servers/audio/audio_effect.h
+++ b/servers/audio/audio_effect.h
@@ -39,7 +39,7 @@ class AudioEffectInstance : public RefCounted {
 	GDCLASS(AudioEffectInstance, RefCounted);
 
 protected:
-	GDVIRTUAL3_REQUIRED(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
+	GDVIRTUAL3_REQUIRED(_process, GDExtensionPtr<const AudioFrame>, GDExtensionPtr<AudioFrame>, int)
 	GDVIRTUAL0RC(bool, _process_silence)
 	static void _bind_methods();
 

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -74,7 +74,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_supported_extensions)
 
 	GDVIRTUAL3R_REQUIRED(Error, _write_begin, const Size2i &, uint32_t, const String &)
-	GDVIRTUAL2R_REQUIRED(Error, _write_frame, const Ref<Image> &, GDExtensionConstPtr<int32_t>)
+	GDVIRTUAL2R_REQUIRED(Error, _write_frame, const Ref<Image> &, GDExtensionPtr<const int32_t>)
 	GDVIRTUAL0_REQUIRED(_write_end)
 
 	static void _bind_methods();

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -1471,13 +1471,13 @@ bool TextServerExtension::shaped_text_is_ready(const RID &p_shaped) const {
 }
 
 const Glyph *TextServerExtension::shaped_text_get_glyphs(const RID &p_shaped) const {
-	GDExtensionConstPtr<const Glyph> ret;
+	GDExtensionPtr<const Glyph> ret;
 	GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret);
 	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_sort_logical(const RID &p_shaped) {
-	GDExtensionConstPtr<const Glyph> ret;
+	GDExtensionPtr<const Glyph> ret;
 	GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret);
 	return ret;
 }
@@ -1531,7 +1531,7 @@ int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped) c
 }
 
 const Glyph *TextServerExtension::shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
-	GDExtensionConstPtr<const Glyph> ret;
+	GDExtensionPtr<const Glyph> ret;
 	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
 	return ret;
 }

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -91,7 +91,7 @@ public:
 	virtual void font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) override;
 	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &);
-	GDVIRTUAL3(_font_set_data_ptr, RID, GDExtensionConstPtr<const uint8_t>, int64_t);
+	GDVIRTUAL3(_font_set_data_ptr, RID, GDExtensionPtr<const uint8_t>, int64_t);
 
 	virtual void font_set_face_index(const RID &p_font_rid, int64_t p_index) override;
 	virtual int64_t font_get_face_index(const RID &p_font_rid) const override;
@@ -542,8 +542,8 @@ public:
 	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override;
 	virtual int64_t shaped_text_get_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_get_glyphs, RID);
-	GDVIRTUAL1R_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_sort_logical, RID);
+	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<const Glyph>, _shaped_text_get_glyphs, RID);
+	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<const Glyph>, _shaped_text_sort_logical, RID);
 	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_glyph_count, RID);
 
 	virtual Vector2i shaped_text_get_range(const RID &p_shaped) const override;
@@ -562,7 +562,7 @@ public:
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override;
 	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_trim_pos, RID);
 	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_pos, RID);
-	GDVIRTUAL1RC_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
+	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
 	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_glyph_count, RID);
 
 	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) override;


### PR DESCRIPTION
A godot-rust user made me aware of hard-to-understand `void*` signatures, and this led me down a rabbit hole that revealed some issues with type registration :slightly_smiling_face: 

The PR merges `GDExtensionConstPtr` into the `GDExtensionPtr` type, and uses top-level CV qualification of the argument:
```cpp
GDExtensionPtr<MyClass>       // MyClass*
GDExtensionPtr<const MyClass> // const MyClass*
```

This is consistent  with other pointer types like `shared_ptr<T>`, `RequiredParam<T>` etc. which don't have a separate `Const*` class either. But reducing this redundant axis is not just cosmetic; it fixes concrete bugs. Previously, `GDExtensionConstPtr<SomeClass>` (note missing `const`) was incorrectly mapped to `void*` on the GDExtension side:

```cpp
GDExtensionPtr<AudioFrame>::get_name() == "AudioFrame"
GDExtensionConstPtr<const AudioFrame>::get_name() == "const AudioFrame"
GDExtensionConstPtr<AudioFrame>::get_name() == "const void"
```

After this change, there is only one way to mark a top-level `const`. (As a side effect, the number of possible template instantiations is reduced.)

This makes methods exposed to GDExtension more type-safe, e.g. in `AudioEffectInstance`:

```cpp
virtual void _process(const void *src_buffer, AudioFrame *r_dst_buffer, int32_t frame_count);
// becomes:
virtual void _process(const AudioFrame *src_buffer, AudioFrame *r_dst_buffer, int32_t frame_count);
```

Here's a diff in `extension_api.json` before/after this PR. Only affects 2 places, but likely prevents also future errors:
```diff
diff --git a/extension_api_base.json b/extension_api_v2.json
index 529c142ce0..832a896222 100644
--- a/extension_api_base.json
+++ b/extension_api_fixed.json
@@ -44202,7 +44202,7 @@ 			"name": "AudioEffectInstance"
 					"arguments": [
 						{
 							"name": "src_buffer",
-							"type": "const void*"
+							"type": "const AudioFrame*"
 						},
 						{
 							"name": "r_dst_buffer",
@@ -166726,7 +166726,7 @@ 			"name": "MovieWriter"
 						},
 						{
 							"name": "audio_frame_block",
-							"type": "const void*"
+							"type": "const int32_t*"
 						}
 					]
 				},
```

Apart from this, I delegated `GDVIRTUAL_NATIVE_PTR` logic to templates, reducing quite a bit of code, but there's now a small `GDExtensionPtrName` metafunction for extracting the name.
