### PR TITLE
Add flip to ninepatch render

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1052,6 +1052,15 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 					} else {
 						src_rect = Rect2(0, 0, 1, 1);
 					}
+
+					if (np->flags & RendererCanvasRender::CANVAS_RECT_FLIP_H) {
+						src_rect.position.x += src_rect.size.x;
+						src_rect.size.x *= -1;
+					}
+					if (np->flags & RendererCanvasRender::CANVAS_RECT_FLIP_V) {
+						src_rect.position.y += src_rect.size.y;
+						src_rect.size.y *= -1;
+					}
 				}
 
 				state.instance_data_array[r_index].modulation[0] = np->color.r * base_color.r;

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -224,7 +224,11 @@ void main() {
 
 	vec2 uv = read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw) * ((read_draw_data_flags & INSTANCE_FLAGS_TRANSPOSE_RECT) != uint(0) ? vertex_base.yx : vertex_base.xy);
 	vec4 color = read_draw_data_modulation;
+#ifdef USE_NINEPATCH
+	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * vertex_base;
+#else
 	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * mix(vertex_base, vec2(1.0, 1.0) - vertex_base, lessThan(read_draw_data_src_rect.zw, vec2(0.0, 0.0)));
+#endif
 
 #endif // USE_ATTRIBUTES
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1724,6 +1724,25 @@ void RendererCanvasCull::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_r
 	style->margin[SIDE_BOTTOM] = p_bottomright.y;
 	style->axis_x = p_x_axis_mode;
 	style->axis_y = p_y_axis_mode;
+
+	style->flags = 0;
+
+	if (p_rect.size.x < 0) {
+		style->flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		style->rect.size.x = -style->rect.size.x;
+	}
+	if (p_source.size.x < 0) {
+		style->flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		style->source.size.x = -style->source.size.x;
+	}
+	if (p_rect.size.y < 0) {
+		style->flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		style->rect.size.y = -style->rect.size.y;
+	}
+	if (p_source.size.y < 0) {
+		style->flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		style->source.size.y = -style->source.size.y;
+	}
 }
 
 void RendererCanvasCull::canvas_item_add_primitive(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, RID p_texture) {

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -223,11 +223,13 @@ public:
 			Color color;
 			RSE::NinePatchAxisMode axis_x;
 			RSE::NinePatchAxisMode axis_y;
+			uint16_t flags;
 
 			RID texture;
 
 			CommandNinePatch() {
 				draw_center = true;
+				flags = 0;
 				type = TYPE_NINEPATCH;
 			}
 		};

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2575,6 +2575,17 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 					instance_data->ninepatch_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
+				if (np->texture.is_valid()) {
+					if (np->flags & CANVAS_RECT_FLIP_H) {
+						src_rect.position.x += src_rect.size.x;
+						src_rect.size.x *= -1;
+					}
+					if (np->flags & CANVAS_RECT_FLIP_V) {
+						src_rect.position.y += src_rect.size.y;
+						src_rect.size.y *= -1;
+					}
+				}
+
 				Color modulated = np->color * base_color;
 				if (use_linear_colors) {
 					modulated = modulated.srgb_to_linear();

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -196,7 +196,11 @@ void main() {
 
 	vec2 uv = read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw) * ((read_draw_data_flags & INSTANCE_FLAGS_TRANSPOSE_RECT) != 0 ? vertex_base.yx : vertex_base.xy);
 	vec4 color = read_draw_data_modulation;
+#ifdef USE_NINEPATCH
+	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * vertex_base;
+#else
 	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * mix(vertex_base, vec2(1.0, 1.0) - vertex_base, lessThan(read_draw_data_src_rect.zw, vec2(0.0, 0.0)));
+#endif
 	uvec4 bones = uvec4(0, 0, 0, 0);
 
 #endif // USE_ATTRIBUTES


### PR DESCRIPTION
Adds flip support for `NinePatchRect`, by analogy with `TextureRect`.

Part of fixing #120501

- Split from #120507

- Required by: #120754