### PR TITLE
Add flip flags to `StyleBoxTexture`

### DIFF
--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -76,6 +76,12 @@
 		<member name="expand_margin_top" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the top margin of this style box when drawing, causing it to be drawn larger than requested.
 		</member>
+		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
+			If [code]true[/code], the texture is flipped horizontally.
+		</member>
+		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" default="false">
+			If [code]true[/code], the texture is flipped vertically.
+		</member>
 		<member name="modulate_color" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			Modulates the color of the texture when this style box is drawn.
 		</member>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1052,6 +1052,15 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 					} else {
 						src_rect = Rect2(0, 0, 1, 1);
 					}
+
+					if (np->flags & RendererCanvasRender::CANVAS_RECT_FLIP_H) {
+						src_rect.position.x += src_rect.size.x;
+						src_rect.size.x *= -1;
+					}
+					if (np->flags & RendererCanvasRender::CANVAS_RECT_FLIP_V) {
+						src_rect.position.y += src_rect.size.y;
+						src_rect.size.y *= -1;
+					}
 				}
 
 				state.instance_data_array[r_index].modulation[0] = np->color.r * base_color.r;

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -224,7 +224,11 @@ void main() {
 
 	vec2 uv = read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw) * ((read_draw_data_flags & INSTANCE_FLAGS_TRANSPOSE_RECT) != uint(0) ? vertex_base.yx : vertex_base.xy);
 	vec4 color = read_draw_data_modulation;
+#ifdef USE_NINEPATCH
+	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * vertex_base;
+#else
 	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * mix(vertex_base, vec2(1.0, 1.0) - vertex_base, lessThan(read_draw_data_src_rect.zw, vec2(0.0, 0.0)));
+#endif
 
 #endif // USE_ATTRIBUTES
 

--- a/scene/resources/style_box_texture.cpp
+++ b/scene/resources/style_box_texture.cpp
@@ -105,6 +105,32 @@ float StyleBoxTexture::get_expand_margin(Side p_side) const {
 	return expand_margin[p_side];
 }
 
+void StyleBoxTexture::set_flip_h(bool p_flip) {
+	if (hflip == p_flip) {
+		return;
+	}
+
+	hflip = p_flip;
+	emit_changed();
+}
+
+bool StyleBoxTexture::is_flipped_h() const {
+	return hflip;
+}
+
+void StyleBoxTexture::set_flip_v(bool p_flip) {
+	if (vflip == p_flip) {
+		return;
+	}
+
+	vflip = p_flip;
+	emit_changed();
+}
+
+bool StyleBoxTexture::is_flipped_v() const {
+	return vflip;
+}
+
 void StyleBoxTexture::set_region_rect(const Rect2 &p_region_rect) {
 	if (region_rect == p_region_rect) {
 		return;
@@ -173,6 +199,11 @@ void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	texture->get_rect_region(rect, src_rect, rect, src_rect);
 
+	// Normalize negative size before applying expand_margin, track direction for flip.
+	bool rect_flip_h = rect.size.x < 0;
+	bool rect_flip_v = rect.size.y < 0;
+	rect = rect.abs();
+
 	rect.position.x -= expand_margin[SIDE_LEFT];
 	rect.position.y -= expand_margin[SIDE_TOP];
 	rect.size.x += expand_margin[SIDE_LEFT] + expand_margin[SIDE_RIGHT];
@@ -180,6 +211,13 @@ void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 
 	Vector2 start_offset = Vector2(texture_margin[SIDE_LEFT], texture_margin[SIDE_TOP]);
 	Vector2 end_offset = Vector2(texture_margin[SIDE_RIGHT], texture_margin[SIDE_BOTTOM]);
+
+	if (hflip != rect_flip_h) {
+		rect.size.x = -rect.size.x;
+	}
+	if (vflip != rect_flip_v) {
+		rect.size.y = -rect.size.y;
+	}
 
 	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_scaled_rid(), start_offset, end_offset, RSE::NinePatchAxisMode(axis_h), RSE::NinePatchAxisMode(axis_v), draw_center, modulate);
 }
@@ -195,6 +233,12 @@ void StyleBoxTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxTexture::set_expand_margin);
 	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxTexture::set_expand_margin_all);
 	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxTexture::get_expand_margin);
+
+	ClassDB::bind_method(D_METHOD("set_flip_h", "flip"), &StyleBoxTexture::set_flip_h);
+	ClassDB::bind_method(D_METHOD("is_flipped_h"), &StyleBoxTexture::is_flipped_h);
+
+	ClassDB::bind_method(D_METHOD("set_flip_v", "flip"), &StyleBoxTexture::set_flip_v);
+	ClassDB::bind_method(D_METHOD("is_flipped_v"), &StyleBoxTexture::is_flipped_v);
 
 	ClassDB::bind_method(D_METHOD("set_region_rect", "region"), &StyleBoxTexture::set_region_rect);
 	ClassDB::bind_method(D_METHOD("get_region_rect"), &StyleBoxTexture::get_region_rect);
@@ -224,6 +268,10 @@ void StyleBoxTexture::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_TOP);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_RIGHT);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_BOTTOM);
+
+	ADD_GROUP("Flip", "flip_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 
 	ADD_GROUP("Axis Stretch", "axis_stretch_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis_stretch_horizontal", PROPERTY_HINT_ENUM, "Stretch,Tile,Tile Fit"), "set_h_axis_stretch_mode", "get_h_axis_stretch_mode");

--- a/scene/resources/style_box_texture.h
+++ b/scene/resources/style_box_texture.h
@@ -46,6 +46,8 @@ public:
 private:
 	float expand_margin[4] = {};
 	float texture_margin[4] = {};
+	bool hflip = false;
+	bool vflip = false;
 	Rect2 region_rect;
 	Ref<Texture2D> texture;
 	bool draw_center = true;
@@ -70,6 +72,12 @@ public:
 	void set_expand_margin_all(float p_expand_margin_size);
 	void set_expand_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
 	float get_expand_margin(Side p_expand_side) const;
+
+	void set_flip_h(bool p_flip);
+	bool is_flipped_h() const;
+
+	void set_flip_v(bool p_flip);
+	bool is_flipped_v() const;
 
 	void set_region_rect(const Rect2 &p_region_rect);
 	Rect2 get_region_rect() const;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1724,6 +1724,25 @@ void RendererCanvasCull::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_r
 	style->margin[SIDE_BOTTOM] = p_bottomright.y;
 	style->axis_x = p_x_axis_mode;
 	style->axis_y = p_y_axis_mode;
+
+	style->flags = 0;
+
+	if (p_rect.size.x < 0) {
+		style->flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		style->rect.size.x = -style->rect.size.x;
+	}
+	if (p_source.size.x < 0) {
+		style->flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		style->source.size.x = -style->source.size.x;
+	}
+	if (p_rect.size.y < 0) {
+		style->flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		style->rect.size.y = -style->rect.size.y;
+	}
+	if (p_source.size.y < 0) {
+		style->flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		style->source.size.y = -style->source.size.y;
+	}
 }
 
 void RendererCanvasCull::canvas_item_add_primitive(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, RID p_texture) {

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -223,11 +223,13 @@ public:
 			Color color;
 			RSE::NinePatchAxisMode axis_x;
 			RSE::NinePatchAxisMode axis_y;
+			uint16_t flags;
 
 			RID texture;
 
 			CommandNinePatch() {
 				draw_center = true;
+				flags = 0;
 				type = TYPE_NINEPATCH;
 			}
 		};

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2575,6 +2575,17 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 					instance_data->ninepatch_pixel_size[1] = tex_info->texpixel_size.height;
 				}
 
+				if (np->texture.is_valid()) {
+					if (np->flags & CANVAS_RECT_FLIP_H) {
+						src_rect.position.x += src_rect.size.x;
+						src_rect.size.x *= -1;
+					}
+					if (np->flags & CANVAS_RECT_FLIP_V) {
+						src_rect.position.y += src_rect.size.y;
+						src_rect.size.y *= -1;
+					}
+				}
+
 				Color modulated = np->color * base_color;
 				if (use_linear_colors) {
 					modulated = modulated.srgb_to_linear();

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -196,7 +196,11 @@ void main() {
 
 	vec2 uv = read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw) * ((read_draw_data_flags & INSTANCE_FLAGS_TRANSPOSE_RECT) != 0 ? vertex_base.yx : vertex_base.xy);
 	vec4 color = read_draw_data_modulation;
+#ifdef USE_NINEPATCH
+	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * vertex_base;
+#else
 	vec2 vertex = read_draw_data_dst_rect.xy + abs(read_draw_data_dst_rect.zw) * mix(vertex_base, vec2(1.0, 1.0) - vertex_base, lessThan(read_draw_data_src_rect.zw, vec2(0.0, 0.0)));
+#endif
 	uvec4 bones = uvec4(0, 0, 0, 0);
 
 #endif // USE_ATTRIBUTES


### PR DESCRIPTION
Adds `flip_h` and `flip_v` properties to `StyleBoxTexture`

Part of fixing #120501

- Split from #120507

- Depends on: #120753
- Required by: #120755