### PR TITLE
Fix various actions causing code autocompletion to desync

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -222,7 +222,6 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
 			text_editor->center_viewport_to_caret(0);
 			text_editor->set_code_hint("");
-			text_editor->cancel_code_completion();
 
 			line_col_changed_for_result = true;
 		}
@@ -1411,7 +1410,6 @@ void CodeTextEditor::goto_line_without_history(int p_line, int p_column) {
 	text_editor->set_caret_line(p_line, false);
 	text_editor->set_caret_column(p_column, false);
 	text_editor->set_code_hint("");
-	text_editor->cancel_code_completion();
 	adjust_viewport_to_caret();
 }
 
@@ -1425,7 +1423,6 @@ void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
 	text_editor->unfold_line(CLAMP(p_line, 0, text_editor->get_line_count() - 1));
 	text_editor->select(p_line, p_begin, p_line, p_end);
 	text_editor->set_code_hint("");
-	text_editor->cancel_code_completion();
 	adjust_viewport_to_caret();
 	trigger_history_save_on_navigate();
 }
@@ -1437,7 +1434,6 @@ void CodeTextEditor::goto_line_centered(int p_line, int p_column) {
 	text_editor->set_caret_line(p_line, false);
 	text_editor->set_caret_column(p_column, false);
 	text_editor->set_code_hint("");
-	text_editor->cancel_code_completion();
 	center_viewport_to_caret();
 	trigger_history_save_on_navigate();
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -760,7 +760,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			accept_event();
 			return;
 		}
-		if (k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_line_end", true)) {
+		if (k->is_action("ui_text_caret_line_end", true)) {
 			cancel_code_completion();
 		}
 		if (k->is_action("ui_text_completion_replace", true) || k->is_action("ui_text_completion_accept", true)) {
@@ -2469,6 +2469,7 @@ void CodeEdit::update_code_completion_options(bool p_forced) {
 	code_completion_forced = p_forced;
 	code_completion_option_sources = code_completion_option_submitted;
 	code_completion_option_submitted.clear();
+	code_completion_caret_line = get_caret_line();
 	_filter_code_completion_candidates_impl();
 }
 
@@ -3749,6 +3750,11 @@ void CodeEdit::_update_scroll_selected_line(float p_mouse_y) {
 void CodeEdit::_filter_code_completion_candidates_impl() {
 	int line_height = get_line_height();
 
+	const int caret_line = get_caret_line();
+	const int caret_column = get_caret_column();
+	const String line = get_line(caret_line);
+	ERR_FAIL_INDEX_MSG(caret_column, line.length() + 1, "Caret column exceeds line length.");
+
 	if (GDVIRTUAL_IS_OVERRIDDEN(_filter_code_completion_candidates)) {
 		Vector<ScriptLanguage::CodeCompletionOption> code_completion_options_new;
 		code_completion_base = "";
@@ -3816,6 +3822,8 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		code_completion_options = code_completion_options_new;
 		code_completion_ac_items.resize_initialized(code_completion_options.size());
 
+		code_completion_caret_column = caret_column;
+		code_completion_line = line;
 		code_completion_longest_line = MIN(max_width, theme_cache.code_completion_max_width * theme_cache.font_size);
 		code_completion_force_item_center = -1;
 		code_completion_active = true;
@@ -3823,11 +3831,6 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		queue_redraw();
 		return;
 	}
-
-	const int caret_line = get_caret_line();
-	const int caret_column = get_caret_column();
-	const String line = get_line(caret_line);
-	ERR_FAIL_INDEX_MSG(caret_column, line.length() + 1, "Caret column exceeds line length.");
 
 	if (caret_column > 0 && line[caret_column - 1] == '(' && !code_completion_forced) {
 		cancel_code_completion();
@@ -4043,6 +4046,8 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	code_completion_options = code_completion_options_new;
 	code_completion_ac_items.resize_initialized(code_completion_options.size());
 
+	code_completion_caret_column = caret_column;
+	code_completion_line = line;
 	code_completion_longest_line = MIN(max_width, theme_cache.code_completion_max_width * theme_cache.font_size);
 	code_completion_force_item_center = -1;
 	code_completion_active = true;
@@ -4086,6 +4091,10 @@ void CodeEdit::_text_set() {
 }
 
 void CodeEdit::_text_changed() {
+	if (code_completion_active && get_line(get_caret_line()) != code_completion_line) {
+		cancel_code_completion();
+	}
+
 	if (lines_edited_from == -1) {
 		return;
 	}
@@ -4121,6 +4130,16 @@ void CodeEdit::_text_changed() {
 	lines_edited_from = -1;
 	lines_edited_to = -1;
 	lines_edited_changed = 0;
+}
+
+void CodeEdit::_line_col_changed() {
+	if (!code_completion_active) {
+		return;
+	}
+
+	if (get_caret_line() != code_completion_caret_line || get_caret_column() != code_completion_caret_column) {
+		cancel_code_completion();
+	}
 }
 
 CodeEdit::CodeEdit() {
@@ -4185,6 +4204,7 @@ CodeEdit::CodeEdit() {
 
 	connect("lines_edited_from", callable_mp(this, &CodeEdit::_lines_edited_from));
 	connect("text_set", callable_mp(this, &CodeEdit::_text_set));
+	connect("caret_changed", callable_mp(this, &CodeEdit::_line_col_changed));
 	connect(SceneStringName(text_changed), callable_mp(this, &CodeEdit::_text_changed));
 
 	connect("gutter_clicked", callable_mp(this, &CodeEdit::_gutter_clicked));

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -229,6 +229,9 @@ private:
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_submitted;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_sources;
 	String code_completion_base;
+	String code_completion_line;
+	int code_completion_caret_line = 0;
+	int code_completion_caret_column = 0;
 
 	void _update_scroll_selected_line(float p_mouse_y);
 	void _filter_code_completion_candidates_impl();
@@ -315,6 +318,7 @@ private:
 
 	void _lines_edited_from(int p_from_line, int p_to_line);
 	void _text_set();
+	void _line_col_changed();
 	void _text_changed();
 
 	void _apply_project_settings();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/107327

Using various shortcuts or other actions while code completion is active would cause code autocompletion to desync. Below are examples of breaking shortcuts/actions that could desync code completion, which this PR fixes:

- `CTRL` + `Backspace` (Backspace word)
- `CTRL` + `Z` (Undo)
- `CTRL` + `X` / `Shift` + `Delete` (Cut)
- `CTRL` + `V` (Paste)
- `CTRL` + `Home` (Caret document start)
- `CTRL` + `Enter` (New blank line)
- `CTRL` + `Left` (Caret word left)
- `CTRL` + `Right` (Caret word right)
- `CTRL` + `Shift` + `K` (Delete line)
- `CTRL` + `Shift` + `J` (Join lines)
- `CTRL` + `Shift` + `Enter` (New line above)
- `CTRL` + `/` & `CTRL` + `K` (Toggle comment)
- `CTRL` + `Shift` + `E` (Evaluate selection)
- `Alt` + `R` (Create code region)
- `Alt` + `Up`/`Down` (Move Up/Down)
- `Shift` + `Left`/`Right`
- `CTRL` + `Shift` + `Left`/`Right`
- `Shift` + `Home`
- `Shift` + `End`
- Edit menu buttons like `Cut`,  `Paste`, `Undo`
- Connecting a signal to a method (`ScriptTextEditor::add_callback`)
- Fold all lines shortcut

## Additional information

To solve the issue, caret line changes as well as any text changes are tracked, and if it finds any unaccounted changes that do not filter code completion, code completion is canceled.

Additionally, `cancel_code_completion` is no longer called for some methods that don't need it anymore, which will include these actions:
- `Ctrl` + `.`/`,` (Go to next/previous breakpoint)
- `Ctrl` + `G` (Go to line)
- `Ctrl` + `B` (Go to next bookmark)
- `Ctrl` + `Shift` + `B` (Go to previous bookmark)
- `Home`

