### PR TITLE
[3.x] Add `[[lifetimebound]]` attribute

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -115,12 +115,12 @@ private:
 public:
 	void operator=(const CowData<T> &p_from) { _ref(p_from); }
 
-	_FORCE_INLINE_ T *ptrw() {
+	_FORCE_INLINE_ T *ptrw() _LIFETIME_BOUND_ {
 		_copy_on_write();
 		return _ptr;
 	}
 
-	_FORCE_INLINE_ const T *ptr() const {
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ {
 		return _ptr;
 	}
 
@@ -133,8 +133,8 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ operator Span<T>() const { return Span<T>(ptr(), size()); }
-	_FORCE_INLINE_ Span<T> span() const { return operator Span<T>(); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return Span<T>(ptr(), size()); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return operator Span<T>(); }
 
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool empty() const { return _ptr == nullptr; }

--- a/core/fixed_array.h
+++ b/core/fixed_array.h
@@ -61,7 +61,7 @@ public:
 	bool is_full() const { return _size == CAPACITY; }
 	uint32_t capacity() const { return CAPACITY; }
 
-	T *request(bool p_construct = true) {
+	T *request(bool p_construct = true) _LIFETIME_BOUND_ {
 		if (size() < CAPACITY) {
 			T *ele = &get(_size++);
 			if (CONSTRUCT && p_construct) {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1728,7 +1728,7 @@ bool Image::empty() const {
 	return (data.size() == 0);
 }
 
-PoolVector<uint8_t> Image::get_data() const {
+const PoolVector<uint8_t> &Image::get_data() const {
 	return data;
 }
 

--- a/core/image.h
+++ b/core/image.h
@@ -265,7 +265,7 @@ public:
 	 */
 	bool empty() const;
 
-	PoolVector<uint8_t> get_data() const;
+	const PoolVector<uint8_t> &get_data() const;
 
 	Error load(const String &p_path);
 	Error save_png(const String &p_path) const;

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -49,11 +49,11 @@ protected:
 	T *data = nullptr;
 
 public:
-	T *ptr() {
+	T *ptr() _LIFETIME_BOUND_ {
 		return data;
 	}
 
-	const T *ptr() const {
+	const T *ptr() const _LIFETIME_BOUND_ {
 		return data;
 	}
 
@@ -284,8 +284,8 @@ public:
 		return ret;
 	}
 
-	_FORCE_INLINE_ Span<T> span() const { return Span(data, count); }
-	_FORCE_INLINE_ operator Span<T>() const { return span(); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(data, count); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
 	_FORCE_INLINE_ LocalVector() {}
 	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {

--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -335,14 +335,14 @@ public:
 		Write() {}
 	};
 
-	Read read() const {
+	Read read() const _LIFETIME_BOUND_ {
 		Read r;
 		if (alloc) {
 			r._ref(alloc);
 		}
 		return r;
 	}
-	Write write() {
+	Write write() _LIFETIME_BOUND_ {
 		Write w;
 		if (alloc) {
 			_copy_on_write(); //make sure there is only one being accessed
@@ -424,8 +424,8 @@ public:
 		return find(p_val) != -1;
 	}
 
-	_FORCE_INLINE_ Span<T> span() const { return Span(read().ptr(), (uint32_t)size()); }
-	_FORCE_INLINE_ operator Span<T>() const { return span(); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(read().ptr(), (uint32_t)size()); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
 	inline int size() const;
 	inline bool empty() const;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -40,6 +40,12 @@
 
 #include "platform_config.h"
 
+#if defined(__has_cpp_attribute)
+#define GD_HAS_CPP_ATTRIBUTE(m_feature) __has_cpp_attribute(m_feature)
+#else
+#define GD_HAS_CPP_ATTRIBUTE(m_feature) 0
+#endif
+
 #ifndef _STR
 #define _STR(m_x) #m_x
 #define _MKSTR(m_x) _STR(m_x)
@@ -123,6 +129,18 @@
 #else
 #define _NO_DISCARD_CLASS_
 #endif
+#endif
+
+#if GD_HAS_CPP_ATTRIBUTE(clang::lifetimebound)
+#define _LIFETIME_BOUND_ [[clang::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(gnu::lifetimebound)
+#define _LIFETIME_BOUND_ [[gnu::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(msvc::lifetimebound)
+#define _LIFETIME_BOUND_ [[msvc::lifetimebound]]
+#elif GD_HAS_CPP_ATTRIBUTE(lifetimebound)
+#define _LIFETIME_BOUND_ [[lifetimebound]]
+#else
+#define _LIFETIME_BOUND_
 #endif
 
 //custom, gcc-safe offsetof, because gcc complains a lot.

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -80,8 +80,8 @@ class CharString {
 	static const char _null;
 
 public:
-	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ char *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 
@@ -108,7 +108,7 @@ public:
 	bool operator<(const CharString &p_right) const;
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
-	const char *get_data() const;
+	const char *get_data() const _LIFETIME_BOUND_;
 	operator const char *() const { return get_data(); };
 
 protected:
@@ -144,8 +144,8 @@ public:
 		npos = -1 ///<for "some" compatibility with std::string (npos is a huge value in std::string)
 	};
 
-	_FORCE_INLINE_ CharType *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const CharType *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ CharType *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const CharType *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
 
 	void remove(int p_index) { _cowdata.remove(p_index); }
 
@@ -193,7 +193,7 @@ public:
 	signed char nocasecmp_to(const String &p_str) const;
 	signed char naturalnocasecmp_to(const String &p_str) const;
 
-	const CharType *c_str() const;
+	const CharType *c_str() const _LIFETIME_BOUND_;
 	/* standard size stuff */
 
 	_FORCE_INLINE_ int length() const {

--- a/core/vector.h
+++ b/core/vector.h
@@ -75,8 +75,8 @@ public:
 	};
 	void invert();
 
-	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ T *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
 
@@ -85,8 +85,8 @@ public:
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 
-	_FORCE_INLINE_ operator Span<T>() const { return _cowdata.span(); }
-	_FORCE_INLINE_ Span<T> span() const { return _cowdata.span(); }
+	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return _cowdata.span(); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return _cowdata.span(); }
 
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -256,7 +256,8 @@ Error AudioDriverPulseAudio::init_device() {
 	attr.maxlength = (uint32_t)-1;
 	attr.minreq = (uint32_t)-1;
 
-	const char *dev = device_name == "Default" ? nullptr : device_name.utf8().get_data();
+	CharString device_name_utf8 = device_name.utf8();
+	const char *dev = device_name == "Default" ? nullptr : device_name_utf8.get_data();
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_playback(pa_str, dev, &attr, flags, nullptr, nullptr);
 	ERR_FAIL_COND_V(error_code < 0, ERR_CANT_OPEN);
@@ -718,7 +719,8 @@ Error AudioDriverPulseAudio::capture_init_device() {
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
-	const char *dev = capture_device_name == "Default" ? nullptr : capture_device_name.utf8().get_data();
+	CharString capture_device_name_utf8 = capture_device_name.utf8();
+	const char *dev = capture_device_name == "Default" ? nullptr : capture_device_name_utf8.get_data();
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_record(pa_rec_str, dev, &attr, flags);
 	if (error_code < 0) {

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -90,7 +90,7 @@ void NavigationPolygon::set_vertices(const PoolVector<Vector2> &p_vertices) {
 	rect_cache_dirty = true;
 }
 
-PoolVector<Vector2> NavigationPolygon::get_vertices() const {
+const PoolVector<Vector2> &NavigationPolygon::get_vertices() const {
 	return vertices;
 }
 

--- a/scene/2d/navigation_polygon.h
+++ b/scene/2d/navigation_polygon.h
@@ -67,7 +67,7 @@ public:
 #endif
 
 	void set_vertices(const PoolVector<Vector2> &p_vertices);
-	PoolVector<Vector2> get_vertices() const;
+	const PoolVector<Vector2> &get_vertices() const;
 
 	void add_polygon(const Vector<int> &p_polygon);
 	int get_polygon_count() const;


### PR DESCRIPTION
* Add to some core containers
* Fix bugs flagged

Port / Inspired by #120746

@Ivorforce has noticed that `[[lifetimebound]]` attribute has been added to compilers, and it is proving super useful for finding bugs. I thought I would have a go at adding it to 3.x and fixing bugs while he is adding to 4.x.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes bugs with r-values being accessed after deletion.
These appear to have been _kind of working_, but is undefined behaviour.

## Additional information

I still want to investigate `PoolVector` a bit more with the use of `Read` for the span operator, but will leave for follow up.

## `PoolVector::Read` / `Write`
I've added the lifetime check to these.
It has exposed a class of bug:

```
PoolVector<uint8_t>::Read r = img->get_data().read();
```
* `get_data()` returns a copy of the `PoolVector`
* `.read()` is performed on the temporary
* that is assigned to `r`
* the temporary is destroyed at the end of the expression, so `r` is a pointer to already-destroyed memory

I considered two approaches:
1) change `Image::get_data()` and `NavigationPolygon::get_vertices()` to return const ref, which removes the problem, as there is no longer a temporary
2) create an explicit local at each call site for the `PoolVector`, and use this in order to guarantee lifetime

(1) is similar to the approach in #120746 .
There are some small risks with it, because the copy uses COW, and thus a call site could rely on the original COW behaviour.

* lifetime issues - if Image is destroyed or changed while we hold reference
* breaking existing code that relies on a copy
* any const compilation issues

However on talking this through with @Ivorforce we decided that it was worth trialling (1), as code that relied on the old behaviour was brittle and likely to break anyway.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
