### PR TITLE
Fix doc tooltip disappears after IME input.

### DIFF
--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -397,7 +397,7 @@ Key KeyMappingWindows::get_keysym(unsigned int p_code) {
 	if (key) {
 		return *key;
 	}
-	return Key::UNKNOWN;
+	return Key::NONE;
 }
 
 unsigned int KeyMappingWindows::get_scancode(Key p_keycode) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

 When using IME to complete input, it sends key events with Unicode values in `WM_CHAR` message handler. On Windows, the key mapping treats these keys as `Key::UNKNOWN`. Additionally, since the design of IME does not generate key release events after corresponding characters are input, the engine internally keeps the state of `Key::UNKNOWN` as pressed until window losts focus, causing `Input::is_anything_pressed` to always return true. Unfortunately the documentation tooltip tool uses this function internally.

I found the key mapping of IME on other platforms, they return `Key::NONE`. Moreover, the engine internally only checks for `Key::NONE` in places where it does not directly check for `Key::UNKNOWN`. Therefore, I believe this fix is safe.

## What problem(s) does this PR solve?

Closes #110804, closes #104870, closes #120547

## Additional information
 

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
