### PR TITLE
Improve button styling

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -152,8 +152,47 @@
 		<theme_item name="disabled_mirrored" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is disabled (for right-to-left layouts).
 		</theme_item>
+		<theme_item name="disabled_pressed" data_type="style" type="StyleBox" keywords="enabled">
+			[StyleBox] used when the [Button] is disabled and pressed. If this property isn't set the [theme_item disabled] will be used instead.
+		</theme_item>
+		<theme_item name="disabled_pressed_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is disabled and pressed. If this property isn't set the [theme_item disabled] will be used instead. (for right-to-left layouts).
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is focused. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
+		</theme_item>
+		<theme_item name="focus_disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being disabled. If this property isn't set the [theme_item focus] will be used instead.
+		</theme_item>
+		<theme_item name="focus_disabled_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being disabled. If this property isn't set the [theme_item focus] will be used instead. (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="focus_disabled_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being disabled and pressed. If this property isn't set the [theme_item focus] will be used instead.
+		</theme_item>
+		<theme_item name="focus_disabled_pressed_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being disabled and pressed. If this property isn't set the [theme_item focus] will be used instead. (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="focus_hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being hovered. If the [Button] is being pressed [theme_item focus_pressed] will take priority. If this property isn't set the [theme_item focus] will be used instead.
+		</theme_item>
+		<theme_item name="focus_hover_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being hovered. If the [Button] is being pressed [theme_item focus_pressed] will take priority. If this property isn't set the [theme_item focus] will be used instead. (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="focus_hover_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being hovered and pressed. If this property isn't set the [theme_item focus] will be used instead.
+		</theme_item>
+		<theme_item name="focus_hover_pressed_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being hovered and pressed. If this property isn't set the [theme_item focus] will be used instead. (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="focus_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons. (for right-to-left layouts)
+		</theme_item>
+		<theme_item name="focus_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being pressed. If this property isn't set the [theme_item focus] will be used instead.
+		</theme_item>
+		<theme_item name="focus_pressed_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused whilst being pressed. If this property isn't set the [theme_item focus] will be used instead. (for right-to-left layouts).
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -391,7 +391,11 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 		if (pressing) {
 			return DRAW_PRESSED;
 		} else {
-			return DRAW_NORMAL;
+			if (is_pressed() && status.hovering) {
+				return DRAW_HOVER_PRESSED;
+			} else {
+				return DRAW_NORMAL;
+			}
 		}
 	}
 }

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -93,6 +93,12 @@ void Button::_update_theme_item_cache() {
 	} else {
 		_update_style_margins(theme_cache.disabled);
 	}
+	if (rtl && has_theme_stylebox(SNAME("disabled_pressed_mirrored"))) {
+		_update_style_margins(theme_cache.disabled_pressed_mirrored);
+	} else {
+		_update_style_margins(theme_cache.disabled_pressed);
+	}
+
 	theme_cache.max_style_size = theme_cache.max_style_size.max(Vector2(theme_cache.style_margin_left + theme_cache.style_margin_right, theme_cache.style_margin_top + theme_cache.style_margin_bottom));
 }
 
@@ -106,14 +112,31 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 
 	switch (get_draw_mode()) {
 		case DRAW_NORMAL: {
-			if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
-				stylebox = theme_cache.normal_mirrored;
+			if (is_pressed() || is_pressing()) {
+				if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
+					stylebox = theme_cache.hover_pressed_mirrored;
+				} else {
+					stylebox = theme_cache.hover_pressed;
+				}
 			} else {
-				stylebox = theme_cache.normal;
+				if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
+					stylebox = theme_cache.normal_mirrored;
+				} else {
+					stylebox = theme_cache.normal;
+				}
 			}
 		} break;
 
 		case DRAW_HOVER_PRESSED: {
+			if (is_pressed() && is_pressing() && is_hovered()) {
+				if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
+					stylebox = theme_cache.pressed_mirrored;
+				} else {
+					stylebox = theme_cache.pressed;
+				}
+				break;
+			}
+
 			// Edge case for CheckButton and CheckBox.
 			if (has_theme_stylebox("hover_pressed")) {
 				if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
@@ -142,10 +165,99 @@ Ref<StyleBox> Button::_get_current_stylebox() const {
 		} break;
 
 		case DRAW_DISABLED: {
+			if (is_pressed()) {
+				if (rtl && has_theme_stylebox(SNAME("disabled_pressed_mirrored"))) {
+					stylebox = theme_cache.disabled_pressed_mirrored;
+					break;
+				} else if (has_theme_stylebox(SNAME("disabled_pressed"))) {
+					stylebox = theme_cache.disabled_pressed;
+					break;
+				}
+			}
+
 			if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
 				stylebox = theme_cache.disabled_mirrored;
 			} else {
 				stylebox = theme_cache.disabled;
+			}
+		} break;
+	}
+
+	return stylebox;
+}
+
+Ref<StyleBox> Button::_get_current_stylebox_focus() const {
+	Ref<StyleBox> stylebox = theme_cache.focus;
+	const bool rtl = is_layout_rtl();
+	if (rtl && has_theme_stylebox(SNAME("focus_mirrored"))) {
+		stylebox = theme_cache.focus_mirrored;
+	}
+
+	switch (get_draw_mode()) {
+		case DRAW_NORMAL: {
+			if (is_pressed() || is_pressing()) {
+				if (is_hovered()) {
+					if (rtl && has_theme_stylebox(SNAME("focus_hover_mirrored"))) {
+						stylebox = theme_cache.focus_hover_mirrored;
+					} else {
+						stylebox = theme_cache.focus_hover;
+					}
+				} else {
+					if (rtl && has_theme_stylebox(SNAME("focus_pressed_mirrored"))) {
+						stylebox = theme_cache.focus_pressed_mirrored;
+					} else {
+						stylebox = theme_cache.focus_pressed;
+					}
+				}
+			} else {
+				if (rtl && has_theme_stylebox(SNAME("focus_mirrored"))) {
+					stylebox = theme_cache.focus_mirrored;
+				} else {
+					stylebox = theme_cache.focus;
+				}
+			}
+		} break;
+
+		case DRAW_HOVER_PRESSED: {
+			if (rtl && has_theme_stylebox(SNAME("focus_hover_pressed_mirrored"))) {
+				stylebox = theme_cache.focus_hover_pressed_mirrored;
+			} else {
+				stylebox = theme_cache.focus_hover_pressed;
+			}
+			break;
+		}
+			[[fallthrough]];
+		case DRAW_PRESSED: {
+			if (rtl && has_theme_stylebox(SNAME("focus_pressed_mirrored"))) {
+				stylebox = theme_cache.focus_pressed_mirrored;
+			} else {
+				stylebox = theme_cache.focus_pressed;
+			}
+		} break;
+
+		case DRAW_HOVER: {
+			if (rtl && has_theme_stylebox(SNAME("focus_hover_mirrored"))) {
+				stylebox = theme_cache.focus_hover_mirrored;
+			} else {
+				stylebox = theme_cache.focus_hover;
+			}
+		} break;
+
+		case DRAW_DISABLED: {
+			if (is_pressed()) {
+				if (rtl && has_theme_stylebox(SNAME("focus_disabled_pressed_mirrored"))) {
+					stylebox = theme_cache.focus_disabled_pressed_mirrored;
+					break;
+				} else if (has_theme_stylebox(SNAME("focus_disabled_pressed"))) {
+					stylebox = theme_cache.focus_disabled_pressed;
+					break;
+				}
+			}
+
+			if (rtl && has_theme_stylebox(SNAME("focus_disabled_mirrored"))) {
+				stylebox = theme_cache.focus_disabled_mirrored;
+			} else {
+				stylebox = theme_cache.focus_disabled;
 			}
 		} break;
 	}
@@ -226,7 +338,8 @@ void Button::_notification(int p_what) {
 			}
 
 			if (has_focus(true)) {
-				theme_cache.focus->draw(ci, Rect2(Point2(), size));
+				Ref<StyleBox> focusStyle = _get_current_stylebox_focus();
+				focusStyle->draw(ci, Rect2(Point2(), size));
 			}
 
 			Ref<Texture2D> _icon = icon;
@@ -245,7 +358,7 @@ void Button::_notification(int p_what) {
 
 			Size2 drawable_size_remained = size;
 
-			{ // The size after the stelybox is stripped.
+			{ // The size after the stylebox is stripped.
 				drawable_size_remained.width -= style_margin_left + style_margin_right;
 				drawable_size_remained.height -= style_margin_top + style_margin_bottom;
 			}
@@ -845,7 +958,20 @@ void Button::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, hover_pressed_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, disabled);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, disabled_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, disabled_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, disabled_pressed_mirrored);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_hover);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_hover_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_pressed_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_hover_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_hover_pressed_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_disabled);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_disabled_mirrored);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_disabled_pressed);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Button, focus_disabled_pressed_mirrored);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Button, font_focus_color);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -67,7 +67,20 @@ private:
 		Ref<StyleBox> hover_pressed_mirrored;
 		Ref<StyleBox> disabled;
 		Ref<StyleBox> disabled_mirrored;
+		Ref<StyleBox> disabled_pressed;
+		Ref<StyleBox> disabled_pressed_mirrored;
 		Ref<StyleBox> focus;
+		Ref<StyleBox> focus_mirrored;
+		Ref<StyleBox> focus_hover;
+		Ref<StyleBox> focus_hover_mirrored;
+		Ref<StyleBox> focus_pressed;
+		Ref<StyleBox> focus_pressed_mirrored;
+		Ref<StyleBox> focus_hover_pressed;
+		Ref<StyleBox> focus_hover_pressed_mirrored;
+		Ref<StyleBox> focus_disabled;
+		Ref<StyleBox> focus_disabled_mirrored;
+		Ref<StyleBox> focus_disabled_pressed;
+		Ref<StyleBox> focus_disabled_pressed_mirrored;
 
 		Size2 max_style_size;
 		float style_margin_left = 0;
@@ -116,6 +129,7 @@ protected:
 
 	Size2 _fit_icon_size(const Size2 &p_size) const;
 	Ref<StyleBox> _get_current_stylebox() const;
+	Ref<StyleBox> _get_current_stylebox_focus() const;
 	Size2 _get_largest_stylebox_size() const;
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -365,9 +365,17 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	flat_button_pressed->set_bg_color(style_pressed_color * Color(1, 1, 1, 0.85));
 
 	theme->set_stylebox(CoreStringName(normal), SceneStringName(FlatButton), flat_button_normal);
+	theme->set_stylebox("focus", SceneStringName(FlatButton), flat_button_normal);
 	theme->set_stylebox(SceneStringName(hover), SceneStringName(FlatButton), flat_button_normal);
+	theme->set_stylebox("focus_hover", SceneStringName(FlatButton), flat_button_normal);
 	theme->set_stylebox(SceneStringName(pressed), SceneStringName(FlatButton), flat_button_pressed);
+	theme->set_stylebox("focus_pressed", SceneStringName(FlatButton), flat_button_pressed);
+	theme->set_stylebox("hover_pressed", SceneStringName(FlatButton), flat_button_pressed);
+	theme->set_stylebox("focus_hover_pressed", SceneStringName(FlatButton), flat_button_pressed);
 	theme->set_stylebox("disabled", SceneStringName(FlatButton), flat_button_normal);
+	theme->set_stylebox("focus_disabled", SceneStringName(FlatButton), flat_button_normal);
+	theme->set_stylebox("disabled_pressed", SceneStringName(FlatButton), flat_button_normal);
+	theme->set_stylebox("focus_disabled_pressed", SceneStringName(FlatButton), flat_button_normal);
 
 	theme->set_stylebox(CoreStringName(normal), "FlatMenuButton", flat_button_normal);
 	theme->set_stylebox(SceneStringName(hover), "FlatMenuButton", flat_button_normal);


### PR DESCRIPTION
## What problem(s) does this PR solve?

* Buttons do not have a style for when a toggle button is currently pressed and the user is pressing it again, it currently defaults to showing the normal style again which looks odd with custom button styling. 
* The toggle button doesn't have any styling for when it is toggled and disabled at the same time and would instead only show the disabled state.
* The focus overlay only supports a single focus state (without right to left support), which is always used regardless of the button state itself.

This PR fixes these 3 issues by selecting the right style for the toggled button being pressed/hovered, adding a `disabled_pressed` style and adding the various focus styles including their right to left versions when available.

The changes are non-breaking and should fall back to the original styling if any of the new styling options aren't used yet. This includes the new `disabled_pressed` which will simply fall back to `disabled` if no styling has been provided for it.

Before:

https://github.com/user-attachments/assets/c7bdb01c-0b49-41dd-b848-521b7e2aae6f

After:

https://github.com/user-attachments/assets/754f813e-fbb6-4a4b-a0a1-b7311e111593

## Additional information

Here's the test project I used during this [GUITest.zip](https://github.com/user-attachments/files/29500567/GUITest.zip) which also includes a texture for the 5 main states (normal, hovered, pressed, disabled, disabled pressed) and their respective focus overlay textures.