### PR TITLE
Don't automatically open virtual keyboard when popup menu shows

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3837,6 +3837,7 @@ PopupMenu::PopupMenu() {
 	search_bar->set_clear_button_enabled(true);
 	search_bar->set_placeholder(ETR("Search"));
 	search_bar->set_keep_editing_on_text_submit(true);
+	search_bar->set_virtual_keyboard_show_on_focus(false);
 	search_bar->connect(SceneStringName(text_changed), callable_mp(this, &PopupMenu::_search_bar_text_changed));
 	search_bar->connect(SceneStringName(focus_entered), callable_mp(this, &PopupMenu::_search_bar_focus_entered));
 	vbox_container->add_child(search_bar, false, INTERNAL_MODE_FRONT);


### PR DESCRIPTION
Currently when search bar is enabled in popup menu, it automatically opens the virtual keyboard when popup menu shows. This makes it frustating on mobile when I don't want to search.

This PR fixes it, now virtual keyboard opens on tapping the search bar.
<details><summary>Before/After video</summary>
<p>

Before:

https://github.com/user-attachments/assets/7a6a0462-d835-4a65-aa1a-9fa7cba51dc9

After:

https://github.com/user-attachments/assets/1941fa3e-ecad-4381-9baa-100cbc4aadbd

</p>
</details> 

