### PR TITLE
ConnectDialog: Fix `Window.reset_size()` after disabling advanced options

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -759,12 +759,13 @@ void ConnectDialog::_advanced_pressed() {
 		vbc_right->show();
 		error_label->hide();
 	} else {
-		reset_size();
 		connect_to_label->set_text(TTR("Connect to Script:"));
 		tree->set_connect_to_script_mode(true);
 
 		vbc_right->hide();
 		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
+
+		reset_size();
 	}
 
 	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "use_advanced_connections", advanced->is_pressed());


### PR DESCRIPTION
## What problem(s) does this PR solve?

`Window.reset_size()` in `ConnectDialog::_advanced_pressed()` is called before any visiblity changes, so it effectively does nothing. Moved it three lines below.

## Before

https://github.com/user-attachments/assets/dc68e9fe-3b68-4c26-adc5-ff21d8c442a5

## After

https://github.com/user-attachments/assets/c6a216b0-9e76-4674-b470-cc4b9cffbc14