### PR TITLE
Fix PCSS soft shadows for SpotLight3D (Forward+)

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -823,7 +823,7 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 			//soft shadow
 
 			//find blocker
-			float z_norm = dot(spot_dir, -light_rel_vec) * spot_lights.data[idx].inv_radius;
+			float z_norm = splane.z;
 
 			vec2 shadow_uv = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
 
@@ -846,7 +846,7 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 				vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
 				suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
 				float d = textureLod(sampler2D(shadow_atlas, SAMPLER_LINEAR_CLAMP), suv, 0.0).r;
-				if (d > splane.z) {
+				if (d > z_norm) {
 					blocker_average += d;
 					blocker_count += 1.0;
 				}
@@ -856,7 +856,8 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 				//blockers found, do soft shadow
 				blocker_average /= blocker_count;
 				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
-				uv_size *= penumbra;
+				// Replace z_norm scale factor with penumbra.
+				uv_size *= penumbra / z_norm;
 
 				shadow = half(0.0);
 
@@ -864,7 +865,7 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 				for (uint i = 0; i < sc_penumbra_shadow_samples(); i++) {
 					vec2 suv = shadow_uv + (disk_rotation * scene_data_block.data.penumbra_shadow_kernel[i].xy) * uv_size;
 					suv = clamp(suv, spot_lights.data[idx].atlas_rect.xy, clamp_max);
-					shadow += half(textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(suv, splane.z, 1.0)));
+					shadow += half(textureProj(sampler2DShadow(shadow_atlas, shadow_sampler), vec4(suv, z_norm, 1.0)));
 				}
 
 				shadow /= half(sc_penumbra_shadow_samples());

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1223,8 +1223,12 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 				if (size > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
-					float half_np = cm.get_z_near() * Math::tan(Math::deg_to_rad(spot_angle));
-					light_data.soft_shadow_size = (size * 0.5 / radius) / (half_np / cm.get_z_near()) * rect.size.width;
+					float tan_half_angle = Math::tan(Math::deg_to_rad(spot_angle));
+					// This factor empirically matches the size of spot's penumbra to omni's
+					// penumbra. The penumbras match across all caster-to-receiver distances,
+					// and the other factors here account for spot angle and shadow atlas size.
+					const float SPOT_SOFTNESS_MATCH = 32.0;
+					light_data.soft_shadow_size = (size * 0.5) / tan_half_angle * rect.size.width * SPOT_SOFTNESS_MATCH;
 				} else {
 					light_data.soft_shadow_size = 0.0;
 					light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->shadows_quality_radius_get(); // Only use quality radius for PCF


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes https://github.com/godotengine/godot/issues/80137

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

https://github.com/godotengine/godot/issues/80137 identified two issues:
1. When a SpotLight3D's range is increased, its shadows get harder instead of remaining unchanged.
2. When a SpotLight3D moves closer to the caster, its shadows get harder instead of softer.

This PR fixes these issues, resulting in shadows that closely match the equivalent OmniLight3D.

I note that I don't have a particularly deep understanding of the soft shadow rendering code. I used AI to answer questions about the code and suggest changes (which I then tested thoroughly and iterated on many times myself). I found the AI's explanations of exactly why this change needs to be this way unconvincing, so I'm not going to try to explain it in any more detail than is in the comments (which I mostly wrote myself). Any feedback/explanations from experts would be much appreciated. I did not use AI to write this description or to do any of the testing.

That said, I tested these changes across varying light size, light range, light angle, caster distance, receiver distance, and atlas size, and it closely matches OmniLight3D in all cases.

BEFORE:

https://github.com/user-attachments/assets/ca3e0e17-1560-4b60-9a28-ab636b533856

AFTER:

https://github.com/user-attachments/assets/114e7e8e-2124-49f8-b063-eb88ae11d089