### PR TITLE
Fix PCSS shadows using shadow range begin in the wrong space.

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2358,7 +2358,7 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 			cull.shadows[p_shadow_index].cascades[i].split = distances[i + 1];
 			cull.shadows[p_shadow_index].cascades[i].shadow_texel_size = radius * 2.0 / texture_size;
 			cull.shadows[p_shadow_index].cascades[i].bias_scale = (z_max - z_min_cam);
-			cull.shadows[p_shadow_index].cascades[i].range_begin = z_max;
+			cull.shadows[p_shadow_index].cascades[i].range_begin = z_max - z_vec.dot(p_cam_transform.origin);
 			cull.shadows[p_shadow_index].cascades[i].uv_scale = uv_scale;
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #86536

PCSS shadows use the range begin value to determine how far into the shadow map the vertex is. However, this value contains the projection of the shadow map center in _world space_, which mismatches with view space computations in the shader. To fix this, we subtract the projection of the camera origin.

## Additional information

This may make the angular distance/blur parameters in existing directional lights look different, but technically, they never worked correctly in the first place, as it was view dependent. So I think this is acceptable.