### PR TITLE
Make build profile editor show a toast for errors when hidden

### DIFF
--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -41,6 +41,7 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
@@ -1327,7 +1328,11 @@ void EditorBuildProfileManager::_import_profile(const String &p_path) {
 	Error err = profile->load_from_file(p_path);
 	String basefile = p_path.get_file();
 	if (err != OK) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("File '%s' format is invalid, import aborted."), basefile));
+		if (is_visible()) {
+			EditorNode::get_singleton()->show_warning(vformat(TTR("File '%s' format is invalid, import aborted."), basefile));
+		} else {
+			EditorToaster::get_singleton()->popup_str(vformat(TTR("Can't load build profile. File '%s' is invalid."), basefile), EditorToaster::SEVERITY_ERROR);
+		}
 		return;
 	}
 


### PR DESCRIPTION
When the build profile dialog attempts to load a file but fails, it will show a warning dialog saying it failed. When the editor starts, it tries to load a profile from the get-go, but when that happens the dialog won't show up, throwing an error instead because it's too soon.

This PR fixes that by making it instead show an toaster instead of a dialog if the profile editor is hidden. This both fixes the issue, and is an UX improvement, since the editor won't throw an dialog at your face at start up.