### PR TITLE
Fix a potential crash on `TOOL_TOGGLE_SCENE_UNIQUE_NAME` handling

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1489,14 +1489,16 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		} break;
 		case TOOL_TOGGLE_SCENE_UNIQUE_NAME: {
 			// Enabling/disabling based on the same node based on which the checkbox in the menu is checked/unchecked.
-			const List<Node *>::Element *first_selected = editor_selection->get_top_selected_node_list().front();
+			const List<Node *> selection = editor_selection->get_top_selected_node_list();
+			Node *first_selected = selection.front() ? selection.front()->get() : nullptr;
 			if (first_selected == nullptr) {
 				return;
 			}
-			if (first_selected->get() == EditorNode::get_singleton()->get_edited_scene()) {
+			if (first_selected == EditorNode::get_singleton()->get_edited_scene()) {
 				// Exclude Root Node. It should never be unique name in its own scene!
-				editor_selection->remove_node(first_selected->get());
-				first_selected = editor_selection->get_top_selected_node_list().front();
+				editor_selection->remove_node(first_selected);
+				const List<Node *> selection1 = editor_selection->get_top_selected_node_list();
+				first_selected = selection1.front() ? selection1.front()->get() : nullptr;
 				if (first_selected == nullptr) {
 					return;
 				}
@@ -1518,7 +1520,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				return;
 			}
 
-			bool enabling = !first_selected->get()->is_unique_name_in_owner();
+			bool enabling = !first_selected->is_unique_name_in_owner();
 
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a potential crash when the `TOOL_TOGGLE_SCENE_UNIQUE_NAME` tool is selected (whatever that means).

The current code is illegal and might crash (if it doesn't, it's by chance).

## Additional information

The code around it is a little awkward, but I'll play agnostic and won't touch it.

Uncovered by https://github.com/godotengine/godot/pull/120787.