### PR TITLE
Add `_LIFETIME_BOUND_` annotations for elements of core containers.

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -302,7 +302,7 @@ public:
 		_size = 0;
 	}
 
-	TValue &get(const TKey &p_key) {
+	TValue &get(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -310,7 +310,7 @@ public:
 		return _elements[element_idx].value;
 	}
 
-	const TValue &get(const TKey &p_key) const {
+	const TValue &get(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -318,7 +318,7 @@ public:
 		return _elements[element_idx].value;
 	}
 
-	const TValue *getptr(const TKey &p_key) const {
+	const TValue *getptr(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -329,7 +329,7 @@ public:
 		return nullptr;
 	}
 
-	TValue *getptr(const TKey &p_key) {
+	TValue *getptr(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -530,20 +530,20 @@ public:
 		MapKeyValue *end = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
+	_FORCE_INLINE_ Iterator begin() _LIFETIME_BOUND_ {
 		return Iterator(_elements, _elements, _elements + _size);
 	}
-	_FORCE_INLINE_ Iterator end() {
+	_FORCE_INLINE_ Iterator end() _LIFETIME_BOUND_ {
 		return Iterator(_elements + _size, _elements, _elements + _size);
 	}
-	_FORCE_INLINE_ Iterator last() {
+	_FORCE_INLINE_ Iterator last() _LIFETIME_BOUND_ {
 		if (unlikely(_size == 0)) {
 			return Iterator(nullptr, nullptr, nullptr);
 		}
 		return Iterator(_elements + _size - 1, _elements, _elements + _size);
 	}
 
-	Iterator find(const TKey &p_key) {
+	Iterator find(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t meta_idx = 0;
 		uint32_t element_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -559,20 +559,20 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ ConstIterator begin() const {
+	_FORCE_INLINE_ ConstIterator begin() const _LIFETIME_BOUND_ {
 		return ConstIterator(_elements, _elements, _elements + _size);
 	}
-	_FORCE_INLINE_ ConstIterator end() const {
+	_FORCE_INLINE_ ConstIterator end() const _LIFETIME_BOUND_ {
 		return ConstIterator(_elements + _size, _elements, _elements + _size);
 	}
-	_FORCE_INLINE_ ConstIterator last() const {
+	_FORCE_INLINE_ ConstIterator last() const _LIFETIME_BOUND_ {
 		if (unlikely(_size == 0)) {
 			return ConstIterator(nullptr, nullptr, nullptr);
 		}
 		return ConstIterator(_elements + _size - 1, _elements, _elements + _size);
 	}
 
-	ConstIterator find(const TKey &p_key) const {
+	ConstIterator find(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -584,7 +584,7 @@ public:
 
 	/* Indexing */
 
-	const TValue &operator[](const TKey &p_key) const {
+	const TValue &operator[](const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
@@ -592,7 +592,7 @@ public:
 		return _elements[element_idx].value;
 	}
 
-	TValue &operator[](const TKey &p_key) {
+	TValue &operator[](const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		uint32_t hash = _hash(p_key);
@@ -608,7 +608,7 @@ public:
 
 	/* Insert */
 
-	Iterator insert(const TKey &p_key, const TValue &p_value) {
+	Iterator insert(const TKey &p_key, const TValue &p_value) _LIFETIME_BOUND_ {
 		uint32_t element_idx = 0;
 		uint32_t meta_idx = 0;
 		uint32_t hash = _hash(p_key);
@@ -623,7 +623,7 @@ public:
 	}
 
 	// Inserts an element without checking if it already exists.
-	Iterator insert_new(const TKey &p_key, const TValue &p_value) {
+	Iterator insert_new(const TKey &p_key, const TValue &p_value) _LIFETIME_BOUND_ {
 		DEV_ASSERT(!has(p_key));
 		uint32_t hash = _hash(p_key);
 		uint32_t element_idx = _insert_element(p_key, p_value, hash);
@@ -633,7 +633,7 @@ public:
 	/* Array methods. */
 
 	// Unsafe. Changing keys and going outside the bounds of an array can lead to undefined behavior.
-	KeyValue<TKey, TValue> *get_elements_ptr() {
+	KeyValue<TKey, TValue> *get_elements_ptr() _LIFETIME_BOUND_ {
 		return _elements;
 	}
 
@@ -648,7 +648,7 @@ public:
 		return element_idx;
 	}
 
-	KeyValue<TKey, TValue> &get_by_index(uint32_t p_index) {
+	KeyValue<TKey, TValue> &get_by_index(uint32_t p_index) _LIFETIME_BOUND_ {
 		CRASH_BAD_UNSIGNED_INDEX(p_index, _size);
 		return _elements[p_index];
 	}

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -185,7 +185,7 @@ public:
 		_ptr[p_index] = p_elem;
 	}
 
-	_FORCE_INLINE_ T &get_m(Size p_index) {
+	_FORCE_INLINE_ T &get_m(Size p_index) _LIFETIME_BOUND_ {
 		CRASH_BAD_INDEX(p_index, size());
 		// If we fail to fork, all we can do is crash,
 		// since the caller may write incorrectly to the unforked array.
@@ -193,7 +193,7 @@ public:
 		return _ptr[p_index];
 	}
 
-	_FORCE_INLINE_ const T &get(Size p_index) const {
+	_FORCE_INLINE_ const T &get(Size p_index) const _LIFETIME_BOUND_ {
 		CRASH_BAD_INDEX(p_index, size());
 
 		return _ptr[p_index];

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -188,21 +188,21 @@ public:
 	// NOTE: Subscripts sanity check the bounds to avoid undefined behavior.
 	//       This is slower than direct buffer access and can prevent autovectorization.
 	//       If the bounds are known, use ptr() subscript instead.
-	constexpr const T &operator[](uint32_t p_index) const {
+	constexpr const T &operator[](uint32_t p_index) const _LIFETIME_BOUND_ {
 		CRASH_COND(p_index >= _size);
 		return ptr()[p_index];
 	}
 
-	constexpr T &operator[](uint32_t p_index) {
+	constexpr T &operator[](uint32_t p_index) _LIFETIME_BOUND_ {
 		CRASH_COND(p_index >= _size);
 		return ptr()[p_index];
 	}
 
-	_FORCE_INLINE_ constexpr T *begin() { return ptr(); }
-	_FORCE_INLINE_ constexpr T *end() { return ptr() + _size; }
+	_FORCE_INLINE_ constexpr T *begin() _LIFETIME_BOUND_ { return ptr(); }
+	_FORCE_INLINE_ constexpr T *end() _LIFETIME_BOUND_ { return ptr() + _size; }
 
-	_FORCE_INLINE_ constexpr const T *begin() const { return ptr(); }
-	_FORCE_INLINE_ constexpr const T *end() const { return ptr() + _size; }
+	_FORCE_INLINE_ constexpr const T *begin() const _LIFETIME_BOUND_ { return ptr(); }
+	_FORCE_INLINE_ constexpr const T *end() const _LIFETIME_BOUND_ { return ptr() + _size; }
 };
 
 GODOT_GCC_WARNING_POP

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -283,21 +283,21 @@ public:
 		sorter.sort(_head_element, _tail_element);
 	}
 
-	TValue &get(const TKey &p_key) {
+	TValue &get(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
 		return _elements[idx]->data.value;
 	}
 
-	const TValue &get(const TKey &p_key) const {
+	const TValue &get(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
 		return _elements[idx]->data.value;
 	}
 
-	const TValue *getptr(const TKey &p_key) const {
+	const TValue *getptr(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 
@@ -307,7 +307,7 @@ public:
 		return nullptr;
 	}
 
-	TValue *getptr(const TKey &p_key) {
+	TValue *getptr(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 
@@ -502,17 +502,17 @@ public:
 		HashMapElement<TKey, TValue> *E = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
+	_FORCE_INLINE_ Iterator begin() _LIFETIME_BOUND_ {
 		return Iterator(_head_element);
 	}
-	_FORCE_INLINE_ Iterator end() {
+	_FORCE_INLINE_ Iterator end() _LIFETIME_BOUND_ {
 		return Iterator(nullptr);
 	}
-	_FORCE_INLINE_ Iterator last() {
+	_FORCE_INLINE_ Iterator last() _LIFETIME_BOUND_ {
 		return Iterator(_tail_element);
 	}
 
-	_FORCE_INLINE_ Iterator find(const TKey &p_key) {
+	_FORCE_INLINE_ Iterator find(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 		if (!exists) {
@@ -527,17 +527,17 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ ConstIterator begin() const {
+	_FORCE_INLINE_ ConstIterator begin() const _LIFETIME_BOUND_ {
 		return ConstIterator(_head_element);
 	}
-	_FORCE_INLINE_ ConstIterator end() const {
+	_FORCE_INLINE_ ConstIterator end() const _LIFETIME_BOUND_ {
 		return ConstIterator(nullptr);
 	}
-	_FORCE_INLINE_ ConstIterator last() const {
+	_FORCE_INLINE_ ConstIterator last() const _LIFETIME_BOUND_ {
 		return ConstIterator(_tail_element);
 	}
 
-	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const {
+	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 		if (!exists) {
@@ -548,14 +548,14 @@ public:
 
 	/* Indexing */
 
-	const TValue &operator[](const TKey &p_key) const {
+	const TValue &operator[](const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t idx = 0;
 		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND(!exists);
 		return _elements[idx]->data.value;
 	}
 
-	TValue &operator[](const TKey &p_key) {
+	TValue &operator[](const TKey &p_key) _LIFETIME_BOUND_ {
 		const uint32_t hash = _hash(p_key);
 		uint32_t idx = 0;
 		bool exists = _elements && _size > 0 && _lookup_idx_unchecked(p_key, hash, idx);

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -380,20 +380,20 @@ public:
 		int32_t _key_idx = -1;
 	};
 
-	_FORCE_INLINE_ Iterator begin() const {
+	_FORCE_INLINE_ Iterator begin() const _LIFETIME_BOUND_ {
 		return _size ? Iterator(_keys, _size, 0) : Iterator();
 	}
-	_FORCE_INLINE_ Iterator end() const {
+	_FORCE_INLINE_ Iterator end() const _LIFETIME_BOUND_ {
 		return Iterator();
 	}
-	_FORCE_INLINE_ Iterator last() const {
+	_FORCE_INLINE_ Iterator last() const _LIFETIME_BOUND_ {
 		if (_size == 0) {
 			return Iterator();
 		}
 		return Iterator(_keys, _size, _size - 1);
 	}
 
-	_FORCE_INLINE_ Iterator find(const TKey &p_key) const {
+	_FORCE_INLINE_ Iterator find(const TKey &p_key) const _LIFETIME_BOUND_ {
 		uint32_t key_idx = 0;
 		bool exists = _lookup_key_idx(p_key, key_idx);
 		if (!exists) {
@@ -410,7 +410,7 @@ public:
 
 	/* Insert */
 
-	Iterator insert(const TKey &p_key) {
+	Iterator insert(const TKey &p_key) _LIFETIME_BOUND_ {
 		uint32_t key_idx = _insert(p_key);
 		return Iterator(_keys, _size, key_idx);
 	}

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -256,35 +256,35 @@ public:
 	/**
 	 * return a const iterator to the beginning of the list.
 	 */
-	_FORCE_INLINE_ const Element *front() const {
+	_FORCE_INLINE_ const Element *front() const _LIFETIME_BOUND_ {
 		return _data ? _data->first : nullptr;
 	}
 
 	/**
 	 * return an iterator to the beginning of the list.
 	 */
-	_FORCE_INLINE_ Element *front() {
+	_FORCE_INLINE_ Element *front() _LIFETIME_BOUND_ {
 		return _data ? _data->first : nullptr;
 	}
 
 	/**
 	 * return a const iterator to the last member of the list.
 	 */
-	_FORCE_INLINE_ const Element *back() const {
+	_FORCE_INLINE_ const Element *back() const _LIFETIME_BOUND_ {
 		return _data ? _data->last : nullptr;
 	}
 
 	/**
 	 * return an iterator to the last member of the list.
 	 */
-	_FORCE_INLINE_ Element *back() {
+	_FORCE_INLINE_ Element *back() _LIFETIME_BOUND_ {
 		return _data ? _data->last : nullptr;
 	}
 
 	/**
 	 * store a new element at the end of the list
 	 */
-	Element *push_back(const T &value) {
+	Element *push_back(const T &value) _LIFETIME_BOUND_ {
 		if (!_data) {
 			_data = memnew_allocator(_Data, A);
 			_data->first = nullptr;
@@ -323,7 +323,7 @@ public:
 	/**
 	 * store a new element at the beginning of the list
 	 */
-	Element *push_front(const T &value) {
+	Element *push_front(const T &value) _LIFETIME_BOUND_ {
 		if (!_data) {
 			_data = memnew_allocator(_Data, A);
 			_data->first = nullptr;
@@ -358,7 +358,7 @@ public:
 		}
 	}
 
-	Element *insert_after(Element *p_element, const T &p_value) {
+	Element *insert_after(Element *p_element, const T &p_value) _LIFETIME_BOUND_ {
 		CRASH_COND(p_element && (!_data || p_element->data != _data));
 
 		if (!p_element) {
@@ -384,7 +384,7 @@ public:
 		return n;
 	}
 
-	Element *insert_before(Element *p_element, const T &p_value) {
+	Element *insert_before(Element *p_element, const T &p_value) _LIFETIME_BOUND_ {
 		CRASH_COND(p_element && (!_data || p_element->data != _data));
 
 		if (!p_element) {
@@ -414,7 +414,7 @@ public:
 	 * find an element in the list,
 	 */
 	template <typename T_v>
-	const Element *find(const T_v &p_val) const {
+	const Element *find(const T_v &p_val) const _LIFETIME_BOUND_ {
 		const Element *it = front();
 		while (it) {
 			if (it->value == p_val) {
@@ -427,7 +427,7 @@ public:
 	}
 
 	template <typename T_v>
-	Element *find(const T_v &p_val) {
+	Element *find(const T_v &p_val) _LIFETIME_BOUND_ {
 		Element *it = front();
 		while (it) {
 			if (it->value == p_val) {
@@ -546,7 +546,7 @@ public:
 
 	// Random access to elements, use with care,
 	// do not use for iteration.
-	T &get(int p_index) {
+	T &get(int p_index) _LIFETIME_BOUND_ {
 		CRASH_BAD_INDEX(p_index, size());
 
 		Element *I = front();
@@ -561,7 +561,7 @@ public:
 
 	// Random access to elements, use with care,
 	// do not use for iteration.
-	const T &get(int p_index) const {
+	const T &get(int p_index) const _LIFETIME_BOUND_ {
 		CRASH_BAD_INDEX(p_index, size());
 
 		const Element *I = front();

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -198,11 +198,11 @@ public:
 	/// This is only available for trivially destructible types (otherwise, trivial resize might be UB).
 	_FORCE_INLINE_ void resize_uninitialized(U p_size) { _resize<false>(p_size); }
 
-	_FORCE_INLINE_ const T &operator[](U p_index) const {
+	_FORCE_INLINE_ const T &operator[](U p_index) const _LIFETIME_BOUND_ {
 		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
 		return data[p_index];
 	}
-	_FORCE_INLINE_ T &operator[](U p_index) {
+	_FORCE_INLINE_ T &operator[](U p_index) _LIFETIME_BOUND_ {
 		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
 		return data[p_index];
 	}
@@ -257,17 +257,17 @@ public:
 		const T *elem_ptr = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
+	_FORCE_INLINE_ Iterator begin() _LIFETIME_BOUND_ {
 		return Iterator(data);
 	}
-	_FORCE_INLINE_ Iterator end() {
+	_FORCE_INLINE_ Iterator end() _LIFETIME_BOUND_ {
 		return Iterator(data + size());
 	}
 
-	_FORCE_INLINE_ ConstIterator begin() const {
+	_FORCE_INLINE_ ConstIterator begin() const _LIFETIME_BOUND_ {
 		return ConstIterator(ptr());
 	}
-	_FORCE_INLINE_ ConstIterator end() const {
+	_FORCE_INLINE_ ConstIterator end() const _LIFETIME_BOUND_ {
 		return ConstIterator(ptr() + size());
 	}
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -98,8 +98,8 @@ public:
 	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
-	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ T get(Size p_index) _LIFETIME_BOUND_ { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const T &get(Size p_index) const _LIFETIME_BOUND_ { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 
 	/// Resize the vector.
@@ -141,7 +141,7 @@ public:
 		return _cowdata.reserve_exact(p_size);
 	}
 
-	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const T &operator[](Size p_index) const _LIFETIME_BOUND_ { return _cowdata.get(p_index); }
 	// Must take a copy instead of a reference (see GH-31736).
 	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, std::move(p_val)); }
 	Size find(const T &p_val, Size p_from = 0) const {
@@ -305,17 +305,17 @@ public:
 		const T *elem_ptr = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
+	_FORCE_INLINE_ Iterator begin() _LIFETIME_BOUND_ {
 		return Iterator(ptrw());
 	}
-	_FORCE_INLINE_ Iterator end() {
+	_FORCE_INLINE_ Iterator end() _LIFETIME_BOUND_ {
 		return Iterator(ptrw() + size());
 	}
 
-	_FORCE_INLINE_ ConstIterator begin() const {
+	_FORCE_INLINE_ ConstIterator begin() const _LIFETIME_BOUND_ {
 		return ConstIterator(ptr());
 	}
-	_FORCE_INLINE_ ConstIterator end() const {
+	_FORCE_INLINE_ ConstIterator end() const _LIFETIME_BOUND_ {
 		return ConstIterator(ptr() + size());
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds safety guarantees for element accesses across core types, which reduces the risk of introducing bugs and regressions.

## Additional information

Most people should be aware that storing element references to a collection outside its lifetime is illegal, but it _can_ happen in weird circumstances, such as https://github.com/godotengine/godot/pull/120785.

Reguires https://github.com/godotengine/godot/pull/120785, until then CI will fail.