### PR TITLE
Prevent `ProgressDialog` and `Save Confirmation Popup` from embedding inside dialogs.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -399,8 +399,10 @@
 		</method>
 		<method name="get_last_exclusive_window" qualifiers="const">
 			<return type="Window" />
+			<param index="0" name="stop_at_dialog" type="bool" default="false" />
 			<description>
 				Returns the [Window] that contains this node, or the last exclusive child in a chain of windows starting with the one that contains this node.
+				If [param stop_at_dialog] is [code]true[/code], the traversal stops before an [AcceptDialog] or any class extending it (such as [ConfirmationDialog]).
 			</description>
 		</method>
 		<method name="get_multiplayer_authority" qualifiers="const">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6850,9 +6850,7 @@ void EditorNode::_cancel_confirmation() {
 }
 
 void EditorNode::_prepare_save_confirmation_popup() {
-	if (save_confirmation->get_window() != get_last_exclusive_window()) {
-		save_confirmation->reparent(get_last_exclusive_window());
-	}
+	save_confirmation->reparent(get_last_exclusive_window(true));
 }
 
 void EditorNode::_toggle_distraction_free_mode() {

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -179,7 +179,7 @@ void ProgressDialog::_popup() {
 }
 
 void ProgressDialog::_reparent_and_show() {
-	Window *current_window = SceneTree::get_singleton()->get_root()->get_last_exclusive_window();
+	Window *current_window = SceneTree::get_singleton()->get_root()->get_last_exclusive_window(true);
 	ERR_FAIL_NULL(current_window);
 	reparent(current_window);
 

--- a/misc/extension_api_validation/4.7-stable/GH-120788.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-120788.txt
@@ -1,0 +1,6 @@
+GH-120788
+--------------
+
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Node/methods/get_last_exclusive_window': arguments
+
+Added a "stop_at_dialogs" boolean parameter, if "true", stops the traversal of Window nodes before a dialog (AcceptDialog or any class extending it, such as ConfirmationDialog/FileDialog). Default is "false" (the old behavior).

--- a/scene/main/node.compat.inc
+++ b/scene/main/node.compat.inc
@@ -42,9 +42,14 @@ Variant Node::_get_rpc_config_bind_compat_106848() const {
 	return _get_node_rpc_config_bind();
 }
 
+Window *Node::_get_last_exclusive_window_bind_compat_120788() const {
+	return get_last_exclusive_window(false);
+}
+
 void Node::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("set_name", "name"), &Node::_set_name_bind_compat_76560);
 	ClassDB::bind_compatibility_method(D_METHOD("get_rpc_config"), &Node::_get_rpc_config_bind_compat_106848);
+	ClassDB::bind_compatibility_method(D_METHOD("get_last_exclusive_window"), &Node::_get_last_exclusive_window_bind_compat_120788);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -47,6 +47,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Engine);
 #include "core/object/script_language.h"
 #include "core/string/print_string.h"
 #include "scene/animation/tween.h"
+#include "scene/gui/dialogs.h"
 #include "scene/main/instance_placeholder.h"
 #include "scene/main/multiplayer_api.h"
 #include "scene/main/scene_tree.h"
@@ -2139,12 +2140,18 @@ Window *Node::get_non_popup_window() const {
 	return w;
 }
 
-Window *Node::get_last_exclusive_window() const {
+Window *Node::get_last_exclusive_window(bool p_stop_at_dialog) const {
 	Window *w = get_window();
-	while (w && w->get_exclusive_child()) {
-		w = w->get_exclusive_child();
+	while (w) {
+		Window *next = w->get_exclusive_child();
+		if (!next) {
+			break;
+		}
+		if (p_stop_at_dialog && Object::cast_to<AcceptDialog>(next)) {
+			break;
+		}
+		w = next;
 	}
-
 	return w;
 }
 
@@ -3855,7 +3862,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_translation_domain_inherited"), &Node::set_translation_domain_inherited);
 
 	ClassDB::bind_method(D_METHOD("get_window"), &Node::get_window);
-	ClassDB::bind_method(D_METHOD("get_last_exclusive_window"), &Node::get_last_exclusive_window);
+	ClassDB::bind_method(D_METHOD("get_last_exclusive_window", "stop_at_dialog"), &Node::get_last_exclusive_window, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_tree"), &Node::get_tree);
 	ClassDB::bind_method(D_METHOD("create_tween"), &Node::create_tween);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -448,6 +448,7 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	void _set_name_bind_compat_76560(const String &p_name);
 	Variant _get_rpc_config_bind_compat_106848() const;
+	Window *_get_last_exclusive_window_bind_compat_120788() const;
 	static void _bind_compatibility_methods();
 #endif
 
@@ -553,7 +554,7 @@ public:
 
 	Window *get_window() const;
 	Window *get_non_popup_window() const;
-	Window *get_last_exclusive_window() const;
+	Window *get_last_exclusive_window(bool p_stop_at_dialogs = false) const;
 
 	_FORCE_INLINE_ SceneTree *get_tree() const {
 		ERR_FAIL_NULL_V(data.tree, nullptr);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120783 

## Additional information

Adds the `stop_at_dialog` parameter to `Node.get_last_exclusive_window()`. This prevents the `ProgressDialog` from embedding inside a dialog/popup, thus modifying the minimum size. Applied the same fix to the save confirmation, you don't want that to appear inside a dialog/popup.

Marking as draft to see if CI complains about compatibility.
