### PR TITLE
Add note to TextEdit docs about using zero-based line and column numbers

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -6,6 +6,7 @@
 	<description>
 		CodeEdit is a specialized [TextEdit] designed for editing plain text code files. It has many features commonly found in code editors such as line numbers, line folding, code completion, indent management, and string/comment management.
 		[b]Note:[/b] Regardless of locale, [CodeEdit] will by default always use left-to-right text direction to correctly display source code.
+		[note]Being a subclass of [TextEdit], line and column numbers are [i]zero-based[/i], like elements of an array. For example, the first line of text can be retrieved by [code]get_line(0)[/code], the second line by [code]get_line(1)[/code], and so on.[/note]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -38,6 +38,7 @@
 		- [kbd]Cmd + Left Arrow[/kbd]: Same as [kbd]Home[/kbd], move the caret to the beginning of the line
 		- [kbd]Cmd + Right Arrow[/kbd]: Same as [kbd]End[/kbd], move the caret to the end of the line
 		[b]Note:[/b] Caret movement shortcuts listed above are not affected by [member shortcut_keys_enabled].
+		[note]Column numbers are [i]zero-based[/i], like elements of an array. For example, [member caret_column] being [code]0[/code] indicates the caret is on the first column (i.e., before the first character).[/note]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -11,6 +11,7 @@
 		- To enter Windows codepoints, hold [kbd]Alt[/kbd] and type the code on the numpad. For example, to enter the character [code]á[/code] (Windows 0225), hold [kbd]Alt[/kbd] and type [kbd]0[/kbd], [kbd]2[/kbd], [kbd]2[/kbd], [kbd]5[/kbd] on the numpad. The leading zero here must [b]not[/b] be omitted, as this is how Windows codepoints are distinguished from OEM codepoints.
 		[b]Note:[/b] Most viewport, caret, and edit methods contain a [code]caret_index[/code] argument for [member caret_multiple] support. The argument should be one of the following: [code]-1[/code] for all carets, [code]0[/code] for the main caret, or greater than [code]0[/code] for secondary carets in the order they were created.
 		[b]Note:[/b] When holding down [kbd]Alt[/kbd], the vertical scroll wheel will scroll 5 times as fast as it would normally do. This also works in the Godot script editor.
+		[b]Note:[/b] Line and column numbers are [i]zero-based[/i], like elements of an array. For example, the first line of text can be retrieved by [code]get_line(0)[/code], the second line by [code]get_line(1)[/code], and so on.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -11,6 +11,7 @@
 		- To enter Windows codepoints, hold [kbd]Alt[/kbd] and type the code on the numpad. For example, to enter the character [code]á[/code] (Windows 0225), hold [kbd]Alt[/kbd] and type [kbd]0[/kbd], [kbd]2[/kbd], [kbd]2[/kbd], [kbd]5[/kbd] on the numpad. The leading zero here must [b]not[/b] be omitted, as this is how Windows codepoints are distinguished from OEM codepoints.
 		[b]Note:[/b] Most viewport, caret, and edit methods contain a [code]caret_index[/code] argument for [member caret_multiple] support. The argument should be one of the following: [code]-1[/code] for all carets, [code]0[/code] for the main caret, or greater than [code]0[/code] for secondary carets in the order they were created.
 		[b]Note:[/b] When holding down [kbd]Alt[/kbd], the vertical scroll wheel will scroll 5 times as fast as it would normally do. This also works in the Godot script editor.
+		[note]Line and column numbers are [i]zero-based[/i], like elements of an array. For example, the first line of text can be retrieved by [code]get_line(0)[/code], the second line by [code]get_line(1)[/code], and so on.[/note]
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

I did not open an issue for this problem, but while working on some other PRs, I found myself unsure of whether the TextEdit APIs used zero- or one-based line and column numbers. 

## Additional information

By looking through the methods' source code, I determined they were all zero-based (e.g., line 0 refers to the first line, line 1 refers to the second line).

This PR specifies this fact in a note on TextEdit's description.

> [!note]
> A part of me would also like to add this note to specific methods' descriptions, as I know I can tend to jump straight to a specific method on the page without reading the "general" description first. But if that were to be done, it might be difficult to determine which descriptions should receive the additional information, and either way it would result in a lot of duplicate information.
> 
> Maybe just referring to `line` as "zero-indexed" would keep it from growing the size of the page too much, while also giving the information to the user where they're looking for it? Something like changing
> > Returns the text of a specific line.
> 
> to
> 
> > Returns the text of a specific zero-indexed line.
> 
> ?
> If you think this would be better than the PR's current approach, I can go through and add "zero-indexed" (or similar) where it seems appropriate for this PR.
