### PR TITLE
Reset dock slot margin index when hover ends

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -166,6 +166,7 @@ void EditorDockDragHint::_notification(int p_what) {
 			can_drop_dock = false;
 			mouse_inside = false;
 			highlighted = false;
+			mouse_margin_index = -1;
 			hide();
 		} break;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes:

[Nagranie ekranu_20260630_230951.webm](https://github.com/user-attachments/assets/6674e20d-2f50-4d59-a7dc-09a48e0a118c)
