### PR TITLE
Fix godot crash in SpriteFrames in the AnimatedSprite2D and 3D

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1808,6 +1808,7 @@ void SpriteFramesEditor::edit(Ref<SpriteFrames> p_frames) {
 	if (p_frames.is_null()) {
 		frames.unref();
 		_remove_sprite_node();
+		close();
 		return;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a crash that occurs when editing an `AnimatedSprite2D` or `AnimatedSprite3D` after its `SpriteFrames` resource has been cleared in the Inspector.

The editor plugin remains active because the selected node is still focused, even though its `SpriteFrames` reference becomes `nullptr`. This leaves the plugin in an invalid state where the user can still interact with it and causing a crash.

---

## Bug lifecycle

The `SpriteFramesEditorPlugin` handles both:

- `AnimatedSprite2D`
- `AnimatedSprite3D`
- `SpriteFrames`

```cpp
bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
    ...
}
```

When an `AnimatedSprite2D` or `AnimatedSprite3D` node is selected, the editor opens the `SpriteFramesEditor` plugin.

During initialization (`_fetch_sprite_node()`), the plugin checks whether the currently selected node references the same `SpriteFrames` resource. If it does, it stores the node and connects to the `sprite_frames_changed` signal.

```cpp
void SpriteFramesEditor::_fetch_sprite_node() {
    ...
}
```

The issue appears when the `SpriteFrames` property is cleared from the Inspector.

At this point:

- the selected node remains selected;
- the editor plugin stays open;
- the edited `SpriteFrames` resource becomes `nullptr`.

Since the plugin is not closed immediately, its UI remains interactive while referencing an invalid resource. Interacting with it can then trigger a crash.

---

## Solution

The plugin already connects to the node's `sprite_frames_changed` signal during initialization.

When the resource changes, `_edit()` is called:

```cpp
void SpriteFramesEditor::_edit() {
    if (!animated_sprite) {
        return;
    }
    edit(animated_sprite->call("get_sprite_frames"));
}
```

When `get_sprite_frames()` now returns `nullptr`, `edit(nullptr)` is called.

Instead of only clearing the edited `SpriteFrames` reference and leaving the editor open, this change ensures the plugin exits the editing state, preventing the user from interacting with an invalid resource.

As a result, the stale editor state is removed before it can lead to a crash.

---

## Demonstration
A video showing both the crash and the fix is attached below.

[A video showing both the crash and the fix is attached below.](https://github.com/user-attachments/assets/58f145c1-e972-4fdb-b896-2777a1f8f917)

---

## Related discussion

A related discussion about a different approach can be found here:

https://github.com/godotengine/godot/pull/112723## 