### PR TITLE
GDScript: Remove unnecessary CoW where possible

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -328,7 +328,7 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 	List<PropertyInfo> props;
 
 	while (sptr) {
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, MemberInfo> &E : sptr->member_indices) {
 			if (!sptr->members.has(E.key)) {
 				continue; // Skip base class members.
@@ -341,8 +341,8 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 
 		msort.sort();
 		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			props.push_front(sptr->member_indices[sort.name].property_info);
 		}
 
 #ifdef TOOLS_ENABLED
@@ -705,18 +705,18 @@ void GDScript::_static_default_init() {
 			const GDScriptDataType element_type = type.get_container_element_type(0);
 			Array default_value;
 			default_value.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		} else if (type.builtin_type == Variant::DICTIONARY && type.has_container_element_types()) {
 			const GDScriptDataType key_type = type.get_container_element_type_or_variant(0);
 			const GDScriptDataType value_type = type.get_container_element_type_or_variant(1);
 			Dictionary default_value;
 			default_value.set_typed(key_type.builtin_type, key_type.native_type, key_type.script_type, value_type.builtin_type, value_type.native_type, value_type.script_type);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		} else {
 			Variant default_value;
 			Callable::CallError err;
 			Variant::construct(type.builtin_type, default_value, nullptr, 0, err);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		}
 	}
 }
@@ -724,8 +724,8 @@ void GDScript::_static_default_init() {
 #ifdef TOOLS_ENABLED
 
 void GDScript::_save_old_static_data() {
-	old_static_variables_indices = static_variables_indices;
-	old_static_variables = static_variables;
+	old_static_variables_indices = std::move(static_variables_indices);
+	old_static_variables = std::move(static_variables);
 	for (KeyValue<StringName, Ref<GDScript>> &inner : subclasses) {
 		inner.value->_save_old_static_data();
 	}
@@ -734,7 +734,7 @@ void GDScript::_save_old_static_data() {
 void GDScript::_restore_old_static_data() {
 	for (KeyValue<StringName, MemberInfo> &E : old_static_variables_indices) {
 		if (static_variables_indices.has(E.key)) {
-			static_variables.write[static_variables_indices[E.key].index] = old_static_variables[E.value.index];
+			static_variables[static_variables_indices[E.key].index] = old_static_variables[E.value.index];
 		}
 	}
 	old_static_variables_indices.clear();
@@ -1057,7 +1057,7 @@ bool GDScript::_set(const StringName &p_name, const Variant &p_value) {
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				top->static_variables.write[member->index] = value;
+				top->static_variables[member->index] = value;
 				return true;
 			}
 		}
@@ -1079,7 +1079,7 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 	}
 
 	for (const List<const GDScript *>::Element *E = classes.back(); E; E = E->prev()) {
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, MemberInfo> &F : E->get()->static_variables_indices) {
 			_GDScriptMemberSort ms;
 			ms.index = F.value.index;
@@ -1088,8 +1088,8 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 		}
 		msort.sort();
 
-		for (int i = 0; i < msort.size(); i++) {
-			p_properties->push_back(E->get()->static_variables_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			p_properties->push_back(E->get()->static_variables_indices[sort.name].property_info);
 		}
 	}
 }
@@ -1146,7 +1146,7 @@ Error GDScript::load_source_code(const String &p_path) {
 		return OK;
 	}
 
-	Vector<uint8_t> sourcef;
+	LocalVector<uint8_t> sourcef;
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 	if (err) {
@@ -1161,7 +1161,7 @@ Error GDScript::load_source_code(const String &p_path) {
 
 	uint64_t len = f->get_length();
 	sourcef.resize(len + 1);
-	uint8_t *w = sourcef.ptrw();
+	uint8_t *w = sourcef.ptr();
 	uint64_t r = f->get_buffer(w, len);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);
 	w[len] = 0;
@@ -1347,7 +1347,7 @@ void GDScript::_save_orphaned_subclasses() {
 		ObjectID id;
 		String fully_qualified_name;
 	};
-	Vector<ClassRefWithName> weak_subclasses;
+	LocalVector<ClassRefWithName> weak_subclasses;
 	// collect subclasses ObjectID and name
 	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
 		E.value->_owner = nullptr; //bye, you are no longer owned cause I died
@@ -1363,8 +1363,7 @@ void GDScript::_save_orphaned_subclasses() {
 	constants.clear();
 
 	// keep orphan subclass only for subclasses that are still in use
-	for (int i = 0; i < weak_subclasses.size(); i++) {
-		ClassRefWithName subclass = weak_subclasses[i];
+	for (const ClassRefWithName &subclass : weak_subclasses) {
 		Object *obj = ObjectDB::get_instance(subclass.id);
 		if (!obj) {
 			continue;
@@ -1598,7 +1597,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 					callp(member->setter, &args, 1, err);
 					return err.error == Callable::CallError::CALL_OK;
 				} else {
-					sptr->static_variables.write[member->index] = value;
+					sptr->static_variables[member->index] = value;
 					return true;
 				}
 			}
@@ -1833,7 +1832,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 
 		//instance a fake script for editing the values
 
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, GDScript::MemberInfo> &F : sptr->member_indices) {
 			if (!sptr->members.has(F.key)) {
 				continue; // Skip base class members.
@@ -1846,8 +1845,8 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 
 		msort.sort();
 		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			props.push_front(sptr->member_indices[sort.name].property_info);
 		}
 
 #ifdef TOOLS_ENABLED
@@ -2101,19 +2100,18 @@ String GDScriptLanguage::get_name() const {
 void GDScriptLanguage::_add_global(const StringName &p_name, const Variant &p_value) {
 	if (globals.has(p_name)) {
 		//overwrite existing
-		global_array.write[globals[p_name]] = p_value;
+		global_array[globals[p_name]] = p_value;
 		return;
 	}
 
 	if (global_array_empty_indexes.size()) {
 		int index = global_array_empty_indexes[global_array_empty_indexes.size() - 1];
 		globals[p_name] = index;
-		global_array.write[index] = p_value;
+		global_array[index] = p_value;
 		global_array_empty_indexes.resize(global_array_empty_indexes.size() - 1);
 	} else {
 		globals[p_name] = global_array.size();
 		global_array.push_back(p_value);
-		_global_array = global_array.ptrw();
 	}
 }
 
@@ -2122,7 +2120,7 @@ void GDScriptLanguage::_remove_global(const StringName &p_name) {
 		return;
 	}
 	global_array_empty_indexes.push_back(globals[p_name]);
-	global_array.write[globals[p_name]] = Variant::NIL;
+	global_array[globals[p_name]] = Variant::NIL;
 	globals.erase(p_name);
 }
 
@@ -2139,7 +2137,7 @@ Variant GDScriptLanguage::get_any_global_constant(const StringName &p_name) {
 		return named_globals[p_name];
 	}
 	if (globals.has(p_name)) {
-		return _global_array[globals[p_name]];
+		return global_array[globals[p_name]];
 	}
 	ERR_FAIL_V_MSG(Variant(), vformat("Could not find any global constant with name: %s.", p_name));
 }

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -284,7 +284,7 @@ StringName GDScript::get_instance_base_type() const {
 }
 
 struct _GDScriptMemberSort {
-	int index = 0;
+	uint32_t index = 0;
 	StringName name;
 	_FORCE_INLINE_ bool operator<(const _GDScriptMemberSort &p_member) const { return index < p_member.index; }
 };
@@ -321,7 +321,7 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 	List<PropertyInfo> props;
 
 	while (sptr) {
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, MemberInfo> &E : sptr->member_indices) {
 			if (!sptr->members.has(E.key)) {
 				continue; // Skip base class members.
@@ -334,8 +334,8 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 
 		msort.sort();
 		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			props.push_front(sptr->member_indices[sort.name].property_info);
 		}
 
 #ifdef TOOLS_ENABLED
@@ -696,18 +696,18 @@ void GDScript::_static_default_init() {
 			const GDScriptDataType element_type = type.get_container_element_type(0);
 			Array default_value;
 			default_value.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		} else if (type.builtin_type == Variant::DICTIONARY && type.has_container_element_types()) {
 			const GDScriptDataType key_type = type.get_container_element_type_or_variant(0);
 			const GDScriptDataType value_type = type.get_container_element_type_or_variant(1);
 			Dictionary default_value;
 			default_value.set_typed(key_type.builtin_type, key_type.native_type, key_type.script_type, value_type.builtin_type, value_type.native_type, value_type.script_type);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		} else {
 			Variant default_value;
 			Callable::CallError err;
 			Variant::construct(type.builtin_type, default_value, nullptr, 0, err);
-			static_variables.write[E.value.index] = default_value;
+			static_variables[E.value.index] = default_value;
 		}
 	}
 }
@@ -715,8 +715,8 @@ void GDScript::_static_default_init() {
 #ifdef TOOLS_ENABLED
 
 void GDScript::_save_old_static_data() {
-	old_static_variables_indices = static_variables_indices;
-	old_static_variables = static_variables;
+	old_static_variables_indices = std::move(static_variables_indices);
+	old_static_variables = std::move(static_variables);
 	for (KeyValue<StringName, Ref<GDScript>> &inner : subclasses) {
 		inner.value->_save_old_static_data();
 	}
@@ -725,7 +725,7 @@ void GDScript::_save_old_static_data() {
 void GDScript::_restore_old_static_data() {
 	for (KeyValue<StringName, MemberInfo> &E : old_static_variables_indices) {
 		if (static_variables_indices.has(E.key)) {
-			static_variables.write[static_variables_indices[E.key].index] = old_static_variables[E.value.index];
+			static_variables[static_variables_indices[E.key].index] = old_static_variables[E.value.index];
 		}
 	}
 	old_static_variables_indices.clear();
@@ -1044,7 +1044,7 @@ bool GDScript::_set(const StringName &p_name, const Variant &p_value) {
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				top->static_variables.write[member->index] = value;
+				top->static_variables[member->index] = value;
 				return true;
 			}
 		}
@@ -1066,7 +1066,7 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 	}
 
 	for (const List<const GDScript *>::Element *E = classes.back(); E; E = E->prev()) {
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, MemberInfo> &F : E->get()->static_variables_indices) {
 			_GDScriptMemberSort ms;
 			ms.index = F.value.index;
@@ -1075,8 +1075,8 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 		}
 		msort.sort();
 
-		for (int i = 0; i < msort.size(); i++) {
-			p_properties->push_back(E->get()->static_variables_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			p_properties->push_back(E->get()->static_variables_indices[sort.name].property_info);
 		}
 	}
 }
@@ -1133,7 +1133,7 @@ Error GDScript::load_source_code(const String &p_path) {
 		return OK;
 	}
 
-	Vector<uint8_t> sourcef;
+	LocalVector<uint8_t> sourcef;
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 	if (err) {
@@ -1148,7 +1148,7 @@ Error GDScript::load_source_code(const String &p_path) {
 
 	uint64_t len = f->get_length();
 	sourcef.resize(len + 1);
-	uint8_t *w = sourcef.ptrw();
+	uint8_t *w = sourcef.ptr();
 	uint64_t r = f->get_buffer(w, len);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);
 	w[len] = 0;
@@ -1186,7 +1186,7 @@ const HashMap<StringName, GDScriptFunction *> &GDScript::debug_get_member_functi
 	return member_functions;
 }
 
-StringName GDScript::debug_get_member_by_index(int p_idx) const {
+StringName GDScript::debug_get_member_by_index(uint32_t p_idx) const {
 	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
 		if (E.value.index == p_idx) {
 			return E.key;
@@ -1196,7 +1196,7 @@ StringName GDScript::debug_get_member_by_index(int p_idx) const {
 	return "<error>";
 }
 
-StringName GDScript::debug_get_static_var_by_index(int p_idx) const {
+StringName GDScript::debug_get_static_var_by_index(uint32_t p_idx) const {
 	for (const KeyValue<StringName, MemberInfo> &E : static_variables_indices) {
 		if (E.value.index == p_idx) {
 			return E.key;
@@ -1334,7 +1334,7 @@ void GDScript::_save_orphaned_subclasses() {
 		ObjectID id;
 		String fully_qualified_name;
 	};
-	Vector<ClassRefWithName> weak_subclasses;
+	LocalVector<ClassRefWithName> weak_subclasses;
 	// collect subclasses ObjectID and name
 	for (KeyValue<StringName, Ref<GDScript>> &E : subclasses) {
 		E.value->_owner = nullptr; //bye, you are no longer owned cause I died
@@ -1350,8 +1350,7 @@ void GDScript::_save_orphaned_subclasses() {
 	constants.clear();
 
 	// keep orphan subclass only for subclasses that are still in use
-	for (int i = 0; i < weak_subclasses.size(); i++) {
-		ClassRefWithName subclass = weak_subclasses[i];
+	for (const ClassRefWithName &subclass : weak_subclasses) {
 		Object *obj = ObjectDB::get_instance(subclass.id);
 		if (!obj) {
 			continue;
@@ -1585,7 +1584,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 					callp(member->setter, &args, 1, err);
 					return err.error == Callable::CallError::CALL_OK;
 				} else {
-					sptr->static_variables.write[member->index] = value;
+					sptr->static_variables[member->index] = value;
 					return true;
 				}
 			}
@@ -1816,7 +1815,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *r_properties) const
 
 		//instance a fake script for editing the values
 
-		Vector<_GDScriptMemberSort> msort;
+		LocalVector<_GDScriptMemberSort> msort;
 		for (const KeyValue<StringName, GDScript::MemberInfo> &F : sptr->member_indices) {
 			if (!sptr->members.has(F.key)) {
 				continue; // Skip base class members.
@@ -1829,8 +1828,8 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *r_properties) const
 
 		msort.sort();
 		msort.reverse();
-		for (int i = 0; i < msort.size(); i++) {
-			props.push_front(sptr->member_indices[msort[i].name].property_info);
+		for (const _GDScriptMemberSort &sort : msort) {
+			props.push_front(sptr->member_indices[sort.name].property_info);
 		}
 
 #ifdef TOOLS_ENABLED
@@ -2079,19 +2078,18 @@ String GDScriptLanguage::get_name() const {
 void GDScriptLanguage::_add_global(const StringName &p_name, const Variant &p_value) {
 	if (globals.has(p_name)) {
 		//overwrite existing
-		global_array.write[globals[p_name]] = p_value;
+		global_array[globals[p_name]] = p_value;
 		return;
 	}
 
 	if (global_array_empty_indexes.size()) {
 		int index = global_array_empty_indexes[global_array_empty_indexes.size() - 1];
 		globals[p_name] = index;
-		global_array.write[index] = p_value;
+		global_array[index] = p_value;
 		global_array_empty_indexes.resize(global_array_empty_indexes.size() - 1);
 	} else {
 		globals[p_name] = global_array.size();
 		global_array.push_back(p_value);
-		_global_array = global_array.ptrw();
 	}
 }
 
@@ -2100,7 +2098,7 @@ void GDScriptLanguage::_remove_global(const StringName &p_name) {
 		return;
 	}
 	global_array_empty_indexes.push_back(globals[p_name]);
-	global_array.write[globals[p_name]] = Variant::NIL;
+	global_array[globals[p_name]] = Variant::NIL;
 	globals.erase(p_name);
 }
 
@@ -2117,7 +2115,7 @@ Variant GDScriptLanguage::get_any_global_constant(const StringName &p_name) {
 		return named_globals[p_name];
 	}
 	if (globals.has(p_name)) {
-		return _global_array[globals[p_name]];
+		return global_array[globals[p_name]];
 	}
 	ERR_FAIL_V_MSG(Variant(), vformat("Could not find any global constant with name: %s.", p_name));
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -89,7 +89,7 @@ class GDScript : public Script {
 
 	// Only static variables of the current class.
 	HashMap<StringName, MemberInfo> static_variables_indices;
-	Vector<Variant> static_variables; // Static variable values.
+	TightLocalVector<Variant> static_variables; // Static variable values.
 
 	HashMap<StringName, Variant> constants;
 	HashMap<StringName, GDScriptFunction *> member_functions;
@@ -132,7 +132,7 @@ private:
 #ifdef TOOLS_ENABLED
 	// For static data storage during hot-reloading.
 	HashMap<StringName, MemberInfo> old_static_variables_indices;
-	Vector<Variant> old_static_variables;
+	TightLocalVector<Variant> old_static_variables;
 	void _save_old_static_data();
 	void _restore_old_static_data();
 
@@ -404,11 +404,10 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	bool finishing = false;
 
-	Variant *_global_array = nullptr;
-	Vector<Variant> global_array;
+	LocalVector<Variant> global_array;
 	HashMap<StringName, int> globals;
 	HashMap<StringName, Variant> named_globals;
-	Vector<int> global_array_empty_indexes;
+	LocalVector<int> global_array_empty_indexes;
 
 	struct CallLevel {
 		Variant *stack = nullptr;
@@ -566,7 +565,7 @@ public:
 	_FORCE_INLINE_ bool should_track_call_stack() const { return track_call_stack; }
 	_FORCE_INLINE_ bool should_track_locals() const { return track_locals; }
 	_FORCE_INLINE_ int get_global_array_size() const { return global_array.size(); }
-	_FORCE_INLINE_ Variant *get_global_array() { return _global_array; }
+	_FORCE_INLINE_ Variant *get_global_array() { return global_array.ptr(); }
 	_FORCE_INLINE_ const HashMap<StringName, int> &get_global_map() const { return globals; }
 	_FORCE_INLINE_ const HashMap<StringName, Variant> &get_named_globals_map() const { return named_globals; }
 	// These two functions should be used when behavior needs to be consistent between in-editor and running the scene

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -62,7 +62,7 @@ class GDScript : public Script {
 	bool _is_abstract = false;
 
 	struct MemberInfo {
-		int index = 0;
+		uint32_t index = 0;
 		StringName setter;
 		StringName getter;
 		GDScriptDataType data_type;
@@ -92,7 +92,7 @@ class GDScript : public Script {
 
 	// Only static variables of the current class.
 	HashMap<StringName, MemberInfo> static_variables_indices;
-	Vector<Variant> static_variables; // Static variable values.
+	TightLocalVector<Variant> static_variables; // Static variable values.
 
 	HashMap<StringName, Variant> constants;
 	HashMap<StringName, GDScriptFunction *> member_functions;
@@ -135,7 +135,7 @@ private:
 #ifdef TOOLS_ENABLED
 	// For static data storage during hot-reloading.
 	HashMap<StringName, MemberInfo> old_static_variables_indices;
-	Vector<Variant> old_static_variables;
+	TightLocalVector<Variant> old_static_variables;
 	void _save_old_static_data();
 	void _restore_old_static_data();
 
@@ -265,8 +265,8 @@ public:
 
 	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
 	const HashMap<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
-	StringName debug_get_member_by_index(int p_idx) const;
-	StringName debug_get_static_var_by_index(int p_idx) const;
+	StringName debug_get_member_by_index(uint32_t p_idx) const;
+	StringName debug_get_static_var_by_index(uint32_t p_idx) const;
 
 	Variant _new(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	virtual bool can_instantiate() const override;
@@ -376,7 +376,7 @@ public:
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
-	Variant debug_get_member_by_index(int p_idx) const { return members[p_idx]; }
+	Variant debug_get_member_by_index(uint32_t p_idx) const { return members[p_idx]; }
 
 	virtual void notification(int p_notification, bool p_reversed = false);
 	String to_string(bool *r_valid);
@@ -403,8 +403,7 @@ class GDScriptLanguage : public ScriptLanguage {
 
 	bool finishing = false;
 
-	Variant *_global_array = nullptr;
-	Vector<Variant> global_array;
+	LocalVector<Variant> global_array;
 	HashMap<StringName, int> globals;
 	HashMap<StringName, Variant> named_globals;
 	Vector<int> global_array_empty_indexes;
@@ -565,7 +564,7 @@ public:
 	_FORCE_INLINE_ bool should_track_call_stack() const { return track_call_stack; }
 	_FORCE_INLINE_ bool should_track_locals() const { return track_locals; }
 	_FORCE_INLINE_ int get_global_array_size() const { return global_array.size(); }
-	_FORCE_INLINE_ Variant *get_global_array() { return _global_array; }
+	_FORCE_INLINE_ Variant *get_global_array() { return global_array.ptr(); }
 	_FORCE_INLINE_ const HashMap<StringName, int> &get_global_map() const { return globals; }
 	_FORCE_INLINE_ const HashMap<StringName, Variant> &get_named_globals_map() const { return named_globals; }
 	// These two functions should be used when behavior needs to be consistent between in-editor and running the scene

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3354,9 +3354,9 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 				}
 
 				// Construct here.
-				Vector<const Variant *> args;
-				for (int i = 0; i < p_call->arguments.size(); i++) {
-					args.push_back(&(p_call->arguments[i]->reduced_value));
+				LocalVector<const Variant *> args;
+				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
+					args.push_back(&(arg->reduced_value));
 				}
 
 				Callable::CallError err;
@@ -3408,7 +3408,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 #ifdef DEBUG_ENABLED
 						mark_node_unsafe(p_call);
 						// Constructors support overloads.
-						Vector<String> types;
+						LocalVector<String> types;
 						for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 							if (i != builtin_type && Variant::can_convert_strict((Variant::Type)i, builtin_type)) {
 								types.push_back(Variant::get_type_name((Variant::Type)i));
@@ -3418,7 +3418,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 						if (types.size() == 1) {
 							expected_types += "\" or \"" + types[0];
 						} else if (types.size() >= 2) {
-							for (int i = 0; i < types.size() - 1; i++) {
+							for (uint32_t i = 0; i < types.size() - 1; i++) {
 								expected_types += "\", \"" + types[i];
 							}
 							expected_types += "\", or \"" + types[types.size() - 1];
@@ -3524,9 +3524,9 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 			if (all_is_constant && GDScriptUtilityFunctions::is_function_constant(function_name)) {
 				// Can call on compilation.
-				Vector<const Variant *> args;
-				for (int i = 0; i < p_call->arguments.size(); i++) {
-					args.push_back(&(p_call->arguments[i]->reduced_value));
+				LocalVector<const Variant *> args;
+				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
+					args.push_back(&(arg->reduced_value));
 				}
 
 				Variant value;
@@ -3575,9 +3575,9 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 			if (all_is_constant && Variant::get_utility_function_type(function_name) == Variant::UTILITY_FUNC_TYPE_MATH) {
 				// Can call on compilation.
-				Vector<const Variant *> args;
-				for (int i = 0; i < p_call->arguments.size(); i++) {
-					args.push_back(&(p_call->arguments[i]->reduced_value));
+				LocalVector<const Variant *> args;
+				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
+					args.push_back(&(arg->reduced_value));
 				}
 
 				Variant value;
@@ -5484,16 +5484,16 @@ Variant GDScriptAnalyzer::make_call_reduced_value(GDScriptParser::CallNode *p_ca
 			return Variant();
 		}
 
-		Vector<Variant> args;
+		LocalVector<Variant> args;
 		args.resize(p_call->arguments.size());
 		const Variant **argptrs = (const Variant **)alloca(sizeof(const Variant *) * args.size());
-		for (int i = 0; i < p_call->arguments.size(); i++) {
+		for (uint32_t i = 0; i < p_call->arguments.size(); i++) {
 			bool is_arg_value_reduced = false;
 			Variant arg_value = make_expression_reduced_value(p_call->arguments[i], is_arg_value_reduced);
 			if (!is_arg_value_reduced) {
 				return Variant();
 			}
-			args.write[i] = arg_value;
+			args[i] = arg_value;
 			argptrs[i] = &args[i];
 		}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3357,7 +3357,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 				}
 
 				// Construct here.
-				Vector<const Variant *> args;
+				LocalVector<const Variant *> args;
 				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
 					args.push_back(&(arg->reduced_value));
 				}
@@ -3411,7 +3411,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 #ifdef DEBUG_ENABLED
 						mark_node_unsafe(p_call);
 						// Constructors support overloads.
-						Vector<String> types;
+						LocalVector<String> types;
 						for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 							if (i != builtin_type && Variant::can_convert_strict((Variant::Type)i, builtin_type)) {
 								types.push_back(Variant::get_type_name((Variant::Type)i));
@@ -3421,7 +3421,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 						if (types.size() == 1) {
 							expected_types += "\" or \"" + types[0];
 						} else if (types.size() >= 2) {
-							for (int i = 0; i < types.size() - 1; i++) {
+							for (uint32_t i = 0; i < types.size() - 1; i++) {
 								expected_types += "\", \"" + types[i];
 							}
 							expected_types += "\", or \"" + types[types.size() - 1];
@@ -3527,7 +3527,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 			if (all_is_constant && GDScriptUtilityFunctions::is_function_constant(function_name)) {
 				// Can call on compilation.
-				Vector<const Variant *> args;
+				LocalVector<const Variant *> args;
 				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
 					args.push_back(&(arg->reduced_value));
 				}
@@ -3578,7 +3578,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 			if (all_is_constant && Variant::get_utility_function_type(function_name) == Variant::UTILITY_FUNC_TYPE_MATH) {
 				// Can call on compilation.
-				Vector<const Variant *> args;
+				LocalVector<const Variant *> args;
 				for (const GDScriptParser::ExpressionNode *arg : p_call->arguments) {
 					args.push_back(&(arg->reduced_value));
 				}
@@ -5487,7 +5487,7 @@ Variant GDScriptAnalyzer::make_call_reduced_value(GDScriptParser::CallNode *p_ca
 			return Variant();
 		}
 
-		Vector<Variant> args;
+		LocalVector<Variant> args;
 		args.resize(p_call->arguments.size());
 		const Variant **argptrs = (const Variant **)alloca(sizeof(const Variant *) * args.size());
 		for (uint32_t i = 0; i < p_call->arguments.size(); i++) {
@@ -5496,7 +5496,7 @@ Variant GDScriptAnalyzer::make_call_reduced_value(GDScriptParser::CallNode *p_ca
 			if (!is_arg_value_reduced) {
 				return Variant();
 			}
-			args.write[i] = arg_value;
+			args[i] = arg_value;
 			argptrs[i] = &args[i];
 		}
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -183,10 +183,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 #endif
 	append_opcode(GDScriptFunction::OPCODE_END);
 
-	for (int i = 0; i < temporaries.size(); i++) {
+	for (uint32_t i = 0; i < temporaries.size(); i++) {
 		int stack_index = i + max_locals + GDScriptFunction::FIXED_ADDRESSES_MAX;
-		for (int j = 0; j < temporaries[i].bytecode_indices.size(); j++) {
-			opcodes.write[temporaries[i].bytecode_indices[j]] = stack_index | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+		for (const int &index : temporaries[i].bytecode_indices) {
+			opcodes[index] = stack_index | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 		}
 		if (temporaries[i].type != Variant::NIL) {
 			function->temporary_slots.push_back(Pair(stack_index, temporaries[i].type));
@@ -196,9 +196,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	if (constant_map.size()) {
 		function->_constant_count = constant_map.size();
 		function->constants.resize(constant_map.size());
-		function->_constants_ptr = function->constants.ptrw();
+		function->_constants_ptr = function->constants.ptr();
 		for (const KeyValue<Variant, int> &K : constant_map) {
-			function->constants.write[K.value] = K.key;
+			function->constants[K.value] = K.key;
 		}
 		for (const KeyValue<StringName, int> &K : local_constants) {
 			function->constant_map.insert(K.key, function->constants[K.value]);
@@ -210,9 +210,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (name_map.size()) {
 		function->global_names.resize(name_map.size());
-		function->_global_names_ptr = &function->global_names[0];
+		function->_global_names_ptr = function->global_names.ptr();
 		for (const KeyValue<StringName, int> &E : name_map) {
-			function->global_names.write[E.value] = E.key;
+			function->global_names[E.value] = E.key;
 		}
 		function->_global_names_count = function->global_names.size();
 
@@ -222,9 +222,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	}
 
 	if (opcodes.size()) {
-		function->code = opcodes;
-		function->_code_ptr = &function->code.write[0];
-		function->_code_size = opcodes.size();
+		function->code = std::move(opcodes);
+		function->_code_ptr = function->code.ptr();
+		function->_code_size = function->code.size();
 
 	} else {
 		function->_code_ptr = nullptr;
@@ -233,7 +233,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (function->default_arguments.size()) {
 		function->_default_arg_count = function->default_arguments.size() - 1;
-		function->_default_arg_ptr = &function->default_arguments[0];
+		function->_default_arg_ptr = function->default_arguments.ptr();
 	} else {
 		function->_default_arg_count = 0;
 		function->_default_arg_ptr = nullptr;
@@ -244,7 +244,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_operator_funcs_count = function->operator_funcs.size();
 		function->_operator_funcs_ptr = function->operator_funcs.ptr();
 		for (const KeyValue<Variant::ValidatedOperatorEvaluator, int> &E : operator_func_map) {
-			function->operator_funcs.write[E.value] = E.key;
+			function->operator_funcs[E.value] = E.key;
 		}
 	} else {
 		function->_operator_funcs_count = 0;
@@ -256,7 +256,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_setters_count = function->setters.size();
 		function->_setters_ptr = function->setters.ptr();
 		for (const KeyValue<Variant::ValidatedSetter, int> &E : setters_map) {
-			function->setters.write[E.value] = E.key;
+			function->setters[E.value] = E.key;
 		}
 	} else {
 		function->_setters_count = 0;
@@ -268,7 +268,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_getters_count = function->getters.size();
 		function->_getters_ptr = function->getters.ptr();
 		for (const KeyValue<Variant::ValidatedGetter, int> &E : getters_map) {
-			function->getters.write[E.value] = E.key;
+			function->getters[E.value] = E.key;
 		}
 	} else {
 		function->_getters_count = 0;
@@ -280,7 +280,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_keyed_setters_count = function->keyed_setters.size();
 		function->_keyed_setters_ptr = function->keyed_setters.ptr();
 		for (const KeyValue<Variant::ValidatedKeyedSetter, int> &E : keyed_setters_map) {
-			function->keyed_setters.write[E.value] = E.key;
+			function->keyed_setters[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_setters_count = 0;
@@ -292,7 +292,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_keyed_getters_count = function->keyed_getters.size();
 		function->_keyed_getters_ptr = function->keyed_getters.ptr();
 		for (const KeyValue<Variant::ValidatedKeyedGetter, int> &E : keyed_getters_map) {
-			function->keyed_getters.write[E.value] = E.key;
+			function->keyed_getters[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_getters_count = 0;
@@ -304,7 +304,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_indexed_setters_count = function->indexed_setters.size();
 		function->_indexed_setters_ptr = function->indexed_setters.ptr();
 		for (const KeyValue<Variant::ValidatedIndexedSetter, int> &E : indexed_setters_map) {
-			function->indexed_setters.write[E.value] = E.key;
+			function->indexed_setters[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_setters_count = 0;
@@ -316,7 +316,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_indexed_getters_count = function->indexed_getters.size();
 		function->_indexed_getters_ptr = function->indexed_getters.ptr();
 		for (const KeyValue<Variant::ValidatedIndexedGetter, int> &E : indexed_getters_map) {
-			function->indexed_getters.write[E.value] = E.key;
+			function->indexed_getters[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_getters_count = 0;
@@ -328,7 +328,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_builtin_methods_ptr = function->builtin_methods.ptr();
 		function->_builtin_methods_count = builtin_method_map.size();
 		for (const KeyValue<Variant::ValidatedBuiltInMethod, int> &E : builtin_method_map) {
-			function->builtin_methods.write[E.value] = E.key;
+			function->builtin_methods[E.value] = E.key;
 		}
 	} else {
 		function->_builtin_methods_ptr = nullptr;
@@ -340,7 +340,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_constructors_ptr = function->constructors.ptr();
 		function->_constructors_count = constructors_map.size();
 		for (const KeyValue<Variant::ValidatedConstructor, int> &E : constructors_map) {
-			function->constructors.write[E.value] = E.key;
+			function->constructors[E.value] = E.key;
 		}
 	} else {
 		function->_constructors_ptr = nullptr;
@@ -352,7 +352,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_utilities_ptr = function->utilities.ptr();
 		function->_utilities_count = utilities_map.size();
 		for (const KeyValue<Variant::ValidatedUtilityFunction, int> &E : utilities_map) {
-			function->utilities.write[E.value] = E.key;
+			function->utilities[E.value] = E.key;
 		}
 	} else {
 		function->_utilities_ptr = nullptr;
@@ -364,7 +364,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_gds_utilities_ptr = function->gds_utilities.ptr();
 		function->_gds_utilities_count = gds_utilities_map.size();
 		for (const KeyValue<GDScriptUtilityFunctions::FunctionPtr, int> &E : gds_utilities_map) {
-			function->gds_utilities.write[E.value] = E.key;
+			function->gds_utilities[E.value] = E.key;
 		}
 	} else {
 		function->_gds_utilities_ptr = nullptr;
@@ -373,10 +373,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (method_bind_map.size()) {
 		function->methods.resize(method_bind_map.size());
-		function->_methods_ptr = function->methods.ptrw();
+		function->_methods_ptr = function->methods.ptr();
 		function->_methods_count = method_bind_map.size();
 		for (const KeyValue<MethodBind *, int> &E : method_bind_map) {
-			function->methods.write[E.value] = E.key;
+			function->methods[E.value] = E.key;
 		}
 	} else {
 		function->_methods_ptr = nullptr;
@@ -385,10 +385,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (lambdas_map.size()) {
 		function->lambdas.resize(lambdas_map.size());
-		function->_lambdas_ptr = function->lambdas.ptrw();
+		function->_lambdas_ptr = function->lambdas.ptr();
 		function->_lambdas_count = lambdas_map.size();
 		for (const KeyValue<GDScriptFunction *, int> &E : lambdas_map) {
-			function->lambdas.write[E.value] = E.key;
+			function->lambdas[E.value] = E.key;
 		}
 	} else {
 		function->_lambdas_ptr = nullptr;
@@ -1384,7 +1384,7 @@ void GDScriptByteCodeGenerator::write_lambda(const Address &p_target, GDScriptFu
 void GDScriptByteCodeGenerator::write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) {
 	// Try to find an appropriate constructor.
 	bool all_have_type = true;
-	Vector<Variant::Type> arg_types;
+	LocalVector<Variant::Type> arg_types;
 	for (int i = 0; i < p_arguments.size(); i++) {
 		if (!HAS_BUILTIN_TYPE(p_arguments[i])) {
 			all_have_type = false;
@@ -1399,7 +1399,7 @@ void GDScriptByteCodeGenerator::write_construct(const Address &p_target, Variant
 				continue;
 			}
 			int types_correct = true;
-			for (int j = 0; j < arg_types.size(); j++) {
+			for (uint32_t j = 0; j < arg_types.size(); j++) {
 				if (arg_types[j] != Variant::get_constructor_argument_type(p_type, i, j)) {
 					types_correct = false;
 					break;

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -183,10 +183,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 #endif
 	append_opcode(GDScriptFunction::OPCODE_END);
 
-	for (int i = 0; i < temporaries.size(); i++) {
+	for (uint32_t i = 0; i < temporaries.size(); i++) {
 		int stack_index = i + max_locals + GDScriptFunction::FIXED_ADDRESSES_MAX;
-		for (int j = 0; j < temporaries[i].bytecode_indices.size(); j++) {
-			opcodes.write[temporaries[i].bytecode_indices[j]] = stack_index | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+		for (const int &index : temporaries[i].bytecode_indices) {
+			opcodes[index] = stack_index | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 		}
 		if (temporaries[i].type != Variant::NIL) {
 			function->temporary_slots.push_back(Pair(stack_index, temporaries[i].type));
@@ -196,9 +196,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	if (constant_map.size()) {
 		function->_constant_count = constant_map.size();
 		function->constants.resize(constant_map.size());
-		function->_constants_ptr = function->constants.ptrw();
+		function->_constants_ptr = function->constants.ptr();
 		for (const KeyValue<Variant, int> &K : constant_map) {
-			function->constants.write[K.value] = K.key;
+			function->constants[K.value] = K.key;
 		}
 		for (const KeyValue<StringName, int> &K : local_constants) {
 			function->constant_map.insert(K.key, function->constants[K.value]);
@@ -210,9 +210,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (name_map.size()) {
 		function->global_names.resize(name_map.size());
-		function->_global_names_ptr = &function->global_names[0];
+		function->_global_names_ptr = function->global_names.ptr();
 		for (const KeyValue<StringName, int> &E : name_map) {
-			function->global_names.write[E.value] = E.key;
+			function->global_names[E.value] = E.key;
 		}
 		function->_global_names_count = function->global_names.size();
 
@@ -222,9 +222,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	}
 
 	if (opcodes.size()) {
-		function->code = opcodes;
-		function->_code_ptr = &function->code.write[0];
-		function->_code_size = opcodes.size();
+		function->code = std::move(opcodes);
+		function->_code_ptr = function->code.ptr();
+		function->_code_size = function->code.size();
 
 	} else {
 		function->_code_ptr = nullptr;
@@ -233,7 +233,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (function->default_arguments.size()) {
 		function->_default_arg_count = function->default_arguments.size() - 1;
-		function->_default_arg_ptr = &function->default_arguments[0];
+		function->_default_arg_ptr = function->default_arguments.ptr();
 	} else {
 		function->_default_arg_count = 0;
 		function->_default_arg_ptr = nullptr;
@@ -244,7 +244,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_operator_funcs_count = function->operator_funcs.size();
 		function->_operator_funcs_ptr = function->operator_funcs.ptr();
 		for (const KeyValue<Variant::ValidatedOperatorEvaluator, int> &E : operator_func_map) {
-			function->operator_funcs.write[E.value] = E.key;
+			function->operator_funcs[E.value] = E.key;
 		}
 	} else {
 		function->_operator_funcs_count = 0;
@@ -256,7 +256,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_setters_count = function->setters.size();
 		function->_setters_ptr = function->setters.ptr();
 		for (const KeyValue<Variant::ValidatedSetter, int> &E : setters_map) {
-			function->setters.write[E.value] = E.key;
+			function->setters[E.value] = E.key;
 		}
 	} else {
 		function->_setters_count = 0;
@@ -268,7 +268,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_getters_count = function->getters.size();
 		function->_getters_ptr = function->getters.ptr();
 		for (const KeyValue<Variant::ValidatedGetter, int> &E : getters_map) {
-			function->getters.write[E.value] = E.key;
+			function->getters[E.value] = E.key;
 		}
 	} else {
 		function->_getters_count = 0;
@@ -280,7 +280,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_keyed_setters_count = function->keyed_setters.size();
 		function->_keyed_setters_ptr = function->keyed_setters.ptr();
 		for (const KeyValue<Variant::ValidatedKeyedSetter, int> &E : keyed_setters_map) {
-			function->keyed_setters.write[E.value] = E.key;
+			function->keyed_setters[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_setters_count = 0;
@@ -292,7 +292,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_keyed_getters_count = function->keyed_getters.size();
 		function->_keyed_getters_ptr = function->keyed_getters.ptr();
 		for (const KeyValue<Variant::ValidatedKeyedGetter, int> &E : keyed_getters_map) {
-			function->keyed_getters.write[E.value] = E.key;
+			function->keyed_getters[E.value] = E.key;
 		}
 	} else {
 		function->_keyed_getters_count = 0;
@@ -304,7 +304,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_indexed_setters_count = function->indexed_setters.size();
 		function->_indexed_setters_ptr = function->indexed_setters.ptr();
 		for (const KeyValue<Variant::ValidatedIndexedSetter, int> &E : indexed_setters_map) {
-			function->indexed_setters.write[E.value] = E.key;
+			function->indexed_setters[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_setters_count = 0;
@@ -316,7 +316,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_indexed_getters_count = function->indexed_getters.size();
 		function->_indexed_getters_ptr = function->indexed_getters.ptr();
 		for (const KeyValue<Variant::ValidatedIndexedGetter, int> &E : indexed_getters_map) {
-			function->indexed_getters.write[E.value] = E.key;
+			function->indexed_getters[E.value] = E.key;
 		}
 	} else {
 		function->_indexed_getters_count = 0;
@@ -328,7 +328,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_builtin_methods_ptr = function->builtin_methods.ptr();
 		function->_builtin_methods_count = builtin_method_map.size();
 		for (const KeyValue<Variant::ValidatedBuiltInMethod, int> &E : builtin_method_map) {
-			function->builtin_methods.write[E.value] = E.key;
+			function->builtin_methods[E.value] = E.key;
 		}
 	} else {
 		function->_builtin_methods_ptr = nullptr;
@@ -340,7 +340,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_constructors_ptr = function->constructors.ptr();
 		function->_constructors_count = constructors_map.size();
 		for (const KeyValue<Variant::ValidatedConstructor, int> &E : constructors_map) {
-			function->constructors.write[E.value] = E.key;
+			function->constructors[E.value] = E.key;
 		}
 	} else {
 		function->_constructors_ptr = nullptr;
@@ -352,7 +352,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_utilities_ptr = function->utilities.ptr();
 		function->_utilities_count = utilities_map.size();
 		for (const KeyValue<Variant::ValidatedUtilityFunction, int> &E : utilities_map) {
-			function->utilities.write[E.value] = E.key;
+			function->utilities[E.value] = E.key;
 		}
 	} else {
 		function->_utilities_ptr = nullptr;
@@ -364,7 +364,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_gds_utilities_ptr = function->gds_utilities.ptr();
 		function->_gds_utilities_count = gds_utilities_map.size();
 		for (const KeyValue<GDScriptUtilityFunctions::FunctionPtr, int> &E : gds_utilities_map) {
-			function->gds_utilities.write[E.value] = E.key;
+			function->gds_utilities[E.value] = E.key;
 		}
 	} else {
 		function->_gds_utilities_ptr = nullptr;
@@ -373,10 +373,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (method_bind_map.size()) {
 		function->methods.resize(method_bind_map.size());
-		function->_methods_ptr = function->methods.ptrw();
+		function->_methods_ptr = function->methods.ptr();
 		function->_methods_count = method_bind_map.size();
 		for (const KeyValue<const MethodBind *, int> &E : method_bind_map) {
-			function->methods.write[E.value] = E.key;
+			function->methods[E.value] = E.key;
 		}
 	} else {
 		function->_methods_ptr = nullptr;
@@ -385,10 +385,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (lambdas_map.size()) {
 		function->lambdas.resize(lambdas_map.size());
-		function->_lambdas_ptr = function->lambdas.ptrw();
+		function->_lambdas_ptr = function->lambdas.ptr();
 		function->_lambdas_count = lambdas_map.size();
 		for (const KeyValue<GDScriptFunction *, int> &E : lambdas_map) {
-			function->lambdas.write[E.value] = E.key;
+			function->lambdas[E.value] = E.key;
 		}
 	} else {
 		function->_lambdas_ptr = nullptr;
@@ -894,14 +894,14 @@ void GDScriptByteCodeGenerator::write_get_member(const Address &p_target, const 
 	append(p_name);
 }
 
-void GDScriptByteCodeGenerator::write_set_static_variable(const Address &p_value, const Address &p_class, int p_index) {
+void GDScriptByteCodeGenerator::write_set_static_variable(const Address &p_value, const Address &p_class, uint32_t p_index) {
 	append_opcode(GDScriptFunction::OPCODE_SET_STATIC_VARIABLE);
 	append(p_value);
 	append(p_class);
 	append(p_index);
 }
 
-void GDScriptByteCodeGenerator::write_get_static_variable(const Address &p_target, const Address &p_class, int p_index) {
+void GDScriptByteCodeGenerator::write_get_static_variable(const Address &p_target, const Address &p_class, uint32_t p_index) {
 	append_opcode(GDScriptFunction::OPCODE_GET_STATIC_VARIABLE);
 	append(p_target);
 	append(p_class);
@@ -1406,13 +1406,13 @@ void GDScriptByteCodeGenerator::write_lambda(const Address &p_target, GDScriptFu
 void GDScriptByteCodeGenerator::write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) {
 	// Try to find an appropriate constructor.
 	bool all_have_type = true;
-	Vector<Variant::Type> arg_types;
-	for (int i = 0; i < p_arguments.size(); i++) {
-		if (!HAS_BUILTIN_TYPE(p_arguments[i])) {
+	LocalVector<Variant::Type> arg_types;
+	for (const Address &arg : p_arguments) {
+		if (!HAS_BUILTIN_TYPE(arg)) {
 			all_have_type = false;
 			break;
 		}
-		arg_types.push_back(p_arguments[i].type.builtin_type);
+		arg_types.push_back(arg.type.builtin_type);
 	}
 	if (all_have_type) {
 		int valid_constructor = -1;
@@ -1421,7 +1421,7 @@ void GDScriptByteCodeGenerator::write_construct(const Address &p_target, Variant
 				continue;
 			}
 			int types_correct = true;
-			for (int j = 0; j < arg_types.size(); j++) {
+			for (uint32_t j = 0; j < arg_types.size(); j++) {
 				if (arg_types[j] != Variant::get_constructor_argument_type(p_type, i, j)) {
 					types_correct = false;
 					break;

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -41,7 +41,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	struct StackSlot {
 		Variant::Type type = Variant::NIL;
 		bool can_contain_object = true;
-		Vector<int> bytecode_indices;
+		LocalVector<int> bytecode_indices;
 
 		StackSlot() = default;
 		StackSlot(Variant::Type p_type, bool p_can_contain_object) :
@@ -78,16 +78,16 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	bool ended = false;
 	GDScriptFunction *function = nullptr;
 
-	Vector<int> opcodes;
+	LocalVector<int> opcodes;
 	List<RBMap<StringName, int>> stack_id_stack;
 	RBMap<StringName, int> stack_identifiers;
 	List<int> stack_identifiers_counts;
 	RBMap<StringName, int> local_constants;
 
-	Vector<StackSlot> locals;
-	HashSet<int> dirty_locals;
+	LocalVector<StackSlot> locals;
+	HashSet<uint32_t> dirty_locals;
 
-	Vector<StackSlot> temporaries;
+	LocalVector<StackSlot> temporaries;
 	List<int> used_temporaries;
 	HashSet<int> temporaries_pending_clear;
 	RBMap<Variant::Type, List<int>> temporaries_pool;
@@ -96,7 +96,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	List<RBMap<StringName, int>> block_identifier_stack;
 	RBMap<StringName, int> block_identifiers;
 
-	int max_locals = 0;
+	uint32_t max_locals = 0;
 	int current_line = 0;
 	int instr_args_max = 0;
 
@@ -191,7 +191,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			ERR_PRINT("Leaving block with non-zero temporary variables: " + itos(used_temporaries.size()));
 		}
 #endif
-		for (int i = current_locals; i < locals.size(); i++) {
+		for (uint32_t i = current_locals; i < locals.size(); i++) {
 			dirty_locals.insert(i + GDScriptFunction::FIXED_ADDRESSES_MAX);
 		}
 		locals.resize(current_locals);
@@ -362,7 +362,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			case Address::FUNCTION_PARAMETER:
 				return p_address.address | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 			case Address::TEMPORARY:
-				temporaries.write[p_address.address].bytecode_indices.push_back(opcodes.size());
+				temporaries[p_address.address].bytecode_indices.push_back(opcodes.size());
 				return -1;
 			case Address::NIL:
 				return GDScriptFunction::ADDR_NIL;
@@ -445,7 +445,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void patch_jump(int p_address) {
-		opcodes.write[p_address] = opcodes.size();
+		opcodes[p_address] = opcodes.size();
 	}
 
 public:

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -41,7 +41,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	struct StackSlot {
 		Variant::Type type = Variant::NIL;
 		bool can_contain_object = true;
-		Vector<int> bytecode_indices;
+		LocalVector<int> bytecode_indices;
 
 		StackSlot() = default;
 		StackSlot(Variant::Type p_type, bool p_can_contain_object) :
@@ -78,16 +78,16 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	bool ended = false;
 	GDScriptFunction *function = nullptr;
 
-	Vector<int> opcodes;
+	LocalVector<int> opcodes;
 	List<RBMap<StringName, int>> stack_id_stack;
 	RBMap<StringName, int> stack_identifiers;
 	List<int> stack_identifiers_counts;
 	RBMap<StringName, int> local_constants;
 
-	Vector<StackSlot> locals;
+	LocalVector<StackSlot> locals;
 	HashSet<int> dirty_locals;
 
-	Vector<StackSlot> temporaries;
+	LocalVector<StackSlot> temporaries;
 	List<int> used_temporaries;
 	HashSet<int> temporaries_pending_clear;
 	RBMap<Variant::Type, List<int>> temporaries_pool;
@@ -96,7 +96,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	List<RBMap<StringName, int>> block_identifier_stack;
 	RBMap<StringName, int> block_identifiers;
 
-	int max_locals = 0;
+	uint32_t max_locals = 0;
 	int current_line = 0;
 	int instr_args_max = 0;
 
@@ -191,7 +191,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			ERR_PRINT("Leaving block with non-zero temporary variables: " + itos(used_temporaries.size()));
 		}
 #endif
-		for (int i = current_locals; i < locals.size(); i++) {
+		for (uint32_t i = current_locals; i < locals.size(); i++) {
 			dirty_locals.insert(i + GDScriptFunction::FIXED_ADDRESSES_MAX);
 		}
 		locals.resize(current_locals);
@@ -362,7 +362,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 			case Address::FUNCTION_PARAMETER:
 				return p_address.address | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 			case Address::TEMPORARY:
-				temporaries.write[p_address.address].bytecode_indices.push_back(opcodes.size());
+				temporaries[p_address.address].bytecode_indices.push_back(opcodes.size());
 				return -1;
 			case Address::NIL:
 				return GDScriptFunction::ADDR_NIL;
@@ -445,7 +445,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void patch_jump(int p_address) {
-		opcodes.write[p_address] = opcodes.size();
+		opcodes[p_address] = opcodes.size();
 	}
 
 public:
@@ -495,8 +495,8 @@ public:
 	virtual void write_get_named(const Address &p_target, const StringName &p_name, const Address &p_source) override;
 	virtual void write_set_member(const Address &p_value, const StringName &p_name) override;
 	virtual void write_get_member(const Address &p_target, const StringName &p_name) override;
-	virtual void write_set_static_variable(const Address &p_value, const Address &p_class, int p_index) override;
-	virtual void write_get_static_variable(const Address &p_target, const Address &p_class, int p_index) override;
+	virtual void write_set_static_variable(const Address &p_value, const Address &p_class, uint32_t p_index) override;
+	virtual void write_get_static_variable(const Address &p_target, const Address &p_class, uint32_t p_index) override;
 	virtual void write_assign(const Address &p_target, const Address &p_source) override;
 	virtual void write_assign_with_conversion(const Address &p_target, const Address &p_source) override;
 	virtual void write_assign_null(const Address &p_target) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -110,8 +110,8 @@ public:
 	virtual void write_get_named(const Address &p_target, const StringName &p_name, const Address &p_source) = 0;
 	virtual void write_set_member(const Address &p_value, const StringName &p_name) = 0;
 	virtual void write_get_member(const Address &p_target, const StringName &p_name) = 0;
-	virtual void write_set_static_variable(const Address &p_value, const Address &p_class, int p_index) = 0;
-	virtual void write_get_static_variable(const Address &p_target, const Address &p_class, int p_index) = 0;
+	virtual void write_set_static_variable(const Address &p_value, const Address &p_class, uint32_t p_index) = 0;
+	virtual void write_get_static_variable(const Address &p_target, const Address &p_class, uint32_t p_index) = 0;
 	virtual void write_assign(const Address &p_target, const Address &p_source) = 0;
 	virtual void write_assign_with_conversion(const Address &p_target, const Address &p_source) = 0;
 	virtual void write_assign_null(const Address &p_target) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -3181,7 +3181,7 @@ GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement
 Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
 	Vector<FunctionLambdaInfo> result;
 	// Only scrape the lambdas inside p_func.
-	for (int i = 0; i < p_func->lambdas.size(); ++i) {
+	for (uint32_t i = 0; i < p_func->lambdas.size(); ++i) {
 		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
 	}
 	return result;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -404,7 +404,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								// No getter or inside getter: direct variable access.
 								GDScriptCodeGenerator::Address temp = codegen.add_temporary(scr->static_variables_indices[identifier].data_type);
 								GDScriptCodeGenerator::Address _class = codegen.add_constant(scr);
-								int index = scr->static_variables_indices[identifier].index;
+								uint32_t index = scr->static_variables_indices[identifier].index;
 								gen->write_get_static_variable(temp, _class, index);
 								return temp;
 							}
@@ -1010,7 +1010,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				bool member_property_is_in_setter = false;
 				bool is_static = false;
 				GDScriptCodeGenerator::Address static_var_class;
-				int static_var_index = 0;
+				uint32_t static_var_index = 0;
 				GDScriptDataType static_var_data_type;
 				StringName var_name;
 				StringName member_property_setter_function;
@@ -1293,7 +1293,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				bool is_in_setter = false;
 				bool is_static = false;
 				GDScriptCodeGenerator::Address static_var_class;
-				int static_var_index = 0;
+				uint32_t static_var_index = 0;
 				GDScriptDataType static_var_data_type;
 				StringName var_name;
 				StringName setter_function;
@@ -3185,7 +3185,7 @@ GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement
 Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
 	Vector<FunctionLambdaInfo> result;
 	// Only scrape the lambdas inside p_func.
-	for (int i = 0; i < p_func->lambdas.size(); ++i) {
+	for (uint32_t i = 0; i < p_func->lambdas.size(); ++i) {
 		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
 	}
 	return result;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -151,13 +151,13 @@ bool GDScriptDataType::is_type(const Variant &p_variant, bool p_allow_implicit_c
 
 /////////////////////
 
-Variant GDScriptFunction::get_constant(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, constants.size(), "<errconst>");
+Variant GDScriptFunction::get_constant(uint32_t p_idx) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_idx, constants.size(), "<errconst>");
 	return constants[p_idx];
 }
 
-StringName GDScriptFunction::get_global_name(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, global_names.size(), "<errgname>");
+StringName GDScriptFunction::get_global_name(uint32_t p_idx) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_idx, global_names.size(), "<errgname>");
 	return global_names[p_idx];
 }
 
@@ -236,12 +236,12 @@ GDScriptFunction::GDScriptFunction() {
 GDScriptFunction::~GDScriptFunction() {
 	get_script()->member_functions.erase(name);
 
-	for (int i = 0; i < lambdas.size(); i++) {
-		memdelete(lambdas[i]);
+	for (GDScriptFunction *lambda : lambdas) {
+		memdelete(lambda);
 	}
 
-	for (int i = 0; i < argument_types.size(); i++) {
-		argument_types.write[i].script_type_ref = Ref<Script>();
+	for (GDScriptDataType &arg_type : argument_types) {
+		arg_type.script_type_ref = Ref<Script>();
 	}
 	return_type.script_type_ref = Ref<Script>();
 

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -151,13 +151,13 @@ bool GDScriptDataType::is_type(const Variant &p_variant, bool p_allow_implicit_c
 
 /////////////////////
 
-Variant GDScriptFunction::get_constant(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, constants.size(), "<errconst>");
+Variant GDScriptFunction::get_constant(uint32_t p_idx) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_idx, constants.size(), "<errconst>");
 	return constants[p_idx];
 }
 
-StringName GDScriptFunction::get_global_name(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, global_names.size(), "<errgname>");
+StringName GDScriptFunction::get_global_name(uint32_t p_idx) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_idx, global_names.size(), "<errgname>");
 	return global_names[p_idx];
 }
 
@@ -236,12 +236,12 @@ GDScriptFunction::GDScriptFunction() {
 GDScriptFunction::~GDScriptFunction() {
 	get_script()->member_functions.erase(name);
 
-	for (int i = 0; i < lambdas.size(); i++) {
-		memdelete(lambdas[i]);
+	for (GDScriptFunction *lambda : lambdas) {
+		memdelete(lambda);
 	}
 
-	for (int i = 0; i < argument_types.size(); i++) {
-		argument_types.write[i].script_type_ref = Ref<Script>();
+	for (GDScriptDataType &arg_type : argument_types) {
+		arg_type.script_type_ref = Ref<Script>();
 	}
 
 	return_type.script_type_ref = Ref<Script>();

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -346,7 +346,7 @@ private:
 	StringName name;
 	StringName source;
 	bool _static = false;
-	Vector<GDScriptDataType> argument_types;
+	LocalVector<GDScriptDataType> argument_types;
 	GDScriptDataType return_type;
 	MethodInfo method_info;
 	Variant rpc_config;
@@ -363,24 +363,24 @@ private:
 	TightLocalVector<Pair<int, Variant::Type>> temporary_slots;
 	List<StackDebug> stack_debug;
 
-	Vector<int> code;
-	Vector<int> default_arguments;
-	Vector<Variant> constants;
+	LocalVector<int> code;
+	LocalVector<int> default_arguments;
+	LocalVector<Variant> constants;
 	HashMap<StringName, Variant> constant_map;
-	Vector<StringName> global_names;
-	Vector<Variant::ValidatedOperatorEvaluator> operator_funcs;
-	Vector<Variant::ValidatedSetter> setters;
-	Vector<Variant::ValidatedGetter> getters;
-	Vector<Variant::ValidatedKeyedSetter> keyed_setters;
-	Vector<Variant::ValidatedKeyedGetter> keyed_getters;
-	Vector<Variant::ValidatedIndexedSetter> indexed_setters;
-	Vector<Variant::ValidatedIndexedGetter> indexed_getters;
-	Vector<Variant::ValidatedBuiltInMethod> builtin_methods;
-	Vector<Variant::ValidatedConstructor> constructors;
-	Vector<Variant::ValidatedUtilityFunction> utilities;
-	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
-	Vector<MethodBind *> methods;
-	Vector<GDScriptFunction *> lambdas;
+	LocalVector<StringName> global_names;
+	LocalVector<Variant::ValidatedOperatorEvaluator> operator_funcs;
+	LocalVector<Variant::ValidatedSetter> setters;
+	LocalVector<Variant::ValidatedGetter> getters;
+	LocalVector<Variant::ValidatedKeyedSetter> keyed_setters;
+	LocalVector<Variant::ValidatedKeyedGetter> keyed_getters;
+	LocalVector<Variant::ValidatedIndexedSetter> indexed_setters;
+	LocalVector<Variant::ValidatedIndexedGetter> indexed_getters;
+	LocalVector<Variant::ValidatedBuiltInMethod> builtin_methods;
+	LocalVector<Variant::ValidatedConstructor> constructors;
+	LocalVector<Variant::ValidatedUtilityFunction> utilities;
+	LocalVector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
+	LocalVector<MethodBind *> methods;
+	LocalVector<GDScriptFunction *> lambdas;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -467,7 +467,7 @@ public:
 		StringName function_name;
 		String script_path;
 #endif
-		Vector<uint8_t> stack;
+		TightLocalVector<uint8_t> stack;
 		int stack_size = 0;
 		int ip = 0;
 		int line = 0;
@@ -485,8 +485,8 @@ public:
 	_FORCE_INLINE_ Variant get_rpc_config() const { return rpc_config; }
 	_FORCE_INLINE_ int get_max_stack_size() const { return _stack_size; }
 
-	Variant get_constant(int p_idx) const;
-	StringName get_global_name(int p_idx) const;
+	Variant get_constant(uint32_t p_idx) const;
+	StringName get_global_name(uint32_t p_idx) const;
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
 	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -345,7 +345,7 @@ private:
 	StringName name;
 	StringName source;
 	bool _static = false;
-	Vector<GDScriptDataType> argument_types;
+	LocalVector<GDScriptDataType> argument_types;
 	// NOTE: This is the expected return type, but coroutines can actually return a `GDScriptFunctionState` object.
 	// In VM it is currently only used to return a default value on error (as a fallback).
 	GDScriptDataType return_type;
@@ -364,24 +364,24 @@ private:
 	TightLocalVector<Pair<int, Variant::Type>> temporary_slots;
 	List<StackDebug> stack_debug;
 
-	Vector<int> code;
-	Vector<int> default_arguments;
-	Vector<Variant> constants;
+	LocalVector<int> code;
+	LocalVector<int> default_arguments;
+	LocalVector<Variant> constants;
 	HashMap<StringName, Variant> constant_map;
-	Vector<StringName> global_names;
-	Vector<Variant::ValidatedOperatorEvaluator> operator_funcs;
-	Vector<Variant::ValidatedSetter> setters;
-	Vector<Variant::ValidatedGetter> getters;
-	Vector<Variant::ValidatedKeyedSetter> keyed_setters;
-	Vector<Variant::ValidatedKeyedGetter> keyed_getters;
-	Vector<Variant::ValidatedIndexedSetter> indexed_setters;
-	Vector<Variant::ValidatedIndexedGetter> indexed_getters;
-	Vector<Variant::ValidatedBuiltInMethod> builtin_methods;
-	Vector<Variant::ValidatedConstructor> constructors;
-	Vector<Variant::ValidatedUtilityFunction> utilities;
-	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
-	Vector<const MethodBind *> methods;
-	Vector<GDScriptFunction *> lambdas;
+	LocalVector<StringName> global_names;
+	LocalVector<Variant::ValidatedOperatorEvaluator> operator_funcs;
+	LocalVector<Variant::ValidatedSetter> setters;
+	LocalVector<Variant::ValidatedGetter> getters;
+	LocalVector<Variant::ValidatedKeyedSetter> keyed_setters;
+	LocalVector<Variant::ValidatedKeyedGetter> keyed_getters;
+	LocalVector<Variant::ValidatedIndexedSetter> indexed_setters;
+	LocalVector<Variant::ValidatedIndexedGetter> indexed_getters;
+	LocalVector<Variant::ValidatedBuiltInMethod> builtin_methods;
+	LocalVector<Variant::ValidatedConstructor> constructors;
+	LocalVector<Variant::ValidatedUtilityFunction> utilities;
+	LocalVector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
+	LocalVector<const MethodBind *> methods;
+	LocalVector<GDScriptFunction *> lambdas;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -468,7 +468,7 @@ public:
 		StringName function_name;
 		String script_path;
 #endif
-		Vector<uint8_t> stack;
+		TightLocalVector<uint8_t> stack;
 		int stack_size = 0;
 		int ip = 0;
 		int line = 0;
@@ -486,8 +486,8 @@ public:
 	_FORCE_INLINE_ Variant get_rpc_config() const { return rpc_config; }
 	_FORCE_INLINE_ int get_max_stack_size() const { return _stack_size; }
 
-	Variant get_constant(int p_idx) const;
-	StringName get_global_name(int p_idx) const;
+	Variant get_constant(uint32_t p_idx) const;
+	StringName get_global_name(uint32_t p_idx) const;
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
 	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -150,12 +150,12 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 	}
 }
 
-GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_COND(p_script.is_null());
 	ERR_FAIL_NULL(p_function);
 	script = p_script;
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }
@@ -282,23 +282,23 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 	}
 }
 
-GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_COND(p_self.is_null());
 	ERR_FAIL_NULL(p_function);
 	reference = p_self;
 	object = p_self.ptr();
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }
 
-GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_NULL(p_self);
 	ERR_FAIL_NULL(p_function);
 	object = p_self;
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -33,7 +33,6 @@
 #include "gdscript.h"
 
 #include "core/object/ref_counted.h"
-#include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
 
@@ -45,7 +44,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	Ref<GDScript> script;
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -63,7 +62,7 @@ public:
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
 	GDScriptLambdaCallable(const GDScriptLambdaCallable &) = delete;
-	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaCallable() = default;
 };
 
@@ -74,7 +73,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	Object *object = nullptr; // For non RefCounted objects, use a direct pointer.
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -92,7 +91,7 @@ public:
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;
 	GDScriptLambdaSelfCallable(const GDScriptLambdaSelfCallable &) = delete;
-	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
+	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaSelfCallable() = default;
 };

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -33,7 +33,6 @@
 #include "gdscript.h"
 
 #include "core/object/ref_counted.h"
-#include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
 
@@ -48,7 +47,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	GDScript::UpdatableFuncPtr function;
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -66,7 +65,7 @@ public:
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
 	GDScriptLambdaCallable(const GDScriptLambdaCallable &) = delete;
-	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaCallable() = default;
 };
 
@@ -77,7 +76,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	Object *object = nullptr; // For non RefCounted objects, use a direct pointer.
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -95,7 +94,7 @@ public:
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;
 	GDScriptLambdaSelfCallable(const GDScriptLambdaSelfCallable &) = delete;
-	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
+	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaSelfCallable() = default;
 };

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4550,7 +4550,7 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 }
 
 static String _get_annotation_error_string(const StringName &p_annotation_name, const Vector<Variant::Type> &p_expected_types, const GDScriptParser::DataType &p_provided_type) {
-	Vector<String> types;
+	LocalVector<String> types;
 	for (int i = 0; i < p_expected_types.size(); i++) {
 		const Variant::Type &type = p_expected_types[i];
 		types.push_back(Variant::get_type_name(type));
@@ -4592,7 +4592,7 @@ static String _get_annotation_error_string(const StringName &p_annotation_name, 
 		string = types[0].quote() + " or " + types[1].quote();
 	} else if (types.size() >= 3) {
 		string = types[0].quote();
-		for (int i = 1; i < types.size() - 1; i++) {
+		for (uint32_t i = 1; i < types.size() - 1; i++) {
 			string += ", " + types[i].quote();
 		}
 		string += ", or " + types[types.size() - 1].quote();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4541,9 +4541,8 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 }
 
 static String _get_annotation_error_string(const StringName &p_annotation_name, const Vector<Variant::Type> &p_expected_types, const GDScriptParser::DataType &p_provided_type) {
-	Vector<String> types;
-	for (int i = 0; i < p_expected_types.size(); i++) {
-		const Variant::Type &type = p_expected_types[i];
+	LocalVector<String> types;
+	for (const Variant::Type &type : p_expected_types) {
 		types.push_back(Variant::get_type_name(type));
 		types.push_back("Array[" + Variant::get_type_name(type) + "]");
 		switch (type) {
@@ -4583,7 +4582,7 @@ static String _get_annotation_error_string(const StringName &p_annotation_name, 
 		string = types[0].quote() + " or " + types[1].quote();
 	} else if (types.size() >= 3) {
 		string = types[0].quote();
-		for (int i = 1; i < types.size() - 1; i++) {
+		for (uint32_t i = 1; i < types.size() - 1; i++) {
 			string += ", " + types[i].quote();
 		}
 		string += ", or " + types[types.size() - 1].quote();

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -255,7 +255,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	char32_t indent_char = '\0';
 	int position = 0;
 	int length = 0;
-	Vector<int> continuation_lines;
+	LocalVector<int> continuation_lines;
 #ifdef DEBUG_ENABLED
 	Vector<String> keyword_list;
 #endif // DEBUG_ENABLED
@@ -298,7 +298,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 public:
 	void set_source_code(const String &p_source_code);
 
-	const Vector<int> &get_continuation_lines() const { return continuation_lines; }
+	const LocalVector<int> &get_continuation_lines() const { return continuation_lines; }
 
 #ifdef TOOLS_ENABLED
 	virtual int get_current_position() const override { return position; }

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -108,7 +108,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::_binary_to_token(const uint8_t
 		case GDScriptTokenizer::Token::ANNOTATION:
 		case GDScriptTokenizer::Token::IDENTIFIER: {
 			// Get name from map.
-			int identifier_pos = token_type >> TOKEN_BITS;
+			uint32_t identifier_pos = token_type >> TOKEN_BITS;
 			if (unlikely(identifier_pos >= identifiers.size())) {
 				Token error;
 				error.type = Token::ERROR;
@@ -120,7 +120,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::_binary_to_token(const uint8_t
 		case GDScriptTokenizer::Token::ERROR:
 		case GDScriptTokenizer::Token::LITERAL: {
 			// Get literal from map.
-			int constant_pos = token_type >> TOKEN_BITS;
+			uint32_t constant_pos = token_type >> TOKEN_BITS;
 			if (unlikely(constant_pos >= constants.size())) {
 				Token error;
 				error.type = Token::ERROR;
@@ -170,20 +170,20 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		total_len -= 4;
 		ERR_FAIL_COND_V((len * 4u) > (uint32_t)total_len, ERR_INVALID_DATA);
 		b += 4;
-		Vector<uint32_t> cs;
+		LocalVector<uint32_t> cs;
 		cs.resize(len);
 		for (uint32_t j = 0; j < len; j++) {
 			uint8_t tmp[4];
 			for (uint32_t k = 0; k < 4; k++) {
 				tmp[k] = b[j * 4 + k] ^ 0xb6;
 			}
-			cs.write[j] = decode_uint32(tmp);
+			cs[j] = decode_uint32(tmp);
 		}
 
 		String s = String::utf32(Span(reinterpret_cast<const char32_t *>(cs.ptr()), len));
 		b += len * 4;
 		total_len -= len * 4;
-		identifiers.write[i] = s;
+		identifiers[i] = s;
 	}
 
 	constants.resize(constant_count);
@@ -196,7 +196,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		}
 		b += len;
 		total_len -= len;
-		constants.write[i] = v;
+		constants[i] = v;
 	}
 
 	for (uint32_t i = 0; i < token_line_count; i++) {
@@ -228,7 +228,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		Token token = _binary_to_token(b);
 		b += token_len;
 		ERR_FAIL_INDEX_V(token.type, Token::TK_MAX, ERR_INVALID_DATA);
-		tokens.write[i] = token;
+		tokens[i] = token;
 		total_len -= token_len;
 	}
 
@@ -266,15 +266,15 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code,
 	}
 
 	// Reverse maps.
-	Vector<StringName> rev_identifier_map;
+	LocalVector<StringName> rev_identifier_map;
 	rev_identifier_map.resize(identifier_map.size());
 	for (const KeyValue<StringName, uint32_t> &E : identifier_map) {
-		rev_identifier_map.write[E.value] = E.key;
+		rev_identifier_map[E.value] = E.key;
 	}
-	Vector<Variant> rev_constant_map;
+	LocalVector<Variant> rev_constant_map;
 	rev_constant_map.resize(constant_map.size());
 	for (const KeyValue<Variant, uint32_t> &E : constant_map) {
-		rev_constant_map.write[E.value] = E.key;
+		rev_constant_map[E.value] = E.key;
 	}
 	HashMap<uint32_t, uint32_t> rev_token_lines;
 	for (const KeyValue<uint32_t, uint32_t> &E : token_lines) {

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -108,7 +108,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::_binary_to_token(const uint8_t
 		case GDScriptTokenizer::Token::ANNOTATION:
 		case GDScriptTokenizer::Token::IDENTIFIER: {
 			// Get name from map.
-			int identifier_pos = token_type >> TOKEN_BITS;
+			uint32_t identifier_pos = token_type >> TOKEN_BITS;
 			if (unlikely(identifier_pos >= identifiers.size())) {
 				Token error;
 				error.type = Token::ERROR;
@@ -120,7 +120,7 @@ GDScriptTokenizer::Token GDScriptTokenizerBuffer::_binary_to_token(const uint8_t
 		case GDScriptTokenizer::Token::ERROR:
 		case GDScriptTokenizer::Token::LITERAL: {
 			// Get literal from map.
-			int constant_pos = token_type >> TOKEN_BITS;
+			uint32_t constant_pos = token_type >> TOKEN_BITS;
 			if (unlikely(constant_pos >= constants.size())) {
 				Token error;
 				error.type = Token::ERROR;
@@ -170,20 +170,20 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		total_len -= 4;
 		ERR_FAIL_COND_V((len * 4u) > (uint32_t)total_len, ERR_INVALID_DATA);
 		b += 4;
-		Vector<uint32_t> cs;
+		LocalVector<uint32_t> cs;
 		cs.resize(len);
 		for (uint32_t j = 0; j < len; j++) {
 			uint8_t tmp[4];
 			for (uint32_t k = 0; k < 4; k++) {
 				tmp[k] = b[j * 4 + k] ^ 0xb6;
 			}
-			cs.write[j] = decode_uint32(tmp);
+			cs[j] = decode_uint32(tmp);
 		}
 
 		String s = String::utf32(Span(reinterpret_cast<const char32_t *>(cs.ptr()), len));
 		b += len * 4;
 		total_len -= len * 4;
-		identifiers.write[i] = s;
+		identifiers[i] = s;
 	}
 
 	constants.resize(constant_count);
@@ -193,7 +193,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		RETURN_IF_ERROR(decode_variant(v, b, total_len, &len, false));
 		b += len;
 		total_len -= len;
-		constants.write[i] = v;
+		constants[i] = v;
 	}
 
 	for (uint32_t i = 0; i < token_line_count; i++) {
@@ -225,7 +225,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 		Token token = _binary_to_token(b);
 		b += token_len;
 		ERR_FAIL_INDEX_V(token.type, Token::TK_MAX, ERR_INVALID_DATA);
-		tokens.write[i] = token;
+		tokens[i] = token;
 		total_len -= token_len;
 	}
 
@@ -263,15 +263,15 @@ Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code,
 	}
 
 	// Reverse maps.
-	Vector<StringName> rev_identifier_map;
+	LocalVector<StringName> rev_identifier_map;
 	rev_identifier_map.resize(identifier_map.size());
 	for (const KeyValue<StringName, uint32_t> &E : identifier_map) {
-		rev_identifier_map.write[E.value] = E.key;
+		rev_identifier_map[E.value] = E.key;
 	}
-	Vector<Variant> rev_constant_map;
+	LocalVector<Variant> rev_constant_map;
 	rev_constant_map.resize(constant_map.size());
 	for (const KeyValue<Variant, uint32_t> &E : constant_map) {
-		rev_constant_map.write[E.value] = E.key;
+		rev_constant_map[E.value] = E.key;
 	}
 	HashMap<uint32_t, uint32_t> rev_token_lines;
 	for (const KeyValue<uint32_t, uint32_t> &E : token_lines) {

--- a/modules/gdscript/gdscript_tokenizer_buffer.h
+++ b/modules/gdscript/gdscript_tokenizer_buffer.h
@@ -44,13 +44,12 @@ public:
 	static constexpr uint32_t TOKEN_BITS = 8;
 	static constexpr uint32_t TOKEN_MASK = (1 << (TOKEN_BITS - 1)) - 1;
 
-	Vector<StringName> identifiers;
-	Vector<Variant> constants;
-	Vector<int> continuation_lines;
-	HashMap<int, int> token_lines;
-	HashMap<int, int> token_columns;
-	Vector<Token> tokens;
-	int current = 0;
+	LocalVector<StringName> identifiers;
+	LocalVector<Variant> constants;
+	HashMap<uint32_t, uint32_t> token_lines;
+	HashMap<uint32_t, uint32_t> token_columns;
+	LocalVector<Token> tokens;
+	uint32_t current = 0;
 	uint32_t current_line = 1;
 
 	bool multiline_mode = false;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -196,13 +196,13 @@ String GDScriptFunction::_get_callable_call_error(const String &p_where, const C
 	if (p_argcount - args_unbound < 0) {
 		return "Callable unbinds " + itos(args_unbound) + " arguments, but called with " + itos(p_argcount);
 	} else {
-		Vector<const Variant *> argptrs;
+		LocalVector<const Variant *> argptrs;
 		argptrs.resize(p_argcount - args_unbound + binds.size());
 		for (int i = 0; i < p_argcount - args_unbound; i++) {
-			argptrs.write[i] = p_argptrs[i];
+			argptrs[i] = p_argptrs[i];
 		}
 		for (int i = 0; i < binds.size(); i++) {
-			argptrs.write[i + p_argcount - args_unbound] = &binds[i];
+			argptrs[i + p_argcount - args_unbound] = &binds[i];
 		}
 		return _get_call_error(p_where, (const Variant **)argptrs.ptr(), argptrs.size(), p_ret, p_err);
 	}
@@ -1355,10 +1355,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GDScript *gdscript = Object::cast_to<GDScript>(_class->operator Object *());
 				GD_ERR_BREAK(!gdscript);
 
-				int index = _code_ptr[ip + 3];
-				GD_ERR_BREAK(index < 0 || index >= gdscript->static_variables.size());
+				uint32_t index = _code_ptr[ip + 3];
+				GD_ERR_BREAK(index >= gdscript->static_variables.size());
 
-				gdscript->static_variables.write[index] = *value;
+				gdscript->static_variables[index] = *value;
 
 				ip += 4;
 			}
@@ -1373,8 +1373,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GDScript *gdscript = Object::cast_to<GDScript>(_class->operator Object *());
 				GD_ERR_BREAK(!gdscript);
 
-				int index = _code_ptr[ip + 3];
-				GD_ERR_BREAK(index < 0 || index >= gdscript->static_variables.size());
+				uint32_t index = _code_ptr[ip + 3];
+				GD_ERR_BREAK(index >= gdscript->static_variables.size());
 
 				*target = gdscript->static_variables[index];
 
@@ -2620,7 +2620,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					// First `FIXED_ADDRESSES_MAX` stack addresses are special, so we just skip them here.
 					for (int i = FIXED_ADDRESSES_MAX; i < _stack_size; i++) {
-						memnew_placement(&gdfs->state.stack.write[sizeof(Variant) * i], Variant(stack[i]));
+						memnew_placement(&gdfs->state.stack[sizeof(Variant) * i], Variant(stack[i]));
 					}
 					gdfs->state.stack_size = _stack_size;
 					gdfs->state.ip = ip + 2;
@@ -2697,14 +2697,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
-				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, captures));
+				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, std::move(captures)));
 
 				GET_INSTRUCTION_ARG(result, captures_count);
 				*result = Callable(callable);
@@ -2728,18 +2728,18 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
 				GDScriptLambdaSelfCallable *callable;
 				if (Object::cast_to<RefCounted>(p_instance->owner)) {
-					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, std::move(captures)));
 				} else {
-					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, std::move(captures)));
 				}
 
 				GET_INSTRUCTION_ARG(result, captures_count);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1355,10 +1355,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GDScript *gdscript = Object::cast_to<GDScript>(_class->operator Object *());
 				GD_ERR_BREAK(!gdscript);
 
-				int index = _code_ptr[ip + 3];
-				GD_ERR_BREAK(index < 0 || index >= gdscript->static_variables.size());
+				uint32_t index = _code_ptr[ip + 3];
+				GD_ERR_BREAK(index >= gdscript->static_variables.size());
 
-				gdscript->static_variables.write[index] = *value;
+				gdscript->static_variables[index] = *value;
 
 				ip += 4;
 			}
@@ -1373,8 +1373,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GDScript *gdscript = Object::cast_to<GDScript>(_class->operator Object *());
 				GD_ERR_BREAK(!gdscript);
 
-				int index = _code_ptr[ip + 3];
-				GD_ERR_BREAK(index < 0 || index >= gdscript->static_variables.size());
+				uint32_t index = _code_ptr[ip + 3];
+				GD_ERR_BREAK(index >= gdscript->static_variables.size());
 
 				*target = gdscript->static_variables[index];
 
@@ -2620,7 +2620,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					// First `FIXED_ADDRESSES_MAX` stack addresses are special, so we just skip them here.
 					for (int i = FIXED_ADDRESSES_MAX; i < _stack_size; i++) {
-						memnew_placement(&gdfs->state.stack.write[sizeof(Variant) * i], Variant(stack[i]));
+						memnew_placement(&gdfs->state.stack[sizeof(Variant) * i], Variant(stack[i]));
 					}
 					gdfs->state.stack_size = _stack_size;
 					gdfs->state.ip = ip + 2;
@@ -2697,14 +2697,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
-				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, captures));
+				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, std::move(captures)));
 
 				GET_INSTRUCTION_ARG(result, captures_count);
 				*result = Callable(callable);
@@ -2728,18 +2728,18 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
 				GDScriptLambdaSelfCallable *callable;
 				if (Object::cast_to<RefCounted>(p_instance->owner)) {
-					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, std::move(captures)));
 				} else {
-					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, std::move(captures)));
 				}
 
 				GET_INSTRUCTION_ARG(result, captures_count);


### PR DESCRIPTION
- Unofficial sequel to #117666.
- Includes #117904.

#117666 converted `GDScriptInstance::members` from `Vector` to `LocalVector`. This PR does the same but for most non-debug `Vectors` in the GDScript codebase that are simple to replace.

Most of these `Vector`s don't even use copy-on-write. The following had some use for it and got a workaround with `std::move`:
- `GDScript::(old_)static_variables`
  - `static_variables` gets assigned to `old_static_variables` followed by a resize in the former, so CoW is mostly irrelevant. 
- `GDScriptByteCodeGenerator::opcodes` and `GDScriptFunction::code`
  - The last time the former is accessed is to assign it to the latter, meaning it's safe to `std::move`.
- `GDScriptLambda(Self)Callable::captures`
  - Same as above. The original `captures` is made inside a function, then given to `captures` through a constructor.

Vectors that grow and are not resized often (due to growth calculation) became `LocalVector`, otherwise they became `TightLocalVector`.

This exists mostly for codestyle, following a "don't use something when you can use a simpler thing" principle, but wouldn't hurt to run benchmarks anyway. Although some changes don't have to do with it (focus was chasing down unnecessary CoW Vectors wherever possible), I tried a similar benchmark to the aforementioned PR:

```gdscript
extends Node2D

const COUNT: int = 100000000

var a: int = 0
var b: int = 1
var c: int = 2


func _ready():
	var time := Time.get_ticks_msec()
	var start := OS.get_static_memory_usage()

	for i: int in COUNT:
		var tmp = c
		c = b
		b = a
		a = tmp

	await get_tree().process_frame
	print(OS.get_static_memory_usage() - start)
	print(OS.get_static_memory_peak_usage())
	var total_time := Time.get_ticks_msec() - time
	print(total_time)
	await get_tree().process_frame
	get_tree().quit()
```

- Build command: `scons target=template_debug production=yes`.
- Run command: `godot --headless --no-header`

### Memory usage difference between start and end
Results were consistent between runs.
|Build | Bytes |
|-|-|
|`master`| 21400|
| PR| 21368|

### Peak memory usage
Results were consistent between runs.
|Build | Bytes |
|-|-|
|`master`| 58177585|
| PR| 58177541|

### Total time
Four runs.
|Build | 1 |2|3|4|
|-|-|-|-|-|
|`master`| 2259|2238|2235|2246|
| PR| 2217|2189|2180|2205|

Additionally, I measured a reduction of 24KiB in binary size (same build command).

Not sure if the tradeoff is significant. I consider this mostly codestyle ("don't use thing when you don't need it") than performance, but I opened this anyway for others to judge. 