### PR TITLE
Enable scroll hint in the "Create New *" dialog for asthetics

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -1077,6 +1077,7 @@ CreateDialog::CreateDialog() {
 
 	search_options = memnew(Tree);
 	search_box->set_forward_control(search_options);
+	search_options->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	search_options->set_accessibility_name(TTRC("Matches:"));
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);


### PR DESCRIPTION
This enables the top scroll hint for the matches tree. Just a basic change to make the it look prettier:

<img width="314" height="225" alt="Screenshot_20260630_194708" src="https://github.com/user-attachments/assets/e4cc08aa-db66-4bc9-a6ad-fe20a4249dff" />