### PR TITLE
GDExtension: Avoid transient null virtual method store during lazy init

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -877,17 +877,17 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 }
 
 void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const {
-	r_fn_ptr = nullptr;
+	void *fn_ptr = nullptr;
 	if (_extension->get_virtual_call_data2 && _extension->call_virtual_with_data) {
-		r_fn_ptr = _extension->get_virtual_call_data2(_extension->class_userdata, &p_fn_name, p_compat_hash);
+		fn_ptr = _extension->get_virtual_call_data2(_extension->class_userdata, &p_fn_name, p_compat_hash);
 	} else if (_extension->get_virtual2) {
-		r_fn_ptr = (void *)_extension->get_virtual2(_extension->class_userdata, &p_fn_name, p_compat_hash);
+		fn_ptr = (void *)_extension->get_virtual2(_extension->class_userdata, &p_fn_name, p_compat_hash);
 #ifndef DISABLE_DEPRECATED
 	} else if (p_compat || ClassDB::get_virtual_method_compatibility_hashes(get_class_name(), p_fn_name).size() == 0) {
 		if (_extension->get_virtual_call_data && _extension->call_virtual_with_data) {
-			r_fn_ptr = _extension->get_virtual_call_data(_extension->class_userdata, &p_fn_name);
+			fn_ptr = _extension->get_virtual_call_data(_extension->class_userdata, &p_fn_name);
 		} else if (_extension->get_virtual) {
-			r_fn_ptr = (void *)_extension->get_virtual(_extension->class_userdata, &p_fn_name);
+			fn_ptr = (void *)_extension->get_virtual(_extension->class_userdata, &p_fn_name);
 		}
 #endif
 	}
@@ -899,9 +899,10 @@ void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr,
 		virtual_method_list = tracker;
 	}
 #endif
-	if (r_fn_ptr == nullptr) {
-		r_fn_ptr = reinterpret_cast<void *>(_INVALID_GDVIRTUAL_FUNC_ADDR);
+	if (fn_ptr == nullptr) {
+		fn_ptr = reinterpret_cast<void *>(_INVALID_GDVIRTUAL_FUNC_ADDR);
 	}
+	r_fn_ptr = fn_ptr;
 }
 
 void Object::_notification_forward(int p_notification) {


### PR DESCRIPTION
My team runs automated stress tests for our product which uses Godot. It loads 50 glTF models in parallel and we were seeing crashes. We found the issue in the way GDExtension virtual methods are lazy initialized. See my all-uppercase comments below:

```c++
_FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const {\
	static const StringName _gdvirtual_##m_name##_sn = StringName(#m_name, true);\
	ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\
	if (_script_instance && _script_instance->has_method(_gdvirtual_##m_name##_sn)) {\
		return true;\
	}\
	if (_get_extension()) {\
		//  TWO THREADS CAN ENTER THIS CONDITION IF THEY BOTH BELIEVE THEY ARE THE FIRST CALLER
		if (unlikely(!_gdvirtual_##m_name)) {\ 
			_gdvirtual_init_method_ptr(_gdvirtual_##m_name##_get_method_info().get_compatibility_hash(), _gdvirtual_##m_name, _gdvirtual_##m_name##_sn, false);\
		}\
		// WILL RETURN TRUE DUE TO INTERMEDIATE NULLPTR STATE WRITTEN BY _gdvirtual_init_method_ptr.
		if (_gdvirtual_##m_name != reinterpret_cast<void*>(_INVALID_GDVIRTUAL_FUNC_ADDR)) {\ 
			return true;\
		}\
	}\
	return false;\
}\
```

The main issue is that the previous implementation of `_gdvirtual_init_method_ptr` would first thing write nullptr to the out parameter, so if two threads enter this function, one can reset the value back to nullptr after the other set the value. Because the above macro only checks for `_INVALID_GDVIRTUAL_FUNC_ADDR`, it will report it as overridden and so later code will try to use this nullptr value and crash.

Here's what the crash stack looked like when the `*_overriden` function incorrectly reports true:

```
(Inline Function) --------`--------     : --------`-------- --------`-------- --------`-------- --------`-------- : MrShell_exe!GLTFDocumentExtension::_gdvirtual__import_pre_generate_call+0x50d
000000fb`7a1fdcc0 00007ff6`3f9bee43     : 000002db`111fc560 000000fb`7a1fdea9 0000029a`4f2eb420 0000029a`4f21b090 : MrShell_exe!GLTFDocumentExtension::import_pre_generate+0x59b
000000fb`7a1fde40 00007ff6`3f9ffa40     : 0000029a`4f21b090 000002db`111fc560 000002db`111fc560 00000004`00000000 : MrShell_exe!GLTFDocument::_generate_scene_node_tree+0x2f3
000000fb`7a1fdf10 00007ff6`3fa05af0     : 00000000`00000000 00000000`00000000 00007ff9`2baedcee 000000fb`7a1fe1c8 : MrShell_exe!GLTFDocument::generate_scene+0xe0
(Inline Function) --------`--------     : --------`-------- --------`-------- --------`-------- --------`-------- : MrShell_exe!call_with_ptr_args_ret_helper+0x7e
(Inline Function) --------`--------     : --------`-------- --------`-------- --------`-------- --------`-------- : MrShell_exe!call_with_ptr_args_ret+0x7e
000000fb`7a1fe030 00007ff6`424e9971     : 000002db`111fc560 00000000`00000000 0000029a`4f769aa0 0000029a`4f2e2ba0 : MrShell_exe!MethodBindTR<GLTFDocument,Node *,Ref<GLTFState>,float,bool,bool>::ptrcall+0x90
000000fb`7a1fe090 00007ff9`2b5647ee     : 00000000`00000000 0000029a`4f769aa0 0000029a`4f769aa0 00007ff9`2b030fef : MrShell_exe!gdextension_object_method_bind_ptrcall+0x11
000000fb`7a1fe0d0 00007ff9`2b0524f0     : 00000000`00000001 000000fb`7a1fe6d0 00000000`00000001 0000029a`54dff0e0 : VolumetricPlatform!volumetricplatform_library_init+0x531d4e
```

We do have a GLTFDocumentExtension in our GDExtension which I suspect is what is lighting up this code path.

To fix this I have `_gdvirtual_init_method_ptr` resolve the value into a temporary local variable and only commit the final value at the very end.

AI Disclosure: I used AI to brainstorm variable names (ended up going with just `fn_ptr`) and looking for edge cases or holes in my logic that I might have missed (essentially code review).