### PR TITLE
Add out of range check for `PacketPeerUDP`

### DIFF
--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -355,7 +355,7 @@ int PacketPeerUDP::get_local_port() const {
 
 void PacketPeerUDP::set_dest_address(const IPAddress &p_address, int p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
-	ERR_FAIL_COND_MSG(p_port < 0 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't set UDP peer destination address on port %d. The port number must be between 0 and 65535 (inclusive).", p_port));
+	ERR_FAIL_COND_V_MSG(p_port < 1 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;
 	peer_port = p_port;
 }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -355,6 +355,7 @@ int PacketPeerUDP::get_local_port() const {
 
 void PacketPeerUDP::set_dest_address(const IPAddress &p_address, int p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
+	ERR_FAIL_COND_MSG(p_port < 1 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't create a TCP server on port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;
 	peer_port = p_port;
 }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -355,7 +355,7 @@ int PacketPeerUDP::get_local_port() const {
 
 void PacketPeerUDP::set_dest_address(const IPAddress &p_address, int p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
-	ERR_FAIL_COND_V_MSG(p_port < 1 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
+	ERR_FAIL_COND_MSG(p_port < 1 || p_port > 65535, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;
 	peer_port = p_port;
 }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -355,7 +355,7 @@ int PacketPeerUDP::get_local_port() const {
 
 void PacketPeerUDP::set_dest_address(const IPAddress &p_address, int p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
-	ERR_FAIL_COND_MSG(p_port < 1 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't create a TCP server on port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
+	ERR_FAIL_COND_MSG(p_port < 0 || p_port > 65535, ERR_PARAMETER_RANGE_ERROR, vformat("Can't set UDP peer destination address on port %d. The port number must be between 0 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;
 	peer_port = p_port;
 }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -223,11 +223,11 @@ void PacketPeerUDP::disconnect_shared_socket() {
 	close();
 }
 
-Error PacketPeerUDP::connect_to_host(const IPAddress &p_host, int p_port) {
+Error PacketPeerUDP::connect_to_host(const IPAddress &p_host, uint16 p_port) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(!p_host.is_valid(), ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V_MSG(p_port < 1 || p_port > 65535, ERR_INVALID_PARAMETER, "The remote port number must be between 1 and 65535 (inclusive).");
+	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER, "The remote port number must be between 0 and 65535 (inclusive).");
 
 	Error err;
 

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -223,7 +223,7 @@ void PacketPeerUDP::disconnect_shared_socket() {
 	close();
 }
 
-Error PacketPeerUDP::connect_to_host(const IPAddress &p_host, uint16 p_port) {
+Error PacketPeerUDP::connect_to_host(const IPAddress &p_host, uint16_t p_port) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(!p_host.is_valid(), ERR_INVALID_PARAMETER);
@@ -353,7 +353,7 @@ int PacketPeerUDP::get_local_port() const {
 	return addr.port();
 }
 
-void PacketPeerUDP::set_dest_address(const IPAddress &p_address, uint16 p_port) {
+void PacketPeerUDP::set_dest_address(const IPAddress &p_address, uint16_t p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
 	ERR_FAIL_COND_MSG(p_port == 0, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -227,7 +227,7 @@ Error PacketPeerUDP::connect_to_host(const IPAddress &p_host, uint16 p_port) {
 	ERR_FAIL_COND_V(udp_server, ERR_LOCKED);
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(!p_host.is_valid(), ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER, "The remote port number must be between 0 and 65535 (inclusive).");
+	ERR_FAIL_COND_V_MSG(p_port == 0, ERR_INVALID_PARAMETER, "The remote port number must be between 0 and 65535 (inclusive).");
 
 	Error err;
 
@@ -353,9 +353,9 @@ int PacketPeerUDP::get_local_port() const {
 	return addr.port();
 }
 
-void PacketPeerUDP::set_dest_address(const IPAddress &p_address, int p_port) {
+void PacketPeerUDP::set_dest_address(const IPAddress &p_address, uint16 p_port) {
 	ERR_FAIL_COND_MSG(connected, "Destination address cannot be set for connected sockets");
-	ERR_FAIL_COND_MSG(p_port < 1 || p_port > 65535, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
+	ERR_FAIL_COND_MSG(p_port == 0, vformat("Can't set UDP peer destination address to port %d. The port number must be between 1 and 65535 (inclusive).", p_port));
 	peer_addr = p_address;
 	peer_port = p_port;
 }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -343,11 +343,11 @@ IPAddress PacketPeerUDP::get_packet_address() const {
 	return packet_ip;
 }
 
-int PacketPeerUDP::get_packet_port() const {
+uint16_t PacketPeerUDP::get_packet_port() const {
 	return packet_port;
 }
 
-int PacketPeerUDP::get_local_port() const {
+uint16_t PacketPeerUDP::get_local_port() const {
 	NetSocket::Address addr;
 	_sock->get_socket_address(&addr);
 	return addr.port();

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -77,13 +77,13 @@ public:
 	Error connect_shared_socket(Ref<NetSocket> p_sock, IPAddress p_ip, uint16_t p_port, UDPServer *ref); // Used by UDPServer
 	void disconnect_shared_socket(); // Used by UDPServer
 	Error store_packet(IPAddress p_ip, uint32_t p_port, uint8_t *p_buf, int p_buf_size); // Used internally and by UDPServer
-	Error connect_to_host(const IPAddress &p_host, int p_port);
+	Error connect_to_host(const IPAddress &p_host, uint16_t p_port);
 	bool is_socket_connected() const;
 
 	IPAddress get_packet_address() const;
-	int get_packet_port() const;
-	int get_local_port() const;
-	void set_dest_address(const IPAddress &p_address, int p_port);
+	uint16_t get_packet_port() const;
+	uint16_t get_local_port() const;
+	void set_dest_address(const IPAddress &p_address, uint16_t p_port);
 
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #
#120521 
## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Fixing the out-of-range network connection issues seen in 4.7, tcp and udp were already covered in #120522  PacketPeerUDP should also have the same check 
