### PR TITLE
[Android] Make `OS.alert()` blocking

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -75,6 +75,7 @@ import org.godotengine.godot.utils.useBenchmark
 import org.godotengine.godot.xr.XRMode
 import java.util.*
 import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.FutureTask
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -882,6 +883,8 @@ class Godot private constructor(val context: Context) {
 	@JvmOverloads
 	fun alert(message: String, title: String, okCallback: Runnable? = null) {
 		val activity = getActivity() ?: return
+
+		val renderLatch = CountDownLatch(1)
 		runOnHostThread {
 			val builder = AlertDialog.Builder(activity)
 			builder.setMessage(message).setTitle(title)
@@ -890,9 +893,25 @@ class Godot private constructor(val context: Context) {
 			) { dialog: DialogInterface, _: Int ->
 				okCallback?.run()
 				dialog.cancel()
+				renderLatch.countDown()
+			}
+			builder.setOnCancelListener {
+				renderLatch.countDown()
 			}
 			val dialog = builder.create()
 			dialog.show()
+		}
+
+		// We only block the render thread.
+		val blockerRunnable = Runnable {
+			try {
+				renderLatch.await()
+			} catch (_: InterruptedException) {}
+		}
+		if (Thread.currentThread() == Looper.getMainLooper().thread) {
+			runOnRenderThread(blockerRunnable)
+		} else {
+			blockerRunnable.run()
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Clean up of https://github.com/godotengine/godot/pull/120756; this make `OS.alert()` blocking on Android bringing it up to parity with the behavior on desktop platforms.

- Closes #

https://github.com/godotengine/godot/issues/49969 for Android

## Additional information

The original PR by @yorkyang2333 was written using AI, and not fully correct. This cleans up the attempt.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
