### PR TITLE
Fix incorrect `p_zoom_step` check in GraphEdit's `set_zoom_step()`

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2469,6 +2469,7 @@ float GraphEdit::get_zoom() const {
 void GraphEdit::set_zoom_step(float p_zoom_step) {
 	p_zoom_step = std::abs(p_zoom_step);
 	ERR_FAIL_COND(!std::isfinite(p_zoom_step));
+	ERR_FAIL_COND_MSG(p_zoom_step < 1.0, "GraphEdit's zoom step must be greater than or equal to 1.0.");
 	if (zoom_step == p_zoom_step) {
 		return;
 	}

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -226,7 +226,7 @@ void ViewPanner::set_scroll_speed(int p_scroll_speed) {
 }
 
 void ViewPanner::set_scroll_zoom_factor(float p_scroll_zoom_factor) {
-	ERR_FAIL_COND(p_scroll_zoom_factor <= 1.0);
+	ERR_FAIL_COND(p_scroll_zoom_factor < 1.0);
 	scroll_zoom_factor = p_scroll_zoom_factor;
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120802

## Additional information

Just adds a missing, simple check to ensure the new zoom step is not below, or equal to, 1.0. Some visual errors occur when its below that right now due to its use in certain zoom calculations (eg. `1.0/zoom_offset`)