### PR TITLE
[3.x] Minor `LocalVector` Improvements

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -89,7 +89,7 @@ public:
 	// Removes the item copying the last value into the position of the one to
 	// remove. It's generally faster than `remove`.
 	void remove_unordered(U p_index) {
-		ERR_FAIL_INDEX(p_index, count);
+		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
 		count--;
 		if (count > p_index) {
 			data[p_index] = std::move(data[count]);
@@ -117,7 +117,7 @@ public:
 
 	U erase_multiple_unordered(const T &p_val) {
 		U from = 0;
-		U count = 0;
+		U removed = 0;
 		while (true) {
 			int64_t idx = find(p_val, from);
 
@@ -126,9 +126,9 @@ public:
 			}
 			remove_unordered(idx);
 			from = idx;
-			count++;
+			removed++;
 		}
-		return count;
+		return removed;
 	}
 
 	void invert() {
@@ -150,6 +150,12 @@ public:
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 
 	_FORCE_INLINE_ void reserve(U p_size, bool p_allow_shrink = false) {
+		if (p_size == 0) {
+			if (p_allow_shrink && empty() && capacity) {
+				reset();
+			}
+			return;
+		}
 		p_size = nearest_power_of_2_templated(p_size);
 		if (!p_allow_shrink ? p_size > capacity : ((p_size >= count) && (p_size != capacity))) {
 			capacity = p_size;
@@ -259,9 +265,11 @@ public:
 
 	explicit operator Vector<T>() const {
 		Vector<T> ret;
-		ret.resize(size());
+		ret.resize(count);
 		T *w = ret.ptrw();
-		memcpy(w, data, sizeof(T) * count);
+		if (w) {
+			copy_arr(w, data, count);
+		}
 		return ret;
 	}
 
@@ -271,7 +279,7 @@ public:
 			pl.resize(size());
 			typename PoolVector<T>::Write w = pl.write();
 			T *dest = w.ptr();
-			memcpy(dest, data, sizeof(T) * count);
+			copy_arr(dest, data, count);
 		}
 		return pl;
 	}

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -35,6 +35,7 @@
 #include "core/safe_refcount.h"
 
 #include <stddef.h>
+#include <string.h>
 #include <type_traits>
 
 #ifndef PAD_ALIGN
@@ -162,6 +163,18 @@ T *memnew_arr_template(size_t p_elements, const char *p_descr = "") {
 	}
 
 	return (T *)mem;
+}
+
+// Convenient alternative to a loop copy pattern.
+template <typename T>
+_FORCE_INLINE_ void copy_arr(T *p_dst, const T *p_src, size_t p_num) {
+	if constexpr (std::is_trivially_copyable<T>::value) {
+		memcpy((uint8_t *)p_dst, (uint8_t *)p_src, p_num * sizeof(T));
+	} else {
+		for (size_t i = 0; i < p_num; i++) {
+			p_dst[i] = p_src[i];
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes some minor 3.x specific issues, particularly where the older version of `LocalVector` has missed out on fixes in 4.x.

## What problem(s) does this PR solve?

* Fixes calling `reserve(0)`. This currently causes unsigned wraparound and reserves a very high amount of memory.
* Changes `remove_unordered_multiple` variable name from `count` to `removed`, because it is shadowing `count` member variable. This is not a bug, but has potential future bug potential, so is probably better not to shadow.
* Changes `ERR_FAIL_INDEX` to unsigned for `remove_unordered()`. Probably fine before but this is better / ensures consistent behaviour.
* Fixes up the operators that create `Vector` and `PoolVector`. These previously used `memcpy` directly and assumed trivially copyable. Here I use an approach similar to Godot 4.x and use correct behaviour for non-trivial types.

## Additional information
Important - while investigating the `copy_arr_placement` approach used in Godot 4.x, I noticed a possible bug present in Godot 4:

* the `Vector` is resized to the number of elements. This constructs them.
* `copy_arr_placement` is run on the _already constructed_ elements.

This means there is no opportunity for the destructor to be called, which can cause leaks etc. It is more correct to just copy the elements one by one, which ensures the elements remain consistent and destructors are called.

It would perhaps be even better to add a fast path just to reserve the memory and not call constructors when resizing the `Vector`, _then_ use placement new, but in Godot 3.x this whole path is not currently used (I tested with `static_assert`) so it doesn't matter that much.

## Notes
* I'm not a massive fan of the `copy_arr`, `copy_arr_placement` etc being in global namespace as it could cause conflicts with third party. It's possible that just extending the name a little from `copy_arr` might be worth it, as an alternative, but leave this up to reviewer.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
