### PR TITLE
Add `Span` constructor to `Vector`

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -219,6 +219,7 @@ public:
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData() { _unref(); }
 	_FORCE_INLINE_ CowData(std::initializer_list<T> p_init);
+	_FORCE_INLINE_ explicit CowData(Span<T> p_span);
 	_FORCE_INLINE_ CowData(const CowData<T> &p_from) { _ref(p_from); }
 	_FORCE_INLINE_ CowData(CowData<T> &&p_from) {
 		_ptr = p_from._ptr;
@@ -575,6 +576,14 @@ CowData<T>::CowData(std::initializer_list<T> p_init) {
 
 	copy_arr_placement(_ptr, p_init.begin(), p_init.size());
 	*_get_size() = p_init.size();
+}
+
+template <typename T>
+CowData<T>::CowData(Span<T> p_span) {
+	CRASH_COND(_alloc_exact(p_span.size()));
+
+	copy_arr_placement(_ptr, p_span.begin(), p_span.size());
+	*_get_size() = p_span.size();
 }
 
 GODOT_GCC_WARNING_POP

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -323,16 +323,6 @@ public:
 		insert(i, p_val);
 	}
 
-	explicit operator Vector<T>() const {
-		Vector<T> ret;
-		ret.resize(count);
-		T *w = ret.ptrw();
-		if (w) {
-			copy_arr_placement(w, data, count);
-		}
-		return ret;
-	}
-
 	Vector<uint8_t> to_byte_array() const { //useful to pass stuff to gpu or variant
 		Vector<uint8_t> ret;
 		ret.resize(count * sizeof(T));

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -322,6 +322,8 @@ public:
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) :
 			_cowdata(p_init) {}
+	_FORCE_INLINE_ explicit Vector(Span<T> p_span) :
+			_cowdata(p_span) {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) = default;
 	_FORCE_INLINE_ Vector(Vector &&p_from) = default;
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Deletes `LocalVector::operator Vector<T>` which was buggy (leaked non-trivial elements during construction).
- Makes conversions from anything holding contiguous `T` easier.

The performance should be slightly better than before, but I'm not aware of any place where this would make a difference.

## Additional information

Bug spotted by @lawnjelly.