### PR TITLE
[3.x] Replace `LocalVector.operator Vector` with `Vector(Span)` constructor.

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -190,6 +190,7 @@ public:
 	_FORCE_INLINE_ CowData();
 	_FORCE_INLINE_ ~CowData();
 	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
+	_FORCE_INLINE_ explicit CowData(Span<T> p_span);
 };
 
 template <class T>
@@ -378,6 +379,15 @@ void CowData<T>::_ref(const CowData &p_from) {
 template <class T>
 CowData<T>::CowData() {
 	_ptr = nullptr;
+}
+
+template <typename T>
+CowData<T>::CowData(Span<T> p_span) {
+	CRASH_COND(resize(p_span.size()));
+	for (size_t i = 0; i < p_span.size(); i++) {
+		_ptr[i] = p_span[i];
+	}
+	*_get_size() = p_span.size();
 }
 
 template <class T>

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -263,16 +263,6 @@ public:
 		insert(i, p_val);
 	}
 
-	explicit operator Vector<T>() const {
-		Vector<T> ret;
-		ret.resize(count);
-		T *w = ret.ptrw();
-		if (w) {
-			copy_arr(w, data, count);
-		}
-		return ret;
-	}
-
 	explicit operator PoolVector<T>() const {
 		PoolVector<T> pl;
 		if (size()) {

--- a/core/vector.h
+++ b/core/vector.h
@@ -123,6 +123,8 @@ public:
 
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	_FORCE_INLINE_ explicit Vector(Span<T> p_from) :
+			_cowdata(p_from) {}
 	inline Vector &operator=(const Vector &p_from) {
 		_cowdata._ref(p_from._cowdata);
 		return *this;


### PR DESCRIPTION
## What problem(s) does this PR solve?

3.x equivalent to https://github.com/godotengine/godot/pull/120810/.

Moves the constructor to the constructee instead of the source data, which allows it to run more efficiently (in theory). In 3.x, this is not as efficient because it's using the older `CowData` implementation, which is not as modular as the 4.x version.
