### PR TITLE
Add warning when attempting to resize embedded game window

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -772,6 +772,7 @@
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(100, 100)">
 			The window's size in pixels. See also [member content_scale_size], which doesn't set the window's physical size but affects how scaling works relative to the current [member content_scale_mode].
+			[b]Note:[/b] Changing the size of the window is not possible when embedded in the editor, and will print a warning instead.
 		</member>
 		<member name="theme" type="Theme" setter="set_theme" getter="get_theme">
 			The [Theme] resource this node and all its [Control] and [Window] children use. If a child node has its own [Theme] resource set, theme items are merged with child's definitions having higher priority.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1299,6 +1299,11 @@ void Window::_update_window_size() {
 			DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 			DisplayServer::get_singleton()->window_set_size(size, window_id);
 		} else if (Engine::get_singleton()->is_embedded_in_editor()) {
+			// This method is hit when first launching the game. Ensure the initial update does not throw the warning.
+			if (!is_first_size_update) {
+				WARN_PRINT("Attempted to resize game window while the game was embedded in the editor. Game window cannot be resized when embedded in the editor.");
+			}
+			is_first_size_update = false;
 			size = DisplayServer::get_singleton()->window_get_size(window_id); // Reset size.
 		}
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -181,6 +181,8 @@ private:
 
 	Rect2i nonclient_area;
 
+	bool is_first_size_update = true;
+
 	Size2i _clamp_limit_size(const Size2i &p_limit_size);
 	Size2i _clamp_window_size(const Size2i &p_size);
 	void _validate_limit_size();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120798

## Additional information

This "regression" was introduced in 4.6-dev2 with #111313 .

Since apparently this is intended behavior as per the comments in the PR (embedded game windows should not be able to be resized), Ive gone ahead and added a warning that throws when you attempt to resize the game window in embedded mode, to clarify to users this is intended behavior and how to "fix" it.

Please note this is my first time touching Godot's engine code and Im also not super fluent in CPP, so please review carefully.

I have tested this in Linux Wayland, but I don't think behavior changes in other environments.

No AI was used in this PR whatsoever.  