### PR TITLE
Enable search bar in the Theme Editor Type drop down

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3586,6 +3586,8 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	theme_type_list->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	theme_type_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	theme_type_list->set_accessibility_name(TTRC("Type"));
+	theme_type_list->set_search_bar_enabled(true);
+	theme_type_list->set_search_bar_min_item_count(10);
 	type_list_hb->add_child(theme_type_list);
 	theme_type_list->connect(SceneStringName(item_selected), callable_mp(this, &ThemeTypeEditor::_list_type_selected));
 


### PR DESCRIPTION
This small enhancement simply enables the new drop down search functionality in the `Theme Editor`'s `Type` drop down so it's easier to use. The search bar shows up when at least 10 items are added.

https://github.com/user-attachments/assets/cb0bbc28-3548-441b-a85f-5abbb0f0e5d4

EDIT: Similar to https://github.com/godotengine/godot/pull/118413