### PR TITLE
[3.x] Ensure `LocalVector` `span()` count is unsigned

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -284,7 +284,12 @@ public:
 		return ret;
 	}
 
-	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(data, count); }
+	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ {
+		// Ensure span is unsigned.
+		// NOOP for default LocalVector, but converts any LocalVectors with signed U.
+		using UnsignedType = std::make_unsigned_t<U>;
+		return Span(data, static_cast<UnsignedType>(count));
+	}
 	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
 	_FORCE_INLINE_ LocalVector() {}


### PR DESCRIPTION
Note that `INT32_MAX` always fits in `UINT32_MAX`.

The only overflow problem would be with negative counts, but these *should* be prevented by the existing `LocalVector` code.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
When expanding the use of `Span`, we noticed that `LocalVectori` can sometimes create warnings due to the signed / unsigned `U` difference.

Fixes compilation errors in #120812 .

## Additional information
Longterm I will try and phase out `LocalVectori`, but this will do as a stop gap.

This same problem can occur in 4.x, but signed counts are not used nearly as much (at all?) in master.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
