### PR TITLE
GDScript: Fix wrong error line indicator position of static typed FOR loop

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1726,11 +1726,12 @@ void GDScriptByteCodeGenerator::write_for(const Address &p_variable, bool p_use_
 	for_jmp_addrs.push_back(opcodes.size());
 	append(0); // End of loop address, will be patched.
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	append(opcodes.size() + (p_is_range ? 7 : 6)); // Skip over 'continue' code.
+	append(opcodes.size() + (p_is_range ? 9 : 8)); // Skip over 'continue' code.
 
 	// Next iteration.
 	int continue_addr = opcodes.size();
 	continue_addrs.push_back(continue_addr);
+	write_newline(current_line);
 	append_opcode(iterate_opcode);
 	append(counter);
 	if (p_is_range) {

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_iterator_array_size.out
@@ -5,17 +5,17 @@ SUBTEST_INIT_ARRAY_EMPTY
 >> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:33 on subtest_init_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadInit".
 SUBTEST_NEXT_ARRAY_LARGE
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:67 on subtest_next_array_large(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:66 on subtest_next_array_large(): There was an error calling "_iter_next" on iterator object of type "BadNext".
 SUBTEST_NEXT_ARRAY_EMPTY
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:72 on subtest_next_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadNext".
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:71 on subtest_next_array_empty(): There was an error calling "_iter_next" on iterator object of type "BadNext".
 SUBTEST_VARIANT_INIT_ARRAY_LARGE
 >> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
 SUBTEST_VARIANT_INIT_ARRAY_EMPTY
 >> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object'.
 SUBTEST_VARIANT_NEXT_ARRAY_LARGE
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
 SUBTEST_VARIANT_NEXT_ARRAY_EMPTY
 1
->> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:3 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).
+>> SCRIPT ERROR at runtime/errors/for_loop_iterator_array_size.gd:2 on iterate(): Unable to iterate on object of type 'Object' (type changed since first iteration?).

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_error_line.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_error_line.gd
@@ -1,0 +1,4 @@
+func test() -> void:
+    var list = [1, 2, "three"]
+    for element: int in list:
+        print(element)

--- a/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_error_line.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/for_loop_typed_iterator_error_line.out
@@ -1,0 +1,4 @@
+GDTEST_RUNTIME_ERROR
+1
+2
+>> SCRIPT ERROR at runtime/errors/for_loop_typed_iterator_error_line.gd:3 on test(): Trying to assign value of type 'String' to a variable of type 'int'.


### PR DESCRIPTION
<!--
Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

-->

## What problem(s) does this PR solve?

- Closes #92681

## Additional information

This PR adds an extra line to the byte code that indicates which line is being interpreted. This allows the VM to point towards the line that defines the `for` loop in case that there is an error with it on iterations after the first. For example when iterating over an array with elements some of which are not compatible with the static type in the for loop.
The following .gd code:
```
func _ready() -> void:
	var my_list := [1, 2, "3.14", 4]
	
	for element :int in my_list:
		element += 10
		print(element)
```

when tested with`./godot.linuxbsd.editor.x86_64 --test gdscript-compiler ./my_test.gd` gives:

> Function _ready()
>  0: line 6: 	var my_list := [1, 2, "3.14", 4]
>  2: make_array stack(8) = [const(1), const(2), const("3.14"), const(4)]
>  10: assign stack(3) = stack(8)
>  13: assign stack(8) = null
>  15: line 9: 	for element :int in my_list:
>  17: assign stack(6) = stack(3)
>  20: for-init (typed ARRAY) stack(7) in stack(6) counter stack(5) end 60
>  25: jump 34
>  **27: line 9: 	for element :int in my_list:   //  <---- New line added**
>  29: for-loop (typed ARRAY) stack(7) in stack(6) counter stack(5) end 60
>  34: assign typed builtin (int) stack(4) = stack(7)
>  38: line 10: 		element += 10
>  40: validated operator stack(9) = stack(4) + const(10)
>  45: assign stack(4) = stack(9)
>  48: line 11: 		print(element)
>  50: call-utility stack(8) = print(stack(4))
>  56: assign stack(8) = null
>  58: jump 27
>  60: == END ==


I had to change the line numbers in another test file: `for_loop_iterator_array_size.out` because the line of the reported errors has shifted by one. I believe that makes sense.
Without this PR, wrong iterations look like this:
<img width="789" height="433" alt="Screenshot from 2026-07-01 14-04-12" src="https://github.com/user-attachments/assets/cdb3b55a-fb80-4096-b44f-24937e171cd4" />


With this PR, wrong iterations look like this:
<img width="791" height="363" alt="image" src="https://github.com/user-attachments/assets/b805cd2b-5118-415e-af38-b15cae881ab6" />

In the screenshots above it is seen that information about `i` and `@container_pos` are not shown after the changes. This should probably be addressed before merging.

### Performance tests:

I ran this code 4 times. From the editor and from a release build with the PR changes and then from the editor and a release build without the PR changes (control version)
```
	for count in 10:
		var i := 0
		var time_start := Time.get_ticks_usec()
		for c in 100_000_000:
			i += 1
		var elapsed := Time.get_ticks_usec() - time_start
		print("done in\t%s" % elapsed) 
```

The median of the 10 iterations for each are:

Release builds | PR | control
-- | -- | --
MEDIAN in ms | 638.6275 | 639.9065
Delta in % |   | -0.20%
Delta in ms |   | -1.28

in editor | PR | control
-- | -- | --
MEDIAN in ms | 973.173 | 861.4955
Delta in %|   | 11.48%
Delta in ms |   | 111.68

The release builds have negligible difference of 1.28 milliseconds for 100 million iterations. The difference is probably due to some changes in the system that I was using for testing and should be ignored.
The execution inside the editor is 11.48% slower due to the extra overhead. In absolute terms that is 1ms for 1 million iterations or 1 nanosecond per iteration. Acceptable cost for the additional clarity of reporting the correct line of an error.



#### AI disclosure
I spent many tokens over the course of several chat conversations to:
1. Find if the problem that I experienced is considered a bug or a feature request;
2. Find an existing issue or feature request;
3. Attempts to translate the fix in PR #118326 from `while` to `for` loops
4. Search for ways to debug the unsuccessful attempts in step 3
5. Discover `gdscript_disassembler.cpp` and the binary parameters `--test gdscript-compiler ./my_test.gd` that allow to view the assembly code;
6. Find a fix for my manually inserted 1 line of code;
7. Help with writing the test file and the out file. Both of which I had to modify manually to make them work.

The branch commits and this PR text are hand-made, organically produced, from a free-range contributor.

I started this earlier than the [changes to the Contribution Policies from yesterday](https://godotengine.org/article/contribution-policy-2026/), but I believe that it still complies with it. 
