### PR TITLE
Add "extend script" option to filesystem dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2711,6 +2711,31 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				EditorNode::get_singleton()->run_editor_script(scr);
 			}
 		} break;
+		case FILE_MENU_EXTEND_SCRIPT: {
+			if (p_selected.size() == 1) {
+				const String &fpath = p_selected[0];
+				Ref<Script> scr = ResourceLoader::load(fpath);
+				ERR_FAIL_COND(scr.is_null());
+				String path = scr->get_path();
+				String inherits = "RefCounted";
+				if (scr.is_valid()) {
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptLanguage *l = ScriptServer::get_language(i);
+						if (l->get_type() == scr->get_class()) {
+							String name = l->get_global_class_name(scr->get_path());
+							if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
+								inherits = name;
+							} else if (l->can_inherit_from_file()) {
+								inherits = "\"" + scr->get_path() + "\"";
+							}
+							break;
+						}
+					}
+				}
+				make_script_dialog->config(inherits, path, false, false);
+				make_script_dialog->popup_centered();
+			}
+		} break;
 
 		case EXTRA_FOCUS_PATH: {
 			focus_on_filter();
@@ -3472,6 +3497,14 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 
 		p_popup->add_submenu_node_item(TTRC("Create New"), new_menu, FILE_MENU_NEW);
 		p_popup->set_item_icon(-1, get_editor_theme_icon(SNAME("Add")));
+
+		String type = EditorFileSystem::get_singleton()->get_file_type(filenames[0]);
+		if (ClassDB::is_parent_class(type, "Script")) {
+			Ref<Script> scr = ResourceLoader::load(filenames[0]);
+			if (scr.is_valid()) {
+				p_popup->add_icon_item(get_editor_theme_icon(SNAME("ScriptExtend")), TTRC("Extend Script..."), FILE_MENU_EXTEND_SCRIPT);
+			}
+		}
 		p_popup->add_separator();
 	}
 

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -137,6 +137,7 @@ private:
 		FILE_MENU_NEW_SCRIPT,
 		FILE_MENU_NEW_SCENE,
 		FILE_MENU_RUN_SCRIPT,
+		FILE_MENU_EXTEND_SCRIPT,
 		FILE_MENU_MAX,
 		// Extra shortcuts that don't exist in the menu.
 		EXTRA_FOCUS_PATH,


### PR DESCRIPTION
## What problem(s) does this PR solve?

The SceneTreeDock makes it possible to extend the script attached to a selected node, but godot is missing an option to do the same when right-clicking a script in the FilesystemDock (which also means there is no shortcut to extending a script that doesn't inherit from `Node`)
This PR solves this by adding a "Extend Script..." popup item as found in the right click menu of the SceneTreeDock.

## Additional information
<img width="363" height="311.25" alt="image" src="https://github.com/user-attachments/assets/eee665b0-24f9-41a4-9223-1a9aca8843d6" /> <img width="363" height="311.25" alt="image" src="https://github.com/user-attachments/assets/2c3b7a07-8a48-4736-8c1f-a502919029ce" />

This addition and it's implementation is subject discussion, especially these points come to mind:
- Should the FileSystem dock even show the "Extend Script..." popup item when right clicking a script or is the additional clutter and vertical space used up not worth it, since you technically can extend scripts by navigating to "Create New">"Script..." and then setting the "Inherits" field to the desired parent script?
- Where should the "Extend Script" popup item be inserted into the right click menu? I currently inserted into the same section as "Create New", both because it fits there due to being a specialization of  "Create New">"Script..." and because it sits on a similar height as the "Extend Script..." popup item in the Scene dock right click menu.
- filesystem_dock.cpp:2714 and filesystem_dock.h:140: Should the enum `FILE_MENU_EXTEND_SCRIPT` and thus the switch case with it be moved further up or down to better fit in with the surrounding cases?

tested on windows build with tests and assertions passed.