### PR TITLE
Fix scene not requesting save for `Load as Placeholder`.

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1398,14 +1398,19 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 
+					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
 					placeholder = !placeholder;
+
+					undo_redo->create_action(TTR("Toggle Load as Placeholder"));
+					undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", !placeholder);
+					undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", placeholder);
 
 					if (placeholder) {
 						EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
 					}
 
-					node->set_scene_instance_load_placeholder(placeholder);
-					scene_tree->update_tree();
+					undo_redo->commit_action();
 				}
 			}
 		} break;


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #120818

## Additional information

Due to a missing UndoRedo action, changing the `Load as Placeholder` toggle does not set the scene as dirty. 
So playing the game after changing it will load the wrong values due to the scene not being saved.


https://github.com/user-attachments/assets/478aacd6-2a25-45e3-9869-e7adc5ba7cfd

