### PR TITLE
Avoid temporary `CowData` `nullptr` state during pointer assignment.

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -558,14 +558,16 @@ void CowData<T>::_ref(const CowData &p_from) {
 		return; // self assign, do nothing.
 	}
 
-	_unref(); // Resets _ptr to nullptr.
+	// Keep _ptr valid at all times. old_data will unref as it goes out of scope.
+	// This isn't strictly necessary but makes us a bit more resilient to multithread misuse.
+	CowData old_data;
+	old_data._ptr = _ptr;
 
-	if (!p_from._ptr) {
-		return; //nothing to do
-	}
-
-	if (p_from._get_refcount()->conditional_increment() > 0) { // could reference
+	if (p_from._ptr && p_from._get_refcount()->conditional_increment() > 0) {
 		_ptr = p_from._ptr;
+	} else {
+		// New data is null or we cannot copy.
+		_ptr = nullptr;
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Supersedes (mostly) https://github.com/godotengine/godot/pull/112586

`CowData` assignment (e.g. string = string1) currently temporarily resets to `nullptr` as it clears first and assigns afterwards. It is observably correct within the same thread. However, other threads might temporarily observe a `nullptr`.

While cross-thread use is not guaranteed by the class, there is no harm in making it a bit more resilient: through this change, other threads will _never_ observe a temporary `nullptr` during assignments.

## Additional information

This is achieved by essentially this code, just reimagined in C++:

```
T *old_ptr = ptr;
ptr = new_ptr;
dealloc(old_ptr);

// instead of
ptr = nullptr;
dealloc(ptr);
ptr = new_ptr;
```

Performance should be the same as before
