### PR TITLE
Fix RichTextLabel mouse scroll drift

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3104,17 +3104,19 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 		bool scroll_value_modified = false;
 		double prev_scroll = vscroll->get_value();
 
-		if (b->get_button_index() == MouseButton::WHEEL_UP) {
-			if (scroll_active) {
-				vscroll->scroll(-vscroll->get_page() * b->get_factor() * 0.5 / 8);
-				scroll_value_modified = true;
+		if ((b->get_button_index() == MouseButton::WHEEL_UP || b->get_button_index() == MouseButton::WHEEL_DOWN) && scroll_active) {
+			const MouseButton button_index = b->get_button_index();
+			const double raw_scroll_amount = vscroll->get_page() * b->get_factor() / (ScrollBar::PAGE_DIVISOR * 2.0);
+			const double step = vscroll->get_step();
+			const double scroll_amount = MAX(Math::snapped(raw_scroll_amount, step), step);
+
+			if (button_index == MouseButton::WHEEL_UP) {
+				vscroll->scroll(-scroll_amount);
+			} else {
+				vscroll->scroll(scroll_amount);
 			}
-		}
-		if (b->get_button_index() == MouseButton::WHEEL_DOWN) {
-			if (scroll_active) {
-				vscroll->scroll(vscroll->get_page() * b->get_factor() * 0.5 / 8);
-				scroll_value_modified = true;
-			}
+
+			scroll_value_modified = true;
 		}
 
 		if (scroll_value_modified && vscroll->get_value() != prev_scroll) {


### PR DESCRIPTION
AI used to assist path tracing. All code was human written.

 Fixes #120781 

Summary of changes: 
Snapped calculated scroll amount to scrollbar step before applying direction
replaced hard coded divisor with ScrollBar::PAGE_DIVISOR

Motivation: Due to rounding differences caused by passing non whole numbers, mouse wheel scrolling drifts depending on direction of scrolling

Overview: 
Simplified the math when getting scroll amount and removed the magic number 8 with ScrollBar::PAGE_DIVISOR
-maintained RichTextLabel half speed scrolling behavior
Perform all math related to scroll amount before vscroll->scroll to ensure consistent rounding regardless of scroll direction

Discussion: This adds some variables and collapses 2 if branches into one behavioral block that uses one calculated value for consistency
Additional Work: No additional work is expected: This is intentionally an extremely small scope fix

Testing: Used MRP and verified that pairs of scroll moves in opposite direction were equivalent, and scrolling over 100 pixels returned to previous values.