### PR TITLE
CI: Bump various CI hooks

### DIFF
--- a/.github/actions/clangd-tidy/action.yml
+++ b/.github/actions/clangd-tidy/action.yml
@@ -22,7 +22,7 @@ runs:
 
         echo "::group::Installing clangd-tidy"
         # Don't know which python we're using, so just access the global scope.
-        python -m pip install clangd clangd-tidy clang-tidy==22.1.0
+        python -m pip install clangd clangd-tidy clang-tidy==22.1.7
         echo "::endgroup::"
 
         echo "::group::Running clangd-tidy"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         exclude: (SConstruct|SCsub)$ # SCons files use shebangs for syntax highlighting only.
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.7
+    rev: v22.1.5
     hooks:
       - id: clang-format
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java)$
@@ -41,12 +41,12 @@ repos:
         # No unknown warning suppression used for easier compatibility with gcc
         args: [--fix, --quiet, --use-color, -p=compile_commands.json, -extra-arg=-Wno-unknown-warning-option]
         types_or: [text]
-        additional_dependencies: [clang-tidy==21.1.6]
+        additional_dependencies: [clang-tidy==22.1.7]
         require_serial: false
         stages: [manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.20
     hooks:
       - id: ruff-check
         args: [--color=always]
@@ -71,7 +71,7 @@ repos:
         additional_dependencies: [tomli]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.34.1
+    rev: 0.37.4
     hooks:
       - id: check-jsonschema
         files: ^core/extension/gdextension_interface\.json$


### PR DESCRIPTION
Bumps various prek hooks that didn't necessitate any changes elsewhere in the repo, and thus are safe to bundle together. The hooks updated are:

- clang-format (21.1.7 → 22.1.5)
- clang-tidy (21.1.6 → 22.1.7)
- ruff (0.15.8 → 0.15.20)
- check-jsonschema (0.34.1 → 0.37.4)

I additionally synced the clang-tidy version called by the clangd-tidy action, which should be safe as it was a patch version