### PR TITLE
Make `AudioFrame` trivially copyable, and remove extraneous warning delints

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -51,29 +51,21 @@ static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear_to_db(AUDIO_PEAK_OFFSE
 
 struct AudioFrame {
 	// Left and right samples.
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			float left;
-			float right;
-		};
-#ifndef DISABLE_DEPRECATED
-		struct {
-			float l;
-			float r;
-		};
-#endif
-		float levels[2] = { 0.0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	float left = 0.0f;
+	float right = 0.0f;
 
 	_ALWAYS_INLINE_ const float &operator[](int p_idx) const {
+		// The pointer math below assumes that the two floats are placed back-to-back, like in an array.
+		// This is always true in practice, but technically not guaranteed. So we safety-check it here.
+		static_assert(offsetof(AudioFrame, left) == 0);
+		static_assert(offsetof(AudioFrame, right) == sizeof(float));
+
 		DEV_ASSERT((unsigned int)p_idx < 2);
-		return levels[p_idx];
+		return (&left)[p_idx];
 	}
 	_ALWAYS_INLINE_ float &operator[](int p_idx) {
 		DEV_ASSERT((unsigned int)p_idx < 2);
-		return levels[p_idx];
+		return (&left)[p_idx];
 	}
 
 	constexpr AudioFrame operator+(const AudioFrame &p_frame) const { return AudioFrame(left + p_frame.left, right + p_frame.right); }
@@ -134,28 +126,16 @@ struct AudioFrame {
 		return res;
 	}
 
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-	constexpr AudioFrame(float p_left, float p_right) :
-			left(p_left), right(p_right) {}
-	constexpr AudioFrame(const AudioFrame &p_frame) :
-			left(p_frame.left), right(p_frame.right) {}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
-
-	constexpr void operator=(const AudioFrame &p_frame) {
-		left = p_frame.left;
-		right = p_frame.right;
-	}
-
-	constexpr operator Vector2() const {
+	constexpr explicit operator Vector2() const {
 		return Vector2(left, right);
 	}
 
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-	constexpr AudioFrame(const Vector2 &p_v2) :
+	constexpr AudioFrame() = default;
+
+	constexpr AudioFrame(float p_left, float p_right) :
+			left(p_left), right(p_right) {}
+	constexpr explicit AudioFrame(const Vector2 &p_v2) :
 			left(p_v2.x), right(p_v2.y) {}
-	constexpr AudioFrame() :
-			left(0), right(0) {}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 constexpr AudioFrame operator*(float p_scalar, const AudioFrame &p_frame) {

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -113,7 +113,7 @@ bool AudioStreamGeneratorPlayback::push_frame(const Vector2 &p_frame) {
 		return false;
 	}
 
-	AudioFrame f = p_frame;
+	AudioFrame f(p_frame);
 
 	buffer.write(&f, 1);
 	return true;
@@ -140,7 +140,7 @@ bool AudioStreamGeneratorPlayback::push_buffer(const PackedVector2Array &p_frame
 		while (to_write) {
 			int w = MIN(to_write, 2048);
 			for (int i = 0; i < w; i++) {
-				buf[i] = r[i + ofs];
+				buf[i] = AudioFrame(r[i + ofs]);
 			}
 			buffer.write(buf, w);
 			ofs += w;


### PR DESCRIPTION
## What problem(s) does this PR solve?

`AudioFrame` is currently not trivially copyable.
While perhaps optimizable in later compiler stages, it is unnecessary to rely on this. It should be cleaned up.

## Additional information

I also made `Vector2` conversions explicit. Besides being a core goal, `Vector2` uses `real_t` while `AudioFrame` uses `float` so there's real risk of data loss.