### PR TITLE
Add playback position mapping curve to "Sync" animation transition

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -40,6 +40,9 @@
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode" default="0">
 			The transition type.
 		</member>
+		<member name="sync_mapping_curve" type="Curve" setter="set_sync_mapping_curve" getter="get_sync_mapping_curve">
+			Curve to map from previous state playback position to next state playback position on sync. Should be a unit [Curve].
+		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
 			Ease curve for better control over cross-fade between this state and the next. Should be a unit [Curve].
 		</member>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -38,6 +38,7 @@
 
 void AnimationNodeStateMachineTransition::set_switch_mode(SwitchMode p_mode) {
 	switch_mode = p_mode;
+	notify_property_list_changed();
 }
 
 AnimationNodeStateMachineTransition::SwitchMode AnimationNodeStateMachineTransition::get_switch_mode() const {
@@ -111,6 +112,15 @@ Ref<Curve> AnimationNodeStateMachineTransition::get_xfade_curve() const {
 	return xfade_curve;
 }
 
+void AnimationNodeStateMachineTransition::set_sync_mapping_curve(const Ref<Curve> &p_curve) {
+	sync_mapping_curve = p_curve;
+	emit_changed();
+}
+
+Ref<Curve> AnimationNodeStateMachineTransition::get_sync_mapping_curve() const {
+	return sync_mapping_curve;
+}
+
 void AnimationNodeStateMachineTransition::set_break_loop_at_end(bool p_enable) {
 	break_loop_at_end = p_enable;
 	emit_changed();
@@ -160,6 +170,9 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_reset", "reset"), &AnimationNodeStateMachineTransition::set_reset);
 	ClassDB::bind_method(D_METHOD("is_reset"), &AnimationNodeStateMachineTransition::is_reset);
 
+	ClassDB::bind_method(D_METHOD("set_sync_mapping_curve", "curve"), &AnimationNodeStateMachineTransition::set_sync_mapping_curve);
+	ClassDB::bind_method(D_METHOD("get_sync_mapping_curve"), &AnimationNodeStateMachineTransition::get_sync_mapping_curve);
+
 	ClassDB::bind_method(D_METHOD("set_priority", "priority"), &AnimationNodeStateMachineTransition::set_priority);
 	ClassDB::bind_method(D_METHOD("get_priority"), &AnimationNodeStateMachineTransition::get_priority);
 
@@ -175,6 +188,7 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,32,1"), "set_priority", "get_priority");
 	ADD_GROUP("Switch", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "switch_mode", PROPERTY_HINT_ENUM, "Immediate,Sync,At End"), "set_switch_mode", "get_switch_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sync_mapping_curve", PROPERTY_HINT_RESOURCE_TYPE, "", PROPERTY_USAGE_NONE, Curve::get_class_static()), "set_sync_mapping_curve", "get_sync_mapping_curve"); // Add this dynamic property here so doctool finds it
 	ADD_GROUP("Advance", "advance_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "advance_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Auto"), "set_advance_mode", "get_advance_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "advance_condition"), "set_advance_condition", "get_advance_condition");
@@ -189,6 +203,30 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	BIND_ENUM_CONSTANT(ADVANCE_MODE_AUTO);
 
 	ADD_SIGNAL(MethodInfo("advance_condition_changed"));
+}
+
+bool AnimationNodeStateMachineTransition::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "sync_mapping_curve") {
+		set_sync_mapping_curve(p_value);
+		return true;
+	}
+
+	return false;
+}
+
+bool AnimationNodeStateMachineTransition::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "sync_mapping_curve") {
+		r_ret = get_sync_mapping_curve();
+		return true;
+	}
+
+	return false;
+}
+
+void AnimationNodeStateMachineTransition::_get_property_list(List<PropertyInfo> *p_list) const {
+	// Conditionally display "Sync mapping curve" if switch_mode is "Sync"
+	p_list->push_back(PropertyInfo(Variant::STRING, "Switch", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP)); // Display under "Switch" group
+	p_list->push_back(PropertyInfo(Variant::OBJECT, "sync_mapping_curve", PROPERTY_HINT_RESOURCE_TYPE, Curve::get_class_static(), switch_mode == SwitchMode::SWITCH_MODE_SYNC ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_NO_EDITOR));
 }
 
 AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
@@ -989,7 +1027,28 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationN
 
 		AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(current);
 		if (next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
-			pi.time = current_nti.position;
+			double position = current_nti.position;
+			if (next.sync_mapping_curve.is_valid()) {
+				// A sync mapping curve is specified, so remap the current time using this curve and the next state length
+				pi.time = 0;
+				pi.is_external_seeking = false;
+				pi.weight = 0;
+				pi.seeked = next.is_reset;
+				AnimationNode::NodeTimeInfo next_nti = p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+
+				double current_alpha = 0.0;
+				if (std::abs(current_nti.length) >= CMP_EPSILON) {
+					current_alpha = current_nti.position / current_nti.length;
+				}
+				current_alpha = CLAMP(current_alpha, 0.0, 1.0);
+
+				double next_alpha = next.sync_mapping_curve->sample_baked(current_alpha);
+				next_alpha = CLAMP(next_alpha, 0.0, 1.0);
+
+				position = next_alpha * next_nti.length;
+			}
+
+			pi.time = position;
 			pi.seeked = true;
 			pi.is_external_seeking = false;
 			pi.weight = 0;
@@ -1089,6 +1148,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 				next.switch_mode = ref_transition->get_switch_mode();
 				next.is_reset = ref_transition->is_reset();
 				next.break_loop_at_end = ref_transition->is_loop_broken_at_end();
+				next.sync_mapping_curve = ref_transition->get_sync_mapping_curve();
 			}
 		}
 	} else {
@@ -1119,6 +1179,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 			next.switch_mode = ref_transition->get_switch_mode();
 			next.is_reset = ref_transition->is_reset();
 			next.break_loop_at_end = ref_transition->is_loop_broken_at_end();
+			next.sync_mapping_curve = ref_transition->get_sync_mapping_curve();
 		}
 	}
 

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -59,6 +59,7 @@ private:
 	Ref<Curve> xfade_curve;
 	bool break_loop_at_end = false;
 	bool reset = true;
+	Ref<Curve> sync_mapping_curve;
 	int priority = 1;
 	String advance_expression;
 
@@ -67,6 +68,10 @@ private:
 
 protected:
 	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
 	void set_switch_mode(SwitchMode p_mode);
@@ -94,6 +99,9 @@ public:
 
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;
+
+	void set_sync_mapping_curve(const Ref<Curve> &p_curve);
+	Ref<Curve> get_sync_mapping_curve() const;
 
 	void set_priority(int p_priority);
 	int get_priority() const;
@@ -254,6 +262,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 		AnimationNodeStateMachineTransition::SwitchMode switch_mode;
 		bool is_reset;
 		bool break_loop_at_end;
+		Ref<Curve> sync_mapping_curve;
 	};
 
 	struct ChildStateMachineInfo {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- closes https://github.com/godotengine/godot-proposals/issues/12195

## Additional information

This PR adds a curve for the "Sync" animation transition switch mode that specifies the mapping from the old state playback position to the new state playback position. This is useful as it allows far more control over how the sync switch mode behaves, allowing for different length states to sync as the artist intends. For my use case, it allows two states that perform the opposite motion to seamlessly transition to each other by using a negative linear mapping. 

<img width="567" height="857" alt="image" src="https://github.com/user-attachments/assets/4a00b701-ade6-4755-b0da-2824e72c3ce9" />

For example, for my game I have an animation that goes from the idle stance to the crouched stance, which plays between the idle and crouch poses. To allow for standing up I use the same animation but reversed. However, before this PR there is not a way to define the transitions such that the crouch can be interrupted half-way through to stand back up smoothly. With this new parameter, the sync mode can now be used to connect inverse states:
<img width="449" height="228" alt="image" src="https://github.com/user-attachments/assets/b1e36968-2e9d-4ad7-a1a2-01fa54a8b3ea" />
The attached proposal also states an example for the use-case of this inverse behaviour and would be solved by this PR.

While the proposal suggests a new switch mode for "From End" syncing, I realised that a general mapping of next position from previous would also account for animations that are different in length or if the artist has a specific sync in mind for the transition. If a new switch mode were added specifically for inverting the sync, then in the future it was requested that more control over sync is given to the artist, the "Sync From End" switch mode could be deprecated and pollute the switch mode namespace.

This PR adds a new parameter to the `AnimationNodeStateMachineTransition` class that is a Curve reference, and modifies the sync transition behaviour to use the curve to remap the playback position if it is valid. It also implements `_get_property_list()` to dynamically display the `sync_mapping_curve` parameter when "Sync" is selected as the `switch_mode`. At [`Line 191` in `animation_node_state_machine.cpp`](https://github.com/low-moon/godot/blob/952715e9ac0a2f3ead1b601c5a656ef4d23edad4/scene/animation/animation_node_state_machine.cpp#L191), I had to define the `sync_mapping_curve` parameter in `_bind_methods()` as `PROPERTY_USAGE_NONE` despite it being added through `_get_property_list()`, so that the documentation tooling respected the parameter. I would appreciate if someone could let me know if this is a good practice. It stores and loads the variable so it seems to behave correctly. I also tested normal sync transitions without a sync mapping curve and these behave as usual.

Note: Apologies about the previous PR. I have fixed my branches and can see that this will contribute one commit with my changes.