### PR TITLE
Core: Purge remaining unions in math structs

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -171,7 +171,7 @@ bool AABB::find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool
 
 		// Prevent float error by making sure the point is exactly
 		// on the AABB border on the relevant axis.
-		r_intersection_point->coord[axis] = (p_dir[axis] >= 0) ? position.coord[axis] : end.coord[axis];
+		(*r_intersection_point)[axis] = (p_dir[axis] >= 0) ? position[axis] : end[axis];
 	}
 	if (r_normal) {
 		*r_normal = Vector3();

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -287,10 +287,10 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 
 	for (int k = 0; k < 3; k++) {
 		for (int i = 0; i < p_point_count; i++) {
-			if (p_points[i].coord[k] > ofs.coord[k] + half_extents.coord[k]) {
+			if (p_points[i][k] > ofs[k] + half_extents[k]) {
 				bad_point_counts_positive[k]++;
 			}
-			if (p_points[i].coord[k] < ofs.coord[k] - half_extents.coord[k]) {
+			if (p_points[i][k] < ofs[k] - half_extents[k]) {
 				bad_point_counts_negative[k]++;
 			}
 		}

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -54,16 +54,17 @@ struct AudioFrame {
 	float left = 0.0f;
 	float right = 0.0f;
 
-	_ALWAYS_INLINE_ const float &operator[](int p_idx) const {
-		// The pointer math below assumes that the two floats are placed back-to-back, like in an array.
-		// This is always true in practice, but technically not guaranteed. So we safety-check it here.
-		static_assert(offsetof(AudioFrame, left) == 0);
-		static_assert(offsetof(AudioFrame, right) == sizeof(float));
+	constexpr float &operator[](int p_idx) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(AudioFrame, left) == 0 * sizeof(float));
+		static_assert(offsetof(AudioFrame, right) == 1 * sizeof(float));
+		static_assert(sizeof(AudioFrame) == 2 * sizeof(float));
 
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return (&left)[p_idx];
 	}
-	_ALWAYS_INLINE_ float &operator[](int p_idx) {
+	constexpr const float &operator[](int p_idx) const {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return (&left)[p_idx];
 	}

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -43,7 +43,7 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 	for (int a = 0; a < p_num_a; a++) {
 		uint32_t ind = r_group_a[a];
 
-		if (r_temp_bounds[ind].min.coord[split_axis] > center.coord[split_axis]) {
+		if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 			// add to b
 			r_group_b[p_num_b++] = ind;
 
@@ -75,7 +75,7 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 			for (int a = 0; a < p_num_a; a++) {
 				uint32_t ind = r_group_a[a];
 
-				if (r_temp_bounds[ind].min.coord[split_axis] > center.coord[split_axis]) {
+				if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					count++;
 				}
 			}
@@ -100,7 +100,7 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 			for (int a = 0; a < p_num_a; a++) {
 				uint32_t ind = r_group_a[a];
 
-				if (r_temp_bounds[ind].min.coord[split_axis] > center.coord[split_axis]) {
+				if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					// add to b
 					r_group_b[p_num_b++] = ind;
 

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -36,17 +36,10 @@
 class String;
 
 struct [[nodiscard]] Color {
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			float r;
-			float g;
-			float b;
-			float a;
-		};
-		float components[4] = { 0, 0, 0, 1.0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
+	float a = 1.0f;
 
 	uint32_t to_rgba32() const;
 	uint32_t to_argb32() const;
@@ -65,12 +58,24 @@ struct [[nodiscard]] Color {
 	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	void set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 
-	_FORCE_INLINE_ float &operator[](int p_idx) {
-		return components[p_idx];
+	constexpr float &operator[](int p_idx) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Color, r) == 0 * sizeof(float));
+		static_assert(offsetof(Color, g) == 1 * sizeof(float));
+		static_assert(offsetof(Color, b) == 2 * sizeof(float));
+		static_assert(offsetof(Color, a) == 3 * sizeof(float));
+		static_assert(sizeof(Color) == 4 * sizeof(float));
+
+		DEV_ASSERT((unsigned int)p_idx < 4);
+		return (&r)[p_idx];
 	}
-	_FORCE_INLINE_ const float &operator[](int p_idx) const {
-		return components[p_idx];
+	constexpr const float &operator[](int p_idx) const {
+		DEV_ASSERT((unsigned int)p_idx < 4);
+		return (&r)[p_idx];
 	}
+
+	constexpr const float *as_float4_buffer() const { return &r; }
 
 	constexpr bool operator==(const Color &p_color) const {
 		return (r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a);
@@ -248,8 +253,7 @@ struct [[nodiscard]] Color {
 		return hash_fmix32(h);
 	}
 
-	constexpr Color() :
-			r(0), g(0), b(0), a(1) {}
+	constexpr Color() = default;
 
 	/**
 	 * RGBA construct parameters.
@@ -270,7 +274,6 @@ struct [[nodiscard]] Color {
 	constexpr Color(const Color &p_c, float p_a) :
 			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
 
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 	Color(const String &p_code) {
 		if (html_is_valid(p_code)) {
 			*this = html(p_code);
@@ -283,7 +286,6 @@ struct [[nodiscard]] Color {
 		*this = Color(p_code);
 		a = p_a;
 	}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 constexpr Color Color::operator+(const Color &p_color) const {

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -157,10 +157,10 @@ private:
 
 			for (int k = 0; k < 3; k++) {
 				for (int i = 0; i < p_point_count; i++) {
-					if (p_points[i].coord[k] > ofs.coord[k] + half_extents.coord[k]) {
+					if (p_points[i][k] > ofs[k] + half_extents[k]) {
 						bad_point_counts_positive[k]++;
 					}
-					if (p_points[i].coord[k] < ofs.coord[k] - half_extents.coord[k]) {
+					if (p_points[i][k] < ofs[k] - half_extents[k]) {
 						bad_point_counts_negative[k]++;
 					}
 				}

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -35,24 +35,28 @@
 #include "core/string/ustring.h"
 
 struct [[nodiscard]] Quaternion {
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			real_t x;
-			real_t y;
-			real_t z;
-			real_t w;
-		};
-		real_t components[4] = { 0, 0, 0, 1.0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	real_t x = 0.0f;
+	real_t y = 0.0f;
+	real_t z = 0.0f;
+	real_t w = 1.0f;
 
-	_FORCE_INLINE_ real_t &operator[](int p_idx) {
-		return components[p_idx];
+	constexpr real_t &operator[](int p_idx) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Quaternion, x) == 0 * sizeof(real_t));
+		static_assert(offsetof(Quaternion, y) == 1 * sizeof(real_t));
+		static_assert(offsetof(Quaternion, z) == 2 * sizeof(real_t));
+		static_assert(offsetof(Quaternion, w) == 3 * sizeof(real_t));
+		static_assert(sizeof(Quaternion) == 4 * sizeof(real_t));
+
+		DEV_ASSERT((unsigned int)p_idx < 4);
+		return (&x)[p_idx];
 	}
-	_FORCE_INLINE_ const real_t &operator[](int p_idx) const {
-		return components[p_idx];
+	constexpr const real_t &operator[](int p_idx) const {
+		DEV_ASSERT((unsigned int)p_idx < 4);
+		return (&x)[p_idx];
 	}
+
 	_FORCE_INLINE_ real_t length_squared() const;
 	bool is_equal_approx(const Quaternion &p_quaternion) const;
 	bool is_same(const Quaternion &p_quaternion) const;
@@ -117,23 +121,12 @@ struct [[nodiscard]] Quaternion {
 
 	explicit operator String() const;
 
-	constexpr Quaternion() :
-			x(0), y(0), z(0), w(1) {}
+	constexpr Quaternion() = default;
 
 	constexpr Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x), y(p_y), z(p_z), w(p_w) {}
 
 	Quaternion(const Vector3 &p_axis, real_t p_angle);
-
-	constexpr Quaternion(const Quaternion &p_q) :
-			x(p_q.x), y(p_q.y), z(p_q.z), w(p_q.w) {}
-
-	constexpr void operator=(const Quaternion &p_q) {
-		x = p_q.x;
-		y = p_q.y;
-		z = p_q.z;
-		w = p_q.w;
-	}
 
 	Quaternion(const Vector3 &p_v0, const Vector3 &p_v1) { // Shortest arc.
 #ifdef MATH_CHECKS

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -51,28 +51,29 @@ struct [[nodiscard]] Vector2 {
 	};
 
 	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			real_t x;
-			real_t y;
-		};
-
-		struct {
-			real_t width;
-			real_t height;
-		};
-
-		real_t coord[2] = { 0 };
-		// NOLINTEND(modernize-use-default-member-init)
+		real_t x = 0.0f;
+		real_t width;
+	};
+	union {
+		real_t y = 0.0f;
+		real_t height;
 	};
 
-	_FORCE_INLINE_ real_t &operator[](int p_axis) {
+	constexpr real_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector2, x) == 0 * sizeof(real_t));
+		static_assert(offsetof(Vector2, width) == 0 * sizeof(real_t));
+		static_assert(offsetof(Vector2, y) == 1 * sizeof(real_t));
+		static_assert(offsetof(Vector2, height) == 1 * sizeof(real_t));
+		static_assert(sizeof(Vector2) == 2 * sizeof(real_t));
+
 		DEV_ASSERT((unsigned int)p_axis < 2);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
+	constexpr const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 2);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	_FORCE_INLINE_ Vector2::Axis min_axis_index() const {
@@ -199,12 +200,9 @@ struct [[nodiscard]] Vector2 {
 		return hash_fmix32(h);
 	}
 
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-	constexpr Vector2() :
-			x(0), y(0) {}
+	constexpr Vector2() = default;
 	constexpr Vector2(real_t p_x, real_t p_y) :
 			x(p_x), y(p_y) {}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 inline constexpr Vector2 Vector2::LEFT = { -1, 0 };

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -51,28 +51,29 @@ struct [[nodiscard]] Vector2i {
 	};
 
 	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			int32_t x;
-			int32_t y;
-		};
-
-		struct {
-			int32_t width;
-			int32_t height;
-		};
-
-		int32_t coord[2] = { 0 };
-		// NOLINTEND(modernize-use-default-member-init)
+		int32_t x = 0;
+		int32_t width;
+	};
+	union {
+		int32_t y = 0;
+		int32_t height;
 	};
 
-	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
+	constexpr int32_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector2i, x) == 0 * sizeof(int32_t));
+		static_assert(offsetof(Vector2i, width) == 0 * sizeof(int32_t));
+		static_assert(offsetof(Vector2i, y) == 1 * sizeof(int32_t));
+		static_assert(offsetof(Vector2i, height) == 1 * sizeof(int32_t));
+		static_assert(sizeof(Vector2i) == 2 * sizeof(int32_t));
+
 		DEV_ASSERT((unsigned int)p_axis < 2);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
+	constexpr const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 2);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	_FORCE_INLINE_ Vector2i::Axis min_axis_index() const {
@@ -154,12 +155,9 @@ struct [[nodiscard]] Vector2i {
 		return hash_fmix32(h);
 	}
 
-	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-	constexpr Vector2i() :
-			x(0), y(0) {}
+	constexpr Vector2i() = default;
 	constexpr Vector2i(int32_t p_x, int32_t p_y) :
 			x(p_x), y(p_y) {}
-	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
 
 inline constexpr Vector2i Vector2i::LEFT = { -1, 0 };

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -60,26 +60,24 @@ struct [[nodiscard]] Vector3 {
 		AXIS_Z,
 	};
 
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			real_t x;
-			real_t y;
-			real_t z;
-		};
+	real_t x = 0.0f;
+	real_t y = 0.0f;
+	real_t z = 0.0f;
 
-		real_t coord[3] = { 0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	constexpr real_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector3, x) == 0 * sizeof(real_t));
+		static_assert(offsetof(Vector3, y) == 1 * sizeof(real_t));
+		static_assert(offsetof(Vector3, z) == 2 * sizeof(real_t));
+		static_assert(sizeof(Vector3) == 3 * sizeof(real_t));
 
-	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-
-	_FORCE_INLINE_ real_t &operator[](int p_axis) {
+	constexpr const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	_FORCE_INLINE_ Vector3::Axis min_axis_index() const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -53,26 +53,24 @@ struct [[nodiscard]] Vector3i {
 		AXIS_Z,
 	};
 
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			int32_t x;
-			int32_t y;
-			int32_t z;
-		};
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
 
-		int32_t coord[3] = { 0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	constexpr int32_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector3i, x) == 0 * sizeof(int32_t));
+		static_assert(offsetof(Vector3i, y) == 1 * sizeof(int32_t));
+		static_assert(offsetof(Vector3i, z) == 2 * sizeof(int32_t));
+		static_assert(sizeof(Vector3i) == 3 * sizeof(int32_t));
 
-	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-
-	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
+	constexpr const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	Vector3i::Axis min_axis_index() const;
@@ -148,8 +146,7 @@ struct [[nodiscard]] Vector3i {
 		return hash_fmix32(h);
 	}
 
-	constexpr Vector3i() :
-			x(0), y(0), z(0) {}
+	constexpr Vector3i() = default;
 	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
 			x(p_x), y(p_y), z(p_z) {}
 };

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -48,25 +48,26 @@ struct [[nodiscard]] Vector4 {
 		AXIS_W,
 	};
 
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			real_t x;
-			real_t y;
-			real_t z;
-			real_t w;
-		};
-		real_t coord[4] = { 0, 0, 0, 0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	real_t x = 0.0f;
+	real_t y = 0.0f;
+	real_t z = 0.0f;
+	real_t w = 0.0f;
 
-	_FORCE_INLINE_ real_t &operator[](int p_axis) {
+	constexpr real_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector4, x) == 0 * sizeof(real_t));
+		static_assert(offsetof(Vector4, y) == 1 * sizeof(real_t));
+		static_assert(offsetof(Vector4, z) == 2 * sizeof(real_t));
+		static_assert(offsetof(Vector4, w) == 3 * sizeof(real_t));
+		static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
+
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
+	constexpr const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	Vector4::Axis min_axis_index() const;
@@ -157,8 +158,7 @@ struct [[nodiscard]] Vector4 {
 		return hash_fmix32(h);
 	}
 
-	constexpr Vector4() :
-			x(0), y(0), z(0), w(0) {}
+	constexpr Vector4() = default;
 	constexpr Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -97,11 +97,4 @@ Vector4i::operator Vector4() const {
 	return Vector4(x, y, z, w);
 }
 
-Vector4i::Vector4i(const Vector4 &p_vec4) {
-	x = (int32_t)p_vec4.x;
-	y = (int32_t)p_vec4.y;
-	z = (int32_t)p_vec4.z;
-	w = (int32_t)p_vec4.w;
-}
-
 static_assert(sizeof(Vector4i) == 4 * sizeof(int32_t));

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -47,27 +47,26 @@ struct [[nodiscard]] Vector4i {
 		AXIS_W,
 	};
 
-	union {
-		// NOLINTBEGIN(modernize-use-default-member-init)
-		struct {
-			int32_t x;
-			int32_t y;
-			int32_t z;
-			int32_t w;
-		};
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
+	int32_t w = 0;
 
-		int32_t coord[4] = { 0 };
-		// NOLINTEND(modernize-use-default-member-init)
-	};
+	constexpr int32_t &operator[](int p_axis) {
+		// The pointer math below assumes that the elements are placed back-to-back, like an array.
+		// This is always true in practice, but technically not guaranteed; we safety-check it here.
+		static_assert(offsetof(Vector4i, x) == 0 * sizeof(int32_t));
+		static_assert(offsetof(Vector4i, y) == 1 * sizeof(int32_t));
+		static_assert(offsetof(Vector4i, z) == 2 * sizeof(int32_t));
+		static_assert(offsetof(Vector4i, w) == 3 * sizeof(int32_t));
+		static_assert(sizeof(Vector4i) == 4 * sizeof(int32_t));
 
-	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
-
-	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
+	constexpr const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return coord[p_axis];
+		return (&x)[p_axis];
 	}
 
 	Vector4i::Axis min_axis_index() const;
@@ -144,9 +143,7 @@ struct [[nodiscard]] Vector4i {
 		return hash_fmix32(h);
 	}
 
-	constexpr Vector4i() :
-			x(0), y(0), z(0), w(0) {}
-	Vector4i(const Vector4 &p_vec4);
+	constexpr Vector4i() = default;
 	constexpr Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) :
 			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -3970,7 +3970,7 @@ void RenderingDeviceDriverD3D12::command_clear_color_texture(CommandBufferID p_c
 
 			cmd_buf_info->cmd_list->ClearRenderTargetView(
 					cmd_buf_info->rtv_alloc.cpu_handle,
-					p_color.components,
+					p_color.as_float4_buffer(),
 					0,
 					nullptr);
 		}
@@ -4003,7 +4003,7 @@ void RenderingDeviceDriverD3D12::command_clear_color_texture(CommandBufferID p_c
 					shader_visible_descriptor_allocation.gpu_handle,
 					cmd_buf_info->uav_alloc.cpu_handle,
 					tex_info->resource,
-					p_color.components,
+					p_color.as_float4_buffer(),
 					0,
 					nullptr);
 		}
@@ -4762,7 +4762,7 @@ void RenderingDeviceDriverD3D12::command_render_clear_attachments(CommandBufferI
 				uint32_t color_idx = fb_info->attachments_handle_inds[attachment];
 				cmd_buf_info->cmd_list->ClearRenderTargetView(
 						get_cpu_handle(fb_info->rtv_alloc.cpu_handle, color_idx, rtv_descriptor_heap_pool.increment_size),
-						p_attachment_clears[i].value.color.components,
+						p_attachment_clears[i].value.color.as_float4_buffer(),
 						rect_ptr ? 1 : 0,
 						rect_ptr);
 			} else {
@@ -4814,7 +4814,7 @@ void RenderingDeviceDriverD3D12::command_bind_render_pipeline(CommandBufferID p_
 	}
 
 	if (cmd_buf_info->pending_dyn_params || (cmd_buf_info->dyn_params.blend_constant != render_info.dyn_params.blend_constant)) {
-		cmd_buf_info->cmd_list->OMSetBlendFactor(render_info.dyn_params.blend_constant.components);
+		cmd_buf_info->cmd_list->OMSetBlendFactor(render_info.dyn_params.blend_constant.as_float4_buffer());
 		cmd_buf_info->dyn_params.blend_constant = render_info.dyn_params.blend_constant;
 	}
 
@@ -5004,7 +5004,7 @@ void RenderingDeviceDriverD3D12::_bind_vertex_buffers(CommandBufferInfo *p_cmd_b
 
 void RenderingDeviceDriverD3D12::command_render_set_blend_constants(CommandBufferID p_cmd_buffer, const Color &p_constants) {
 	const CommandBufferInfo *cmd_buf_info = (const CommandBufferInfo *)p_cmd_buffer.id;
-	cmd_buf_info->cmd_list->OMSetBlendFactor(p_constants.components);
+	cmd_buf_info->cmd_list->OMSetBlendFactor(p_constants.as_float4_buffer());
 }
 
 void RenderingDeviceDriverD3D12::command_render_set_line_width(CommandBufferID p_cmd_buffer, float p_width) {

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2791,7 +2791,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	// b) We are rendering to a non-intermediate framebuffer with ENV_BG_CANVAS (shared between 2D and 3D).
 	if (!keep_color && (!draw_canvas || (rt && fbo != rt->fbo))) {
 		clear_color.a = render_data.transparent_bg ? 0.0f : 1.0f;
-		glClearBufferfv(GL_COLOR, 0, clear_color.components);
+		glClearBufferfv(GL_COLOR, 0, clear_color.as_float4_buffer());
 	}
 	if ((keep_color || draw_canvas) && rt && fbo != rt->fbo) {
 		// Need to copy our current contents to our intermediate/MSAA buffer

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -3325,7 +3325,7 @@ void TextureStorage::render_target_do_clear_request(RID p_render_target) {
 	}
 	glBindFramebuffer(GL_FRAMEBUFFER, rt->fbo);
 
-	glClearBufferfv(GL_COLOR, 0, rt->clear_color.components);
+	glClearBufferfv(GL_COLOR, 0, rt->clear_color.as_float4_buffer());
 	rt->clear_requested = false;
 	glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
 }

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -5162,7 +5162,7 @@ void RenderingDeviceDriverVulkan::command_resolve_texture(CommandBufferID p_cmd_
 
 void RenderingDeviceDriverVulkan::command_clear_color_texture(CommandBufferID p_cmd_buffer, TextureID p_texture, TextureLayout p_texture_layout, const Color &p_color, const TextureSubresourceRange &p_subresources) {
 	VkClearColorValue vk_color = {};
-	memcpy(&vk_color.float32, p_color.components, sizeof(VkClearColorValue::float32));
+	memcpy(&vk_color.float32, p_color.as_float4_buffer(), sizeof(VkClearColorValue::float32));
 
 	VkImageSubresourceRange vk_subresources = {};
 	_texture_subresource_range_to_vk(p_subresources, &vk_subresources);
@@ -5792,7 +5792,7 @@ void RenderingDeviceDriverVulkan::command_render_bind_index_buffer(CommandBuffer
 
 void RenderingDeviceDriverVulkan::command_render_set_blend_constants(CommandBufferID p_cmd_buffer, const Color &p_constants) {
 	const CommandBufferInfo *command_buffer = (const CommandBufferInfo *)p_cmd_buffer.id;
-	vkCmdSetBlendConstants(command_buffer->vk_command_buffer, p_constants.components);
+	vkCmdSetBlendConstants(command_buffer->vk_command_buffer, p_constants.as_float4_buffer());
 }
 
 void RenderingDeviceDriverVulkan::command_render_set_line_width(CommandBufferID p_cmd_buffer, float p_width) {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -715,7 +715,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 		lights_buffer = rd->storage_buffer_create(lb.size(), lb);
 
 		// Even when there are no seams, the buffer must exist.
-		static const Vector2i empty_seams[2];
+		static const Vector2i empty_seams[2] = {};
 		Span<uint8_t> sb = (seam_buffer_vec.is_empty() ? Span(empty_seams) : seam_buffer_vec.span()).reinterpret<uint8_t>();
 		seams_buffer = rd->storage_buffer_create(sb.size(), sb);
 

--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -45,14 +45,14 @@ String ColorModeRGB::get_slider_label(int idx) const {
 
 float ColorModeRGB::get_slider_value(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, get_slider_count(), 0, "Couldn't get slider value.");
-	return color_picker->color_normalized.components[idx] * 255;
+	return color_picker->color_normalized[idx] * 255;
 }
 
 Color ColorModeRGB::get_color() const {
 	Vector<float> values = color_picker->get_active_slider_values();
 	Color color;
 	for (int i = 0; i < 4; i++) {
-		color.components[i] = values[i] / 255.0;
+		color[i] = values[i] / 255.0;
 	}
 	return color;
 }
@@ -62,7 +62,7 @@ void ColorModeRGB::_greater_value_inputted() {
 	Color color_prev = color_picker->color;
 	for (int i = 0; i < 3; i++) {
 		if (sliders[i]->get_value() > 255) {
-			color_prev.components[i] = sliders[i]->get_value() / 255.0;
+			color_prev[i] = sliders[i]->get_value() / 255.0;
 		}
 	}
 	Color linear_color = color_prev.srgb_to_linear();
@@ -234,7 +234,7 @@ float ColorModeLinear::get_slider_max(int idx) const {
 float ColorModeLinear::get_slider_value(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, get_slider_count(), 0, "Couldn't get slider value.");
 	Color color = color_picker->color_normalized.srgb_to_linear();
-	return color.components[idx];
+	return color[idx];
 }
 
 float ColorModeLinear::get_alpha_slider_max() const {
@@ -249,7 +249,7 @@ Color ColorModeLinear::get_color() const {
 	Vector<float> values = color_picker->get_active_slider_values();
 	Color color;
 	for (int i = 0; i < 4; i++) {
-		color.components[i] = values[i];
+		color[i] = values[i];
 	}
 	return color.linear_to_srgb();
 }
@@ -260,7 +260,7 @@ void ColorModeLinear::_greater_value_inputted() {
 	Color linear_color = color_prev.srgb_to_linear();
 	for (int i = 0; i < 3; i++) {
 		if (sliders[i]->get_value() > 1 + CMP_EPSILON) {
-			linear_color.components[i] = sliders[i]->get_value();
+			linear_color[i] = sliders[i]->get_value();
 		}
 	}
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -595,7 +595,7 @@ Color ColorPicker::_color_apply_intensity(const Color &col) const {
 	Color result;
 	float multiplier = Math::pow(2, intensity);
 	for (int i = 0; i < 3; i++) {
-		result.components[i] = linear_color.components[i] * multiplier;
+		result[i] = linear_color[i] * multiplier;
 	}
 	result.a = col.a;
 	return result.linear_to_srgb();
@@ -609,7 +609,7 @@ void ColorPicker::_copy_color_to_normalized_and_intensity() {
 	Color linear_color = color.srgb_to_linear();
 	float multiplier = MAX(1, MAX(MAX(linear_color.r, linear_color.g), linear_color.b));
 	for (int i = 0; i < 3; i++) {
-		color_normalized.components[i] = linear_color.components[i] / multiplier;
+		color_normalized[i] = linear_color[i] / multiplier;
 	}
 	color_normalized.a = linear_color.a;
 	color_normalized = color_normalized.linear_to_srgb();

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -452,7 +452,7 @@ _FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type,
 			float *gui = reinterpret_cast<float *>(data);
 
 			for (int i = 0; i < 3; i++) {
-				gui[i] = c.components[i];
+				gui[i] = c[i];
 			}
 
 		} break;
@@ -465,7 +465,7 @@ _FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type,
 			float *gui = reinterpret_cast<float *>(data);
 
 			for (int i = 0; i < 4; i++) {
-				gui[i] = c.components[i];
+				gui[i] = c[i];
 			}
 		} break;
 		case ShaderLanguage::TYPE_MAT2: {

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -161,7 +161,7 @@ void RendererMeshStorage::multimesh_instance_set_color(RID p_multimesh, int p_in
 
 		if (mmi->_vf_size_color == 4) {
 			for (int n = 0; n < 4; n++) {
-				ptr[n] = p_color.components[n];
+				ptr[n] = p_color[n];
 			}
 		} else {
 #ifdef DEV_ENABLED
@@ -188,7 +188,7 @@ void RendererMeshStorage::multimesh_instance_set_custom_data(RID p_multimesh, in
 
 		if (mmi->_vf_size_data == 4) {
 			for (int n = 0; n < 4; n++) {
-				ptr[n] = p_color.components[n];
+				ptr[n] = p_color[n];
 			}
 		} else {
 #ifdef DEV_ENABLED


### PR DESCRIPTION
- Includes #120840

## What problem(s) does this PR solve?

Mirrors the above goal to make `AudioFrame` trivially copyable; now extended to `Vector2`, `Vector2i`, `Vector3`, `Vector3i`, `Vector4`, `Vector4i`, `Quaternion`, and `Color`

## Additional information

A few areas of code were relying on `Color` array access directly, but were able to be worked around by reinterpreting the struct itself as a container of floats (which, functionally, it is). Beyond that, the bracket accessors were all made `constexpr` and given proper `DEV_ASSERT` checks if they weren't already present