### PR TITLE
Fix ZIPPacker returning OK when zipio_write() fails to write

### DIFF
--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -110,8 +110,13 @@ uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong size) {
 	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
-	(*fa)->store_buffer((uint8_t *)buf, size);
-	return size;
+	bool fa_success = (*fa)->store_buffer((uint8_t *)buf, size);
+
+	if (fa_success) {
+		return size;
+	}
+
+	return 0;
 }
 
 long zipio_tell(voidpf opaque, voidpf stream) {


### PR DESCRIPTION
fixes #119010 

zipio_write previously returned size regardless of success of write operation. Now it returns size if successful or 0 if it fails

Testing included writing multiple zips under conditions in issue and had visible failure

Discussion: This could change behavior of other callers that relied on false positives when using zipio_write. This is more accurate to actual state and while this specific issue is windows specific, false state could impact other platforms with different operations.

AI used for path tracing and caller discovery