### PR TITLE
Implement `OS.get_processor_name()` on Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -471,8 +471,8 @@
 		<method name="get_processor_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the full name of the CPU model on the host machine (e.g. [code]"Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"[/code]).
-				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android and Web, [method get_processor_name] returns an empty string.
+				Returns the full name of the CPU model on the host machine (e.g. [code]"Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"[/code]). On Android and iOS, this returns the SoC model instead (e.g. [code]"SM8650"[/code], [code]"Apple A18 Pro"[/code]).
+				[b]Note:[/b] This method is only implemented on Android, iOS, Linux, macOS, and Windows. On Web, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
 		<method name="get_restart_on_exit_arguments" qualifiers="const">

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -44,6 +44,7 @@
 #include "core/config/engine.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"
+#include "core/io/file_access.h"
 #include "core/io/xml_parser.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -485,6 +486,27 @@ String OS_Android::get_model_name() const {
 	}
 
 	return OS_Unix::get_model_name();
+}
+
+String OS_Android::get_processor_name() const {
+	// The SoC model is only guaranteed to be set on devices launching with Android 12 or later.
+	const String soc_model = get_system_property("ro.soc.model");
+	if (!soc_model.is_empty()) {
+		return soc_model;
+	}
+
+	// Older devices: the SoC name is exposed by the kernel as the "Hardware" line in `/proc/cpuinfo`.
+	Ref<FileAccess> f = FileAccess::open("/proc/cpuinfo", FileAccess::READ);
+	if (f.is_valid()) {
+		while (!f->eof_reached()) {
+			const String line = f->get_line();
+			if (line.begins_with("Hardware")) {
+				return line.get_slicec(':', 1).strip_edges();
+			}
+		}
+	}
+
+	ERR_FAIL_V_MSG(String(), "Couldn't get the SoC model name.");
 }
 
 String OS_Android::get_data_path() const {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -151,6 +151,7 @@ public:
 	virtual String get_resource_dir() const override;
 	virtual String get_locale() const override;
 	virtual String get_model_name() const override;
+	virtual String get_processor_name() const override;
 
 	virtual String get_unique_id() const override;
 


### PR DESCRIPTION
Implements `OS.get_processor_name()` on Android, as discussed in #120816.

- Returns the SoC model from the `ro.soc.model` system property, which is standardized since Android 12 (e.g. `SM8650`, `MT6899`, `Tensor G4`).
- Falls back to the `Hardware` line in `/proc/cpuinfo` on older devices.
- If neither source is available, fails with an error message like the Linux/macOS implementations instead of silently returning an empty string.

Also updates the `OS.get_processor_name()` documentation: with this PR, only Web still returns an empty string. Note that iOS is *not* missing an implementation as the issue claimed — `OS_AppleEmbedded::get_processor_name()` (shared by iOS/visionOS) has returned the SoC name via a device-model lookup table since 4.6 (c96d142f97); the issue's source inspection missed the base class. Web has no API to query the CPU/SoC name, so it is documented as returning an empty string.

Tested end-to-end with an exported debug APK built from this branch (arm64), printing `OS.get_processor_name()` in `_ready()`:

| Device | Android | Result |
|---|---|---|
| Pixel 10a | 17 | `Tensor G4` |
| REDMAGIC 9 (NX769J) | 16 | `SM8650` |
| POCO (2511FPC34G) | 16 | `MT6899` |

All test devices run Android 12+, so they exercise the `ro.soc.model` path; the `/proc/cpuinfo` fallback is compile-tested only (mirrors the existing Linux implementation).

Fixes #120816.

## AI disclosure

Per the [AI-assisted contributions guidelines](https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#ai-assisted-contributions): the code and documentation changes in this PR were written with AI assistance (Claude Code), implementing the approach I outlined in #120816 (`ro.soc.model` with a `/proc/cpuinfo` fallback, mirroring the existing Linux implementation). I reviewed the diff and verified the change end-to-end on the three physical devices listed above.
