### PR TITLE
Avoid duplicate Button presses from touch-emulated mouse

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -988,6 +988,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				button_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
+				button_event->set_emulated_from_touch(true);
 				button_event->set_pressed(st->is_pressed());
 				button_event->set_canceled(st->is_canceled());
 				button_event->set_button_index(MouseButton::LEFT);
@@ -1025,6 +1026,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			motion_event->set_pressure(sd->get_pressure());
 			motion_event->set_position(sd->get_position());
 			motion_event->set_global_position(sd->get_position());
+			motion_event->set_emulated_from_touch(true);
 			motion_event->set_relative(sd->get_relative());
 			motion_event->set_relative_screen_position(sd->get_relative_screen_position());
 			motion_event->set_velocity(sd->get_velocity());
@@ -1526,6 +1528,7 @@ void Input::ensure_touch_mouse_raised() {
 		button_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 		button_event->set_position(mouse_pos);
 		button_event->set_global_position(mouse_pos);
+		button_event->set_emulated_from_touch(true);
 		button_event->set_pressed(false);
 		button_event->set_button_index(MouseButton::LEFT);
 		BitField<MouseButtonMask> ev_bm = mouse_button_mask;

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -697,6 +697,15 @@ Vector2 InputEventMouse::get_global_position() const {
 	return global_pos;
 }
 
+void InputEventMouse::set_emulated_from_touch(bool p_emulated) {
+	emulated_from_touch = p_emulated;
+	emit_changed();
+}
+
+bool InputEventMouse::is_emulated_from_touch() const {
+	return emulated_from_touch;
+}
+
 void InputEventMouse::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_mask", "button_mask"), &InputEventMouse::set_button_mask);
 	ClassDB::bind_method(D_METHOD("get_button_mask"), &InputEventMouse::get_button_mask);
@@ -764,6 +773,7 @@ RequiredResult<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &
 
 	mb->set_position(l);
 	mb->set_global_position(g);
+	mb->set_emulated_from_touch(is_emulated_from_touch());
 
 	mb->set_button_mask(get_button_mask());
 	mb->set_pressed(pressed);
@@ -987,6 +997,7 @@ RequiredResult<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &
 	mm->set_pen_inverted(get_pen_inverted());
 	mm->set_tilt(get_tilt());
 	mm->set_global_position(get_global_position());
+	mm->set_emulated_from_touch(is_emulated_from_touch());
 
 	mm->set_button_mask(get_button_mask());
 	mm->set_relative(p_xform.basis_xform(get_relative()));
@@ -1047,6 +1058,10 @@ bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
 	}
 
 	if (get_button_mask() != motion->get_button_mask()) {
+		return false;
+	}
+
+	if (is_emulated_from_touch() != motion->is_emulated_from_touch()) {
 		return false;
 	}
 

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -209,6 +209,7 @@ class InputEventMouse : public InputEventWithModifiers {
 	GDCLASS(InputEventMouse, InputEventWithModifiers);
 
 	BitField<MouseButtonMask> button_mask = MouseButtonMask::NONE;
+	bool emulated_from_touch = false;
 
 	Vector2 pos;
 	Vector2 global_pos;
@@ -225,6 +226,9 @@ public:
 
 	void set_global_position(const Vector2 &p_global_pos);
 	Vector2 get_global_position() const;
+
+	void set_emulated_from_touch(bool p_emulated);
+	bool is_emulated_from_touch() const;
 
 	InputEventMouse();
 };

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -94,16 +94,18 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseButton> mouse_button = p_event;
-	bool ui_accept = p_event->is_action("ui_accept", true) && !p_event->is_echo();
+	bool is_mouse_button_emulated_from_touch = mouse_button.is_valid() && mouse_button->is_emulated_from_touch();
+	bool ui_accept = p_event->is_action("ui_accept", true) && !p_event->is_echo() && !is_mouse_button_emulated_from_touch;
 
-	bool button_masked = mouse_button.is_valid() && button_mask.has_flag(mouse_button_to_mask(mouse_button->get_button_index()));
+	bool button_masked = mouse_button.is_valid() && !is_mouse_button_emulated_from_touch &&
+			button_mask.has_flag(mouse_button_to_mask(mouse_button->get_button_index()));
 	if (button_masked || ui_accept) {
 		was_mouse_pressed = button_masked;
 		on_action_event(p_event);
 		was_mouse_pressed = false;
 	} else {
 		Ref<InputEventMouseMotion> mouse_motion = p_event;
-		if (mouse_motion.is_valid()) {
+		if (mouse_motion.is_valid() && !mouse_motion->is_emulated_from_touch()) {
 			if (status.press_attempt) {
 				bool last_press_inside = status.pressing_inside;
 				status.pressing_inside = has_point(mouse_motion->get_position());

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -32,17 +32,20 @@
 
 TEST_FORCE_LINK(test_button)
 
+#include "core/input/input.h"
+#include "core/input/input_map.h"
 #include "scene/gui/button.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
+#include "tests/signal_watcher.h"
 
 namespace TestButton {
 
 TEST_CASE("[SceneTree][Button] is_hovered()") {
 	// Create new button instance.
 	Button *button = memnew(Button);
-	CHECK(button != nullptr);
+	REQUIRE(button != nullptr);
 	Window *root = SceneTree::get_singleton()->get_root();
 	root->add_child(button);
 
@@ -61,6 +64,111 @@ TEST_CASE("[SceneTree][Button] is_hovered()") {
 	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(150, 150), MouseButtonMask::NONE, Key::NONE);
 	CHECK(button->is_hovered() == false);
 
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] touch event with emulated mouse triggers pressed once") {
+	Button *button = memnew(Button);
+	REQUIRE(button != nullptr);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+	button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+
+	const bool was_emulating_mouse_from_touch = Input::get_singleton()->is_emulating_mouse_from_touch();
+	Input::get_singleton()->set_emulate_mouse_from_touch(true);
+
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+	CHECK(button->is_hovered());
+
+	SIGNAL_WATCH(button, SNAME("pressed"));
+
+	SEND_GUI_TOUCH_EVENT(Point2i(25, 25), true, false);
+	SIGNAL_CHECK(SNAME("pressed"), { {} });
+
+	SEND_GUI_TOUCH_EVENT(Point2i(25, 25), false, false);
+	SIGNAL_CHECK_FALSE(SNAME("pressed"));
+
+	SIGNAL_UNWATCH(button, SNAME("pressed"));
+	Input::get_singleton()->set_emulate_mouse_from_touch(was_emulating_mouse_from_touch);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] touch event with emulated mouse ui_accept triggers pressed once") {
+	Button *button = memnew(Button);
+	REQUIRE(button != nullptr);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+	button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+
+	Ref<InputEventMouseButton> ui_accept_event;
+	ui_accept_event.instantiate();
+	ui_accept_event->set_device(InputMap::ALL_DEVICES);
+	ui_accept_event->set_button_index(MouseButton::LEFT);
+	ui_accept_event->set_button_mask(MouseButtonMask::LEFT);
+	InputMap::get_singleton()->action_add_event(SNAME("ui_accept"), ui_accept_event);
+
+	const bool was_emulating_mouse_from_touch = Input::get_singleton()->is_emulating_mouse_from_touch();
+	Input::get_singleton()->set_emulate_mouse_from_touch(true);
+
+	SIGNAL_WATCH(button, SNAME("pressed"));
+
+	SEND_GUI_TOUCH_EVENT(Point2i(25, 25), true, false);
+	SIGNAL_CHECK(SNAME("pressed"), { {} });
+
+	SEND_GUI_TOUCH_EVENT(Point2i(25, 25), false, false);
+	SIGNAL_CHECK_FALSE(SNAME("pressed"));
+
+	SIGNAL_UNWATCH(button, SNAME("pressed"));
+	Input::get_singleton()->set_emulate_mouse_from_touch(was_emulating_mouse_from_touch);
+	InputMap::get_singleton()->action_erase_event(SNAME("ui_accept"), ui_accept_event);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][Button] emulated mouse ui_accept event triggers pressed") {
+	Button *button = memnew(Button);
+	REQUIRE(button != nullptr);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+	button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+
+	Ref<InputEventMouseButton> ui_accept_event;
+	ui_accept_event.instantiate();
+	ui_accept_event->set_device(InputMap::ALL_DEVICES);
+	ui_accept_event->set_button_index(MouseButton::LEFT);
+	ui_accept_event->set_button_mask(MouseButtonMask::LEFT);
+	InputMap::get_singleton()->action_add_event(SNAME("ui_accept"), ui_accept_event);
+
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+	CHECK(button->is_hovered());
+
+	SIGNAL_WATCH(button, SNAME("pressed"));
+
+	Ref<InputEventMouseButton> event;
+	event.instantiate();
+	event->set_device(InputEvent::DEVICE_ID_EMULATION);
+	event->set_position(Point2i(25, 25));
+	event->set_button_index(MouseButton::LEFT);
+	event->set_button_mask(MouseButtonMask::LEFT);
+	event->set_factor(1);
+	event->set_pressed(true);
+	CHECK(event->is_action(SNAME("ui_accept"), true));
+
+	_SEND_DISPLAYSERVER_EVENT(event);
+	MessageQueue::get_singleton()->flush();
+
+	SIGNAL_CHECK(SNAME("pressed"), { {} });
+
+	SIGNAL_UNWATCH(button, SNAME("pressed"));
+	InputMap::get_singleton()->action_erase_event(SNAME("ui_accept"), ui_accept_event);
 	memdelete(button);
 }
 


### PR DESCRIPTION
Close #120439.
Touch input with mouse emulation enabled can make `BaseButton` handle both the generated mouse event and the original touch event, causing `pressed` to emit twice.

This marks mouse events generated from touch and makes `BaseButton` ignore them, including the `ui_accept` path.

Regular emulated mouse events still work. Regression tests were added for the duplicate press case and the emulated mouse boundary.
