### PR TITLE
Add iPhone 17e (`iPhone18,5`) to the Apple SoC model list and DPI list

### DIFF
--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -519,7 +519,7 @@ static const _ModelInfo _models[] = {
 	{ { "iPad17,1", "iPad17,2", "iPad17,3", "iPad17,4", "RealityDevice17,1" }, "Apple M5" },
 	{ { "iPhone17,3", "iPhone17,4", "iPhone17,5" }, "Apple A18" },
 	{ { "iPhone17,1", "iPhone17,2" }, "Apple A18 Pro" },
-	{ { "iPhone18,3" }, "Apple A19" },
+	{ { "iPhone18,3", "iPhone18,5" }, "Apple A19" },
 	{ { "iPhone18,1", "iPhone18,2", "iPhone18,4" }, "Apple A19 Pro" },
 };
 

--- a/platform/ios/device_metrics.mm
+++ b/platform/ios/device_metrics.mm
@@ -216,6 +216,7 @@
 			@"iPhone18,2", // iPhone 17 Pro Max
 			@"iPhone18,3", // iPhone 17
 			@"iPhone18,4", // iPhone Air
+			@"iPhone18,5", // iPhone 17e
 		] : @460,
 		@[
 			@"iPhone13,1", // iPhone 12 Mini


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
## What problem(s) does this PR solve?

### Summary 
While testing #120816 on a physical device, I noticed that `OS.get_processor_name()` was returning an empty string on the iPhone 17e.

### Motivation
Accoding to the docs.
iOS return not empty-string.
But iPhone 17e only cause it.

### Technical overview
This was because `iPhone18,5` was missing from the SoC name lookup table. I have added it to the "Apple A19" entry. I have verified that it returns "Apple A19" on the actual device (iPhone 17e / iOS 26.5.1).

### Testing
I created simple view processor_name app and check that.
The test device return A19.


## Additional information

a little fix, just testing on my device.

## AI disclosure

Per the [AI-assisted contributions guidelines](https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html): I found this gap while verifying #120816 on my own hardware, and used AI assistance (Claude Code) to locate the SoC lookup table and prepare the one-line change. I reviewed the diff and verified the result end-to-end on the physical iPhone 17e ( iOS 26.5.1)
