### PR TITLE
Implement `OS.get_processor_name()` on Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -471,8 +471,8 @@
 		<method name="get_processor_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the full name of the CPU model on the host machine (e.g. [code]"Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"[/code]).
-				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android and Web, [method get_processor_name] returns an empty string.
+				Returns the full name of the CPU model on the host machine (e.g. [code]"Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"[/code]). On Android and iOS, this returns the SoC model instead (e.g. [code]"SM8650"[/code], [code]"Apple A18 Pro"[/code]).
+				[b]Note:[/b] This method is only implemented on Android, iOS, Linux, macOS, and Windows. On Web, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
 		<method name="get_restart_on_exit_arguments" qualifiers="const">

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -44,6 +44,7 @@
 #include "core/config/engine.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"
+#include "core/io/file_access.h"
 #include "core/io/xml_parser.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -485,6 +486,27 @@ String OS_Android::get_model_name() const {
 	}
 
 	return OS_Unix::get_model_name();
+}
+
+String OS_Android::get_processor_name() const {
+	// The SoC model is only guaranteed to be set on devices launching with Android 12 or later.
+	const String soc_model = get_system_property("ro.soc.model");
+	if (!soc_model.is_empty()) {
+		return soc_model;
+	}
+
+	// Older devices: the SoC name is exposed by the kernel as the "Hardware" line in `/proc/cpuinfo`.
+	Ref<FileAccess> f = FileAccess::open("/proc/cpuinfo", FileAccess::READ);
+	if (f.is_valid()) {
+		while (!f->eof_reached()) {
+			const String line = f->get_line();
+			if (line.begins_with("Hardware")) {
+				return line.get_slicec(':', 1).strip_edges();
+			}
+		}
+	}
+
+	ERR_FAIL_V_MSG(String(), "Couldn't get the SoC model name.");
 }
 
 String OS_Android::get_data_path() const {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -151,6 +151,7 @@ public:
 	virtual String get_resource_dir() const override;
 	virtual String get_locale() const override;
 	virtual String get_model_name() const override;
+	virtual String get_processor_name() const override;
 
 	virtual String get_unique_id() const override;
 


### PR DESCRIPTION
Returns the SoC model from the `ro.soc.model` system property (standardized in Android 12), falling back to the "Hardware" line in `/proc/cpuinfo` on older devices.

Also updates the `OS.get_processor_name()` documentation: only Web returns an empty string now. iOS has been implemented since 4.6 via the device SoC list in `OS_AppleEmbedded`, contrary to what the note implied about the empty-string platforms.

Fixes #120816.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
