### PR TITLE
Make `AudioStreamWAV/MP3::data` use CoW `Vector`

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -230,7 +230,7 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 }
 
 Vector<uint8_t> AudioStreamMP3::get_data() const {
-	return Vector<uint8_t>(data);
+	return data;
 }
 
 void AudioStreamMP3::set_loop(bool p_enable) {

--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -245,7 +245,7 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 }
 
 Vector<uint8_t> AudioStreamMP3::get_data() const {
-	return Vector<uint8_t>(data);
+	return data;
 }
 
 void AudioStreamMP3::set_loop(bool p_enable) {

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -94,7 +94,7 @@ class AudioStreamMP3 : public AudioStream {
 
 	friend class AudioStreamPlaybackMP3;
 
-	TightLocalVector<uint8_t> data;
+	Vector<uint8_t> data;
 
 	float sample_rate = 1.0;
 	int channels = 1;

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -94,7 +94,7 @@ class AudioStreamMP3 : public AudioStream {
 
 	friend class AudioStreamPlaybackMP3;
 
-	TightLocalVector<uint8_t> data;
+	Vector<uint8_t> data;
 	LocalVector<drmp3_seek_point> seek_table;
 
 	float sample_rate = 1.0;

--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -526,7 +526,7 @@ void AudioStreamWAV::set_data(const Vector<uint8_t> &p_data) {
 }
 
 Vector<uint8_t> AudioStreamWAV::get_data() const {
-	return Vector<uint8_t>(data);
+	return data;
 }
 
 Error AudioStreamWAV::save_to_wav(const String &p_path) {

--- a/scene/resources/audio/audio_stream_wav.h
+++ b/scene/resources/audio/audio_stream_wav.h
@@ -120,7 +120,7 @@ private:
 	int64_t loop_begin = 0;
 	int64_t loop_end = 0;
 	uint32_t mix_rate = 44100;
-	TightLocalVector<uint8_t, uint64_t> data;
+	Vector<uint8_t> data;
 
 	Dictionary tags;
 


### PR DESCRIPTION
- Plays around #96017
- Partially reverts #97026

`set_data()` and `get_data()` (both exposed in GDScript) currently do straight operations between a provided `Vector` and an internal `TightLocalVector`. No adding or removing stuff.

This implies the usage of any of them will inevitably create copies in memory, when the internal storage could be a `Vector` and just take a reference.

As playback uses a force-inlined read-only access to the data, performance shouldn't be affected at all.

It was justified in #96017, as it stored a data pad for playback around that time, but with that removed, not anymore.

As for #97026, it was previously enforcing a copy, so there wasn't much difference, but I believe that was an oversight and a copy isn't necessary at all.