### PR TITLE
[Render] Crash Fix use-after-return instance shader parameter lists

### DIFF
--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -977,7 +977,7 @@ public:
 	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)
 	FUNC2RC(Variant, instance_geometry_get_shader_parameter, RID, const StringName &)
 	FUNC2RC(Variant, instance_geometry_get_shader_parameter_default_value, RID, const StringName &)
-	FUNC2C(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
+	FUNC2SC(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
 
 	FUNC3R(TypedArray<Image>, bake_render_uv2, RID, const TypedArray<RID> &, const Size2i &)
 	FUNC4R(PackedByteArray, bake_render_area_light_atlas, const TypedArray<RID> &, const TypedArray<Rect2> &, const Size2i &, int)
@@ -1064,7 +1064,7 @@ public:
 	FUNC3(canvas_item_set_instance_shader_parameter, RID, const StringName &, const Variant &)
 	FUNC2RC(Variant, canvas_item_get_instance_shader_parameter, RID, const StringName &)
 	FUNC2RC(Variant, canvas_item_get_instance_shader_parameter_default_value, RID, const StringName &)
-	FUNC2C(canvas_item_get_instance_shader_parameter_list, RID, List<PropertyInfo> *)
+	FUNC2SC(canvas_item_get_instance_shader_parameter_list, RID, List<PropertyInfo> *)
 
 	FUNC2(canvas_item_set_use_parent_material, RID, bool)
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Crash in released game when upgrading to 4.7 sigsev crash most on Quest 3 and Steam versions.
Sigsev crash which could be hit by anyone I think not sure why we are the first to report it from what I can tell.
This resolved our issue by introducing a sync into the prop list. Not sure if there is a less coarse mechanism for this.

## Additional information

Upgrading our game to 4.7 we started getting a crash and managed to use dmps to track it down to a use after free of a list and isolated it to 

    Fatal signal 11 (SIGSEGV) ... fault addr 0xe7fea88ca3c79ed5
    #00 List<PropertyInfo>::push_back(PropertyInfo const&)
    #01 CommandQueueMT::_flush()
    #02 CommandQueueMT::flush_all()
    #03 Callable::call()
    #04 WorkerThreadPool::_thread_function()

Fuurther investigation led us to prop lists on instances.

GeometryInstance3D::_get_property_list() and CanvasItem::_get_property_list() each build a temporary List<PropertyInfo> on their own stack, ask RenderingServer to fill it with the node's per-instance shader parameters, then immediately read the list and return it.

This is easy to trigger by accident. Both _get_property_list() overrides run unconditionally whenever anything enumerates the node's properties - most commonly Node.duplicate() or scene saving - even if the node has no instance shader parameters set at all. Any project that duplicates or pools mesh or canvas item nodes at runtime can hit this, and because it depends on whether the caller's stack happens to be overwritten before the background thread catches up, it shows up intermittently rather than on every call. 

Obviously this could introduce a slowdown but it doesn't look like its on any super hot paths. Not sure if there is a better fix but this resolved our issue for now. Hope this helps.
