### PR TITLE
Add remove_recursive and remove_recursive_absolute to DirAccess

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -660,6 +660,7 @@ void DirAccess::_bind_methods() {
 	ClassDB::bind_static_method("DirAccess", D_METHOD("make_dir_absolute", "path"), &DirAccess::make_dir_absolute);
 	ClassDB::bind_method(D_METHOD("make_dir_recursive", "path"), &DirAccess::make_dir_recursive);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("make_dir_recursive_absolute", "path"), &DirAccess::make_dir_recursive_absolute);
+	ClassDB::bind_method(D_METHOD("erase_contents_recursive"), &DirAccess::erase_contents_recursive);
 	ClassDB::bind_method(D_METHOD("file_exists", "path"), &DirAccess::file_exists);
 	ClassDB::bind_method(D_METHOD("dir_exists", "path"), &DirAccess::dir_exists);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("dir_exists_absolute", "path"), &DirAccess::dir_exists_absolute);

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -310,6 +310,11 @@ Error DirAccess::remove_absolute(const String &p_path) {
 	return d->remove(p_path);
 }
 
+Error DirAccess::remove_recursive_absolute(const String &p_path) {
+	Ref<DirAccess> d = DirAccess::create_for_path(p_path);
+	return d->remove_recursive(p_path);
+}
+
 Ref<DirAccess> DirAccess::create(AccessType p_access) {
 	Ref<DirAccess> da = create_func[p_access] ? create_func[p_access]() : nullptr;
 	if (da.is_valid()) {
@@ -543,6 +548,35 @@ Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int 
 	return OK;
 }
 
+Error DirAccess::remove_recursive(const String &p_path) {
+	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Directory path is empty.");
+	ERR_FAIL_COND_V_MSG(!dir_exists(p_path), ERR_FILE_NOT_FOUND, "Directory doesn't exist.");
+
+	String dir_name = p_path.get_file();
+	String parent_dir = p_path.get_base_dir();
+	if (parent_dir.is_empty()) {
+		parent_dir = ".";
+	}
+
+	DirChanger dir_changer(this, parent_dir);
+	Error err = change_dir(dir_name);
+	if (err != OK) {
+		return err;
+	}
+
+	err = erase_contents_recursive();
+	if (err != OK) {
+		return err;
+	}
+
+	err = change_dir("..");
+	if (err != OK) {
+		return err;
+	}
+
+	return remove(dir_name);
+}
+
 Error DirAccess::copy_dir(const String &p_from, String p_to, int p_chmod_flags, bool p_copy_links) {
 	ERR_FAIL_COND_V_MSG(!dir_exists(p_from), ERR_FILE_NOT_FOUND, "Source directory doesn't exist.");
 
@@ -660,7 +694,6 @@ void DirAccess::_bind_methods() {
 	ClassDB::bind_static_method("DirAccess", D_METHOD("make_dir_absolute", "path"), &DirAccess::make_dir_absolute);
 	ClassDB::bind_method(D_METHOD("make_dir_recursive", "path"), &DirAccess::make_dir_recursive);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("make_dir_recursive_absolute", "path"), &DirAccess::make_dir_recursive_absolute);
-	ClassDB::bind_method(D_METHOD("erase_contents_recursive"), &DirAccess::erase_contents_recursive);
 	ClassDB::bind_method(D_METHOD("file_exists", "path"), &DirAccess::file_exists);
 	ClassDB::bind_method(D_METHOD("dir_exists", "path"), &DirAccess::dir_exists);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("dir_exists_absolute", "path"), &DirAccess::dir_exists_absolute);
@@ -670,7 +703,9 @@ void DirAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rename", "from", "to"), &DirAccess::rename);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("rename_absolute", "from", "to"), &DirAccess::rename_absolute);
 	ClassDB::bind_method(D_METHOD("remove", "path"), &DirAccess::remove);
+	ClassDB::bind_method(D_METHOD("remove_recursive", "path"), &DirAccess::remove_recursive);
 	ClassDB::bind_static_method("DirAccess", D_METHOD("remove_absolute", "path"), &DirAccess::remove_absolute);
+	ClassDB::bind_static_method("DirAccess", D_METHOD("remove_recursive_absolute", "path"), &DirAccess::remove_recursive_absolute);
 
 	ClassDB::bind_method(D_METHOD("is_link", "path"), &DirAccess::is_link);
 	ClassDB::bind_method(D_METHOD("read_link", "path"), &DirAccess::read_link);

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -112,6 +112,7 @@ public:
 	virtual Error copy(const String &p_from, const String &p_to, int p_chmod_flags = -1);
 	virtual Error rename(String p_from, String p_to) = 0;
 	virtual Error remove(String p_name) = 0;
+	Error remove_recursive(const String &p_path);
 
 	virtual bool is_link(String p_file) = 0;
 	virtual String read_link(String p_file) = 0;
@@ -156,6 +157,7 @@ public:
 	static Error copy_absolute(const String &p_from, const String &p_to, int p_chmod_flags = -1);
 	static Error rename_absolute(const String &p_from, const String &p_to);
 	static Error remove_absolute(const String &p_path);
+	static Error remove_recursive_absolute(const String &p_path);
 
 	PackedStringArray get_files();
 	static PackedStringArray get_files_at(const String &p_path);

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -349,6 +349,14 @@
 				Returns one of the [enum Error] code constants ([constant OK] on success).
 			</description>
 		</method>
+		<method name="erase_contents_recursive">
+			<return type="int" enum="Error" />
+			<description>
+				Recursively deletes all files and directories inside the currently opened directory.
+				The current directory itself is not removed.
+				Returns one of the [enum Error] code constants ([constant OK] on success).
+			</description>
+		</method>
 		<method name="remove_absolute" qualifiers="static">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -349,19 +349,25 @@
 				Returns one of the [enum Error] code constants ([constant OK] on success).
 			</description>
 		</method>
-		<method name="erase_contents_recursive">
-			<return type="int" enum="Error" />
-			<description>
-				Recursively deletes all files and directories inside the currently opened directory.
-				The current directory itself is not removed.
-				Returns one of the [enum Error] code constants ([constant OK] on success).
-			</description>
-		</method>
 		<method name="remove_absolute" qualifiers="static">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Static version of [method remove]. Supports only absolute paths.
+			</description>
+		</method>
+		<method name="remove_recursive">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Recursively deletes the target directory and all of its contents. The argument can be relative to the current directory, or an absolute path. Returns one of the [enum Error] code constants ([constant OK] on success).
+			</description>
+		</method>
+		<method name="remove_recursive_absolute" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Static version of [method remove_recursive]. Supports only absolute paths.
 			</description>
 		</method>
 		<method name="rename">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/11598

## Additional information

_~~This just exposes an existing DirAccess function to allow its use in GDScript. The function allows you to recursively remove the contents of a directory. I don't know if there is an important reason why it wasn't exposed in the first place, but~~_ I proposed this idea a while ago, and several people agreed it would be a nice QOL feature, because there is not currently a DirAccess method that allows you to remove a non-empty directory easily. From my testing, it works perfectly fine, and I can't find a reason to not include it.

See https://github.com/godotengine/godot/pull/120860#issuecomment-4878078076 for new implementation