### PR TITLE
Fix `Curve` points reordering in the inspector

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1407,8 +1407,8 @@ void ClassDB::add_property_subgroup(const StringName &p_class, const String &p_n
 	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_SUBGROUP));
 }
 
-void ClassDB::add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage) {
-	add_property(p_class, PropertyInfo(Variant::INT, p_count_property, PROPERTY_HINT_NONE, "", p_count_usage | PROPERTY_USAGE_ARRAY, vformat("%s,%s", p_label, p_array_element_prefix)), p_count_setter, p_count_getter);
+void ClassDB::add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage, const String &p_custom_options) {
+	add_property(p_class, PropertyInfo(Variant::INT, p_count_property, PROPERTY_HINT_NONE, "", p_count_usage | PROPERTY_USAGE_ARRAY, vformat("%s,%s%s", p_label, p_array_element_prefix, p_custom_options)), p_count_setter, p_count_getter);
 }
 
 void ClassDB::add_property_array(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -464,7 +464,7 @@ public:
 
 	static void add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix = "", int p_indent_depth = 0);
 	static void add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix = "", int p_indent_depth = 0);
-	static void add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage = PROPERTY_USAGE_DEFAULT);
+	static void add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage = PROPERTY_USAGE_DEFAULT, const String &p_custom_options = "");
 	static void add_property_array(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix);
 	static void add_property(const StringName &p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index = -1);
 	static void set_property_default_value(const StringName &p_class, const StringName &p_name, const Variant &p_default);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -60,6 +60,7 @@
 #endif
 
 #define ADD_ARRAY_COUNT(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix)
+#define ADD_ARRAY_COUNT_WITH_CUSTOM_OPTIONS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_custom_options) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix, PROPERTY_USAGE_DEFAULT, m_custom_options)
 #define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, StringName(m_count_property_setter), StringName(m_count_property_getter), m_prefix, m_property_usage_flags)
 #define ADD_ARRAY(m_array_path, m_prefix) ClassDB::add_property_array(get_class_static(), m_array_path, m_prefix)
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -599,7 +599,39 @@ void Curve::ensure_default_setup(real_t p_min, real_t p_max) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
+
+void Curve::_inspector_array_swap_point(uint32_t p_index_a, uint32_t p_index_b) {
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index_a, _points.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index_b, _points.size());
+
+	// Swap everything besides the offset, as the points are kept sorted by the offset.
+	Point &a = _points[p_index_a];
+	Point &b = _points[p_index_b];
+	Point a_copy = _points[p_index_a];
+
+	a.position.y = b.position.y;
+	a.left_tangent = b.left_tangent;
+	a.right_tangent = b.right_tangent;
+	a.left_mode = b.left_mode;
+	a.right_mode = b.right_mode;
+
+	b.position.y = a_copy.position.y;
+	b.left_tangent = a_copy.left_tangent;
+	b.right_tangent = a_copy.right_tangent;
+	b.left_mode = a_copy.left_mode;
+	b.right_mode = a_copy.right_mode;
+
+	notify_property_list_changed();
+}
+
+#endif
+
 void Curve::_bind_methods() {
+#ifdef TOOLS_ENABLED
+	ClassDB::bind_method(D_METHOD("_inspector_array_swap_point", "index_a", "index_b"), &Curve::_inspector_array_swap_point);
+#endif
+
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve::get_point_count);
 	ClassDB::bind_method(D_METHOD("set_point_count", "count"), &Curve::set_point_count);
 	ClassDB::bind_method(D_METHOD("add_point", "position", "left_tangent", "right_tangent", "left_mode", "right_mode"), &Curve::add_point, DEFVAL(0), DEFVAL(0), DEFVAL(TANGENT_FREE), DEFVAL(TANGENT_FREE));
@@ -644,7 +676,7 @@ void Curve::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "_limits", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_limits", "_get_limits");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bake_resolution", PROPERTY_HINT_RANGE, "1,1000,1"), "set_bake_resolution", "get_bake_resolution");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
-	ADD_ARRAY_COUNT("Points", "point_count", "set_point_count", "get_point_count", "point_");
+	ADD_ARRAY_COUNT_WITH_CUSTOM_OPTIONS("Points", "point_count", "set_point_count", "get_point_count", "point_", ",swap_method=_inspector_array_swap_point");
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_RANGE_CHANGED));
 	ADD_SIGNAL(MethodInfo(SIGNAL_DOMAIN_CHANGED));

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -165,6 +165,10 @@ private:
 	void _remove_point(int p_index, bool p_mark_dirty = true);
 	void _set_point_position(int p_index, const Vector2 &p_position);
 
+#ifdef TOOLS_ENABLED
+	void _inspector_array_swap_point(uint32_t p_index_a, uint32_t p_index_b);
+#endif
+
 	LocalVector<Point> _points;
 	mutable bool _baked_cache_dirty = false;
 	mutable Vector<real_t> _baked_cache;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes #120722.

## Additional information

Makes Curve point reordering in the inspector work by copying/swapping all point data besides the point offset (`Curve::Point::position.x`), as the points in the Curve `_points` array are kept sorted by the offsets (so changing the point offset would make the point move to a different spot). Moving the point to a different index now preserves the offsets, and only changes the rest of the point data.

Keeping as a draft for now, as I dislike the current solution which uses `"swap_method=..."` hint for the `EditorInspectorArray`. So e.g. moving the point from index `0` to `999` would result in 999 swap calls, and as a result 999 `notify_property_list_changed()`. I think it should be done at once with a single "move method" call. Kinda what @groud was mentioning in https://github.com/godotengine/godot/pull/63266#pullrequestreview-1046127484 and following comments.