### PR TITLE
Fix duplicated button press event on touch input

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -64,32 +64,34 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->get_device() != InputEvent::DEVICE_ID_EMULATION) {
-		Ref<InputEventScreenTouch> touch = p_event;
-		if (touch.is_valid()) {
-			if (status.touch_index == -1) {
-				if (touch->is_pressed()) {
-					status.touch_index = touch->get_index();
-					status.press_attempt = true;
-					status.pressing_inside = has_point(touch->get_position());
-					on_action_event(p_event);
-				}
-			} else if (touch->get_index() == status.touch_index) {
-				if (!touch->is_pressed()) {
-					status.touch_index = -1;
-					on_action_event(p_event);
-				}
+	if (p_event->get_device() == InputEvent::DEVICE_ID_EMULATION) {
+		return;
+	}
+
+	Ref<InputEventScreenTouch> touch = p_event;
+	if (touch.is_valid()) {
+		if (status.touch_index == -1) {
+			if (touch->is_pressed()) {
+				status.touch_index = touch->get_index();
+				status.press_attempt = true;
+				status.pressing_inside = has_point(touch->get_position());
+				on_action_event(p_event);
+			}
+		} else if (touch->get_index() == status.touch_index) {
+			if (!touch->is_pressed()) {
+				status.touch_index = -1;
+				on_action_event(p_event);
 			}
 		}
+	}
 
-		Ref<InputEventScreenDrag> drag = p_event;
-		if (drag.is_valid() && drag->get_index() == status.touch_index && status.press_attempt) {
-			bool last_press_inside = status.pressing_inside;
-			status.pressing_inside = has_point(drag->get_position());
+	Ref<InputEventScreenDrag> drag = p_event;
+	if (drag.is_valid() && drag->get_index() == status.touch_index && status.press_attempt) {
+		bool last_press_inside = status.pressing_inside;
+		status.pressing_inside = has_point(drag->get_position());
 
-			if (last_press_inside != status.pressing_inside) {
-				queue_redraw();
-			}
+		if (last_press_inside != status.pressing_inside) {
+			queue_redraw();
 		}
 	}
 


### PR DESCRIPTION
Currently touch input and drag input is being handled twice. Once as the screen touch and then below as mouse events.

This PR returns early if `p_event->get_device() == InputEvent::DEVICE_ID_EMULATION` because we have logic for handling both screen touch and mouse events, so there's no need for emulated events here.

closes https://github.com/godotengine/godot/issues/120439