### PR TITLE
Fix editor margins with modern theme and low spacing

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1530,10 +1530,10 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 
 void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
-		bus_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		bus_mc->set_theme_type_variation("NoBorderBottomPanel");
 		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
 	} else {
-		bus_mc->set_theme_type_variation("NoBorderHorizontal");
+		bus_mc->set_theme_type_variation("NoBorderPanel");
 		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 	}
 }
@@ -1578,7 +1578,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorAudioBuses::_menu_option));
 
 	bus_mc = memnew(MarginContainer);
-	bus_mc->set_theme_type_variation("NoBorderHorizontal");
+	bus_mc->set_theme_type_variation("NoBorderPanel");
 	bus_mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	main_vb->add_child(bus_mc);
 

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -513,7 +513,7 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				toolbar2_hbc->show();
 
 				tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
-				tree_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+				tree_mc->set_theme_type_variation("NoBorderBottomPanel");
 			}
 			button_file_list_display_mode->hide();
 

--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -918,7 +918,7 @@ GroupsEditor::GroupsEditor() {
 	hbc->add_child(filter);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderBottomPanel");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	holder->add_child(mc);
 

--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -270,7 +270,7 @@ HistoryDock::HistoryDock() {
 	global_history_checkbox->connect(SceneStringName(toggled), callable_mp(this, &HistoryDock::refresh_history).unbind(1));
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderBottomPanel");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	main_vb->add_child(mc);
 

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -785,7 +785,7 @@ ImportDock::ImportDock() {
 	hb->add_child(preset);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontal");
+	mc->set_theme_type_variation("NoBorderPanel");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	content->add_child(mc);
 

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -867,7 +867,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 
 	MarginContainer *mc = memnew(MarginContainer);
 	main_vb->add_child(mc);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderBottomPanel");
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	inspector = EditorInspector::create_default_inspector(search);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4716,7 +4716,7 @@ void SceneTreeDock::_update_create_root_dialog_visibility() {
 		create_root_dialog->show();
 		scene_tree->hide();
 	} else {
-		main_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		main_mc->set_theme_type_variation("NoBorderBottomPanel");
 		create_root_dialog->hide();
 		scene_tree->show();
 	}

--- a/editor/import/import_defaults_editor.cpp
+++ b/editor/import/import_defaults_editor.cpp
@@ -216,7 +216,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	add_child(hb);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontal");
+	mc->set_theme_type_variation("NoBorderPanel");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(mc);
 

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1758,7 +1758,7 @@ ConnectionsDock::ConnectionsDock() {
 	holder->add_child(search_box);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontal");
+	mc->set_theme_type_variation("NoBorderPanel");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	holder->add_child(mc);
 

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -528,7 +528,7 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	hbc->add_child(add_button);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	mc->set_theme_type_variation("NoBorderBottomWideWindow");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(mc);
 

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -624,7 +624,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	mc->set_theme_type_variation("NoBorderActionEditor");
+	mc->set_theme_type_variation("NoBorderBottomPanel");
 	main_vbox->add_child(mc);
 
 	// Action Editor Tree

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -891,7 +891,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
-	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	mc->set_theme_type_variation("NoBorderBottomWideWindow");
 	add_child(mc);
 
 	tree = memnew(Tree);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1050,7 +1050,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderBottomPanel");
 	tab_shortcuts->add_child(mc);
 
 	shortcuts = memnew(Tree);

--- a/editor/shader/shader_globals_editor.cpp
+++ b/editor/shader/shader_globals_editor.cpp
@@ -492,7 +492,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	variable_add->connect(SceneStringName(pressed), callable_mp(this, &ShaderGlobalsEditor::_variable_added));
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	mc->set_theme_type_variation("NoBorderBottomWideWindow");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(mc);
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2080,7 +2080,25 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_constant("margin_right", "NoBorderAssetLibProjectManagerHorizontal", margin);
 
 			int bottom_panel_margin = p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
-			margin = -panel_margin - bottom_panel_margin;
+
+			p_theme->set_type_variation("NoBorderPanel", "MarginContainer");
+			p_theme->set_constant("margin_left", "NoBorderPanel", -bottom_panel_margin);
+			p_theme->set_constant("margin_right", "NoBorderPanel", -bottom_panel_margin);
+
+			p_theme->set_type_variation("NoBorderBottomPanel", "NoBorderPanel");
+			p_theme->set_constant("margin_bottom", "NoBorderBottomPanel", -bottom_panel_margin);
+
+			margin = -p_theme->get_stylebox(SceneStringName(panel), SNAME("AcceptDialog"))->get_content_margin(SIDE_LEFT);
+
+			p_theme->set_type_variation("NoBorderHorizontalWindow", "MarginContainer");
+			p_theme->set_constant("margin_left", "NoBorderHorizontalWindow", margin);
+			p_theme->set_constant("margin_right", "NoBorderHorizontalWindow", margin);
+
+			margin = 2 * -bottom_panel_margin;
+
+			// Same as above, including the bottom.
+			p_theme->set_type_variation("NoBorderBottomWideWindow", "NoBorderHorizontalWindow");
+			p_theme->set_constant("margin_bottom", "NoBorderBottomWideWindow", margin);
 
 			// Used in the animation track editor.
 			p_theme->set_type_variation("NoBorderAnimation", "MarginContainer");
@@ -2090,25 +2108,6 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Used in the OpenXR action map editor.
 			p_theme->set_type_variation("NoBorderOpenXR", "NoBorderAnimation");
 			p_theme->set_constant("margin_bottom", "NoBorderOpenXR", -panel_margin);
-
-			margin = -p_theme->get_stylebox(SceneStringName(panel), SNAME("AcceptDialog"))->get_content_margin(SIDE_LEFT);
-
-			p_theme->set_type_variation("NoBorderHorizontalWindow", "MarginContainer");
-			p_theme->set_constant("margin_left", "NoBorderHorizontalWindow", margin);
-			p_theme->set_constant("margin_right", "NoBorderHorizontalWindow", margin);
-
-			// Used in nested containers.
-			p_theme->set_type_variation("NoBorderHorizontalWide", "MarginContainer");
-			p_theme->set_constant("margin_left", "NoBorderHorizontalWide", margin);
-			p_theme->set_constant("margin_right", "NoBorderHorizontalWide", margin);
-
-			// Same as above, including the bottom.
-			p_theme->set_type_variation("NoBorderHorizontalBottomWide", "NoBorderHorizontalWide");
-			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottomWide", 2 * -bottom_panel_margin);
-
-			// Used in the action map editor.
-			p_theme->set_type_variation("NoBorderActionEditor", "NoBorderHorizontalWide");
-			p_theme->set_constant("margin_bottom", "NoBorderActionEditor", -bottom_panel_margin);
 		}
 
 		// Buttons in material previews.

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -770,7 +770,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+		mc->set_theme_type_variation("NoBorderBottomWideWindow");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -808,7 +808,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalWide");
+		mc->set_theme_type_variation("NoBorderHorizontalWindow");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -836,7 +836,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+		mc->set_theme_type_variation("NoBorderBottomWideWindow");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -885,7 +885,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(template_generate_button);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalWide");
+		mc->set_theme_type_variation("NoBorderHorizontalWindow");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -77,7 +77,7 @@ void OpenXRActionMapEditor::_notification(int p_what) {
 
 void OpenXRActionMapEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
-		actionsets_mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+		actionsets_mc->set_theme_type_variation("NoBorderBottomWideWindow");
 		actionsets_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
 	} else {
 		actionsets_mc->set_theme_type_variation("NoBorderOpenXR");


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Continuation of #120737

Fixes the editor settings shortcuts and the main docks.
It also aims to fix other wrong margins that i'm currently searching.

## Additional information

#### Renaming:
I used names similar to already-present theme type variations, but i think that removing the repetitive "Horizontal" from every name, making it implicit, would be better.
In this way, only "Bottom" would have to be specified, to make names less verbose, more clear and reusable.

#### EditorSettingsDialog:
With spacing=0, the editor settings clip on the right and bottom sides. To avoid this, should a MarginContainer be added between the container and the SectionedInspector?

<img width="300" height="45" alt="EditorSettings1" src="https://github.com/user-attachments/assets/b2b401bd-0f7b-428c-a452-39fb7c2a76f8" /> <img width="455" height="45" alt="EditorSettings2" src="https://github.com/user-attachments/assets/3c3265ac-fc25-4d79-b7ae-4cf9fa9e1f65" />

#### SceneTreeDock :
I also found that the SceneTreeDock vertical scroll is always detached from the border, while the horizontal one detaches as spacing increases. In other docks, such as the FileSystem, this overlapping is not present. Is this intended?

<img width="303" height="208" alt="image" src="https://github.com/user-attachments/assets/b14a629f-207f-4374-9ae6-aff500174bef" /> <img width="311" height="189" alt="image" src="https://github.com/user-attachments/assets/67e0c3ff-2636-4370-8e3d-820eca4faa5f" />