### PR TITLE
[3.x] Return primitive types by value

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -63,7 +63,7 @@ struct _NO_DISCARD_CLASS_ Color {
 	_FORCE_INLINE_ float &operator[](int p_idx) {
 		return components[p_idx];
 	}
-	_FORCE_INLINE_ const float &operator[](int p_idx) const {
+	_FORCE_INLINE_ float operator[](int p_idx) const {
 		return components[p_idx];
 	}
 

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -54,7 +54,7 @@ struct AudioFrame {
 	//left and right samples
 	float l = 0.f, r = 0.f;
 
-	_ALWAYS_INLINE_ const float &operator[](int idx) const { return idx == 0 ? l : r; }
+	_ALWAYS_INLINE_ float operator[](int idx) const { return idx == 0 ? l : r; }
 	_ALWAYS_INLINE_ float &operator[](int idx) { return idx == 0 ? l : r; }
 
 	_ALWAYS_INLINE_ AudioFrame operator+(const AudioFrame &p_frame) const { return AudioFrame(l + p_frame.l, r + p_frame.r); }

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -64,7 +64,7 @@ public:
 	const BVHABB_CLASS &get_aabb(uint32_t p_id) const { return aabbs[p_id]; }
 
 	uint32_t &get_item_ref_id(uint32_t p_id) { return item_ref_ids[p_id]; }
-	const uint32_t &get_item_ref_id(uint32_t p_id) const { return item_ref_ids[p_id]; }
+	uint32_t get_item_ref_id(uint32_t p_id) const { return item_ref_ids[p_id]; }
 
 	bool is_dirty() const { return dirty; }
 	void set_dirty(bool p) { dirty = p; }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -63,7 +63,7 @@ struct _NO_DISCARD_CLASS_ Vector2 {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
-	_FORCE_INLINE_ const real_t &operator[](int p_idx) const {
+	_FORCE_INLINE_ real_t operator[](int p_idx) const {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
@@ -297,7 +297,7 @@ struct _NO_DISCARD_CLASS_ Vector2i {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
-	_FORCE_INLINE_ const int &operator[](int p_idx) const {
+	_FORCE_INLINE_ int operator[](int p_idx) const {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -55,7 +55,7 @@ struct _NO_DISCARD_CLASS_ Vector3 {
 		real_t coord[3];
 	};
 
-	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
+	_FORCE_INLINE_ real_t operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}

--- a/servers/physics_2d/shape_2d_sw.h
+++ b/servers/physics_2d/shape_2d_sw.h
@@ -272,7 +272,7 @@ class CircleShape2DSW : public Shape2DSW {
 	real_t radius;
 
 public:
-	_FORCE_INLINE_ const real_t &get_radius() const { return radius; }
+	_FORCE_INLINE_ real_t get_radius() const { return radius; }
 
 	virtual Physics2DServer::ShapeType get_type() const { return Physics2DServer::SHAPE_CIRCLE; }
 
@@ -378,8 +378,8 @@ class CapsuleShape2DSW : public Shape2DSW {
 	real_t height;
 
 public:
-	_FORCE_INLINE_ const real_t &get_radius() const { return radius; }
-	_FORCE_INLINE_ const real_t &get_height() const { return height; }
+	_FORCE_INLINE_ real_t get_radius() const { return radius; }
+	_FORCE_INLINE_ real_t get_height() const { return height; }
 
 	virtual Physics2DServer::ShapeType get_type() const { return Physics2DServer::SHAPE_CAPSULE; }
 


### PR DESCRIPTION
## Update
@Ivorforce has rightly pointed out there are some potential avenues for regressions here, so I need to spend some more time investigating which of these will be caught by the compiler and whether we can mitigate this risk changing existing functions, so I'll close until I'm sure that these can be dealt with.

However the discussion here is very relevant for deciding on general policy for return by value / const ref in the future.

---

Changes low hanging fruit from returning primitive types (32/64 bit) from `const T&` to by `T` (by value).
I traced these back and the main problematic versions (`Vector2` etc) had been like this for years.

For small primitive types, returning by `const reference` is generally regarded as suboptimal compared to returning by value.

This is a bit of general issue of principle that has wider implications than just this PR (maybe in terms of coding standards / preferences).

## What problem(s) does passing by value solve?
Benefits:
* performance - register rather than indirection _(although see below about compiler optimization)_
* simplicity & clarity - callers don't think about lifetimes / dangling references
* compiler optimizations - being clear on _intention_ to the compiler makes it easier to optimize. RVO, copy elision, move semantics, no aliasing to deal with
* safety - no risk of dangling references
* DEV builds - faster (marginally) because inlining / optimizations are disabled

`const ref` is effectively (officially) treated by the compiler as a pointer. For types that fit in a register, there is no benefit, and potentially downsides, to using a pointer.

Costs / gotchas:
* grabbing a persistent _pointer_ to the data needs to be done explicitly.

i.e. You can't grab the address of the value and expect it to persist / reflect subsequent changes. However making persistent pointers more explicit has advantages in terms of reasoning about the code / grepping / detecting dangling pointer access.

## Regression Risk
This means that modifying existing functions there is the potential for regressions:
* checking existing usage in the engine
* possibility of third party code relying on "pointer grabbing" behaviour

### L value vs R value
Todo.

### Types of regression
* pointer operations on getters
* ABI mismatch - may require third party recompiling against 3.7
* compilation failure - caught immediately by CI
 
## Additional information
During optimization compilers can often (_but not always_) see that a pointer is not optimal, and instead substitute passing in a register even when you specify a `const ref` (especially when inlined), however this is not guaranteed:

* it will not occur reliably in non-optimized `DEV` builds
* fails across ABI boundaries, or if the definition is in a `cpp` file
* they can't do it if there is risk of aliasing, they need to insert guards

General rule of thumb I've often seen is:
* return by value for 64 bit and lower primitive types (and often up to 128 bit on modern CPUs with SIMD)
* return by `const ref` for larger / expensive to copy types

Profile when in doubt, as modern CPUs / compilers can make by-value surprisingly good even for medium sized structs.

### Containers
Containers like `stl::vector` tend to return as `const ref` because being templates, they don't know ahead of time the size / complexity of `T`. Returning as `const ref` leaves it up to the compiler, and it will _usually_ work out correctly.

## Notes
* Same applies in 4.x
* The same principle applies to function params, but that is a whole other PR
* I removed the changes to `String` that @Repiteo found, as it does seem like a barrel of worms for compatibility, as a lot of functions seem to use this to grab an address rather than using the value (i.e. they use it as a pointer)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
