### PR TITLE
Use `int` for `DockTabContainer`'s slot

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1528,7 +1528,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 	open_layout(ResourceUID::path_to_uid(p_string));
 }
 
-void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		bus_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -238,7 +238,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	void open_layout(const String &p_path);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -236,7 +236,7 @@ void EditorDebuggerNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("breakpoints_cleared_in_tree", PropertyInfo(Variant::INT, "debugger")));
 }
 
-void EditorDebuggerNode::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void EditorDebuggerNode::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
 		dbg->update_layout(p_layout, p_slot);
 	});

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -164,7 +164,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	static EditorDebuggerNode *get_singleton() { return singleton; }

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2107,7 +2107,7 @@ void ScriptEditorDebugger::toggle_profiler(const String &p_profiler, bool p_enab
 	_put_msg("profiler:" + p_profiler, msg_data);
 }
 
-void ScriptEditorDebugger::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void ScriptEditorDebugger::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		vmem_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -395,7 +395,7 @@ public:
 	void send_message(const String &p_message, const Array &p_args);
 	void toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data);
 
-	void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot);
+	void update_layout(EditorDock::DockLayout p_layout, int p_slot);
 
 	ScriptEditorDebugger();
 	~ScriptEditorDebugger();

--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -332,7 +332,7 @@ Rect2 DockTabContainer::get_default_floating_dock_rect(EditorDock *p_dock) {
 	return ret;
 }
 
-DockTabContainer::DockTabContainer(EditorDock::DockSlot p_slot) {
+DockTabContainer::DockTabContainer(int p_slot) {
 	ERR_FAIL_INDEX(p_slot, EditorDock::DOCK_SLOT_MAX);
 	dock_slot = p_slot;
 
@@ -357,7 +357,7 @@ Rect2 SideDockTabContainer::get_floating_dock_rect(EditorDock *p_dock) {
 	return Rect2(get_screen_position() + Vector2(0, tab_bar_height), get_size() - Vector2(0, tab_bar_height));
 }
 
-SideDockTabContainer::SideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect) :
+SideDockTabContainer::SideDockTabContainer(int p_slot, const Rect2i &p_slot_rect) :
 		DockTabContainer(p_slot) {
 	grid_rect = p_slot_rect;
 	set_custom_minimum_size(Size2(170 * EDSCALE, 0));
@@ -373,7 +373,7 @@ Rect2 BottomSideDockTabContainer::get_floating_dock_rect(EditorDock *p_dock) {
 	return Rect2(get_screen_position() + Vector2(0, tab_bar_height), get_size() - Vector2(0, tab_bar_height));
 }
 
-BottomSideDockTabContainer::BottomSideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect) :
+BottomSideDockTabContainer::BottomSideDockTabContainer(int p_slot, const Rect2i &p_slot_rect) :
 		DockTabContainer(p_slot) {
 	grid_rect = p_slot_rect;
 	layout = EditorDock::DOCK_LAYOUT_HORIZONTAL;

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -95,7 +95,7 @@ public:
 		TEXT_AND_ICON,
 	};
 
-	EditorDock::DockSlot dock_slot = EditorDock::DOCK_SLOT_NONE;
+	int dock_slot = EditorDock::DOCK_SLOT_NONE;
 	EditorDock::DockLayout layout = EditorDock::DOCK_LAYOUT_VERTICAL;
 	Rect2i grid_rect;
 
@@ -125,7 +125,7 @@ public:
 
 	static Rect2 get_default_floating_dock_rect(EditorDock *p_dock);
 
-	DockTabContainer(EditorDock::DockSlot p_slot);
+	DockTabContainer(int p_slot);
 };
 
 class SideDockTabContainer : public DockTabContainer {
@@ -134,7 +134,7 @@ class SideDockTabContainer : public DockTabContainer {
 public:
 	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) override;
 
-	SideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect);
+	SideDockTabContainer(int p_slot, const Rect2i &p_slot_rect);
 };
 
 class BottomSideDockTabContainer : public DockTabContainer {
@@ -143,5 +143,5 @@ class BottomSideDockTabContainer : public DockTabContainer {
 public:
 	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) override;
 
-	BottomSideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect);
+	BottomSideDockTabContainer(int p_slot, const Rect2i &p_slot_rect);
 };

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -161,7 +161,7 @@ public:
 	void update_tab_style();
 	Ref<Texture2D> get_effective_icon(const Callable &p_icon_fetch);
 
-	virtual void update_layout(DockLayout p_layout, DockSlot p_slot) { GDVIRTUAL_CALL(_update_layout, p_layout, p_slot); }
+	virtual void update_layout(DockLayout p_layout, int p_slot) { GDVIRTUAL_CALL(_update_layout, p_layout, p_slot); }
 	DockLayout get_current_layout() const { return current_layout; }
 	DockSlot get_current_slot() const { return (DockSlot)dock_slot_index; }
 

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -936,7 +936,7 @@ void DockContextPopup::_update_buttons() {
 	// Update tab move buttons.
 	tab_move_left_button->set_disabled(true);
 	tab_move_right_button->set_disabled(true);
-	TabContainer *context_tab_container = context_dock->get_parent_container();
+	DockTabContainer *context_tab_container = context_dock->get_parent_container();
 	if (context_tab_container && context_tab_container->get_tab_count() > 0) {
 		int context_tab_index = context_tab_container->get_tab_idx_from_control(context_dock);
 		tab_move_left_button->set_disabled(context_tab_index == 0);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4171,7 +4171,7 @@ MenuButton *FileSystemDock::_create_file_menu_button() {
 	return button;
 }
 
-void FileSystemDock::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void FileSystemDock::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	bool new_horizontal = (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL);
 	bool new_touches_bottom = (p_slot != EditorDock::DOCK_SLOT_BOTTOM);
 	if (horizontal == new_horizontal && touches_bottom == new_touches_bottom) {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -400,7 +400,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
 	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2161,7 +2161,7 @@ void TileMapLayerEditorTilesPlugin::edit(ObjectID p_tile_map_layer_id) {
 	edited_tile_map_layer_id = p_tile_map_layer_id;
 }
 
-void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	bool is_vertical = (p_layout == EditorDock::DOCK_LAYOUT_VERTICAL);
 	atlas_sources_split_container->set_vertical(is_vertical);
 	atlas_sources_split_container->move_child(split_container_left_side, is_vertical ? -1 : 0);
@@ -3505,7 +3505,7 @@ void TileMapLayerEditorTerrainsPlugin::edit(ObjectID p_edited_tile_map_layer_id)
 	}
 }
 
-void TileMapLayerEditorTerrainsPlugin::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void TileMapLayerEditorTerrainsPlugin::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
 	// Main Panel.
 	main_box_container->set_vertical(is_vertical);
@@ -4485,7 +4485,7 @@ void TileMapLayerEditor::_update_layer_selector_layout(bool p_is_vertical) {
 	}
 }
 
-void TileMapLayerEditor::update_layout(DockLayout p_layout, DockSlot p_slot) {
+void TileMapLayerEditor::update_layout(DockLayout p_layout, int p_slot) {
 	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
 	tile_map_toolbar->set_vertical(is_vertical);
 	layer_selector_separator->set_vertical(is_vertical);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -88,7 +88,7 @@ public:
 	virtual void tile_set_changed() {}
 	virtual void edit(ObjectID p_tile_map_layer_id) {}
 	virtual void draw_tile_coords_over_viewport(Control *p_overlay, const TileMapLayer *p_edited_layer, Ref<TileSet> p_tile_set, bool p_show_rectangle_size, const Vector2i &p_rectangle_origin);
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {}
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) {}
 };
 
 class TileMapLayerEditorTilesPlugin : public TileMapLayerSubEditorPlugin {
@@ -264,7 +264,7 @@ public:
 	virtual Vector<TabData> get_tabs() const override;
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
@@ -358,7 +358,7 @@ public:
 	virtual Vector<TabData> get_tabs() const override;
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
@@ -447,7 +447,7 @@ private:
 protected:
 	void _notification(int p_what);
 	void _draw_shape(Control *p_control, Rect2 p_region, TileSet::TileShape p_shape, TileSet::TileOffsetAxis p_offset_axis, Color p_color);
-	virtual void update_layout(DockLayout p_layout, DockSlot p_slot) override;
+	virtual void update_layout(DockLayout p_layout, int p_slot) override;
 
 public:
 	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -413,7 +413,7 @@ void TileSetEditor::_notification(int p_what) {
 	}
 }
 
-void TileSetEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void TileSetEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		patterns_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		patterns_item_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -115,7 +115,7 @@ private:
 protected:
 	void _notification(int p_what);
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }

--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -368,7 +368,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 	}
 }
 
-void ResourcePreloaderEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void ResourcePreloaderEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL && p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		mc->set_theme_type_variation("NoBorderHorizontal");
 		tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);

--- a/editor/scene/resource_preloader_editor_plugin.h
+++ b/editor/scene/resource_preloader_editor_plugin.h
@@ -80,7 +80,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	void edit(ResourcePreloader *p_preloader);

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -737,7 +737,7 @@ void FindInFilesPanel::stop_search() {
 	cancel_button->hide();
 }
 
-void FindInFilesPanel::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void FindInFilesPanel::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		results_display->set_theme_type_variation("NoBorderHorizontal");
 		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
@@ -1456,7 +1456,7 @@ void FindInFilesContainer::_bar_input(const Ref<InputEvent> &p_input) {
 	}
 }
 
-void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	for (Node *node : tabs->iterate_children()) {
 		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(node);
 		if (panel) {

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -224,7 +224,7 @@ public:
 	void start_search();
 	void stop_search();
 
-	void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot);
+	void update_layout(EditorDock::DockLayout p_layout, int p_slot);
 
 	FindInFilesPanel();
 };
@@ -269,7 +269,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 	FindInFilesPanel *get_panel_for_results(const String &p_label);
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1139,7 +1139,7 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 	update_palette();
 }
 
-void GridMapEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void GridMapEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (categories->is_visible()) {
 		item_palette_mc->set_theme_type_variation("");
 		mesh_library_palette->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_DISABLED);

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -294,7 +294,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	EditorPlugin::AfterGUIInput forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event);

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -532,7 +532,7 @@ void ReplicationEditor::_update_config() {
 	}
 }
 
-void ReplicationEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void ReplicationEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		tree_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -96,7 +96,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 public:
 	void edit(MultiplayerSynchronizer *p_object);

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -75,7 +75,7 @@ void OpenXRActionMapEditor::_notification(int p_what) {
 	}
 }
 
-void OpenXRActionMapEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+void OpenXRActionMapEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		actionsets_mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
 		actionsets_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -97,7 +97,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 	void _clear_action_map();
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Related to #114381 and #120033

This PR changes the `dock_slot` member of DockTabContainer from `DockSlot` enum to plain `int`. This is necessary to support arbitrary slot ranges required by the aforementioned PRs. I've split this change to make the other PRs smaller, as `update_layout()` method also needed updating and it just creates noise.