### PR TITLE
Fix extracting materials without a per-material override

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1612,12 +1612,35 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						continue;
 					}
 					const String mat_id = mat->get_meta("import_id", mat->get_name());
-					if (mat_id.is_empty() || !p_material_data.has(mat_id)) {
+					if (mat_id.is_empty()) {
 						continue;
 					}
-					Dictionary matdata = p_material_data[mat_id];
+					// Start with per-material import settings, if any. This is populated by the
+					// Advanced Import Settings dialog, but may be empty when using only the Import dock.
+					Dictionary matdata;
+					if (p_material_data.has(mat_id)) {
+						matdata = p_material_data[mat_id];
+					}
+					String file_path;
+					// Read any existing "use_external" settings to get the enabled status and file path.
+					if (matdata.has("use_external/enabled")) {
+						const bool enabled = bool(matdata["use_external/enabled"]);
+						// If the user has explicitly overwrote this material to not be external, skip it.
+						if (!enabled) {
+							continue;
+						}
+						// Read any existing file path from this material's import settings, if present.
+						if (matdata.has("use_external/fallback_path")) {
+							file_path = matdata["use_external/fallback_path"];
+						} else if (matdata.has("use_external/path")) {
+							file_path = matdata["use_external/path"];
+							if (file_path.begins_with("uid://")) {
+								file_path = ResourceUID::get_singleton()->uid_to_path(file_path);
+							}
+						}
+					}
+					// For any material settings that are missing, fill them with default values.
 					{
-						//fill node settings for this node with default values
 						List<ImportOption> iopts;
 						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_MATERIAL, &iopts);
 						for (const ImportOption &E : iopts) {
@@ -1630,18 +1653,21 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						post_importer_plugins.write[j]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MATERIAL, p_root, p_node, mat, matdata);
 					}
 					if (extract_mat != 0) {
-						const String ext = material_extension[p_options.has("materials/extract_format") ? (int)p_options["materials/extract_format"] : 0];
-						const String path = spath.path_join(mat_id.validate_filename() + ext);
-						const String uid_path = ResourceUID::path_to_uid(path);
-
-						matdata["use_external/enabled"] = true;
-						matdata["use_external/path"] = uid_path;
-						matdata["use_external/fallback_path"] = path;
-						if (!FileAccess::exists(path) || extract_mat == 2 /*overwrite*/) {
-							ResourceSaver::save(mat, path);
+						// If no file path was specified, generate one based on the material name and the selected format.
+						if (file_path.is_empty()) {
+							const String ext = material_extension[p_options.has("materials/extract_format") ? (int)p_options["materials/extract_format"] : 0];
+							file_path = spath.path_join(mat_id.validate_filename() + ext);
+							const String uid_path = ResourceUID::path_to_uid(file_path);
+							matdata["use_external/enabled"] = true;
+							matdata["use_external/path"] = uid_path;
+							matdata["use_external/fallback_path"] = file_path;
+						}
+						// Write the file if it doesn't exist, or if the user has selected to overwrite existing files.
+						if (!FileAccess::exists(file_path) || extract_mat == 2 /*overwrite*/) {
+							ResourceSaver::save(mat, file_path);
 						}
 
-						Ref<Material> external_mat = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
+						Ref<Material> external_mat = ResourceLoader::load(file_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
 						if (external_mat.is_valid()) {
 							m->set_surface_material(i, external_mat);
 						}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #120382

## Additional information

PR #115528 made it so that materials not present in `p_material_data` would be skipped and not extracted to external files. This could be argued to be better than the previous version of the code because it avoids an error, however, `p_material_data` does not contain information for materials that are not individually overridden in the Advanced Import Settings dialog, so when only using the Import dock, materials could not be extracted to files.

I looked into what populates `p_material_data`, and I believe it is correct to keep this empty for simple use cases involving only the Import dock. So, upon closer investigation, we *should* allow this to be empty, we just need to handle this case better, in a way that doesn't show any error messages.

This PR fixes the code to handle this case, reads existing file paths instead of always overwriting them, permits individual materials to opt-out of extracting, and adds several comments to improve the clarity of the code.
