### PR TITLE
Add mute toggle to AudioStreamPlayers

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -72,6 +72,10 @@
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
 			The mix target channels. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="pitch_scale" type="float" setter="set_pitch_scale" getter="get_pitch_scale" default="1.0">
 			The audio's pitch and tempo, as a multiplier of the [member stream]'s sample rate. A value of [code]2.0[/code] doubles the audio's pitch, while a value of [code]0.5[/code] halves the pitch.
 		</member>
@@ -101,6 +105,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when a sound finishes playing without interruptions. This signal is [i]not[/i] emitted when calling [method stop], or when exiting the tree while sounds are playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -72,6 +72,10 @@
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/2d_panning_strength] with this factor. Higher values will pan audio from left to right more dramatically than lower values.
 		</member>
@@ -102,6 +106,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when the audio stops playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -94,6 +94,10 @@
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/3d_panning_strength] by this factor. If the product is [code]0.0[/code] then stereo panning is disabled and the volume is the same for all channels. If the product is [code]1.0[/code] then one of the channels will be muted when the sound is located exactly to the left (or right) of the listener.
 			Two speaker stereo arrangements implement the [url=https://webaudio.github.io/web-audio-api/#stereopanner-algorithm]WebAudio standard for StereoPannerNode Panning[/url] where the volume is cosine of half the azimuth angle to the ear.
@@ -129,6 +133,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when the audio stops playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -104,6 +104,17 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 			if (mb->is_pressed()) {
 				Vector2 tree_mouse_pos = tree->get_transform().xform_inv(mb->get_position());
 				int tree_button_id = tree->get_button_id_at_position(tree_mouse_pos);
+				if (tree_button_id == BUTTON_MUTE) {
+					TreeItem *tree_item = tree->get_item_at_position(tree_mouse_pos);
+					ERR_FAIL_NULL(tree_item);
+					NodePath node_path = tree_item->get_metadata(0);
+					Node *node = get_node_or_null(node_path);
+					if (node != nullptr) {
+						mute_drag_value = !node->call("is_muted");
+						mute_drag_start_pos = tree_mouse_pos;
+						mute_drag_start_node = node->get_instance_id();
+					}
+				}
 				if (tree_button_id == BUTTON_VISIBILITY) {
 					TreeItem *tree_item = tree->get_item_at_position(tree_mouse_pos);
 					ERR_FAIL_NULL(tree_item);
@@ -115,8 +126,21 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 						visibility_drag_start_node = node->get_instance_id();
 					}
 				}
-			} else if (mb->is_released() && visibility_drag_start_node.is_valid()) {
-				if (!visibility_drag_nodes.is_empty()) {
+			} else if (mb->is_released()) {
+				if (mute_drag_start_node.is_valid() && !mute_drag_nodes.is_empty()) {
+					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+					undo_redo->create_action(vformat(TTR("Toggle Mute of %d Nodes"), mute_drag_nodes.size()));
+
+					for (ObjectID id : mute_drag_nodes) {
+						Node *node = ObjectDB::get_instance<Node>(id);
+						if (node != nullptr) {
+							undo_redo->add_do_method(node, "set_mute", mute_drag_value);
+							undo_redo->add_undo_method(node, "set_mute", !mute_drag_value);
+						}
+					}
+
+					undo_redo->commit_action(false);
+				} else if (visibility_drag_start_node.is_valid() && !visibility_drag_nodes.is_empty()) {
 					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 					undo_redo->create_action(vformat(TTR("Toggle Visibility of %d Nodes"), visibility_drag_nodes.size()));
 
@@ -131,12 +155,18 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 					undo_redo->commit_action(false);
 				}
 
-				// Defer this so that `_cell_button_pressed` can still react to the dragging.
+				// Defer these so that `_cell_button_pressed` can still react to the dragging.
+				callable_mp(this, &SceneTreeEditor::_reset_mute_drag).call_deferred();
 				callable_mp(this, &SceneTreeEditor::_reset_visibility_drag).call_deferred();
 			}
-		} else if (mb->get_button_index() == MouseButton::RIGHT && visibility_drag_start_node.is_valid()) {
-			_reset_visibility_drag();
-			accept_event();
+		} else if (mb->get_button_index() == MouseButton::RIGHT) {
+			if (mute_drag_start_node.is_valid()) {
+				_reset_mute_drag();
+				accept_event();
+			} else if (visibility_drag_start_node.is_valid()) {
+				_reset_visibility_drag();
+				accept_event();
+			}
 		}
 
 		return;
@@ -144,7 +174,27 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		if (visibility_drag_start_node.is_valid()) {
+		if (mute_drag_start_node.is_valid()) {
+			Vector2 tree_mouse_pos = tree->get_transform().xform_inv(mm->get_position());
+			int tree_button_id = tree->get_button_id_at_position(tree_mouse_pos);
+			bool crossed_drag_threshold = mute_drag_start_pos.distance_to(tree_mouse_pos) > get_viewport()->get_drag_threshold();
+			if (tree_button_id == BUTTON_MUTE && (crossed_drag_threshold || !mute_drag_nodes.is_empty())) {
+				Node *start_node = ObjectDB::get_instance<Node>(mute_drag_start_node);
+				if (start_node != nullptr && (bool)start_node->call("is_muted") != mute_drag_value) {
+					start_node->call("set_mute", mute_drag_value);
+					mute_drag_nodes.push_back(mute_drag_start_node);
+				}
+
+				TreeItem *tree_item = tree->get_item_at_position(tree_mouse_pos);
+				ERR_FAIL_NULL(tree_item);
+				NodePath node_path = tree_item->get_metadata(0);
+				Node *node = get_node_or_null(node_path);
+				if (node != nullptr && (bool)node->call("is_muted") != mute_drag_value) {
+					node->call("set_mute", mute_drag_value);
+					mute_drag_nodes.push_back(node->get_instance_id());
+				}
+			}
+		} else if (visibility_drag_start_node.is_valid()) {
 			Vector2 tree_mouse_pos = tree->get_transform().xform_inv(mm->get_position());
 			int tree_button_id = tree->get_button_id_at_position(tree_mouse_pos);
 			bool crossed_drag_threshold = visibility_drag_start_pos.distance_to(tree_mouse_pos) > get_viewport()->get_drag_threshold();
@@ -170,9 +220,14 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_action_type()) {
-		if (p_event->is_action_pressed(SNAME("ui_cancel")) && visibility_drag_start_node.is_valid()) {
-			_reset_visibility_drag();
-			accept_event();
+		if (p_event->is_action_pressed(SNAME("ui_cancel"))) {
+			if (mute_drag_start_node.is_valid()) {
+				_reset_mute_drag();
+				accept_event();
+			} else if (visibility_drag_start_node.is_valid()) {
+				_reset_visibility_drag();
+				accept_event();
+			}
 		}
 	}
 }
@@ -208,7 +263,24 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		if (script_typed.is_valid()) {
 			emit_signal(SNAME("open_script"), script_typed);
 		}
+	} else if (p_id == BUTTON_MUTE) {
+		if (!mute_drag_nodes.is_empty()) {
+			return;
+		}
 
+		undo_redo->create_action(TTR("Toggle Mute"));
+		_toggle_mute(n);
+		List<Node *> selection = editor_selection->get_top_selected_node_list();
+		if (selection.size() > 1 && selection.find(n) != nullptr) {
+			for (Node *nv : selection) {
+				ERR_FAIL_NULL(nv);
+				if (nv == n) {
+					continue;
+				}
+				_toggle_mute(nv);
+			}
+		}
+		undo_redo->commit_action();
 	} else if (p_id == BUTTON_VISIBILITY) {
 		if (!visibility_drag_nodes.is_empty()) {
 			return;
@@ -343,6 +415,15 @@ void SceneTreeEditor::_revoke_unique_name() {
 	undo_redo->add_do_method(this, "_update_tree");
 	undo_redo->add_undo_method(this, "_update_tree");
 	undo_redo->commit_action();
+}
+
+void SceneTreeEditor::_toggle_mute(Node *p_node) {
+	if (p_node->has_method("is_muted") && p_node->has_method("set_mute")) {
+		bool muted = bool(p_node->call("is_muted"));
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->add_do_method(p_node, "set_mute", !muted);
+		undo_redo->add_undo_method(p_node, "set_mute", muted);
+	}
 }
 
 void SceneTreeEditor::_toggle_visible(Node *p_node) {
@@ -712,6 +793,19 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			p_item->add_button(0, get_editor_theme_icon(SNAME("Group")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make them selectable."));
 		}
 
+		if (p_node->has_method("is_muted") && p_node->has_method("set_mute") && p_node->has_signal(SceneStringName(mute_toggled))) {
+			bool is_muted = p_node->call("is_muted");
+			if (!is_muted) {
+				p_item->add_button(0, get_editor_theme_icon(SNAME("AudioStreamPlayer")), BUTTON_MUTE, false, TTR("Toggle Mute"));
+			} else {
+				p_item->add_button(0, get_editor_theme_icon(SNAME("AudioMute")), BUTTON_MUTE, false, TTR("Toggle Mute"));
+			}
+			const Callable mute_toggled_clb = callable_mp(this, &SceneTreeEditor::_node_mute_toggled);
+			if (!p_node->is_connected(SceneStringName(mute_toggled), mute_toggled_clb)) {
+				p_node->connect(SceneStringName(mute_toggled), mute_toggled_clb.bind(p_node));
+			}
+		}
+
 		if (p_node->has_method("is_visible") && p_node->has_method("set_visible") && p_node->has_signal(SceneStringName(visibility_changed))) {
 			bool is_visible = p_node->call("is_visible");
 			if (is_visible) {
@@ -801,6 +895,45 @@ void SceneTreeEditor::_update_node_tooltip(Node *p_node, TreeItem *p_item) {
 	}
 
 	p_item->set_tooltip_text(0, tooltip);
+}
+
+void SceneTreeEditor::_node_mute_toggled(Node *p_node) {
+	HashMap<Node *, CachedNode>::Iterator I = node_cache.get(p_node, false);
+	if (!I) {
+		// We leave these signals connected when switching tabs.
+		// If the node is not in cache it was for a different tab.
+		return;
+	}
+
+	if (!p_node || (p_node != get_scene_node() && !p_node->get_owner())) {
+		return;
+	}
+
+	TreeItem *item;
+	if (I->value.item && I->value.item->get_metadata(0) == p_node->get_path()) {
+		item = I->value.item;
+	} else {
+		item = _find(tree->get_root(), p_node->get_path());
+	}
+
+	if (!item) {
+		return;
+	}
+
+	int idx = item->get_button_by_id(0, BUTTON_MUTE);
+	ERR_FAIL_COND(idx == -1);
+
+	bool node_muted = false;
+
+	if (p_node->has_method("is_muted")) {
+		node_muted = p_node->call("is_muted");
+	}
+
+	if (!node_muted) {
+		item->set_button(0, idx, get_editor_theme_icon(SNAME("AudioStreamPlayer")));
+	} else {
+		item->set_button(0, idx, get_editor_theme_icon(SNAME("AudioMute")));
+	}
 }
 
 void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
@@ -1467,6 +1600,13 @@ void SceneTreeEditor::_tree_scroll_to_item(ObjectID p_item_id) {
 	}
 }
 
+void SceneTreeEditor::_reset_mute_drag() {
+	mute_drag_value = false;
+	mute_drag_start_pos = Vector2();
+	mute_drag_start_node = ObjectID();
+	mute_drag_nodes.clear();
+}
+
 void SceneTreeEditor::_reset_visibility_drag() {
 	visibility_drag_value = false;
 	visibility_drag_start_pos = Vector2();
@@ -1540,6 +1680,7 @@ void SceneTreeEditor::_notification(int p_what) {
 
 		case NOTIFICATION_APPLICATION_FOCUS_OUT:
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			_reset_mute_drag();
 			_reset_visibility_drag();
 		} break;
 	}

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -57,6 +57,7 @@ class SceneTreeEditor : public Control {
 		BUTTON_GROUPS = 7,
 		BUTTON_PIN = 8,
 		BUTTON_UNIQUE = 9,
+		BUTTON_MUTE = 10,
 	};
 
 	struct CachedNode {
@@ -189,6 +190,11 @@ class SceneTreeEditor : public Control {
 	bool pending_selection_update = false;
 	Timer *update_node_tooltip_delay = nullptr;
 
+	bool mute_drag_value = false;
+	Vector2 mute_drag_start_pos;
+	ObjectID mute_drag_start_node;
+	LocalVector<ObjectID> mute_drag_nodes;
+
 	bool visibility_drag_value = false;
 	Vector2 visibility_drag_start_pos;
 	ObjectID visibility_drag_start_node;
@@ -198,17 +204,20 @@ class SceneTreeEditor : public Control {
 
 	void _gui_input(const Ref<InputEvent> &p_event);
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
+	void _toggle_mute(Node *p_node);
 	void _toggle_visible(Node *p_node);
 	void _cell_multi_selected(Object *p_object, int p_cell, bool p_selected);
 	void _process_selection_update();
 	void _update_selection(TreeItem *item);
 	void _node_script_changed(Node *p_node);
+	void _node_mute_toggled(Node *p_node);
 	void _node_visibility_changed(Node *p_node);
 	void _update_visibility_color(Node *p_node, TreeItem *p_item);
 	void _set_item_custom_color(TreeItem *p_item, Color p_color);
 	void _update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _queue_update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _tree_scroll_to_item(ObjectID p_item_id);
+	void _reset_mute_drag();
 	void _reset_visibility_drag();
 
 	void _selection_changed();

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -66,7 +66,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 			if (setplayback.is_valid() && setplay.get() >= 0) {
 				internal->active.set();
-				AudioServer::get_singleton()->start_playback_stream(setplayback, _get_actual_bus(), volume_vector, setplay.get(), internal->pitch_scale);
+				AudioServer::get_singleton()->start_playback_stream(setplayback, _get_actual_bus(), volume_vector, setplay.get(), internal->pitch_scale, internal->muted);
 				setplayback.unref();
 				setplay.set(-1);
 			}
@@ -227,6 +227,14 @@ void AudioStreamPlayer2D::set_volume_linear(float p_volume) {
 
 float AudioStreamPlayer2D::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
+}
+
+void AudioStreamPlayer2D::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer2D::is_muted() const {
+	return internal->muted;
 }
 
 void AudioStreamPlayer2D::set_pitch_scale(float p_pitch_scale) {
@@ -390,6 +398,9 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer2D::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer2D::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer2D::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer2D::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer2D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer2D::get_pitch_scale);
 
@@ -435,6 +446,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_ONESHOT, "", PROPERTY_USAGE_EDITOR), "set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
@@ -448,6 +460,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 }
 
 AudioStreamPlayer2D::AudioStreamPlayer2D() {

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -100,6 +100,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -290,7 +290,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				internal->active.set();
 				HashMap<StringName, Vector<AudioFrame>> bus_map;
 				bus_map[_get_actual_bus()] = volume_vector;
-				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
+				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, internal->muted, linear_attenuation, attenuation_filter_cutoff_hz);
 				setplayback.unref();
 				setplay.set(-1);
 			}
@@ -621,6 +621,14 @@ float AudioStreamPlayer3D::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
 }
 
+void AudioStreamPlayer3D::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer3D::is_muted() const {
+	return internal->muted;
+}
+
 void AudioStreamPlayer3D::set_unit_size(float p_volume) {
 	unit_size = p_volume;
 	update_gizmos();
@@ -867,6 +875,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer3D::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer3D::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer3D::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer3D::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_unit_size", "unit_size"), &AudioStreamPlayer3D::set_unit_size);
 	ClassDB::bind_method(D_METHOD("get_unit_size"), &AudioStreamPlayer3D::get_unit_size);
 
@@ -937,6 +948,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,Inverse Square,Logarithmic,Disabled"), "set_attenuation_model", "get_attenuation_model");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_size", PROPERTY_HINT_RANGE, "0.1,100,0.01,or_greater"), "set_unit_size", "get_unit_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_db", PROPERTY_HINT_RANGE, "-24,6,suffix:dB"), "set_max_db", "get_max_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
@@ -969,6 +981,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_PHYSICS_STEP);
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 }
 
 AudioStreamPlayer3D::AudioStreamPlayer3D() {

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -152,6 +152,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_unit_size(float p_volume);
 	float get_unit_size() const;
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -90,6 +90,14 @@ float AudioStreamPlayer::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
 }
 
+void AudioStreamPlayer::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer::is_muted() const {
+	return internal->muted;
+}
+
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {
 	internal->set_pitch_scale(p_pitch_scale);
 }
@@ -111,7 +119,8 @@ void AudioStreamPlayer::play(float p_from_pos) {
 	if (stream_playback.is_null()) {
 		return;
 	}
-	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale);
+
+	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale, internal->muted);
 	internal->ensure_playback_limit();
 
 	// Sample handling.
@@ -247,6 +256,9 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
@@ -283,6 +295,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_ONESHOT, "", PROPERTY_USAGE_EDITOR), "set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
@@ -293,6 +306,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 
 	BIND_ENUM_CONSTANT(MIX_TARGET_STEREO);
 	BIND_ENUM_CONSTANT(MIX_TARGET_SURROUND);

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -82,6 +82,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -181,7 +181,7 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 void AudioStreamPlayerInternal::set_stream_paused(bool p_pause) {
 	// TODO this does not have perfect recall, fix that maybe? If there are zero playbacks registered with the AudioServer, this bool isn't persisted.
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_paused(playback, p_pause);
+		AudioServer::get_singleton()->set_playback_paused(playback, p_pause, muted);
 		if (_is_sample() && playback->get_sample_playback().is_valid()) {
 			AudioServer::get_singleton()->set_sample_playback_pause(playback->get_sample_playback(), p_pause);
 		}
@@ -320,6 +320,16 @@ void AudioStreamPlayerInternal::set_pitch_scale(float p_pitch_scale) {
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->set_playback_pitch_scale(playback, pitch_scale);
 	}
+}
+
+void AudioStreamPlayerInternal::set_mute(bool p_mute) {
+	muted = p_mute;
+
+	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+		AudioServer::get_singleton()->set_playback_muted(playback, p_mute, get_stream_paused());
+	}
+
+	node->emit_signal(SceneStringName(mute_toggled));
 }
 
 void AudioStreamPlayerInternal::set_max_polyphony(int p_max_polyphony) {

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -71,6 +71,7 @@ public:
 
 	SafeFlag active;
 
+	bool muted = false;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
@@ -87,6 +88,7 @@ public:
 	void get_property_list(List<PropertyInfo> *p_list) const;
 
 	void set_stream(Ref<AudioStream> p_stream);
+	void set_mute(bool p_mute);
 	void set_pitch_scale(float p_pitch_scale);
 	void set_max_polyphony(int p_max_polyphony);
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -131,6 +131,8 @@ public:
 
 	const StringName Master = "Master"; // Audio bus name.
 
+	const StringName mute_toggled = "mute_toggled";
+
 	const StringName theme_changed = "theme_changed";
 	const StringName shader = "shader";
 	const StringName shader_overrides_group = "_shader_overrides_group_";

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -407,7 +407,7 @@ void AudioServer::_mix_step() {
 		// If `fading_out` is true, we're in the process of fading out the stream playback.
 		// TODO: Currently this sets the volume of the stream to 0 which creates a linear interpolation between its previous volume and silence.
 		//  A more punchy option for fading out could be to just use the lookahead buffer.
-		bool fading_out = playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+		bool fading_out = playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 
 		AudioFrame *buf = mix_buffer.ptrw();
 
@@ -418,6 +418,11 @@ void AudioServer::_mix_step() {
 
 		// Mix the audio stream.
 		unsigned int mixed_frames = playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE], playback->pitch_scale.get(), buffer_size);
+		if (playback->state.load() == AudioStreamPlaybackListNode::MUTED || playback->state.load() == AudioStreamPlaybackListNode::AWAITING_DELETION) {
+			for (unsigned int i = 0; i < mixed_frames; i++) {
+				buf[i] = AudioFrame(0, 0);
+			}
+		}
 
 		if (tag_used_audio_streams && playback->stream_playback->is_playing()) {
 			playback->stream_playback->tag_used_streams();
@@ -425,23 +430,33 @@ void AudioServer::_mix_step() {
 
 		// Check to see if the stream has run out of samples.
 		if (mixed_frames != buffer_size) {
-			// We know we have at least the size of our lookahead buffer for fade-out purposes.
+			AudioStreamPlaybackListNode::PlaybackState old_state;
+			old_state = playback->state.load();
+			if (!(old_state == AudioStreamPlaybackListNode::MUTED)) {
+				// We know we have at least the size of our lookahead buffer for fade-out purposes.
 
-			float fadeout_base = 0.94;
-			float fadeout_coefficient = 1;
-			static_assert(LOOKAHEAD_BUFFER_SIZE == 64, "Update fadeout_base and comment here if you change LOOKAHEAD_BUFFER_SIZE.");
-			// 0.94 ^ 64 = 0.01906. There might still be a pop but it'll be way better than if we didn't do this.
-			for (unsigned int idx = mixed_frames; idx < buffer_size; idx++) {
-				fadeout_coefficient *= fadeout_base;
-				buf[idx] *= fadeout_coefficient;
+				float fadeout_base = 0.94;
+				float fadeout_coefficient = 1;
+				static_assert(LOOKAHEAD_BUFFER_SIZE == 64, "Update fadeout_base and comment here if you change LOOKAHEAD_BUFFER_SIZE.");
+				// 0.94 ^ 64 = 0.01906. There might still be a pop but it'll be way better than if we didn't do this.
+				for (unsigned int idx = mixed_frames; idx < buffer_size; idx++) {
+					fadeout_coefficient *= fadeout_base;
+					buf[idx] *= fadeout_coefficient;
+				}
 			}
 			AudioStreamPlaybackListNode::PlaybackState new_state;
 			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION;
 			playback->state.store(new_state);
 		} else {
 			// Move the last little bit of what we just mixed into our lookahead buffer for the next call to _mix_step.
-			for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
-				playback->lookahead[i] = buf[buffer_size + i];
+			if (!(playback->state.load() == AudioStreamPlaybackListNode::MUTED)) {
+				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+					playback->lookahead[i] = buf[buffer_size + i];
+				}
+			} else {
+				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+					playback->lookahead[i] = AudioFrame(0, 0);
+				}
 			}
 		}
 
@@ -537,12 +552,17 @@ void AudioServer::_mix_step() {
 				// Remove the playback from the list.
 				_delete_stream_playback_list_node(playback);
 				break;
-			case AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE: {
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE:
 				// Pause the stream.
 				playback->state.store(AudioStreamPlaybackListNode::PAUSED);
-			} break;
+				break;
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE:
+				// Mute the stream.
+				playback->state.store(AudioStreamPlaybackListNode::MUTED);
+				break;
 			case AudioStreamPlaybackListNode::PLAYING:
 			case AudioStreamPlaybackListNode::PAUSED:
+			case AudioStreamPlaybackListNode::MUTED:
 				// No-op!
 				break;
 		}
@@ -1236,16 +1256,16 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale, bool p_muted) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	HashMap<StringName, Vector<AudioFrame>> map;
 	map[p_bus] = p_volume_db_vector;
 
-	start_playback_stream(p_playback, map, p_start_time, p_pitch_scale);
+	start_playback_stream(p_playback, map, p_start_time, p_pitch_scale, p_muted);
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time, float p_pitch_scale, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time, float p_pitch_scale, bool p_muted, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = new AudioStreamPlaybackListNode();
@@ -1281,7 +1301,11 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 		frame = AudioFrame(0, 0);
 	}
 
-	playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+	if (!p_muted) {
+		playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+	} else {
+		playback_node->state.store(AudioStreamPlaybackListNode::MUTED);
+	}
 
 	playback_list.insert(playback_node);
 }
@@ -1314,7 +1338,11 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 		if (old_state == AudioStreamPlaybackListNode::AWAITING_DELETION) {
 			break; // Don't fade out again.
 		}
-		new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
+		if (old_state == AudioStreamPlaybackListNode::MUTED) {
+			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION; // No need to fade out.
+		} else {
+			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
+		}
 
 	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
 }
@@ -1406,7 +1434,7 @@ void AudioServer::set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, 
 	playback_node->pitch_scale.set(p_pitch_scale);
 }
 
-void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused) {
+void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
@@ -1417,11 +1445,58 @@ void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool 
 	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
 	do {
 		old_state = playback_node->state.load();
-		new_state = p_paused ? AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE : AudioStreamPlaybackListNode::PLAYING;
-		if (!p_paused && old_state == AudioStreamPlaybackListNode::PLAYING) {
+		if (p_paused) {
+			if (!p_muted) {
+				new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+			} else {
+				new_state = AudioStreamPlaybackListNode::PAUSED;
+			}
+		} else {
+			if (!p_muted) {
+				new_state = AudioStreamPlaybackListNode::PLAYING;
+			} else {
+				new_state = AudioStreamPlaybackListNode::MUTED;
+			}
+		}
+
+		if (!p_paused && (old_state == AudioStreamPlaybackListNode::PLAYING || old_state == AudioStreamPlaybackListNode::MUTED)) {
 			return; // No-op.
 		}
 		if (p_paused && (old_state == AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+			return; // No-op.
+		}
+
+	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+}
+
+void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+
+	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	do {
+		old_state = playback_node->state.load();
+		new_state = p_mute ? AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE : AudioStreamPlaybackListNode::PLAYING;
+		if (p_mute && !p_paused) {
+			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
+		} else if (!p_mute && !p_paused) {
+			new_state = AudioStreamPlaybackListNode::PLAYING;
+		} else {
+			new_state = AudioStreamPlaybackListNode::PAUSED;
+		}
+
+		if (!p_mute) {
+			if (!p_paused && old_state == AudioStreamPlaybackListNode::PLAYING) {
+				return; // No-op.
+			} else if (p_paused && old_state == (AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+				return; // No-op.
+			}
+		}
+		if (p_mute && !p_paused && (old_state == AudioStreamPlaybackListNode::MUTED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
 			return; // No-op.
 		}
 
@@ -1456,7 +1531,7 @@ bool AudioServer::is_playback_active(Ref<AudioStreamPlayback> p_playback) {
 		return false;
 	}
 
-	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING;
+	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING || playback_node->state.load() == AudioStreamPlaybackListNode::MUTED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 }
 
 float AudioServer::get_playback_position(Ref<AudioStreamPlayback> p_playback) {
@@ -1485,6 +1560,18 @@ bool AudioServer::is_playback_paused(Ref<AudioStreamPlayback> p_playback) {
 	}
 
 	return playback_node->state.load() == AudioStreamPlaybackListNode::PAUSED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+}
+
+// Unused. Will return `false` if paused and the player is muted.
+bool AudioServer::is_playback_muted(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND_V(p_playback.is_null(), false);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return false;
+	}
+
+	return playback_node->state.load() == AudioStreamPlaybackListNode::MUTED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 }
 
 uint64_t AudioServer::get_mix_count() const {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -279,16 +279,20 @@ private:
 		// 1. The playback is created and added to the playback list in the playing state.
 		// 2. The playback is (maybe) paused, and the state is set to FADE_OUT_TO_PAUSE.
 		// 2.1. The playback is mixed after being paused, and the audio server thread atomically sets the state to PAUSED after performing a brief fade-out.
-		// 3. The playback is (maybe) deleted, and the state is set to FADE_OUT_TO_DELETION.
-		// 3.1. The playback is mixed after being deleted, and the audio server thread atomically sets the state to AWAITING_DELETION after performing a brief fade-out.
+		// 3. The playback is (maybe) muted, and the state is set to FADE_OUT_TO_MUTE.
+		// 3.1. The playback is mixed after being muted, and the audio server thread atomically sets the state to MUTED after performing a brief fade-out.
+		// 4. The playback is (maybe) deleted, and the state is set to FADE_OUT_TO_DELETION.
+		// 4.1. The playback is mixed after being deleted, and the audio server thread atomically sets the state to AWAITING_DELETION after performing a brief fade-out.
 		// 		NOTE: The playback is not deallocated at this time because allocation and deallocation are not realtime-safe.
-		// 4. The playback is removed and deallocated on the main thread using the SafeList maybe_cleanup method.
+		// 5. The playback is removed and deallocated on the main thread using the SafeList maybe_cleanup method.
 		enum PlaybackState {
 			PAUSED = 0, // Paused. Keep this stream playback around though so it can be restarted.
 			PLAYING = 1, // Playing. Fading may still be necessary if volume changes!
-			FADE_OUT_TO_PAUSE = 2, // About to pause.
-			FADE_OUT_TO_DELETION = 3, // About to stop.
-			AWAITING_DELETION = 4,
+			MUTED = 2, // Playing while muted. Buffer is filled with `AudioFrame(0, 0)`.
+			FADE_OUT_TO_PAUSE = 3, // About to pause.
+			FADE_OUT_TO_MUTE = 4, // About to mute.
+			FADE_OUT_TO_DELETION = 5, // About to stop.
+			AWAITING_DELETION = 6,
 		};
 		// If zero or positive, a place in the stream to seek to during the next mix.
 		SafeNumeric<float> setseek;
@@ -431,21 +435,23 @@ public:
 	float get_playback_speed_scale() const;
 
 	// Convenience method.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1, bool p_muted = false);
 	// Expose all parameters.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, bool p_muted = false, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
 
 	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes);
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes);
 	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
 	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);
-	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused);
+	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted);
+	void set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused);
 	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);
 
 	bool is_playback_active(Ref<AudioStreamPlayback> p_playback);
 	float get_playback_position(Ref<AudioStreamPlayback> p_playback);
 	bool is_playback_paused(Ref<AudioStreamPlayback> p_playback);
+	bool is_playback_muted(Ref<AudioStreamPlayback> p_playback);
 
 	uint64_t get_mix_count() const;
 	uint64_t get_mixed_frames() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
## Important note
This PR is a draft because we haven't reached a conclusion on how button to the scene tree should be added for this.
Here's a simpler PR that just adds the methods: https://github.com/godotengine/godot/pull/120894

### Overview
- Closes https://github.com/godotengine/godot-proposals/issues/2037

This PR introduces mute toggles that can be accessed via an AudioStreamPlayer's inspector, and the scene tree.
While -80 dB (minimum volume in the inspector slider) is not really audible, the only way to truly mute audio is to either set linear volume to 0 (-INF dB, both unavailable to the editor) or muting in the bus. Adjusting the slider or muting in the bus are not desirable in every case, since one could just want to mute one or multiple players, and easily return to the previous levels.


<img width="287" height="287" alt="mute_players_img_1" src="https://github.com/user-attachments/assets/0b0b44da-c859-47fd-bb09-6fe40c1b5172" />


https://github.com/user-attachments/assets/88fe6c2b-b321-499e-a231-6ce25b844df1



### Limitations
- Mute only works for the Stream playback type

I'm not comfortable editing code related to the Sample playback type. A little too much. I suggest someone to try adding that. This limitation is mentioned in the documentation.

- Mute only works in the regular/local scene tree

The toggle is not available in the remote tree. There was an attempt, but wasn't working properly. Again, I suggest someone to try adding that eventually, since it could be useful.

### Notes for reviewers
In general, despite a few of my small contributions in this repository (mostly related to audio), I'm not a very experienced programmer. This is my first time modifying the AudioServer. Would appreciate someone checking that.
I'm also not super experienced with the editor code. Most of it was copied from code related to the visibility button, but modified a bit so it'd make sense.

I've tested the changes, and things seem to work on my end.

If a new button in the scene tree really is too much, I could make an alternative PR that just adds the mute property to AudioStreamPlayers, but then the proposal wouldn't be closed.