### PR TITLE
Fix crash in Project Settings when an autoload has been freed

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -502,7 +502,7 @@ void EditorAutoloadSettings::update_autoload() {
 			if (old_info.path == info.path) {
 				// Still the same resource, check status
 				info.node = old_info.node;
-				if (info.node) {
+				if (info.node && info.node->is_instance()) {
 					Ref<Script> scr = info.node->get_script();
 					info.in_editor = scr.is_valid() && scr->is_tool();
 					if (info.is_singleton == old_info.is_singleton && info.in_editor == old_info.in_editor) {


### PR DESCRIPTION
The `EditorAutoloadSettings` class does not expect an autoload node to be freed in between its initial instantiation and any calls to `update_autoload()`. But this actually *can* happen if the autoload is an editor script and happens to run something like `queue_free()` shortly after being initialized.

When this happens, opening the project settings panel results in a crash, since the editor is trying to locate data such as the node's script after it has already been deleted.

To fix this, just verify that the node still exists prior to accessing any of the node's data.

## What problem(s) does this PR solve?

- Fixes a crash when opening the Project Settings dialog in the editor after an autoload node has been freed after it was initialized.
  - I've uploaded a reference project that recreates this issue [at this URL](https://www.mew151.net/creative/godot-editor-autoload-crash-project.zip), though you can easily reproduce this by creating a new autoload and:
    1. Giving it the `@tool` declaration
    2. Having it immediately run `queue_free()` on initialization. 

## Additional information

- No AI tools were used in the creation of the pull request.
- I'd be happy to write tests for this, but it doesn't look like there's a precedent for automated tests in editor code? I think?