### PR TITLE
Fix incorrect non-unique resource indicator

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4767,7 +4767,6 @@ void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state) {
 
 	Node *old_scene = get_editor_data().get_edited_scene_root();
 
-	resource_count.clear();
 	editor_selection->clear();
 	SceneTreeDock::get_singleton()->clear_previous_node_selection();
 	editor_data.set_edited_scene(p_idx);
@@ -4799,6 +4798,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state) {
 
 		EditorUndoRedoManager::get_singleton()->clear_history(editor_data.get_scene_history_id(p_idx), false);
 	}
+	resource_count.clear();
 	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 
 	_update_title();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120581

## Additional information

The scene reconstruction in `_set_current_scene_nocheck` will trigger `update_resource_count` which will end up counting both references from the old and the new scene. There are many execution paths that can run `update_resource_count`, the most common being `_update_if_clean` issuing a deferred call to `_update_tree` which then calls `_update_node_subtree` which will `update_resource_count` on every node.

Since the count will be corrupted anyway, I believe there is no point in clearing the count (`resource_count.clear();`) before the reconstruction.

During local reproduction `update_resource_count` will end with the incorrect count before `_set_current_scene_nocheck` finishes, so it makes sense to me intervene near the end of `_set_current_scene_nocheck`. This intervention would consist of clearing the count (`resource_count.clear();`) and triggering a recount (`SceneTreeDock::get_singleton()->clear_previous_node_selection();`). The code already had the recount call, so I inserted the clear right before it.

I have tested that after this change the issue is no longer reproduced, and the indicator still appears for any embedded resource used multiple times, and for external resources.

*This particular issue is a common annoyance for our indie studio Psyches Media, so I'm glad to be able put time to fix it.*