### PR TITLE
Docs: Add missing C# examples for Tween

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -264,11 +264,18 @@
 			<description>
 				If [param parallel] is [code]true[/code], the [Tweener]s appended after this method will by default run simultaneously, as opposed to sequentially.
 				[b]Note:[/b] Just like with [method parallel], the tweener added right before this method will also be part of the parallel step.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				tween.tween_property(self, "position", Vector2(300, 0), 0.5)
 				tween.set_parallel()
 				tween.tween_property(self, "modulate", Color.GREEN, 0.5) # Runs together with the position tweener.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				tween.TweenProperty(this, "position", new Vector2(300, 0), 0.5f);
+				tween.SetParallel();
+				tween.TweenProperty(this, "modulate", Colors.Green, 0.5f); // Runs together with the position tweener.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_pause_mode">
@@ -300,12 +307,20 @@
 			<description>
 				Sets the default transition type for [PropertyTweener]s and [MethodTweener]s appended after this method.
 				Before this method is called, the default transition type is [constant TRANS_LINEAR].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_property(self, "position", Vector2(300, 0), 0.5) # Uses TRANS_LINEAR.
 				tween.set_trans(Tween.TRANS_SINE)
 				tween.tween_property(self, "rotation_degrees", 45.0, 0.5) # Uses TRANS_SINE.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenProperty(this, "position", new Vector2(300, 0), 0.5f); // Uses TransitionType.Linear.
+				tween.SetTrans(Tween.TransitionType.Sine);
+				tween.TweenProperty(this, "rotation_degrees", 45.0f, 0.5f); // Uses TransitionType.Sine.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="stop">
@@ -313,7 +328,8 @@
 			<description>
 				Stops the tweening and resets the [Tween] to its initial state. This will not remove any appended [Tweener]s.
 				[b]Note:[/b] This does [i]not[/i] reset targets of [PropertyTweener]s to their values when the [Tween] first started.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 
 				# Will move from 0 to 500 over 1 second.
@@ -327,7 +343,23 @@
 				# thus at half the speed as before.
 				tween.stop()
 				tween.play()
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+
+				// Will move from 0 to 500 over 1 second.
+				Position = Position with { X = 0.0f };
+				tween.TweenProperty(this, "position:x", 500.0f, 1.0f);
+
+				// Will be at (about) 250 when the timer finishes.
+				await ToSignal(GetTree().CreateTimer(0.5f), Timer.SignalName.Timeout);
+
+				// Will now move from (about) 250 to 500 over 1 second,
+				// thus at half the speed as before.
+				tween.Stop();
+				tween.Play();
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] If a Tween is stopped and not bound to any node, it will exist indefinitely until manually started or invalidated. If you lose a reference to such Tween, you can retrieve it using [method SceneTree.get_processed_tweens].
 			</description>
 		</method>
@@ -339,27 +371,52 @@
 				The animation will not progress to the next step until the awaited signal is emitted or the connection becomes invalid (e.g. as a result of freeing the target object). If you know that the emission may not happen, use [method AwaitTweener.set_timeout].
 				[b]Note:[/b] The awaited signal should be emitted during the step when [AwaitTweener] is active.
 				[b]Example:[/b] An object launches itself and explodes upon collision or after 4 seconds.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_callback(launch)
 				tween.tween_await(collided).set_timeout(4.0)
 				tween.tween_callback(explode)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenCallback(Callable.From(Launch));
+				tween.TweenAwait(new Signal(this, SignalName.Collided)).SetTimeout(4.0f);
+				tween.TweenCallback(Callable.From(Explode));
+				[/csharp]
+				[/codeblocks]
 				[b]Example:[/b] A character walks to a specific point, says some lines and walks back when the player closes the message box.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_callback(walk_to.bind(600.0))
 				tween.tween_await(destination_reached)
 				tween.tween_callback(say_dialogue.bind("Good day, sir!"))
 				tween.tween_await(dialogue_closed)
 				tween.tween_callback(walk_to.bind(0.0))
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenCallback(Callable.From(() => WalkTo(600.0f)));
+				tween.TweenAwait(new Signal(this, SignalName.DestinationReached));
+				tween.TweenCallback(Callable.From(() => SayDialogue("Good day, sir!")));
+				tween.TweenAwait(new Signal(this, SignalName.DialogueClosed));
+				tween.TweenCallback(Callable.From(() => WalkTo(0.0f)));
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] If you are awaiting a signal from a callback called in the same [Tween], make sure the signal is emitted [i]after[/i] the await starts. If it can't be reasonably guaranteed, you can await and emit in the same step:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_await(signal)
 				tween.parallel().tween_callback(method_that_emits_signal)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenAwait(new Signal(this, SignalName.Signal));
+				tween.Parallel().TweenCallback(Callable.From(MethodThatEmitsSignal));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="tween_callback">
@@ -523,7 +580,8 @@
 			<param index="0" name="subtween" type="Tween" />
 			<description>
 				Creates and appends a [SubtweenTweener]. This method can be used to nest [param subtween] within this [Tween], allowing for the creation of more complex and composable sequences.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# Subtween will rotate the object.
 				var subtween = create_tween()
 				subtween.tween_property(self, "rotation_degrees", 45.0, 1.0)
@@ -534,7 +592,20 @@
 				tween.tween_property(self, "position:x", 500, 3.0)
 				tween.tween_subtween(subtween)
 				tween.tween_property(self, "position:x", 300, 2.0)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// Subtween will rotate the object.
+				Tween subtween = CreateTween();
+				subtween.TweenProperty(this, "rotation_degrees", 45.0f, 1.0f);
+				subtween.TweenProperty(this, "rotation_degrees", 0.0f, 1.0f);
+
+				// Parent tween will execute the subtween as one of its steps.
+				Tween tween = CreateTween();
+				tween.TweenProperty(this, "position:x", 500.0f, 3.0f);
+				tween.TweenSubtween(subtween);
+				tween.TweenProperty(this, "position:x", 300.0f, 2.0f);
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] The methods [method pause], [method stop], and [method set_loops] can cause the parent [Tween] to get stuck on the subtween step; see the documentation for those methods for more information.
 				[b]Note:[/b] The pause and process modes set by [method set_pause_mode] and [method set_process_mode] on [param subtween] will be overridden by the parent [Tween]'s settings.
 			</description>


### PR DESCRIPTION
Addressing godotengine/godot-docs#11962. I also added all the previously missing examples for said class. The following methods now have valid C# examples:
- Tween.SetParallel
- Tween.SetTrans
- Tween.Stop
- Tween.TweenAwait
- Tween.TweenSubtween

