### PR TITLE
Fix CanvasItem transform notification flag being ignored on tree entry

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -423,7 +423,7 @@ void CanvasItem::_notification(int p_what) {
 			_update_texture_filter_changed(false);
 			_update_texture_repeat_changed(false);
 
-			if (!block_transform_notify && !xform_change.in_list()) {
+			if (notify_transform && !block_transform_notify && !xform_change.in_list()) {
 				get_tree()->xform_change_list.add(&xform_change);
 			}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Introduced #120892

Previously, a CanvasItem could be added to `xform_change_list `when entering the scene tree even if transform notifications were disabled with `set_notify_transform(false)`. As a result, the node could still receive `NOTIFICATION_TRANSFORM_CHANGED `despite explicitly disabling transform notifications.

The fix adds a notify_transform check before adding the item to `xform_change_list`:

```gdscript
if (notify_transform && !block_transform_notify && !xform_change.in_list()) {
	get_tree()->xform_change_list.add(&xform_change);
}
``` 

AI was used only to help translate and polish the text of this pull request. The code change, testing, and debugging were done manually

- Closes #84172
- Closes #120892