### PR TITLE
Add mute property to AudioStreamPlayers

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -72,6 +72,10 @@
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
 			The mix target channels. Has no effect when two speakers or less are detected (see [enum AudioServer.SpeakerMode]).
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="pitch_scale" type="float" setter="set_pitch_scale" getter="get_pitch_scale" default="1.0">
 			The audio's pitch and tempo, as a multiplier of the [member stream]'s sample rate. A value of [code]2.0[/code] doubles the audio's pitch, while a value of [code]0.5[/code] halves the pitch.
 		</member>
@@ -101,6 +105,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when a sound finishes playing without interruptions. This signal is [i]not[/i] emitted when calling [method stop], or when exiting the tree while sounds are playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -72,6 +72,10 @@
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/2d_panning_strength] with this factor. Higher values will pan audio from left to right more dramatically than lower values.
 		</member>
@@ -102,6 +106,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when the audio stops playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -94,6 +94,10 @@
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 		</member>
+		<member name="mute" type="bool" setter="set_mute" getter="is_muted" default="false">
+			The mute control. If [code]true[/code], audio will be silenced, while continuing to play.
+			[b]Note:[/b] This only works if [member playback_type] is set to [constant AudioServer.PLAYBACK_TYPE_STREAM].
+		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/3d_panning_strength] by this factor. If the product is [code]0.0[/code] then stereo panning is disabled and the volume is the same for all channels. If the product is [code]1.0[/code] then one of the channels will be muted when the sound is located exactly to the left (or right) of the listener.
 			Two speaker stereo arrangements implement the [url=https://webaudio.github.io/web-audio-api/#stereopanner-algorithm]WebAudio standard for StereoPannerNode Panning[/url] where the volume is cosine of half the azimuth angle to the ear.
@@ -129,6 +133,11 @@
 		<signal name="finished">
 			<description>
 				Emitted when the audio stops playing.
+			</description>
+		</signal>
+		<signal name="mute_toggled">
+			<description>
+				Emitted when [member mute] is toggled.
 			</description>
 		</signal>
 	</signals>

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -66,7 +66,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 			if (setplayback.is_valid() && setplay.get() >= 0) {
 				internal->active.set();
-				AudioServer::get_singleton()->start_playback_stream(setplayback, _get_actual_bus(), volume_vector, setplay.get(), internal->pitch_scale);
+				AudioServer::get_singleton()->start_playback_stream(setplayback, _get_actual_bus(), volume_vector, setplay.get(), internal->pitch_scale, internal->muted);
 				setplayback.unref();
 				setplay.set(-1);
 			}
@@ -227,6 +227,14 @@ void AudioStreamPlayer2D::set_volume_linear(float p_volume) {
 
 float AudioStreamPlayer2D::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
+}
+
+void AudioStreamPlayer2D::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer2D::is_muted() const {
+	return internal->muted;
 }
 
 void AudioStreamPlayer2D::set_pitch_scale(float p_pitch_scale) {
@@ -390,6 +398,9 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer2D::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer2D::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer2D::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer2D::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer2D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer2D::get_pitch_scale);
 
@@ -435,6 +446,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_ONESHOT, "", PROPERTY_USAGE_EDITOR), "set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
@@ -448,6 +460,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 }
 
 AudioStreamPlayer2D::AudioStreamPlayer2D() {

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -100,6 +100,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -290,7 +290,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				internal->active.set();
 				HashMap<StringName, Vector<AudioFrame>> bus_map;
 				bus_map[_get_actual_bus()] = volume_vector;
-				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
+				AudioServer::get_singleton()->start_playback_stream(setplayback, bus_map, setplay.get(), actual_pitch_scale, internal->muted, linear_attenuation, attenuation_filter_cutoff_hz);
 				setplayback.unref();
 				setplay.set(-1);
 			}
@@ -621,6 +621,14 @@ float AudioStreamPlayer3D::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
 }
 
+void AudioStreamPlayer3D::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer3D::is_muted() const {
+	return internal->muted;
+}
+
 void AudioStreamPlayer3D::set_unit_size(float p_volume) {
 	unit_size = p_volume;
 	update_gizmos();
@@ -867,6 +875,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer3D::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer3D::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer3D::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer3D::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_unit_size", "unit_size"), &AudioStreamPlayer3D::set_unit_size);
 	ClassDB::bind_method(D_METHOD("get_unit_size"), &AudioStreamPlayer3D::get_unit_size);
 
@@ -937,6 +948,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,Inverse Square,Logarithmic,Disabled"), "set_attenuation_model", "get_attenuation_model");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_size", PROPERTY_HINT_RANGE, "0.1,100,0.01,or_greater"), "set_unit_size", "get_unit_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_db", PROPERTY_HINT_RANGE, "-24,6,suffix:dB"), "set_max_db", "get_max_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
@@ -969,6 +981,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOPPLER_TRACKING_PHYSICS_STEP);
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 }
 
 AudioStreamPlayer3D::AudioStreamPlayer3D() {

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -152,6 +152,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_unit_size(float p_volume);
 	float get_unit_size() const;
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -90,6 +90,14 @@ float AudioStreamPlayer::get_volume_linear() const {
 	return Math::db_to_linear(get_volume_db());
 }
 
+void AudioStreamPlayer::set_mute(bool p_mute) {
+	internal->set_mute(p_mute);
+}
+
+bool AudioStreamPlayer::is_muted() const {
+	return internal->muted;
+}
+
 void AudioStreamPlayer::set_pitch_scale(float p_pitch_scale) {
 	internal->set_pitch_scale(p_pitch_scale);
 }
@@ -111,7 +119,8 @@ void AudioStreamPlayer::play(float p_from_pos) {
 	if (stream_playback.is_null()) {
 		return;
 	}
-	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale);
+
+	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale, internal->muted);
 	internal->ensure_playback_limit();
 
 	// Sample handling.
@@ -247,6 +256,9 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_volume_linear", "volume_linear"), &AudioStreamPlayer::set_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_volume_linear"), &AudioStreamPlayer::get_volume_linear);
 
+	ClassDB::bind_method(D_METHOD("set_mute", "mute"), &AudioStreamPlayer::set_mute);
+	ClassDB::bind_method(D_METHOD("is_muted"), &AudioStreamPlayer::is_muted);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer::get_pitch_scale);
 
@@ -283,6 +295,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mute"), "set_mute", "is_muted");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_ONESHOT, "", PROPERTY_USAGE_EDITOR), "set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
@@ -293,6 +306,7 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_type", PROPERTY_HINT_ENUM, "Default,Stream,Sample"), "set_playback_type", "get_playback_type");
 
 	ADD_SIGNAL(MethodInfo("finished"));
+	ADD_SIGNAL(MethodInfo("mute_toggled"));
 
 	BIND_ENUM_CONSTANT(MIX_TARGET_STEREO);
 	BIND_ENUM_CONSTANT(MIX_TARGET_SURROUND);

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -82,6 +82,9 @@ public:
 	void set_volume_linear(float p_volume);
 	float get_volume_linear() const;
 
+	void set_mute(bool p_mute);
+	bool is_muted() const;
+
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
 

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -181,7 +181,7 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 void AudioStreamPlayerInternal::set_stream_paused(bool p_pause) {
 	// TODO this does not have perfect recall, fix that maybe? If there are zero playbacks registered with the AudioServer, this bool isn't persisted.
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_paused(playback, p_pause, muted);
+		AudioServer::get_singleton()->set_playback_paused(playback, p_pause);
 		if (_is_sample() && playback->get_sample_playback().is_valid()) {
 			AudioServer::get_singleton()->set_sample_playback_pause(playback->get_sample_playback(), p_pause);
 		}
@@ -326,7 +326,7 @@ void AudioStreamPlayerInternal::set_mute(bool p_mute) {
 	muted = p_mute;
 
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_muted(playback, p_mute, get_stream_paused());
+		AudioServer::get_singleton()->set_playback_muted(playback, p_mute);
 	}
 
 	node->emit_signal(SceneStringName(mute_toggled));

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -181,7 +181,7 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 void AudioStreamPlayerInternal::set_stream_paused(bool p_pause) {
 	// TODO this does not have perfect recall, fix that maybe? If there are zero playbacks registered with the AudioServer, this bool isn't persisted.
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_paused(playback, p_pause);
+		AudioServer::get_singleton()->set_playback_paused(playback, p_pause, muted);
 		if (_is_sample() && playback->get_sample_playback().is_valid()) {
 			AudioServer::get_singleton()->set_sample_playback_pause(playback->get_sample_playback(), p_pause);
 		}
@@ -320,6 +320,16 @@ void AudioStreamPlayerInternal::set_pitch_scale(float p_pitch_scale) {
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->set_playback_pitch_scale(playback, pitch_scale);
 	}
+}
+
+void AudioStreamPlayerInternal::set_mute(bool p_mute) {
+	muted = p_mute;
+
+	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+		AudioServer::get_singleton()->set_playback_muted(playback, p_mute, get_stream_paused());
+	}
+
+	node->emit_signal(SceneStringName(mute_toggled));
 }
 
 void AudioStreamPlayerInternal::set_max_polyphony(int p_max_polyphony) {

--- a/scene/audio/audio_stream_player_internal.h
+++ b/scene/audio/audio_stream_player_internal.h
@@ -71,6 +71,7 @@ public:
 
 	SafeFlag active;
 
+	bool muted = false;
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
@@ -87,6 +88,7 @@ public:
 	void get_property_list(List<PropertyInfo> *p_list) const;
 
 	void set_stream(Ref<AudioStream> p_stream);
+	void set_mute(bool p_mute);
 	void set_pitch_scale(float p_pitch_scale);
 	void set_max_polyphony(int p_max_polyphony);
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -131,6 +131,8 @@ public:
 
 	const StringName Master = "Master"; // Audio bus name.
 
+	const StringName mute_toggled = "mute_toggled";
+
 	const StringName theme_changed = "theme_changed";
 	const StringName shader = "shader";
 	const StringName shader_overrides_group = "_shader_overrides_group_";

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -447,14 +447,8 @@ void AudioServer::_mix_step() {
 			playback->state.store(new_state);
 		} else {
 			// Move the last little bit of what we just mixed into our lookahead buffer for the next call to _mix_step.
-			if (playback->state.load() != AudioStreamPlaybackListNode::MUTED) {
-				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
-					playback->lookahead[i] = buf[buffer_size + i];
-				}
-			} else {
-				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
-					playback->lookahead[i] = AudioFrame(0, 0);
-				}
+			for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+				playback->lookahead[i] = buf[buffer_size + i];
 			}
 		}
 
@@ -1446,29 +1440,23 @@ void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool 
 	do {
 		current_state = playback_node->state.load();
 		if (p_paused) {
-			if (current_state == AudioStreamPlaybackListNode::MUTED) {
+			if (playback_node->mute_check.is_set()) {
 				new_state = AudioStreamPlaybackListNode::PAUSED;
-				print_line("DEBUG: In paused: new_state = PAUSED");
 			} else {
 				new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
-				print_line("DEBUG: In paused: new_state = FADE PAUSE");
 			}
 		} else {
 			if (playback_node->mute_check.is_set()) {
 				new_state = AudioStreamPlaybackListNode::MUTED;
-				print_line("DEBUG: In paused: new_state = MUTED");
 			} else {
 				new_state = AudioStreamPlaybackListNode::PLAYING;
-				print_line("DEBUG: In paused: new_state = PLAYING");
 			}
 		}
 
-		if (!p_paused && (current_state == AudioStreamPlaybackListNode::PLAYING || current_state == AudioStreamPlaybackListNode::MUTED)) {
-			print_line("DEBUG: In paused: No-op 1");
+		if (p_paused && (current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
 			return; // No-op.
 		}
-		if (p_paused && (current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
-			print_line("DEBUG: In paused: No-op 2");
+		if (!p_paused && !(current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
 			return; // No-op.
 		}
 
@@ -1486,31 +1474,32 @@ void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p
 	if (p_mute) {
 		if (!playback_node->mute_check.is_set()) {
 			playback_node->mute_check.set();
-			print_line("DEBUG: In mute: set mute_check");
 		}
 	} else {
 		if (playback_node->mute_check.is_set()) {
 			playback_node->mute_check.clear();
-			print_line("DEBUG: In mute: clear mute_check");
 		}
 	}
 
 	AudioStreamPlaybackListNode::PlaybackState new_state, current_state;
 	do {
 		current_state = playback_node->state.load();
-		if (p_mute && current_state != AudioStreamPlaybackListNode::PAUSED) {
+		bool paused = current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE ? true : false;
+		if (p_mute && !paused) {
 			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
-			print_line("DEBUG: In mute: new_state = FADE MUTE");
-		} else if (!p_mute && !(current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+		} else if (!p_mute && !paused) {
 			new_state = AudioStreamPlaybackListNode::PLAYING;
-			print_line("DEBUG: In mute: new_state = PLAYING");
 		} else {
-			new_state = AudioStreamPlaybackListNode::PAUSED;
-			print_line("DEBUG: In mute: new_state = PAUSED");
+			new_state = current_state;
 		}
 
+		if (paused) {
+			return; // No-op.
+		}
 		if (p_mute && (current_state == AudioStreamPlaybackListNode::MUTED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
-			print_line("DEBUG: In mute: No-op");
+			return; // No-op.
+		}
+		if (!p_mute && !(current_state == AudioStreamPlaybackListNode::MUTED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
 			return; // No-op.
 		}
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -430,9 +430,7 @@ void AudioServer::_mix_step() {
 
 		// Check to see if the stream has run out of samples.
 		if (mixed_frames != buffer_size) {
-			AudioStreamPlaybackListNode::PlaybackState old_state;
-			old_state = playback->state.load();
-			if (!(old_state == AudioStreamPlaybackListNode::MUTED)) {
+			if (playback->state.load() != AudioStreamPlaybackListNode::MUTED) {
 				// We know we have at least the size of our lookahead buffer for fade-out purposes.
 
 				float fadeout_base = 0.94;
@@ -449,7 +447,7 @@ void AudioServer::_mix_step() {
 			playback->state.store(new_state);
 		} else {
 			// Move the last little bit of what we just mixed into our lookahead buffer for the next call to _mix_step.
-			if (!(playback->state.load() == AudioStreamPlaybackListNode::MUTED)) {
+			if (playback->state.load() != AudioStreamPlaybackListNode::MUTED) {
 				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
 					playback->lookahead[i] = buf[buffer_size + i];
 				}
@@ -1303,8 +1301,10 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 
 	if (!p_muted) {
 		playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+		playback_node->mute_check.clear();
 	} else {
 		playback_node->state.store(AudioStreamPlaybackListNode::MUTED);
+		playback_node->mute_check.set();
 	}
 
 	playback_list.insert(playback_node);
@@ -1332,19 +1332,19 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 		return;
 	}
 
-	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	AudioStreamPlaybackListNode::PlaybackState new_state, current_state;
 	do {
-		old_state = playback_node->state.load();
-		if (old_state == AudioStreamPlaybackListNode::AWAITING_DELETION) {
+		current_state = playback_node->state.load();
+		if (current_state == AudioStreamPlaybackListNode::AWAITING_DELETION) {
 			break; // Don't fade out again.
 		}
-		if (old_state == AudioStreamPlaybackListNode::MUTED) {
+		if (current_state == AudioStreamPlaybackListNode::MUTED) {
 			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION; // No need to fade out.
 		} else {
 			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
 		}
 
-	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+	} while (!playback_node->state.compare_exchange_strong(current_state, new_state));
 }
 
 void AudioServer::set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes) {
@@ -1434,7 +1434,7 @@ void AudioServer::set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, 
 	playback_node->pitch_scale.set(p_pitch_scale);
 }
 
-void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted) {
+void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
@@ -1442,34 +1442,40 @@ void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool 
 		return;
 	}
 
-	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	AudioStreamPlaybackListNode::PlaybackState new_state, current_state;
 	do {
-		old_state = playback_node->state.load();
+		current_state = playback_node->state.load();
 		if (p_paused) {
-			if (!p_muted) {
-				new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
-			} else {
+			if (current_state == AudioStreamPlaybackListNode::MUTED) {
 				new_state = AudioStreamPlaybackListNode::PAUSED;
+				print_line("DEBUG: In paused: new_state = PAUSED");
+			} else {
+				new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+				print_line("DEBUG: In paused: new_state = FADE PAUSE");
 			}
 		} else {
-			if (!p_muted) {
-				new_state = AudioStreamPlaybackListNode::PLAYING;
-			} else {
+			if (playback_node->mute_check.is_set()) {
 				new_state = AudioStreamPlaybackListNode::MUTED;
+				print_line("DEBUG: In paused: new_state = MUTED");
+			} else {
+				new_state = AudioStreamPlaybackListNode::PLAYING;
+				print_line("DEBUG: In paused: new_state = PLAYING");
 			}
 		}
 
-		if (!p_paused && (old_state == AudioStreamPlaybackListNode::PLAYING || old_state == AudioStreamPlaybackListNode::MUTED)) {
+		if (!p_paused && (current_state == AudioStreamPlaybackListNode::PLAYING || current_state == AudioStreamPlaybackListNode::MUTED)) {
+			print_line("DEBUG: In paused: No-op 1");
 			return; // No-op.
 		}
-		if (p_paused && (old_state == AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+		if (p_paused && (current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+			print_line("DEBUG: In paused: No-op 2");
 			return; // No-op.
 		}
 
-	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+	} while (!playback_node->state.compare_exchange_strong(current_state, new_state));
 }
 
-void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused) {
+void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
@@ -1477,30 +1483,38 @@ void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p
 		return;
 	}
 
-	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	if (p_mute) {
+		if (!playback_node->mute_check.is_set()) {
+			playback_node->mute_check.set();
+			print_line("DEBUG: In mute: set mute_check");
+		}
+	} else {
+		if (playback_node->mute_check.is_set()) {
+			playback_node->mute_check.clear();
+			print_line("DEBUG: In mute: clear mute_check");
+		}
+	}
+
+	AudioStreamPlaybackListNode::PlaybackState new_state, current_state;
 	do {
-		old_state = playback_node->state.load();
-		new_state = p_mute ? AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE : AudioStreamPlaybackListNode::PLAYING;
-		if (p_mute && !p_paused) {
+		current_state = playback_node->state.load();
+		if (p_mute && current_state != AudioStreamPlaybackListNode::PAUSED) {
 			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
-		} else if (!p_mute && !p_paused) {
+			print_line("DEBUG: In mute: new_state = FADE MUTE");
+		} else if (!p_mute && !(current_state == AudioStreamPlaybackListNode::PAUSED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
 			new_state = AudioStreamPlaybackListNode::PLAYING;
+			print_line("DEBUG: In mute: new_state = PLAYING");
 		} else {
 			new_state = AudioStreamPlaybackListNode::PAUSED;
+			print_line("DEBUG: In mute: new_state = PAUSED");
 		}
 
-		if (!p_mute) {
-			if (!p_paused && old_state == AudioStreamPlaybackListNode::PLAYING) {
-				return; // No-op.
-			} else if (p_paused && old_state == (AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
-				return; // No-op.
-			}
-		}
-		if (p_mute && !p_paused && (old_state == AudioStreamPlaybackListNode::MUTED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
+		if (p_mute && (current_state == AudioStreamPlaybackListNode::MUTED || current_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
+			print_line("DEBUG: In mute: No-op");
 			return; // No-op.
 		}
 
-	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+	} while (!playback_node->state.compare_exchange_strong(current_state, new_state));
 }
 
 void AudioServer::set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz) {
@@ -1562,7 +1576,7 @@ bool AudioServer::is_playback_paused(Ref<AudioStreamPlayback> p_playback) {
 	return playback_node->state.load() == AudioStreamPlaybackListNode::PAUSED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
 }
 
-// Unused. Will return `false` if paused and the player is muted.
+// Unused.
 bool AudioServer::is_playback_muted(Ref<AudioStreamPlayback> p_playback) {
 	ERR_FAIL_COND_V(p_playback.is_null(), false);
 
@@ -1571,7 +1585,7 @@ bool AudioServer::is_playback_muted(Ref<AudioStreamPlayback> p_playback) {
 		return false;
 	}
 
-	return playback_node->state.load() == AudioStreamPlaybackListNode::MUTED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
+	return playback_node->mute_check.is_set();
 }
 
 uint64_t AudioServer::get_mix_count() const {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -407,7 +407,7 @@ void AudioServer::_mix_step() {
 		// If `fading_out` is true, we're in the process of fading out the stream playback.
 		// TODO: Currently this sets the volume of the stream to 0 which creates a linear interpolation between its previous volume and silence.
 		//  A more punchy option for fading out could be to just use the lookahead buffer.
-		bool fading_out = playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+		bool fading_out = playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE || playback->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 
 		AudioFrame *buf = mix_buffer.ptrw();
 
@@ -418,6 +418,11 @@ void AudioServer::_mix_step() {
 
 		// Mix the audio stream.
 		unsigned int mixed_frames = playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE], playback->pitch_scale.get(), buffer_size);
+		if (playback->state.load() == AudioStreamPlaybackListNode::MUTED || playback->state.load() == AudioStreamPlaybackListNode::AWAITING_DELETION) {
+			for (unsigned int i = 0; i < mixed_frames; i++) {
+				buf[i] = AudioFrame(0, 0);
+			}
+		}
 
 		if (tag_used_audio_streams && playback->stream_playback->is_playing()) {
 			playback->stream_playback->tag_used_streams();
@@ -425,23 +430,33 @@ void AudioServer::_mix_step() {
 
 		// Check to see if the stream has run out of samples.
 		if (mixed_frames != buffer_size) {
-			// We know we have at least the size of our lookahead buffer for fade-out purposes.
+			AudioStreamPlaybackListNode::PlaybackState old_state;
+			old_state = playback->state.load();
+			if (!(old_state == AudioStreamPlaybackListNode::MUTED)) {
+				// We know we have at least the size of our lookahead buffer for fade-out purposes.
 
-			float fadeout_base = 0.94;
-			float fadeout_coefficient = 1;
-			static_assert(LOOKAHEAD_BUFFER_SIZE == 64, "Update fadeout_base and comment here if you change LOOKAHEAD_BUFFER_SIZE.");
-			// 0.94 ^ 64 = 0.01906. There might still be a pop but it'll be way better than if we didn't do this.
-			for (unsigned int idx = mixed_frames; idx < buffer_size; idx++) {
-				fadeout_coefficient *= fadeout_base;
-				buf[idx] *= fadeout_coefficient;
+				float fadeout_base = 0.94;
+				float fadeout_coefficient = 1;
+				static_assert(LOOKAHEAD_BUFFER_SIZE == 64, "Update fadeout_base and comment here if you change LOOKAHEAD_BUFFER_SIZE.");
+				// 0.94 ^ 64 = 0.01906. There might still be a pop but it'll be way better than if we didn't do this.
+				for (unsigned int idx = mixed_frames; idx < buffer_size; idx++) {
+					fadeout_coefficient *= fadeout_base;
+					buf[idx] *= fadeout_coefficient;
+				}
 			}
 			AudioStreamPlaybackListNode::PlaybackState new_state;
 			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION;
 			playback->state.store(new_state);
 		} else {
 			// Move the last little bit of what we just mixed into our lookahead buffer for the next call to _mix_step.
-			for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
-				playback->lookahead[i] = buf[buffer_size + i];
+			if (!(playback->state.load() == AudioStreamPlaybackListNode::MUTED)) {
+				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+					playback->lookahead[i] = buf[buffer_size + i];
+				}
+			} else {
+				for (int i = 0; i < LOOKAHEAD_BUFFER_SIZE; i++) {
+					playback->lookahead[i] = AudioFrame(0, 0);
+				}
 			}
 		}
 
@@ -537,12 +552,17 @@ void AudioServer::_mix_step() {
 				// Remove the playback from the list.
 				_delete_stream_playback_list_node(playback);
 				break;
-			case AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE: {
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE:
 				// Pause the stream.
 				playback->state.store(AudioStreamPlaybackListNode::PAUSED);
-			} break;
+				break;
+			case AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE:
+				// Mute the stream.
+				playback->state.store(AudioStreamPlaybackListNode::MUTED);
+				break;
 			case AudioStreamPlaybackListNode::PLAYING:
 			case AudioStreamPlaybackListNode::PAUSED:
+			case AudioStreamPlaybackListNode::MUTED:
 				// No-op!
 				break;
 		}
@@ -1236,16 +1256,16 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale, bool p_muted) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	HashMap<StringName, Vector<AudioFrame>> map;
 	map[p_bus] = p_volume_db_vector;
 
-	start_playback_stream(p_playback, map, p_start_time, p_pitch_scale);
+	start_playback_stream(p_playback, map, p_start_time, p_pitch_scale, p_muted);
 }
 
-void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time, float p_pitch_scale, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
+void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time, float p_pitch_scale, bool p_muted, float p_highshelf_gain, float p_attenuation_cutoff_hz) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = new AudioStreamPlaybackListNode();
@@ -1281,7 +1301,11 @@ void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, con
 		frame = AudioFrame(0, 0);
 	}
 
-	playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+	if (!p_muted) {
+		playback_node->state.store(AudioStreamPlaybackListNode::PLAYING);
+	} else {
+		playback_node->state.store(AudioStreamPlaybackListNode::MUTED);
+	}
 
 	playback_list.insert(playback_node);
 }
@@ -1314,7 +1338,11 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 		if (old_state == AudioStreamPlaybackListNode::AWAITING_DELETION) {
 			break; // Don't fade out again.
 		}
-		new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
+		if (old_state == AudioStreamPlaybackListNode::MUTED) {
+			new_state = AudioStreamPlaybackListNode::AWAITING_DELETION; // No need to fade out.
+		} else {
+			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION;
+		}
 
 	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
 }
@@ -1406,7 +1434,7 @@ void AudioServer::set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, 
 	playback_node->pitch_scale.set(p_pitch_scale);
 }
 
-void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused) {
+void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted) {
 	ERR_FAIL_COND(p_playback.is_null());
 
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
@@ -1417,11 +1445,58 @@ void AudioServer::set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool 
 	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
 	do {
 		old_state = playback_node->state.load();
-		new_state = p_paused ? AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE : AudioStreamPlaybackListNode::PLAYING;
-		if (!p_paused && old_state == AudioStreamPlaybackListNode::PLAYING) {
+		if (p_paused) {
+			if (!p_muted) {
+				new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+			} else {
+				new_state = AudioStreamPlaybackListNode::PAUSED;
+			}
+		} else {
+			if (!p_muted) {
+				new_state = AudioStreamPlaybackListNode::PLAYING;
+			} else {
+				new_state = AudioStreamPlaybackListNode::MUTED;
+			}
+		}
+
+		if (!p_paused && (old_state == AudioStreamPlaybackListNode::PLAYING || old_state == AudioStreamPlaybackListNode::MUTED)) {
 			return; // No-op.
 		}
 		if (p_paused && (old_state == AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+			return; // No-op.
+		}
+
+	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
+}
+
+void AudioServer::set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused) {
+	ERR_FAIL_COND(p_playback.is_null());
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return;
+	}
+
+	AudioStreamPlaybackListNode::PlaybackState new_state, old_state;
+	do {
+		old_state = playback_node->state.load();
+		new_state = p_mute ? AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE : AudioStreamPlaybackListNode::PLAYING;
+		if (p_mute && !p_paused) {
+			new_state = AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
+		} else if (!p_mute && !p_paused) {
+			new_state = AudioStreamPlaybackListNode::PLAYING;
+		} else {
+			new_state = AudioStreamPlaybackListNode::PAUSED;
+		}
+
+		if (!p_mute) {
+			if (!p_paused && old_state == AudioStreamPlaybackListNode::PLAYING) {
+				return; // No-op.
+			} else if (p_paused && old_state == (AudioStreamPlaybackListNode::PAUSED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE)) {
+				return; // No-op.
+			}
+		}
+		if (p_mute && !p_paused && (old_state == AudioStreamPlaybackListNode::MUTED || old_state == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE)) {
 			return; // No-op.
 		}
 
@@ -1456,7 +1531,7 @@ bool AudioServer::is_playback_active(Ref<AudioStreamPlayback> p_playback) {
 		return false;
 	}
 
-	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING;
+	return playback_node->state.load() == AudioStreamPlaybackListNode::PLAYING || playback_node->state.load() == AudioStreamPlaybackListNode::MUTED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 }
 
 float AudioServer::get_playback_position(Ref<AudioStreamPlayback> p_playback) {
@@ -1485,6 +1560,18 @@ bool AudioServer::is_playback_paused(Ref<AudioStreamPlayback> p_playback) {
 	}
 
 	return playback_node->state.load() == AudioStreamPlaybackListNode::PAUSED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_PAUSE;
+}
+
+// Unused. Will return `false` if paused and the player is muted.
+bool AudioServer::is_playback_muted(Ref<AudioStreamPlayback> p_playback) {
+	ERR_FAIL_COND_V(p_playback.is_null(), false);
+
+	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
+	if (!playback_node) {
+		return false;
+	}
+
+	return playback_node->state.load() == AudioStreamPlaybackListNode::MUTED || playback_node->state.load() == AudioStreamPlaybackListNode::FADE_OUT_TO_MUTE;
 }
 
 uint64_t AudioServer::get_mix_count() const {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -279,16 +279,20 @@ private:
 		// 1. The playback is created and added to the playback list in the playing state.
 		// 2. The playback is (maybe) paused, and the state is set to FADE_OUT_TO_PAUSE.
 		// 2.1. The playback is mixed after being paused, and the audio server thread atomically sets the state to PAUSED after performing a brief fade-out.
-		// 3. The playback is (maybe) deleted, and the state is set to FADE_OUT_TO_DELETION.
-		// 3.1. The playback is mixed after being deleted, and the audio server thread atomically sets the state to AWAITING_DELETION after performing a brief fade-out.
+		// 3. The playback is (maybe) muted, and the state is set to FADE_OUT_TO_MUTE.
+		// 3.1. The playback is mixed after being muted, and the audio server thread atomically sets the state to MUTED after performing a brief fade-out.
+		// 4. The playback is (maybe) deleted, and the state is set to FADE_OUT_TO_DELETION.
+		// 4.1. The playback is mixed after being deleted, and the audio server thread atomically sets the state to AWAITING_DELETION after performing a brief fade-out.
 		// 		NOTE: The playback is not deallocated at this time because allocation and deallocation are not realtime-safe.
-		// 4. The playback is removed and deallocated on the main thread using the SafeList maybe_cleanup method.
+		// 5. The playback is removed and deallocated on the main thread using the SafeList maybe_cleanup method.
 		enum PlaybackState {
 			PAUSED = 0, // Paused. Keep this stream playback around though so it can be restarted.
 			PLAYING = 1, // Playing. Fading may still be necessary if volume changes!
-			FADE_OUT_TO_PAUSE = 2, // About to pause.
-			FADE_OUT_TO_DELETION = 3, // About to stop.
-			AWAITING_DELETION = 4,
+			MUTED = 2, // Playing while muted. Buffer is filled with `AudioFrame(0, 0)`.
+			FADE_OUT_TO_PAUSE = 3, // About to pause.
+			FADE_OUT_TO_MUTE = 4, // About to mute.
+			FADE_OUT_TO_DELETION = 5, // About to stop.
+			AWAITING_DELETION = 6,
 		};
 		// If zero or positive, a place in the stream to seek to during the next mix.
 		SafeNumeric<float> setseek;
@@ -431,21 +435,23 @@ public:
 	float get_playback_speed_scale() const;
 
 	// Convenience method.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1, bool p_muted = false);
 	// Expose all parameters.
-	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
+	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, bool p_muted = false, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
 
 	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, const StringName &p_bus, Vector<AudioFrame> p_volumes);
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes);
 	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
 	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);
-	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused);
+	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted);
+	void set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused);
 	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);
 
 	bool is_playback_active(Ref<AudioStreamPlayback> p_playback);
 	float get_playback_position(Ref<AudioStreamPlayback> p_playback);
 	bool is_playback_paused(Ref<AudioStreamPlayback> p_playback);
+	bool is_playback_muted(Ref<AudioStreamPlayback> p_playback);
 
 	uint64_t get_mix_count() const;
 	uint64_t get_mixed_frames() const;

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -304,6 +304,8 @@ private:
 		Ref<AudioStreamPlayback> stream_playback;
 		// Playback state determines the fate of a particular AudioStreamListNode during the mix step. Must be atomically replaced.
 		std::atomic<PlaybackState> state = AWAITING_DELETION;
+		// Used to ensure playback returns to the correct state.
+		SafeFlag mute_check;
 		// This data should only ever be modified by an atomic replacement of the pointer.
 		std::atomic<AudioStreamPlaybackBusDetails *> bus_details = nullptr;
 		// Previous bus details should only be accessed on the audio thread.
@@ -444,8 +446,8 @@ public:
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, const HashMap<StringName, Vector<AudioFrame>> &p_bus_volumes);
 	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
 	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);
-	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused, bool p_muted);
-	void set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute, bool p_paused);
+	void set_playback_paused(Ref<AudioStreamPlayback> p_playback, bool p_paused);
+	void set_playback_muted(Ref<AudioStreamPlayback> p_playback, bool p_mute);
 	void set_playback_highshelf_params(Ref<AudioStreamPlayback> p_playback, float p_gain, float p_attenuation_cutoff_hz);
 
 	bool is_playback_active(Ref<AudioStreamPlayback> p_playback);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

While -80 dB (minimum volume in the inspector slider) is not really audible, the only way to truly mute audio is to either set linear volume to 0 (-INF dB, both unavailable to the editor) or muting in the bus. Adjusting the slider or muting in the bus are not desirable in every case, since one could just want to mute one or multiple players, and easily return to the previous levels.

No open proposals seem to be closed by this PR.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
### Important note
This PR is a simpler version of https://github.com/godotengine/godot/pull/120871 . Only the property is added. Buttons to the scene tree might be added once we've reached a conclusion on how it should be implemented. Thankfully, this PR serves as a complete foundation for that too, and the only thing that would need to be changed is the editor code.

### Limitations
- Mute only works for the Stream playback type

I'm not comfortable editing code related to the Sample playback type. A little too much. I suggest someone to try adding that. This limitation is mentioned in the documentation.

- Unmuting can be produce a click

There is no existing fade-in state (for good reason), and I didn't implement one because it could be controversial. I do believe there should be a `FADE_IN_TO_PLAY` state, for the case of unmuting. I'd argue transients aren't a problem if the user unmutes AFTER the stream has played. I could try adding that, if we prefer to have this merged without any clicking issues.

### Notes for reviewers
In general, despite a few of my small contributions in this repository (mostly related to audio), I'm not a very experienced programmer. This is my first time modifying the AudioServer. Would appreciate someone checking that.

I've tested the changes, and things seem to work on my end.