### PR TITLE
Fix crash when assigning more than 2047 MiB to Jolt temp buffer

### DIFF
--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -112,7 +112,7 @@ void JoltProjectSettings::read_settings() {
 	joint_world_node = (JoltJointWorldNode)(int)GLOBAL_GET("physics/jolt_physics_3d/joints/world_node");
 
 	temp_memory_mib = GLOBAL_GET("physics/jolt_physics_3d/limits/temporary_memory_buffer_size");
-	temp_memory_b = temp_memory_mib * 1024 * 1024;
+	temp_memory_b = (int64_t)temp_memory_mib * 1024 * 1024;
 	world_boundary_shape_size = GLOBAL_GET("physics/jolt_physics_3d/limits/world_boundary_shape_size");
 	max_linear_velocity = GLOBAL_GET("physics/jolt_physics_3d/limits/max_linear_velocity");
 	max_angular_velocity = GLOBAL_GET("physics/jolt_physics_3d/limits/max_angular_velocity");


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120855.

## Additional information

As mentioned [here](https://github.com/godotengine/godot/issues/120855#issuecomment-4867863875), while the destination variable (`temp_memory_b`) is an `int64_t`, the calculation from MiB to bytes was being done entirely as `int`, leading to overflow when the resulting bytes exceeded 2^31.

There may very well be a reasonable maximum we can clamp this setting to as well, but I figured this fix is simple enough without having to argue about what that should be.