### PR TITLE
Implement `OS::get_processor_name()` for Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -472,7 +472,7 @@
 			<return type="String" />
 			<description>
 				Returns the full name of the CPU model on the host machine (e.g. [code]"Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz"[/code]).
-				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android and Web, [method get_processor_name] returns an empty string.
+				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux, Android (API level 31+), and iOS. On Web, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
 		<method name="get_restart_on_exit_arguments" qualifiers="const">

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -487,6 +487,10 @@ String OS_Android::get_model_name() const {
 	return OS_Unix::get_model_name();
 }
 
+String OS_Android::get_processor_name() const {
+	return get_system_property("ro.soc.model");
+}
+
 String OS_Android::get_data_path() const {
 	return OS::get_user_data_dir();
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -151,6 +151,7 @@ public:
 	virtual String get_resource_dir() const override;
 	virtual String get_locale() const override;
 	virtual String get_model_name() const override;
+	virtual String get_processor_name() const override;
 
 	virtual String get_unique_id() const override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
## What problem(s) does this PR solve?

### Summary 
Implements get_processor_name return SoC name for Android.

### Motivation
According to  the docs. 
`OS::get_processor_name` returns empty-string in Android.

But I want to know the SoC name via GodotEngine.
Because my product switch the logic from SoC ( NPU types ).

### Technical overview
The code reads  `ro.soc.model` system property.
This property was added after Android 12. 

### Testing
I create simple view SoC name apk and see that.
I tested on 3 devices with diffrent SoC phones.

I could read `Tensor G4`, `SM8650` and `MT6899`.
Test devicies is under those.

- Pixel 10a returns `Tensor G4`
- Nubia NX769J return `SM8650`
- Xiaomi 2511FPC34G return `MT6899`

and 

- Closes #120816

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
## Additional information

### Discussion
- Current implements is not for Android 11 and older.
Because Android  11 and older does not exist `ro.soc.model`.
- I wrote the error handling that copy as Windows version, is it correct way?
