### PR TITLE
Fix struct padding on double precision builds

### DIFF
--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -48,6 +48,9 @@ public:
 		uint32_t smooth_group = 0; // Must be first.
 
 		Color color;
+#ifdef REAL_T_IS_DOUBLE
+		float _ = 0; // needed to fill field padding consistently
+#endif
 		Vector3 normal;
 		Vector4 tangent; // xyz tangent, w orientation.
 		Vector2 uv;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes a hashing issue that manifested itself through an error during vertex indexing in [`surface_tool.cpp`](https://github.com/godotengine/godot/blob/7177493c122a563c2473073c039e568e0eec4079/scene/resources/surface_tool.cpp#L755): specifically [this `DEV_ASSERT` failed in `a_hash_map.h`](https://github.com/godotengine/godot/blob/7177493c122a563c2473073c039e568e0eec4079/core/templates/a_hash_map.h#L627).

It seems like it's the combination of the following two things:

- Vertex hashing is implemented by [hashing the raw memory bytes of the Vertex struct](https://github.com/godotengine/godot/blob/7177493c122a563c2473073c039e568e0eec4079/scene/resources/surface_tool.cpp#L141-L143)
- Double precision builds introduce a padding between fields that is uninitialized before this change

The fix works by forcing the padding to be zero-filled so hashing stays consistent for similar vertex instances.

## Additional information

This might not be the most desirable fix, alternatively I was considering hashing a Vertex's struct raw bytes from start to before the padding, and then hash from after the padding until the end. It doesn't really sound much sexier IMO but I'm open to suggestions.

Current Vertex struct layout in double precision builds:

```cpp
struct Vertex {
	uint32_t smooth_group; // offset 0 size 4
	Color color; // offset 4 size 16
	
	// offset 20 padding 4
	
	Vector3 normal; // offset 24 size 24
	
	// ...
};
```

Both `smooth_group` and `color` require an alignment of 4 but `Vector3` requires an alignment of 8 because it contains `double` fields in double precision, hence `normal`'s offset not being 20 but 24.