### PR TITLE
Fix tangent/bitagent encoding when computing vertex skinning

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -634,7 +634,7 @@ void vertex_shader(vec4 vertex_angle_attrib_input,
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = axis_tangent_attrib.zw * 2.0 - 1.0;
 		tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
-		binormal_sign = sign(signed_tangent_attrib.y);
+		binormal_sign = signed_tangent_attrib.y >= 0.0 ? 1.0 : -1.0;
 		binormal = normalize(cross(normal, tangent) * binormal_sign);
 	} else {
 		// Compressed format.

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -752,7 +752,7 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = p_normal_in.zw * 2.0 - 1.0;
 		r_tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
-		binormal_sign = sign(signed_tangent_attrib.y);
+		binormal_sign = signed_tangent_attrib.y >= 0.0 ? 1.0 : -1.0;
 		r_binormal = normalize(cross(r_normal, r_tangent) * binormal_sign);
 	} else {
 		// Compressed format.

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -232,7 +232,7 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = p_normal_in.zw * 2.0 - 1.0;
 		r_tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
-		binormal_sign = sign(signed_tangent_attrib.y);
+		binormal_sign = signed_tangent_attrib.y >= 0.0 ? 1.0 : -1.0;
 		r_binormal = normalize(cross(r_normal, r_tangent) * binormal_sign);
 	} else {
 		// Compressed format.

--- a/servers/rendering/renderer_rd/shaders/skeleton.glsl
+++ b/servers/rendering/renderer_rd/shaders/skeleton.glsl
@@ -83,7 +83,8 @@ vec4 decode_uint_oct_to_tang(uint base) {
 	vec2 oct_sign_encoded = uint_to_vec2(base);
 	// Binormal sign encoded in y component
 	vec2 oct = vec2(oct_sign_encoded.x, abs(oct_sign_encoded.y) * 2.0 - 1.0);
-	return vec4(oct_to_vec3(oct), sign(oct_sign_encoded.y));
+	float binormal_sign = oct_sign_encoded.y >= 0.0 ? 1.0 : -1.0;
+	return vec4(oct_to_vec3(oct), binormal_sign);
 }
 
 vec2 signNotZero(vec2 v) {
@@ -107,15 +108,13 @@ uint encode_norm_to_uint_oct(vec3 base) {
 
 uint encode_tang_to_uint_oct(vec4 base) {
 	vec2 oct = vec3_to_oct(base.xyz);
+
+	// 0.5 cannot be represented in UNORM16
+	oct.y = clamp(oct.y, 1.0 / 65535.0, 65534.0 / 65535.0);
+
 	// Encode binormal sign in y component
 	oct.y = oct.y * 0.5f + 0.5f;
 	oct.y = base.w >= 0.0f ? oct.y : 1 - oct.y;
-
-	if (oct.x == 0.0 && oct.y == 1.0) {
-		// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
-		// So we sanitize here.
-		oct.x = 1.0;
-	}
 
 	return vec2_to_uint(oct);
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Proper fix for #81446

## Additional information

My previous PR #117401 had some caveats. For instance, it did not take the binormal sign encoding into account.

The way it works is that the binormal sign is encoded in Oct.y. Oct.y is encoded as UNORM16, so values > 0.5 means positive, and values < 0.5 means negative. Since UNORM16 encoding does not allow a value of exactly 0.5 (aka zero once unpacked), the binormal sign was flip-flopping between positive and negative.

The fix is to clamp the Oct.Y value between [1.0/65535.0; 1-(1.0/65535.0)]. This also avoids the issue with compression detection altogether (what PR #117401 tried to fix).

I also removed usage of some `sign` function as its not very efficient on the GPU because it handles many different cases (+/-INF and zero). It's a lot simpler to just check if >= 0