### PR TITLE
Re-add -v option to wayland-scanner

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -237,7 +237,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(CPPDEFINES=["SOWRAP_ENABLED"])
 
     if env["wayland"]:
-        if subprocess.run(["wayland-scanner"], capture_output=True).returncode != 0:
+        if subprocess.run(["wayland-scanner", "-v"], capture_output=True).returncode != 0:
             print_warning("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120904

## Additional information

This adds back the "-v" command line option to wayland-scanner that was removed by eca80a8f3cbdf545f2e960ac2f6022b153acdba3.

No AI was used in any way shape or form.