### PR TITLE
CI: Clean up codespell ignores

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -100,7 +100,7 @@ BreakConstructorInitializers: AfterColon
 # BreakInheritanceList: BeforeColon
 # BreakStringLiterals: true
 ColumnLimit: 0
-# CommentPragmas: "^ IWYU pragma:"
+CommentPragmas: "^ (IWYU pragma|codespell):"
 # CompactNamespaces: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -638,7 +638,7 @@ String DirAccessPack::get_drive(int p_drive) {
 }
 
 PackedData::PackedDir *DirAccessPack::_find_dir(const String &p_dir) {
-	String nd = p_dir.replace_char('\\', '/');
+	String dir_name = p_dir.replace_char('\\', '/');
 
 	// Special handling since simplify_path() will forbid it
 	if (p_dir == "..") {
@@ -646,23 +646,23 @@ PackedData::PackedDir *DirAccessPack::_find_dir(const String &p_dir) {
 	}
 
 	bool absolute = false;
-	if (nd.begins_with("res://")) {
-		nd = nd.replace_first("res://", "");
+	if (dir_name.begins_with("res://")) {
+		dir_name = dir_name.replace_first("res://", "");
 		absolute = true;
 	}
 
-	nd = nd.simplify_path();
+	dir_name = dir_name.simplify_path();
 
-	if (nd.is_empty()) {
-		nd = ".";
+	if (dir_name.is_empty()) {
+		dir_name = ".";
 	}
 
-	if (nd.begins_with("/")) {
-		nd = nd.replace_first("/", "");
+	if (dir_name.begins_with("/")) {
+		dir_name = dir_name.replace_first("/", "");
 		absolute = true;
 	}
 
-	Vector<String> paths = nd.split("/");
+	Vector<String> paths = dir_name.split("/");
 
 	PackedData::PackedDir *pd;
 

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -312,18 +312,18 @@ Vector3 Face3::get_closest_point_to(const Vector3 &p_point) const {
 			s = CLAMP(-d / a, 0.f, 1.f);
 			t = 0.f;
 		} else {
-			real_t invDet = 1.f / det;
-			s *= invDet;
-			t *= invDet;
+			real_t inv_det = 1.f / det;
+			s *= inv_det;
+			t *= inv_det;
 		}
 	} else {
 		if (s < 0.f) {
 			real_t tmp0 = b + d;
 			real_t tmp1 = c + e;
 			if (tmp1 > tmp0) {
-				real_t numer = tmp1 - tmp0;
-				real_t denom = a - 2 * b + c;
-				s = CLAMP(numer / denom, 0.f, 1.f);
+				real_t numerator = tmp1 - tmp0;
+				real_t denominator = a - 2 * b + c;
+				s = CLAMP(numerator / denominator, 0.f, 1.f);
 				t = 1 - s;
 			} else {
 				t = CLAMP(-e / c, 0.f, 1.f);
@@ -331,18 +331,18 @@ Vector3 Face3::get_closest_point_to(const Vector3 &p_point) const {
 			}
 		} else if (t < 0.f) {
 			if (a + d > b + e) {
-				real_t numer = c + e - b - d;
-				real_t denom = a - 2 * b + c;
-				s = CLAMP(numer / denom, 0.f, 1.f);
+				real_t numerator = c + e - b - d;
+				real_t denominator = a - 2 * b + c;
+				s = CLAMP(numerator / denominator, 0.f, 1.f);
 				t = 1 - s;
 			} else {
 				s = CLAMP(-d / a, 0.f, 1.f);
 				t = 0.f;
 			}
 		} else {
-			real_t numer = c + e - b - d;
-			real_t denom = a - 2 * b + c;
-			s = CLAMP(numer / denom, 0.f, 1.f);
+			real_t numerator = c + e - b - d;
+			real_t denominator = a - 2 * b + c;
+			s = CLAMP(numerator / denominator, 0.f, 1.f);
 			t = 1.f - s;
 		}
 	}

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -366,7 +366,7 @@ void Projection::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, rea
 	ERR_FAIL_COND(p_top <= p_bottom);
 	ERR_FAIL_COND(p_far <= p_near);
 
-	real_t *te = &columns[0][0];
+	real_t *matrix = &columns[0][0];
 	real_t x = 2 * p_near / (p_right - p_left);
 	real_t y = 2 * p_near / (p_top - p_bottom);
 
@@ -375,22 +375,22 @@ void Projection::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, rea
 	real_t c = -(p_far + p_near) / (p_far - p_near);
 	real_t d = -2 * p_far * p_near / (p_far - p_near);
 
-	te[0] = x;
-	te[1] = 0;
-	te[2] = 0;
-	te[3] = 0;
-	te[4] = 0;
-	te[5] = y;
-	te[6] = 0;
-	te[7] = 0;
-	te[8] = a;
-	te[9] = b;
-	te[10] = c;
-	te[11] = -1;
-	te[12] = 0;
-	te[13] = 0;
-	te[14] = d;
-	te[15] = 0;
+	matrix[0] = x;
+	matrix[1] = 0;
+	matrix[2] = 0;
+	matrix[3] = 0;
+	matrix[4] = 0;
+	matrix[5] = y;
+	matrix[6] = 0;
+	matrix[7] = 0;
+	matrix[8] = a;
+	matrix[9] = b;
+	matrix[10] = c;
+	matrix[11] = -1;
+	matrix[12] = 0;
+	matrix[13] = 0;
+	matrix[14] = d;
+	matrix[15] = 0;
 }
 
 void Projection::set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -231,9 +231,9 @@ bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_en
 						Vector3 res;
 
 						if (f3.intersects_segment(p_begin, p_end, &res)) {
-							real_t nd = n.dot(res);
-							if (nd < d) {
-								d = nd;
+							real_t ndist = n.dot(res);
+							if (ndist < d) {
+								d = ndist;
 								r_point = res;
 								r_normal = f3.get_plane().get_normal();
 								if (r_surf_index) {
@@ -339,9 +339,9 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 						Vector3 res;
 
 						if (f3.intersects_ray(p_begin, p_dir, &res)) {
-							real_t nd = n.dot(res);
-							if (nd < d) {
-								d = nd;
+							real_t ndist = n.dot(res);
+							if (ndist < d) {
+								d = ndist;
 								r_point = res;
 								r_normal = f3.get_plane().get_normal();
 								if (r_surf_index) {

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -602,7 +602,7 @@
 			<description>
 				Returns the first [param length] characters from the beginning of the string. If [param length] is negative, strips the last [param length] characters from the string's end.
 				[codeblock]
-				print("Hello World!".left(3))  # Prints "Hel"
+				print("Hello World!".left(2))  # Prints "He"
 				print("Hello World!".left(-4)) # Prints "Hello Wo"
 				[/codeblock]
 			</description>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -568,7 +568,7 @@
 			<description>
 				Returns the first [param length] characters from the beginning of the string. If [param length] is negative, strips the last [param length] characters from the string's end.
 				[codeblock]
-				print("Hello World!".left(3))  # Prints "Hel"
+				print("Hello World!".left(2))  # Prints "He"
 				print("Hello World!".left(-4)) # Prints "Hello Wo"
 				[/codeblock]
 			</description>

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -427,12 +427,12 @@ void light_compute(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional
 }
 
 float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 #if !defined(DISABLE_LIGHT_OMNI) || (defined(ADDITIVE_OMNI) && defined(USE_ADDITIVE_LIGHTING))
@@ -1717,12 +1717,12 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 }
 
 float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 #if !defined(DISABLE_LIGHT_OMNI) || defined(ADDITIVE_OMNI)

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -427,12 +427,12 @@ void light_compute(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional
 }
 
 float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 #if !defined(DISABLE_LIGHT_OMNI) || (defined(ADDITIVE_OMNI) && defined(USE_ADDITIVE_LIGHTING))
@@ -1718,12 +1718,12 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 }
 
 float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 #if !defined(DISABLE_LIGHT_OMNI) || defined(ADDITIVE_OMNI)

--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -119,7 +119,7 @@ vec3 allenwp_curve(vec3 x) {
 vec3 tonemap_agx(vec3 color) {
 	// Input color should be non-negative!
 	// Large negative values in one channel and large positive values in other
-	// channels can result in a colour that appears darker and more saturated than
+	// channels can result in a color that appears darker and more saturated than
 	// desired after passing it through the inset matrix. For this reason, it is
 	// best to prevent negative input values.
 	// This is done before the Rec. 2020 transform to allow the Rec. 2020
@@ -156,7 +156,7 @@ vec3 tonemap_agx(vec3 color) {
 	// providing stability across all variable dyanimc range (SDR, HDR, EDR).
 	color = allenwp_curve(color);
 
-	// Clipping to output_max_value is required to address a cyan colour that occurs
+	// Clipping to output_max_value is required to address a cyan color that occurs
 	// with very bright inputs.
 	color = min(vec3(output_max_value), color);
 

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -824,7 +824,7 @@ void LightStorage::reflection_probe_release_atlas_index(RID p_instance) {
 	atlas->reflections.write[rpi->atlas_index].owner = RID();
 
 	if (rpi->rendering) {
-		// We were cancelled mid rendering, trigger refresh.
+		// We were canceled mid rendering, trigger refresh.
 		rpi->rendering = false;
 		rpi->dirty = true;
 		rpi->processing_layer = 0;

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -875,7 +875,7 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 	}
 }
 
-void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *mis, int p_current_vertex_buffer, int p_prev_vertex_buffer) {
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &p_version, Mesh::Surface *p_mesh_surface, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *p_mesh_instance_surface, int p_current_vertex_buffer, int p_prev_vertex_buffer) {
 	Mesh::Surface::Attrib attribs[RSE::ARRAY_MAX];
 
 	int position_stride = 0; // Vertex position only.
@@ -886,7 +886,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	for (int i = 0; i < RSE::ARRAY_INDEX; i++) {
 		attribs[i].enabled = false;
 		attribs[i].integer = false;
-		if (!(s->format & (1ULL << i))) {
+		if (!(p_mesh_surface->format & (1ULL << i))) {
 			continue;
 		}
 
@@ -901,11 +901,11 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				attribs[i].offset = 0;
 				attribs[i].type = GL_FLOAT;
 				attribs[i].normalized = GL_FALSE;
-				if (s->format & RSE::ARRAY_FLAG_USE_2D_VERTICES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_USE_2D_VERTICES) {
 					attribs[i].size = 2;
 					position_stride = attribs[i].size * sizeof(float);
 				} else {
-					if (!mis && (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+					if (!p_mesh_instance_surface && (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 						attribs[i].size = 4;
 						position_stride = attribs[i].size * sizeof(uint16_t);
 						attribs[i].type = GL_UNSIGNED_SHORT;
@@ -917,7 +917,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				}
 			} break;
 			case RSE::ARRAY_NORMAL: {
-				if (!mis && (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+				if (!p_mesh_instance_surface && (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 					attribs[i].size = 2;
 					normal_tangent_stride += 2 * attribs[i].size;
 				} else {
@@ -925,22 +925,22 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 					// A small trick here: if we are uncompressed and we have normals, but no tangents. We need
 					// the shader to think there are 4 components to "axis_tangent_attrib". So we give a size of 4,
 					// but a stride based on only having 2 elements.
-					if (!(s->format & RSE::ARRAY_FORMAT_TANGENT)) {
-						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 2;
+					if (!(p_mesh_surface->format & RSE::ARRAY_FORMAT_TANGENT)) {
+						normal_tangent_stride += (p_mesh_instance_surface ? sizeof(float) : sizeof(uint16_t)) * 2;
 					} else {
-						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 4;
+						normal_tangent_stride += (p_mesh_instance_surface ? sizeof(float) : sizeof(uint16_t)) * 4;
 					}
 				}
 
-				if (mis) {
+				if (p_mesh_instance_surface) {
 					// Transform feedback has interleave all or no attributes. It can't mix interleaving.
 					attribs[i].offset = position_stride;
 					normal_tangent_stride += position_stride;
 					position_stride = normal_tangent_stride;
 				} else {
-					attribs[i].offset = position_stride * s->vertex_count;
+					attribs[i].offset = position_stride * p_mesh_surface->vertex_count;
 				}
-				attribs[i].type = (mis ? GL_FLOAT : GL_UNSIGNED_SHORT);
+				attribs[i].type = (p_mesh_instance_surface ? GL_FLOAT : GL_UNSIGNED_SHORT);
 				attribs[i].normalized = GL_TRUE;
 			} break;
 			case RSE::ARRAY_TANGENT: {
@@ -958,7 +958,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			case RSE::ARRAY_TEX_UV: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				if (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
 					attribs[i].type = GL_UNSIGNED_SHORT;
 					attributes_stride += 2 * sizeof(uint16_t);
 					attribs[i].normalized = GL_TRUE;
@@ -971,7 +971,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			case RSE::ARRAY_TEX_UV2: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				if (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
 					attribs[i].type = GL_UNSIGNED_SHORT;
 					attributes_stride += 2 * sizeof(uint16_t);
 					attribs[i].normalized = GL_TRUE;
@@ -989,7 +989,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 				int idx = i - RSE::ARRAY_CUSTOM0;
 				uint32_t fmt_shift[RSE::ARRAY_CUSTOM_COUNT] = { RSE::ARRAY_FORMAT_CUSTOM0_SHIFT, RSE::ARRAY_FORMAT_CUSTOM1_SHIFT, RSE::ARRAY_FORMAT_CUSTOM2_SHIFT, RSE::ARRAY_FORMAT_CUSTOM3_SHIFT };
-				uint32_t fmt = (s->format >> fmt_shift[idx]) & RSE::ARRAY_FORMAT_CUSTOM_MASK;
+				uint32_t fmt = (p_mesh_surface->format >> fmt_shift[idx]) & RSE::ARRAY_FORMAT_CUSTOM_MASK;
 				uint32_t fmtsize[RSE::ARRAY_CUSTOM_MAX] = { 4, 4, 4, 8, 4, 8, 12, 16 };
 				GLenum gl_type[RSE::ARRAY_CUSTOM_MAX] = { GL_UNSIGNED_BYTE, GL_BYTE, GL_HALF_FLOAT, GL_HALF_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT };
 				GLboolean norm[RSE::ARRAY_CUSTOM_MAX] = { GL_TRUE, GL_TRUE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
@@ -1017,8 +1017,8 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		}
 	}
 
-	glGenVertexArrays(1, &v.vertex_array);
-	glBindVertexArray(v.vertex_array);
+	glGenVertexArrays(1, &p_version.vertex_array);
+	glBindVertexArray(p_version.vertex_array);
 
 	for (int i = 0; i < RSE::ARRAY_INDEX; i++) {
 		if (!attribs[i].enabled) {
@@ -1027,17 +1027,17 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		}
 		if (i <= RSE::ARRAY_TANGENT) {
 			attribs[i].stride = (i == RSE::ARRAY_VERTEX) ? position_stride : normal_tangent_stride;
-			if (mis) {
-				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffers[p_current_vertex_buffer]);
+			if (p_mesh_instance_surface) {
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_instance_surface->vertex_buffers[p_current_vertex_buffer]);
 			} else {
-				glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->vertex_buffer);
 			}
 		} else if (i <= RSE::ARRAY_CUSTOM3) {
 			attribs[i].stride = attributes_stride;
-			glBindBuffer(GL_ARRAY_BUFFER, s->attribute_buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->attribute_buffer);
 		} else {
 			attribs[i].stride = skin_stride;
-			glBindBuffer(GL_ARRAY_BUFFER, s->skin_buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->skin_buffer);
 		}
 
 		if (attribs[i].integer) {
@@ -1050,10 +1050,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 	if (p_uses_motion_vectors) {
 		for (int i = 0; i < RSE::ARRAY_TANGENT; i++) {
-			if (mis) {
-				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffers[mis->prev_vertex_buffer]);
+			if (p_mesh_instance_surface) {
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_instance_surface->vertex_buffers[p_mesh_instance_surface->prev_vertex_buffer]);
 			} else {
-				glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->vertex_buffer);
 			}
 
 			glVertexAttribPointer(i + 16, attribs[i].size, attribs[i].type, attribs[i].normalized, attribs[i].stride, CAST_INT_TO_UCHAR_PTR(attribs[i].offset));
@@ -1066,10 +1066,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	v.input_mask = p_input_mask;
-	v.uses_motion_vectors = p_uses_motion_vectors;
-	v.current_vertex_buffer = p_current_vertex_buffer;
-	v.prev_vertex_buffer = p_prev_vertex_buffer;
+	p_version.input_mask = p_input_mask;
+	p_version.uses_motion_vectors = p_uses_motion_vectors;
+	p_version.current_vertex_buffer = p_current_vertex_buffer;
+	p_version.prev_vertex_buffer = p_prev_vertex_buffer;
 }
 
 void MeshStorage::mesh_surface_remove(RID p_mesh, int p_surface) {

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -875,7 +875,7 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 	}
 }
 
-void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *mis, int p_current_vertex_buffer, int p_prev_vertex_buffer) {
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &p_version, Mesh::Surface *p_mesh_surface, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *p_mesh_instance_surface, int p_current_vertex_buffer, int p_prev_vertex_buffer) {
 	Mesh::Surface::Attrib attribs[RSE::ARRAY_MAX];
 
 	int position_stride = 0; // Vertex position only.
@@ -886,7 +886,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	for (int i = 0; i < RSE::ARRAY_INDEX; i++) {
 		attribs[i].enabled = false;
 		attribs[i].integer = false;
-		if (!(s->format & (1ULL << i))) {
+		if (!(p_mesh_surface->format & (1ULL << i))) {
 			continue;
 		}
 
@@ -901,11 +901,11 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				attribs[i].offset = 0;
 				attribs[i].type = GL_FLOAT;
 				attribs[i].normalized = GL_FALSE;
-				if (s->format & RSE::ARRAY_FLAG_USE_2D_VERTICES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_USE_2D_VERTICES) {
 					attribs[i].size = 2;
 					position_stride = attribs[i].size * sizeof(float);
 				} else {
-					if (!mis && (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+					if (!p_mesh_instance_surface && (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 						attribs[i].size = 4;
 						position_stride = attribs[i].size * sizeof(uint16_t);
 						attribs[i].type = GL_UNSIGNED_SHORT;
@@ -917,7 +917,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				}
 			} break;
 			case RSE::ARRAY_NORMAL: {
-				if (!mis && (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+				if (!p_mesh_instance_surface && (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 					attribs[i].size = 2;
 					normal_tangent_stride += 2 * attribs[i].size;
 				} else {
@@ -925,22 +925,22 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 					// A small trick here: if we are uncompressed and we have normals, but no tangents. We need
 					// the shader to think there are 4 components to "axis_tangent_attrib". So we give a size of 4,
 					// but a stride based on only having 2 elements.
-					if (!(s->format & RSE::ARRAY_FORMAT_TANGENT)) {
-						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 2;
+					if (!(p_mesh_surface->format & RSE::ARRAY_FORMAT_TANGENT)) {
+						normal_tangent_stride += (p_mesh_instance_surface ? sizeof(float) : sizeof(uint16_t)) * 2;
 					} else {
-						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 4;
+						normal_tangent_stride += (p_mesh_instance_surface ? sizeof(float) : sizeof(uint16_t)) * 4;
 					}
 				}
 
-				if (mis) {
+				if (p_mesh_instance_surface) {
 					// Transform feedback has interleave all or no attributes. It can't mix interleaving.
 					attribs[i].offset = position_stride;
 					normal_tangent_stride += position_stride;
 					position_stride = normal_tangent_stride;
 				} else {
-					attribs[i].offset = position_stride * s->vertex_count;
+					attribs[i].offset = position_stride * p_mesh_surface->vertex_count;
 				}
-				attribs[i].type = (mis ? GL_FLOAT : GL_UNSIGNED_SHORT);
+				attribs[i].type = (p_mesh_instance_surface ? GL_FLOAT : GL_UNSIGNED_SHORT);
 				attribs[i].normalized = GL_TRUE;
 			} break;
 			case RSE::ARRAY_TANGENT: {
@@ -958,7 +958,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			case RSE::ARRAY_TEX_UV: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				if (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
 					attribs[i].type = GL_UNSIGNED_SHORT;
 					attributes_stride += 2 * sizeof(uint16_t);
 					attribs[i].normalized = GL_TRUE;
@@ -971,7 +971,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			case RSE::ARRAY_TEX_UV2: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				if (s->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+				if (p_mesh_surface->format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
 					attribs[i].type = GL_UNSIGNED_SHORT;
 					attributes_stride += 2 * sizeof(uint16_t);
 					attribs[i].normalized = GL_TRUE;
@@ -989,7 +989,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 				int idx = i - RSE::ARRAY_CUSTOM0;
 				uint32_t fmt_shift[RSE::ARRAY_CUSTOM_COUNT] = { RSE::ARRAY_FORMAT_CUSTOM0_SHIFT, RSE::ARRAY_FORMAT_CUSTOM1_SHIFT, RSE::ARRAY_FORMAT_CUSTOM2_SHIFT, RSE::ARRAY_FORMAT_CUSTOM3_SHIFT };
-				uint32_t fmt = (s->format >> fmt_shift[idx]) & RSE::ARRAY_FORMAT_CUSTOM_MASK;
+				uint32_t fmt = (p_mesh_surface->format >> fmt_shift[idx]) & RSE::ARRAY_FORMAT_CUSTOM_MASK;
 				uint32_t fmtsize[RSE::ARRAY_CUSTOM_MAX] = { 4, 4, 4, 8, 4, 8, 12, 16 };
 				GLenum gl_type[RSE::ARRAY_CUSTOM_MAX] = { GL_UNSIGNED_BYTE, GL_BYTE, GL_HALF_FLOAT, GL_HALF_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT };
 				GLboolean norm[RSE::ARRAY_CUSTOM_MAX] = { GL_TRUE, GL_TRUE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
@@ -1016,8 +1016,8 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		}
 	}
 
-	glGenVertexArrays(1, &v.vertex_array);
-	glBindVertexArray(v.vertex_array);
+	glGenVertexArrays(1, &p_version.vertex_array);
+	glBindVertexArray(p_version.vertex_array);
 
 	for (int i = 0; i < RSE::ARRAY_INDEX; i++) {
 		if (!attribs[i].enabled) {
@@ -1026,17 +1026,17 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		}
 		if (i <= RSE::ARRAY_TANGENT) {
 			attribs[i].stride = (i == RSE::ARRAY_VERTEX) ? position_stride : normal_tangent_stride;
-			if (mis) {
-				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffers[p_current_vertex_buffer]);
+			if (p_mesh_instance_surface) {
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_instance_surface->vertex_buffers[p_current_vertex_buffer]);
 			} else {
-				glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->vertex_buffer);
 			}
 		} else if (i <= RSE::ARRAY_CUSTOM3) {
 			attribs[i].stride = attributes_stride;
-			glBindBuffer(GL_ARRAY_BUFFER, s->attribute_buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->attribute_buffer);
 		} else {
 			attribs[i].stride = skin_stride;
-			glBindBuffer(GL_ARRAY_BUFFER, s->skin_buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->skin_buffer);
 		}
 
 		if (attribs[i].integer) {
@@ -1049,10 +1049,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 	if (p_uses_motion_vectors) {
 		for (int i = 0; i < RSE::ARRAY_TANGENT; i++) {
-			if (mis) {
-				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffers[mis->prev_vertex_buffer]);
+			if (p_mesh_instance_surface) {
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_instance_surface->vertex_buffers[p_mesh_instance_surface->prev_vertex_buffer]);
 			} else {
-				glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+				glBindBuffer(GL_ARRAY_BUFFER, p_mesh_surface->vertex_buffer);
 			}
 
 			glVertexAttribPointer(i + 16, attribs[i].size, attribs[i].type, attribs[i].normalized, attribs[i].stride, CAST_INT_TO_UCHAR_PTR(attribs[i].offset));
@@ -1065,10 +1065,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	v.input_mask = p_input_mask;
-	v.uses_motion_vectors = p_uses_motion_vectors;
-	v.current_vertex_buffer = p_current_vertex_buffer;
-	v.prev_vertex_buffer = p_prev_vertex_buffer;
+	p_version.input_mask = p_input_mask;
+	p_version.uses_motion_vectors = p_uses_motion_vectors;
+	p_version.current_vertex_buffer = p_current_vertex_buffer;
+	p_version.prev_vertex_buffer = p_prev_vertex_buffer;
 }
 
 void MeshStorage::mesh_surface_remove(RID p_mesh, int p_surface) {

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -253,7 +253,7 @@ private:
 
 	mutable RID_Owner<Mesh, true> mesh_owner;
 
-	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *mis = nullptr, int p_current_vertex_buffer = 0, int p_prev_vertex_buffer = 0);
+	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &p_version, Mesh::Surface *p_mesh_surface, uint64_t p_input_mask, bool p_uses_motion_vectors, MeshInstance::Surface *p_mesh_instance_surface = nullptr, int p_current_vertex_buffer = 0, int p_prev_vertex_buffer = 0);
 	void _mesh_surface_clear(Mesh *mesh, int p_surface);
 
 	/* Mesh Instance API */
@@ -487,40 +487,40 @@ public:
 		Mesh *mesh = mi->mesh;
 		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
 
-		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
+		MeshInstance::Surface *mi_surface = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];
 
-		uint32_t current_buffer = mis->current_vertex_buffer;
+		uint32_t current_buffer = mi_surface->current_vertex_buffer;
 
 		// Using the previous buffer is only allowed if the surface was updated this frame and motion vectors are required.
-		uint32_t previous_buffer = p_uses_motion_vectors && (RSG::rasterizer->get_frame_number() == mis->last_change) ? mis->prev_vertex_buffer : current_buffer;
+		uint32_t previous_buffer = p_uses_motion_vectors && (RSG::rasterizer->get_frame_number() == mi_surface->last_change) ? mi_surface->prev_vertex_buffer : current_buffer;
 
 		s->version_lock.lock();
 
 		//there will never be more than, at much, 3 or 4 versions, so iterating is the fastest way
 
-		for (uint32_t i = 0; i < mis->version_count; i++) {
-			if (mis->versions[i].input_mask != p_input_mask || mis->versions[i].uses_motion_vectors != p_uses_motion_vectors) {
+		for (uint32_t i = 0; i < mi_surface->version_count; i++) {
+			if (mi_surface->versions[i].input_mask != p_input_mask || mi_surface->versions[i].uses_motion_vectors != p_uses_motion_vectors) {
 				continue;
 			}
 
-			if (mis->versions[i].current_vertex_buffer != current_buffer || mis->versions[i].prev_vertex_buffer != previous_buffer) {
+			if (mi_surface->versions[i].current_vertex_buffer != current_buffer || mi_surface->versions[i].prev_vertex_buffer != previous_buffer) {
 				continue;
 			}
 
 			//we have this version, hooray
-			r_vertex_array_gl = mis->versions[i].vertex_array;
+			r_vertex_array_gl = mi_surface->versions[i].vertex_array;
 			s->version_lock.unlock();
 			return;
 		}
 
-		uint32_t version = mis->version_count;
-		mis->version_count++;
-		mis->versions = (Mesh::Surface::Version *)memrealloc(mis->versions, sizeof(Mesh::Surface::Version) * mis->version_count);
+		uint32_t version = mi_surface->version_count;
+		mi_surface->version_count++;
+		mi_surface->versions = (Mesh::Surface::Version *)memrealloc(mi_surface->versions, sizeof(Mesh::Surface::Version) * mi_surface->version_count);
 
-		_mesh_surface_generate_version_for_input_mask(mis->versions[version], s, p_input_mask, p_uses_motion_vectors, mis, current_buffer, previous_buffer);
+		_mesh_surface_generate_version_for_input_mask(mi_surface->versions[version], s, p_input_mask, p_uses_motion_vectors, mi_surface, current_buffer, previous_buffer);
 
-		r_vertex_array_gl = mis->versions[version].vertex_array;
+		r_vertex_array_gl = mi_surface->versions[version].vertex_array;
 
 		s->version_lock.unlock();
 	}

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -118,7 +118,7 @@ static void _setup_clock() {
 	mach_timebase_info_data_t info;
 	kern_return_t ret = mach_timebase_info(&info);
 	ERR_FAIL_COND_MSG(ret != 0, "OS CLOCK IS NOT WORKING!");
-	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0;
+	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0; // codespell:ignore numer.
 	_clock_start = mach_absolute_time() * _clock_scale;
 }
 #else

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -104,7 +104,7 @@ static void _setup_clock() {
 	mach_timebase_info_data_t info;
 	kern_return_t ret = mach_timebase_info(&info);
 	ERR_FAIL_COND_MSG(ret != 0, "OS CLOCK IS NOT WORKING!");
-	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0;
+	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0; // codespell:ignore numer.
 	_clock_start = mach_absolute_time() * _clock_scale;
 }
 #else

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2361,12 +2361,12 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 }
 
 void AnimationPlayerEditorPlugin::_property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance) {
-	AnimationTrackEditor *te = anim_editor->get_track_editor();
-	if (!te || !te->has_keying()) {
+	AnimationTrackEditor *track_editor = anim_editor->get_track_editor();
+	if (!track_editor || !track_editor->has_keying()) {
 		return;
 	}
-	te->_clear_selection();
-	te->insert_value_key(p_keyed, p_advance);
+	track_editor->_clear_selection();
+	track_editor->insert_value_key(p_keyed, p_advance);
 }
 
 void AnimationPlayerEditorPlugin::_transform_3d_key_request(Object *sp, const String &p_sub, const Transform3D &p_key) {

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2363,12 +2363,12 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 }
 
 void AnimationPlayerEditorPlugin::_property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance) {
-	AnimationTrackEditor *te = anim_editor->get_track_editor();
-	if (!te || !te->has_keying()) {
+	AnimationTrackEditor *track_editor = anim_editor->get_track_editor();
+	if (!track_editor || !track_editor->has_keying()) {
 		return;
 	}
-	te->_clear_selection();
-	te->insert_value_key(p_keyed, p_advance);
+	track_editor->_clear_selection();
+	track_editor->insert_value_key(p_keyed, p_advance);
 }
 
 void AnimationPlayerEditorPlugin::_transform_3d_key_request(Object *sp, const String &p_sub, const Transform3D &p_key) {

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3173,15 +3173,15 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					if (ap) {
 						NodePath npath = animation->track_get_path(track);
 						Node *a_ap_root_node = ap->get_node_or_null(ap->get_root_node());
-						Node *nd = nullptr;
-						// We must test that we have a valid a_ap_root_node before trying to access its content to init the nd Node.
+						Node *node = nullptr;
+						// We must test that we have a valid a_ap_root_node before trying to access its content to init the `node` Node.
 						if (a_ap_root_node) {
-							nd = a_ap_root_node->get_node_or_null(NodePath(npath.get_concatenated_names()));
+							node = a_ap_root_node->get_node_or_null(NodePath(npath.get_concatenated_names()));
 						}
-						if (nd) {
+						if (node) {
 							StringName prop = npath.get_concatenated_subnames();
 							PropertyInfo prop_info;
-							ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+							ClassDB::get_property_info(node->get_class(), prop, &prop_info);
 #ifdef DISABLE_DEPRECATED
 							bool is_angle = prop_info.type == Variant::FLOAT && prop_info.hint_string.contains("radians_as_degrees");
 #else
@@ -6894,15 +6894,15 @@ bool AnimationTrackEditor::_is_track_compatible(int p_target_track_idx, Variant:
 						if (ap) {
 							NodePath npath = animation->track_get_path(p_target_track_idx);
 							Node *a_ap_root_node = ap->get_node(ap->get_root_node());
-							Node *nd = nullptr;
-							// We must test that we have a valid a_ap_root_node before trying to access its content to init the nd Node.
+							Node *node = nullptr;
+							// We must test that we have a valid a_ap_root_node before trying to access its content to init the `node` Node.
 							if (a_ap_root_node) {
-								nd = a_ap_root_node->get_node(NodePath(npath.get_concatenated_names()));
+								node = a_ap_root_node->get_node(NodePath(npath.get_concatenated_names()));
 							}
-							if (nd) {
+							if (node) {
 								StringName prop = npath.get_concatenated_subnames();
 								PropertyInfo prop_info;
-								path_valid = ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+								path_valid = ClassDB::get_property_info(node->get_class(), prop, &prop_info);
 								property_type = prop_info.type;
 							}
 						}

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3171,15 +3171,15 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					if (ap) {
 						NodePath npath = animation->track_get_path(track);
 						Node *a_ap_root_node = ap->get_node_or_null(ap->get_root_node());
-						Node *nd = nullptr;
-						// We must test that we have a valid a_ap_root_node before trying to access its content to init the nd Node.
+						Node *node = nullptr;
+						// We must test that we have a valid a_ap_root_node before trying to access its content to init the `node` Node.
 						if (a_ap_root_node) {
-							nd = a_ap_root_node->get_node_or_null(NodePath(npath.get_concatenated_names()));
+							node = a_ap_root_node->get_node_or_null(NodePath(npath.get_concatenated_names()));
 						}
-						if (nd) {
+						if (node) {
 							StringName prop = npath.get_concatenated_subnames();
 							PropertyInfo prop_info;
-							ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+							ClassDB::get_property_info(node->get_class(), prop, &prop_info);
 #ifdef DISABLE_DEPRECATED
 							bool is_angle = prop_info.type == Variant::FLOAT && prop_info.hint_string.contains("radians_as_degrees");
 #else
@@ -6891,15 +6891,15 @@ bool AnimationTrackEditor::_is_track_compatible(int p_target_track_idx, Variant:
 						if (ap) {
 							NodePath npath = animation->track_get_path(p_target_track_idx);
 							Node *a_ap_root_node = ap->get_node(ap->get_root_node());
-							Node *nd = nullptr;
-							// We must test that we have a valid a_ap_root_node before trying to access its content to init the nd Node.
+							Node *node = nullptr;
+							// We must test that we have a valid a_ap_root_node before trying to access its content to init the `node` Node.
 							if (a_ap_root_node) {
-								nd = a_ap_root_node->get_node(NodePath(npath.get_concatenated_names()));
+								node = a_ap_root_node->get_node(NodePath(npath.get_concatenated_names()));
 							}
-							if (nd) {
+							if (node) {
 								StringName prop = npath.get_concatenated_subnames();
 								PropertyInfo prop_info;
-								path_valid = ClassDB::get_property_info(nd->get_class(), prop, &prop_info);
+								path_valid = ClassDB::get_property_info(node->get_class(), prop, &prop_info);
 								property_type = prop_info.type;
 							}
 						}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5571,7 +5571,7 @@ void EditorNode::add_io_error(const String &p_error) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Error"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_error + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// When a progress dialog is displayed, we will wait for it to close before displaying
 	// the io errors to prevent the io popup to set it's parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;
@@ -5584,7 +5584,7 @@ void EditorNode::add_io_warning(const String &p_warning) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Warning"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_warning + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// When a progress dialog is displayed, we will wait for it to close before displaying
 	// the io errors to prevent the io popup to set it's parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5604,7 +5604,7 @@ void EditorNode::add_io_error(const String &p_error) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Error"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_error + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// When a progress dialog is displayed, we will wait for it to close before displaying
 	// the io errors to prevent the io popup to set it's parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;
@@ -5617,7 +5617,7 @@ void EditorNode::add_io_warning(const String &p_warning) {
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 	singleton->load_errors->add_image(singleton->theme->get_icon(SNAME("Warning"), EditorStringName(EditorIcons)));
 	singleton->load_errors->add_text(p_warning + "\n");
-	// When a progress dialog is displayed, we will wait for it ot close before displaying
+	// When a progress dialog is displayed, we will wait for it to close before displaying
 	// the io errors to prevent the io popup to set it's parent to the progress dialog.
 	if (singleton->progress_dialog->is_visible()) {
 		singleton->load_errors_queued_to_display = true;

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2540,12 +2540,12 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 							Dictionary device_event = devices[i];
 							if (device_event["Event"] == "DeviceDetected") {
 								Dictionary device_info = device_event["Device"];
-								Device nd;
-								nd.id = device_info["DeviceIdentifier"];
-								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
-								nd.wifi = device_event["Interface"] == "WIFI";
-								nd.use_ios_deploy = true;
-								ldevices.push_back(nd);
+								Device device;
+								device.id = device_info["DeviceIdentifier"];
+								device.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
+								device.wifi = device_event["Interface"] == "WIFI";
+								device.use_ios_deploy = true;
+								ldevices.push_back(device);
 							}
 						}
 					}
@@ -2583,11 +2583,11 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						const Dictionary &conn_props = device_info["connectionProperties"];
 						const Dictionary &dev_props = device_info["deviceProperties"];
 						if (dev_props.has("developerModeStatus") && conn_props.has("pairingState") && conn_props.has("transportType") && conn_props["pairingState"] == "paired" && dev_props["developerModeStatus"] == "enabled") {
-							Device nd;
-							nd.id = device_info["identifier"];
-							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
-							nd.wifi = conn_props["transportType"] == "localNetwork";
-							ldevices.push_back(nd);
+							Device device;
+							device.id = device_info["identifier"];
+							device.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
+							device.wifi = conn_props["transportType"] == "localNetwork";
+							ldevices.push_back(device);
 						}
 					}
 				}

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2535,12 +2535,12 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 							Dictionary device_event = devices[i];
 							if (device_event["Event"] == "DeviceDetected") {
 								Dictionary device_info = device_event["Device"];
-								Device nd;
-								nd.id = device_info["DeviceIdentifier"];
-								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
-								nd.wifi = device_event["Interface"] == "WIFI";
-								nd.use_ios_deploy = true;
-								ldevices.push_back(nd);
+								Device device;
+								device.id = device_info["DeviceIdentifier"];
+								device.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
+								device.wifi = device_event["Interface"] == "WIFI";
+								device.use_ios_deploy = true;
+								ldevices.push_back(device);
 							}
 						}
 					}
@@ -2578,11 +2578,11 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						const Dictionary &conn_props = device_info["connectionProperties"];
 						const Dictionary &dev_props = device_info["deviceProperties"];
 						if (dev_props.has("developerModeStatus") && conn_props.has("pairingState") && conn_props.has("transportType") && conn_props["pairingState"] == "paired" && dev_props["developerModeStatus"] == "enabled") {
-							Device nd;
-							nd.id = device_info["identifier"];
-							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
-							nd.wifi = conn_props["transportType"] == "localNetwork";
-							ldevices.push_back(nd);
+							Device device;
+							device.id = device_info["identifier"];
+							device.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
+							device.wifi = conn_props["transportType"] == "localNetwork";
+							ldevices.push_back(device);
 						}
 					}
 				}

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -424,7 +424,7 @@ void ShaderBakerExportPlugin::_customize_shader_version(ShaderRD *p_shader, RID 
 
 void ShaderBakerExportPlugin::_process_work_item(WorkItem p_work_item) {
 	if (!tasks_cancelled) {
-		// Only process the item if the tasks haven't been cancelled by the user yet.
+		// Only process the item if the tasks haven't been canceled by the user yet.
 		Vector<RD::ShaderStageSPIRVData> spirv_data = ShaderRD::compile_stages(p_work_item.stage_sources, p_work_item.dynamic_buffers);
 		if (unlikely(spirv_data.is_empty())) {
 			ERR_PRINT("Unable to retrieve SPIR-V data for shader.");

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -108,7 +108,7 @@ void GotoLinePopup::_notification(int p_what) {
 
 void GotoLinePopup::_input_from_window(const Ref<InputEvent> &p_event) {
 	if (p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
-		// Cancelled, go back to original state.
+		// Canceled, go back to original state.
 		text_editor->set_edit_state(original_state);
 	}
 	PopupPanel::_input_from_window(p_event);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -434,7 +434,7 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 	item->set_selectable(0, true);
 
 	if (!node_map.has(import_id)) {
-		NodeData nd;
+		NodeData node_data;
 
 		if (p_node != scene) {
 			ResourceImporterScene::InternalImportCategory category;
@@ -454,10 +454,10 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 				category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_NODE;
 			}
 
-			_load_default_subresource_settings(nd.settings, "nodes", import_id, category);
+			_load_default_subresource_settings(node_data.settings, "nodes", import_id, category);
 		}
 
-		node_map[import_id] = nd;
+		node_map[import_id] = node_data;
 	}
 	NodeData &node_data = node_map[import_id];
 
@@ -869,9 +869,9 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		}
 		material_tree->deselect_all();
 		mesh_tree->deselect_all();
-		NodeData &nd = node_map[p_id];
+		NodeData &node_data = node_map[p_id];
 
-		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(nd.node);
+		MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(node_data.node);
 		if (mi) {
 			Ref<Mesh> base_mesh = mi->get_mesh();
 			if (base_mesh.is_valid()) {
@@ -886,18 +886,18 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 			}
 		}
 
-		if (nd.node == scene) {
+		if (node_data.node == scene) {
 			scene_import_settings_data->settings = &defaults;
 			scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX;
 		} else {
-			scene_import_settings_data->settings = &nd.settings;
+			scene_import_settings_data->settings = &node_data.settings;
 			if (mi) {
 				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE;
 				scene_import_settings_data->hide_options = hide_node_gen_options;
-			} else if (Object::cast_to<AnimationPlayer>(nd.node)) {
+			} else if (Object::cast_to<AnimationPlayer>(node_data.node)) {
 				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE;
 				scene_import_settings_data->hide_options = hide_anim_and_skel_options;
-			} else if (Object::cast_to<Skeleton3D>(nd.node)) {
+			} else if (Object::cast_to<Skeleton3D>(node_data.node)) {
 				scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_SKELETON_3D_NODE;
 				bones_mesh_preview->show();
 				scene_import_settings_data->hide_options = hide_anim_and_skel_options;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1974,7 +1974,7 @@ void EditorPropertyEasing::setup(bool p_positive_only, bool p_flip) {
 void EditorPropertyEasing::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			preset->set_item_icon(preset->get_item_index(EASING_LINEAR), get_editor_theme_icon(SNAME("CurveLinear")));
+			preset->set_item_icon(preset->get_item_index(EASING_LINEAR), get_editor_theme_icon(SNAME("CurveLinear"))); // codespell:ignore curvelinear.
 			preset->set_item_icon(preset->get_item_index(EASING_IN), get_editor_theme_icon(SNAME("CurveIn")));
 			preset->set_item_icon(preset->get_item_index(EASING_OUT), get_editor_theme_icon(SNAME("CurveOut")));
 			preset->set_item_icon(preset->get_item_index(EASING_ZERO), get_editor_theme_icon(SNAME("CurveConstant")));

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1973,7 +1973,7 @@ void EditorPropertyEasing::setup(bool p_positive_only, bool p_flip) {
 void EditorPropertyEasing::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			preset->set_item_icon(preset->get_item_index(EASING_LINEAR), get_editor_theme_icon(SNAME("CurveLinear")));
+			preset->set_item_icon(preset->get_item_index(EASING_LINEAR), get_editor_theme_icon(SNAME("CurveLinear"))); // codespell:ignore curvelinear.
 			preset->set_item_icon(preset->get_item_index(EASING_IN), get_editor_theme_icon(SNAME("CurveIn")));
 			preset->set_item_icon(preset->get_item_index(EASING_OUT), get_editor_theme_icon(SNAME("CurveOut")));
 			preset->set_item_icon(preset->get_item_index(EASING_ZERO), get_editor_theme_icon(SNAME("CurveConstant")));

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -764,7 +764,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 
 	valid = valid && test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, "project setting");
 
-	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map");
+	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map"); // codespell:ignore doubleclick.
 
 	valid = valid && test_conversion_basic("Transform", "Transform3D", RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
 

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -763,7 +763,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 
 	valid = valid && test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, "project setting");
 
-	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map");
+	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map"); // codespell:ignore doubleclick.
 
 	valid = valid && test_conversion_basic("Transform", "Transform3D", RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
 

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -63,9 +63,9 @@ void TilesEditorUtils::_pattern_preview_done() {
 }
 
 void TilesEditorUtils::_thread_func(void *ud) {
-	TilesEditorUtils *te = static_cast<TilesEditorUtils *>(ud);
+	TilesEditorUtils *utils = static_cast<TilesEditorUtils *>(ud);
 	set_current_thread_safe_for_nodes(true);
-	te->_thread();
+	utils->_thread();
 }
 
 void TilesEditorUtils::_thread() {

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -284,22 +284,22 @@ void BonePropertiesEditor::set_target(const String &p_prop) {
 }
 
 void BonePropertiesEditor::_property_keyed(const String &p_path, bool p_advance) {
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (!te || !te->has_keying()) {
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	if (!track_editor || !track_editor->has_keying()) {
 		return;
 	}
-	te->_clear_selection();
+	track_editor->_clear_selection();
 	PackedStringArray split = p_path.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		int bone_idx = split[1].to_int();
 		if (split[2] == "position") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_POSITION_3D, (Vector3)skeleton->get(p_path) / skeleton->get_motion_scale());
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_POSITION_3D, (Vector3)skeleton->get(p_path) / skeleton->get_motion_scale());
 		}
 		if (split[2] == "rotation") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_ROTATION_3D, skeleton->get(p_path));
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_ROTATION_3D, skeleton->get(p_path));
 		}
 		if (split[2] == "scale") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_SCALE_3D, skeleton->get(p_path));
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_SCALE_3D, skeleton->get(p_path));
 		}
 	}
 }
@@ -467,10 +467,10 @@ void Skeleton3DEditor::reset_pose(const bool p_all_bones) {
 void Skeleton3DEditor::insert_keys(const bool p_all_bones, const bool p_enable_modifier) {
 	ERR_FAIL_COND(!skeleton);
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	bool is_read_only = te->is_read_only();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	bool is_read_only = track_editor->is_read_only();
 	if (is_read_only) {
-		te->popup_read_only_dialog();
+		track_editor->popup_read_only_dialog();
 		return;
 	}
 	if (p_enable_modifier) {
@@ -501,8 +501,8 @@ void Skeleton3DEditor::_insert_keys(const bool p_all_bones) {
 	Node *root = EditorNode::get_singleton()->get_tree()->get_root();
 	String path = String(root->get_path_to(skeleton));
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	te->make_insert_queue();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	track_editor->make_insert_queue();
 	for (int i = 0; i < bone_len; i++) {
 		const String name = skeleton->get_bone_name(i);
 
@@ -510,17 +510,17 @@ void Skeleton3DEditor::_insert_keys(const bool p_all_bones) {
 			continue;
 		}
 
-		if (pos_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_POSITION_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_POSITION_3D, skeleton->get_bone_pose_position(i) / skeleton->get_motion_scale());
+		if (pos_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_POSITION_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_POSITION_3D, skeleton->get_bone_pose_position(i) / skeleton->get_motion_scale());
 		}
-		if (rot_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_ROTATION_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_ROTATION_3D, skeleton->get_bone_pose_rotation(i));
+		if (rot_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_ROTATION_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_ROTATION_3D, skeleton->get_bone_pose_rotation(i));
 		}
-		if (scl_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_SCALE_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_SCALE_3D, skeleton->get_bone_pose_scale(i));
+		if (scl_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_SCALE_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_SCALE_3D, skeleton->get_bone_pose_scale(i));
 		}
 	}
-	te->commit_insert_queue();
+	track_editor->commit_insert_queue();
 }
 
 void Skeleton3DEditor::pose_to_rest(const bool p_all_bones) {
@@ -1063,7 +1063,7 @@ void Skeleton3DEditor::create_editors() {
 	set_focus_mode(FOCUS_ALL);
 
 	Node3DEditor *ne = Node3DEditor::get_singleton();
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
 
 	// Create File dialog.
 	file_dialog = memnew(EditorFileDialog);
@@ -1211,7 +1211,7 @@ void Skeleton3DEditor::create_editors() {
 	pose_editor->set_visible(false);
 	add_child(pose_editor);
 
-	set_keyable(te->has_keying());
+	set_keyable(track_editor->has_keying());
 }
 
 void Skeleton3DEditor::_loc_toggled(bool p_toggled_on) {

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -284,22 +284,22 @@ void BonePropertiesEditor::set_target(const String &p_prop) {
 }
 
 void BonePropertiesEditor::_property_keyed(const String &p_path, bool p_advance) {
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (!te || !te->has_keying()) {
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	if (!track_editor || !track_editor->has_keying()) {
 		return;
 	}
-	te->_clear_selection();
+	track_editor->_clear_selection();
 	PackedStringArray split = p_path.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		int bone_idx = split[1].to_int();
 		if (split[2] == "position") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_POSITION_3D, (Vector3)skeleton->get(p_path) / skeleton->get_motion_scale());
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_POSITION_3D, (Vector3)skeleton->get(p_path) / skeleton->get_motion_scale());
 		}
 		if (split[2] == "rotation") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_ROTATION_3D, skeleton->get(p_path));
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_ROTATION_3D, skeleton->get(p_path));
 		}
 		if (split[2] == "scale") {
-			te->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_SCALE_3D, skeleton->get(p_path));
+			track_editor->insert_transform_3d_key(skeleton, skeleton->get_bone_name(bone_idx), Animation::TYPE_SCALE_3D, skeleton->get(p_path));
 		}
 	}
 }
@@ -467,10 +467,10 @@ void Skeleton3DEditor::reset_pose(const bool p_all_bones) {
 void Skeleton3DEditor::insert_keys(const bool p_all_bones, const bool p_enable_modifier) {
 	ERR_FAIL_COND(!skeleton);
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	bool is_read_only = te->is_read_only();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	bool is_read_only = track_editor->is_read_only();
 	if (is_read_only) {
-		te->popup_read_only_dialog();
+		track_editor->popup_read_only_dialog();
 		return;
 	}
 	if (p_enable_modifier) {
@@ -499,8 +499,8 @@ void Skeleton3DEditor::_insert_keys(const bool p_all_bones) {
 
 	int bone_len = skeleton->get_bone_count();
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	te->make_insert_queue();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	track_editor->make_insert_queue();
 	for (int i = 0; i < bone_len; i++) {
 		const String name = skeleton->get_bone_name(i);
 
@@ -508,17 +508,17 @@ void Skeleton3DEditor::_insert_keys(const bool p_all_bones) {
 			continue;
 		}
 
-		if (pos_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_POSITION_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_POSITION_3D, skeleton->get_bone_pose_position(i) / skeleton->get_motion_scale());
+		if (pos_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_POSITION_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_POSITION_3D, skeleton->get_bone_pose_position(i) / skeleton->get_motion_scale());
 		}
-		if (rot_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_ROTATION_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_ROTATION_3D, skeleton->get_bone_pose_rotation(i));
+		if (rot_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_ROTATION_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_ROTATION_3D, skeleton->get_bone_pose_rotation(i));
 		}
-		if (scl_enabled && (p_all_bones || te->has_transform_3d_track(skeleton, name, Animation::TYPE_SCALE_3D))) {
-			te->insert_transform_3d_key(skeleton, name, Animation::TYPE_SCALE_3D, skeleton->get_bone_pose_scale(i));
+		if (scl_enabled && (p_all_bones || track_editor->has_transform_3d_track(skeleton, name, Animation::TYPE_SCALE_3D))) {
+			track_editor->insert_transform_3d_key(skeleton, name, Animation::TYPE_SCALE_3D, skeleton->get_bone_pose_scale(i));
 		}
 	}
-	te->commit_insert_queue();
+	track_editor->commit_insert_queue();
 }
 
 void Skeleton3DEditor::pose_to_rest(const bool p_all_bones) {
@@ -1061,7 +1061,7 @@ void Skeleton3DEditor::create_editors() {
 	set_focus_mode(FOCUS_ALL);
 
 	Node3DEditor *ne = Node3DEditor::get_singleton();
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
 
 	// Create File dialog.
 	file_dialog = memnew(EditorFileDialog);
@@ -1210,7 +1210,7 @@ void Skeleton3DEditor::create_editors() {
 	pose_editor->set_visible(false);
 	add_child(pose_editor);
 
-	set_keyable(te->has_keying());
+	set_keyable(track_editor->has_keying());
 }
 
 void Skeleton3DEditor::_loc_toggled(bool p_toggled_on) {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -568,8 +568,8 @@ Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
 }
 
 void CanvasItemEditor::_keying_changed() {
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (te && te->is_visible_in_tree() && te->get_current_animation().is_valid()) {
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	if (track_editor && track_editor->is_visible_in_tree() && track_editor->get_current_animation().is_valid()) {
 		animation_hb->show();
 	} else {
 		animation_hb->hide();
@@ -4730,15 +4730,15 @@ void CanvasItemEditor::_button_tool_select(int p_index) {
 void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, bool p_scale, bool p_on_existing) {
 	const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	ERR_FAIL_COND_MSG(te->get_current_animation().is_null(), "Cannot insert animation key. No animation selected.");
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	ERR_FAIL_COND_MSG(track_editor->get_current_animation().is_null(), "Cannot insert animation key. No animation selected.");
 
-	bool is_read_only = te->is_read_only();
+	bool is_read_only = track_editor->is_read_only();
 	if (is_read_only) {
-		te->popup_read_only_dialog();
+		track_editor->popup_read_only_dialog();
 		return;
 	}
-	te->make_insert_queue();
+	track_editor->make_insert_queue();
 	for (const KeyValue<ObjectID, Object *> &E : selection) {
 		CanvasItem *ci = ObjectDB::get_instance<CanvasItem>(E.key);
 		if (!ci || !ci->is_visible_in_tree()) {
@@ -4749,13 +4749,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Node2D *n2d = Object::cast_to<Node2D>(ci);
 
 			if (key_pos && p_location) {
-				te->insert_node_value_key(n2d, "position", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "position", p_on_existing);
 			}
 			if (key_rot && p_rotation) {
-				te->insert_node_value_key(n2d, "rotation", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "rotation", p_on_existing);
 			}
 			if (key_scale && p_scale) {
-				te->insert_node_value_key(n2d, "scale", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "scale", p_on_existing);
 			}
 
 			if (n2d->has_meta("_edit_bone_") && n2d->get_parent_item()) {
@@ -4781,13 +4781,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 				if (has_chain && ik_chain.size()) {
 					for (Node2D *&F : ik_chain) {
 						if (key_pos) {
-							te->insert_node_value_key(F, "position", p_on_existing);
+							track_editor->insert_node_value_key(F, "position", p_on_existing);
 						}
 						if (key_rot) {
-							te->insert_node_value_key(F, "rotation", p_on_existing);
+							track_editor->insert_node_value_key(F, "rotation", p_on_existing);
 						}
 						if (key_scale) {
-							te->insert_node_value_key(F, "scale", p_on_existing);
+							track_editor->insert_node_value_key(F, "scale", p_on_existing);
 						}
 					}
 				}
@@ -4797,17 +4797,17 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Control *ctrl = Object::cast_to<Control>(ci);
 
 			if (key_pos) {
-				te->insert_node_value_key(ctrl, "position", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "position", p_on_existing);
 			}
 			if (key_rot) {
-				te->insert_node_value_key(ctrl, "rotation", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "rotation", p_on_existing);
 			}
 			if (key_scale) {
-				te->insert_node_value_key(ctrl, "size", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "size", p_on_existing);
 			}
 		}
 	}
-	te->commit_insert_queue();
+	track_editor->commit_insert_queue();
 }
 
 void CanvasItemEditor::_prepare_view_menu() {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -584,8 +584,8 @@ Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
 }
 
 void CanvasItemEditor::_keying_changed() {
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (te && te->is_visible_in_tree() && te->get_current_animation().is_valid()) {
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	if (track_editor && track_editor->is_visible_in_tree() && track_editor->get_current_animation().is_valid()) {
 		animation_hb->show();
 	} else {
 		animation_hb->hide();
@@ -4848,15 +4848,15 @@ void CanvasItemEditor::_button_tool_select(int p_index) {
 void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, bool p_scale, bool p_on_existing) {
 	const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
 
-	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	ERR_FAIL_COND_MSG(te->get_current_animation().is_null(), "Cannot insert animation key. No animation selected.");
+	AnimationTrackEditor *track_editor = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	ERR_FAIL_COND_MSG(track_editor->get_current_animation().is_null(), "Cannot insert animation key. No animation selected.");
 
-	bool is_read_only = te->is_read_only();
+	bool is_read_only = track_editor->is_read_only();
 	if (is_read_only) {
-		te->popup_read_only_dialog();
+		track_editor->popup_read_only_dialog();
 		return;
 	}
-	te->make_insert_queue();
+	track_editor->make_insert_queue();
 	for (const KeyValue<ObjectID, Object *> &E : selection) {
 		CanvasItem *ci = ObjectDB::get_instance<CanvasItem>(E.key);
 		if (!ci || !ci->is_visible_in_tree()) {
@@ -4867,13 +4867,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Node2D *n2d = Object::cast_to<Node2D>(ci);
 
 			if (key_pos && p_location) {
-				te->insert_node_value_key(n2d, "position", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "position", p_on_existing);
 			}
 			if (key_rot && p_rotation) {
-				te->insert_node_value_key(n2d, "rotation", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "rotation", p_on_existing);
 			}
 			if (key_scale && p_scale) {
-				te->insert_node_value_key(n2d, "scale", p_on_existing);
+				track_editor->insert_node_value_key(n2d, "scale", p_on_existing);
 			}
 
 			if (n2d->has_meta("_edit_bone_") && n2d->get_parent_item()) {
@@ -4899,13 +4899,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 				if (has_chain && ik_chain.size()) {
 					for (Node2D *&F : ik_chain) {
 						if (key_pos) {
-							te->insert_node_value_key(F, "position", p_on_existing);
+							track_editor->insert_node_value_key(F, "position", p_on_existing);
 						}
 						if (key_rot) {
-							te->insert_node_value_key(F, "rotation", p_on_existing);
+							track_editor->insert_node_value_key(F, "rotation", p_on_existing);
 						}
 						if (key_scale) {
-							te->insert_node_value_key(F, "scale", p_on_existing);
+							track_editor->insert_node_value_key(F, "scale", p_on_existing);
 						}
 					}
 				}
@@ -4915,17 +4915,17 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Control *ctrl = Object::cast_to<Control>(ci);
 
 			if (key_pos) {
-				te->insert_node_value_key(ctrl, "position", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "position", p_on_existing);
 			}
 			if (key_rot) {
-				te->insert_node_value_key(ctrl, "rotation", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "rotation", p_on_existing);
 			}
 			if (key_scale) {
-				te->insert_node_value_key(ctrl, "size", p_on_existing);
+				track_editor->insert_node_value_key(ctrl, "size", p_on_existing);
 			}
 		}
 	}
-	te->commit_insert_queue();
+	track_editor->commit_insert_queue();
 }
 
 void CanvasItemEditor::_prepare_view_menu() {

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -966,7 +966,7 @@ void CurveEditor::_notification(int p_what) {
 			PopupMenu *p = presets_button->get_popup();
 			p->clear();
 			p->add_icon_item(get_editor_theme_icon(SNAME("CurveConstant")), TTR("Constant"), CurveEdit::PRESET_CONSTANT);
-			p->add_icon_item(get_editor_theme_icon(SNAME("CurveLinear")), TTR("Linear"), CurveEdit::PRESET_LINEAR);
+			p->add_icon_item(get_editor_theme_icon(SNAME("CurveLinear")), TTR("Linear"), CurveEdit::PRESET_LINEAR); // codespell:ignore curvelinear.
 			p->add_icon_item(get_editor_theme_icon(SNAME("CurveIn")), TTR("Ease In"), CurveEdit::PRESET_EASE_IN);
 			p->add_icon_item(get_editor_theme_icon(SNAME("CurveOut")), TTR("Ease Out"), CurveEdit::PRESET_EASE_OUT);
 			p->add_icon_item(get_editor_theme_icon(SNAME("CurveInOut")), TTR("Smoothstep"), CurveEdit::PRESET_SMOOTHSTEP);

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -382,10 +382,10 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	le->set_text(TTR("Disabled LineEdit"));
 	le->set_editable(false);
 	second_vb->add_child(le);
-	TextEdit *te = memnew(TextEdit);
-	te->set_text("TextEdit");
-	te->set_custom_minimum_size(Size2(0, 100));
-	second_vb->add_child(te);
+	TextEdit *text_edit = memnew(TextEdit);
+	text_edit->set_text("TextEdit");
+	text_edit->set_custom_minimum_size(Size2(0, 100));
+	second_vb->add_child(text_edit);
 	second_vb->add_child(memnew(SpinBox));
 
 	HBoxContainer *vhb = memnew(HBoxContainer);

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -382,10 +382,10 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	le->set_text(TTRC("Disabled LineEdit"));
 	le->set_editable(false);
 	second_vb->add_child(le);
-	TextEdit *te = memnew(TextEdit);
-	te->set_text("TextEdit");
-	te->set_custom_minimum_size(Size2(0, 100));
-	second_vb->add_child(te);
+	TextEdit *text_edit = memnew(TextEdit);
+	text_edit->set_text("TextEdit");
+	text_edit->set_custom_minimum_size(Size2(0, 100));
+	second_vb->add_child(text_edit);
 	second_vb->add_child(memnew(SpinBox));
 
 	HBoxContainer *vhb = memnew(HBoxContainer);

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -588,7 +588,7 @@ bool SpriteFramesEditor::_matches_background_color(const Color &p_background_col
 	}
 
 	Color d = p_background_color - p_pixel_color;
-	// 0.04f is the threshold for how much a colour can deviate from background colour and still be considered a match. Arrived at through experimentation, can be tweaked.
+	// 0.04f is the threshold for how much a color can deviate from background color and still be considered a match. Arrived at through experimentation, can be tweaked.
 	return (d.r * d.r) + (d.g * d.g) + (d.b * d.b) + (d.a * d.a) < 0.04f;
 }
 

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -555,9 +555,9 @@ void TextEditorBase::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highl
 void TextEditorBase::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 	p_highlighter->_set_edited_resource(edited_res);
-	te->set_syntax_highlighter(p_highlighter);
+	text_editor->set_syntax_highlighter(p_highlighter);
 }
 
 void TextEditorBase::set_edited_resource(const Ref<Resource> &p_res) {
@@ -597,33 +597,33 @@ void TextEditorBase::tag_saved_version() {
 void TextEditorBase::reload_text() {
 	ERR_FAIL_COND(edited_res.is_null());
 
-	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->get_caret_column();
-	int row = te->get_caret_line();
-	int h = te->get_h_scroll();
-	int v = te->get_v_scroll();
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	int column = text_editor->get_caret_column();
+	int row = text_editor->get_caret_line();
+	int h = text_editor->get_h_scroll();
+	int v = text_editor->get_v_scroll();
 
 	Ref<TextFile> text_file = edited_res;
 	if (text_file.is_valid()) {
-		te->set_text(text_file->get_text());
+		text_editor->set_text(text_file->get_text());
 	}
 
 	Ref<JSON> json_file = edited_res;
 	if (json_file.is_valid()) {
-		te->set_text(json_file->get_parsed_text());
+		text_editor->set_text(json_file->get_parsed_text());
 	}
 
 	Ref<Script> script = edited_res;
 	if (script.is_valid()) {
-		te->set_text(script->get_source_code());
+		text_editor->set_text(script->get_source_code());
 	}
 
-	te->set_caret_line(row);
-	te->set_caret_column(column);
-	te->set_h_scroll(h);
-	te->set_v_scroll(v);
+	text_editor->set_caret_line(row);
+	text_editor->set_caret_column(column);
+	text_editor->set_h_scroll(h);
+	text_editor->set_v_scroll(v);
 
-	te->tag_saved_version();
+	text_editor->tag_saved_version();
 
 	code_editor->update_line_and_column();
 	if (editor_enabled) {

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -597,9 +597,9 @@ void TextEditorBase::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highl
 void TextEditorBase::set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
 
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 	p_highlighter->_set_edited_resource(edited_res);
-	te->set_syntax_highlighter(p_highlighter);
+	text_editor->set_syntax_highlighter(p_highlighter);
 }
 
 void TextEditorBase::set_edited_resource(const Ref<Resource> &p_res) {
@@ -639,43 +639,43 @@ void TextEditorBase::tag_saved_version() {
 void TextEditorBase::reload_text() {
 	ERR_FAIL_COND(edited_res.is_null());
 
-	CodeEdit *te = code_editor->get_text_editor();
-	int column = te->get_caret_column();
-	int row = te->get_caret_line();
-	int h = te->get_h_scroll();
-	int v = te->get_v_scroll();
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	int column = text_editor->get_caret_column();
+	int row = text_editor->get_caret_line();
+	int h = text_editor->get_h_scroll();
+	int v = text_editor->get_v_scroll();
 
 	Ref<TextFile> text_file = edited_res;
 	if (text_file.is_valid()) {
-		te->set_text(text_file->get_text());
+		text_editor->set_text(text_file->get_text());
 	}
 
 	Ref<JSON> json_file = edited_res;
 	if (json_file.is_valid()) {
-		te->set_text(json_file->get_parsed_text());
+		text_editor->set_text(json_file->get_parsed_text());
 	}
 
 	Ref<Script> script = edited_res;
 	if (script.is_valid()) {
-		te->set_text(script->get_source_code());
+		text_editor->set_text(script->get_source_code());
 	}
 
 	Ref<ShaderInclude> shader_inc = edited_res;
 	if (shader_inc.is_valid()) {
-		te->set_text(shader_inc->get_code());
+		text_editor->set_text(shader_inc->get_code());
 	}
 
 	Ref<Shader> shader = edited_res;
 	if (shader.is_valid()) {
-		te->set_text(shader->get_code());
+		text_editor->set_text(shader->get_code());
 	}
 
-	te->set_caret_line(row);
-	te->set_caret_column(column);
-	te->set_h_scroll(h);
-	te->set_v_scroll(v);
+	text_editor->set_caret_line(row);
+	text_editor->set_caret_column(column);
+	text_editor->set_h_scroll(h);
+	text_editor->set_v_scroll(v);
 
-	te->tag_saved_version();
+	text_editor->tag_saved_version();
 	_saved_update();
 
 	code_editor->update_line_and_column();

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3849,9 +3849,9 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 	if (text_file.is_valid()) {
 		edit(text_file);
 
-		TextEditor *te = Object::cast_to<TextEditor>(_get_current_editor());
-		if (te) {
-			te->goto_line_selection(line_number - 1, begin, end);
+		TextEditor *text_editor = Object::cast_to<TextEditor>(_get_current_editor());
+		if (text_editor) {
+			text_editor->goto_line_selection(line_number - 1, begin, end);
 		}
 	}
 	ScriptEditorNavigationMarker::get_singleton()->locate_end();

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4000,9 +4000,9 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 	if (text_file.is_valid()) {
 		edit(text_file);
 
-		TextEditor *te = Object::cast_to<TextEditor>(_get_current_editor());
-		if (te) {
-			te->goto_line_selection(line_number - 1, begin, end);
+		TextEditor *text_editor = Object::cast_to<TextEditor>(_get_current_editor());
+		if (text_editor) {
+			text_editor->goto_line_selection(line_number - 1, begin, end);
 		}
 	}
 	ScriptEditorNavigationMarker::get_singleton()->locate_end();

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -212,8 +212,8 @@ ScriptTextEditor::EditMenusSTE::EditMenusSTE() {
 ////////////////////////////////////////////////////////////////////////////////
 
 Vector<String> ScriptTextEditor::get_functions() {
-	CodeEdit *te = code_editor->get_text_editor();
-	String text = te->get_text();
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	String text = text_editor->get_text();
 	List<String> fnc;
 
 	Ref<Script> script = edited_res;
@@ -703,26 +703,26 @@ void ScriptTextEditor::_update_color_constructor_options() {
 
 void ScriptTextEditor::_update_background_color() {
 	// Clear background lines.
-	CodeEdit *te = code_editor->get_text_editor();
-	for (int i = 0; i < te->get_line_count(); i++) {
-		bool is_folded_code_region = te->is_line_code_region_start(i) && te->is_line_folded(i);
-		te->set_line_background_color(i, is_folded_code_region ? folded_code_region_color : Color(0, 0, 0, 0));
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	for (int i = 0; i < text_editor->get_line_count(); i++) {
+		bool is_folded_code_region = text_editor->is_line_code_region_start(i) && text_editor->is_line_folded(i);
+		text_editor->set_line_background_color(i, is_folded_code_region ? folded_code_region_color : Color(0, 0, 0, 0));
 	}
 
 	// Set the warning background.
 	if (warning_line_color.a != 0.0) {
 		for (const ScriptLanguage::Warning &warning : warnings) {
-			int warning_start_line = CLAMP(warning.start_line - 1, 0, te->get_line_count() - 1);
-			int warning_end_line = CLAMP(warning.end_line - 1, 0, te->get_line_count() - 1);
-			int folded_line_header = te->get_folded_line_header(warning_start_line);
+			int warning_start_line = CLAMP(warning.start_line - 1, 0, text_editor->get_line_count() - 1);
+			int warning_end_line = CLAMP(warning.end_line - 1, 0, text_editor->get_line_count() - 1);
+			int folded_line_header = text_editor->get_folded_line_header(warning_start_line);
 
 			// If the warning highlight is too long, only highlight the start line.
 			const int warning_max_lines = 20;
 
-			te->set_line_background_color(folded_line_header, warning_line_color);
+			text_editor->set_line_background_color(folded_line_header, warning_line_color);
 			if (warning_end_line - warning_start_line < warning_max_lines) {
 				for (int i = warning_start_line + 1; i <= warning_end_line; i++) {
-					te->set_line_background_color(i, warning_line_color);
+					text_editor->set_line_background_color(i, warning_line_color);
 				}
 			}
 		}
@@ -731,10 +731,10 @@ void ScriptTextEditor::_update_background_color() {
 	// Set the error background.
 	if (marked_line_color.a != 0.0) {
 		for (const ScriptLanguage::ScriptError &error : errors) {
-			int error_line = CLAMP(error.line - 1, 0, te->get_line_count() - 1);
-			int folded_line_header = te->get_folded_line_header(error_line);
+			int error_line = CLAMP(error.line - 1, 0, text_editor->get_line_count() - 1);
+			int folded_line_header = text_editor->get_folded_line_header(error_line);
 
-			te->set_line_background_color(folded_line_header, marked_line_color);
+			text_editor->set_line_background_color(folded_line_header, marked_line_color);
 		}
 	}
 }
@@ -847,9 +847,9 @@ struct ScriptErrorLineComparator {
 };
 
 void ScriptTextEditor::_validate_script() {
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 
-	String text = te->get_text();
+	String text = text_editor->get_text();
 	List<String> fnc;
 
 	warnings.clear();
@@ -884,7 +884,7 @@ void ScriptTextEditor::_validate_script() {
 		if (!script->is_tool()) {
 			script->set_source_code(text);
 			script->update_exports();
-			te->get_syntax_highlighter()->update_cache();
+			text_editor->get_syntax_highlighter()->update_cache();
 		}
 
 		functions.clear();
@@ -1030,21 +1030,21 @@ void ScriptTextEditor::_update_errors() {
 
 	bool highlight_safe = EDITOR_GET("text_editor/appearance/gutters/highlight_type_safe_lines");
 	bool last_is_safe = false;
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 
-	for (int i = 0; i < te->get_line_count(); i++) {
+	for (int i = 0; i < text_editor->get_line_count(); i++) {
 		if (highlight_safe) {
 			if (safe_lines.has(i + 1)) {
-				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 				last_is_safe = true;
-			} else if (last_is_safe && (te->is_in_comment(i) != -1 || te->get_line(i).strip_edges().is_empty())) {
-				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
+			} else if (last_is_safe && (text_editor->is_in_comment(i) != -1 || text_editor->get_line(i).strip_edges().is_empty())) {
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 			} else {
-				te->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
 				last_is_safe = false;
 			}
 		} else {
-			te->set_line_gutter_item_color(i, 1, default_line_number_color);
+			text_editor->set_line_gutter_item_color(i, 1, default_line_number_color);
 		}
 	}
 }
@@ -2083,18 +2083,18 @@ String ScriptTextEditor::_get_dropped_resource_as_exported_member(const Ref<Reso
 void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	CodeEdit *te = code_editor->get_text_editor();
-	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(text_editor->get_caret_line(0), text_editor->get_caret_column(0)) : text_editor->get_line_column_at_pos(p_point);
 	int drop_at_line = pos.y;
 	int drop_at_column = pos.x;
-	int selection_index = te->get_selection_at_line_column(drop_at_line, drop_at_column);
+	int selection_index = text_editor->get_selection_at_line_column(drop_at_line, drop_at_column);
 
 	bool is_empty_line = false;
 	if (selection_index >= 0) {
 		// Dropped on a selection, it will be replaced.
-		drop_at_line = te->get_selection_from_line(selection_index);
-		drop_at_column = te->get_selection_from_column(selection_index);
-		is_empty_line = drop_at_column <= te->get_first_non_whitespace_column(drop_at_line) && te->get_selection_to_column(selection_index) == te->get_line(te->get_selection_to_line(selection_index)).length();
+		drop_at_line = text_editor->get_selection_from_line(selection_index);
+		drop_at_column = text_editor->get_selection_from_column(selection_index);
+		is_empty_line = drop_at_column <= text_editor->get_first_non_whitespace_column(drop_at_line) && text_editor->get_selection_to_column(selection_index) == text_editor->get_line(text_editor->get_selection_to_line(selection_index)).length();
 	}
 
 	Node *scene_root = get_tree()->get_edited_scene_root();
@@ -2103,10 +2103,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	const bool export_drop_modifier_pressed = Input::get_singleton()->is_key_pressed(Key::ALT);
 
 	const bool allow_uid = Input::get_singleton()->is_key_pressed(Key::SHIFT) != bool(EDITOR_GET("text_editor/behavior/files/drop_preload_resources_as_uid"));
-	const String &line = te->get_line(drop_at_line);
+	const String &line = text_editor->get_line(drop_at_line);
 
 	if (selection_index < 0) {
-		is_empty_line = line.is_empty() || te->get_first_non_whitespace_column(drop_at_line) == line.length();
+		is_empty_line = line.is_empty() || text_editor->get_first_non_whitespace_column(drop_at_line) == line.length();
 	}
 
 	String text_to_drop;
@@ -2171,11 +2171,11 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		}
 		String join_string;
 		if (is_empty_line) {
-			int indent_level = te->get_indent_level(drop_at_line);
-			if (te->is_indent_using_spaces()) {
+			int indent_level = text_editor->get_indent_level(drop_at_line);
+			if (text_editor->is_indent_using_spaces()) {
 				join_string = "\n" + String(" ").repeat(indent_level);
 			} else {
-				join_string = "\n" + String("\t").repeat(indent_level / te->get_tab_size());
+				join_string = "\n" + String("\t").repeat(indent_level / text_editor->get_tab_size());
 			}
 		} else {
 			join_string = ", ";
@@ -2308,23 +2308,23 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	// Remove drag caret before any actions so it is not included in undo.
-	te->remove_drag_caret();
-	te->begin_complex_operation();
+	text_editor->remove_drag_caret();
+	text_editor->begin_complex_operation();
 	if (selection_index >= 0) {
-		te->delete_selection(selection_index);
+		text_editor->delete_selection(selection_index);
 	}
-	te->remove_secondary_carets();
-	te->deselect();
-	te->set_caret_line(drop_at_line);
+	text_editor->remove_secondary_carets();
+	text_editor->deselect();
+	text_editor->set_caret_line(drop_at_line);
 	if (add_new_line) {
-		te->set_caret_column(te->get_line(drop_at_line).length());
+		text_editor->set_caret_column(text_editor->get_line(drop_at_line).length());
 		text_to_drop = "\n" + text_to_drop;
 	} else {
-		te->set_caret_column(drop_at_column);
+		text_editor->set_caret_column(drop_at_column);
 	}
-	te->insert_text_at_caret(text_to_drop);
-	te->end_complex_operation();
-	te->grab_focus();
+	text_editor->insert_text_at_caret(text_to_drop);
+	text_editor->end_complex_operation();
+	text_editor->grab_focus();
 
 	drag_info_label->hide();
 }

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -168,8 +168,8 @@ ScriptTextEditor::EditMenusScTE::EditMenusScTE(ScriptEditor *p_se) : EditMenusCE
 ////////////////////////////////////////////////////////////////////////////////
 
 Vector<String> ScriptTextEditor::get_functions() {
-	CodeEdit *te = code_editor->get_text_editor();
-	String text = te->get_text();
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	String text = text_editor->get_text();
 	List<String> fnc;
 
 	Ref<Script> script = edited_res;
@@ -735,35 +735,35 @@ void ScriptTextEditor::_update_color_constructor_options() {
 
 void ScriptTextEditor::_update_background_color() {
 	// Clear background lines.
-	CodeEdit *te = code_editor->get_text_editor();
-	for (int i = 0; i < te->get_line_count(); i++) {
-		bool is_folded_code_region = te->is_line_code_region_start(i) && te->is_line_folded(i);
-		te->set_line_background_color(i, is_folded_code_region ? folded_code_region_color : Color(0, 0, 0, 0));
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	for (int i = 0; i < text_editor->get_line_count(); i++) {
+		bool is_folded_code_region = text_editor->is_line_code_region_start(i) && text_editor->is_line_folded(i);
+		text_editor->set_line_background_color(i, is_folded_code_region ? folded_code_region_color : Color(0, 0, 0, 0));
 	}
 
-	te->clear_underlines();
+	text_editor->clear_underlines();
 
 	// Set the warning background.
 	if (warning_line_color.a != 0.0 || warning_underline_color.a != 0.0) {
 		for (const ScriptLanguage::Warning &warning : warnings) {
-			int warning_start_line = CLAMP(warning.start_line - 1, 0, te->get_line_count() - 1);
+			int warning_start_line = CLAMP(warning.start_line - 1, 0, text_editor->get_line_count() - 1);
 			int warning_start_column = warning.start_column - 1;
-			int warning_end_line = CLAMP(warning.end_line - 1, 0, te->get_line_count() - 1);
+			int warning_end_line = CLAMP(warning.end_line - 1, 0, text_editor->get_line_count() - 1);
 			int warning_end_column = warning.end_column - 1;
-			int folded_line_header = te->get_folded_line_header(warning_start_line);
+			int folded_line_header = text_editor->get_folded_line_header(warning_start_line);
 
 			if (warning_underline_color.a != 0.0) {
-				te->add_underline(warning_underline_color, warning_start_line, warning_start_column, warning_end_line, warning_end_column);
+				text_editor->add_underline(warning_underline_color, warning_start_line, warning_start_column, warning_end_line, warning_end_column);
 			}
 
 			if (warning_line_color.a != 0.0) {
 				// If the warning highlight is too long, only highlight the start line.
 				const int warning_max_lines = 20;
 
-				te->set_line_background_color(folded_line_header, warning_line_color);
+				text_editor->set_line_background_color(folded_line_header, warning_line_color);
 				if (warning_end_line - warning_start_line < warning_max_lines) {
 					for (int i = warning_start_line + 1; i <= warning_end_line; i++) {
-						te->set_line_background_color(i, warning_line_color);
+						text_editor->set_line_background_color(i, warning_line_color);
 					}
 				}
 			}
@@ -773,18 +773,18 @@ void ScriptTextEditor::_update_background_color() {
 	// Set the error background.
 	if (marked_line_color.a != 0.0 || error_underline_color.a != 0.0) {
 		for (const ScriptLanguage::ScriptError &error : errors) {
-			int error_start_line = CLAMP(error.start_line - 1, 0, te->get_line_count() - 1);
+			int error_start_line = CLAMP(error.start_line - 1, 0, text_editor->get_line_count() - 1);
 			int error_start_column = error.start_column - 1;
-			int error_end_line = CLAMP(error.end_line - 1, 0, te->get_line_count() - 1);
+			int error_end_line = CLAMP(error.end_line - 1, 0, text_editor->get_line_count() - 1);
 			int error_end_column = error.end_column - 1;
-			int folded_line_header = te->get_folded_line_header(error_start_line);
+			int folded_line_header = text_editor->get_folded_line_header(error_start_line);
 
 			if (error_underline_color.a != 0.0) {
-				te->add_underline(error_underline_color, error_start_line, error_start_column, error_end_line, error_end_column);
+				text_editor->add_underline(error_underline_color, error_start_line, error_start_column, error_end_line, error_end_column);
 			}
 
 			if (marked_line_color.a != 0.0) {
-				te->set_line_background_color(folded_line_header, marked_line_color);
+				text_editor->set_line_background_color(folded_line_header, marked_line_color);
 			}
 		}
 	}
@@ -898,9 +898,9 @@ struct ScriptErrorLineComparator {
 };
 
 void ScriptTextEditor::_validate_script() {
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 
-	String text = te->get_text();
+	String text = text_editor->get_text();
 	List<String> fnc;
 
 	warnings.clear();
@@ -935,7 +935,7 @@ void ScriptTextEditor::_validate_script() {
 		if (!script->is_tool()) {
 			script->set_source_code(text);
 			script->update_exports();
-			te->get_syntax_highlighter()->update_cache();
+			text_editor->get_syntax_highlighter()->update_cache();
 		}
 
 		functions.clear();
@@ -1080,21 +1080,21 @@ void ScriptTextEditor::_update_errors() {
 
 	bool highlight_safe = EDITOR_GET("text_editor/appearance/gutters/highlight_type_safe_lines");
 	bool last_is_safe = false;
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *text_editor = code_editor->get_text_editor();
 
-	for (int i = 0; i < te->get_line_count(); i++) {
+	for (int i = 0; i < text_editor->get_line_count(); i++) {
 		if (highlight_safe) {
 			if (safe_lines.has(i + 1)) {
-				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 				last_is_safe = true;
-			} else if (last_is_safe && (te->is_in_comment(i) != -1 || te->get_line(i).strip_edges().is_empty())) {
-				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
+			} else if (last_is_safe && (text_editor->is_in_comment(i) != -1 || text_editor->get_line(i).strip_edges().is_empty())) {
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 			} else {
-				te->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
+				text_editor->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
 				last_is_safe = false;
 			}
 		} else {
-			te->set_line_gutter_item_color(i, 1, default_line_number_color);
+			text_editor->set_line_gutter_item_color(i, 1, default_line_number_color);
 		}
 	}
 }
@@ -2071,18 +2071,18 @@ String ScriptTextEditor::_get_dropped_resource_as_exported_member(const Ref<Reso
 void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	CodeEdit *te = code_editor->get_text_editor();
-	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(text_editor->get_caret_line(0), text_editor->get_caret_column(0)) : text_editor->get_line_column_at_pos(p_point);
 	int drop_at_line = pos.y;
 	int drop_at_column = pos.x;
-	int selection_index = te->get_selection_at_line_column(drop_at_line, drop_at_column);
+	int selection_index = text_editor->get_selection_at_line_column(drop_at_line, drop_at_column);
 
 	bool is_empty_line = false;
 	if (selection_index >= 0) {
 		// Dropped on a selection, it will be replaced.
-		drop_at_line = te->get_selection_from_line(selection_index);
-		drop_at_column = te->get_selection_from_column(selection_index);
-		is_empty_line = drop_at_column <= te->get_first_non_whitespace_column(drop_at_line) && te->get_selection_to_column(selection_index) == te->get_line(te->get_selection_to_line(selection_index)).length();
+		drop_at_line = text_editor->get_selection_from_line(selection_index);
+		drop_at_column = text_editor->get_selection_from_column(selection_index);
+		is_empty_line = drop_at_column <= text_editor->get_first_non_whitespace_column(drop_at_line) && text_editor->get_selection_to_column(selection_index) == text_editor->get_line(text_editor->get_selection_to_line(selection_index)).length();
 	}
 
 	Node *scene_root = get_tree()->get_edited_scene_root();
@@ -2091,10 +2091,10 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	const bool export_drop_modifier_pressed = Input::get_singleton()->is_key_pressed(Key::ALT);
 
 	const bool allow_uid = Input::get_singleton()->is_key_pressed(Key::SHIFT) != bool(EDITOR_GET("text_editor/behavior/files/drop_preload_resources_as_uid"));
-	const String &line = te->get_line(drop_at_line);
+	const String &line = text_editor->get_line(drop_at_line);
 
 	if (selection_index < 0) {
-		is_empty_line = line.is_empty() || te->get_first_non_whitespace_column(drop_at_line) == line.length();
+		is_empty_line = line.is_empty() || text_editor->get_first_non_whitespace_column(drop_at_line) == line.length();
 	}
 
 	String text_to_drop;
@@ -2159,11 +2159,11 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		}
 		String join_string;
 		if (is_empty_line) {
-			int indent_level = te->get_indent_level(drop_at_line);
-			if (te->is_indent_using_spaces()) {
+			int indent_level = text_editor->get_indent_level(drop_at_line);
+			if (text_editor->is_indent_using_spaces()) {
 				join_string = "\n" + String(" ").repeat(indent_level);
 			} else {
-				join_string = "\n" + String("\t").repeat(indent_level / te->get_tab_size());
+				join_string = "\n" + String("\t").repeat(indent_level / text_editor->get_tab_size());
 			}
 		} else {
 			join_string = ", ";
@@ -2296,23 +2296,23 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	// Remove drag caret before any actions so it is not included in undo.
-	te->remove_drag_caret();
-	te->begin_complex_operation();
+	text_editor->remove_drag_caret();
+	text_editor->begin_complex_operation();
 	if (selection_index >= 0) {
-		te->delete_selection(selection_index);
+		text_editor->delete_selection(selection_index);
 	}
-	te->remove_secondary_carets();
-	te->deselect();
-	te->set_caret_line(drop_at_line);
+	text_editor->remove_secondary_carets();
+	text_editor->deselect();
+	text_editor->set_caret_line(drop_at_line);
 	if (add_new_line) {
-		te->set_caret_column(te->get_line(drop_at_line).length());
+		text_editor->set_caret_column(text_editor->get_line(drop_at_line).length());
 		text_to_drop = "\n" + text_to_drop;
 	} else {
-		te->set_caret_column(drop_at_column);
+		text_editor->set_caret_column(drop_at_column);
 	}
-	te->insert_text_at_caret(text_to_drop);
-	te->end_complex_operation();
-	te->grab_focus();
+	text_editor->insert_text_at_caret(text_to_drop);
+	text_editor->end_complex_operation();
+	text_editor->grab_focus();
 
 	drag_info_label->hide();
 }

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -39,15 +39,15 @@ void TextEditor::_validate_script() {
 
 	Ref<JSON> json_file = edited_res;
 	if (json_file.is_valid()) {
-		CodeEdit *te = code_editor->get_text_editor();
+		CodeEdit *text_editor = code_editor->get_text_editor();
 
-		te->set_line_background_color(code_editor->get_error_pos().x, Color(0, 0, 0, 0));
+		text_editor->set_line_background_color(code_editor->get_error_pos().x, Color(0, 0, 0, 0));
 		code_editor->set_error("");
 
-		if (json_file->parse(te->get_text(), true) != OK) {
+		if (json_file->parse(text_editor->get_text(), true) != OK) {
 			code_editor->set_error(json_file->get_error_message().replace("[", "[lb]"));
 			code_editor->set_error_pos(json_file->get_error_line(), 0);
-			te->set_line_background_color(code_editor->get_error_pos().x, EDITOR_GET("text_editor/theme/highlighting/mark_color"));
+			text_editor->set_line_background_color(code_editor->get_error_pos().x, EDITOR_GET("text_editor/theme/highlighting/mark_color"));
 		}
 	}
 }

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -395,7 +395,7 @@ static LocalVector<String> _get_skipped_locales() {
 		locales_to_skip.push_back("ml"); // Malayalam.
 		locales_to_skip.push_back("si"); // Sinhala.
 		locales_to_skip.push_back("ta"); // Tamil.
-		locales_to_skip.push_back("te"); // Telugu.
+		locales_to_skip.push_back("te"); // Telugu. // codespell:ignore te.
 	}
 	return locales_to_skip;
 }

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -394,7 +394,7 @@ static LocalVector<String> _get_skipped_locales() {
 		locales_to_skip.push_back("ml"); // Malayalam.
 		locales_to_skip.push_back("si"); // Sinhala.
 		locales_to_skip.push_back("ta"); // Tamil.
-		locales_to_skip.push_back("te"); // Telugu.
+		locales_to_skip.push_back("te"); // Telugu. // codespell:ignore te.
 	}
 	return locales_to_skip;
 }

--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -859,23 +859,23 @@ void ShaderTextEditor::_remove_shader_preview(int p_line) {
 }
 
 void ShaderTextEditor::_load_theme_settings() {
-	CodeEdit *te = code_editor->get_text_editor();
+	CodeEdit *teditor = code_editor->get_text_editor();
 	Color updated_marked_line_color = EDITOR_GET("text_editor/theme/highlighting/mark_color");
 	if (updated_marked_line_color != marked_line_color) {
-		for (int i = 0; i < te->get_line_count(); i++) {
-			if (te->get_line_background_color(i) == marked_line_color) {
-				te->set_line_background_color(i, updated_marked_line_color);
+		for (int i = 0; i < teditor->get_line_count(); i++) {
+			if (teditor->get_line_background_color(i) == marked_line_color) {
+				teditor->set_line_background_color(i, updated_marked_line_color);
 			}
 		}
 		marked_line_color = updated_marked_line_color;
 	}
 
-	te->clear_comment_delimiters();
-	te->add_comment_delimiter("/*", "*/", false);
-	te->add_comment_delimiter("//", "", true);
+	teditor->clear_comment_delimiters();
+	teditor->add_comment_delimiter("/*", "*/", false);
+	teditor->add_comment_delimiter("//", "", true);
 
-	if (!te->has_auto_brace_completion_open_key("/*")) {
-		te->add_auto_brace_completion_pair("/*", "*/");
+	if (!teditor->has_auto_brace_completion_open_key("/*")) {
+		teditor->add_auto_brace_completion_pair("/*", "*/");
 	}
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
 }
@@ -1060,8 +1060,8 @@ bool ShaderTextEditor::_edit_option(int p_option) {
 void ShaderTextEditor::_validate_script() {
 	apply_code();
 
-	CodeEdit *te = code_editor->get_text_editor();
-	String code = te->get_text();
+	CodeEdit *text_editor = code_editor->get_text_editor();
+	String code = text_editor->get_text();
 
 	ShaderPreprocessor preprocessor;
 	String code_pp;

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -952,19 +952,19 @@ void ShaderTextEditor::reload_text() {
 		code = shader_inc->get_code();
 	}
 
-	CodeEdit *te = get_text_editor();
-	int column = te->get_caret_column();
-	int row = te->get_caret_line();
-	int h = te->get_h_scroll();
-	int v = te->get_v_scroll();
+	CodeEdit *teditor = get_text_editor();
+	int column = teditor->get_caret_column();
+	int row = teditor->get_caret_line();
+	int h = teditor->get_h_scroll();
+	int v = teditor->get_v_scroll();
 
-	te->set_text(code);
-	te->set_caret_line(row);
-	te->set_caret_column(column);
-	te->set_h_scroll(h);
-	te->set_v_scroll(v);
+	teditor->set_text(code);
+	teditor->set_caret_line(row);
+	teditor->set_caret_column(column);
+	teditor->set_h_scroll(h);
+	teditor->set_v_scroll(v);
 
-	te->tag_saved_version();
+	teditor->tag_saved_version();
 
 	update_line_and_column();
 }
@@ -974,12 +974,12 @@ void ShaderTextEditor::set_warnings_panel(RichTextLabel *p_warnings_panel) {
 }
 
 void ShaderTextEditor::_load_theme_settings() {
-	CodeEdit *te = get_text_editor();
+	CodeEdit *teditor = get_text_editor();
 	Color updated_marked_line_color = EDITOR_GET("text_editor/theme/highlighting/mark_color");
 	if (updated_marked_line_color != marked_line_color) {
-		for (int i = 0; i < te->get_line_count(); i++) {
-			if (te->get_line_background_color(i) == marked_line_color) {
-				te->set_line_background_color(i, updated_marked_line_color);
+		for (int i = 0; i < teditor->get_line_count(); i++) {
+			if (teditor->get_line_background_color(i) == marked_line_color) {
+				teditor->set_line_background_color(i, updated_marked_line_color);
 			}
 		}
 		marked_line_color = updated_marked_line_color;
@@ -1110,12 +1110,12 @@ void ShaderTextEditor::_load_theme_settings() {
 	// Disabled preprocessor branches use translucent text color to be easier to distinguish from comments.
 	syntax_highlighter->set_disabled_branch_color(Color(EDITOR_GET("text_editor/theme/highlighting/text_color")) * Color(1, 1, 1, 0.5));
 
-	te->clear_comment_delimiters();
-	te->add_comment_delimiter("/*", "*/", false);
-	te->add_comment_delimiter("//", "", true);
+	teditor->clear_comment_delimiters();
+	teditor->add_comment_delimiter("/*", "*/", false);
+	teditor->add_comment_delimiter("//", "", true);
 
-	if (!te->has_auto_brace_completion_open_key("/*")) {
-		te->add_auto_brace_completion_pair("/*", "*/");
+	if (!teditor->has_auto_brace_completion_open_key("/*")) {
+		teditor->add_auto_brace_completion_pair("/*", "*/");
 	}
 
 	// Colorize preprocessor include strings.

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -332,9 +332,9 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 		memset(&param, 0, sizeof(param));
 
 		param.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-		param.parm.capture.capability = V4L2_CAP_TIMEPERFRAME;
-		param.parm.capture.timeperframe.numerator = feed_format.frame_numerator;
-		param.parm.capture.timeperframe.denominator = feed_format.frame_denominator;
+		param.parm.capture.capability = V4L2_CAP_TIMEPERFRAME; // codespell:ignore parm.
+		param.parm.capture.timeperframe.numerator = feed_format.frame_numerator; // codespell:ignore parm.
+		param.parm.capture.timeperframe.denominator = feed_format.frame_denominator; // codespell:ignore parm.
 
 		if (ioctl(file_descriptor, VIDIOC_S_PARM, &param) == -1) {
 			close(file_descriptor);

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -330,9 +330,9 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 		memset(&param, 0, sizeof(param));
 
 		param.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-		param.parm.capture.capability = V4L2_CAP_TIMEPERFRAME;
-		param.parm.capture.timeperframe.numerator = feed_format.frame_numerator;
-		param.parm.capture.timeperframe.denominator = feed_format.frame_denominator;
+		param.parm.capture.capability = V4L2_CAP_TIMEPERFRAME; // codespell:ignore parm.
+		param.parm.capture.timeperframe.numerator = feed_format.frame_numerator; // codespell:ignore parm.
+		param.parm.capture.timeperframe.denominator = feed_format.frame_denominator; // codespell:ignore parm.
 
 		if (ioctl(file_descriptor, VIDIOC_S_PARM, &param) == -1) {
 			close(file_descriptor);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -506,11 +506,11 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 	// Warn about parsing an empty script file:
 	if (current.type == GDScriptTokenizer::Token::TK_EOF) {
 		// Create a dummy Node for the warning, pointing to the very beginning of the file
-		Node *nd = alloc_node<PassNode>();
-		nd->start_line = 1;
-		nd->start_column = 1;
-		nd->end_line = 1;
-		push_warning(nd, GDScriptWarning::EMPTY_FILE);
+		Node *dummy = alloc_node<PassNode>();
+		dummy->start_line = 1;
+		dummy->start_column = 1;
+		dummy->end_line = 1;
+		push_warning(dummy, GDScriptWarning::EMPTY_FILE);
 	}
 #endif // DEBUG_ENABLED
 

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -546,9 +546,9 @@ bool GodotConvexPolygonShape2D::intersect_segment(const Vector2 &p_begin, const 
 			continue;
 		}
 
-		real_t nd = n.dot(res);
-		if (nd < d) {
-			d = nd;
+		real_t ndist = n.dot(res);
+		if (ndist < d) {
+			d = ndist;
 			r_point = res;
 			r_normal = points[i].normal;
 			inters = true;
@@ -719,9 +719,9 @@ bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const
 						Vector2 res;
 
 						if (Geometry2D::segment_intersects_segment(p_begin, p_end, a, b, &res)) {
-							real_t nd = n.dot(res);
-							if (nd < d) {
-								d = nd;
+							real_t ndist = n.dot(res);
+							if (ndist < d) {
+								d = ndist;
 								r_point = res;
 								r_normal = (b - a).orthogonal().normalized();
 								inters = true;

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -545,9 +545,9 @@ bool GodotConvexPolygonShape2D::intersect_segment(const Vector2 &p_begin, const 
 			continue;
 		}
 
-		real_t nd = n.dot(res);
-		if (nd < d) {
-			d = nd;
+		real_t ndist = n.dot(res);
+		if (ndist < d) {
+			d = ndist;
 			r_point = res;
 			r_normal = points[i].normal;
 			inters = true;
@@ -718,9 +718,9 @@ bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const
 						Vector2 res;
 
 						if (Geometry2D::segment_intersects_segment(p_begin, p_end, a, b, &res)) {
-							real_t nd = n.dot(res);
-							if (nd < d) {
-								d = nd;
+							real_t ndist = n.dot(res);
+							if (ndist < d) {
+								d = ndist;
 								r_point = res;
 								r_normal = (b - a).orthogonal().normalized();
 								inters = true;

--- a/modules/jolt_physics/misc/jolt_stream_wrappers.h
+++ b/modules/jolt_physics/misc/jolt_stream_wrappers.h
@@ -36,7 +36,7 @@
 
 #include <Jolt/Jolt.h>
 
-#include <Jolt/Core/StreamIn.h>
+#include <Jolt/Core/StreamIn.h> // codespell:ignore streamin.
 #include <Jolt/Core/StreamOut.h>
 
 class JoltStreamOutputWrapper final : public JPH::StreamOut {
@@ -55,7 +55,7 @@ public:
 	}
 };
 
-class JoltStreamInputWrapper final : public JPH::StreamIn {
+class JoltStreamInputWrapper final : public JPH::StreamIn { // codespell:ignore streamin.
 	Ref<FileAccess> file_access;
 
 public:

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -395,12 +395,12 @@ vec3 generate_ray_dir_from_normal(vec3 normal, inout uint noise) {
 #if defined(MODE_DIRECT_LIGHT) || defined(MODE_BOUNCE_LIGHT) || defined(MODE_LIGHT_PROBES)
 
 float get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 const int AA_SAMPLES = 16;

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/EditorProgress.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/EditorProgress.cs
@@ -13,8 +13,8 @@ namespace GodotTools.Internals
         {
             Task = task;
             using godot_string taskIn = Marshaling.ConvertStringToNative(task);
-            using godot_string labelIn = Marshaling.ConvertStringToNative(label);
-            Internal.godot_icall_EditorProgress_Create(taskIn, labelIn, amount, canCancel);
+            using godot_string labelIn = Marshaling.ConvertStringToNative(label); // codespell:ignore labelin.
+            Internal.godot_icall_EditorProgress_Create(taskIn, labelIn, amount, canCancel); // codespell:ignore labelin.
         }
 
         ~EditorProgress()

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Globals.cs
@@ -54,8 +54,8 @@ namespace GodotTools.Internals
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public static string TTR(this string text)
         {
-            using godot_string textIn = Marshaling.ConvertStringToNative(text);
-            Internal.godot_icall_Globals_TTR(textIn, out godot_string dest);
+            using godot_string textIn = Marshaling.ConvertStringToNative(text); // codespell:ignore textin.
+            Internal.godot_icall_Globals_TTR(textIn, out godot_string dest); // codespell:ignore textin.
             using (dest)
                 return Marshaling.ConvertStringToManaged(dest);
         }

--- a/modules/navigation_2d/triangle2.cpp
+++ b/modules/navigation_2d/triangle2.cpp
@@ -82,9 +82,9 @@ Vector2 Triangle2::get_closest_point_to(const Vector2 &p_point) const {
 			real_t tmp0 = b + d;
 			real_t tmp1 = c + e;
 			if (tmp1 > tmp0) {
-				real_t numer = tmp1 - tmp0;
-				real_t denom = a - 2 * b + c;
-				s = CLAMP(numer / denom, 0.f, 1.f);
+				real_t numerator = tmp1 - tmp0;
+				real_t denominator = a - 2 * b + c;
+				s = CLAMP(numerator / denominator, 0.f, 1.f);
 				t = 1 - s;
 			} else {
 				t = CLAMP(-e / c, 0.f, 1.f);
@@ -92,18 +92,18 @@ Vector2 Triangle2::get_closest_point_to(const Vector2 &p_point) const {
 			}
 		} else if (t < 0.f) {
 			if (a + d > b + e) {
-				real_t numer = c + e - b - d;
-				real_t denom = a - 2 * b + c;
-				s = CLAMP(numer / denom, 0.f, 1.f);
+				real_t numerator = c + e - b - d;
+				real_t denominator = a - 2 * b + c;
+				s = CLAMP(numerator / denominator, 0.f, 1.f);
 				t = 1 - s;
 			} else {
 				s = CLAMP(-d / a, 0.f, 1.f);
 				t = 0.f;
 			}
 		} else {
-			real_t numer = c + e - b - d;
-			real_t denom = a - 2 * b + c;
-			s = CLAMP(numer / denom, 0.f, 1.f);
+			real_t numerator = c + e - b - d;
+			real_t denominator = a - 2 * b + c;
+			s = CLAMP(numerator / denominator, 0.f, 1.f);
 			t = 1.f - s;
 		}
 	}

--- a/modules/openxr/doc_classes/OpenXRFutureResult.xml
+++ b/modules/openxr/doc_classes/OpenXRFutureResult.xml
@@ -46,7 +46,7 @@
 		<signal name="completed">
 			<param index="0" name="result" type="OpenXRFutureResult" />
 			<description>
-				Emitted when the asynchronous function is finished or has been cancelled.
+				Emitted when the asynchronous function is finished or has been canceled.
 			</description>
 		</signal>
 	</signals>
@@ -58,7 +58,7 @@
 			The asynchronous function has finished.
 		</constant>
 		<constant name="RESULT_CANCELLED" value="2" enum="ResultStatus">
-			The asynchronous function has been cancelled.
+			The asynchronous function has been canceled.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
@@ -62,7 +62,7 @@
 			<return type="void" />
 			<param index="0" name="spatial_context" type="RID" />
 			<description>
-				Frees a spatial context previously created when calling [method create_spatial_context]. If the spatial context creation is still ongoing, the asynchronous process is cancelled.
+				Frees a spatial context previously created when calling [method create_spatial_context]. If the spatial context creation is still ongoing, the asynchronous process is canceled.
 			</description>
 		</method>
 		<method name="free_spatial_entity">
@@ -76,7 +76,7 @@
 			<return type="void" />
 			<param index="0" name="spatial_snapshot" type="RID" />
 			<description>
-				Frees a spatial snapshot previously created when calling [method discover_spatial_entities]. If the spatial snapshot creation is still ongoing, the asynchronous process is cancelled.
+				Frees a spatial snapshot previously created when calling [method discover_spatial_entities]. If the spatial snapshot creation is still ongoing, the asynchronous process is canceled.
 			</description>
 		</method>
 		<method name="get_float_buffer" qualifiers="const">

--- a/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
@@ -65,7 +65,7 @@
 			<return type="void" />
 			<param index="0" name="spatial_context" type="RID" />
 			<description>
-				Frees a spatial context previously created when calling [method create_spatial_context]. If the spatial context creation is still ongoing, the asynchronous process is cancelled.
+				Frees a spatial context previously created when calling [method create_spatial_context]. If the spatial context creation is still ongoing, the asynchronous process is canceled.
 			</description>
 		</method>
 		<method name="free_spatial_entity">
@@ -79,7 +79,7 @@
 			<return type="void" />
 			<param index="0" name="spatial_snapshot" type="RID" />
 			<description>
-				Frees a spatial snapshot previously created when calling [method discover_spatial_entities]. If the spatial snapshot creation is still ongoing, the asynchronous process is cancelled.
+				Frees a spatial snapshot previously created when calling [method discover_spatial_entities]. If the spatial snapshot creation is still ongoing, the asynchronous process is canceled.
 			</description>
 		</method>
 		<method name="get_float_buffer" qualifiers="const">

--- a/modules/openxr/extensions/openxr_future_extension.cpp
+++ b/modules/openxr/extensions/openxr_future_extension.cpp
@@ -173,7 +173,7 @@ void OpenXRFutureExtension::on_session_destroyed() {
 			WARN_PRINT("OpenXR: Failed to cancel future [" + openxr_api->get_error_string(result) + "]");
 		}
 
-		// Make sure we mark our future result as cancelled
+		// Make sure we mark our future result as canceled.
 		element.value->_mark_as_cancelled();
 	}
 	futures.clear();
@@ -214,7 +214,7 @@ void OpenXRFutureExtension::cancel_future(XrFutureEXT p_future) {
 		WARN_PRINT("OpenXR: Failed to cancel future [" + openxr_api->get_error_string(result) + "]");
 	}
 
-	// Make sure we mark our future result as cancelled
+	// Make sure we mark our future result as canceled.
 	futures[p_future]->_mark_as_cancelled();
 
 	// And erase it from the futures we track

--- a/modules/openxr/openxr_platform_inc.h
+++ b/modules/openxr/openxr_platform_inc.h
@@ -82,7 +82,7 @@
 #ifdef WINDOWS_ENABLED
 #define COM_NO_WINDOWS_H
 #include <objbase.h>
-#include <unknwn.h> // codespell:ignore unknwn
+#include <unknwn.h> // codespell:ignore unknwn.
 #endif // WINDOWS_ENABLED
 
 #ifdef ANDROID_ENABLED

--- a/modules/tilemap/editor/tiles_editor_plugin.cpp
+++ b/modules/tilemap/editor/tiles_editor_plugin.cpp
@@ -64,9 +64,9 @@ void TilesEditorUtils::_pattern_preview_done() {
 }
 
 void TilesEditorUtils::_thread_func(void *ud) {
-	TilesEditorUtils *te = static_cast<TilesEditorUtils *>(ud);
+	TilesEditorUtils *utils = static_cast<TilesEditorUtils *>(ud);
 	set_current_thread_safe_for_nodes(true);
-	te->_thread();
+	utils->_thread();
 }
 
 void TilesEditorUtils::_thread() {

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -116,7 +116,7 @@ public class GodotLib {
 	/**
 	 * Dispatch mouse events
 	 */
-	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY);
+	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY); // codespell:ignore doubleclick.
 
 	public static native void magnify(float x, float y, float factor);
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -647,7 +647,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 		return handleMouseEvent(eventAction, 0, 0f, 0f, 0f, 0f, false, sourceMouseRelative, 1f, 0f, 0f);
 	}
 
-	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) { // codespell:ignore doubleclick.
 		InputEventRunnable runnable = InputEventRunnable.obtain();
 		if (runnable == null) {
 			return false;
@@ -680,7 +680,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			case MotionEvent.ACTION_HOVER_MOVE:
 			case MotionEvent.ACTION_MOVE:
 			case MotionEvent.ACTION_SCROLL: {
-				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY);
+				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY); // codespell:ignore doubleclick.
 				dispatchInputEventRunnable(runnable);
 				return true;
 			}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
@@ -135,7 +135,7 @@ final class InputEventRunnable implements Runnable {
 	private float pressure;
 	private float tiltX;
 	private float tiltY;
-	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) { // codespell:ignore doubleclick.
 		this.currentEventType = EventType.MOUSE;
 		this.eventAction = eventAction;
 		this.buttonsMask = buttonsMask;
@@ -143,7 +143,7 @@ final class InputEventRunnable implements Runnable {
 		this.eventY = y;
 		this.eventDeltaX = deltaX;
 		this.eventDeltaY = deltaY;
-		this.doubleTap = doubleClick;
+		this.doubleTap = doubleClick; // codespell:ignore doubleclick.
 		this.sourceMouseRelative = sourceMouseRelative;
 		this.pressure = pressure;
 		this.tiltX = tiltX;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3109,7 +3109,7 @@ void WaylandThread::_wp_pointer_gesture_pinch_on_update(void *data, struct zwp_p
 	}
 }
 
-void WaylandThread::_wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled) {
+void WaylandThread::_wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled) { // codespell:ignore cancelled.
 	SeatState *ss = (SeatState *)data;
 	ERR_FAIL_NULL(ss);
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3139,7 +3139,7 @@ void WaylandThread::_wp_pointer_gesture_pinch_on_update(void *data, struct zwp_p
 	}
 }
 
-void WaylandThread::_wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled) {
+void WaylandThread::_wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled) { // codespell:ignore cancelled.
 	SeatState *ss = (SeatState *)data;
 	ERR_FAIL_NULL(ss);
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -863,7 +863,7 @@ private:
 
 	static void _wp_pointer_gesture_pinch_on_begin(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, struct wl_surface *surface, uint32_t fingers);
 	static void _wp_pointer_gesture_pinch_on_update(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t time, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t scale, wl_fixed_t rotation);
-	static void _wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *zp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled);
+	static void _wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *zp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled); // codespell:ignore cancelled.
 
 	static void _wp_primary_selection_device_on_data_offer(void *data, struct zwp_primary_selection_device_v1 *wp_primary_selection_device_v1, struct zwp_primary_selection_offer_v1 *offer);
 	static void _wp_primary_selection_device_on_selection(void *data, struct zwp_primary_selection_device_v1 *wp_primary_selection_device_v1, struct zwp_primary_selection_offer_v1 *id);
@@ -1006,7 +1006,7 @@ private:
 	static constexpr struct wl_data_source_listener wl_data_source_listener = {
 		.target = _wl_data_source_on_target,
 		.send = _wl_data_source_on_send,
-		.cancelled = _wl_data_source_on_cancelled,
+		.cancelled = _wl_data_source_on_cancelled, // codespell:ignore cancelled.
 		.dnd_drop_performed = _wl_data_source_on_dnd_drop_performed,
 		.dnd_finished = _wl_data_source_on_dnd_finished,
 		.action = _wl_data_source_on_action,
@@ -1098,7 +1098,7 @@ private:
 
 	static constexpr struct zwp_primary_selection_source_v1_listener wp_primary_selection_source_listener = {
 		.send = _wp_primary_selection_source_on_send,
-		.cancelled = _wp_primary_selection_source_on_cancelled,
+		.cancelled = _wp_primary_selection_source_on_cancelled, // codespell:ignore cancelled.
 	};
 
 	static constexpr struct zwp_tablet_seat_v2_listener wp_tablet_seat_listener = {

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -855,7 +855,7 @@ private:
 
 	static void _wp_pointer_gesture_pinch_on_begin(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, struct wl_surface *surface, uint32_t fingers);
 	static void _wp_pointer_gesture_pinch_on_update(void *data, struct zwp_pointer_gesture_pinch_v1 *wp_pointer_gesture_pinch_v1, uint32_t time, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t scale, wl_fixed_t rotation);
-	static void _wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *zp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled);
+	static void _wp_pointer_gesture_pinch_on_end(void *data, struct zwp_pointer_gesture_pinch_v1 *zp_pointer_gesture_pinch_v1, uint32_t serial, uint32_t time, int32_t cancelled); // codespell:ignore cancelled.
 
 	static void _wp_primary_selection_device_on_data_offer(void *data, struct zwp_primary_selection_device_v1 *wp_primary_selection_device_v1, struct zwp_primary_selection_offer_v1 *offer);
 	static void _wp_primary_selection_device_on_selection(void *data, struct zwp_primary_selection_device_v1 *wp_primary_selection_device_v1, struct zwp_primary_selection_offer_v1 *id);
@@ -998,7 +998,7 @@ private:
 	static constexpr struct wl_data_source_listener wl_data_source_listener = {
 		.target = _wl_data_source_on_target,
 		.send = _wl_data_source_on_send,
-		.cancelled = _wl_data_source_on_cancelled,
+		.cancelled = _wl_data_source_on_cancelled, // codespell:ignore cancelled.
 		.dnd_drop_performed = _wl_data_source_on_dnd_drop_performed,
 		.dnd_finished = _wl_data_source_on_dnd_finished,
 		.action = _wl_data_source_on_action,
@@ -1085,7 +1085,7 @@ private:
 
 	static constexpr struct zwp_primary_selection_source_v1_listener wp_primary_selection_source_listener = {
 		.send = _wp_primary_selection_source_on_send,
-		.cancelled = _wp_primary_selection_source_on_cancelled,
+		.cancelled = _wp_primary_selection_source_on_cancelled, // codespell:ignore cancelled.
 	};
 
 	static constexpr struct zwp_tablet_seat_v2_listener wp_tablet_seat_listener = {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -733,7 +733,7 @@ void DisplayServerX11::clipboard_set_primary(const String &p_text) {
 }
 
 Bool DisplayServerX11::_predicate_clipboard_selection(Display *display, XEvent *event, XPointer arg) {
-	if (event->type == SelectionNotify && event->xselection.requestor == *(Window *)arg) {
+	if (event->type == SelectionNotify && event->xselection.requestor == *(Window *)arg) { // codespell:ignore requestor.
 		return True;
 	} else {
 		return False;
@@ -4397,17 +4397,17 @@ void DisplayServerX11::_handle_selection_request_event(XSelectionRequestEvent *p
 		unsigned long len;
 		unsigned long remaining;
 		unsigned char *data = nullptr;
-		if (XGetWindowProperty(x11_display, p_event->requestor, p_event->property, 0, LONG_MAX, False, atom_pair, &type, &format, &len, &remaining, &data) == Success) {
+		if (XGetWindowProperty(x11_display, p_event->requestor, p_event->property, 0, LONG_MAX, False, atom_pair, &type, &format, &len, &remaining, &data) == Success) { // codespell:ignore requestor.
 			if ((len >= 2) && data) {
 				Atom *targets = (Atom *)data;
 				for (uint64_t i = 0; i < len; i += 2) {
 					Atom target = targets[i];
 					Atom &property = targets[i + 1];
-					property = _process_selection_request_target(target, p_event->requestor, property, p_event->selection);
+					property = _process_selection_request_target(target, p_event->requestor, property, p_event->selection); // codespell:ignore requestor.
 				}
 
 				XChangeProperty(x11_display,
-						p_event->requestor,
+						p_event->requestor, // codespell:ignore requestor.
 						p_event->property,
 						atom_pair,
 						32,
@@ -4421,17 +4421,17 @@ void DisplayServerX11::_handle_selection_request_event(XSelectionRequestEvent *p
 		}
 	} else {
 		// Request for target conversion.
-		respond.xselection.property = _process_selection_request_target(p_event->target, p_event->requestor, p_event->property, p_event->selection);
+		respond.xselection.property = _process_selection_request_target(p_event->target, p_event->requestor, p_event->property, p_event->selection); // codespell:ignore requestor.
 	}
 
 	respond.xselection.type = SelectionNotify;
 	respond.xselection.display = p_event->display;
-	respond.xselection.requestor = p_event->requestor;
+	respond.xselection.requestor = p_event->requestor; // codespell:ignore requestor.
 	respond.xselection.selection = p_event->selection;
 	respond.xselection.target = p_event->target;
 	respond.xselection.time = p_event->time;
 
-	XSendEvent(x11_display, p_event->requestor, True, NoEventMask, &respond);
+	XSendEvent(x11_display, p_event->requestor, True, NoEventMask, &respond); // codespell:ignore requestor.
 	XFlush(x11_display);
 }
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -733,7 +733,7 @@ void DisplayServerX11::clipboard_set_primary(const String &p_text) {
 }
 
 Bool DisplayServerX11::_predicate_clipboard_selection(Display *display, XEvent *event, XPointer arg) {
-	if (event->type == SelectionNotify && event->xselection.requestor == *(Window *)arg) {
+	if (event->type == SelectionNotify && event->xselection.requestor == *(Window *)arg) { // codespell:ignore requestor.
 		return True;
 	} else {
 		return False;
@@ -4445,17 +4445,17 @@ void DisplayServerX11::_handle_selection_request_event(XSelectionRequestEvent *p
 		unsigned long len;
 		unsigned long remaining;
 		unsigned char *data = nullptr;
-		if (XGetWindowProperty(x11_display, p_event->requestor, p_event->property, 0, LONG_MAX, False, atom_pair, &type, &format, &len, &remaining, &data) == Success) {
+		if (XGetWindowProperty(x11_display, p_event->requestor, p_event->property, 0, LONG_MAX, False, atom_pair, &type, &format, &len, &remaining, &data) == Success) { // codespell:ignore requestor.
 			if ((len >= 2) && data) {
 				Atom *targets = (Atom *)data;
 				for (uint64_t i = 0; i < len; i += 2) {
 					Atom target = targets[i];
 					Atom &property = targets[i + 1];
-					property = _process_selection_request_target(target, p_event->requestor, property, p_event->selection);
+					property = _process_selection_request_target(target, p_event->requestor, property, p_event->selection); // codespell:ignore requestor.
 				}
 
 				XChangeProperty(x11_display,
-						p_event->requestor,
+						p_event->requestor, // codespell:ignore requestor.
 						p_event->property,
 						atom_pair,
 						32,
@@ -4469,17 +4469,17 @@ void DisplayServerX11::_handle_selection_request_event(XSelectionRequestEvent *p
 		}
 	} else {
 		// Request for target conversion.
-		respond.xselection.property = _process_selection_request_target(p_event->target, p_event->requestor, p_event->property, p_event->selection);
+		respond.xselection.property = _process_selection_request_target(p_event->target, p_event->requestor, p_event->property, p_event->selection); // codespell:ignore requestor.
 	}
 
 	respond.xselection.type = SelectionNotify;
 	respond.xselection.display = p_event->display;
-	respond.xselection.requestor = p_event->requestor;
+	respond.xselection.requestor = p_event->requestor; // codespell:ignore requestor.
 	respond.xselection.selection = p_event->selection;
 	respond.xselection.target = p_event->target;
 	respond.xselection.time = p_event->time;
 
-	XSendEvent(x11_display, p_event->requestor, True, NoEventMask, &respond);
+	XSendEvent(x11_display, p_event->requestor, True, NoEventMask, &respond); // codespell:ignore requestor.
 	XFlush(x11_display);
 }
 

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -501,8 +501,8 @@ DisplayServerEnums::NotificationID WinRTUtils::send_toast_notification(const Str
 	title.instantiate();
 	title->set_string(p_title);
 
-	Ref<WinRTNotificationData> nd;
-	nd.instantiate();
+	Ref<WinRTNotificationData> ndata;
+	ndata.instantiate();
 	DisplayServerEnums::NotificationID nid = notification_id++;
 
 	ComPtr<ROToastNotificationManagerStatics> toastman_fact;
@@ -538,7 +538,7 @@ DisplayServerEnums::NotificationID WinRTUtils::send_toast_notification(const Str
 		}
 		img->save_png(img_path);
 
-		nd->temp_file = img_path;
+		ndata->temp_file = img_path;
 		Ref<HStringWrapper> himage;
 		himage.instantiate();
 		himage->set_string(img_path);
@@ -582,32 +582,32 @@ DisplayServerEnums::NotificationID WinRTUtils::send_toast_notification(const Str
 
 	ComPtr<ROToastNotificationFactory> toast_fact;
 	ERR_FAIL_COND_V(FAILED(WinRTUtils::activation_factory(ROToastNotificationName, IID_PPV_ARGS(&toast_fact))), DisplayServerEnums::INVALID_NOTIFICATION_ID);
-	ERR_FAIL_COND_V(FAILED(toast_fact->CreateToastNotification(xml.Get(), (void **)nd->nt.GetAddressOf())), DisplayServerEnums::INVALID_NOTIFICATION_ID);
+	ERR_FAIL_COND_V(FAILED(toast_fact->CreateToastNotification(xml.Get(), (void **)ndata->nt.GetAddressOf())), DisplayServerEnums::INVALID_NOTIFICATION_ID);
 
-	nd->nid = nid;
-	nd->cb = p_callback;
+	ndata->nid = nid;
+	ndata->cb = p_callback;
 
 	ComPtr<ROTypedEventHandler_ToastNotification_IInspectable> handler_a;
 	GodotToastActivatedEventHandler *handler_act = new GodotToastActivatedEventHandler(nid);
 	ERR_FAIL_COND_V(FAILED(handler_act->QueryInterface(IID_PPV_ARGS(&handler_a))), DisplayServerEnums::INVALID_NOTIFICATION_ID);
-	ERR_FAIL_COND_V(FAILED(nd->nt->add_Activated(handler_a.Get(), &nd->act_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
+	ERR_FAIL_COND_V(FAILED(ndata->nt->add_Activated(handler_a.Get(), &ndata->act_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
 
 	ComPtr<ROTypedEventHandler_ToastNotification_ToastDismissedEventArgs> handler_d;
 	GodotToastDismissedEventHandler *handler_dis = new GodotToastDismissedEventHandler(nid);
 	ERR_FAIL_COND_V(FAILED(handler_dis->QueryInterface(IID_PPV_ARGS(&handler_d))), DisplayServerEnums::INVALID_NOTIFICATION_ID);
-	ERR_FAIL_COND_V(FAILED(nd->nt->add_Dismissed(handler_d.Get(), &nd->dis_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
+	ERR_FAIL_COND_V(FAILED(ndata->nt->add_Dismissed(handler_d.Get(), &ndata->dis_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
 
 	ComPtr<ROTypedEventHandler_ToastNotification_ToastFailedEventArgs> handler_f;
 	GodotToastFailedEventHandler *handler_fail = new GodotToastFailedEventHandler(nid);
 	ERR_FAIL_COND_V(FAILED(handler_fail->QueryInterface(IID_PPV_ARGS(&handler_f))), DisplayServerEnums::INVALID_NOTIFICATION_ID);
-	ERR_FAIL_COND_V(FAILED(nd->nt->add_Failed(handler_f.Get(), &nd->fail_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
+	ERR_FAIL_COND_V(FAILED(ndata->nt->add_Failed(handler_f.Get(), &ndata->fail_token)), DisplayServerEnums::INVALID_NOTIFICATION_ID);
 
 	{
 		MutexLock lock(noti_mutex);
-		notifications[nid] = nd;
+		notifications[nid] = ndata;
 	}
 
-	ERR_FAIL_COND_V(FAILED(notifier->Show(nd->nt.Get())), DisplayServerEnums::INVALID_NOTIFICATION_ID);
+	ERR_FAIL_COND_V(FAILED(notifier->Show(ndata->nt.Get())), DisplayServerEnums::INVALID_NOTIFICATION_ID);
 	return nid;
 }
 
@@ -620,8 +620,8 @@ void WinRTUtils::hide_toast_notification(DisplayServerEnums::NotificationID p_id
 	if (!notifications.has(p_id)) {
 		return;
 	}
-	Ref<WinRTNotificationData> nd = notifications[p_id];
+	Ref<WinRTNotificationData> ndata = notifications[p_id];
 	notifications.erase(p_id);
 
-	notifier->Hide(nd->nt.Get());
+	notifier->Hide(ndata->nt.Get());
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,36 +72,21 @@ skip = [
 	"core/string/locales.h",
 	"DONORS.md",
 	"editor/import/unicode_ranges.inc",
-	"editor/project_converter_3_to_4.cpp",
+	"editor/project_upgrade/renames_map_3_to_4.cpp",
 	"platform/android/java/lib/src/main/java/com/*",
 	"platform/web/package-lock.json",
 ]
 ignore-words-list = [
-	"breaked",
-	"cancelled",
-	"checkin",
-	"colour",
-	"curvelinear",
-	"doubleclick",
-	"expct",
-	"findn",
-	"gird",
-	"hel",
-	"inout",
-	"labelin",
-	"lod",
-	"masia",
-	"mis",
-	"nd",
-	"numer",
-	"ot",
-	"outin",
-	"parm",
+	"breaked",     # Debugger contexts.
+	"checkin",     # Proper name of a database on Android.
+	"findn",       # Our case-insensitive `find` function.
+	"inout",       # Shader attribute.
+	"lod",         # "Level of Detail".
+	"thirdparty",  # Prefer as one word.
+
+	# Allow specific camelCase/PascalCase exceptions for these phrases:
+	"Masia",
+	"OT",
 	"pEvent",
-	"requestor",
-	"streamin",
-	"te",
-	"textin",
-	"thirdparty",
-	"vai",
 ]
+ignore-regex = '\bkeywords\b=".*"'  # Skip documentation's "keywords" field.

--- a/scene/3d/aim_modifier_3d.cpp
+++ b/scene/3d/aim_modifier_3d.cpp
@@ -202,12 +202,12 @@ void AimModifier3D::_process_constraint_by_bone(int p_index, Skeleton3D *p_skele
 }
 
 void AimModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
-	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
-	if (!nd) {
+	Node3D *node = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!node) {
 		return;
 	}
 	Transform3D skel_tr = p_skeleton->get_global_transform_interpolated();
-	Vector3 reference_origin = nd->get_global_transform_interpolated().origin - skel_tr.origin;
+	Vector3 reference_origin = node->get_global_transform_interpolated().origin - skel_tr.origin;
 	_process_aim(p_index, p_skeleton, p_apply_bone, skel_tr.basis.get_rotation_quaternion().xform_inv(reference_origin), p_amount);
 }
 

--- a/scene/3d/convert_transform_modifier_3d.cpp
+++ b/scene/3d/convert_transform_modifier_3d.cpp
@@ -348,8 +348,8 @@ void ConvertTransformModifier3D::_process_constraint_by_bone(int p_index, Skelet
 }
 
 void ConvertTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
-	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
-	if (!nd) {
+	Node3D *node = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!node) {
 		return;
 	}
 	Transform3D skel_tr = p_skeleton->get_global_transform_interpolated();
@@ -357,7 +357,7 @@ void ConvertTransformModifier3D::_process_constraint_by_node(int p_index, Skelet
 	if (parent >= 0) {
 		skel_tr = skel_tr * p_skeleton->get_bone_global_pose(parent);
 	}
-	Transform3D dest_tr = nd->get_global_transform_interpolated();
+	Transform3D dest_tr = node->get_global_transform_interpolated();
 	Transform3D reference_dest = skel_tr.affine_inverse() * dest_tr;
 	_process_convert(p_index, p_skeleton, p_apply_bone, reference_dest, p_amount);
 }

--- a/scene/3d/convert_transform_modifier_3d.cpp
+++ b/scene/3d/convert_transform_modifier_3d.cpp
@@ -388,8 +388,8 @@ void ConvertTransformModifier3D::_process_constraint_by_bone(int p_index, Skelet
 }
 
 void ConvertTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
-	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
-	if (!nd) {
+	Node3D *node = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!node) {
 		return;
 	}
 	Transform3D skel_tr = p_skeleton->get_global_transform_interpolated();
@@ -397,7 +397,7 @@ void ConvertTransformModifier3D::_process_constraint_by_node(int p_index, Skelet
 	if (parent >= 0) {
 		skel_tr = skel_tr * p_skeleton->get_bone_global_pose(parent);
 	}
-	Transform3D dest_tr = nd->get_global_transform_interpolated();
+	Transform3D dest_tr = node->get_global_transform_interpolated();
 	Transform3D reference_dest = skel_tr.affine_inverse() * dest_tr;
 	_process_convert(p_index, p_skeleton, p_apply_bone, reference_dest, p_amount);
 }

--- a/scene/3d/copy_transform_modifier_3d.cpp
+++ b/scene/3d/copy_transform_modifier_3d.cpp
@@ -383,8 +383,8 @@ void CopyTransformModifier3D::_process_constraint_by_bone(int p_index, Skeleton3
 }
 
 void CopyTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
-	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
-	if (!nd) {
+	Node3D *node = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!node) {
 		return;
 	}
 	Transform3D skel_tr = p_skeleton->get_global_transform_interpolated();
@@ -392,7 +392,7 @@ void CopyTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3
 	if (parent >= 0) {
 		skel_tr = skel_tr * p_skeleton->get_bone_global_pose(parent);
 	}
-	Transform3D dest_tr = nd->get_global_transform_interpolated();
+	Transform3D dest_tr = node->get_global_transform_interpolated();
 	Transform3D reference_dest = skel_tr.affine_inverse() * dest_tr;
 	_process_copy(p_index, p_skeleton, p_apply_bone, reference_dest, p_amount);
 }

--- a/scene/3d/copy_transform_modifier_3d.cpp
+++ b/scene/3d/copy_transform_modifier_3d.cpp
@@ -423,8 +423,8 @@ void CopyTransformModifier3D::_process_constraint_by_bone(int p_index, Skeleton3
 }
 
 void CopyTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
-	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
-	if (!nd) {
+	Node3D *node = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!node) {
 		return;
 	}
 	Transform3D skel_tr = p_skeleton->get_global_transform_interpolated();
@@ -432,7 +432,7 @@ void CopyTransformModifier3D::_process_constraint_by_node(int p_index, Skeleton3
 	if (parent >= 0) {
 		skel_tr = skel_tr * p_skeleton->get_bone_global_pose(parent);
 	}
-	Transform3D dest_tr = nd->get_global_transform_interpolated();
+	Transform3D dest_tr = node->get_global_transform_interpolated();
 	Transform3D reference_dest = skel_tr.affine_inverse() * dest_tr;
 	_process_copy(p_index, p_skeleton, p_apply_bone, reference_dest, p_amount);
 }

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -493,7 +493,7 @@ void LookAtModifier3D::_bind_methods() {
 	ADD_GROUP("Time Based Interpolation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater,suffix:s"), "set_duration", "get_duration");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transition_type", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Quad,Expo,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_transition_type", "get_transition_type");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_ease_type", "get_ease_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_ease_type", "get_ease_type"); // codespell:ignore outin.
 
 	ADD_GROUP("Angle Limitation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_angle_limitation"), "set_use_angle_limitation", "is_using_angle_limitation");

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -505,7 +505,7 @@ void LookAtModifier3D::_bind_methods() {
 	ADD_GROUP("Time Based Interpolation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater,suffix:s"), "set_duration", "get_duration");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transition_type", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Quad,Expo,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_transition_type", "get_transition_type");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_ease_type", "get_ease_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_ease_type", "get_ease_type"); // codespell:ignore outin.
 
 	ADD_GROUP("Angle Limitation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_angle_limitation"), "set_use_angle_limitation", "is_using_angle_limitation");

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1756,11 +1756,11 @@ void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSet
 		if (setting->center_node == NodePath()) {
 			setting->cached_center = Transform3D();
 		} else {
-			Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(setting->center_node));
-			if (!nd) {
+			Node3D *node = Object::cast_to<Node3D>(get_node_or_null(setting->center_node));
+			if (!node) {
 				setting->cached_center = Transform3D();
 			} else {
-				setting->cached_center = nd->get_global_transform_interpolated().affine_inverse() * p_skeleton->get_global_transform_interpolated();
+				setting->cached_center = node->get_global_transform_interpolated().affine_inverse() * p_skeleton->get_global_transform_interpolated();
 			}
 		}
 	} else {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1072,7 +1072,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playback_auto_capture"), "set_auto_capture", "is_auto_capture");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_auto_capture_duration", PROPERTY_HINT_NONE, "suffix:s"), "set_auto_capture_duration", "get_auto_capture_duration");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_auto_capture_transition_type", PROPERTY_HINT_ENUM, "Linear,Sine,Quint,Quart,Quad,Expo,Elastic,Cubic,Circ,Bounce,Back,Spring"), "set_auto_capture_transition_type", "get_auto_capture_transition_type");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_auto_capture_ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_auto_capture_ease_type", "get_auto_capture_ease_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_auto_capture_ease_type", PROPERTY_HINT_ENUM, "In,Out,InOut,OutIn"), "set_auto_capture_ease_type", "get_auto_capture_ease_type"); // codespell:ignore outin.
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:s"), "set_default_blend_time", "get_default_blend_time");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -259,7 +259,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	//Vector<Variant> properties;
 
-	const NodeData *nd = &nodes[0];
+	const NodeData *node_data = &nodes[0];
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
 	ret_nodes[0] = nullptr; // Sidesteps "maybe uninitialized" false-positives on GCC.
@@ -273,7 +273,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	bool deep_search_warned = false;
 
 	for (int i = 0; i < nc; i++) {
-		const NodeData &n = nd[i];
+		const NodeData &n = node_data[i];
 
 		Node *parent = nullptr;
 		String old_parent_path;
@@ -886,21 +886,21 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		is_editable_instance = true;
 	}
 
-	NodeData nd;
+	NodeData node_data;
 
-	nd.name = _nm_get_string(p_node->get_name(), name_map);
-	nd.instance = -1; //not instantiated by default
+	node_data.name = _nm_get_string(p_node->get_name(), name_map);
+	node_data.instance = -1; //not instantiated by default
 
 	//really convoluted condition, but it basically checks that index is only saved when part of an inherited scene OR the node parent is from the edited scene
 	if (p_owner->get_scene_inherited_state().is_null() && (p_node == p_owner || (p_node->get_owner() == p_owner && (p_node->get_parent() == p_owner || p_node->get_parent()->get_owner() == p_owner)))) {
 		//do not save index, because it belongs to saved scene and scene is not inherited
-		nd.index = -1;
+		node_data.index = -1;
 	} else if (p_node == p_owner) {
 		//This (hopefully) happens if the node is a scene root, so its index is irrelevant.
-		nd.index = -1;
+		node_data.index = -1;
 	} else {
 		//part of an inherited scene, or parent is from an instantiated scene
-		nd.index = p_node->get_index();
+		node_data.index = p_node->get_index();
 	}
 
 	// if this node is part of an instantiated scene or sub-instantiated scene
@@ -914,8 +914,8 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	if (p_node->is_instance() && p_node->get_owner() == p_owner && instantiated_by_owner) {
 		if (p_node->get_scene_instance_load_placeholder()) {
 			//it's a placeholder, use the placeholder path
-			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
-			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
+			node_data.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
+			node_data.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
 		} else {
 			//must instance ourselves
 			Ref<PackedScene> instance = ResourceLoader::load(p_node->get_scene_file_path());
@@ -923,7 +923,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				return ERR_CANT_OPEN;
 			}
 
-			nd.instance = _vm_get_variant(instance, variant_map);
+			node_data.instance = _vm_get_variant(instance, variant_map);
 		}
 	}
 
@@ -1074,7 +1074,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		if (use_deferred_node_path_bit) {
 			prop.name |= FLAG_PATH_PROPERTY_IS_NODE;
 		}
-		nd.properties.push_back(prop);
+		node_data.properties.push_back(prop);
 	}
 
 	// save the groups this node is into
@@ -1100,7 +1100,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			continue;
 		}
 
-		nd.groups.push_back(_nm_get_string(gi.name, name_map));
+		node_data.groups.push_back(_nm_get_string(gi.name, name_map));
 	}
 
 	// save the right owner
@@ -1110,12 +1110,12 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	if (p_node == p_owner) {
 		//saved scene root
-		nd.owner = -1;
+		node_data.owner = -1;
 	} else if (p_node->get_owner() == p_owner) {
 		//part of saved scene
-		nd.owner = 0;
+		node_data.owner = 0;
 	} else {
-		nd.owner = -1;
+		node_data.owner = -1;
 	}
 
 	MissingNode *missing_node = Object::cast_to<MissingNode>(p_node);
@@ -1126,14 +1126,14 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		//This node is not part of an instantiation process, so save the type.
 		if (missing_node != nullptr) {
 			// It's a missing node (type non existent on load).
-			nd.type = _nm_get_string(missing_node->get_original_class(), name_map);
+			node_data.type = _nm_get_string(missing_node->get_original_class(), name_map);
 		} else {
-			nd.type = _nm_get_string(p_node->get_class(), name_map);
+			node_data.type = _nm_get_string(p_node->get_class(), name_map);
 		}
 	} else {
 		// this node is part of an instantiated process, so do not save the type.
 		// instead, save that it was instantiated
-		nd.type = TYPE_INSTANTIATED;
+		node_data.type = TYPE_INSTANTIATED;
 	}
 
 	// determine whether to save this node or not
@@ -1144,7 +1144,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	bool save_node = p_node == p_owner; // owner is always saved
 	save_node = save_node || (p_node->get_owner() == p_owner && instantiated_by_owner); //part of scene and not instanced
-	bool save_data = nd.properties.size() || nd.groups.size(); // some local properties or groups exist
+	bool save_data = node_data.properties.size() || node_data.groups.size(); // some local properties or groups exist
 
 	int idx = nodes.size();
 	int parent_node = NO_PARENT_SAVED;
@@ -1164,9 +1164,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				nodepath_map[p_node->get_parent()] = sidx;
 			}
 
-			nd.parent = FLAG_ID_IS_PATH | sidx;
+			node_data.parent = FLAG_ID_IS_PATH | sidx;
 		} else {
-			nd.parent = p_parent_idx;
+			node_data.parent = p_parent_idx;
 		}
 
 		int32_t unique_scene_id = p_node->get_unique_scene_id();
@@ -1196,7 +1196,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		ids.push_back(unique_scene_id);
 
 		parent_node = idx;
-		nodes.push_back(nd);
+		nodes.push_back(node_data);
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -1221,7 +1221,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 	_signals.sort();
 
 	//ERR_FAIL_COND_V( !node_map.has(p_node), ERR_BUG);
-	//NodeData &nd = nodes[node_map[p_node]];
+	//NodeData &node_data = nodes[node_map[p_node]];
 
 	for (const MethodInfo &E : _signals) {
 		List<Node::Connection> conns;
@@ -1778,23 +1778,23 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		const int *r = snodes.ptr();
 		int idx = 0;
 		for (int i = 0; i < node_count; i++) {
-			NodeData &nd = nodes.write[i];
-			nd.parent = r[idx++];
-			nd.owner = r[idx++];
-			nd.type = r[idx++];
+			NodeData &node_data = nodes.write[i];
+			node_data.parent = r[idx++];
+			node_data.owner = r[idx++];
+			node_data.type = r[idx++];
 			uint32_t name_index = r[idx++];
-			nd.name = name_index & ((1 << NAME_INDEX_BITS) - 1);
-			nd.index = (name_index >> NAME_INDEX_BITS);
-			nd.index--; //0 is invalid, stored as 1
-			nd.instance = r[idx++];
-			nd.properties.resize(r[idx++]);
-			for (int j = 0; j < nd.properties.size(); j++) {
-				nd.properties.write[j].name = r[idx++];
-				nd.properties.write[j].value = r[idx++];
+			node_data.name = name_index & ((1 << NAME_INDEX_BITS) - 1);
+			node_data.index = (name_index >> NAME_INDEX_BITS);
+			node_data.index--; //0 is invalid, stored as 1
+			node_data.instance = r[idx++];
+			node_data.properties.resize(r[idx++]);
+			for (int j = 0; j < node_data.properties.size(); j++) {
+				node_data.properties.write[j].name = r[idx++];
+				node_data.properties.write[j].value = r[idx++];
 			}
-			nd.groups.resize(r[idx++]);
-			for (int j = 0; j < nd.groups.size(); j++) {
-				nd.groups.write[j] = r[idx++];
+			node_data.groups.resize(r[idx++]);
+			for (int j = 0; j < node_data.groups.size(); j++) {
+				node_data.groups.write[j] = r[idx++];
 			}
 		}
 	}
@@ -1882,24 +1882,24 @@ Dictionary SceneState::get_bundled_scene() const {
 	d["node_count"] = nodes.size();
 
 	for (int i = 0; i < nodes.size(); i++) {
-		const NodeData &nd = nodes[i];
-		rnodes.push_back(nd.parent);
-		rnodes.push_back(nd.owner);
-		rnodes.push_back(nd.type);
-		uint32_t name_index = nd.name;
-		if (nd.index < (1 << (32 - NAME_INDEX_BITS)) - 1) { //save if less than 16k children
-			name_index |= uint32_t(nd.index + 1) << NAME_INDEX_BITS; //for backwards compatibility, index 0 is no index
+		const NodeData &node_data = nodes[i];
+		rnodes.push_back(node_data.parent);
+		rnodes.push_back(node_data.owner);
+		rnodes.push_back(node_data.type);
+		uint32_t name_index = node_data.name;
+		if (node_data.index < (1 << (32 - NAME_INDEX_BITS)) - 1) { //save if less than 16k children
+			name_index |= uint32_t(node_data.index + 1) << NAME_INDEX_BITS; //for backwards compatibility, index 0 is no index
 		}
 		rnodes.push_back(name_index);
-		rnodes.push_back(nd.instance);
-		rnodes.push_back(nd.properties.size());
-		for (int j = 0; j < nd.properties.size(); j++) {
-			rnodes.push_back(nd.properties[j].name);
-			rnodes.push_back(nd.properties[j].value);
+		rnodes.push_back(node_data.instance);
+		rnodes.push_back(node_data.properties.size());
+		for (int j = 0; j < node_data.properties.size(); j++) {
+			rnodes.push_back(node_data.properties[j].name);
+			rnodes.push_back(node_data.properties[j].value);
 		}
-		rnodes.push_back(nd.groups.size());
-		for (int j = 0; j < nd.groups.size(); j++) {
-			rnodes.push_back(nd.groups[j]);
+		rnodes.push_back(node_data.groups.size());
+		for (int j = 0; j < node_data.groups.size(); j++) {
+			rnodes.push_back(node_data.groups[j]);
 		}
 	}
 
@@ -2066,11 +2066,11 @@ Node *SceneState::_recover_node_path_index(Node *p_base, int p_idx) const {
 			break; // Do not go further, we have the path.
 		}
 
-		const NodeData &nd = ss->nodes[idx];
+		const NodeData &node_data = ss->nodes[idx];
 		// Get instance
-		ERR_FAIL_COND_V(nd.instance < 0, nullptr); // Not an instance, middle of path should be an instance.
-		ERR_FAIL_COND_V(nd.instance & FLAG_INSTANCE_IS_PLACEHOLDER, nullptr); // Instance is somehow a placeholder?!
-		Ref<PackedScene> sdata = ss->variants[nd.instance & FLAG_MASK];
+		ERR_FAIL_COND_V(node_data.instance < 0, nullptr); // Not an instance, middle of path should be an instance.
+		ERR_FAIL_COND_V(node_data.instance & FLAG_INSTANCE_IS_PLACEHOLDER, nullptr); // Instance is somehow a placeholder?!
+		Ref<PackedScene> sdata = ss->variants[node_data.instance & FLAG_MASK];
 		ERR_FAIL_COND_V(sdata.is_null(), nullptr);
 		Ref<SceneState> sstate = sdata->get_state();
 		ss = sstate.ptr();
@@ -2386,15 +2386,15 @@ int SceneState::add_node_path(const NodePath &p_path, const PackedInt32Array &p_
 }
 
 int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int32_t p_unique_id) {
-	NodeData nd;
-	nd.parent = p_parent;
-	nd.owner = p_owner;
-	nd.type = p_type;
-	nd.name = p_name;
-	nd.instance = p_instance;
-	nd.index = p_index;
+	NodeData node_data;
+	node_data.parent = p_parent;
+	node_data.owner = p_owner;
+	node_data.type = p_type;
+	node_data.name = p_name;
+	node_data.instance = p_instance;
+	node_data.index = p_index;
 
-	nodes.push_back(nd);
+	nodes.push_back(node_data);
 
 	ids.push_back(p_unique_id);
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -259,7 +259,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	//Vector<Variant> properties;
 
-	const NodeData *nd = &nodes[0];
+	const NodeData *node_data = &nodes[0];
 
 	Node **ret_nodes = (Node **)alloca(sizeof(Node *) * nc);
 	ret_nodes[0] = nullptr; // Sidesteps "maybe uninitialized" false-positives on GCC.
@@ -273,7 +273,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	bool deep_search_warned = false;
 
 	for (int i = 0; i < nc; i++) {
-		const NodeData &n = nd[i];
+		const NodeData &n = node_data[i];
 
 		Node *parent = nullptr;
 		String old_parent_path;
@@ -886,21 +886,21 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		is_editable_instance = true;
 	}
 
-	NodeData nd;
+	NodeData node_data;
 
-	nd.name = _nm_get_string(p_node->get_name(), name_map);
-	nd.instance = -1; //not instantiated by default
+	node_data.name = _nm_get_string(p_node->get_name(), name_map);
+	node_data.instance = -1; //not instantiated by default
 
 	//really convoluted condition, but it basically checks that index is only saved when part of an inherited scene OR the node parent is from the edited scene
 	if (p_owner->get_scene_inherited_state().is_null() && (p_node == p_owner || (p_node->get_owner() == p_owner && (p_node->get_parent() == p_owner || p_node->get_parent()->get_owner() == p_owner)))) {
 		//do not save index, because it belongs to saved scene and scene is not inherited
-		nd.index = -1;
+		node_data.index = -1;
 	} else if (p_node == p_owner) {
 		//This (hopefully) happens if the node is a scene root, so its index is irrelevant.
-		nd.index = -1;
+		node_data.index = -1;
 	} else {
 		//part of an inherited scene, or parent is from an instantiated scene
-		nd.index = p_node->get_index();
+		node_data.index = p_node->get_index();
 	}
 
 	// if this node is part of an instantiated scene or sub-instantiated scene
@@ -914,8 +914,8 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	if (p_node->is_instance() && p_node->get_owner() == p_owner && instantiated_by_owner) {
 		if (p_node->get_scene_instance_load_placeholder()) {
 			//it's a placeholder, use the placeholder path
-			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
-			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
+			node_data.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
+			node_data.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
 		} else {
 			//must instance ourselves
 			Ref<PackedScene> instance = ResourceLoader::load(p_node->get_scene_file_path());
@@ -923,7 +923,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				return ERR_CANT_OPEN;
 			}
 
-			nd.instance = _vm_get_variant(instance, variant_map);
+			node_data.instance = _vm_get_variant(instance, variant_map);
 		}
 	}
 
@@ -1074,7 +1074,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		if (use_deferred_node_path_bit) {
 			prop.name |= FLAG_PATH_PROPERTY_IS_NODE;
 		}
-		nd.properties.push_back(prop);
+		node_data.properties.push_back(prop);
 	}
 
 	// save the groups this node is into
@@ -1100,7 +1100,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			continue;
 		}
 
-		nd.groups.push_back(_nm_get_string(gi.name, name_map));
+		node_data.groups.push_back(_nm_get_string(gi.name, name_map));
 	}
 
 	// save the right owner
@@ -1110,12 +1110,12 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	if (p_node == p_owner) {
 		//saved scene root
-		nd.owner = -1;
+		node_data.owner = -1;
 	} else if (p_node->get_owner() == p_owner) {
 		//part of saved scene
-		nd.owner = 0;
+		node_data.owner = 0;
 	} else {
-		nd.owner = -1;
+		node_data.owner = -1;
 	}
 
 	MissingNode *missing_node = Object::cast_to<MissingNode>(p_node);
@@ -1126,14 +1126,14 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		//This node is not part of an instantiation process, so save the type.
 		if (missing_node != nullptr) {
 			// It's a missing node (type non existent on load).
-			nd.type = _nm_get_string(missing_node->get_original_class(), name_map);
+			node_data.type = _nm_get_string(missing_node->get_original_class(), name_map);
 		} else {
-			nd.type = _nm_get_string(p_node->get_class(), name_map);
+			node_data.type = _nm_get_string(p_node->get_class(), name_map);
 		}
 	} else {
 		// this node is part of an instantiated process, so do not save the type.
 		// instead, save that it was instantiated
-		nd.type = TYPE_INSTANTIATED;
+		node_data.type = TYPE_INSTANTIATED;
 	}
 
 	// determine whether to save this node or not
@@ -1144,7 +1144,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	bool save_node = p_node == p_owner; // owner is always saved
 	save_node = save_node || (p_node->get_owner() == p_owner && instantiated_by_owner); //part of scene and not instanced
-	bool save_data = nd.properties.size() || nd.groups.size(); // some local properties or groups exist
+	bool save_data = node_data.properties.size() || node_data.groups.size(); // some local properties or groups exist
 
 	int idx = nodes.size();
 	int parent_node = NO_PARENT_SAVED;
@@ -1164,9 +1164,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				nodepath_map[p_node->get_parent()] = sidx;
 			}
 
-			nd.parent = FLAG_ID_IS_PATH | sidx;
+			node_data.parent = FLAG_ID_IS_PATH | sidx;
 		} else {
-			nd.parent = p_parent_idx;
+			node_data.parent = p_parent_idx;
 		}
 
 		int32_t unique_scene_id = p_node->get_unique_scene_id();
@@ -1196,7 +1196,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		ids.push_back(unique_scene_id);
 
 		parent_node = idx;
-		nodes.push_back(nd);
+		nodes.push_back(node_data);
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -1218,7 +1218,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 	_signals.sort();
 
 	//ERR_FAIL_COND_V( !node_map.has(p_node), ERR_BUG);
-	//NodeData &nd = nodes[node_map[p_node]];
+	//NodeData &node_data = nodes[node_map[p_node]];
 
 	for (const MethodInfo &E : _signals) {
 		List<Node::Connection> conns;
@@ -1772,23 +1772,23 @@ void SceneState::set_bundled_scene(const Dictionary &p_dictionary) {
 		const int *r = snodes.ptr();
 		int idx = 0;
 		for (int i = 0; i < node_count; i++) {
-			NodeData &nd = nodes.write[i];
-			nd.parent = r[idx++];
-			nd.owner = r[idx++];
-			nd.type = r[idx++];
+			NodeData &node_data = nodes.write[i];
+			node_data.parent = r[idx++];
+			node_data.owner = r[idx++];
+			node_data.type = r[idx++];
 			uint32_t name_index = r[idx++];
-			nd.name = name_index & ((1 << NAME_INDEX_BITS) - 1);
-			nd.index = (name_index >> NAME_INDEX_BITS);
-			nd.index--; //0 is invalid, stored as 1
-			nd.instance = r[idx++];
-			nd.properties.resize(r[idx++]);
-			for (int j = 0; j < nd.properties.size(); j++) {
-				nd.properties.write[j].name = r[idx++];
-				nd.properties.write[j].value = r[idx++];
+			node_data.name = name_index & ((1 << NAME_INDEX_BITS) - 1);
+			node_data.index = (name_index >> NAME_INDEX_BITS);
+			node_data.index--; //0 is invalid, stored as 1
+			node_data.instance = r[idx++];
+			node_data.properties.resize(r[idx++]);
+			for (int j = 0; j < node_data.properties.size(); j++) {
+				node_data.properties.write[j].name = r[idx++];
+				node_data.properties.write[j].value = r[idx++];
 			}
-			nd.groups.resize(r[idx++]);
-			for (int j = 0; j < nd.groups.size(); j++) {
-				nd.groups.write[j] = r[idx++];
+			node_data.groups.resize(r[idx++]);
+			for (int j = 0; j < node_data.groups.size(); j++) {
+				node_data.groups.write[j] = r[idx++];
 			}
 		}
 	}
@@ -1876,24 +1876,24 @@ Dictionary SceneState::get_bundled_scene() const {
 	d["node_count"] = nodes.size();
 
 	for (int i = 0; i < nodes.size(); i++) {
-		const NodeData &nd = nodes[i];
-		rnodes.push_back(nd.parent);
-		rnodes.push_back(nd.owner);
-		rnodes.push_back(nd.type);
-		uint32_t name_index = nd.name;
-		if (nd.index < (1 << (32 - NAME_INDEX_BITS)) - 1) { //save if less than 16k children
-			name_index |= uint32_t(nd.index + 1) << NAME_INDEX_BITS; //for backwards compatibility, index 0 is no index
+		const NodeData &node_data = nodes[i];
+		rnodes.push_back(node_data.parent);
+		rnodes.push_back(node_data.owner);
+		rnodes.push_back(node_data.type);
+		uint32_t name_index = node_data.name;
+		if (node_data.index < (1 << (32 - NAME_INDEX_BITS)) - 1) { //save if less than 16k children
+			name_index |= uint32_t(node_data.index + 1) << NAME_INDEX_BITS; //for backwards compatibility, index 0 is no index
 		}
 		rnodes.push_back(name_index);
-		rnodes.push_back(nd.instance);
-		rnodes.push_back(nd.properties.size());
-		for (int j = 0; j < nd.properties.size(); j++) {
-			rnodes.push_back(nd.properties[j].name);
-			rnodes.push_back(nd.properties[j].value);
+		rnodes.push_back(node_data.instance);
+		rnodes.push_back(node_data.properties.size());
+		for (int j = 0; j < node_data.properties.size(); j++) {
+			rnodes.push_back(node_data.properties[j].name);
+			rnodes.push_back(node_data.properties[j].value);
 		}
-		rnodes.push_back(nd.groups.size());
-		for (int j = 0; j < nd.groups.size(); j++) {
-			rnodes.push_back(nd.groups[j]);
+		rnodes.push_back(node_data.groups.size());
+		for (int j = 0; j < node_data.groups.size(); j++) {
+			rnodes.push_back(node_data.groups[j]);
 		}
 	}
 
@@ -2060,11 +2060,11 @@ Node *SceneState::_recover_node_path_index(Node *p_base, int p_idx) const {
 			break; // Do not go further, we have the path.
 		}
 
-		const NodeData &nd = ss->nodes[idx];
+		const NodeData &node_data = ss->nodes[idx];
 		// Get instance
-		ERR_FAIL_COND_V(nd.instance < 0, nullptr); // Not an instance, middle of path should be an instance.
-		ERR_FAIL_COND_V(nd.instance & FLAG_INSTANCE_IS_PLACEHOLDER, nullptr); // Instance is somehow a placeholder?!
-		Ref<PackedScene> sdata = ss->variants[nd.instance & FLAG_MASK];
+		ERR_FAIL_COND_V(node_data.instance < 0, nullptr); // Not an instance, middle of path should be an instance.
+		ERR_FAIL_COND_V(node_data.instance & FLAG_INSTANCE_IS_PLACEHOLDER, nullptr); // Instance is somehow a placeholder?!
+		Ref<PackedScene> sdata = ss->variants[node_data.instance & FLAG_MASK];
 		ERR_FAIL_COND_V(sdata.is_null(), nullptr);
 		Ref<SceneState> sstate = sdata->get_state();
 		ss = sstate.ptr();
@@ -2380,15 +2380,15 @@ int SceneState::add_node_path(const NodePath &p_path, const PackedInt32Array &p_
 }
 
 int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int32_t p_unique_id) {
-	NodeData nd;
-	nd.parent = p_parent;
-	nd.owner = p_owner;
-	nd.type = p_type;
-	nd.name = p_name;
-	nd.instance = p_instance;
-	nd.index = p_index;
+	NodeData node_data;
+	node_data.parent = p_parent;
+	node_data.owner = p_owner;
+	node_data.type = p_type;
+	node_data.name = p_name;
+	node_data.instance = p_instance;
+	node_data.index = p_index;
 
-	nodes.push_back(nd);
+	nodes.push_back(node_data);
 
 	ids.push_back(p_unique_id);
 

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -86,14 +86,14 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 	*/
 
 	double magn, phase, tmp, window, real, imag;
-	double freqPerBin, expct;
+	double freqPerBin, expect;
 	long i,k, qpd, index, inFifoLatency, stepSize, fftFrameSize2;
 
 	/* set up some handy variables */
 	fftFrameSize2 = fftFrameSize/2;
 	stepSize = fftFrameSize/osamp;
 	freqPerBin = sampleRate/(double)fftFrameSize;
-	expct = 2.*Math::PI*(double)stepSize/(double)fftFrameSize;
+	expect = 2.*Math::PI*(double)stepSize/(double)fftFrameSize;
 	inFifoLatency = fftFrameSize-stepSize;
 	if (gRover == 0) { gRover = inFifoLatency;
 }
@@ -138,7 +138,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				gLastPhase[k] = phase;
 
 				/* subtract expected phase difference */
-				tmp -= (double)k*expct;
+				tmp -= (double)k*expect;
 
 				/* map delta phase into +/- Pi interval */
 				qpd = tmp/Math::PI;
@@ -193,7 +193,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 				tmp = 2.*Math::PI*tmp/osamp;
 
 				/* add the overlap phase advance back in */
-				tmp += (double)k*expct;
+				tmp += (double)k*expect;
 
 				/* accumulate delta phase to get bin phase */
 				gSumPhase[k] += tmp;

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -179,7 +179,7 @@ vec3 allenwp_curve(vec3 x) {
 vec3 tonemap_agx(vec3 color) {
 	// Input color should be non-negative!
 	// Large negative values in one channel and large positive values in other
-	// channels can result in a colour that appears darker and more saturated than
+	// channels can result in a color that appears darker and more saturated than
 	// desired after passing it through the inset matrix. For this reason, it is
 	// best to prevent negative input values.
 	// This is done before the Rec. 2020 transform to allow the Rec. 2020
@@ -214,7 +214,7 @@ vec3 tonemap_agx(vec3 color) {
 	// providing stability across all variable dyanimc range (SDR, HDR, EDR).
 	color = allenwp_curve(color);
 
-	// Clipping to output_max_value is required to address a cyan colour that occurs
+	// Clipping to output_max_value is required to address a cyan color that occurs
 	// with very bright inputs.
 	color = min(vec3(params.output_max_value), color);
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
@@ -190,7 +190,7 @@ vec3 allenwp_curve(vec3 x) {
 vec3 tonemap_agx(vec3 color) {
 	// Input color should be non-negative!
 	// Large negative values in one channel and large positive values in other
-	// channels can result in a colour that appears darker and more saturated than
+	// channels can result in a color that appears darker and more saturated than
 	// desired after passing it through the inset matrix. For this reason, it is
 	// best to prevent negative input values.
 	// This is done before the Rec. 2020 transform to allow the Rec. 2020
@@ -225,7 +225,7 @@ vec3 tonemap_agx(vec3 color) {
 	// providing stability across all variable dyanimc range (SDR, HDR, EDR).
 	color = allenwp_curve(color);
 
-	// Clipping to output_max_value is required to address a cyan colour that occurs
+	// Clipping to output_max_value is required to address a cyan color that occurs
 	// with very bright inputs.
 	color = min(vec3(params.output_max_value), color);
 

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
@@ -123,12 +123,12 @@ vec2 octahedron_encode(vec3 n) {
 }
 
 float get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 void compute_area_light(uint index, vec3 position, out float attenuation, out vec3 light_vec, out float light_distance, out vec3 texture_color) {

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -236,12 +236,12 @@ vec3 hash3f(uvec3 x) {
 }
 
 float get_omni_attenuation(float dist, float inv_range, float decay) {
-	float nd = dist * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(dist, 0.0001), -decay);
+	float ndist = dist * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(dist, 0.0001), -decay);
 }
 
 void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max, out uint item_from, out uint item_to) {

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -235,12 +235,12 @@ vec3 hash3f(uvec3 x) {
 }
 
 float get_omni_attenuation(float dist, float inv_range, float decay) {
-	float nd = dist * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(dist, 0.0001), -decay);
+	float ndist = dist * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(dist, 0.0001), -decay);
 }
 
 void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max, out uint item_from, out uint item_to) {

--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
@@ -199,12 +199,12 @@ float raymarch(float distance, float distance_adv, vec3 from, vec3 direction) {
 }
 
 float get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return ndist * pow(max(distance, 0.0001), -decay);
 }
 
 bool compute_light_vector(uint light, vec3 pos, out float attenuation, out vec3 light_pos) {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -202,12 +202,12 @@ vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
 }
 
 vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
-	vec3 s, t, se, te;
+	vec3 s, t, se, te; // codespell:ignore te.
 	s = two_sum(base_a, base_b, se);
-	t = two_sum(prec_a, prec_b, te);
+	t = two_sum(prec_a, prec_b, te); // codespell:ignore te.
 	se += t;
 	s = quick_two_sum(s, se, se);
-	se += te;
+	se += te; // codespell:ignore te.
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -201,12 +201,12 @@ vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
 }
 
 vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
-	vec3 s, t, se, te;
+	vec3 s, t, se, te; // codespell:ignore te.
 	s = two_sum(base_a, base_b, se);
-	t = two_sum(prec_a, prec_b, te);
+	t = two_sum(prec_a, prec_b, te); // codespell:ignore te.
 	se += t;
 	s = quick_two_sum(s, se, se);
-	se += te;
+	se += te; // codespell:ignore te.
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -188,12 +188,12 @@ vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
 }
 
 vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
-	vec3 s, t, se, te;
+	vec3 s, t, se, te; // codespell:ignore te.
 	s = two_sum(base_a, base_b, se);
-	t = two_sum(prec_a, prec_b, te);
+	t = two_sum(prec_a, prec_b, te); // codespell:ignore te.
 	se += t;
 	s = quick_two_sum(s, se, se);
-	se += te;
+	se += te; // codespell:ignore te.
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -455,12 +455,12 @@ half sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex_
 #endif // SHADOWS_DISABLED
 
 half get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return half(nd * pow(max(distance, 0.0001), -decay));
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return half(ndist * pow(max(distance, 0.0001), -decay));
 }
 
 void light_process_omni(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, hvec3 f0, half roughness, half metallic, float taa_frame_count, hvec3 albedo, inout half alpha, vec2 screen_uv, hvec3 energy_compensation,

--- a/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
@@ -39,12 +39,12 @@ void light_compute_vertex(hvec3 N, hvec3 L, hvec3 V, hvec3 light_color, bool is_
 }
 
 half get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return half(nd * pow(max(distance, 0.0001), -decay));
+	float ndist = distance * inv_range;
+	ndist *= ndist;
+	ndist *= ndist; // ndist^4
+	ndist = max(1.0 - ndist, 0.0);
+	ndist *= ndist; // ndist^2
+	return half(ndist * pow(max(distance, 0.0001), -decay));
 }
 
 void light_process_omni_vertex(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, half roughness,

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1658,7 +1658,7 @@ void LightStorage::reflection_probe_release_atlas_index(RID p_instance) {
 	// TODO investigate if this is enough? shouldn't we be freeing our textures and framebuffers?
 
 	if (rpi->rendering) {
-		// We were cancelled mid rendering, trigger refresh.
+		// We were canceled mid rendering, trigger refresh.
 		rpi->rendering = false;
 		rpi->dirty = true;
 		rpi->processing_layer = 1;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1660,7 +1660,7 @@ void LightStorage::reflection_probe_release_atlas_index(RID p_instance) {
 	// TODO investigate if this is enough? shouldn't we be freeing our textures and framebuffers?
 
 	if (rpi->rendering) {
-		// We were cancelled mid rendering, trigger refresh.
+		// We were canceled mid rendering, trigger refresh.
 		rpi->rendering = false;
 		rpi->dirty = true;
 		rpi->processing_layer = 1;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1485,9 +1485,9 @@ RD::VertexFormatID MeshStorage::_mesh_surface_generate_vertex_format(uint64_t p_
 	return RD::get_singleton()->vertex_format_create(attributes);
 }
 
-void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, MeshInstance::Surface *mis, uint32_t p_current_buffer, uint32_t p_previous_buffer) {
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &p_version, Mesh::Surface *p_mesh_surface, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, MeshInstance::Surface *p_mesh_instance_surface, uint32_t p_current_buffer, uint32_t p_previous_buffer) {
 	uint32_t position_stride = 0;
-	v.vertex_format = _mesh_surface_generate_vertex_format(s->format, p_input_mask, mis != nullptr, p_input_motion_vectors, p_point_size_emulated, position_stride);
+	p_version.vertex_format = _mesh_surface_generate_vertex_format(p_mesh_surface->format, p_input_mask, p_mesh_instance_surface != nullptr, p_input_motion_vectors, p_point_size_emulated, position_stride);
 
 	Vector<RID> buffers;
 	Vector<uint64_t> offsets;
@@ -1496,7 +1496,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	for (int i = 0; i < RSE::ARRAY_INDEX; i++) {
 		offset = 0;
 
-		if (!(s->format & (1ULL << i))) {
+		if (!(p_mesh_surface->format & (1ULL << i))) {
 			// Not supplied by surface, use default buffers.
 			buffer = mesh_default_rd_buffers[i];
 		} else {
@@ -1504,8 +1504,8 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			switch (i) {
 				case RSE::ARRAY_VERTEX:
 				case RSE::ARRAY_NORMAL:
-					offset = i == RSE::ARRAY_NORMAL ? position_stride * s->vertex_count : 0;
-					buffer = mis != nullptr ? mis->vertex_buffer[p_current_buffer] : s->vertex_buffer;
+					offset = i == RSE::ARRAY_NORMAL ? position_stride * p_mesh_surface->vertex_count : 0;
+					buffer = p_mesh_instance_surface != nullptr ? p_mesh_instance_surface->vertex_buffer[p_current_buffer] : p_mesh_surface->vertex_buffer;
 					break;
 				case RSE::ARRAY_TANGENT:
 					buffer = mesh_default_rd_buffers[i];
@@ -1517,11 +1517,11 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				case RSE::ARRAY_CUSTOM1:
 				case RSE::ARRAY_CUSTOM2:
 				case RSE::ARRAY_CUSTOM3:
-					buffer = s->attribute_buffer;
+					buffer = p_mesh_surface->attribute_buffer;
 					break;
 				case RSE::ARRAY_BONES:
 				case RSE::ARRAY_WEIGHTS:
-					buffer = s->skin_buffer;
+					buffer = p_mesh_surface->skin_buffer;
 					break;
 			}
 		}
@@ -1536,8 +1536,8 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		if (p_input_motion_vectors) {
 			// Push the buffer for motion vector inputs.
 			if (i == RSE::ARRAY_VERTEX || i == RSE::ARRAY_NORMAL || i == RSE::ARRAY_TANGENT) {
-				if (mis && buffer != mesh_default_rd_buffers[i]) {
-					buffers.push_back(mis->vertex_buffer[p_previous_buffer]);
+				if (p_mesh_instance_surface && buffer != mesh_default_rd_buffers[i]) {
+					buffers.push_back(p_mesh_instance_surface->vertex_buffer[p_previous_buffer]);
 				} else {
 					buffers.push_back(buffer);
 				}
@@ -1547,12 +1547,12 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		}
 	}
 
-	v.input_mask = p_input_mask;
-	v.current_buffer = p_current_buffer;
-	v.previous_buffer = p_previous_buffer;
-	v.input_motion_vectors = p_input_motion_vectors;
-	v.point_size_emulated = p_point_size_emulated;
-	v.vertex_array = RD::get_singleton()->vertex_array_create(p_point_size_emulated ? 0 : s->vertex_count, v.vertex_format, buffers, offsets);
+	p_version.input_mask = p_input_mask;
+	p_version.current_buffer = p_current_buffer;
+	p_version.previous_buffer = p_previous_buffer;
+	p_version.input_motion_vectors = p_input_motion_vectors;
+	p_version.point_size_emulated = p_point_size_emulated;
+	p_version.vertex_array = RD::get_singleton()->vertex_array_create(p_point_size_emulated ? 0 : p_mesh_surface->vertex_count, p_version.vertex_format, buffers, offsets);
 }
 
 ////////////////// MULTIMESH

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -211,7 +211,7 @@ private:
 	};
 
 	RD::VertexFormatID _mesh_surface_generate_vertex_format(uint64_t p_surface_format, uint64_t p_input_mask, bool p_instanced_surface, bool p_input_motion_vectors, bool p_point_size_emulated, uint32_t &r_position_stride);
-	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, MeshInstance::Surface *mis = nullptr, uint32_t p_current_buffer = 0, uint32_t p_previous_buffer = 0);
+	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &p_version, Mesh::Surface *p_mesh_surface, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, MeshInstance::Surface *p_mesh_instance_surface = nullptr, uint32_t p_current_buffer = 0, uint32_t p_previous_buffer = 0);
 	void _mesh_surface_clear(Mesh *p_mesh, int p_surface);
 
 	void _mesh_instance_clear(MeshInstance *mi);
@@ -550,43 +550,43 @@ public:
 		Mesh *mesh = mi->mesh;
 		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
 
-		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
+		MeshInstance::Surface *p_mis = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];
-		uint32_t current_buffer = mis->current_buffer;
+		uint32_t current_buffer = p_mis->current_buffer;
 
 		// Using the previous buffer is only allowed if the surface was updated this frame and motion vectors are required.
-		uint32_t previous_buffer = p_input_motion_vectors && (RSG::rasterizer->get_frame_number() == mis->last_change) ? mis->previous_buffer : current_buffer;
+		uint32_t previous_buffer = p_input_motion_vectors && (RSG::rasterizer->get_frame_number() == p_mis->last_change) ? p_mis->previous_buffer : current_buffer;
 
 		s->version_lock.lock();
 
 		//there will never be more than, at much, 3 or 4 versions, so iterating is the fastest way
 
-		for (uint32_t i = 0; i < mis->version_count; i++) {
-			if (mis->versions[i].input_mask != p_input_mask || mis->versions[i].input_motion_vectors != p_input_motion_vectors) {
+		for (uint32_t i = 0; i < p_mis->version_count; i++) {
+			if (p_mis->versions[i].input_mask != p_input_mask || p_mis->versions[i].input_motion_vectors != p_input_motion_vectors) {
 				// Find the version that matches the inputs required.
 				continue;
 			}
 
-			if (mis->versions[i].current_buffer != current_buffer || mis->versions[i].previous_buffer != previous_buffer) {
+			if (p_mis->versions[i].current_buffer != current_buffer || p_mis->versions[i].previous_buffer != previous_buffer) {
 				// Find the version that corresponds to the correct buffers that should be used.
 				continue;
 			}
 
 			//we have this version, hooray
-			r_vertex_format = mis->versions[i].vertex_format;
-			r_vertex_array_rd = mis->versions[i].vertex_array;
+			r_vertex_format = p_mis->versions[i].vertex_format;
+			r_vertex_array_rd = p_mis->versions[i].vertex_array;
 			s->version_lock.unlock();
 			return;
 		}
 
-		uint32_t version = mis->version_count;
-		mis->version_count++;
-		mis->versions = (Mesh::Surface::Version *)memrealloc(mis->versions, sizeof(Mesh::Surface::Version) * mis->version_count);
+		uint32_t version = p_mis->version_count;
+		p_mis->version_count++;
+		p_mis->versions = (Mesh::Surface::Version *)memrealloc(p_mis->versions, sizeof(Mesh::Surface::Version) * p_mis->version_count);
 
-		_mesh_surface_generate_version_for_input_mask(mis->versions[version], s, p_input_mask, p_input_motion_vectors, p_point_size_emulated, mis, current_buffer, previous_buffer);
+		_mesh_surface_generate_version_for_input_mask(p_mis->versions[version], s, p_input_mask, p_input_motion_vectors, p_point_size_emulated, p_mis, current_buffer, previous_buffer);
 
-		r_vertex_format = mis->versions[version].vertex_format;
-		r_vertex_array_rd = mis->versions[version].vertex_array;
+		r_vertex_format = p_mis->versions[version].vertex_format;
+		r_vertex_array_rd = p_mis->versions[version].vertex_array;
 
 		s->version_lock.unlock();
 	}

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -412,7 +412,7 @@ public:
 		TEXTURE_USAGE_VRS_ATTACHMENT_BIT = (1 << 10),
 		// When set, the texture is not backed by actual memory. It only ever lives in the cache.
 		// This is particularly useful for:
-		//	1. Depth/stencil buffers that are not needed after producing the colour output.
+		//	1. Depth/stencil buffers that are not needed after producing the color output.
 		//	2. MSAA surfaces that are immediately resolved (i.e. its raw content isn't needed).
 		//
 		// This flag heavily improves performance & saves memory on TBDR GPUs (e.g. mobile).

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -1810,7 +1810,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->add_caret(0, 7);
 		code_edit->add_caret(0, 2);
 		code_edit->do_indent();
-		CHECK(code_edit->get_line(0) == "te\tst \tte\txt");
+		CHECK(code_edit->get_line(0) == "te\tst \tte\txt"); // codespell:ignore te.
 		CHECK(code_edit->get_caret_count() == 3);
 		CHECK(code_edit->get_caret_column(0) == 7);
 		CHECK(code_edit->get_caret_column(1) == 10);
@@ -1961,7 +1961,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->add_caret(0, 7);
 		code_edit->add_caret(0, 2);
 		code_edit->do_indent();
-		CHECK(code_edit->get_line(0) == "te  st    te  xt");
+		CHECK(code_edit->get_line(0) == "te  st    te  xt"); // codespell:ignore te.
 		CHECK(code_edit->get_caret_count() == 3);
 		CHECK(code_edit->get_caret_column(0) == 10);
 		CHECK(code_edit->get_caret_column(1) == 14);
@@ -2686,7 +2686,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("    test");
 			code_edit->set_caret_column(6);
 			SEND_GUI_ACTION("ui_text_newline");
-			CHECK(code_edit->get_line(0) == "    te");
+			CHECK(code_edit->get_line(0) == "    te"); // codespell:ignore te.
 			CHECK(code_edit->get_line(1) == "    st");
 			CHECK(code_edit->get_caret_line() == 1);
 			CHECK(code_edit->get_caret_column() == 4);
@@ -3898,7 +3898,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->set_auto_brace_completion_enabled(true);
 		CHECK(code_edit->is_auto_brace_completion_enabled());
 
-		code_edit->insert_text_at_caret("(te)");
+		code_edit->insert_text_at_caret("(te)"); // codespell:ignore te.
 		code_edit->set_caret_column(3);
 
 		// Full completion.
@@ -4362,7 +4362,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 	SUBCASE("[CodeEdit] autocomplete suggestion order") {
 		/* Prefer less fragmented suggestion. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test", "test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "tset", "tset");
@@ -4372,7 +4372,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer suggestion starting with the string to complete (matching start). */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test", "test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "stest", "stest");
@@ -4382,7 +4382,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer less fragment over matching start. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "tset", "tset");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "stest", "stest");
@@ -4392,7 +4392,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer good capitalization. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test", "test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "Test", "Test");
@@ -4402,7 +4402,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer matching start over good capitalization. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "Test", "Test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "stest_bis", "test_bis");
@@ -4412,7 +4412,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer closer location. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test", "test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test_bis", "test_bis", Color(1, 1, 1), Ref<Resource>(), Variant::NIL, CodeEdit::LOCATION_LOCAL);
@@ -4422,7 +4422,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer good capitalization over location. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "test", "test");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "Test", "Test", Color(1, 1, 1), Ref<Resource>(), Variant::NIL, CodeEdit::LOCATION_LOCAL);
@@ -4432,7 +4432,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer the start of the string to complete being closest to the start of the suggestion (closest to start). */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "stest", "stest");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "sstest", "sstest");
@@ -4442,7 +4442,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Prefer location over closest to start. */
 		code_edit->clear();
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "stest", "stest");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "sstest", "sstest", Color(1, 1, 1), Ref<Resource>(), Variant::NIL, CodeEdit::LOCATION_LOCAL);
@@ -4456,7 +4456,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		REQUIRE(code_edit->is_code_completion_enabled());
 
 		// Initially select item 0.
-		code_edit->insert_text_at_caret("te");
+		code_edit->insert_text_at_caret("te"); // codespell:ignore te.
 		code_edit->set_caret_column(2);
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "te1", "te1");
 		code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "te3", "te3");

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -572,11 +572,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Setting to a shorter line, selection and caret should be adjusted. Also works if not editable.
 			text_edit->set_editable(false);
-			text_edit->set_line(0, "te");
+			text_edit->set_line(0, "te"); // codespell:ignore te.
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "te");
+			CHECK(text_edit->get_selected_text() == "te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
@@ -598,7 +598,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -610,7 +610,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			ERR_PRINT_OFF;
 			text_edit->set_line(-1, "test");
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
@@ -618,7 +618,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->set_line(1, "test");
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
@@ -5403,7 +5403,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin(0));
 
 			CHECK(text_edit->has_selection(1));
-			CHECK(text_edit->get_selected_text(1) == "some te");
+			CHECK(text_edit->get_selected_text(1) == "some te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 8);
 			CHECK(text_edit->get_selection_origin_line(1) == 2);
@@ -5683,7 +5683,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin(0));
 
 			CHECK(text_edit->has_selection(1));
-			CHECK(text_edit->get_selected_text(1) == " te");
+			CHECK(text_edit->get_selected_text(1) == " te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 12);
 			CHECK(text_edit->get_selection_origin_line(1) == 2);
@@ -5785,7 +5785,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
-			CHECK(text_edit->get_selected_text(0) == "st te");
+			CHECK(text_edit->get_selected_text(0) == "st te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(0) == 0);
 			CHECK(text_edit->get_caret_column(0) == 20);
 			CHECK(text_edit->get_selection_origin_line(0) == 0);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -572,11 +572,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Setting to a shorter line, selection and caret should be adjusted. Also works if not editable.
 			text_edit->set_editable(false);
-			text_edit->set_line(0, "te");
+			text_edit->set_line(0, "te"); // codespell:ignore te.
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "te");
+			CHECK(text_edit->get_selected_text() == "te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
@@ -598,7 +598,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -610,7 +610,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			ERR_PRINT_OFF;
 			text_edit->set_line(-1, "test");
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
@@ -618,7 +618,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->set_line(1, "test");
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_line(0) == "te");
+			CHECK(text_edit->get_line(0) == "te"); // codespell:ignore te.
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
@@ -5405,7 +5405,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin(0));
 
 			CHECK(text_edit->has_selection(1));
-			CHECK(text_edit->get_selected_text(1) == "some te");
+			CHECK(text_edit->get_selected_text(1) == "some te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 8);
 			CHECK(text_edit->get_selection_origin_line(1) == 2);
@@ -5685,7 +5685,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin(0));
 
 			CHECK(text_edit->has_selection(1));
-			CHECK(text_edit->get_selected_text(1) == " te");
+			CHECK(text_edit->get_selected_text(1) == " te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 12);
 			CHECK(text_edit->get_selection_origin_line(1) == 2);
@@ -5787,7 +5787,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
-			CHECK(text_edit->get_selected_text(0) == "st te");
+			CHECK(text_edit->get_selected_text(0) == "st te"); // codespell:ignore te.
 			CHECK(text_edit->get_caret_line(0) == 0);
 			CHECK(text_edit->get_caret_column(0) == 20);
 			CHECK(text_edit->get_selection_origin_line(0) == 0);

--- a/tests/servers/test_text_server.cpp
+++ b/tests/servers/test_text_server.cpp
@@ -795,7 +795,7 @@ TEST_SUITE("[TextServer]") {
 					},
 					{
 							2,
-							{ 0x54, 0x65, 0x2A, 0x73, 0x74, 0, 0, 0, 0, 0 }, // "Te*st"
+							{ 0x54, 0x65, 0x2A, 0x73, 0x74, 0, 0, 0, 0, 0 }, // "Te*st" // codespell:ignore te.
 					},
 					{
 							4,


### PR DESCRIPTION
## What problem(s) does this PR solve?

Our number of codespell exceptions was overzealous, causing actual errors and bad practices to slip through the cracks. This PR strips out the majority of those ignored words, whether by addressing their use directly or ignoring instances that can't be reasonably worked around

## Additional information

Adds a special regex to handle "colour" as an alias in documentation. Now codespell will ignore any text within a `keywords` block