### PR TITLE
CI: Fix Wayland breakage in `clangd-tidy`

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -30,11 +30,11 @@
 
 #include "wayland_thread.h"
 
+#ifdef WAYLAND_ENABLED
+
 #include "core/config/engine.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
-
-#ifdef WAYLAND_ENABLED
 
 #ifdef __FreeBSD__
 #include <dev/evdev/input-event-codes.h>


### PR DESCRIPTION
Fixes GHA halting because of `wayland_thread.cpp` initial includes not being wrapped by `WAYLAND_ENABLED`