### PR TITLE
Fix desired size space allocation not respecting minimum sizes correctly

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -117,8 +117,8 @@ void BoxContainer::_resort() {
 	stretch_space += stretch_diff; //available stretch space.
 
 	// First, allocate extra space to Controls which have a desired size larger than their minimum size, up to their desired size, in proportion to how much extra space they want.
-	if (stretch_space > 0 && desired_extra_space > 0) {
-		real_t space_available_ratio = MIN(real_t(stretch_space) / real_t(desired_extra_space), 1.0);
+	if (stretch_diff > 0 && desired_extra_space > 0) {
+		real_t space_available_ratio = MIN(real_t(stretch_diff) / real_t(desired_extra_space), 1.0);
 
 		for (Node *child : iterate_children()) {
 			Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -134,19 +134,24 @@ void GridContainer::_resort() {
 
 	// Evaluate the remaining space for expanded columns/rows.
 	Size2 remaining_space = get_size();
+	Size2 empty_space = remaining_space;
 	for (const KeyValue<int, int> &E : col_minw) {
 		if (!col_expanded.has(E.key)) {
 			remaining_space.width -= E.value;
 		}
+		empty_space.width -= E.value;
 	}
 
 	for (const KeyValue<int, int> &E : row_minh) {
 		if (!row_expanded.has(E.key)) {
 			remaining_space.height -= E.value;
 		}
+		empty_space.height -= E.value;
 	}
 	remaining_space.height -= theme_cache.v_separation * MAX(max_row - 1, 0);
 	remaining_space.width -= theme_cache.h_separation * MAX(max_col - 1, 0);
+	empty_space.height -= theme_cache.v_separation * MAX(max_row - 1, 0);
+	empty_space.width -= theme_cache.h_separation * MAX(max_col - 1, 0);
 
 	// Distribute the remaining space to cols/rows which have a desired size larger than their minimum size, up to their desired size, in proportion to how much extra space they want.
 	int total_desired_extra_space = 0;
@@ -156,8 +161,8 @@ void GridContainer::_resort() {
 			total_desired_extra_space += desired_extra_space;
 		}
 	}
-	if (remaining_space.width > 0 && total_desired_extra_space > 0) {
-		real_t space_available_ratio = MIN(real_t(remaining_space.width) / real_t(total_desired_extra_space), 1.0);
+	if (empty_space.width > 0 && total_desired_extra_space > 0) {
+		real_t space_available_ratio = MIN(real_t(empty_space.width) / real_t(total_desired_extra_space), 1.0);
 		for (const KeyValue<int, int> &E : col_desiredw) {
 			int desired_extra_space = E.value - col_minw[E.key];
 			if (desired_extra_space > 0) {
@@ -176,8 +181,8 @@ void GridContainer::_resort() {
 			total_desired_extra_space += desired_extra_space;
 		}
 	}
-	if (remaining_space.height > 0 && total_desired_extra_space > 0) {
-		real_t space_available_ratio = MIN(real_t(remaining_space.height) / real_t(total_desired_extra_space), 1.0);
+	if (empty_space.height > 0 && total_desired_extra_space > 0) {
+		real_t space_available_ratio = MIN(real_t(empty_space.height) / real_t(total_desired_extra_space), 1.0);
 		for (const KeyValue<int, int> &E : row_desiredh) {
 			int desired_extra_space = E.value - row_minh[E.key];
 			if (desired_extra_space > 0) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow up to #120640 

In that PR, I made `BoxContainer` and `GridContainer` (and `FlowContainer`, but that one isn't bugged) allocate space to children whose desired sizes were greater than their minimum sizes. 
As described in the PR, the flow would go: 
1. Give each child its minimum size
2. From the remaining space, distribute to children with a desired size
3. If any, from the remaining space, distribute to children with the SIZE_EXPAND flag

The problem is, in both cases, the "remaining space" computed for step 3, which I used for step 2, also includes the space occupied by the minimum size of the children who have the `SIZE_EXPAND` flag. This is done such that their final sizes are computed irrespective of their minimum sizes, and only take into account the stretch ratios. 
However, using that in step 2 resulted in the children in step 2 overallocating, using the minimum size of the expanding children as free space to stretch into. This is completely erroneous and results in the step 2 children taking up more space than is available. 

The images below use `HBoxContainer`, the project has both, but they look the same, so I only put images for one.
Before:
<img width="641" height="52" alt="image" src="https://github.com/user-attachments/assets/6552ea8e-9a48-4a37-82b0-de1fd918d132" />

After PR:
<img width="459" height="54" alt="image" src="https://github.com/user-attachments/assets/38c706be-2410-40b6-80b8-d8bd9aa29dc4" />

Project:
[respect-desired-sizes-mrp.zip](https://github.com/user-attachments/files/29649228/respect-desired-sizes-mrp.zip)


## Additional information

The project additionally contains the previous tests from #120640 to ensure no regressions against that PR. 

This bug slipped through because of a lack of test coverage for the new system, which I should have added earlier. I will work to expand test coverage for these containers so that this kind of oversight does not happen again. 