### PR TITLE
Profiler: Fix visual profiler showing inaccurate times for categories 

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -388,7 +388,7 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 
 		if (name.begins_with("<")) {
 			stack.pop_back();
-			
+
 			// Update the time of parent categories after the end of this category.
 			for (TreeItem *E : stack) {
 				float total_cpu = E->get_metadata(1);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -388,6 +388,16 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 
 		if (name.begins_with("<")) {
 			stack.pop_back();
+			
+			//update the time of parent categorys after the end of this category
+			for (TreeItem *E : stack) {
+				float total_cpu = E->get_metadata(1);
+				float total_gpu = E->get_metadata(2);
+				total_cpu += cpu_time;
+				total_gpu += gpu_time;
+				E->set_metadata(1, total_cpu);
+				E->set_metadata(2, total_gpu);
+			}
 			continue;
 		}
 		TreeItem *category = variables->create_item(parent);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -389,7 +389,7 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 		if (name.begins_with("<")) {
 			stack.pop_back();
 			
-			//update the time of parent categorys after the end of this category
+			// Update the time of parent categories after the end of this category.
 			for (TreeItem *E : stack) {
 				float total_cpu = E->get_metadata(1);
 				float total_gpu = E->get_metadata(2);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #97854

## Additional information

This PR adds time to the GPU and CPU times, which is rendered in the Graph but is missing in the overview:

<img width="1342" height="584" alt="Screenshot 2026-07-03 211351" src="https://github.com/user-attachments/assets/3896fccc-2550-4a31-ac56-820cfc69fbdc" />

<img width="1341" height="624" alt="Screenshot 2026-07-03 235102" src="https://github.com/user-attachments/assets/85b293cd-9d62-417b-a442-b760ae35e8b4" />

For reproduction and further explanation of the issue please read the issue and especially this comment:
https://github.com/godotengine/godot/issues/97854#issuecomment-4879338035

## Issues and uncertainties with this PR

1. Areas in the Graph, which are associated with a Category instead of an Item aren't clickable in the Graph. This might cause confusion for the User.

2. A new TimeStamp could be added which encapsulates swap_buffer() and its surrounding functions. This shows the user more transparently what is happening in the Visual Profiler and would make the specific Area from #97854 clickable and explained.

3. The for loop in the commit is copied from a few lines below it. Instead of having duplicate code, an if statement could be added after that loop, which would just continue. I didn't do this because I think the current version is easier to read.

4. This PR adds the time from closing Categories to it's parent Categories, but not to itself. This makes the most sense in my opinion, but the color displayed in the graph for this time still belongs to the closing category. This is probably not a big issue since the color of categories is not displayed in the overview, so Categories aren't associated with specific colors from the viewpoint of the user.

##Disclaimers

This is my first PR, hopefully it's enough/ not to much information. 

No AI was used in this PR or the code.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
