### PR TITLE
CommandQueueMT: Fix deadlock when contending with an in-progress flush

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -168,9 +168,20 @@ class CommandQueueMT {
 		MutexLock lock(mutex);
 
 		if (unlikely(flush_read_ptr)) {
-			// Another thread is flushing.
-			lock.temp_unlock(); // Not really temp.
-			sync();
+			// Another thread is flushing. Enqueue a sync command and wait for it to be
+			// reached. Two subtleties matter here:
+			// - The sync command must be enqueued without releasing the lock, so the
+			//   in-progress flush pass can't retire before it's in the queue. Otherwise,
+			//   it (and this thread) could be left waiting for a flusher that may never
+			//   run again; e.g., the physics pump task refuses to flush while the main
+			//   thread is inside the scene-tree sync window.
+			// - Waiting for the sync command (at a fixed position in the queue) instead
+			//   of the end of the pass keeps the wait bounded even if other threads
+			//   push commands faster than the flusher can drain them.
+			using SyncCommand = Command<CommandQueueMT, void (CommandQueueMT::*)(), true>;
+			create_command<SyncCommand>(this, &CommandQueueMT::_no_op);
+			sync_tail++;
+			_wait_for_sync(lock);
 			flushing = false;
 			return;
 		}


### PR DESCRIPTION
In _flush(), when another thread's flush pass was in progress, the contention path released the queue mutex and then called sync() to wait for the queue to drain. Between the unlock and the sync command being enqueued, the in-progress pass could retire. The sync command would then sit in the queue waiting for a flusher that may never run again: with physics/3d/run_on_separate_thread enabled, the physics pump task skips flushing while doing_sync is set, and only the main thread - now asleep inside _flush() - can clear doing_sync. Result: a permanent deadlock of the main thread, typically triggered from flush_if_pending() when a CollisionObject3D transform changes inside the scene-tree sync window.

Fix by enqueuing the sync command while still holding the lock. The in-progress pass cannot retire before servicing it (the drain loop re-checks the queue size under the same lock), so the wait is always serviced, and it stays bounded by the command's fixed queue position even under sustained pushes from other threads.


Claude-Session: https://claude.ai/code/session_01EhiPMXPKTuge7nUdVJ3zRc

Investigation artifact https://claude.ai/code/artifact/22289005-f820-402d-b5d7-8905d5a1462d?via=auto_preview


| Run | Binary | 500µs sleep? | Result |
| :--- | :--- | :--- | :--- |
| **Amplified stock** | upstream code | Yes — after `temp_unlock()`, before `sync()` | Permanent deadlock at 6s; stacks matched your Quest capture (main in `_wait_for_sync` via `sync()`, pump parked in `yield`) |
| **Plain fix** | marker-under-lock | No | Clean 600s, 36,578 frames |
| **Amplified fix** | marker-under-lock | Yes — same 500µs, same source position, but the lock is still held | Clean 600s, 36,589 frames — no stall, no watchdog fire, frame rate identical to the unamplified run |

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
