### PR TITLE
Fix file dialog open button state

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1084,6 +1084,8 @@ void FileDialog::update_file_list() {
 		int selected = _get_selected_file_idx();
 		if (selected == -1) {
 			_file_list_select_first();
+		} else {
+			_file_list_selected(selected);
 		}
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #118859  

When opening Scene -> New inherited scene, the open button is disabled even though there is a default scene already selected, causing the user to have to manually deselect the re-select the scene to open.

## Additional information

This will call the same selection handler for the default selection, so the Open button is enabled when there is a default selection.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
