### PR TITLE
Make ItemList and Tree scroll by a visible page's amount when pressing the Page Up/Down keys

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1020,32 +1020,55 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		} else if (p_event->is_action("ui_page_up", true)) {
 			search_string = ""; //any mousepress cancels
 
-			for (int i = 4; i > 0; i--) {
-				int index = current - current_columns * i;
-				if (index >= 0 && index < items.size() && CAN_SELECT(index)) {
-					set_current(index);
+			if (current != -1) {
+				int prev = current;
+				int cur_height = items[current].rect_cache.size.height;
+				int page_height = scroll_bar_v->get_page();
+				while (cur_height < page_height) {
+					int index = prev - current_columns;
+					if (index >= 0) {
+						prev = index;
+					} else {
+						break;
+					}
+					cur_height += items[index].rect_cache.size.height;
+				}
+
+				if (prev >= 0 && prev < items.size() && CAN_SELECT(prev)) {
+					set_current(prev);
+					scroll_bar_v->scroll(-scroll_bar_v->get_page());
 					ensure_current_is_visible();
 					if (select_mode == SELECT_SINGLE) {
 						emit_signal(SceneStringName(item_selected), current);
 					}
 					accept_event();
-					break;
 				}
 			}
 		} else if (p_event->is_action("ui_page_down", true)) {
 			search_string = ""; //any mousepress cancels
 
-			for (int i = 4; i > 0; i--) {
-				int index = current + current_columns * i;
-				if (index >= 0 && index < items.size() && CAN_SELECT(index)) {
-					set_current(index);
+			if (current != -1) {
+				int next = current;
+				int cur_height = items[current].rect_cache.size.height;
+				int page_height = scroll_bar_v->get_page();
+				while (cur_height < page_height) {
+					int index = next + current_columns;
+					if (index < items.size()) {
+						next = index;
+					} else {
+						break;
+					}
+					cur_height += items[index].rect_cache.size.height;
+				}
+
+				if (next >= 0 && next < items.size() && CAN_SELECT(next)) {
+					set_current(next);
+					scroll_bar_v->scroll(scroll_bar_v->get_page());
 					ensure_current_is_visible();
 					if (select_mode == SELECT_SINGLE) {
 						emit_signal(SceneStringName(item_selected), current);
 					}
 					accept_event();
-
-					break;
 				}
 			}
 		}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3913,14 +3913,18 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		next = selected_item;
 
-		for (int i = 0; i < 10; i++) {
+		int cur_height = get_item_height(next);
+		int page_height = v_scroll->get_page();
+		while (cur_height < page_height) {
 			TreeItem *_n = next->get_next_visible();
 			if (_n) {
 				next = _n;
 			} else {
 				break;
 			}
+			cur_height += get_item_height(next);
 		}
+
 		if (next == selected_item) {
 			return;
 		}
@@ -3940,6 +3944,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			next->select(selected_col);
 		}
 
+		v_scroll->scroll(v_scroll->get_page());
 		ensure_cursor_is_visible();
 	} else if (p_event->is_action("ui_page_up") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
@@ -3952,14 +3957,18 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		prev = selected_item;
 
-		for (int i = 0; i < 10; i++) {
+		int cur_height = get_item_height(prev);
+		int page_height = v_scroll->get_page();
+		while (cur_height < page_height) {
 			TreeItem *_n = prev->get_prev_visible();
 			if (_n) {
 				prev = _n;
 			} else {
 				break;
 			}
+			cur_height += get_item_height(prev);
 		}
+
 		if (prev == selected_item) {
 			return;
 		}
@@ -3978,6 +3987,8 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			}
 			prev->select(selected_col);
 		}
+
+		v_scroll->scroll(-v_scroll->get_page());
 		ensure_cursor_is_visible();
 	} else if (p_event->is_action("ui_select") && p_event->is_pressed()) {
 		if (select_mode == SELECT_MULTI) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15120

## Additional information
Make ItemList and Tree scroll by a page's amount when pressing the <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, similar to RichTextLabel.

https://github.com/user-attachments/assets/fcc18534-d9ae-434a-b637-af60f75f3265

