### PR TITLE
Add `effect_time_scale` to `RichTextLabel` for controlling text effect playback speed

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -731,15 +731,15 @@
 			The currently installed custom effects. This is an array of [RichTextEffect]s.
 			To add a custom effect, it's more convenient to use [method install_effect].
 		</member>
-		<member name="effect_speed_scale" type="float" setter="set_effect_speed_scale" getter="get_effect_speed_scale" default="1.0">
-			The speed scaling ratio for text effects. For example, if this value is [code]1[/code], then the text effect plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
-			If set to a negative value, the text effect will be paused.
-		</member>
 		<member name="deselect_on_focus_loss_enabled" type="bool" setter="set_deselect_on_focus_loss_enabled" getter="is_deselect_on_focus_loss_enabled" default="true">
 			If [code]true[/code], the selected text will be deselected when focus is lost.
 		</member>
 		<member name="drag_and_drop_selection_enabled" type="bool" setter="set_drag_and_drop_selection_enabled" getter="is_drag_and_drop_selection_enabled" default="true">
 			If [code]true[/code], allow drag and drop of selected text.
+		</member>
+		<member name="effect_speed_scale" type="float" setter="set_effect_speed_scale" getter="get_effect_speed_scale" default="1.0">
+			The speed scaling ratio for text effects. For example, if this value is [code]1[/code], then the text effect plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
+			If set to a negative value, the text effect will be paused.
 		</member>
 		<member name="fit_content" type="bool" setter="set_fit_content" getter="is_fit_content_enabled" default="false">
 			If [code]true[/code], the label's minimum size will be automatically updated to fit its content, matching the behavior of [Label].

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -731,6 +731,10 @@
 			The currently installed custom effects. This is an array of [RichTextEffect]s.
 			To add a custom effect, it's more convenient to use [method install_effect].
 		</member>
+		<member name="effect_speed_scale" type="float" setter="set_effect_speed_scale" getter="get_effect_speed_scale" default="1.0">
+			The speed scaling ratio for text effects. For example, if this value is [code]1[/code], then the text effect plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
+			If set to a negative value, the text effect will be paused.
+		</member>
 		<member name="deselect_on_focus_loss_enabled" type="bool" setter="set_deselect_on_focus_loss_enabled" getter="is_deselect_on_focus_loss_enabled" default="true">
 			If [code]true[/code], the selected text will be deselected when focus is lost.
 		</member>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2177,7 +2177,7 @@ void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, double p_delta
 			continue;
 		}
 
-		ifx->elapsed_time += p_delta_time;
+		ifx->elapsed_time += p_delta_time * MAX(effect_speed_scale, 0.0);
 
 		ItemShake *shake = nullptr;
 
@@ -5394,6 +5394,14 @@ bool RichTextLabel::is_hint_underlined() const {
 	return underline_hint;
 }
 
+void RichTextLabel::set_effect_speed_scale(float p_effect_speed_scale) {
+	effect_speed_scale = p_effect_speed_scale;
+}
+
+float RichTextLabel::get_effect_speed_scale() const {
+	return effect_speed_scale;
+}
+
 void RichTextLabel::set_offset(int p_pixel) {
 	vscroll->set_value(p_pixel);
 	queue_accessibility_update();
@@ -7894,6 +7902,9 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_autowrap_trim_flags", "autowrap_trim_flags"), &RichTextLabel::set_autowrap_trim_flags);
 	ClassDB::bind_method(D_METHOD("get_autowrap_trim_flags"), &RichTextLabel::get_autowrap_trim_flags);
 
+	ClassDB::bind_method(D_METHOD("set_effect_speed_scale", "effect_speed_scale"), &RichTextLabel::set_effect_speed_scale);
+	ClassDB::bind_method(D_METHOD("get_effect_speed_scale"), &RichTextLabel::get_effect_speed_scale);
+
 	ClassDB::bind_method(D_METHOD("set_meta_underline", "enable"), &RichTextLabel::set_meta_underline);
 	ClassDB::bind_method(D_METHOD("is_meta_underlined"), &RichTextLabel::is_meta_underlined);
 
@@ -8026,6 +8037,7 @@ void RichTextLabel::_bind_methods() {
 
 	ADD_GROUP("Markup", "");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "custom_effects", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("RichTextEffect"), (PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SCRIPT_VARIABLE)), "set_effects", "get_effects");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "effect_speed_scale", PROPERTY_HINT_RANGE, "0,4,0.001,or_greater"), "set_effect_speed_scale", "get_effect_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "meta_underlined"), "set_meta_underline", "is_meta_underlined");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hint_underlined"), "set_hint_underline", "is_hint_underlined");
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2177,7 +2177,7 @@ void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, double p_delta
 			continue;
 		}
 
-		ifx->elapsed_time += p_delta_time * MAX(effect_speed_scale, 0.0);
+		ifx->elapsed_time += p_delta_time * effect_speed_scale;
 
 		ItemShake *shake = nullptr;
 
@@ -5395,7 +5395,7 @@ bool RichTextLabel::is_hint_underlined() const {
 }
 
 void RichTextLabel::set_effect_speed_scale(float p_effect_speed_scale) {
-	effect_speed_scale = p_effect_speed_scale;
+	effect_speed_scale = MAX(p_effect_speed_scale, 0.0);
 }
 
 float RichTextLabel::get_effect_speed_scale() const {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -566,6 +566,7 @@ private:
 	Variant current_meta;
 
 	Array custom_effects;
+	float effect_speed_scale = 1.0;
 
 	HashMap<RID, Rect2> ac_element_bounds_cache;
 
@@ -873,6 +874,9 @@ public:
 	void clear();
 
 	void set_offset(int p_pixel);
+
+	void set_effect_speed_scale(float p_effect_speed_scale);
+	float get_effect_speed_scale() const;
 
 	void set_meta_underline(bool p_underline);
 	bool is_meta_underlined() const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15031

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Add `effect_speed_scale` property for controlling the playback speed of text effect in `RichTextLabel`. 


<img width="682" height="522" alt="text_effect_speed" src="https://github.com/user-attachments/assets/6c05acb2-0638-4d26-b3e7-a999d867fd30" />

<img width="1150" height="700" alt="text_effect_speed" src="https://github.com/user-attachments/assets/8fcabeaa-4d63-4604-ad7a-d72981166233" />
