### PR TITLE
Add a simple example for `_get_line_syntax_highlighting`

### DIFF
--- a/doc/classes/SyntaxHighlighter.xml
+++ b/doc/classes/SyntaxHighlighter.xml
@@ -54,6 +54,56 @@
 					}
 				}
 				[/codeblock]
+				[b]Example:[/b] Sample implementation. Colors the word [code]Godot[/code] blue.
+				[codeblocks]
+				[gdscript]
+				func _get_line_syntax_highlighting(line: int) -&gt; Dictionary:
+					var pattern_text = "Godot"
+					var result = Dictionary()
+					var text_edit = get_text_edit()
+					var line_text = text_edit.get_line(line)
+
+					var pos = line_text.find(pattern_text)
+					while pos != -1:
+						result[pos] = { "color": Color(0.0, 0.0, 1.0) }
+						var end_pos = pos + pattern_text.length()
+						pos = line_text.find(pattern_text, end_pos)
+						if pos != end_pos:
+							result[end_pos] = { "color": Color(1.0, 1.0, 1.0) }
+
+					return result
+
+				[/gdscript]
+				[csharp]
+				public override Dictionary _GetLineSyntaxHighlighting(int line)
+				{
+					string patternText = "Godot";
+					Dictionary result = new Dictionary();
+					TextEdit textEdit = GetTextEdit();
+					string lineText = textEdit.GetLine(line);
+
+					var pos = lineText.Find(patternText);
+					while (pos != -1)
+					{
+						result[pos] = new Dictionary()
+						{
+							{ "color", new Color(0.0f, 0.0f, 1.0f) }
+						};
+						var endPos = pos + patternText.Length;
+						pos = lineText.Find(patternText, endPos);
+						if (pos != endPos)
+						{
+							result[endPos] = new Dictionary()
+							{
+								{ "color", new Color(1.0f, 1.0f, 1.0f) }
+							};
+						}
+					}
+
+					return result;
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_text_edit" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- The original API of function __get_line_syntax_highlighting was really confusing about the return value and didn't clearly tell users how to write function _get_line_syntax_highlighting. So, we've added an extra new simple example while keeping the original description. Here’s a zip file of the sample project and some screenshots of the results.There’s a discussion about this issue in https://github.com/godotengine/godot-docs/issues/11575 .

## Additional information
project is: [higjtlight-text.zip](https://github.com/user-attachments/files/29652757/higjtlight-text.zip)

<img width="1024" height="1024" alt="result" src="https://github.com/user-attachments/assets/362b6ad9-f75a-439f-831b-2f4430d92fe3" />

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

- *Maintainer edit:* closes https://github.com/godotengine/godot-docs/issues/11575