### PR TITLE
Project Manager: Add Search Bar to the language selector in Quick Settings

### DIFF
--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -324,6 +324,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			language_option_button = memnew(OptionButton);
 			language_option_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 			language_option_button->set_fit_to_longest_item(false);
+			language_option_button->set_search_bar_enabled(true);
 			language_option_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_language_selected));
 
 			for (int i = 0; i < editor_languages.size(); i++) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Slight inconvenience when changing the language using the Project Manager. 

## Overview

This adds a search bar to the language selector in Quick Settings, which is how it is in the main Editor Settings:

<img width="404" height="325" alt="image" src="https://github.com/user-attachments/assets/2ac58c62-c099-4326-9e7a-fbc25ba871b4" />

## Additional information

Showcase:

https://github.com/user-attachments/assets/da9b926e-95a1-46cd-bff2-cfbbf24b94a1

AI wasn't used in any way.