### PR TITLE
Project Manager: Resize background Panel on window resize in Quick Settings

### DIFF
--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -313,6 +313,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		_fetch_setting_values();
 
 		settings_list_panel = memnew(PanelContainer);
+		settings_list_panel->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		main_vbox->add_child(settings_list_panel);
 
 		settings_list = memnew(VBoxContainer);
@@ -437,6 +438,7 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		Button *open_full_settings = memnew(Button);
 		open_full_settings->set_text(TTRC("Edit All Settings"));
 		open_full_settings->set_h_size_flags(Control::SIZE_SHRINK_END);
+		open_full_settings->set_v_size_flags(Control::SIZE_SHRINK_END | Control::SIZE_EXPAND);
 		settings_list->add_child(open_full_settings);
 		open_full_settings->connect(SceneStringName(pressed), callable_mp(this, &QuickSettingsDialog::_show_full_settings));
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

When the Quick Settings window is resized, the background Panel doesn't resize with it, creating a weird look.

## Before

<img width="632" height="455" alt="image" src="https://github.com/user-attachments/assets/f2d9cbae-955d-4071-80c7-46902fddbc7a" />

## After

<img width="632" height="455" alt="image" src="https://github.com/user-attachments/assets/e80c219f-6558-44f9-b840-519017c7874e" />

## Additional information

No clanker was used.