### PR TITLE
GDScript: Reload scripts that depend on changed scripts

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2437,6 +2437,18 @@ void GDScriptLanguage::reload_all_scripts() {
 void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) {
 #ifdef DEBUG_ENABLED
 
+	HashSet<String> paths_to_reload;
+	for (int i = 0; i < p_scripts.size(); i++) {
+		Ref<GDScript> script = p_scripts[i];
+		if (script.is_null() || script->get_path().is_empty()) {
+			continue;
+		}
+
+		const String path = script->get_path();
+		paths_to_reload.insert(path);
+		GDScriptCache::get_script_dependents(path, &paths_to_reload);
+	}
+
 	List<Ref<GDScript>> scripts;
 	{
 		MutexLock lock(mutex);
@@ -2460,7 +2472,7 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 	scripts.sort_custom<GDScriptDepSort>(); //update in inheritance dependency order
 
 	for (Ref<GDScript> &scr : scripts) {
-		bool reload = p_scripts.has(scr) || to_reload.has(scr->get_base());
+		bool reload = p_scripts.has(scr) || paths_to_reload.has(scr->get_path()) || to_reload.has(scr->get_base());
 
 		if (!reload) {
 			continue;

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -267,6 +267,33 @@ void GDScriptCache::remove_parser(const String &p_path) {
 	}
 }
 
+void GDScriptCache::get_script_dependents(const String &p_path, HashSet<String> *r_dependents) {
+	ERR_FAIL_NULL(r_dependents);
+
+	MutexLock lock(singleton->mutex);
+
+	HashSet<String> pending;
+	pending.insert(p_path);
+
+	while (!pending.is_empty()) {
+		const String path = *pending.begin();
+		pending.erase(path);
+
+		if (!singleton->parser_inverse_dependencies.has(path)) {
+			continue;
+		}
+
+		for (const String &dependent : singleton->parser_inverse_dependencies[path]) {
+			if (r_dependents->has(dependent)) {
+				continue;
+			}
+
+			r_dependents->insert(dependent);
+			pending.insert(dependent);
+		}
+	}
+}
+
 String GDScriptCache::get_source_code(const String &p_path) {
 	Vector<uint8_t> source_file;
 	Error err;

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -114,6 +114,7 @@ public:
 	static Ref<GDScriptParserRef> get_parser(const String &p_path, GDScriptParserRef::Status status, Error &r_error, const String &p_owner = String());
 	static bool has_parser(const String &p_path);
 	static void remove_parser(const String &p_path);
+	static void get_script_dependents(const String &p_path, HashSet<String> *r_dependents);
 	static String get_source_code(const String &p_path);
 	static Vector<uint8_t> get_binary_tokens(const String &p_path);
 	static Ref<GDScript> get_shallow_script(const String &p_path, Error &r_error, const String &p_owner = String());

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -35,11 +35,11 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
-#include "core/object/script_language.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/object/script_language.h"
 #include "core/os/os.h"
 #endif
 
@@ -56,6 +56,7 @@ public:
 	}
 };
 
+#ifdef TOOLS_ENABLED
 static void write_test_script(const String &p_path, const String &p_source) {
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::ModeFlags::WRITE);
 	REQUIRE(fa.is_valid());
@@ -77,7 +78,6 @@ static PropertyInfo find_script_property(const Ref<GDScript> &p_script, const St
 }
 
 // TODO: Handle some cases failing on release builds. See: https://github.com/godotengine/godot/pull/88452
-#ifdef TOOLS_ENABLED
 TEST_SUITE("[Modules][GDScript]") {
 	TEST_CASE("Script compilation and runtime") {
 		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -35,6 +35,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/object/script_language.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 
@@ -54,6 +55,26 @@ public:
 		return GDScriptCache::singleton->full_gdscript_cache.has(p_path);
 	}
 };
+
+static void write_test_script(const String &p_path, const String &p_source) {
+	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::ModeFlags::WRITE);
+	REQUIRE(fa.is_valid());
+	fa->store_string(p_source);
+	fa->close();
+}
+
+static PropertyInfo find_script_property(const Ref<GDScript> &p_script, const StringName &p_property) {
+	List<PropertyInfo> properties;
+	p_script->get_script_property_list(&properties);
+
+	for (const PropertyInfo &property : properties) {
+		if (property.name == p_property) {
+			return property;
+		}
+	}
+
+	return PropertyInfo();
+}
 
 // TODO: Handle some cases failing on release builds. See: https://github.com/godotengine/godot/pull/88452
 #ifdef TOOLS_ENABLED
@@ -110,6 +131,63 @@ TEST_CASE("[Modules][GDScript] Loading keeps ResourceCache and GDScriptCache in 
 	CHECK(!TestGDScriptCacheAccessor::has_shallow(path));
 	CHECK(TestGDScriptCacheAccessor::has_full(path));
 }
+
+#ifdef TOOLS_ENABLED
+TEST_CASE("[Modules][GDScript] Reloading a script refreshes dependent enum exports") {
+	GDScriptLanguage::get_singleton()->init();
+
+	const String provider_path = TestUtils::get_temp_path("gdscript_external_enum_provider.gd");
+	const String consumer_path = TestUtils::get_temp_path("gdscript_external_enum_consumer.gd");
+	const StringName provider_class_name = SNAME("ExternalTestEnum");
+	ScriptServer::remove_global_class(provider_class_name);
+
+	write_test_script(provider_path, R"(
+class_name ExternalTestEnum
+extends Resource
+
+enum Kind { First, Second }
+)");
+
+	String base_type;
+	bool is_abstract = false;
+	bool is_tool = false;
+	String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(provider_path, &base_type, nullptr, &is_abstract, &is_tool);
+	REQUIRE(class_name == provider_class_name);
+	ScriptServer::add_global_class(provider_class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), provider_path, is_abstract, is_tool);
+
+	write_test_script(consumer_path, R"(
+extends Resource
+
+@export var external_enum: ExternalTestEnum.Kind
+)");
+
+	Ref<GDScript> provider = ResourceLoader::load(provider_path);
+	Ref<GDScript> consumer = ResourceLoader::load(consumer_path);
+	REQUIRE(provider.is_valid());
+	REQUIRE(consumer.is_valid());
+
+	const PropertyInfo original_property = find_script_property(consumer, SNAME("external_enum"));
+	CHECK(original_property.hint == PROPERTY_HINT_ENUM);
+	CHECK(original_property.hint_string == "First:0,Second:1");
+
+	write_test_script(provider_path, R"(
+class_name ExternalTestEnum
+extends Resource
+
+enum Kind { First, Second, Third }
+)");
+
+	GDScriptLanguage::get_singleton()->reload_tool_script(provider, true);
+
+	const PropertyInfo updated_property = find_script_property(consumer, SNAME("external_enum"));
+	CHECK(updated_property.hint == PROPERTY_HINT_ENUM);
+	CHECK(updated_property.hint_string == "First:0,Second:1,Third:2");
+
+	ScriptServer::remove_global_class(provider_class_name);
+	GDScriptCache::remove_script(consumer_path);
+	GDScriptCache::remove_script(provider_path);
+}
+#endif // TOOLS_ENABLED
 
 TEST_CASE("[Modules][GDScript] Validate built-in API") {
 	GDScriptLanguage *lang = GDScriptLanguage::get_singleton();


### PR DESCRIPTION
Fixes godotengine/godot#83346.

When a script exported a property typed with an enum from another script, changes to the enum provider were not reflected in the inspector until the dependent script was edited or reloaded manually.

This updates GDScript reloads to also include scripts that depend on the script being reloaded, using the existing parser inverse dependency tracking. That lets exported property metadata be rebuilt when an external enum changes.

A regression test was added for a `class_name` enum provider used by an exported property in another script.

Tested with:

- `scons platform=macos target=editor dev_build=yes tests=yes debug_symbols=no -j8`
- `scons platform=macos target=template_release tests=yes debug_symbols=no -j8`
- `bin/godot.macos.editor.dev.arm64 --test --test-case="*[Modules][GDScript] Reloading a script refreshes dependent enum exports*"`
- `bin/godot.macos.editor.dev.arm64 --test --source-file="*gdscript_test_runner_suite.h"`
- `python3 misc/scripts/file_format.py modules/gdscript/gdscript_cache.h modules/gdscript/gdscript_cache.cpp modules/gdscript/gdscript.cpp modules/gdscript/tests/gdscript_test_runner_suite.h`
- `python3 misc/scripts/validate_includes.py modules/gdscript/gdscript_cache.h modules/gdscript/gdscript_cache.cpp modules/gdscript/gdscript.cpp modules/gdscript/tests/gdscript_test_runner_suite.h`
- `git diff --check`
