### PR TITLE
Work around crash when creating new scenes

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2743,6 +2743,7 @@ StringName Node::get_property_store_alias(const StringName &p_property) const {
 
 bool Node::is_part_of_edited_scene() const {
 	return Engine::get_singleton()->is_editor_hint() && is_inside_tree() && data.tree->get_edited_scene_root() &&
+			data.tree->get_edited_scene_root()->get_parent() && // Defend against edge cases when creating new scenes and they are not fully added to the tree yet.
 			data.tree->get_edited_scene_root()->get_parent()->is_ancestor_of(this);
 }
 #endif


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes a crash when creating new scenes, introduced by https://github.com/godotengine/godot/pull/111165
- *Bugsquad:* Fixes #120967 

## Additional information

When creating a new scene we are calling `is_ancestor_of` on a `nullptr`. For the prior implementation of `is_ancestor_of` this was not an issue, but now we are actually accessing `this`.

The issue seems to arise from an edge case were the scene tree already has an edited scene set, but this edited scene was not fully added to the tree yet. (Thus `data.tree->get_edited_scene_root()->get_parent() == nullptr`). For now I just added a check whether the edited scene root is in the tree.

However we might want to check whether we can make sure that the edited scene root is always in tree, by changing some setup ordering. I don't have the knowledge to do that though.