### PR TITLE
Fix debug `NavigationRegion3D` colors not updating until project re-start

### DIFF
--- a/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
@@ -184,7 +184,23 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, face_mesh_array);
-	p_gizmo->add_mesh(debug_mesh, navigationregion->is_enabled() ? get_material("face_material", p_gizmo) : get_material("face_material_disabled", p_gizmo));
+
+	const String face_material_name = navigationregion->is_enabled() ? "face_material" : "face_material_disabled";
+	Ref<StandardMaterial3D> face_material = get_material(face_material_name, p_gizmo);
+	if (navigationregion->is_enabled()) {
+		Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+		if (!p_gizmo->is_selected()) {
+			mat_color.a *= 0.3;
+		}
+		face_material->set_albedo(mat_color);
+	} else {
+		Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color();
+		if (!p_gizmo->is_selected()) {
+			mat_color.a *= 0.3;
+		}
+		face_material->set_albedo(mat_color);
+	}
+	p_gizmo->add_mesh(debug_mesh, face_material);
 
 	// if enabled build geometry edge line surface
 	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
@@ -203,6 +219,21 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			line_vertex_array.push_back(vertices[polygon[0]]);
 		}
 
-		p_gizmo->add_lines(line_vertex_array, navigationregion->is_enabled() ? get_material("edge_material", p_gizmo) : get_material("edge_material_disabled", p_gizmo));
+		const String line_material_name = navigationregion->is_enabled() ? "edge_material" : "edge_material_disabled";
+		Ref<StandardMaterial3D> line_material = get_material(line_material_name, p_gizmo);
+		if (navigationregion->is_enabled()) {
+			Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color();
+			if (!p_gizmo->is_selected()) {
+				mat_color.a *= 0.3;
+			}
+			line_material->set_albedo(mat_color);
+		} else {
+			Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color();
+			if (!p_gizmo->is_selected()) {
+				mat_color.a *= 0.3;
+			}
+			line_material->set_albedo(mat_color);
+		}
+		p_gizmo->add_lines(line_vertex_array, line_material);
 	}
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120915 

## Additional information

This makes the NavigationRegion3D debug color gizmos update inside the editor correctly, without an editor re-start required.
Now the debug color inside the editor will always match with the in-game debug colors. No reload required.

https://github.com/user-attachments/assets/d7c2d264-29ee-4dfc-a186-8f2a3b77e7e3

---

Previously, it did not take into account changes without a restart, only displaying some change on the face color because of the random color hue vertex color applied to the original color using the changed color as a base.