### PR TITLE
Docs: Remove `;` from GDScript example of `EditorContextMenuPlugin` class reference

### DIFF
--- a/doc/classes/EditorContextMenuPlugin.xml
+++ b/doc/classes/EditorContextMenuPlugin.xml
@@ -102,7 +102,7 @@
 			Context menu of Script editor's code editor. [method _popup_menu] will be called with the path to the [CodeEdit] node. You can fetch it using this code:
 			[codeblock]
 			func _popup_menu(paths):
-				var code_edit = Engine.get_main_loop().root.get_node(paths[0]);
+				var code_edit = Engine.get_main_loop().root.get_node(paths[0])
 			[/codeblock]
 			The option callback will receive reference to that node. You can use [CodeEdit] methods to perform symbol lookups etc.
 		</constant>
@@ -113,7 +113,7 @@
 			Context menu of 2D editor's basic right-click menu. [method _popup_menu] will be called with paths to all [CanvasItem] nodes under the cursor. You can fetch them using this code:
 			[codeblock]
 			func _popup_menu(paths):
-				var canvas_item = Engine.get_main_loop().root.get_node(paths[0]); # Replace 0 with the desired index.
+				var canvas_item = Engine.get_main_loop().root.get_node(paths[0]) # Replace 0 with the desired index.
 			[/codeblock]
 			The paths array is empty if there weren't any nodes under cursor. The option callback will receive a typed array of [CanvasItem] nodes.
 		</constant>


### PR DESCRIPTION
## What problem(s) does this PR solve?

Removes additional semicolons (;) in example GDScript code in [EditorContextMenuPlugin](https://docs.godotengine.org/en/stable/classes/class_editorcontextmenuplugin.html#editorcontextmenuplugin) class reference.

## Additional information

This is very simple, small, and low priority: Just fix a nitpick and non-blocking issue. Searched some other files for similar occurrences, not found.