### PR TITLE
Speed up removing many child nodes

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1768,7 +1768,25 @@ void Node::remove_child(RequiredParam<Node> rp_child) {
 
 	data.blocked--;
 
-	data.children_cache_dirty = true;
+	if (!data.children_cache_dirty && !data.children_cache.is_empty() && data.children_cache[data.children_cache.size() - 1] == p_child) {
+		// Removing the last child keeps the cache and the counters valid, so pop it
+		// instead of dirtying the cache. This keeps interleaving removals with reads
+		// (like get_child()) linear, as long as children are removed back to front.
+		data.children_cache.resize(data.children_cache.size() - 1);
+		switch (p_child->data.internal_mode) {
+			case INTERNAL_MODE_DISABLED: {
+				data.external_children_count_cache--;
+			} break;
+			case INTERNAL_MODE_FRONT: {
+				data.internal_children_front_count_cache--;
+			} break;
+			case INTERNAL_MODE_BACK: {
+				data.internal_children_back_count_cache--;
+			} break;
+		}
+	} else {
+		data.children_cache_dirty = true;
+	}
 	bool success = data.children.erase(p_child->data.name);
 	ERR_FAIL_COND_MSG(!success, "Children name does not match parent name in hashtable, this is a bug.");
 


### PR DESCRIPTION
Helps with the part of #61929 that is still present on `master`.

`remove_child()` currently always marks the parent's children cache dirty. The next call that reads the cache (`get_child()`, `get_child_count()`, `get_index()`, child iteration, ...) then pays a full rebuild: a hashmap walk plus a sort. When removals are interleaved with reads, every removal triggers a rebuild, which makes clearing a node's children quadratic:

```gdscript
while parent.get_child_count() > 0:
    var c := parent.get_child(parent.get_child_count() - 1)
    parent.remove_child(c)
    c.free()
```

This PR keeps the cache valid when the removed child is the last element of the cache: pop it and decrement the matching internal-mode counter instead of dirtying. When the cache is clean it exactly mirrors the real state (adds keep it incrementally exact via the existing `can_push_back` fast path, moves update it in place), so popping the last element and decrementing its segment counter leaves every remaining child's cached index correct, and no rebuild is needed.

The fast path is strictly O(1), so no other pattern can regress: batch removals without interleaved reads still take the dirty-flag path and behave exactly as before.

#### Benchmarks

Editor build (MSVC, default optimization), headless, N plain Node children, times in usec:

Back-to-front interleaved removal (pattern above), before / after:

| N | master | this PR |
| --- | --- | --- |
| 1000 | 6,442 | 1,092 |
| 2000 | 29,896 | 1,519 |
| 4000 | 116,788 | 3,115 |
| 8000 | 528,951 | 6,156 |
| 16000 | 3,134,578 | 14,056 |

Quadratic before, linear after; ~220x at N=16000.

Batch removal (`remove_child` in a loop over a `get_children()` snapshot, no interleaved reads) is unchanged: 4,142 vs 4,299 usec at N=16000 (noise). `free()` loops likewise unchanged.

Front-to-back interleaved removal is also unchanged (removing a non-last child still dirties the cache; keeping the cache valid there costs O(N) per removal, which would regress batch patterns).

- Bugsquad edit: Supersedes https://github.com/godotengine/godot/pull/111157