### PR TITLE
Remove `AudioStreamMP3::clear_data()`

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -211,10 +211,6 @@ Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
 	return mp3s;
 }
 
-void AudioStreamMP3::clear_data() {
-	data.clear();
-}
-
 void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 	drmp3 *mp3d = memnew(drmp3);
 	int success = drmp3_init_memory(mp3d, p_data.ptr(), p_data.size(), (drmp3_allocation_callbacks *)&dr_alloc_calls);

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -101,7 +101,6 @@ class AudioStreamMP3 : public AudioStream {
 	float length = 0.0;
 	bool loop = false;
 	float loop_offset = 0.0;
-	void clear_data();
 
 	double bpm = 0;
 	int beat_count = 0;


### PR DESCRIPTION
- Follow-up of #118869.

Possibly the last remnant of when `AudioStreamMP3` used a manual allocation instead of a vector.

I was investigating a possible situation: "What if `clear_data()` is called followed by asking the stream for its number of channels, length or sample rate?", then realized the function isn't called at all anywhere, nor it is exposed.

`clear_data()` was previously used in the class' destructor, to free the memory allocated for the data, but since it uses a vector, it has no reason to exist anymore. And honestly, this should have been in that previous PR.