### PR TITLE
Add script editor type hints for `preload()`

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2052,7 +2052,21 @@ static String _get_dropped_resource_as_member(const Ref<Resource> &p_resource, b
 	} else {
 		variable_name = variable_name.to_snake_case().to_upper().validate_unicode_identifier();
 	}
-	return vformat("const %s = preload(%s)", variable_name, _quote_drop_data(path));
+
+	const bool use_type = EDITOR_GET("text_editor/completion/add_type_hints");
+
+	if (use_type) {
+		StringName custom_class_name;
+		Ref<Script> resource_script = p_resource->get_script();
+		while (resource_script.is_valid() && custom_class_name.is_empty()) {
+			custom_class_name = resource_script->get_global_name();
+			resource_script = resource_script->get_base_script();
+		}
+		const StringName class_name = custom_class_name.is_empty() ? p_resource->get_class_name() : custom_class_name;
+		return vformat("const %s: %s = preload(%s)", variable_name, class_name, _quote_drop_data(path));
+	} else {
+		return vformat("const %s = preload(%s)", variable_name, _quote_drop_data(path));
+	}
 }
 
 String ScriptTextEditor::_get_dropped_resource_as_exported_member(const Ref<Resource> &p_resource, const Vector<ObjectID> &p_script_instance_obj_ids) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15128

## Additional information

This PR adds static types to the code generated when ctrl-dropping a resource from the file system into the script editor when `text_editor/completion/add_type_hints` is enabled in editor settings, expanding coverage for the existing feature.

This is a small change that I thought would be a good first-time contribution as the missing types were a minor annoyance I ran into frequently. The code is heavily based on the implementation for the `@onready` version of this feature, where it's used for Scene tree nodes. Tested with files imported as built-in types, scene files, script files, and `.tres`/`.res` files which hold custom classes inheriting from `Resource`.

Side note: While working on this, I discovered alt-dropping nodes and resources (shorthand for an `@export`, implemented just after the `@onready` code) actually ignores the editor setting and always includes static typing. Was this an oversight?