### PR TITLE
Avoid per-sample copy-on-write checks in audio drivers

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -208,15 +208,14 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 		ad->start_counting_ticks();
 
 		if (!ad->active.is_set()) {
-			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out.write[i] = 0;
-			}
+			ad->samples_out.fill(0);
 
 		} else {
 			ad->audio_server_process(ad->period_size, ad->samples_in.ptrw());
 
+			int16_t *out_ptr = ad->samples_out.ptrw();
 			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
-				ad->samples_out.write[i] = ad->samples_in[i] >> 16;
+				out_ptr[i] = ad->samples_in[i] >> 16;
 			}
 		}
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -754,9 +754,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 			if (ad->audio_output.active.is_set()) {
 				ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
 			} else {
-				for (int i = 0; i < ad->samples_in.size(); i++) {
-					ad->samples_in.write[i] = 0;
-				}
+				ad->samples_in.fill(0);
 			}
 
 			avail_frames = ad->buffer_frames;
@@ -788,7 +786,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 						// We're using WASAPI Shared Mode so we must convert the buffer
 						if (ad->channels == ad->audio_output.channels) {
 							for (unsigned int i = 0; i < write_frames * ad->channels; i++) {
-								ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i, ad->samples_in.write[write_ofs++]);
+								ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i, ad->samples_in[write_ofs++]);
 							}
 						} else if (ad->channels == ad->audio_output.channels + 1) {
 							// Pass all channels except the last two as-is, and then mix the last two
@@ -796,17 +794,17 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 							unsigned int last_chan = ad->audio_output.channels - 1;
 							for (unsigned int i = 0; i < write_frames; i++) {
 								for (unsigned int j = 0; j < last_chan; j++) {
-									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in.write[write_ofs++]);
+									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in[write_ofs++]);
 								}
-								int32_t l = ad->samples_in.write[write_ofs++];
-								int32_t r = ad->samples_in.write[write_ofs++];
+								int32_t l = ad->samples_in[write_ofs++];
+								int32_t r = ad->samples_in[write_ofs++];
 								int32_t c = (int32_t)(((int64_t)l + (int64_t)r) / 2);
 								ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + last_chan, c);
 							}
 						} else {
 							for (unsigned int i = 0; i < write_frames; i++) {
 								for (unsigned int j = 0; j < MIN(ad->channels, ad->audio_output.channels); j++) {
-									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in.write[write_ofs++]);
+									ad->write_sample(ad->audio_output.format_tag, ad->audio_output.bits_per_sample, buffer, i * ad->audio_output.channels + j, ad->samples_in[write_ofs++]);
 								}
 								if (ad->audio_output.channels > ad->channels) {
 									for (unsigned int j = ad->channels; j < ad->audio_output.channels; j++) {


### PR DESCRIPTION
The WASAPI and ALSA output threads access their sample buffers through `Vector::write[]` inside the per-sample conversion loops. Every `write[]` access goes through `CowData::ptrw()` and its `_copy_on_write()` refcount check, which performs an atomic load per element. WASAPI does this even for pure reads of `samples_in`, and both drivers zero the buffer with a manual per-element `write[]` loop.

This changes the loops to match what the PulseAudio driver already does (`audio_driver_pulseaudio.cpp`): read through the const `operator[]`, write through a pointer hoisted once outside the loop, and zero with `fill()`. No behavior change; the buffers are never shared, so the copy-on-write check can never trigger a copy there, it is just per-sample overhead on the audio thread.

Sizes are unchanged: both zero loops covered exactly the full vector (`samples_in.size()` in WASAPI; `period_size * channels` in ALSA, which is what `samples_out` is resized to in `init_output_device()`).

Tested on Windows by pushing an `AudioStreamGenerator` sine tone through the rebuilt editor binary (WASAPI shared mode, stereo): clean playback start/stop, no errors. ALSA compiles on Linux CI; the change there is the same mechanical pattern.
