### PR TITLE
Fix "missing directory on disk" check in `editor_file_system.cpp` not working for folder renames

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1932,7 +1932,8 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 		if (idx == -1) {
 			// Only create a missing directory in memory when it exists on disk.
-			if (!dir->dir_exists(fs->get_path().path_join(path_bit))) {
+			String dir_path = fs->get_path().path_join(path_bit);
+			if (!dir->dir_exists(ProjectSettings::get_singleton()->globalize_path(dir_path))) {
 				return false;
 			}
 			EditorFileSystemDirectory *efsd = memnew(EditorFileSystemDirectory);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120948

## Additional information
```cpp
// Only create a missing directory in memory when it exists on disk.
if (!dir->dir_exists(fs->get_path().path_join(path_bit))) {
	return false;
}
```
In the code above dir uses `DirAccess::ACCESS_FILESYSTEM` but the path that it is given is one starting with `res://`, this caused the code to say that the directory didn't exist even when it did exist on disk. 

The issue linked above is caused by this false non existence as the part that assigns the new path gets skipped by the code below in `EditorFileSystem::update_files`:
```cpp
if (!_find_file(file, &fs, cpos)) {
	if (!fs) {
		continue;
	}
}
```

Tested with the issues linked in #94435, which added the code this PR changes, and couldn’t reproduce them still
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
