### PR TITLE
Call `emit_changed` when setting compositor effects array

### DIFF
--- a/scene/resources/compositor.cpp
+++ b/scene/resources/compositor.cpp
@@ -246,6 +246,8 @@ void Compositor::set_compositor_effects(const TypedArray<CompositorEffect> &p_co
 		}
 	}
 
+	emit_changed();
+
 	RenderingServer::get_singleton()->compositor_set_compositor_effects(compositor, effect_rids);
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
I am writing a compositor effect addon and wanted to hook up a script to the `changed` signal of the Compositor Resource, which is stored on the WorldEnvironment.
However, I found out, that this specific Resource does not even emit changed as expected. So I added that.

## Additional information
Nothing much. Its just a single added line, calling `emit_changed`.
