### PR TITLE
Use SCons way to detect wayland-scanner

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -237,7 +237,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(CPPDEFINES=["SOWRAP_ENABLED"])
 
     if env["wayland"]:
-        if subprocess.run(["wayland-scanner", "-v"], capture_output=True, shell=True).returncode != 0:
+        if not env.WhereIs("wayland-scanner"):
             print_warning("wayland-scanner not found. Disabling Wayland support.")
             env["wayland"] = False
 


### PR DESCRIPTION
Use SCons way to detect wayland-scanner

## What problem(s) does this PR solve?

#120936 introduced build issues on linuxbsd platform by adding shell=True, which caused `-v` argument to be passed to shell instead of `wayland-scanner`. 

## Additional information

This PR uses SCons-way to detect if program exists in PATH and is executable by calling `env.WhereIs` which should be more safe and error-prone
