### PR TITLE
Avoid full project list reload in `ProjectList::_notification()` on language change

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -663,8 +663,10 @@ void ProjectList::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (is_ready()) {
-				// FIXME: Technically this only needs to update some dynamic texts, not the whole list.
-				update_project_list();
+				for (const Item &item : _projects) {
+					_update_project_control_translatable_fields(item);
+				}
+				update_dock_menu();
 			}
 		} break;
 
@@ -1208,15 +1210,16 @@ void ProjectList::_create_project_item_control(int p_index) {
 	ERR_FAIL_COND(item.control != nullptr); // Already created
 
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
+	item.control = hb;
+
 	hb->add_theme_constant_override("separation", 10 * EDSCALE);
 
-	hb->set_project_title(!item.missing ? item.project_name : TTR("Missing Project"));
+	_update_project_control_translatable_fields(item);
+
 	hb->set_project_path(item.path);
 	hb->set_tooltip_text(item.description);
 	hb->set_tags(item.tags, this);
-	hb->set_unsupported_features(item.unsupported_features.duplicate());
 	hb->set_project_version(item.project_version);
-	hb->set_last_edited_info(item.get_last_edited_string());
 
 	hb->set_is_favorite(item.favorite);
 	hb->set_is_missing(item.missing);
@@ -1240,7 +1243,14 @@ void ProjectList::_create_project_item_control(int p_index) {
 	}
 
 	project_list_vbox->add_child(hb);
-	item.control = hb;
+}
+
+void ProjectList::_update_project_control_translatable_fields(const Item &item) {
+	ProjectListItemControl *control = item.control;
+
+	control->set_project_title(!item.missing ? item.project_name : TTR("Missing Project"));
+	control->set_last_edited_info(item.get_last_edited_string());
+	control->set_unsupported_features(item.unsupported_features.duplicate());
 }
 
 void ProjectList::_toggle_project(int p_index) {

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -270,6 +270,7 @@ private:
 	// Project list items.
 
 	void _create_project_item_control(int p_index);
+	void _update_project_control_translatable_fields(const Item &item);
 	void _toggle_project(int p_index);
 	void _remove_project(int p_index, bool p_update_settings);
 


### PR DESCRIPTION
## Requires https://github.com/godotengine/godot/pull/121367 to be merged first.

## What problem(s) does this PR solve?

- FIXME in `editor/project_manager/project_list.cpp` (added in https://github.com/godotengine/godot/pull/104845)
https://github.com/godotengine/godot/blob/a3fc1cbcfb88e59935194b2a873f32789656125f/editor/project_manager/project_list.cpp#L664-L667

- Not optimal performance, as mentioned in the called function:
https://github.com/godotengine/godot/blob/a3fc1cbcfb88e59935194b2a873f32789656125f/editor/project_manager/project_list.cpp#L932-L934

## Overview

Created a new function `ProjectList::_update_project_control_translation(const Item &item)`, which updates the translations of a specific project list item. When the notification `NOTIFICATION_TRANSLATION_CHANGED` is recieved, it loops over every item and calls it.

## Profiling data

I was testing on my setup (50 projects).

`ProjectList::_notification(NOTIFICATION_TRANSLATION_CHANGED)` went from `73 ms` to `0.5 ms`
`EditorSettings::get_singleton()->set(LANGUAGE)` (propagates the notification) went from `172 ms` to `87 ms`

Note that results may vary, especially in the second one, as I only did a few runs.

## Additional information

This adds some code duplication, but I think that the benefit is worth it.

AI was NOT used.

Related: https://github.com/godotengine/godot/pull/120646