### PR TITLE
Fix `BaseButton` input when `enable_long_press_as_right_click` is true

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -254,8 +254,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 
 	if (status.press_attempt && status.pressing_inside) {
 		if (toggle_mode) {
-			bool is_pressed = p_event->is_pressed();
-			if ((is_pressed && action_mode == ACTION_MODE_BUTTON_PRESS) || (!is_pressed && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (p_event->is_released() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
 				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
 					status.press_attempt = false;
 					status.pressing_inside = false;
@@ -271,7 +270,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				queue_accessibility_update();
 			}
 		} else {
-			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (p_event->is_released() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
 				_pressed();
 			}
 		}


### PR DESCRIPTION
This PR fixes a touch behavior issue that occurs when `enable_long_press_as_right_click` is enabled.
regression from https://github.com/godotengine/godot/pull/110893

The following describes the behavior before and after this change. A normal tap always generates a press event.

When `Action Mode = Button Release` and `Button Mask = Mouse Left`

- Before this PR: A long press triggers a button press action even though the button has not been released yet.
- After this PR: A long press does not trigger any action. When a long press is detected, the original touch is canceled and `enable_long_press_as_right_click` generates a `Mouse Right` event instead. Since the button is configured for `Mouse Left`, no action is triggered.

When `Action Mode = Button Release` and `Button Mask = Mouse Right`

- Before this PR: A long press triggers a button press action before the touch is released, and another press action is triggered when the touch is released.
- After this PR: A long press triggers a single button press action when the touch is released.

When `Action Mode = Button Press`, the behavior remains unchanged:

- `Button Mask = Mouse Left`: A press action is triggered immediately on touch.
- `Button Mask = Mouse Right`: A press action is triggered immediately on touch. If the touch is held long enough to become a long press, an additional press action is triggered for the right-click event.