### PR TITLE
Prevented null pointer crash when adding a new scene root with no possible parents

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2743,7 +2743,7 @@ StringName Node::get_property_store_alias(const StringName &p_property) const {
 
 bool Node::is_part_of_edited_scene() const {
 	return Engine::get_singleton()->is_editor_hint() && is_inside_tree() && data.tree->get_edited_scene_root() &&
-			data.tree->get_edited_scene_root()->get_parent()->is_ancestor_of(this);
+			data.tree->get_edited_scene_root()->get_parent() && data.tree->get_edited_scene_root()->get_parent()->is_ancestor_of(this);
 }
 #endif
 


### PR DESCRIPTION
Author:    McOmghall <McOmghall@users.noreply.github.com>

## What problem(s) does this PR solve?

- Found null pointer crash when creating a new project and fixed it. This prevents a bad UX case for new users.

