### PR TITLE
Add help labels in the TileAtlasSource editor

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -982,12 +982,16 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	if (tile_set.is_null()) {
 		return;
 	} else {
+		String cmd_or_ctrl = keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL);
 		if (tools_button_group->get_pressed_button() == tool_setup_atlas_source_button) {
 			help_label->set_visible(true);
-			help_label->set_text(TTR("Hold Ctrl to create multiple tiles.") + "\n" + TTR("Hold Shift to create big tiles."));
+			help_label->set_text(vformat(TTR("Hold %s to create multiple tiles."), cmd_or_ctrl) + "\n" + TTR("Hold Shift to create big tiles."));
 		} else if (tools_button_group->get_pressed_button() == tool_select_button) {
 			help_label->set_visible(true);
 			help_label->set_text(TTR("Hold Shift to select multiple regions."));
+		} else if (tools_button_group->get_pressed_button() == tool_paint_button) {
+			help_label->set_visible(true);
+			help_label->set_text(vformat(TTR("Hold %s to pick a tile's value."), cmd_or_ctrl) + "\n" + vformat(TTR("Hold %s+Shift to paint multiple tiles."), cmd_or_ctrl));
 		} else {
 			help_label->set_visible(false);
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120956

## Additional information
I added help label in the paint panel the same way they are in the other panels.
Also replaced Ctrl by Cmd on macOS in the TileAtlasSource editor.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->