### PR TITLE
Sort monitored_bodies in area2d queries

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -211,6 +211,9 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
+			// sort to get a good execution order for callbacks, goal is to process entered before exited
+			monitored_bodies.sort_custom<BodyStateReverseSort>();
+
 			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_bodies.begin(); E;) {
 				if (E->value.state == 0) { // Nothing happened
 					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;

--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -256,6 +256,9 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
+			// sort to get a good execution order for callbacks, goal is to process entered before exited
+			monitored_areas.sort_custom<BodyStateReverseSort>();
+
 			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_areas.begin(); E;) {
 				if (E->value.state == 0) { // Nothing happened
 					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;

--- a/modules/godot_physics_2d/godot_area_2d.h
+++ b/modules/godot_physics_2d/godot_area_2d.h
@@ -89,6 +89,12 @@ class GodotArea2D : public GodotCollisionObject2D {
 		_FORCE_INLINE_ void dec() { state--; }
 	};
 
+	struct BodyStateReverseSort {
+		bool operator()(const KeyValue<BodyKey, BodyState> &p_a, const KeyValue<BodyKey, BodyState> &p_b) {
+			return p_a.value.state > p_b.value.state;
+		}
+	};
+
 	HashMap<BodyKey, BodyState, BodyKey> monitored_bodies;
 	HashMap<BodyKey, BodyState, BodyKey> monitored_areas;
 


### PR DESCRIPTION
getting good execution order in body_exited POV
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #86640

## Additional information

i sorted monitored_bodies before area2d queries to get good execution order for associated callbacks to get body_in processing before body_out, cause calling body_out processing first trigger a body_exited detection

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
