### PR TITLE
Make shader compiler float constant formatting deterministic

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -179,7 +179,7 @@ static String _mkid(const String &p_id) {
 }
 
 static String f2sp0(float p_float) {
-	String num = rtos(p_float);
+	String num = String::num_scientific(p_float);
 	if (!num.contains_char('.') && !num.contains_char('e')) {
 		num += ".0";
 	}


### PR DESCRIPTION
While working on the PS5 platform port, we came across a determinism bug in the shader compiler.
For PS5, we prebake Shaders on a Windows machine to target PS5. 

rtos() which uses String::num() and that uses snprintf(), outputs a different result across platforms, for Windows during baking and on PS5 during runtime. This issue might also be true for other platforms or across windows machines.

With this, the baker and runtime compute different hashes for the same shader. When the runtime, without a runtime compiler, then looks up a cache entry, there is a miss and it reports that it cannot find the shader.

We replace this with String::num_scientific(), which uses Grisu2, a pure-integer algorithm that is fully deterministic across platforms, compilers and locales.

Note this will change all shader cache hashes once.

Tested on Windows and on PS5 across multiple projects.