### PR TITLE
Add filter to bezier curve editor animation tracks

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -875,6 +875,14 @@ bool AnimationBezierTrackEdit::_is_track_displayed(int p_track_index) {
 		return false;
 	}
 
+	String filter_text = editor->timeline->filter_track->get_text();
+	if (!filter_text.is_empty()) {
+		String target = String(animation->track_get_path(p_track_index));
+		if (!target.containsn(filter_text)) {
+			return false;
+		}
+	}
+
 	if (is_filtered) {
 		String path = String(animation->track_get_path(p_track_index));
 		if (root && root->has_node(path)) {

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8189,6 +8189,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit->set_editor(this);
 	bezier_edit->set_timeline(timeline);
 	bezier_edit->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
+	timeline->connect("filter_changed", callable_mp(static_cast<CanvasItem *>(bezier_edit), &CanvasItem::queue_redraw));
 
 	marker_edit = memnew(AnimationMarkerEdit);
 	timeline->get_child(0)->add_child(marker_edit);


### PR DESCRIPTION
The text input allowing filtering tracks works only in the normal view of the animation editor. This add the support for the Bezier curve editor.

## What problem(s) does this PR solve?

It doesn't close an existing issue but is related to this PR: #119759

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
