### PR TITLE
GDScript: remove temporary when calling void function or uncaptured return value

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1084,16 +1084,27 @@ GDScriptByteCodeGenerator::CallTarget GDScriptByteCodeGenerator::get_call_target
 }
 
 void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	append_opcode_and_argcount(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
-	for (int i = 0; i < p_arguments.size(); i++) {
-		append(p_arguments[i]);
+	if (p_target.mode == Address::NIL) {
+		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
+		for (int i = 0; i < p_arguments.size(); i++) {
+			append(p_arguments[i]);
+		}
+		append(p_base);
+		append(Address());
+		append(p_arguments.size());
+		append(p_function_name);
+	} else {
+		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
+		for (int i = 0; i < p_arguments.size(); i++) {
+			append(p_arguments[i]);
+		}
+		append(p_base);
+		CallTarget ct = get_call_target(p_target);
+		append(ct.target);
+		append(p_arguments.size());
+		append(p_function_name);
+		ct.cleanup();
 	}
-	append(p_base);
-	CallTarget ct = get_call_target(p_target);
-	append(ct.target);
-	append(p_arguments.size());
-	append(p_function_name);
-	ct.cleanup();
 }
 
 void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
@@ -1343,16 +1354,27 @@ void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &
 }
 
 void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	append_opcode_and_argcount(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
-	for (int i = 0; i < p_arguments.size(); i++) {
-		append(p_arguments[i]);
+	if (p_target.mode == Address::NIL) {
+		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
+		for (int i = 0; i < p_arguments.size(); i++) {
+			append(p_arguments[i]);
+		}
+		append(GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+		append(Address());
+		append(p_arguments.size());
+		append(p_function_name);
+	} else {
+		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
+		for (int i = 0; i < p_arguments.size(); i++) {
+			append(p_arguments[i]);
+		}
+		append(GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+		CallTarget ct = get_call_target(p_target);
+		append(ct.target);
+		append(p_arguments.size());
+		append(p_function_name);
+		ct.cleanup();
 	}
-	append(GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-	CallTarget ct = get_call_target(p_target);
-	append(ct.target);
-	append(p_arguments.size());
-	append(p_function_name);
-	ct.cleanup();
 }
 
 void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {

--- a/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.gd
@@ -7,6 +7,7 @@ class TestRefCounted:
 func test() -> void:
 	test1()
 	test2()
+	test3()
 
 func test1(_a: Array = []) -> void:
 	print("test1 (untyped Array default)")
@@ -16,4 +17,12 @@ func test1(_a: Array = []) -> void:
 func test2(_a: Array[String] = []) -> void:
 	print("test2 (typed Array[String] default)")
 	var _count = TestRefCounted.new().get_reference_count()
+	print("    end of statement")
+
+func returns_param(param):
+	return param
+
+func test3() -> void:
+	print("test3 (function call)")
+	returns_param(TestRefCounted.new())
 	print("    end of statement")

--- a/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.out
+++ b/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.out
@@ -5,3 +5,6 @@ test1 (untyped Array default)
 test2 (typed Array[String] default)
     TestRefCounted released
     end of statement
+test3 (function call)
+    TestRefCounted released
+    end of statement


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Removes an unnecessary null assignment when calling functions with unused return value.
  - This applies whether or not the function itself returns a value

## Additional information

Currently a simple function call `f()` would generate the following bytecode:

```
 0: line 5:     f()
 2: call self.f()
 8: assign stack(3) = null
```

With the changes, this becomes:
```
 0: line 5:     f()
 2: call self.f()
```

## Performance

<details>
<summary>Test setup</summary>

Run on release templates MinGW Windows 11.

```
func fn() -> void:
	pass

func _on_fn_button_pressed() -> void:
	var t = Time.get_ticks_usec()
	for i in 10_000_000:
		fn()
	
	print((Time.get_ticks_usec() - t) / 1000000.)

static func fn2() -> void:
	pass

func _on_fn_2_button_pressed() -> void:
	var t = Time.get_ticks_usec()
	
	for i in 10_000_000:
		fn2()
	
	print((Time.get_ticks_usec() - t) / 1000000.)
```

Run 10 times and averaged.

</details>

| Case | PR | Master | Diff |
| --- | --- | --- | --- |
| Instance | 0.2307s | 0.2375s | -2.9% |
| Static | 0.1883s | 0.1979s | -4.8% |

As the performance gain is small and constant per function call, this change can be considered more for bytecode cleanup.

## Future Work

There are a few other opcodes that do the same thing. However the implementation varies. See comments.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
