### PR TITLE
Allow reselecting recent files when the directory is changed to a different one

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -360,15 +360,16 @@ Vector<String> FileDialog::get_selected_files() const {
 }
 
 void FileDialog::update_dir() {
-	full_dir = dir_access->get_current_dir();
+	const String current_dir = dir_access->get_current_dir();
+	const String current_dir_no_drive = dir_access->get_current_dir(false);
 	if (root_prefix.is_empty()) {
-		directory_edit->set_text(dir_access->get_current_dir(false));
+		directory_edit->set_text(current_dir_no_drive);
 	} else {
-		directory_edit->set_text(dir_access->get_current_dir(false).trim_prefix(root_prefix).trim_prefix("/"));
+		directory_edit->set_text(current_dir_no_drive.trim_prefix(root_prefix).trim_prefix("/"));
 	}
 
 	if (drives->is_visible()) {
-		if (dir_access->get_current_dir().is_network_share_path()) {
+		if (current_dir.is_network_share_path()) {
 			_update_drives(false);
 			PopupMenu *pm = drives->get_popup();
 			pm->add_item(ETR("Network"));
@@ -391,6 +392,13 @@ void FileDialog::update_dir() {
 					break;
 				}
 			}
+		}
+	}
+
+	for (int p_item : recent_list->get_selected_items()) {
+		const String selected_item = ((String)recent_list->get_item_metadata(p_item)).trim_suffix("/");
+		if (selected_item.filecasecmp_to(current_dir) != 0) {
+			recent_list->deselect(p_item);
 		}
 	}
 
@@ -1646,6 +1654,7 @@ void FileDialog::_change_dir(const String &p_new_dir) {
 	} else {
 		String old_dir = dir_access->get_current_dir();
 		dir_access->change_dir(p_new_dir);
+
 		if (!dir_access->get_current_dir().begins_with(root_prefix)) {
 			dir_access->change_dir(old_dir);
 			return;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -362,6 +362,7 @@ Vector<String> FileDialog::get_selected_files() const {
 void FileDialog::update_dir() {
 	const String current_dir = dir_access->get_current_dir();
 	const String current_dir_no_drive = dir_access->get_current_dir(false);
+	full_dir = current_dir;
 	if (root_prefix.is_empty()) {
 		directory_edit->set_text(current_dir_no_drive);
 	} else {
@@ -1654,7 +1655,6 @@ void FileDialog::_change_dir(const String &p_new_dir) {
 	} else {
 		String old_dir = dir_access->get_current_dir();
 		dir_access->change_dir(p_new_dir);
-
 		if (!dir_access->get_current_dir().begins_with(root_prefix)) {
 			dir_access->change_dir(old_dir);
 			return;


### PR DESCRIPTION
Allow reselecting recent files when the directory is changed to a dfiferent one. Little code cleanup on file_dialog.cpp.

## What problem(s) does this PR solve?

- After changing directory from a recently selected one, the dialog can't go back to that same recent directory by selecting it as it's already selected. This deselects the directory when a selected one doesn't fit the current directory of the dialog.
