### PR TITLE
Core: Rename `Script::is_valid` to `is_script_valid`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -862,7 +862,7 @@ bool ClassDB::can_instantiate(const StringName &p_class) {
 
 use_script:
 	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_valid() && !scr->is_abstract();
+	return scr.is_valid() && scr->is_script_valid() && !scr->is_abstract();
 }
 
 bool ClassDB::is_abstract(const StringName &p_class) {
@@ -894,7 +894,7 @@ bool ClassDB::is_abstract(const StringName &p_class) {
 
 use_script:
 	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_valid() && scr->is_abstract();
+	return scr.is_valid() && scr->is_script_valid() && scr->is_abstract();
 }
 
 bool ClassDB::is_virtual(const StringName &p_class) {
@@ -920,7 +920,7 @@ bool ClassDB::is_virtual(const StringName &p_class) {
 
 use_script:
 	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_valid() && scr->is_abstract();
+	return scr.is_valid() && scr->is_script_valid() && scr->is_abstract();
 }
 
 bool ClassDB::is_gdextension(const StringName &p_class) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1539,7 +1539,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 #ifdef TOOLS_ENABLED
 			else {
 				//allow connecting signals anyway if script is invalid, see issue #17070
-				if (!script_instance->get_script()->is_valid()) {
+				if (!script_instance->get_script()->is_script_valid()) {
 					signal_is_valid = true;
 				}
 			}

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -177,7 +177,7 @@ public:
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
 	virtual bool is_tool() const = 0;
-	virtual bool is_valid() const = 0;
+	virtual bool is_script_valid() const = 0;
 	virtual bool is_abstract() const = 0;
 
 	virtual ScriptLanguage *get_language() const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -131,7 +131,14 @@ public:
 	}
 
 	EXBIND0RC(bool, is_tool)
-	EXBIND0RC(bool, is_valid)
+
+	// TODO: Rename to _is_script_valid in Godot 5.
+	GDVIRTUAL0RC_REQUIRED(bool, _is_valid);
+	virtual bool is_script_valid() const override {
+		bool ret = false;
+		GDVIRTUAL_CALL(_is_valid, ret);
+		return ret;
+	}
 
 	virtual bool is_abstract() const override {
 		bool abst;

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1229,7 +1229,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					}
 				} else {
 					Ref<Script> script = resource;
-					if (script.is_valid() && script->is_valid()) {
+					if (script.is_valid() && script->is_script_valid()) {
 						key_type = Variant::OBJECT;
 						key_class_name = script->get_instance_base_type();
 						key_script = script;
@@ -1275,7 +1275,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					}
 				} else {
 					Ref<Script> script = resource;
-					if (script.is_valid() && script->is_valid()) {
+					if (script.is_valid() && script->is_script_valid()) {
 						value_type = Variant::OBJECT;
 						value_class_name = script->get_instance_base_type();
 						value_script = script;
@@ -1365,7 +1365,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 					}
 				} else {
 					Ref<Script> script = resource;
-					if (script.is_valid() && script->is_valid()) {
+					if (script.is_valid() && script->is_script_valid()) {
 						array.set_typed(Variant::OBJECT, script->get_instance_base_type(), script);
 					}
 				}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6587,7 +6587,7 @@ bool EditorNode::validate_custom_directory() {
 
 void EditorNode::run_editor_script(const Ref<Script> &p_script) {
 	Error err = p_script->reload(true); // Always hard reload the script before running.
-	if (err != OK || !p_script->is_valid()) {
+	if (err != OK || !p_script->is_script_valid()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Cannot run the script because it contains errors, check the output log."), EditorToaster::SEVERITY_WARNING);
 		return;
 	}

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -337,7 +337,7 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 
 		Ref<Script> scr = res;
 		if (scr.is_valid()) {
-			ERR_FAIL_COND_V_MSG(!scr->is_valid(), nullptr, vformat("Failed to create an autoload, script '%s' is not compiling.", p_path));
+			ERR_FAIL_COND_V_MSG(!scr->is_script_valid(), nullptr, vformat("Failed to create an autoload, script '%s' is not compiling.", p_path));
 
 			StringName ibt = scr->get_instance_base_type();
 			bool valid_type = ClassDB::is_parent_class(ibt, "Node");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4366,7 +4366,7 @@ int Main::start() {
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), EXIT_FAILURE, "Can't load script: " + script);
 
 		if (check_only) {
-			return script_res->is_valid() ? EXIT_SUCCESS : EXIT_FAILURE;
+			return script_res->is_script_valid() ? EXIT_SUCCESS : EXIT_FAILURE;
 		}
 
 		if (script_res->can_instantiate()) {

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -354,7 +354,7 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 
 	doc.script_path = p_script->get_script_path();
 
-	if (p_script->base.is_valid() && p_script->base->is_valid()) {
+	if (p_script->base.is_valid() && p_script->base->is_script_valid()) {
 		// See GH-105926. Evaluate the doc name of the base class instead of using `p_script->base->doc.name`
 		// to avoid load/compile order issues in case of complex circular dependencies.
 		doc.inherits = _get_gdscript_name(p_script->base.ptr());

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -274,7 +274,7 @@ StringName GDScript::get_instance_base_type() const {
 	if (native.is_valid()) {
 		return native->get_name();
 	}
-	if (base.is_valid() && base->is_valid()) {
+	if (base.is_valid() && base->is_script_valid()) {
 		return base->get_instance_base_type();
 	}
 	return StringName();
@@ -583,7 +583,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 	placeholder_fallback_enabled = false;
 
-	if (base_cache.is_valid() && base_cache->is_valid()) {
+	if (base_cache.is_valid() && base_cache->is_script_valid()) {
 		for (int i = 0; i < base_caches.size(); i++) {
 			if (base_caches[i] == base_cache.ptr()) {
 				if (r_err) {
@@ -804,7 +804,7 @@ Error GDScript::reload(bool p_keep_state) {
 	bool can_run = ScriptServer::is_scripting_enabled() || is_tool();
 
 #ifdef TOOLS_ENABLED
-	if (p_keep_state && can_run && is_valid()) {
+	if (p_keep_state && can_run && is_script_valid()) {
 		_save_old_static_data();
 	}
 #endif
@@ -1769,7 +1769,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 							String elem_type;
 							if (arr.is_typed()) {
 								const Ref<Script> script_type = arr.get_typed_script();
-								if (script_type.is_valid() && script_type->is_valid()) {
+								if (script_type.is_valid() && script_type->is_script_valid()) {
 									elem_type = GDScript::debug_get_script_name(script_type);
 								} else if (!arr.get_typed_class_name().is_empty()) {
 									elem_type = arr.get_typed_class_name();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -229,7 +229,7 @@ public:
 	// Cancels all functions of the script that are are waiting to be resumed after using await.
 	void cancel_pending_functions(bool warn);
 
-	virtual bool is_valid() const override { return valid; }
+	virtual bool is_script_valid() const override { return valid; }
 
 	bool inherits_script(const Ref<Script> &p_script) const override;
 

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -449,7 +449,7 @@ Error GDScriptCache::finish_compiling(const String &p_owner) {
 
 void GDScriptCache::add_static_script(Ref<GDScript> p_script) {
 	ERR_FAIL_COND_MSG(p_script.is_null(), "Trying to cache empty script as static.");
-	ERR_FAIL_COND_MSG(!p_script->is_valid(), "Trying to cache non-compiled script as static.");
+	ERR_FAIL_COND_MSG(!p_script->is_script_valid(), "Trying to cache non-compiled script as static.");
 	singleton->static_gdscript_cache[p_script->get_fully_qualified_name()] = p_script;
 }
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2791,7 +2791,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 				if (err) {
 					return err;
 				}
-			} else if (!base->is_valid()) {
+			} else if (!base->is_script_valid()) {
 				String base_qualified_name = base->fully_qualified_name;
 				String base_path = base->path;
 

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -163,7 +163,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				StringName native_type = get_global_name(_code_ptr[ip + 5]);
 
-				if (script_type.is_valid() && script_type->is_valid()) {
+				if (script_type.is_valid() && script_type->is_script_valid()) {
 					text += "script(";
 					text += GDScript::debug_get_script_name(script_type);
 					text += ")";
@@ -188,7 +188,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				StringName key_native_type = get_global_name(_code_ptr[ip + 6]);
 
-				if (key_script_type.is_valid() && key_script_type->is_valid()) {
+				if (key_script_type.is_valid() && key_script_type->is_script_valid()) {
 					text += "script(";
 					text += GDScript::debug_get_script_name(key_script_type);
 					text += ")";
@@ -204,7 +204,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				StringName value_native_type = get_global_name(_code_ptr[ip + 8]);
 
-				if (value_script_type.is_valid() && value_script_type->is_valid()) {
+				if (value_script_type.is_valid() && value_script_type->is_script_valid()) {
 					text += "script(";
 					text += GDScript::debug_get_script_name(value_script_type);
 					text += ")";
@@ -578,7 +578,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				StringName native_type = get_global_name(_code_ptr[ip + argc + 5]);
 
 				String type_name;
-				if (script_type.is_valid() && script_type->is_valid()) {
+				if (script_type.is_valid() && script_type->is_script_valid()) {
 					type_name = "script(" + GDScript::debug_get_script_name(script_type) + ")";
 				} else if (native_type != StringName()) {
 					type_name = native_type;
@@ -633,7 +633,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				StringName key_native_type = get_global_name(_code_ptr[ip + argc * 2 + 6]);
 
 				String key_type_name;
-				if (key_script_type.is_valid() && key_script_type->is_valid()) {
+				if (key_script_type.is_valid() && key_script_type->is_script_valid()) {
 					key_type_name = "script(" + GDScript::debug_get_script_name(key_script_type) + ")";
 				} else if (key_native_type != StringName()) {
 					key_type_name = key_native_type;
@@ -646,7 +646,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				StringName value_native_type = get_global_name(_code_ptr[ip + argc * 2 + 8]);
 
 				String value_type_name;
-				if (value_script_type.is_valid() && value_script_type->is_valid()) {
+				if (value_script_type.is_valid() && value_script_type->is_script_valid()) {
 					value_type_name = "script(" + GDScript::debug_get_script_name(value_script_type) + ")";
 				} else if (value_native_type != StringName()) {
 					value_type_name = value_native_type;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3046,7 +3046,7 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				base_type = base_type.class_type->base_type;
 			} break;
 			case GDScriptParser::DataType::SCRIPT: {
-				if (base_type.script_type->is_valid() && base_type.script_type->has_method(method)) {
+				if (base_type.script_type->is_script_valid() && base_type.script_type->has_method(method)) {
 					r_arghint = _make_arguments_hint(base_type.script_type->get_method_info(method), p_argidx);
 					return;
 				}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -50,7 +50,7 @@ static bool _profile_count_as_native(const Object *p_base_obj, const StringName 
 }
 
 static String _get_element_type(Variant::Type builtin_type, const StringName &native_type, const Ref<Script> &script_type) {
-	if (script_type.is_valid() && script_type->is_valid()) {
+	if (script_type.is_valid() && script_type->is_script_valid()) {
 		return GDScript::debug_get_script_name(script_type);
 	} else if (native_type != StringName()) {
 		return native_type.string();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1647,7 +1647,7 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 }
 
 void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
-	if (!script->is_valid() || !script->valid) {
+	if (!script->is_script_valid() || !script->valid) {
 		return;
 	}
 
@@ -1668,7 +1668,7 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 }
 
 int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *r_is_valid) const {
-	if (!script->is_valid() || !script->valid) {
+	if (!script->is_script_valid() || !script->valid) {
 		if (r_is_valid) {
 			*r_is_valid = false;
 		}

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -266,7 +266,7 @@ public:
 	bool is_tool() const override {
 		return type_info.is_tool;
 	}
-	bool is_valid() const override {
+	bool is_script_valid() const override {
 		return valid;
 	}
 	bool is_abstract() const override {


### PR DESCRIPTION
## What problem(s) does this PR solve?

When working with `Ref<Script> scr` there is both `scr.is_valid` coming from `Ref` and `scr->is_valid` coming from `Script`.

This is easy to miss in a review. To make things worse, when using `clangd` for autocompletion it will silently convert `.` to `->` on accepting the completion.

I'm not aware of any regressions caused by this. But I'd still like to address the foot-gun preemptively.

## Additional information

To appease the compat gods, the virtual method on `ScriptLanguageExtension` is still called `_is_valid`.
