### PR TITLE
Fix changing scene when trying to open automatically imported scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5023,7 +5023,9 @@ Error EditorNode::open_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	Error err = load_scene(p_scene, p_ignore_broken_deps, p_set_inherited, p_force_open_imported);
-	if (err != OK) {
+	if (err == ERR_CANT_OPEN) {
+		return OK; // The scene was automatically imported, show confirmation popup.
+	} else if (err != OK) {
 		return err;
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4912,7 +4912,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 			open_imported->popup_centered();
 			new_inherited_button->grab_focus();
 			open_import_request = lpath;
-			return OK;
+			return ERR_CANT_OPEN;
 		}
 	}
 
@@ -5023,7 +5023,9 @@ Error EditorNode::open_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	Error err = load_scene(p_scene, p_ignore_broken_deps, p_set_inherited, p_force_open_imported);
-	if (err != OK) {
+	if (err == ERR_CANT_OPEN) {
+		return OK; // The scene was automatically imported, show confirmation popup.
+	} else if (err != OK) {
 		return err;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120957

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
When opening an automatically imported scene from the SceneTree, `EditorNode::open_scene` would switch to the last opened scene in the editor, regardless of the user's selection in the confirmation popup. Now, `EditorNode::open_scene` checks the result of `EditorNode::load_scene`; if `EditorNode::load_scene` returns `Error::ERR_CANT_OPEN`, `EditorNode::open_scene` returns `Error::OK` and exits without opening a new scene, instead simply storing the path to the imported scene in `open_import_request` (to be opened if the user selects "New Inherited" in the popup).