### PR TITLE
Apply `[[gnu::warn_unused]]` to core collections

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -80,7 +80,7 @@ class Variant;
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>>
-class AHashMap {
+class _WARN_UNUSED_ AHashMap {
 public:
 	// Must be a power of two.
 	static constexpr uint32_t INITIAL_CAPACITY = 16;

--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -34,7 +34,7 @@
 #include "core/templates/paged_array.h"
 
 template <typename T>
-class BinSortedArray {
+class _WARN_UNUSED_ BinSortedArray {
 	PagedArray<T> array;
 	LocalVector<uint64_t> bin_limits;
 

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -44,7 +44,7 @@ GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
  *
  */
 template <class T, uint32_t CAPACITY>
-class FixedVector {
+class _WARN_UNUSED_ FixedVector {
 	// This declaration allows us to access other FixedVector's private members.
 	template <class T_, uint32_t CAPACITY_>
 	friend class FixedVector;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -66,7 +66,7 @@ template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>,
 		typename Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
-class HashMap : private Allocator {
+class _WARN_UNUSED_ HashMap : private Allocator {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
 	static constexpr float MAX_OCCUPANCY = 0.75;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -46,7 +46,7 @@
 template <typename TKey,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>>
-class HashSet {
+class _WARN_UNUSED_ HashSet {
 public:
 	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
 	static constexpr float MAX_OCCUPANCY = 0.75;

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -45,7 +45,7 @@
  */
 
 template <typename T, typename A = DefaultAllocator>
-class List {
+class _WARN_UNUSED_ List {
 	struct _Data;
 
 public:

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -42,7 +42,7 @@
 // If tight, it grows strictly as much as needed.
 // Otherwise, it grows exponentially (the default and what you want in most cases).
 template <typename T, typename U = uint32_t, bool force_trivial = false, bool tight = false>
-class LocalVector {
+class _WARN_UNUSED_ LocalVector {
 	static_assert(!force_trivial, "force_trivial is no longer supported. Use resize_uninitialized instead.");
 
 private:

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -34,7 +34,7 @@
 #include "core/templates/list.h"
 
 template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>, void (*BeforeEvict)(TKey &, TData &) = nullptr>
-class LRUCache {
+class _WARN_UNUSED_ LRUCache {
 public:
 	struct Pair {
 		TKey key;

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -135,7 +135,7 @@ public:
 // It is safe to use multiple PagedArrays from different threads, sharing a single PagedArrayPool
 
 template <typename T>
-class PagedArray {
+class _WARN_UNUSED_ PagedArray {
 	PagedArrayPool<T> *page_pool = nullptr;
 
 	T **page_data = nullptr;

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -55,7 +55,7 @@
 #include "core/templates/local_vector.h"
 
 template <typename T, typename U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
-class PooledList {
+class _WARN_UNUSED_ PooledList {
 	LocalVector<T, U> list;
 	LocalVector<U, U> freelist;
 

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -40,7 +40,7 @@
 // https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
 
 template <typename K, typename V, typename C = Comparator<K>, typename A = DefaultAllocator>
-class RBMap {
+class _WARN_UNUSED_ RBMap {
 	enum Color {
 		RED,
 		BLACK

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -39,7 +39,7 @@
 // https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
 
 template <typename T, typename C = Comparator<T>, typename A = DefaultAllocator>
-class RBSet {
+class _WARN_UNUSED_ RBSet {
 	enum Color {
 		RED,
 		BLACK

--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -33,7 +33,7 @@
 #include "core/templates/local_vector.h"
 
 template <typename T>
-class RingBuffer {
+class _WARN_UNUSED_ RingBuffer {
 	LocalVector<T> data;
 	int read_pos = 0;
 	int write_pos = 0;

--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -35,7 +35,7 @@
 #include "core/typedefs.h"
 
 template <typename T>
-class SelfList {
+class _WARN_UNUSED_ SelfList {
 public:
 	class List {
 		SelfList<T> *_first = nullptr;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -41,6 +41,7 @@
 #include "core/error/error_macros.h"
 #include "core/templates/cowdata.h"
 #include "core/templates/sort_array.h"
+#include "core/typedefs.h"
 
 #include <initializer_list>
 
@@ -58,7 +59,7 @@ public:
 };
 
 template <typename T>
-class Vector {
+class _WARN_UNUSED_ Vector {
 	friend class VectorWriteProxy<T>;
 
 public:

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -34,7 +34,7 @@
 #include "core/typedefs.h"
 
 template <typename T>
-class VSet {
+class _WARN_UNUSED_ VSet {
 	Vector<T> _data;
 
 protected:

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -284,6 +284,13 @@ struct is_zero_constructible<const volatile T> : is_zero_constructible<T> {};
 template <typename T>
 inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 
+#if GD_HAS_CPP_ATTRIBUTE(gnu::warn_unused)
+// https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-warn_005funused
+#define _WARN_UNUSED_ [[gnu::warn_unused]]
+#else
+#define _WARN_UNUSED_
+#endif
+
 // Warning suppression helper macros.
 #if defined(__clang__)
 #define GODOT_CLANG_PRAGMA(m_content) _Pragma(#m_content)

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1288,7 +1288,6 @@ RDD::TextureID RenderingDeviceDriverD3D12::texture_create(const TextureFormat &p
 			relaxed_casting_format_count++;
 		}
 
-		HashMap<DataFormat, D3D12_RESOURCE_FLAGS> aliases_forbidden_flags;
 		for (int i = 0; i < p_format.shareable_formats.size(); i++) {
 			DataFormat curr_format = p_format.shareable_formats[i];
 			String format_text = "'" + String(FORMAT_NAMES[p_format.format]) + "'";
@@ -5131,7 +5130,6 @@ RDD::PipelineID RenderingDeviceDriverD3D12::render_pipeline_create(
 	RenderPipelineInfo render_info;
 
 	// Attachments.
-	LocalVector<uint32_t> color_attachments;
 	{
 		const Subpass &subpass = pass_info->subpasses[p_render_subpass];
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -619,7 +619,6 @@ Error FileAccessWindows::_set_extended_attribute(const String &p_file, const Str
 	file += ":" + p_attribute_name;
 	const Char16String &file_utf16 = file.utf16();
 
-	PackedByteArray data;
 	HANDLE h = CreateFileW((LPCWSTR)file_utf16.get_data(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
 	if (h == INVALID_HANDLE_VALUE) {
 		return FAILED;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -6712,7 +6712,6 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 
 		// Reselect duplicated.
-		RBMap<SelectedKey, KeyInfo> new_selection;
 		for (const Pair<int, float> &E : new_selection_values) {
 			undo_redo->add_do_method(this, "_select_at_anim", animation, E.first, E.second);
 		}

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -774,8 +774,6 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
-	HashSet<ResourceUID::ID> existing_uids;
-
 	Vector<ResourceUID::ID> *history = _get_history();
 	if (history) {
 		for (const ResourceUID::ID &uid : *history) {

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -1197,7 +1197,6 @@ void Collada::_parse_skin_controller(XMLParser &p_parser, const String &p_id) {
 
 	/* STORE REST MATRICES */
 
-	Vector<Transform3D> rests;
 	ERR_FAIL_COND(!skindata.joints.sources.has("JOINT"));
 	ERR_FAIL_COND(!skindata.joints.sources.has("INV_BIND_MATRIX"));
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2011,7 +2011,6 @@ void ResourceImporterScene::_create_slices(AnimationPlayer *ap, Ref<Animation> a
 		Ref<Animation> new_anim = memnew(Animation);
 
 		for (int j = 0; j < anim->get_track_count(); j++) {
-			List<float> keys;
 			int kc = anim->track_get_key_count(j);
 			int dtrack = -1;
 			for (int k = 0; k < kc; k++) {

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -1108,7 +1108,6 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 // Validate in all arrays if names don't do cyclic renames "Node" -> "Node2D" | "Node2D" -> "2DNode"
 bool ProjectConverter3To4::test_array_names() {
 	bool valid = true;
-	Vector<String> names = Vector<String>();
 
 	// Validate if all classes are valid.
 	{

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3193,7 +3193,6 @@ void TileMapLayerEditorTerrainsPlugin::forward_canvas_draw_over_viewport(Control
 				rect.set_end(tile_set->local_to_map(mpos));
 				rect = rect.abs();
 
-				HashMap<Vector2i, TileSet::TerrainsPattern> to_draw;
 				for (int x = rect.position.x; x <= rect.get_end().x; x++) {
 					for (int y = rect.position.y; y <= rect.get_end().y; y++) {
 						preview.insert(Vector2i(x, y));

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -157,7 +157,6 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 		const int &alternative = tiles.front()->get().alternative;
 
 		if (alternative == 0) {
-			Vector<String> components = String(p_name).split("/", true, 2);
 			if (p_name == "atlas_coords") {
 				Vector2i as_vector2i = Vector2i(p_value);
 				bool has_room_for_tile = tile_set_atlas_source->has_room_for_tile(as_vector2i, tile_set_atlas_source->get_tile_size_in_atlas(coords), tile_set_atlas_source->get_tile_animation_columns(coords), tile_set_atlas_source->get_tile_animation_separation(coords), tile_set_atlas_source->get_tile_animation_frames_count(coords), coords);
@@ -314,7 +313,6 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_get(const StringName &p_na
 		const int &alternative = tiles.front()->get().alternative;
 
 		if (alternative == 0) {
-			Vector<String> components = String(p_name).split("/", true, 2);
 			if (p_name == "atlas_coords") {
 				r_ret = coords;
 				return true;

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -100,15 +100,8 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	int current_line = 0;
 	int instr_args_max = 0;
 
-#ifdef DEBUG_ENABLED
-	List<int> temp_stack;
-#endif
-
 	HashMap<Variant, int> constant_map;
 	RBMap<StringName, int> name_map;
-#ifdef TOOLS_ENABLED
-	Vector<StringName> named_globals;
-#endif
 	RBMap<Variant::ValidatedOperatorEvaluator, int> operator_func_map;
 	RBMap<Variant::ValidatedSetter, int> setters_map;
 	RBMap<Variant::ValidatedGetter, int> getters_map;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -51,8 +51,6 @@
 namespace GDScriptTests {
 
 void init_autoloads() {
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads(ProjectSettings::get_singleton()->get_autoload_list());
-
 	// First pass, add the constants so they exist before any script is loaded.
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		const ProjectSettings::AutoloadInfo &info = E.value;

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -109,7 +109,6 @@ void SceneExporterGLTFPlugin::_popup_gltf_export_dialog() {
 void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	ERR_FAIL_NULL(root);
-	List<String> deps;
 	Ref<GLTFState> state;
 	state.instantiate();
 	state->set_copyright(_export_settings->get_copyright());

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -1162,17 +1162,6 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 					attributes["COLOR_0"] = GLTFAccessor::encode_new_accessor_from_colors(p_state, a, GLTFBufferView::TARGET_ARRAY_BUFFER);
 				}
 			}
-			HashMap<int, int> joint_i_to_bone_i;
-			for (GLTFNodeIndex node_i = 0; node_i < p_state->nodes.size(); node_i++) {
-				GLTFSkinIndex skin_i = -1;
-				if (p_state->nodes[node_i]->mesh == gltf_mesh_i) {
-					skin_i = p_state->nodes[node_i]->skin;
-				}
-				if (skin_i != -1) {
-					joint_i_to_bone_i = p_state->skins[skin_i]->joint_i_to_bone_i;
-					break;
-				}
-			}
 			{
 				const Array &a = array[Mesh::ARRAY_BONES];
 				const Vector<Vector3> &vertex_array = array[Mesh::ARRAY_VERTEX];

--- a/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
@@ -174,8 +174,6 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			polygon_color.set_hsv(debug_navigation_geometry_face_color.get_h() + rand.random(-1.0, 1.0) * 0.1, debug_navigation_geometry_face_color.get_s(), debug_navigation_geometry_face_color.get_v() + rand.random(-1.0, 1.0) * 0.2);
 			polygon_color.a = debug_navigation_geometry_face_color.a;
 
-			Vector<int> polygon = navigationmesh->get_polygon(i);
-
 			face_color_array.push_back(polygon_color);
 			face_color_array.push_back(polygon_color);
 			face_color_array.push_back(polygon_color);

--- a/modules/visual_shader/visual_shader.cpp
+++ b/modules/visual_shader/visual_shader.cpp
@@ -1630,9 +1630,6 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 		return String();
 	}
 
-	List<String> input_names;
-	List<String> output_names;
-
 	for (int i = 0; i < p_node->get_input_port_count(); i++) {
 		if (!p_output && i == p_port_id) {
 			continue;

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -1498,8 +1498,6 @@ bool JavaClassWrapper::_wrap_class_components(JNIEnv *p_env, const Ref<JavaClass
 			p_env->DeleteLocalRef(name);
 		}
 
-		Vector<String> params;
-
 		jint mods = p_env->CallIntMethod(obj, is_constructor ? Constructor_getModifiers : Method_getModifiers);
 		bool is_public = (mods & 0x0001) != 0; // java.lang.reflect.Modifier.PUBLIC
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -195,7 +195,6 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 }
 
 Vector<EditorExportPlatformAppleEmbedded::IconInfo> EditorExportPlatformIOS::get_icon_infos() const {
-	Vector<EditorExportPlatformAppleEmbedded::IconInfo> icon_infos;
 	return {
 		// Settings on iPhone, iPad Pro, iPad, iPad mini
 		{ PNAME("icons/settings_58x58"), "universal", "Icon-58", "58", "2x", "29x29", false },

--- a/platform/linuxbsd/wayland/wayland_embedder.h
+++ b/platform/linuxbsd/wayland/wayland_embedder.h
@@ -526,7 +526,6 @@ class WaylandEmbedder {
 
 	Thread proxy_thread;
 
-	List<int> client_fds;
 	List<int> compositor_fds;
 
 	uint32_t serial_counter = 0;

--- a/platform/web/javascript_bridge_singleton.cpp
+++ b/platform/web/javascript_bridge_singleton.cpp
@@ -258,7 +258,6 @@ void JavaScriptObjectImpl::callback(void *p_ref, int p_args_id, int p_argc) {
 	const JavaScriptObjectImpl *obj = (JavaScriptObjectImpl *)p_ref;
 	ERR_FAIL_COND_MSG(!obj->_callable.is_valid(), "JavaScript callback failed.");
 
-	Vector<const Variant *> argp;
 	Array arg_arr;
 	for (int i = 0; i < p_argc; i++) {
 		godot_js_wrapper_ex exchange;

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -201,8 +201,6 @@ void MeshInstance2D::navmesh_parse_source_geometry(const Ref<NavigationPolygon> 
 
 	//path_solution = RamerDouglasPeucker(path_solution, 0.025);
 
-	Vector<Vector<Vector2>> polypaths;
-
 	for (const PathD &scaled_path : path_solution) {
 		Vector<Vector2> shape_outline;
 		for (const PointD &scaled_point : scaled_path) {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -720,7 +720,6 @@ bool TileMap::_set(const StringName &p_name, const Variant &p_value) {
 bool TileMap::_get(const StringName &p_name, Variant &r_ret) const {
 	const String sname = p_name;
 
-	Vector<String> components = String(p_name).split("/", true, 2);
 	if (p_name == "format") {
 		r_ret = TileMapDataFormat::TILE_MAP_DATA_FORMAT_MAX - 1; // When saving, always save highest format.
 		return true;

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2431,7 +2431,6 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_constrain
 HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_connect(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains) const {
 	ERR_FAIL_COND_V(tile_set.is_null(), (HashMap<Vector2i, TileSet::TerrainsPattern>()));
 	ERR_FAIL_INDEX_V(p_terrain_set, tile_set->get_terrain_sets_count(), (HashMap<Vector2i, TileSet::TerrainsPattern>()));
-	HashMap<Vector2i, TileSet::TerrainsPattern> output;
 
 	// Build list and set of tiles that can be modified (painted and their surroundings).
 	Vector<Vector2i> can_modify_list;
@@ -2607,7 +2606,6 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_path(cons
 HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_pattern(const Vector<Vector2i> &p_coords_array, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern, bool p_ignore_empty_terrains) const {
 	ERR_FAIL_COND_V(tile_set.is_null(), (HashMap<Vector2i, TileSet::TerrainsPattern>()));
 	ERR_FAIL_INDEX_V(p_terrain_set, tile_set->get_terrain_sets_count(), (HashMap<Vector2i, TileSet::TerrainsPattern>()));
-	HashMap<Vector2i, TileSet::TerrainsPattern> output;
 
 	// Build list and set of tiles that can be modified (painted and their surroundings).
 	Vector<Vector2i> can_modify_list;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1324,7 +1324,6 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 	LocalVector<float> vertices;
 	LocalVector<float> normals;
 	LocalVector<int> indices;
-	LocalVector<float> uv;
 	LocalVector<Pair<int, int>> uv_indices;
 
 	Vector<EditorSceneFormatImporterMeshLightmapSurface> lightmap_surfaces;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2092,7 +2092,6 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 	LocalVector<float> vertices;
 	LocalVector<float> normals;
 	LocalVector<int> indices;
-	LocalVector<float> uv;
 	LocalVector<Pair<int, int>> uv_indices;
 
 	Vector<ArrayMeshLightmapSurface> lightmap_surfaces;

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -1254,8 +1254,6 @@ PackedInt32Array TextServer::shaped_text_get_word_breaks(const RID &p_shaped, Bi
 }
 
 CaretInfo TextServer::shaped_text_get_carets(const RID &p_shaped, int64_t p_position) const {
-	Vector<Rect2> carets;
-
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 	const Vector2 &range = shaped_text_get_range(p_shaped);
 	real_t ascent = shaped_text_get_ascent(p_shaped);

--- a/tests/core/threads/test_worker_thread_pool.cpp
+++ b/tests/core/threads/test_worker_thread_pool.cpp
@@ -141,7 +141,6 @@ TEST_CASE("[WorkerThreadPool] Run a yielding daemon as the only hope for other t
 		task_ids.push_back(WorkerThreadPool::get_singleton()->add_native_task(static_busy_task, nullptr, true));
 	}
 
-	LocalVector<WorkerThreadPool::TaskID> legit_task_ids;
 	LocalVector<bool> legit_task_needed_yield;
 	int legit_tasks_count = num_threads * 4;
 	legit_task_needed_yield.resize(legit_tasks_count);

--- a/tests/scene/test_gradient.cpp
+++ b/tests/scene/test_gradient.cpp
@@ -108,7 +108,6 @@ TEST_CASE("[Gradient] Custom gradient (points specified out-of-order)") {
 	// HSL rainbow with points specified out of order.
 	// These should be sorted automatically when adding points.
 	Ref<Gradient> gradient = memnew(Gradient);
-	LocalVector<Gradient::Point> points;
 	Vector<float> offsets = { 0.2, 0.0, 0.8, 0.4, 1.0, 0.6 };
 	Vector<Color> colors = { Color(1, 0, 0), Color(1, 1, 0), Color(0, 1, 0), Color(0, 1, 1), Color(0, 0, 1), Color(1, 0, 1) };
 

--- a/tests/scene/test_primitives.cpp
+++ b/tests/scene/test_primitives.cpp
@@ -190,7 +190,6 @@ TEST_CASE("[SceneTree][Primitive][Box] Box Primitive") {
 		int subdivide_height{ 2 };
 		int subdivide_depth{ 8 };
 		BoxMesh::create_mesh_array(data, size, subdivide_width, subdivide_height, subdivide_depth);
-		Vector<Vector3> points = data[RSE::ARRAY_VERTEX];
 		Vector<Vector3> normals = data[RSE::ARRAY_NORMAL];
 
 		SUBCASE("Only 6 distinct normals.") {


### PR DESCRIPTION
## What problem(s) does this PR solve?

By default compilers do not warn about unused vars, if their type is not trivially construct-able because the initializer might be the point of construction for e.g. RAII.

GCC and clang support an attribute to mark types, so that their vars produce those warnings: https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-warn_005funused

This PR applies this attribute to our core collection types. It also removes some unused stuff brought to light by this.

## Additional information

GCC does not warn about unused class members, so compiling with clang gives more results. Clang does only warn about unused private class members, so there are still some cases that go undetected. In theory since we bind everything that's exposed to ClassDB it would probably be save to also warn about unused public members, but I'm not sure if there's a way to do so.
