### PR TITLE
Fix children's `parent_maximum_size_cache` unable to update twice in a frame

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1781,7 +1781,7 @@ void Control::update_maximum_size() {
 
 	for (Node *child : iterate_children()) {
 		Control *child_control = Object::cast_to<Control>(child);
-		if (child_control && !child_control->is_set_as_top_level() && child_control->data.maximum_size_valid) {
+		if (child_control && !child_control->is_set_as_top_level()) {
 			if (child_control->data.parent_maximum_size_cache == parent_max) {
 				continue;
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes an issue whereby parent `Control` could not update their children's `parent_maximum_size_cache` more than once per frame.

## Additional information

Whilst working on tests for containers for all the desired size behavior, I discovered that the `parent_maximum_size_cache` wouldn't update as intended when the following code was executed:
```cpp
parent->set_custom_maximum_size(Size2(100, 100));
parent->set_propagate_maximum_size(false);
SceneTree::get_singleton()->process(0);
child->get_combined_maximum_size() //  would return Size2(100, 100) instead of Size2(-1, -1)
```
But it would work if the first two setters were flipped:
```cpp
parent->set_propagate_maximum_size(false);
parent->set_custom_maximum_size(Size2(100, 100));
SceneTree::get_singleton()->process(0);
child->get_combined_maximum_size() //  would return Size2(-1, -1)
```

Turns out the `&& child_control->data.maximum_size_valid` condition that I had copied from `update_minimum_size` when creating `update_maximum_size` was preventing the children's `parent_maximum_size_cache` from being updated more than once per frame.


Edit: 
MRP [mrp-parent-cache.zip](https://github.com/user-attachments/files/29858997/mrp-parent-cache.zip)
Run the scene and press the big button, check the console output.