### PR TITLE
Fix `register_extension_class` never iterating parents for exposed checks

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2278,7 +2278,7 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 		// The parent classes should be exposed if it has an exposed child class.
 		while (parent && !parent->exposed) {
 			parent->exposed = true;
-			parent = classes.getptr(parent->gdtype->get_name());
+			parent = classes.getptr(parent->gdtype->get_super_type_name());
 		}
 	}
 	c.reloadable = p_extension->reloadable;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a regression from https://github.com/godotengine/godot/pull/117442 where the parent classes aren't auto-exposed by an exposed child class being registered.
This is likely niche.
