### PR TITLE
Fix text not wrapping on long error messages (e.g. URLs)

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -809,7 +809,8 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 
 	if (!error_text.is_empty()) {
 		download_error->set_text(TTR("Asset Download Error:") + "\n" + error_text);
-		download_error->popup_centered();
+		download_error->set_autowrap(true);
+		download_error->popup_centered(get_window()->get_size_with_decorations() / 3);
 		// Let the user retry the download.
 		retry_button->show();
 		return;


### PR DESCRIPTION
Makes the error message wrap automatically with a reasonable minimum size relative to the main editor window the user has (1/3).

## What problem(s) does this PR solve?

- Closes #120977 