### PR TITLE
Fix blank Godot icons on Linux file managers

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -3,20 +3,20 @@
   <mime-type type="application/x-godot-project">
     <comment>Godot Engine project</comment>
     <sub-class-of type="text/plain"/>
-    <icon name="x-godot-project"/>
+    <icon name="application-x-godot-project"/>
     <glob pattern="project.godot"/>
   </mime-type>
 
   <mime-type type="application/x-godot-resource">
     <comment>Godot Engine resource</comment>
-    <icon name="x-godot-resource"/>
+    <icon name="application-x-godot-resource"/>
     <glob pattern="*.res"/>
     <glob pattern="*.tres"/>
   </mime-type>
 
   <mime-type type="application/x-godot-scene">
     <comment>Godot Engine scene</comment>
-    <icon name="x-godot-scene"/>
+    <icon name="application-x-godot-scene"/>
     <glob pattern="*.scn"/>
     <glob pattern="*.tscn"/>
     <glob pattern="*.escn"/>
@@ -25,14 +25,14 @@
   <mime-type type="application/x-godot-shader">
     <comment>Godot Engine shader</comment>
     <sub-class-of type="text/plain"/>
-    <icon name="x-godot-shader"/>
+    <icon name="application-x-godot-shader"/>
     <glob pattern="*.gdshader"/>
   </mime-type>
 
   <mime-type type="application/x-gdscript">
     <comment>GDScript script</comment>
     <sub-class-of type="text/plain"/>
-    <icon name="x-gdscript"/>
+    <icon name="application-x-gdscript"/>
     <glob pattern="*.gd"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Icons missing for Linux desktop environments, including (and tested on) KDE Plasma's default Breeze icons.

(I did not create an issue for it, but can if that helps with tracking)

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

There is a [comment](https://github.com/godotengine/godot/pull/45871#discussion_r574442355) on #45871 (which originally attempted to improve this but it missed the XDG icon conventions by omitting the `application-` prefix) which this should better address.

An alternate solution could be to remove these `icon` lines entirely and have the system derrive them directly from the MIME type.

Claude Code (AI) was used to identify why icons were not appearing on my system and to search for the original context on this topic and the PR linked above.