### PR TITLE
Linuxbsd: Offload can_create_rendering_device() Vulkan probe to a subprocess

### DIFF
--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -2190,10 +2190,14 @@ bool DisplayServer::can_create_rendering_device() {
 
 	Error err;
 
-#ifdef WINDOWS_ENABLED
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
 	// On some NVIDIA drivers combining OpenGL and RenderingDevice can result in crash, offload the check to the subprocess.
 	List<String> arguments;
 	arguments.push_back("--test-rd-creation");
+	if (get_singleton()) {
+		arguments.push_back("--display-driver");
+		arguments.push_back(get_singleton()->get_name().to_lower());
+	}
 
 	String pipe;
 	int exitcode = 0;
@@ -2204,7 +2208,7 @@ bool DisplayServer::can_create_rendering_device() {
 	} else {
 		created_rendering_device = DisplayServerEnums::RenderingDeviceCreationStatus::FAILURE;
 	}
-#else // WINDOWS_ENABLED
+#else // WINDOWS_ENABLED || LINUXBSD_ENABLED
 
 	RenderingContextDriver *rcd = nullptr;
 


### PR DESCRIPTION
6ed12bfc5d ("[Linux/BSD] Offload RenderingDevice creation test to subprocess") added the `LINUXBSD_ENABLED` subprocess offload to `is_rendering_device_supported()`, but missed the sibling `can_create_rendering_device()` a bit further down in the same file, which still creates and initializes a `RenderingContextDriverVulkan` in-process on Linux.

On NVIDIA + GLVND setups, this can crash the active GLES3/Compatibility renderer: Vulkan ICD enumeration loads `libGLX_nvidia.so`, which calls `eglMakeCurrent(..., EGL_NO_CONTEXT)` as a side effect through the shared GLVND `libEGL` dispatcher, unbinding the live EGL context out from under the running GL renderer on that thread. Reproduces reliably on Linux/Wayland with an NVIDIA GPU present; does not reproduce on X11 (GLX, not EGL).

This PR applies the same fix already used for `is_rendering_device_supported()`: extend the `WINDOWS_ENABLED` guard to also cover `LINUXBSD_ENABLED`.

## Steps to reproduce

1. Create a new project and set its renderer to Compatibility
2. Force the editor onto the Wayland backend by making X11 unavailable, and open the project with the OpenGL driver:
   ```sh
   DISPLAY=<anything invalid> godot --editor --path /path/to/project
   ```

3. On a machine with an NVIDIA GPU present, this crashes within a few seconds with a `Vertex shader compilation failed` error carrying an empty driver info log, followed by a `SIGSEGV`.

## Testing

Verified locally (Fedora, Mesa 25.3.6, NVIDIA + AMD iGPU) using the steps above: before the fix, it crashes within seconds; after, repeated runs complete with no crash.
