### PR TITLE
Add unit tests for `BaseButton` and `ButtonGroup`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v21.1.7
     hooks:
       - id: clang-format
-        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|mc|mm|inc|java)$
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java)$
         types_or: [text]
       - id: clang-format
         name: clang-format-glsl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v21.1.7
     hooks:
       - id: clang-format
-        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java)$
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|mc|mm|inc|java)$
         types_or: [text]
       - id: clang-format
         name: clang-format-glsl

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -36,6 +36,9 @@ TEST_FORCE_LINK(test_button)
 #include "scene/gui/button.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
+#include "scene/resources/placeholder_textures.h"
+#include "servers/display/accessibility_server_dummy.h"
+#include "servers/display/accessibility_server_enums.h"
 #include "tests/display_server_mock.h"
 
 namespace TestButton {
@@ -97,7 +100,7 @@ TEST_CASE("[SceneTree][BaseButton] is_pressed()") {
 	memdelete(button);
 }
 
-// Utilitary class to listen to button pressed and toggled signals.
+// Utility class to listen to button pressed and toggled signals.
 class ButtonCompleteInteractionListener : public Object {
 	GDCLASS(ButtonCompleteInteractionListener, Object);
 
@@ -325,7 +328,7 @@ TEST_CASE("[SceneTree][BaseButton] Disabled State Behavior") {
 	}
 
 	SUBCASE("Should ignore mouse clicks and emit no signals") {
-		button->set_toggle_mode(true); // Ativa toggle só para garantir o teste mais rigoroso
+		button->set_toggle_mode(true);
 
 		// Move the mouse over the button and try to click
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
@@ -435,6 +438,388 @@ TEST_CASE("[SceneTree][BaseButton] get_draw_mode() State Machine") {
 		CHECK(button->get_draw_mode() == BaseButton::DRAW_DISABLED);
 	}
 
+	memdelete(button);
+}
+
+// Tests related to `ButtonGroup` class and its interaction with `BaseButton`, using `Button` as a concrete implementation.
+TEST_CASE("[SceneTree][ButtonGroup] Click interactions and allow_unpress") {
+	// Scenario and Group Creation
+	Window *root = SceneTree::get_singleton()->get_root();
+	Ref<ButtonGroup> group = memnew(ButtonGroup);
+	// Creating two toggle buttons and adding them to the same ButtonGroup.
+	Button *btn1 = memnew(Button);
+	btn1->set_toggle_mode(true);
+	btn1->set_button_group(group);
+	btn1->set_size(Size2i(40, 40));
+	btn1->set_position(Size2i(10, 10)); // Occupies the area from (10, 10) to (50, 50)
+	root->add_child(btn1);
+	Button *btn2 = memnew(Button);
+	btn2->set_toggle_mode(true);
+	btn2->set_button_group(group);
+	btn2->set_size(Size2i(40, 40));
+	btn2->set_position(Size2i(60, 10)); // Occupies the area from (60, 10) to (100, 50)
+	root->add_child(btn2);
+
+	// Ensure the initial state is clean (no button pressed).
+	CHECK(group->get_pressed_button() == nullptr);
+
+	SUBCASE("Mutual exclusion between buttons") {
+		group->set_allow_unpress(false);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(btn1->is_pressed() == true);
+		CHECK(group->get_pressed_button() == btn1);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(80, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(80, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(btn1->is_pressed() == false);
+		CHECK(btn2->is_pressed() == true);
+		CHECK(group->get_pressed_button() == btn2);
+	}
+
+	SUBCASE("Attempt to uncheck with allow_unpress DISABLED") {
+		group->set_allow_unpress(false);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(btn1->is_pressed() == true);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(btn1->is_pressed() == true);
+		CHECK(group->get_pressed_button() == btn1);
+	}
+
+	SUBCASE("Allow unchecking with allow_unpress ENABLED") {
+		group->set_allow_unpress(true);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(btn1->is_pressed() == true);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(30, 30), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(btn1->is_pressed() == false);
+		CHECK(group->get_pressed_button() == nullptr);
+	}
+
+	root->remove_child(btn1);
+	root->remove_child(btn2);
+	memdelete(btn1);
+	memdelete(btn2);
+}
+
+TEST_CASE("[SceneTree][ButtonGroup] Management and Lifecycle of Buttons") {
+	Window *root = SceneTree::get_singleton()->get_root();
+	Ref<ButtonGroup> group = memnew(ButtonGroup);
+
+	SUBCASE("Addition of buttons and exposure of lists") {
+		Button *btn1 = memnew(Button);
+		Button *btn2 = memnew(Button);
+		root->add_child(btn1);
+		root->add_child(btn2);
+
+		// Adding buttons to the group
+		btn1->set_button_group(group);
+		btn2->set_button_group(group);
+
+		// 1. Testing get_buttons method (used internally in C++)
+		List<BaseButton *> button_list;
+		group->get_buttons(&button_list);
+		CHECK(button_list.size() == 2);
+		CHECK(button_list.find(btn1) != nullptr);
+		CHECK(button_list.find(btn2) != nullptr);
+
+		// 2. Testing the _get_buttons method (the binder exposed for GDScript)
+		TypedArray<BaseButton> typed_array = group->_get_buttons();
+		CHECK(typed_array.size() == 2);
+		CHECK(typed_array.find(btn1) != -1);
+		CHECK(typed_array.find(btn2) != -1);
+
+		memdelete(btn1);
+		memdelete(btn2);
+	}
+
+	SUBCASE("Automatic removal of button when deleted (Lifecycle)") {
+		Button *btn = memnew(Button);
+		root->add_child(btn);
+		btn->set_button_group(group);
+
+		// Ensure the button was added to the group
+		TypedArray<BaseButton> list_antes = group->_get_buttons();
+		CHECK(list_antes.size() == 1);
+
+		// Delete the button from memory, BaseButton has a destructor that notifies ButtonGroup to clean up.
+		root->remove_child(btn);
+		memdelete(btn);
+
+		// The internal list of the ButtonGroup MUST be empty now
+		TypedArray<BaseButton> list_depois = group->_get_buttons();
+		CHECK(list_depois.size() == 0);
+	}
+}
+
+// =========================================================================
+// FOURTH WEEK: NEW TEST CASES BASED ON COVERAGE AND SPECIFICATION
+// =========================================================================
+TEST_CASE("[SceneTree][BaseButton] Input de Toque e Gestos") {
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Global setup to prepare the button for the subcases.
+	button->show();
+	button->grab_focus();
+
+	// Create a local listener to validate signal emissions.
+	ButtonCompleteInteractionListener *gestures_listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(gestures_listener, &ButtonCompleteInteractionListener::on_pressed));
+
+	SUBCASE("InputEventScreenTouch - Pressionar e Soltar na tela usando macros") {
+		SEND_GUI_TOUCH_EVENT(Point2i(25, 25), true, false);
+		CHECK(button->is_pressed() == true);
+		CHECK(gestures_listener->pressed_count == 0);
+
+		SEND_GUI_TOUCH_EVENT(Point2i(25, 25), false, false);
+		CHECK(button->is_pressed() == false);
+		CHECK(gestures_listener->pressed_count == 1);
+	}
+
+	SUBCASE("InputEventScreenDrag - Mover o dedo para fora do botão") {
+		button->set_keep_pressed_outside(false);
+
+		SEND_GUI_TOUCH_EVENT(Point2i(25, 25), true, false);
+		CHECK(button->is_pressed() == true);
+
+		Ref<InputEventScreenDrag> touch_drag_out;
+		touch_drag_out.instantiate();
+		touch_drag_out->set_index(0);
+		touch_drag_out->set_position(Point2i(-200, -200));
+
+		_SEND_DISPLAYSERVER_EVENT(touch_drag_out);
+		MessageQueue::get_singleton()->flush();
+
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_NORMAL);
+
+		SEND_GUI_TOUCH_EVENT(Point2i(-200, -200), false, false);
+		CHECK(gestures_listener->pressed_count == 0);
+
+		button->set_keep_pressed_outside(true);
+		CHECK(button->is_keep_pressed_outside() == true);
+
+		SEND_GUI_TOUCH_EVENT(Point2i(25, 25), true, false);
+		CHECK(button->is_pressed() == true);
+
+		_SEND_DISPLAYSERVER_EVENT(touch_drag_out->duplicate());
+		MessageQueue::get_singleton()->flush();
+
+		CHECK(button->is_pressed() == true);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_PRESSED);
+
+		SEND_GUI_TOUCH_EVENT(Point2i(-200, -200), false, false);
+		CHECK(gestures_listener->pressed_count == 0);
+	}
+
+	SUBCASE("InputEventMouseMotion - Mover mouse para fora segurando clique") {
+		button->set_keep_pressed_outside(false);
+
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true);
+
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(-150, -150), MouseButtonMask::LEFT, Key::NONE);
+
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_NORMAL);
+
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(-150, -150), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(gestures_listener->pressed_count == 0);
+
+		button->set_keep_pressed_outside(true);
+
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true);
+
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(-150, -150), MouseButtonMask::LEFT, Key::NONE);
+
+		CHECK(button->is_pressed() == true);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_PRESSED);
+
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(-150, -150), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(gestures_listener->pressed_count == 0);
+	}
+
+	button->disconnect("pressed", callable_mp(gestures_listener, &ButtonCompleteInteractionListener::on_pressed));
+	memdelete(gestures_listener);
+	root->remove_child(button);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] Notifications and System Lifecycle (_notification)") {
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Listener used to catch any unintended signal emission.
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+
+	SUBCASE("Cancellation by NOTIFICATION_DRAG_BEGIN and NOTIFICATION_SCROLL_BEGIN") {
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+
+		button->notification(Control::NOTIFICATION_DRAG_BEGIN);
+
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(listener->pressed_count == 0);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		button->notification(Control::NOTIFICATION_SCROLL_BEGIN);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(listener->pressed_count == 0);
+	}
+
+	SUBCASE("Losing keyboard/gamepad focus cancels the click in progress") {
+		button->grab_focus();
+
+		SEND_GUI_KEY_EVENT(Key::SPACE);
+
+		button->notification(Control::NOTIFICATION_FOCUS_EXIT);
+
+		SEND_GUI_KEY_UP_EVENT(Key::SPACE);
+
+		CHECK(listener->pressed_count == 0);
+	}
+
+	root->remove_child(button);
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] Dynamic Transition State Changes") {
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("toggled", callable_mp(listener, &ButtonCompleteInteractionListener::on_toggled));
+
+	SUBCASE("set_toggle_mode(false) clears retained presses") {
+		button->set_toggle_mode(true);
+
+		button->set_pressed_no_signal(true);
+		CHECK(button->is_pressed() == true);
+
+		button->set_toggle_mode(false);
+		CHECK(button->is_pressed() == false);
+	}
+
+	SUBCASE("set_button_group replaces and removes old references") {
+		Ref<ButtonGroup> group_a = memnew(ButtonGroup);
+		Ref<ButtonGroup> group_b = memnew(ButtonGroup);
+
+		button->set_button_group(group_a);
+		TypedArray<BaseButton> lista_a = group_a->_get_buttons();
+		CHECK(lista_a.size() == 1);
+
+		button->set_button_group(group_b);
+
+		TypedArray<BaseButton> lista_a_pos = group_a->_get_buttons();
+		TypedArray<BaseButton> lista_b_pos = group_b->_get_buttons();
+		CHECK(lista_a_pos.size() == 0);
+		CHECK(lista_b_pos.size() == 1);
+
+		// Remover passando nulo
+		button->set_button_group(Ref<ButtonGroup>());
+	}
+
+	root->remove_child(button);
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] Máscaras de Botão e Atalhos (Shortcut)") {
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+
+	SUBCASE("Button mask API and behavior") {
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(listener->pressed_count == 1);
+		listener->pressed_count = 0;
+
+		button->set_button_mask(MouseButtonMask::RIGHT);
+		CHECK(button->get_button_mask() == MouseButtonMask::RIGHT);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(listener->pressed_count == 0);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::RIGHT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(listener->pressed_count == 1);
+		listener->pressed_count = 0;
+
+		button->set_button_mask(MouseButtonMask::LEFT);
+		CHECK(button->get_button_mask() == MouseButtonMask::LEFT);
+
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(listener->pressed_count == 1);
+		listener->pressed_count = 0;
+
+		button->disconnect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+	}
+
+	SUBCASE("Shortcut association and in_shortcut_feedback validation") {
+		Ref<Shortcut> shortcut;
+		shortcut.instantiate();
+
+		Ref<InputEventKey> key_event;
+		key_event.instantiate();
+		key_event->set_keycode(Key::ENTER);
+
+		TypedArray<InputEvent> events;
+		events.append(key_event);
+		shortcut->set_events(events);
+
+		button->set_shortcut(shortcut);
+		CHECK(button->get_shortcut() == shortcut);
+
+		button->set_shortcut_feedback(false);
+		CHECK(button->is_shortcut_feedback() == false);
+
+		button->set_shortcut_in_tooltip(true);
+		CHECK(button->is_shortcut_in_tooltip_enabled() == true);
+
+		key_event->set_pressed(true);
+		_SEND_DISPLAYSERVER_EVENT(key_event);
+		MessageQueue::get_singleton()->flush();
+
+		CHECK(listener->pressed_count == 1);
+	}
+
+	root->remove_child(button);
+	memdelete(listener);
 	memdelete(button);
 }
 } // namespace TestButton

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -32,13 +32,14 @@
 
 TEST_FORCE_LINK(test_button)
 
+#include "core/object/callable_mp.h"
 #include "scene/gui/button.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 
 namespace TestButton {
-
+// Tests related to `BaseButton` using `Button` as a concrete implementation.
 TEST_CASE("[SceneTree][Button] is_hovered()") {
 	// Create new button instance.
 	Button *button = memnew(Button);
@@ -64,4 +65,389 @@ TEST_CASE("[SceneTree][Button] is_hovered()") {
 	memdelete(button);
 }
 
+TEST_CASE("[SceneTree][BaseButton] is_pressed()") {
+	// Create new button instance.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Set up button's size and position.
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+	SUBCASE("Mouse Not pressed") {
+		// Button should initially be not pressed.
+		CHECK(button->is_pressed() == false);
+	}
+
+	SUBCASE("Mouse Pressed") {
+		// Simulate mouse press on the button.
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true);
+	}
+
+	SUBCASE("Mouse Released") {
+		// Simulate mouse release on the button.
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == false);
+	}
+
+	memdelete(button);
+}
+
+// Utilitary class to listen to button pressed and toggled signals.
+class ButtonCompleteInteractionListener : public Object {
+	GDCLASS(ButtonCompleteInteractionListener, Object);
+
+public:
+	int pressed_count = 0;
+	int toggled_count = 0;
+	bool last_toggled_state = false;
+
+	void on_pressed() {
+		pressed_count++;
+	}
+
+	void on_toggled(bool p_state) {
+		toggled_count++;
+		last_toggled_state = p_state;
+	}
+};
+
+TEST_CASE("[SceneTree][BaseButton] Action Mode (Press vs Release)") {
+	// Button configuration.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Ensure mouse is over the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+	// Listener configuration.
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+	button->connect("toggled", callable_mp(listener, &ButtonCompleteInteractionListener::on_toggled));
+
+	SUBCASE("Default Action Mode: ACTION_MODE_BUTTON_RELEASE") {
+		// Ensure the default mode is to trigger on release.
+		CHECK(button->get_action_mode() == BaseButton::ACTION_MODE_BUTTON_RELEASE);
+
+		// Simulate pressing the button.
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true); // Button should be in pressed state immediately on press, regardless of action mode.
+		CHECK(listener->pressed_count == 0);
+		CHECK(listener->toggled_count == 0); // Should not emit toggle signal since toggle mode is off
+
+		// Simulate releasing the button.
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == false); // Button should return to not pressed state on release.
+		CHECK(listener->pressed_count == 1);
+		CHECK(listener->toggled_count == 0); // Should not emit toggled signal since toggle mode is off
+	}
+
+	SUBCASE("Modified Action Mode: ACTION_MODE_BUTTON_PRESS") {
+		// Change action mode to trigger on press instead of release.
+		button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+
+		// Simulate pressing the button.
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true); // Button should be in pressed state immediately on press.
+		CHECK(listener->pressed_count == 1);
+		CHECK(listener->toggled_count == 0); // Should not emit toggled signal since toggle mode is off
+
+		// Simulate releasing the button.
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == false); // Button should return to not pressed state on release.
+		CHECK(listener->pressed_count == 1); // Should not increment on release since we're in press mode.
+		CHECK(listener->toggled_count == 0); // Should not emit toggled signal since toggle mode is off
+	}
+
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] Toggle Mode") {
+	// Button configuration.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Listener configuration: connect to both pressed and toggled signals to verify their behavior in toggle mode.
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+	button->connect("toggled", callable_mp(listener, &ButtonCompleteInteractionListener::on_toggled));
+
+	// Ensure mouse is over the button.
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+	SUBCASE("Toggle Mode with Release Action Mode") {
+		button->set_toggle_mode(true);
+
+		// Mouse pressed
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == false); // With toggle mode on, is_pressed represents the toggled state, which should not change until the click is released.
+		CHECK(listener->pressed_count == 0); // Not emit until release
+		CHECK(listener->toggled_count == 0); // Not emit until release
+
+		// Mouse released
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == true); // Retain state
+		CHECK(listener->pressed_count == 1); // Emit on release
+		CHECK(listener->toggled_count == 1); // Emit on release
+		CHECK(listener->last_toggled_state == true);
+
+		// Mouse pressed again to untoggle
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(listener->pressed_count == 1); // Not emit until release
+		CHECK(listener->toggled_count == 1); // Not emit until release
+
+		// Mouse released
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == false); // Retain state
+		CHECK(listener->pressed_count == 2); // Emit on release
+		CHECK(listener->toggled_count == 2); // Emit on release
+		CHECK(listener->last_toggled_state == false);
+	}
+
+	SUBCASE("Toggle Mode with Press Action Mode") {
+		button->set_toggle_mode(true);
+		button->set_action_mode(BaseButton::ACTION_MODE_BUTTON_PRESS);
+
+		// Mouse pressed
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true); // With toggle mode on and action mode set to press, is_pressed should reflect the toggled state immediately on press.
+		CHECK(listener->pressed_count == 1); // Emit on press
+		CHECK(listener->toggled_count == 1); // Emit on press
+		CHECK(listener->last_toggled_state == true);
+
+		// Mouse released
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == true); // State should remain the same after release since it toggled on press.
+		CHECK(listener->pressed_count == 1); // Should not emit on release since we're in press mode.
+		CHECK(listener->toggled_count == 1); // Should not emit on release since we're in press mode.
+
+		// Mouse pressed again to untoggle
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == false); // Should toggle immediately on press.
+		CHECK(listener->pressed_count == 2); // Emit on press
+		CHECK(listener->toggled_count == 2); // Emit on press
+		CHECK(listener->last_toggled_state == false);
+
+		// Mouse released
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->is_pressed() == false); // State should remain the same after release since it toggled on press.
+		CHECK(listener->pressed_count == 2); // Should not emit on release since we're in press mode.
+		CHECK(listener->toggled_count == 2); // Should not emit on release since we're in press mode.
+	}
+
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] set_pressed_no_signal Behavior") {
+	// Button configuration.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+
+	// Listener configuration
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+	button->connect("toggled", callable_mp(listener, &ButtonCompleteInteractionListener::on_toggled));
+
+	SUBCASE("With toggle_mode = false (Should be ignored)") {
+		CHECK(button->is_toggle_mode() == false);
+
+		// Attempt to set the button as pressed using set_pressed_no_signal.
+		button->set_pressed_no_signal(true);
+
+		// Only works if toggle_mode is true
+		// The state should not change, and no signals should be emitted.
+		CHECK(button->is_pressed() == false);
+		CHECK(listener->pressed_count == 0);
+		CHECK(listener->toggled_count == 0);
+	}
+
+	SUBCASE("With toggle_mode = true (Changes state silently)") {
+		button->set_toggle_mode(true);
+
+		// Set as pressed using set_pressed_no_signal.
+		button->set_pressed_no_signal(true);
+
+		// The state should change to true
+		CHECK(button->is_pressed() == true);
+		// Signals should not be emitted.
+		CHECK(listener->pressed_count == 0);
+		CHECK(listener->toggled_count == 0);
+
+		// Set as not pressed using set_pressed_no_signal.
+		button->set_pressed_no_signal(false);
+
+		// The state should change to false
+		CHECK(button->is_pressed() == false);
+		// Signals should not be emitted.
+		CHECK(listener->pressed_count == 0);
+		CHECK(listener->toggled_count == 0);
+	}
+
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] Disabled State Behavior") {
+	// Button configuration.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	// Listener configuration
+	ButtonCompleteInteractionListener *listener = memnew(ButtonCompleteInteractionListener);
+	button->connect("pressed", callable_mp(listener, &ButtonCompleteInteractionListener::on_pressed));
+	button->connect("toggled", callable_mp(listener, &ButtonCompleteInteractionListener::on_toggled));
+
+	// Disable the button
+	button->set_disabled(true);
+
+	SUBCASE("Should ignore mouse hover") {
+		// Move the mouse over the button
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+		// Since it's disabled, it should not enter the hovered state
+		CHECK(button->is_hovered() == false);
+	}
+
+	SUBCASE("Should ignore mouse clicks and emit no signals") {
+		button->set_toggle_mode(true); // Ativa toggle só para garantir o teste mais rigoroso
+
+		// Move the mouse over the button and try to click
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+
+		// State should remain unchanged (not pressed) since the button is disabled
+		CHECK(button->is_pressed() == false);
+		// Simulate mouse release
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		// No signals should be emitted when interacting with a disabled button
+		CHECK(listener->pressed_count == 0);
+		CHECK(listener->toggled_count == 0);
+	}
+
+	SUBCASE("Re-enabling button restores normal behavior") {
+		// Re-enable the button
+		button->set_disabled(false);
+		CHECK(button->is_disabled() == false);
+
+		// Move the mouse over the button
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+		// Now it should enter the hovered state
+		CHECK(button->is_hovered() == true);
+
+		// Try clicking the button
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		CHECK(button->is_pressed() == true); // State should change to pressed since the button is now enabled
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		// Signals should be emitted as normal when the button is enabled
+		CHECK(listener->pressed_count == 1);
+	}
+
+	memdelete(listener);
+	memdelete(button);
+}
+
+TEST_CASE("[SceneTree][BaseButton] get_draw_mode() State Machine") {
+	// Button configuration.
+	Button *button = memnew(Button);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(button);
+	button->set_size(Size2i(50, 50));
+	button->set_position(Size2i(10, 10));
+
+	SUBCASE("DRAW_NORMAL State") {
+		// Initially, the button should be in the normal state.
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_NORMAL);
+	}
+
+	SUBCASE("DRAW_HOVER State") {
+		// Move the mouse over the button to trigger hover state.
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER);
+	}
+
+	SUBCASE("DRAW_PRESSED State with toggle_mode") {
+		// To test the pure DRAW_PRESSED state (without hover), the mouse needs to click
+		// and then move away from the button while holding the click (or using toggle_mode)
+		button->set_toggle_mode(true);
+
+		// Click and release on the button to activate the toggle
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		// Move the mouse away while the button is toggled (pressed)
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(150, 150), MouseButtonMask::NONE, Key::NONE);
+
+		// Now the button should be in the pressed state without hover
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_PRESSED);
+	}
+
+	SUBCASE("DRAW_PRESSED State without toggle_mode") {
+		// Click and hold on the button to trigger pressed state without toggle mode
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(100, 100), MouseButtonMask::NONE, Key::NONE);
+
+		// The button should be in the pressed state even if the mouse moves away while holding the click
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_PRESSED);
+
+		// Release the click to return to normal state
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(100, 100), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_NORMAL);
+	}
+	SUBCASE("DRAW_HOVER_PRESSED State with toggle_mode") {
+		button->set_toggle_mode(true);
+
+		// Click and release on the button to activate the toggle
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+
+		// Button should be in pressed + hovered state since it's toggled on and mouse is still over it
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER_PRESSED);
+	}
+
+	SUBCASE("DRAW_HOVER_PRESSED State without toggle_mode") {
+		// Click and hold on the button to trigger hover+pressed state without toggle mode
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+
+		// The button should be in the hover+pressed state while the click is held and mouse is over it
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER_PRESSED);
+
+		// Release the click to return to normal state
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER);
+	}
+
+	SUBCASE("DRAW_DISABLED State") {
+		// Disable the button to trigger the disabled state.
+		button->set_disabled(true);
+
+		// Move the mouse over the button to verify it remains in the disabled state.
+		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
+
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_DISABLED);
+	}
+
+	memdelete(button);
+}
 } // namespace TestButton

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -316,11 +316,11 @@ TEST_CASE("[SceneTree][BaseButton] Disabled State Behavior") {
 	// Disable the button
 	button->set_disabled(true);
 
-	SUBCASE("Should ignore mouse hover") {
+	SUBCASE("Should receive mouse hover") {
 		// Move the mouse over the button
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
 
-		// Since it's disabled, it should not enter the hovered state
+		// Even when disabled, the button should still detect hover state changes (but not pressed state).
 		CHECK(button->is_hovered() == false);
 	}
 
@@ -404,15 +404,15 @@ TEST_CASE("[SceneTree][BaseButton] get_draw_mode() State Machine") {
 		// Click and hold on the button to trigger pressed state without toggle mode
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
 		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(100, 100), MouseButtonMask::NONE, Key::NONE);
 
-		// The button should be in the pressed state even if the mouse moves away while holding the click
+		// The button should be
 		CHECK(button->get_draw_mode() == BaseButton::DRAW_PRESSED);
 
-		// Release the click to return to normal state
-		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(100, 100), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-		CHECK(button->get_draw_mode() == BaseButton::DRAW_NORMAL);
+		// Release the click to return to hover state
+		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER); // Should return to hover state since mouse is still over it
 	}
+
 	SUBCASE("DRAW_HOVER_PRESSED State with toggle_mode") {
 		button->set_toggle_mode(true);
 
@@ -423,19 +423,6 @@ TEST_CASE("[SceneTree][BaseButton] get_draw_mode() State Machine") {
 
 		// Button should be in pressed + hovered state since it's toggled on and mouse is still over it
 		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER_PRESSED);
-	}
-
-	SUBCASE("DRAW_HOVER_PRESSED State without toggle_mode") {
-		// Click and hold on the button to trigger hover+pressed state without toggle mode
-		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
-		SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-
-		// The button should be in the hover+pressed state while the click is held and mouse is over it
-		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER_PRESSED);
-
-		// Release the click to return to normal state
-		SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(25, 25), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-		CHECK(button->get_draw_mode() == BaseButton::DRAW_HOVER);
 	}
 
 	SUBCASE("DRAW_DISABLED State") {

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -321,7 +321,7 @@ TEST_CASE("[SceneTree][BaseButton] Disabled State Behavior") {
 		SEND_GUI_MOUSE_MOTION_EVENT(Point2i(25, 25), MouseButtonMask::NONE, Key::NONE);
 
 		// Even when disabled, the button should still detect hover state changes (but not pressed state).
-		CHECK(button->is_hovered() == false);
+		CHECK(button->is_hovered() == true);
 	}
 
 	SUBCASE("Should ignore mouse clicks and emit no signals") {


### PR DESCRIPTION
### Description
This Pull Request attends to issue #43440 implementing unit tests for `BaseButton` and `ButtonGroup` classes. These tests were developed using specification testing and then structural testing, using branch coverage and code analysis. 

### Changes Covered by New Tests

#### **`BaseButton` Core Interaction & State Machine**
* **Press/Release Mechanics:** Validated `is_pressed()` conditions and verified correct state behavior across both action modes (`ACTION_MODE_BUTTON_PRESS` vs `ACTION_MODE_BUTTON_RELEASE`).
* **Toggle System:** Tested toggle states under both press and release action modes, ensuring the `pressed` and `toggled` signals emit at precise, expected times.
* **Silent State Changes:** Verified that `set_pressed_no_signal()` updates the button state cleanly without triggering any signal listeners (and ensures it is ignored when `toggle_mode` is off).
* **Disabled State Guardrails:** Ensured disabled buttons still receive mouse hover events but strictly ignore input clicks and suppress signal emissions.
* **Draw Mode State Machine:** Covered all structural transitions for `get_draw_mode()` (`DRAW_NORMAL`, `DRAW_HOVER`, `DRAW_PRESSED`, `DRAW_HOVER_PRESSED`, and `DRAW_DISABLED`).

#### **Input Gestures & System Notifications**
* **Touch & Drag Input:** Emulated touch workflows (`InputEventScreenTouch`, `InputEventScreenDrag`) along with mouse motion events to validate complex pointer interactions under varying `keep_pressed_outside` conditions.
* **Notification Lifecycle:** Tested click cancellation mechanisms via standard GUI notifications such as `NOTIFICATION_DRAG_BEGIN`, `NOTIFICATION_SCROLL_BEGIN`, and focus loss (`NOTIFICATION_FOCUS_EXIT`).
* **Masks & Shortcuts:** Validated custom mouse button masks (`MouseButtonMask`) and tested automatic trigger responses mapped via `Shortcut` associations.

#### **`ButtonGroup` Mechanics & Lifecycle**
* **Mutual Exclusion:** Validated radio-button style exclusion behaviors and the `allow_unpress` property configuration.
* **Exposed Bindings:** Added validations for exposed list methods (`get_buttons` internally and `_get_buttons` exposed to GDScript).
* **Safe Cleanup:** Guaranteed that buttons are automatically and safely removed from their assigned `ButtonGroup` when destroyed in memory.

---

### Core Files Involved
* `tests/scene/test_button.cpp`
* `tests/scene/test_button.h`

### Results of the coverage report in `base_button.cpp`
| Branch | Line Coverage percentage | Line Coverage | Branches percentage| Branches |
| :--- | :--- | :--- | :--- | :--- |
| Master branch | 42.1 % | 182 / 432 | 17.8 % | 56 / 314 | 
| This branch | 79.5 % | 348 / 438 | 57.5 % | 214 / 372 | 

