### PR TITLE
Fix incorrect debugger line for errors with the loop variable

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -180,7 +180,6 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	int oc = 0;
 	HashMap<StringName, _GDFKC> sdmap;
 	for (const StackDebug &sd : stack_debug) {
-
 		if (sd.added) {
 			if (sd.line > p_line) {
 				// Stack debug member added on a line later than the paused line.

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -180,11 +180,12 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	int oc = 0;
 	HashMap<StringName, _GDFKC> sdmap;
 	for (const StackDebug &sd : stack_debug) {
-		if (sd.line >= p_line) {
-			break;
-		}
 
 		if (sd.added) {
+			if (sd.line > p_line) {
+				// Stack debug member added on a line later than the paused line.
+				break;
+			}
 			if (!sdmap.has(sd.identifier)) {
 				_GDFKC d;
 				d.order = oc++;
@@ -195,6 +196,10 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 				sdmap[sd.identifier].pos.push_back(sd.pos);
 			}
 		} else {
+			if (sd.line >= p_line) {
+				// Stack debug member removed on a line later than the paused line.
+				break;
+			}
 			ERR_CONTINUE(!sdmap.has(sd.identifier));
 
 			sdmap[sd.identifier].pos.pop_back();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120993 

## Additional information

This should be merged before #120821. That PR exposes a bug with `GDScriptFunction::debug_get_stack_member_state()` that is otherwise not visible: Local members of the for-loop block are not shown if the debugger pauses on the line of the for-header.
~Github Actions CI unit tests are failing yet when I run the tests locally they are all passing. I need to review what is going on.~ **Edit:** the CI unit tests are now passing, not sure what was the problem there.


#### AI disclosure
* I used genAI to discover `debug_get_stack_member_state` and suggest how to update this
* I used genAI for the creation of the example project to test all cases where `debug_get_stack_member_state` might change the list of members due to changes in its code
* [Link to the full chat conversation history](https://claude.ai/share/a0eb38d4-b2bb-447e-bfd7-b607ad35f9cc)

Here is a test project with many breakpoints to see how the debugger treats local variables [breakpoints.zip](https://github.com/user-attachments/files/29716199/breakpoints.zip)