### PR TITLE
🤖 Windows: Extract PE_SIGNATURE constant from duplicated magic number

### DIFF
--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -37,6 +37,7 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
+#include "platform/windows/windows_utils.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
 
@@ -190,7 +191,7 @@ int64_t get_image_base(const String &p_path) {
 
 		f->seek(pe_pos);
 		uint32_t magic = f->get_32();
-		if (magic != 0x00004550) {
+		if (magic != PE_SIGNATURE) {
 			return 0;
 		}
 	}

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -49,6 +49,8 @@
 
 #include "modules/svg/image_loader_svg.h"
 
+#include "platform/windows/windows_utils.h"
+
 #ifdef WINDOWS_ENABLED
 #include "shlobj.h"
 
@@ -784,7 +786,7 @@ String EditorExportPlatformWindows::_get_exe_arch(const String &p_path) const {
 
 		f->seek(pe_pos);
 		uint32_t magic = f->get_32();
-		if (magic != 0x00004550) {
+		if (magic != PE_SIGNATURE) {
 			return "invalid";
 		}
 	}
@@ -829,7 +831,7 @@ Error EditorExportPlatformWindows::fixup_embedded_pck(const String &p_path, int6
 
 		f->seek(pe_pos);
 		uint32_t magic = f->get_32();
-		if (magic != 0x00004550) {
+		if (magic != PE_SIGNATURE) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("PCK Embedding"), TTR("Executable file header corrupted."));
 			return ERR_FILE_CORRUPT;
 		}

--- a/platform/windows/export/template_modifier.cpp
+++ b/platform/windows/export/template_modifier.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
 #include "editor/export/editor_export_preset.h"
+#include "platform/windows/windows_utils.h"
 
 void TemplateModifier::ByteStream::save(uint8_t p_value, Vector<uint8_t> &r_bytes) const {
 	save(p_value, r_bytes, 1);
@@ -347,7 +348,7 @@ uint32_t TemplateModifier::_get_pe_header_offset(Ref<FileAccess> p_executable) c
 	p_executable->seek(pe_header_offset);
 	uint32_t magic = p_executable->get_32();
 
-	return magic == 0x00004550 ? pe_header_offset : 0;
+	return magic == PE_SIGNATURE ? pe_header_offset : 0;
 }
 
 uint32_t TemplateModifier::_snap(uint32_t p_value, uint32_t p_size) const {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2386,7 +2386,7 @@ uint64_t OS_Windows::get_embedded_pck_offset() const {
 
 		f->seek(pe_pos);
 		uint32_t magic = f->get_32();
-		if (magic != 0x00004550) {
+		if (magic != PE_SIGNATURE) {
 			return 0;
 		}
 	}

--- a/platform/windows/windows_utils.h
+++ b/platform/windows/windows_utils.h
@@ -30,6 +30,12 @@
 
 #pragma once
 
+#include <cstdint>
+
+// PE (Portable Executable) file format constants.
+// Used both by the Windows platform code and by the (cross-platform) Windows export plugin.
+constexpr uint32_t PE_SIGNATURE = 0x00004550; // "PE\0\0"
+
 #ifdef WINDOWS_ENABLED
 
 #include "core/string/ustring.h"


### PR DESCRIPTION
The raw PE header magic number 0x00004550 was duplicated across five call sites in Windows platform and export code. Centralize it as PE_SIGNATURE in windows_utils.h so future PE-parsing code has one source of truth.

> [!INFO] AI disclosure: This contribution was authored by an autonomous AI agent, on behalf of a user, to remove duplicated PE format magic numbers.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
