### PR TITLE
Disable sticky header in `Skeleton3D` joint tree

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1202,6 +1202,7 @@ void Skeleton3DEditor::create_editors() {
 	joint_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	joint_tree->set_h_size_flags(SIZE_EXPAND_FILL);
 	joint_tree->set_allow_rmb_select(true);
+	joint_tree->add_theme_constant_override("scroll_max_sticky_items", 0);
 	joint_tree->set_theme_type_variation("TreeSecondary");
 	SET_DRAG_FORWARDING_GCD(joint_tree, Skeleton3DEditor);
 	s_con->add_child(joint_tree);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120991

## Additional information

As discussed on RC, in the joint tree sticky header is a net negative for now because:

1. Skeletons have much more nesting than most other hierarchies and you're almost guaranteed to hit max default sticky item count in them
2. It's a pretty small tree in inspector and sticky header takes too much space from its useful scrollable area

This can be revisited in the future if anything changes either in the sticky item implementation or in the skeleton editor ui, but for now it makes sense to disable it there