### PR TITLE
Don't multiply FileDialog size by theme scale

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -53,7 +53,7 @@
 #include "servers/display/display_server.h"
 
 void FileDialog::popup_file_dialog() {
-	popup_centered_clamped(Vector2(1050, 700) * get_theme_default_base_scale(), 0.8f);
+	popup_centered_clamped(Vector2(1050, 700), 0.8f);
 	_focus_file_text();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When editor scale is bigger than 100%, the EditorFileDialog appears too big. Turns out the scale is already applied somewhere internally, so adding it on popup is wrong.

## Additional information

The dialog seems to appear with correct size now, but it might need more testing.