### PR TITLE
DisplayServer: Bind default value for new parameter in display cutouts/safe area methods

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -857,7 +857,7 @@
 		</method>
 		<method name="get_display_cutouts" qualifiers="const">
 			<return type="Rect2[]" />
-			<param index="0" name="screen" type="int" />
+			<param index="0" name="screen" type="int" default="-1" />
 			<description>
 				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
 				[b]Note:[/b] The returned rectangles are relative to the physical screen and not the virtual desktop.
@@ -867,7 +867,7 @@
 		</method>
 		<method name="get_display_safe_area" qualifiers="const">
 			<return type="Rect2i" />
-			<param index="0" name="screen" type="int" />
+			<param index="0" name="screen" type="int" default="-1" />
 			<description>
 				Returns the unobscured area of the display where interactive controls should be rendered. See also [method get_display_cutouts].
 				[b]Note:[/b] The returned rectangle is relative to the physical screen and not the virtual desktop.

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1462,8 +1462,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clipboard_set_primary", "clipboard_primary"), &DisplayServer::clipboard_set_primary);
 	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);
 
-	ClassDB::bind_method(D_METHOD("get_display_cutouts", "screen"), &DisplayServer::get_display_cutouts);
-	ClassDB::bind_method(D_METHOD("get_display_safe_area", "screen"), &DisplayServer::get_display_safe_area);
+	ClassDB::bind_method(D_METHOD("get_display_cutouts", "screen"), &DisplayServer::get_display_cutouts, DEFVAL(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("get_display_safe_area", "screen"), &DisplayServer::get_display_safe_area, DEFVAL(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW));
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("get_primary_screen"), &DisplayServer::get_primary_screen);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes unintentional compat breakage from #119196 which forgot to bind the default values for the `screen` parameter.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/120997*