### PR TITLE
Fix regression with `_update_layout()` breaking plugins

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -50,14 +50,25 @@
 				Implement this method to handle saving this dock's layout. It's equivalent to [method EditorPlugin._get_window_layout]. [param section] is a unique section based on [member layout_key].
 			</description>
 		</method>
-		<method name="_update_layout" qualifiers="virtual">
+		<method name="_update_layout" qualifiers="virtual" deprecated="Use [method _update_layout_and_slot] instead.">
+			<return type="void" />
+			<param index="0" name="layout" type="int" />
+			<description>
+				Implement this method to handle the layout switching for this dock. [param layout] is one of the [enum DockLayout] constants.
+				[codeblock]
+				func _update_layout(layout):
+					box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
+				[/codeblock]
+			</description>
+		</method>
+		<method name="_update_layout_and_slot" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="layout" type="int" />
 			<param index="1" name="slot" type="int" />
 			<description>
 				Implement this method to handle the layout/slot switching for this dock. [param layout] is one of the [enum DockLayout] constants, and [param slot] is one of the [enum DockSlot] ones.
 				[codeblock]
-				func _update_layout(layout, slot):
+				func _update_layout_and_slot(layout, slot):
 					box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
 				[/codeblock]
 			</description>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -143,12 +143,12 @@ void EditorDock::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOCK_SLOT_BOTTOM_R);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 
-	GDVIRTUAL_BIND(_update_layout, "layout", "slot");
+	GDVIRTUAL_BIND(_update_layout_and_slot, "layout", "slot");
 	GDVIRTUAL_BIND(_save_layout_to_config, "config", "section");
 	GDVIRTUAL_BIND(_load_layout_from_config, "config", "section");
 
 #ifndef DISABLE_DEPRECATED
-	GDVIRTUAL_BIND_COMPAT(_update_layout_bind_compat_117080, "layout");
+	GDVIRTUAL_BIND(_update_layout, "layout");
 #endif
 }
 
@@ -330,6 +330,16 @@ Ref<Texture2D> EditorDock::get_effective_icon(const Callable &p_icon_fetch) {
 		icon = p_icon_fetch.call(icon_name);
 	}
 	return icon;
+}
+
+void EditorDock::update_layout(DockLayout p_layout, int p_slot) {
+	if (GDVIRTUAL_CALL(_update_layout_and_slot, p_layout, p_slot)) {
+		return;
+	}
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_CALL(_update_layout, p_layout);
+#endif
 }
 
 EditorDock::EditorDock() {

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -103,12 +103,12 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	GDVIRTUAL2(_update_layout, int, int)
+	GDVIRTUAL2(_update_layout_and_slot, int, int)
 	GDVIRTUAL2C(_save_layout_to_config, Ref<ConfigFile>, const String &)
 	GDVIRTUAL2(_load_layout_from_config, Ref<ConfigFile>, const String &)
 
 #ifndef DISABLE_DEPRECATED
-	GDVIRTUAL1_COMPAT(_update_layout_bind_compat_117080, _update_layout, int)
+	GDVIRTUAL1(_update_layout, int)
 #endif
 
 public:
@@ -161,7 +161,7 @@ public:
 	void update_tab_style();
 	Ref<Texture2D> get_effective_icon(const Callable &p_icon_fetch);
 
-	virtual void update_layout(DockLayout p_layout, int p_slot) { GDVIRTUAL_CALL(_update_layout, p_layout, p_slot); }
+	virtual void update_layout(DockLayout p_layout, int p_slot);
 	DockLayout get_current_layout() const { return current_layout; }
 	DockSlot get_current_slot() const { return (DockSlot)dock_slot_index; }
 

--- a/misc/extension_api_validation/4.7-stable/GH-117080.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-117080.txt
@@ -1,5 +1,0 @@
-GH-117080
----------
-Validate extension JSON: Error: Field 'classes/EditorDock/methods/_update_layout/arguments': size changed value in new API, from 1 to 2.
-
-Add an extra argument for the slot. Compatibility method registered.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Addresses https://github.com/godotengine/godot/pull/117080#issuecomment-4894319802.

## Additional information

GDScript doesn't handle compatibility methods for virtuals, which means that the change adding an extra argument to `EditorDock._update_layout()` broke plugins that relied on the original single-argument version.

This PR creates a new virtual called `_update_layout_and_slot()`, which contains both arguments, while also removing the extra one in `_update_layout()` and marking it as deprecated.

Another way of solving this would be to add virtual compatibility support to GDScript, but that's an area I almost never touched, so I would rather leave that to someone else (which I would eternally thank if they did! :slightly_smiling_face:).