### PR TITLE
Fix `TextEdit` max scroll when size isn't an integer

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -9255,7 +9255,7 @@ void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 	}
 
 	if (smooth_scroll_enabled) {
-		int max_v_scroll = std::round(v_scroll->get_max() - v_scroll->get_page());
+		double max_v_scroll = v_scroll->get_max() - v_scroll->get_page();
 		if (target_v_scroll > max_v_scroll) {
 			target_v_scroll = max_v_scroll;
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121008 

## Additional information

There's no reason for it to be rounded to an integer, the renderer does that internally.

This chunk of code may seem similar, but from what I understand the conversion is intentional:
https://github.com/godotengine/godot/blob/f5af32893ba3774235b5d3c570d8433d079a4b82/scene/gui/text_edit.cpp#L6916-L6921
