### PR TITLE
Fix `ItemList` items showing focus when they shouldn't 

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1550,7 +1550,7 @@ void ItemList::_notification(int p_what) {
 				bool is_hovered = (hovered == i);
 				bool is_selected = items[i].selected;
 				bool is_disabled = items[i].disabled;
-				bool is_focused = has_focus();
+				bool is_focused = has_focus(true);
 
 				if (is_disabled) {
 					if (is_hovered) {


### PR DESCRIPTION
An oversight revealed by #109352 showed that ~the styling for hovered focused items for `ItemList` wasn't set up correctly in the modern theme~ `ItemList` was missing a focus hide check. This PR fixes that.