### PR TITLE
Move physics shapes to protected for subclassing with custom physics shapes

### DIFF
--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -55,6 +55,7 @@ class GodotPhysicsServer3D : public PhysicsServer3D {
 	GodotStep3D *stepper = nullptr;
 	HashSet<GodotSpace3D *> active_spaces;
 
+protected:
 	mutable RID_PtrOwner<GodotShape3D, true> shape_owner;
 	mutable RID_PtrOwner<GodotSpace3D, true> space_owner;
 	mutable RID_PtrOwner<GodotArea3D, true> area_owner;
@@ -62,6 +63,7 @@ class GodotPhysicsServer3D : public PhysicsServer3D {
 	mutable RID_PtrOwner<GodotSoftBody3D, true> soft_body_owner;
 	mutable RID_PtrOwner<GodotJoint3D, true> joint_owner;
 
+private:
 	//void _clear_query(QuerySW *p_query);
 	friend class GodotCollisionObject3D;
 	SelfList<GodotCollisionObject3D>::List pending_shape_update_list;


### PR DESCRIPTION
## What problem(s) does this PR solve?

These variables being private prevents developers from being able to properly extend the physics engine with new physics types. Making them protected allows us to extend them instead of having to write our own physics server for things like implementing physics for things like SVO worlds.

## Additional information

If these are protected intentionally, I'd be curious why or whether there's a better way to implement custom physics? From my reading of the code so far, I think this may have been done defensively.

AI was used for the commit message and building/testing the engine.

Thanks!