### PR TITLE
Fix `Path3DGizmo::redraw()` using hardcoded interval instead of `bake_interval`, improving performance

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -362,7 +362,7 @@ void Path3DGizmo::redraw() {
 		debug_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 	}
 
-	real_t interval = 0.1;
+	real_t interval = c->get_bake_interval();
 	const real_t length = c->get_baked_length();
 
 	// 1. Draw curve and bones if it is visible (alpha > 0.0).


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Partially fixes https://github.com/godotengine/godot/issues/81707

The current implementation of `Path3DGizmo::redraw()` uses an arbitrary, hardcoded value of `0.1` for the curve sampling interval:
```
real_t interval = 0.1;
```
For very long curves, this means that an extreme number of tiny curve segments are generated, causing heavy stuttering in the editor. This simple one-line fix changes it to instead use the `bake_interval` property of the embedded `Curve3D`, significantly improving performance:
```
real_t interval = c->get_bake_interval();
```


## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
### Related Issues and Pull Requests
- https://github.com/godotengine/godot/issues/81707
- https://github.com/godotengine/godot/pull/90357
- https://github.com/godotengine/godot-proposals/issues/9459

### Limitations
Unlike the more complex Pull Request in the second bullet point, this PR does not add a separate preview resolution. As such, this change does not improve performance for `Curve3D`s which need to be long while also keeping a small `bake_interval` like `0.1`. This makes it a partial fix of the issue.

### Demo
https://github.com/user-attachments/assets/6f96e9d1-276e-4d27-9e7c-0d1e616964b3

### Minimal Reproduction Project
- [path-3d-interval-demo.zip](https://github.com/user-attachments/files/29723558/path-3d-interval-demo.zip)

Open the project and its `main.tscn`. Zoom out until the whole `Path3D` is visible. Try editing its points, observe performance before and after the change.

