### PR TITLE
Fix `character_body_2d.cpp` compilation with `deprecated=no`

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "servers/physics_2d/direct_states/physics_direct_body_state_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 
 #ifndef DISABLE_DEPRECATED
 #include "servers/physics_2d/physics_server_2d_extension.h"


### PR DESCRIPTION
In `character_body_2d.cpp`, there is code whose compilation is controlled by `DISABLE_DEPRECATED`, including
```cpp
#ifndef DISABLE_DEPRECATED
#include "servers/physics_2d/physics_server_2d_extension.h"
#endif
```
When compiling with the `deprecated=no` option, `physics_server_2d.h`—which is indirectly included by that header—is also excluded; consequently, any code accessing `PhysicsServer2D` results in a compilation error(`name followed by '::' must be a class or namespace name`).
<img width="1128" height="129" alt="image" src="https://github.com/user-attachments/assets/e0a54e7d-5b08-4e10-a385-9422c1b8b0b7" />