### PR TITLE
Close all docks when entering distraction free mode while the game tab is selected

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -665,6 +665,15 @@ void EditorDockManager::close_dock(EditorDock *p_dock) {
 	_update_layout();
 }
 
+void EditorDockManager::close_docks_by_slot(EditorDock::DockSlot slot) {
+	for (size_t i = 0; i < all_docks.size(); i++) {
+		EditorDock *dock = all_docks[i];
+		if (dock->get_current_slot() == slot && dock->is_visible()) {
+			dock->hide();
+		}
+	}
+}
+
 void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 	ERR_FAIL_NULL(p_dock);
 	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot open unknown dock '%s'.", p_dock->get_display_title()));

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -152,6 +152,7 @@ public:
 
 	void set_dock_enabled(EditorDock *p_dock, bool p_enabled);
 	void close_dock(EditorDock *p_dock);
+	void close_docks_by_slot(EditorDock::DockSlot slot);
 	void open_dock(EditorDock *p_dock, bool p_set_current = true);
 	void focus_dock(EditorDock *p_dock);
 	void make_dock_floating(EditorDock *p_dock);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6918,6 +6918,10 @@ void EditorNode::set_distraction_free_mode(bool p_enter) {
 		if (editor_dock_manager->are_docks_visible()) {
 			editor_dock_manager->set_docks_visible(false);
 		}
+
+		if (editor_main_screen->get_selected_index() == EditorMainScreen::EDITOR_GAME) {
+			editor_dock_manager->close_docks_by_slot(EditorDock::DOCK_SLOT_BOTTOM);
+		}
 	} else {
 		editor_dock_manager->set_docks_visible(true);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This PR forces all bottom docks down when you're on the game tab. This helps in case you wish to get the maximum space when testing your game without having to manually pull down the console which was automatically pulled up when you started playing.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->