### PR TITLE
Bump macOS min. version to 11.0 (Intel) / 13.0 (ARM) and iOS min. version to 15.0

### DIFF
--- a/drivers/apple_embedded/godot_app_delegate.mm
+++ b/drivers/apple_embedded/godot_app_delegate.mm
@@ -509,7 +509,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 
 // MARK: SiriKit
 
-- (id)application:(UIApplication *)application handlerForIntent:(INIntent *)intent API_AVAILABLE(ios(14.0)) {
+- (id)application:(UIApplication *)application handlerForIntent:(INIntent *)intent {
 	for (GDTAppDelegateServiceProtocol *service in services) {
 		if (![service respondsToSelector:_cmd]) {
 			continue;

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -127,7 +127,7 @@ Error AudioDriverCoreAudio::init() {
 	AudioDeviceID device_id;
 	UInt32 dev_id_size = sizeof(AudioDeviceID);
 
-	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster };
+	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain };
 	result = AudioObjectGetPropertyData(kAudioObjectSystemObject, &property_dev_id, 0, nullptr, &dev_id_size, &device_id);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 

--- a/misc/dist/macos_tools.app/Contents/Info.plist
+++ b/misc/dist/macos_tools.app/Contents/Info.plist
@@ -50,9 +50,9 @@
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>arm64</key>
-		<string>11.0</string>
+		<string>13.0</string>
 		<key>x86_64</key>
-		<string>10.12</string>
+		<string>11.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -385,32 +385,27 @@ bool CameraFeedApple::activate_feed() {
 	}
 
 	// Start camera capture, check permission.
-	if (@available(macOS 10.14, iOS 14.0, visionOS 1.0, *)) {
-		AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-		if (status == AVAuthorizationStatusAuthorized) {
-			capture_session = [[MyCaptureSession alloc] initForFeed:this andDevice:device];
-			return capture_session != nullptr;
-		} else if (status == AVAuthorizationStatusNotDetermined) {
-			// Request permission asynchronously.
-			[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
-									 completionHandler:^(BOOL granted) {
-										 if (granted) {
-											 capture_session = [[MyCaptureSession alloc] initForFeed:this andDevice:device];
-										 }
-									 }];
-			return false;
-		} else if (status == AVAuthorizationStatusDenied) {
-			print_line("Camera permission denied by user.");
-			return false;
-		} else if (status == AVAuthorizationStatusRestricted) {
-			print_line("Camera access restricted.");
-			return false;
-		}
-		return false;
-	} else {
+	AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+	if (status == AVAuthorizationStatusAuthorized) {
 		capture_session = [[MyCaptureSession alloc] initForFeed:this andDevice:device];
 		return capture_session != nullptr;
+	} else if (status == AVAuthorizationStatusNotDetermined) {
+		// Request permission asynchronously.
+		[AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+								 completionHandler:^(BOOL granted) {
+									 if (granted) {
+										 capture_session = [[MyCaptureSession alloc] initForFeed:this andDevice:device];
+									 }
+								 }];
+		return false;
+	} else if (status == AVAuthorizationStatusDenied) {
+		print_line("Camera permission denied by user.");
+		return false;
+	} else if (status == AVAuthorizationStatusRestricted) {
+		print_line("Camera access restricted.");
+		return false;
 	}
+	return false;
 }
 
 void CameraFeedApple::deactivate_feed() {
@@ -484,21 +479,13 @@ void CameraApple::update_feeds() {
 		devices = session.devices;
 	}
 #else // APPLE_EMBEDDED_ENABLED
-#if defined(__x86_64__)
-	if (@available(macOS 10.15, *)) {
-#endif // __x86_64__
-		AVCaptureDeviceDiscoverySession *session;
-		if (@available(macOS 14.0, *)) {
-			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-		} else {
-			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-		}
-		devices = session.devices;
-#if defined(__x86_64__)
+	AVCaptureDeviceDiscoverySession *session;
+	if (@available(macOS 14.0, *)) {
+		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 	} else {
-		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 	}
-#endif // __x86_64__
+	devices = session.devices;
 #endif // APPLE_EMBEDDED_ENABLED
 
 	// Deactivate feeds that are gone before removing them.

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -103,14 +103,14 @@ def configure(env: "SConsEnvironment"):
 
     if env["simulator"]:
         env["APPLE_PLATFORM"] = "iossimulator"
-        env.Append(ASFLAGS=["-mios-simulator-version-min=14.0"])
-        env.Append(CCFLAGS=["-mios-simulator-version-min=14.0"])
+        env.Append(ASFLAGS=["-mios-simulator-version-min=15.0"])
+        env.Append(CCFLAGS=["-mios-simulator-version-min=15.0"])
         env.Append(CPPDEFINES=["IOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         env["APPLE_PLATFORM"] = "ios"
-        env.Append(ASFLAGS=["-miphoneos-version-min=14.0"])
-        env.Append(CCFLAGS=["-miphoneos-version-min=14.0"])
+        env.Append(ASFLAGS=["-miphoneos-version-min=15.0"])
+        env.Append(CCFLAGS=["-miphoneos-version-min=15.0"])
     detect_darwin_sdk_path(env["APPLE_PLATFORM"], env)
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
@@ -120,7 +120,7 @@ def configure(env: "SConsEnvironment"):
             print_error("Building for iOS with 'arch=x86_64' requires 'simulator=yes'.")
             sys.exit(255)
 
-        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
+        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
         env.Append(
             CCFLAGS=(
                 "-fobjc-arc -arch x86_64"

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -41,7 +41,7 @@ class EditorExportPlatformIOS : public EditorExportPlatformAppleEmbedded {
 	virtual String get_sdk_name() const override { return "iphoneos"; }
 	virtual const Vector<String> get_device_types() const override { return device_types; }
 
-	virtual String get_minimum_deployment_target() const override { return "14.0"; }
+	virtual String get_minimum_deployment_target() const override { return "15.0"; }
 
 	virtual Vector<IconInfo> get_icon_infos() const override;
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -105,15 +105,15 @@ def configure(env: "SConsEnvironment"):
 
     # CPU architecture.
     if env["arch"] == "arm64":
-        print("Building for macOS 11.0+.")
-        env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
-        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
-        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
+        print("Building for macOS 13.0+.")
+        env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=13.0"])
+        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=13.0"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=13.0"])
     elif env["arch"] == "x86_64":
-        print("Building for macOS 10.13+.")
-        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
-        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
-        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+        print("Building for macOS 11.0+.")
+        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
     env.Append(CCFLAGS=["-fobjc-arc", "-fvisibility=hidden"])

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2969,13 +2969,8 @@ void DisplayServerMacOS::window_get_edr_values(DisplayServerEnums::WindowID p_wi
 		*v = val; \
 	}
 
-	if (@available(macOS 10.15, *)) {
-		SET_VAL(r_max_potential_edr_value, screen.maximumPotentialExtendedDynamicRangeColorComponentValue);
-		SET_VAL(r_max_edr_value, screen.maximumExtendedDynamicRangeColorComponentValue);
-	} else {
-		SET_VAL(r_max_potential_edr_value, 1.0);
-		SET_VAL(r_max_edr_value, 1.0);
-	}
+	SET_VAL(r_max_potential_edr_value, screen.maximumPotentialExtendedDynamicRangeColorComponentValue);
+	SET_VAL(r_max_edr_value, screen.maximumExtendedDynamicRangeColorComponentValue);
 
 #undef SET_VAL
 }

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -378,76 +378,46 @@ void DisplayServerMacOSBase::show_emoji_and_symbol_picker() const {
 }
 
 bool DisplayServerMacOSBase::is_dark_mode_supported() const {
-	if (@available(macOS 10.14, *)) {
-		return true;
-	} else {
-		return false;
-	}
+	return true;
 }
 
 bool DisplayServerMacOSBase::is_dark_mode() const {
-	if (@available(macOS 10.14, *)) {
-		if (![[NSUserDefaults standardUserDefaults] objectForKey:@"AppleInterfaceStyle"]) {
-			return false;
-		} else {
-			return ([[[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"] isEqual:@"Dark"]);
-		}
-	} else {
+	if (![[NSUserDefaults standardUserDefaults] objectForKey:@"AppleInterfaceStyle"]) {
 		return false;
+	} else {
+		return ([[[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"] isEqual:@"Dark"]);
 	}
 }
 
 Color DisplayServerMacOSBase::get_accent_color() const {
-	if (@available(macOS 10.14, *)) {
-		__block NSColor *color = nullptr;
-		if (@available(macOS 11.0, *)) {
-			[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
-				color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			}];
-			if (!color) {
-				color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			}
-		} else {
-			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
-			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
-			color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			[NSAppearance setCurrentAppearance:saved_appearance];
-		}
-		if (color) {
-			CGFloat components[4];
-			[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
-			return Color(components[0], components[1], components[2], components[3]);
-		} else {
-			return Color(0, 0, 0, 0);
-		}
+	__block NSColor *color = nullptr;
+	[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
+		color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+	}];
+	if (!color) {
+		color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+	}
+	if (color) {
+		CGFloat components[4];
+		[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+		return Color(components[0], components[1], components[2], components[3]);
 	} else {
 		return Color(0, 0, 0, 0);
 	}
 }
 
 Color DisplayServerMacOSBase::get_base_color() const {
-	if (@available(macOS 10.14, *)) {
-		__block NSColor *color = nullptr;
-		if (@available(macOS 11.0, *)) {
-			[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
-				color = [[NSColor windowBackgroundColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			}];
-			if (!color) {
-				color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			}
-		} else {
-			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
-			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
-			color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-			[NSAppearance setCurrentAppearance:saved_appearance];
-		}
-		if (color) {
-			CGFloat components[4];
-			[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
-			return Color(components[0], components[1], components[2], components[3]);
-		} else {
-			return Color(0, 0, 0, 0);
-		}
+	__block NSColor *color = nullptr;
+	[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
+		color = [[NSColor windowBackgroundColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+	}];
+	if (!color) {
+		color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+	}
+	if (color) {
+		CGFloat components[4];
+		[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+		return Color(components[0], components[1], components[2], components[3]);
 	} else {
 		return Color(0, 0, 0, 0);
 	}

--- a/platform/macos/display_server_macos_embedded.mm
+++ b/platform/macos/display_server_macos_embedded.mm
@@ -716,13 +716,8 @@ void DisplayServerMacOSEmbedded::window_get_edr_values(DisplayServerEnums::Windo
 		*v = val; \
 	}
 
-	if (@available(macOS 10.15, *)) {
-		SET_VAL(r_max_potential_edr_value, state.screen_max_edr);
-		SET_VAL(r_max_edr_value, state.screen_max_potential_edr);
-	} else {
-		SET_VAL(r_max_potential_edr_value, 1.0);
-		SET_VAL(r_max_edr_value, 1.0);
-	}
+	SET_VAL(r_max_potential_edr_value, state.screen_max_edr);
+	SET_VAL(r_max_edr_value, state.screen_max_potential_edr);
 
 #undef SET_VAL
 }

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -490,8 +490,8 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version", PROPERTY_HINT_PLACEHOLDER_TEXT, "Leave empty to use project version"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "application/copyright_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "10.12"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_arm64"), "11.00"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "11.00"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_arm64"), "13.00"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_angle", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), true));
 

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -70,9 +70,7 @@
 		int default_idx = item["default"];
 
 		NSTextField *label = [NSTextField labelWithString:[NSString stringWithUTF8String:name.utf8().get_data()]];
-		if (@available(macOS 10.14, *)) {
-			label.textColor = NSColor.secondaryLabelColor;
-		}
+		label.textColor = NSColor.secondaryLabelColor;
 		if (@available(macOS 11.10, *)) {
 			label.font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
 		}
@@ -107,9 +105,7 @@
 	bool has_type_popup = false;
 	{
 		NSTextField *label = [NSTextField labelWithString:[NSString stringWithUTF8String:RTR("Format").utf8().get_data()]];
-		if (@available(macOS 10.14, *)) {
-			label.textColor = NSColor.secondaryLabelColor;
-		}
+		label.textColor = NSColor.secondaryLabelColor;
 		if (@available(macOS 11.10, *)) {
 			label.font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
 		}
@@ -128,33 +124,26 @@
 					for (int j = 0; j < filter_slice_count; j++) {
 						String str = (flt.get_slicec(',', j).strip_edges());
 						if (!str.is_empty()) {
-							if (@available(macOS 11, *)) {
-								UTType *ut = nullptr;
-								if (str == "*.*") {
-									ut = UTTypeData;
-								} else {
-									ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
-								}
-								if (ut) {
-									[type_filters addObject:ut];
-									pref_type.push_back(str.replace("*.", "").strip_edges());
-								}
+							UTType *ut = nullptr;
+							if (str == "*.*") {
+								ut = UTTypeData;
 							} else {
-								[type_filters addObject:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+								ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+							}
+							if (ut) {
+								[type_filters addObject:ut];
 								pref_type.push_back(str.replace("*.", "").strip_edges());
 							}
 						}
 					}
 
-					if (@available(macOS 11, *)) {
-						filter_slice_count = mime.get_slice_count(",");
-						for (int j = 0; j < filter_slice_count; j++) {
-							String str = mime.get_slicec(',', j).strip_edges();
-							if (!str.is_empty()) {
-								UTType *ut = [UTType typeWithMIMEType:[NSString stringWithUTF8String:str.strip_edges().utf8().get_data()]];
-								if (ut) {
-									[type_filters addObject:ut];
-								}
+					filter_slice_count = mime.get_slice_count(",");
+					for (int j = 0; j < filter_slice_count; j++) {
+						String str = mime.get_slicec(',', j).strip_edges();
+						if (!str.is_empty()) {
+							UTType *ut = [UTType typeWithMIMEType:[NSString stringWithUTF8String:str.strip_edges().utf8().get_data()]];
+							if (ut) {
+								[type_filters addObject:ut];
 							}
 						}
 					}
@@ -186,32 +175,25 @@
 				for (int j = 0; j < filter_slice_count; j++) {
 					String str = (flt.get_slicec(',', j).strip_edges());
 					if (!str.is_empty()) {
-						if (@available(macOS 11, *)) {
-							UTType *ut = nullptr;
-							if (str == "*.*") {
-								ut = UTTypeData;
-							} else {
-								ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
-							}
-							if (ut) {
-								[type_filters addObject:ut];
-								pref_type.push_back(str.replace("*.", "").strip_edges());
-							}
+						UTType *ut = nullptr;
+						if (str == "*.*") {
+							ut = UTTypeData;
 						} else {
-							[type_filters addObject:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+							ut = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:str.replace("*.", "").strip_edges().utf8().get_data()]];
+						}
+						if (ut) {
+							[type_filters addObject:ut];
 							pref_type.push_back(str.replace("*.", "").strip_edges());
 						}
 					}
 				}
-				if (@available(macOS 11, *)) {
-					filter_slice_count = mime.get_slice_count(",");
-					for (int j = 0; j < filter_slice_count; j++) {
-						String str = mime.get_slicec(',', j).strip_edges();
-						if (!str.is_empty()) {
-							UTType *ut = [UTType typeWithMIMEType:[NSString stringWithUTF8String:str.strip_edges().utf8().get_data()]];
-							if (ut) {
-								[type_filters addObject:ut];
-							}
+				filter_slice_count = mime.get_slice_count(",");
+				for (int j = 0; j < filter_slice_count; j++) {
+					String str = mime.get_slicec(',', j).strip_edges();
+					if (!str.is_empty()) {
+						UTType *ut = [UTType typeWithMIMEType:[NSString stringWithUTF8String:str.strip_edges().utf8().get_data()]];
+						if (ut) {
+							[type_filters addObject:ut];
 						}
 					}
 				}
@@ -236,29 +218,15 @@
 	}
 	if ([new_allowed_types count] > 0) {
 		NSMutableArray *type_filters = [new_allowed_types objectAtIndex:0];
-		if (@available(macOS 11, *)) {
-			if (type_filters && [type_filters count] == 1 && [type_filters objectAtIndex:0] == UTTypeData) {
-				[p_panel setAllowedContentTypes:@[ UTTypeData ]];
-				[p_panel setAllowsOtherFileTypes:true];
-			} else {
-				[p_panel setAllowsOtherFileTypes:false];
-				[p_panel setAllowedContentTypes:type_filters];
-			}
+		if (type_filters && [type_filters count] == 1 && [type_filters objectAtIndex:0] == UTTypeData) {
+			[p_panel setAllowedContentTypes:@[ UTTypeData ]];
+			[p_panel setAllowsOtherFileTypes:true];
 		} else {
-			if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
-				[p_panel setAllowedFileTypes:nil];
-				[p_panel setAllowsOtherFileTypes:true];
-			} else {
-				[p_panel setAllowsOtherFileTypes:false];
-				[p_panel setAllowedFileTypes:type_filters];
-			}
+			[p_panel setAllowsOtherFileTypes:false];
+			[p_panel setAllowedContentTypes:type_filters];
 		}
 	} else {
-		if (@available(macOS 11, *)) {
-			[p_panel setAllowedContentTypes:@[ UTTypeData ]];
-		} else {
-			[p_panel setAllowedFileTypes:nil];
-		}
+		[p_panel setAllowedContentTypes:@[ UTTypeData ]];
 		[p_panel setAllowsOtherFileTypes:true];
 	}
 }
@@ -322,30 +290,16 @@
 		NSUInteger index = [btn indexOfSelectedItem];
 		if (allowed_types && index < [allowed_types count]) {
 			NSMutableArray *type_filters = [allowed_types objectAtIndex:index];
-			if (@available(macOS 11, *)) {
-				if (type_filters && [type_filters count] == 1 && [type_filters objectAtIndex:0] == UTTypeData) {
-					[dialog setAllowedContentTypes:@[ UTTypeData ]];
-					[dialog setAllowsOtherFileTypes:true];
-				} else {
-					[dialog setAllowsOtherFileTypes:false];
-					[dialog setAllowedContentTypes:type_filters];
-				}
+			if (type_filters && [type_filters count] == 1 && [type_filters objectAtIndex:0] == UTTypeData) {
+				[dialog setAllowedContentTypes:@[ UTTypeData ]];
+				[dialog setAllowsOtherFileTypes:true];
 			} else {
-				if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
-					[dialog setAllowedFileTypes:nil];
-					[dialog setAllowsOtherFileTypes:true];
-				} else {
-					[dialog setAllowsOtherFileTypes:false];
-					[dialog setAllowedFileTypes:type_filters];
-				}
+				[dialog setAllowsOtherFileTypes:false];
+				[dialog setAllowedContentTypes:type_filters];
 			}
 			cur_index = index;
 		} else {
-			if (@available(macOS 11, *)) {
-				[dialog setAllowedContentTypes:@[ UTTypeData ]];
-			} else {
-				[dialog setAllowedFileTypes:nil];
-			}
+			[dialog setAllowedContentTypes:@[ UTTypeData ]];
 			[dialog setAllowsOtherFileTypes:true];
 			cur_index = -1;
 		}
@@ -357,15 +311,13 @@
 }
 
 - (String)validateFilename:(const String &)p_path {
-	if (@available(macOS 11, *)) {
-		if (allowed_types) {
-			NSMutableArray *type_filters = [allowed_types objectAtIndex:cur_index];
-			UTType *ut = [type_filters objectAtIndex:0];
-			String ext = String::utf8([[ut preferredFilenameExtension] UTF8String]);
-			Vector<String> pref_ext = preferred_types[cur_index];
-			if (!pref_ext.is_empty() && !pref_ext.has(ext) && p_path.has_extension(ext) && pref_ext[0] != "*") {
-				return p_path.get_basename() + "." + pref_ext[0];
-			}
+	if (allowed_types) {
+		NSMutableArray *type_filters = [allowed_types objectAtIndex:cur_index];
+		UTType *ut = [type_filters objectAtIndex:0];
+		String ext = String::utf8([[ut preferredFilenameExtension] UTF8String]);
+		Vector<String> pref_ext = preferred_types[cur_index];
+		if (!pref_ext.is_empty() && !pref_ext.has(ext) && p_path.has_extension(ext) && pref_ext[0] != "*") {
+			return p_path.get_basename() + "." + pref_ext[0];
 		}
 	}
 	return p_path;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -118,18 +118,12 @@ bool OS_MacOS::is_sandboxed() const {
 }
 
 bool OS_MacOS::request_permission(const String &p_name) {
-	if (@available(macOS 11.0, *)) {
-		if (p_name == "macos.permission.RECORD_SCREEN") {
-			if (CGPreflightScreenCaptureAccess()) {
-				return true;
-			} else {
-				CGRequestScreenCaptureAccess();
-				return false;
-			}
-		}
-	} else {
-		if (p_name == "macos.permission.RECORD_SCREEN") {
+	if (p_name == "macos.permission.RECORD_SCREEN") {
+		if (CGPreflightScreenCaptureAccess()) {
 			return true;
+		} else {
+			CGRequestScreenCaptureAccess();
+			return false;
 		}
 	}
 	return false;
@@ -138,11 +132,7 @@ bool OS_MacOS::request_permission(const String &p_name) {
 Vector<String> OS_MacOS::get_granted_permissions() const {
 	Vector<String> ret;
 
-	if (@available(macOS 11.0, *)) {
-		if (CGPreflightScreenCaptureAccess()) {
-			ret.push_back("macos.permission.RECORD_SCREEN");
-		}
-	} else {
+	if (CGPreflightScreenCaptureAccess()) {
 		ret.push_back("macos.permission.RECORD_SCREEN");
 	}
 
@@ -822,59 +812,35 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 		for (const String &arg : p_arguments) {
 			[arguments addObject:[NSString stringWithUTF8String:arg.utf8().get_data()]];
 		}
-#if defined(__x86_64__)
-		if (@available(macOS 10.15, *)) {
-#endif
-			NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
-			[configuration setArguments:arguments];
-			[configuration setCreatesNewApplicationInstance:YES];
-			[configuration setEnvironment:[[NSProcessInfo processInfo] environment]];
-			__block dispatch_semaphore_t lock = dispatch_semaphore_create(0);
-			__block Error err = ERR_TIMEOUT;
-			__block pid_t pid = 0;
+		NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
+		[configuration setArguments:arguments];
+		[configuration setCreatesNewApplicationInstance:YES];
+		[configuration setEnvironment:[[NSProcessInfo processInfo] environment]];
+		__block dispatch_semaphore_t lock = dispatch_semaphore_create(0);
+		__block Error err = ERR_TIMEOUT;
+		__block pid_t pid = 0;
 
-			[[NSWorkspace sharedWorkspace] openApplicationAtURL:url
-												  configuration:configuration
-											  completionHandler:^(NSRunningApplication *app, NSError *error) {
-												  if (error) {
-													  err = ERR_CANT_FORK;
-													  NSLog(@"Failed to execute: %@", error.localizedDescription);
-												  } else {
-													  pid = [app processIdentifier];
-													  err = OK;
-												  }
-												  dispatch_semaphore_signal(lock);
-											  }];
-			dispatch_semaphore_wait(lock, dispatch_time(DISPATCH_TIME_NOW, 20000000000)); // 20 sec timeout, wait for app to launch.
+		[[NSWorkspace sharedWorkspace] openApplicationAtURL:url
+											  configuration:configuration
+										  completionHandler:^(NSRunningApplication *app, NSError *error) {
+											  if (error) {
+												  err = ERR_CANT_FORK;
+												  NSLog(@"Failed to execute: %@", error.localizedDescription);
+											  } else {
+												  pid = [app processIdentifier];
+												  err = OK;
+											  }
+											  dispatch_semaphore_signal(lock);
+										  }];
+		dispatch_semaphore_wait(lock, dispatch_time(DISPATCH_TIME_NOW, 20000000000)); // 20 sec timeout, wait for app to launch.
 
-			if (err == OK) {
-				if (r_child_id) {
-					*r_child_id = (ProcessID)pid;
-				}
+		if (err == OK) {
+			if (r_child_id) {
+				*r_child_id = (ProcessID)pid;
 			}
-
-			return err;
-#if defined(__x86_64__)
-		} else {
-			Error err = ERR_TIMEOUT;
-			NSError *error = nullptr;
-			NSDictionary *config = @{
-				NSWorkspaceLaunchConfigurationArguments : arguments,
-				NSWorkspaceLaunchConfigurationEnvironment : [[NSProcessInfo processInfo] environment]
-			};
-			NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url options:NSWorkspaceLaunchNewInstance configuration:config error:&error];
-			if (error) {
-				err = ERR_CANT_FORK;
-				NSLog(@"Failed to execute: %@", error.localizedDescription);
-			} else {
-				if (r_child_id) {
-					*r_child_id = (ProcessID)[app processIdentifier];
-				}
-				err = OK;
-			}
-			return err;
 		}
-#endif
+
+		return err;
 	} else {
 		return OS_Unix::create_process(p_path, p_arguments, r_child_id, p_open_console);
 	}
@@ -933,39 +899,26 @@ Error OS_MacOS::open_with_program(const String &p_program_path, const List<Strin
 		return ERR_INVALID_PARAMETER;
 	}
 
-#if defined(__x86_64__)
-	if (@available(macOS 10.15, *)) {
-#endif
-		NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
-		[configuration setCreatesNewApplicationInstance:NO];
-		__block dispatch_semaphore_t lock = dispatch_semaphore_create(0);
-		__block Error err = ERR_TIMEOUT;
+	NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
+	[configuration setCreatesNewApplicationInstance:NO];
+	__block dispatch_semaphore_t lock = dispatch_semaphore_create(0);
+	__block Error err = ERR_TIMEOUT;
 
-		[[NSWorkspace sharedWorkspace] openURLs:urls_to_open
-						   withApplicationAtURL:app_url
-								  configuration:configuration
-							  completionHandler:^(NSRunningApplication *app, NSError *error) {
-								  if (error) {
-									  err = ERR_CANT_FORK;
-									  NSLog(@"Failed to open paths: %@", error.localizedDescription);
-								  } else {
-									  err = OK;
-								  }
-								  dispatch_semaphore_signal(lock);
-							  }];
-		dispatch_semaphore_wait(lock, dispatch_time(DISPATCH_TIME_NOW, 20000000000)); // 20 sec timeout, wait for app to launch.
+	[[NSWorkspace sharedWorkspace] openURLs:urls_to_open
+					   withApplicationAtURL:app_url
+							  configuration:configuration
+						  completionHandler:^(NSRunningApplication *app, NSError *error) {
+							  if (error) {
+								  err = ERR_CANT_FORK;
+								  NSLog(@"Failed to open paths: %@", error.localizedDescription);
+							  } else {
+								  err = OK;
+							  }
+							  dispatch_semaphore_signal(lock);
+						  }];
+	dispatch_semaphore_wait(lock, dispatch_time(DISPATCH_TIME_NOW, 20000000000)); // 20 sec timeout, wait for app to launch.
 
-		return err;
-#if defined(__x86_64__)
-	} else {
-		NSError *error = nullptr;
-		[[NSWorkspace sharedWorkspace] openURLs:urls_to_open withApplicationAtURL:app_url options:NSWorkspaceLaunchDefault configuration:@{} error:&error];
-		if (error) {
-			return ERR_CANT_FORK;
-		}
-		return OK;
-	}
-#endif
+	return err;
 }
 
 bool OS_MacOS::is_process_running(const ProcessID &p_pid) const {
@@ -981,7 +934,11 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
+#if defined(__x86_64) || defined(__x86_64__)
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#else
+		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#endif
 		CFStringRef serial_number_cf_string = nullptr;
 		if (platform_expert) {
 			serial_number_cf_string = (CFStringRef)IORegistryEntryCreateCFProperty(platform_expert, CFSTR(kIOPlatformSerialNumberKey), kCFAllocatorDefault, 0);

--- a/platform/macos/tts_macos.h
+++ b/platform/macos/tts_macos.h
@@ -46,16 +46,10 @@
 struct TTSUtterance;
 
 @interface TTS_MacOS : NSObject <AVSpeechSynthesizerDelegate> {
-	// AVSpeechSynthesizer
 	bool speaking;
 	HashMap<id, int64_t> ids;
 
-	// NSSpeechSynthesizer
-	bool paused;
-	bool have_utterance;
-	int64_t last_utterance;
-
-	id synth; // NSSpeechSynthesizer or AVSpeechSynthesizer
+	id synth;
 	List<TTSUtterance> queue;
 }
 

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -37,24 +37,13 @@
 - (id)init {
 	self = [super init];
 	self->speaking = false;
-	self->have_utterance = false;
-	self->last_utterance = -1;
-	self->paused = false;
-	if (@available(macOS 10.14, *)) {
-		self->synth = [[AVSpeechSynthesizer alloc] init];
-		[self->synth setDelegate:self];
-		print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
-	} else {
-		self->synth = [[NSSpeechSynthesizer alloc] init];
-		[self->synth setDelegate:self];
-		print_verbose("Text-to-Speech: NSSpeechSynthesizer initialized.");
-	}
+	self->synth = [[AVSpeechSynthesizer alloc] init];
+	[self->synth setDelegate:self];
+	print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	return self;
 }
 
-// AVSpeechSynthesizer callback (macOS 10.14+)
-
-- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth willSpeakRangeOfSpeechString:(NSRange)characterRange utterance:(AVSpeechUtterance *)utterance API_AVAILABLE(macosx(10.14)) {
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth willSpeakRangeOfSpeechString:(NSRange)characterRange utterance:(AVSpeechUtterance *)utterance {
 	NSString *string = [utterance speechString];
 
 	// Convert from UTF-16 to UTF-32 position.
@@ -70,51 +59,16 @@
 	DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_BOUNDARY, ids[utterance], pos);
 }
 
-// AVSpeechSynthesizer callback (macOS 10.14+)
-
-- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth didCancelSpeechUtterance:(AVSpeechUtterance *)utterance API_AVAILABLE(macosx(10.14)) {
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth didCancelSpeechUtterance:(AVSpeechUtterance *)utterance {
 	DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_CANCELED, ids[utterance]);
 	ids.erase(utterance);
 	speaking = false;
 	[self update];
 }
 
-// AVSpeechSynthesizer callback (macOS 10.14+)
-
-- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth didFinishSpeechUtterance:(AVSpeechUtterance *)utterance API_AVAILABLE(macosx(10.14)) {
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)av_synth didFinishSpeechUtterance:(AVSpeechUtterance *)utterance {
 	DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_ENDED, ids[utterance]);
 	ids.erase(utterance);
-	speaking = false;
-	[self update];
-}
-
-// NSSpeechSynthesizer callback (macOS 10.4+)
-
-- (void)speechSynthesizer:(NSSpeechSynthesizer *)ns_synth willSpeakWord:(NSRange)characterRange ofString:(NSString *)string {
-	if (!paused && have_utterance) {
-		// Convert from UTF-16 to UTF-32 position.
-		int pos = 0;
-		for (NSUInteger i = 0; i < MIN(characterRange.location, string.length); i++) {
-			unichar c = [string characterAtIndex:i];
-			if ((c & 0xfffffc00) == 0xd800) {
-				i++;
-			}
-			pos++;
-		}
-
-		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_BOUNDARY, last_utterance, pos);
-	}
-}
-
-- (void)speechSynthesizer:(NSSpeechSynthesizer *)ns_synth didFinishSpeaking:(BOOL)success {
-	if (!paused && have_utterance) {
-		if (success) {
-			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_ENDED, last_utterance);
-		} else {
-			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_CANCELED, last_utterance);
-		}
-		have_utterance = false;
-	}
 	speaking = false;
 	[self update];
 }
@@ -123,33 +77,20 @@
 	if (!speaking && queue.size() > 0) {
 		TTSUtterance &message = queue.front()->get();
 
-		if (@available(macOS 10.14, *)) {
-			AVSpeechSynthesizer *av_synth = synth;
-			AVSpeechUtterance *new_utterance = [[AVSpeechUtterance alloc] initWithString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
-			[new_utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:[NSString stringWithUTF8String:message.voice.utf8().get_data()]]];
-			if (message.rate > 1.f) {
-				[new_utterance setRate:Math::remap(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
-			} else if (message.rate < 1.f) {
-				[new_utterance setRate:Math::remap(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
-			}
-			[new_utterance setPitchMultiplier:message.pitch];
-			[new_utterance setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
-
-			ids[new_utterance] = message.id;
-			[av_synth speakUtterance:new_utterance];
-		} else {
-			NSSpeechSynthesizer *ns_synth = synth;
-			[ns_synth setObject:nil forProperty:NSSpeechResetProperty error:nil];
-			[ns_synth setVoice:[NSString stringWithUTF8String:message.voice.utf8().get_data()]];
-			int base_pitch = [[ns_synth objectForProperty:NSSpeechPitchBaseProperty error:nil] intValue];
-			[ns_synth setObject:[NSNumber numberWithInt:(base_pitch * (message.pitch / 2.f + 0.5f))] forProperty:NSSpeechPitchBaseProperty error:nullptr];
-			[ns_synth setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
-			[ns_synth setRate:(message.rate * 200)];
-
-			last_utterance = message.id;
-			have_utterance = true;
-			[ns_synth startSpeakingString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
+		AVSpeechSynthesizer *av_synth = synth;
+		AVSpeechUtterance *new_utterance = [[AVSpeechUtterance alloc] initWithString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
+		[new_utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:[NSString stringWithUTF8String:message.voice.utf8().get_data()]]];
+		if (message.rate > 1.f) {
+			[new_utterance setRate:Math::remap(message.rate, 1.f, 10.f, AVSpeechUtteranceDefaultSpeechRate, AVSpeechUtteranceMaximumSpeechRate)];
+		} else if (message.rate < 1.f) {
+			[new_utterance setRate:Math::remap(message.rate, 0.1f, 1.f, AVSpeechUtteranceMinimumSpeechRate, AVSpeechUtteranceDefaultSpeechRate)];
 		}
+		[new_utterance setPitchMultiplier:message.pitch];
+		[new_utterance setVolume:(Math::remap(message.volume, 0.f, 100.f, 0.f, 1.f))];
+
+		ids[new_utterance] = message.id;
+		[av_synth speakUtterance:new_utterance];
+
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_STARTED, message.id);
 		queue.pop_front();
 
@@ -158,25 +99,13 @@
 }
 
 - (void)pauseSpeaking {
-	if (@available(macOS 10.14, *)) {
-		AVSpeechSynthesizer *av_synth = synth;
-		[av_synth pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
-	} else {
-		NSSpeechSynthesizer *ns_synth = synth;
-		[ns_synth pauseSpeakingAtBoundary:NSSpeechImmediateBoundary];
-	}
-	paused = true;
+	AVSpeechSynthesizer *av_synth = synth;
+	[av_synth pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 }
 
 - (void)resumeSpeaking {
-	if (@available(macOS 10.14, *)) {
-		AVSpeechSynthesizer *av_synth = synth;
-		[av_synth continueSpeaking];
-	} else {
-		NSSpeechSynthesizer *ns_synth = synth;
-		[ns_synth continueSpeaking];
-	}
-	paused = false;
+	AVSpeechSynthesizer *av_synth = synth;
+	[av_synth continueSpeaking];
 }
 
 - (void)stopSpeaking {
@@ -184,19 +113,9 @@
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_CANCELED, message.id);
 	}
 	queue.clear();
-	if (@available(macOS 10.14, *)) {
-		AVSpeechSynthesizer *av_synth = synth;
-		[av_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
-	} else {
-		NSSpeechSynthesizer *ns_synth = synth;
-		if (have_utterance) {
-			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_CANCELED, last_utterance);
-		}
-		[ns_synth stopSpeaking];
-	}
-	have_utterance = false;
+	AVSpeechSynthesizer *av_synth = synth;
+	[av_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	speaking = false;
-	paused = false;
 }
 
 - (bool)isSpeaking {
@@ -204,12 +123,8 @@
 }
 
 - (bool)isPaused {
-	if (@available(macOS 10.14, *)) {
-		AVSpeechSynthesizer *av_synth = synth;
-		return [av_synth isPaused];
-	} else {
-		return paused;
-	}
+	AVSpeechSynthesizer *av_synth = synth;
+	return [av_synth isPaused];
 }
 
 - (void)speak:(const String &)text voice:(const String &)voice volume:(int)volume pitch:(float)pitch rate:(float)rate utterance_id:(int64_t)utterance_id interrupt:(bool)interrupt {
@@ -240,27 +155,15 @@
 
 - (Array)getVoices {
 	Array list;
-	if (@available(macOS 10.14, *)) {
-		for (AVSpeechSynthesisVoice *voice in [AVSpeechSynthesisVoice speechVoices]) {
-			NSString *voiceIdentifierString = [voice identifier];
-			NSString *voiceLocaleIdentifier = [voice language];
-			NSString *voiceName = [voice name];
-			Dictionary voice_d;
-			voice_d["name"] = String::utf8([voiceName UTF8String]);
-			voice_d["id"] = String::utf8([voiceIdentifierString UTF8String]);
-			voice_d["language"] = String::utf8([voiceLocaleIdentifier UTF8String]);
-			list.push_back(voice_d);
-		}
-	} else {
-		for (NSString *voiceIdentifierString in [NSSpeechSynthesizer availableVoices]) {
-			NSString *voiceLocaleIdentifier = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceLocaleIdentifier];
-			NSString *voiceName = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceName];
-			Dictionary voice_d;
-			voice_d["name"] = String([voiceName UTF8String]);
-			voice_d["id"] = String([voiceIdentifierString UTF8String]);
-			voice_d["language"] = String([voiceLocaleIdentifier UTF8String]);
-			list.push_back(voice_d);
-		}
+	for (AVSpeechSynthesisVoice *voice in [AVSpeechSynthesisVoice speechVoices]) {
+		NSString *voiceIdentifierString = [voice identifier];
+		NSString *voiceLocaleIdentifier = [voice language];
+		NSString *voiceName = [voice name];
+		Dictionary voice_d;
+		voice_d["name"] = String::utf8([voiceName UTF8String]);
+		voice_d["id"] = String::utf8([voiceIdentifierString UTF8String]);
+		voice_d["language"] = String::utf8([voiceLocaleIdentifier UTF8String]);
+		list.push_back(voice_d);
 	}
 	return list;
 }

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -311,10 +311,10 @@ def setup_swift_builder(env, apple_platform, sdk_path, current_path, bridging_he
         target_suffix = "macosx10.9"
 
     elif apple_platform == "ios":
-        target_suffix = "ios14.0"  # iOS 14.0 needed for SwiftUI lifecycle
+        target_suffix = "ios15.0"  # iOS 15.0 needed for SwiftUI lifecycle
 
     elif apple_platform == "iossimulator":
-        target_suffix = "ios14.0-simulator"  # iOS 14.0 needed for SwiftUI lifecycle
+        target_suffix = "ios15.0-simulator"  # iOS 15.0 needed for SwiftUI lifecycle
 
     elif apple_platform == "visionos":
         target_suffix = "xros26.0"


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes build with Xcode 27.

Closes https://github.com/godotengine/godot/issues/120621

## Additional information

Alternative to https://github.com/godotengine/godot/pull/120187 and https://github.com/godotengine/godot/pull/120114, removes old code and bumps min. versions to versions supported by Xcode 27.

Running on Apple Silicon macOS 12/11 was broken since https://github.com/godotengine/godot/pull/114484 (dev1), every single Apple Silicon Mac supports all newer macOS versions up to upcoming 27, and versions older than 15 no longer receiving security updates, so there's no practical reason to support them.