### PR TITLE
Fix leaks from expanded Array and Dict from parentless buttons on invisible slots

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -342,6 +342,7 @@ void EditorPropertyArray::_create_new_property_slot() {
 	reorder_button->connect(SNAME("button_down"), callable_mp(this, &EditorPropertyArray::_reorder_button_down).bind(idx));
 
 	hbox->add_child(prop);
+	prop->add_inline_control(reorder_button, INLINE_CONTROL_LEFT);
 
 	bool is_untyped_array = object->get_array().get_type() == Variant::ARRAY && subtype == Variant::NIL;
 
@@ -354,6 +355,7 @@ void EditorPropertyArray::_create_new_property_slot() {
 		edit_btn->set_disabled(is_read_only());
 		edit_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
 		edit_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_change_type).bind(edit_btn, idx));
+		prop->add_inline_control(edit_btn, INLINE_CONTROL_RIGHT);
 	} else {
 		remove_btn = memnew(Button);
 		remove_btn->set_accessibility_name(TTRC("Remove"));
@@ -361,6 +363,7 @@ void EditorPropertyArray::_create_new_property_slot() {
 		remove_btn->set_disabled(is_read_only());
 		remove_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
 		remove_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_remove_pressed).bind(idx));
+		prop->add_inline_control(remove_btn, INLINE_CONTROL_RIGHT);
 	}
 	property_vbox->add_child(hbox);
 
@@ -1131,6 +1134,7 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 		edit_btn->set_disabled(is_read_only());
 		edit_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
 		edit_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_change_type).bind(edit_btn, slots.size()));
+		prop->add_inline_control(edit_btn, INLINE_CONTROL_RIGHT);
 	} else if (p_idx >= 0) {
 		remove_btn = memnew(Button);
 		remove_btn->set_accessibility_name(TTRC("Remove"));
@@ -1138,6 +1142,7 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 		remove_btn->set_disabled(is_read_only());
 		remove_btn->set_theme_type_variation(SNAME("EditorInspectorFlatButton"));
 		remove_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_remove_pressed).bind(slots.size()));
+		prop->add_inline_control(remove_btn, INLINE_CONTROL_RIGHT);
 	}
 
 	if (add_panel) {


### PR DESCRIPTION
Closes #120035
_Bugsquad edit:_ Closes #121031

When Dict or Array are expanded in the editor, slots up to page size are also created with buttons that don't have parents. Once the slot is made visible the buttons are reparented with add_inline_control(). However if slot is invisible buttons are never parented and leak.

Fix was to immediately parent the buttons on creation as add_inline_control safely reparents them once the slot is visible.

Testing included logging arrays with less than pagesize(20) items and the leaks grew smaller as more items were added. No leak occurs when a multiple of pagesize items exist. After parenting the buttons existing editor behavior remained unchanged and no RID /ObjectDB leaks were reported.