### PR TITLE
Cache modified time of projects

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -855,17 +855,17 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 
 	uint64_t last_edited = 0;
 	if (cf_err == OK) {
-		// The modification date marks the date the project was last edited.
-		// This is because the `project.godot` file will always be modified
-		// when editing a project (but not when running it).
-		last_edited = FileAccess::get_modified_time(conf);
-
-		String fscache = p_path.path_join(".fscache");
-		if (FileAccess::exists(fscache)) {
-			uint64_t cache_modified = FileAccess::get_modified_time(fscache);
-			if (cache_modified > last_edited) {
-				last_edited = cache_modified;
-			}
+		int *cached_time = modified_time_cache.getptr(p_path);
+		if (cached_time) {
+			// Modified time may change as a result of Project Manager actions, which will affect sorting.
+			// For that reason, the time is read only once.
+			last_edited = *cached_time;
+		} else {
+			// The modification date marks the date the project was last edited.
+			// This is because the `project.godot` file will always be modified
+			// when editing a project (but not when running it).
+			last_edited = FileAccess::get_modified_time(conf);
+			modified_time_cache[p_path] = last_edited;
 		}
 	} else {
 		grayed = true;

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -229,6 +229,7 @@ private:
 	ConfigFile _config;
 
 	Vector<Item> _projects;
+	static inline HashMap<String, int> modified_time_cache;
 
 	int _icon_load_index = 0;
 	bool project_opening_initiated = false;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When renaming project or editing tags, the project's `project.godot` is getting modified, which affects Last Modified sorting.

[Nagranie ekranu_20260707_131531.webm](https://github.com/user-attachments/assets/90bbe119-a561-41e2-88a7-79f738618f9c)

This PR makes the time cached when the project is initialized for the first time, so modifications don't affect order.

[Nagranie ekranu_20260707_132304.webm](https://github.com/user-attachments/assets/85e5a6c1-ae42-4f33-b074-868b86e1fc15)

## Additional information

The obvious downside is that the modified time does not update during Project Manager sessions, however it's not really a problem.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
