### PR TITLE
Fix sRGB conversion note in drawable texture format docs

### DIFF
--- a/doc/classes/DrawableTexture2D.xml
+++ b/doc/classes/DrawableTexture2D.xml
@@ -79,7 +79,7 @@
 		</constant>
 		<constant name="DRAWABLE_FORMAT_RGBA8_SRGB" value="1" enum="DrawableFormat">
 			OpenGL texture format RGBA with four components, each with a bitdepth of 8.
-			When drawn to, an sRGB to linear color space conversion is performed.
+			When drawn to, a linear to sRGB color encoding conversion is performed.
 		</constant>
 		<constant name="DRAWABLE_FORMAT_RGBAH" value="2" enum="DrawableFormat">
 			OpenGL texture format GL_RGBA16F where there are four components, each a 16-bit "half-precision" floating-point value.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4806,7 +4806,7 @@
 		</constant>
 		<constant name="TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB" value="1" enum="TextureDrawableFormat">
 			OpenGL texture format RGBA with four components, each with a bitdepth of 8.
-			When drawn to, an sRGB to linear color space conversion is performed.
+			When drawn to, a linear to sRGB color encoding conversion is performed.
 		</constant>
 		<constant name="TEXTURE_DRAWABLE_FORMAT_RGBAH" value="2" enum="TextureDrawableFormat">
 			OpenGL texture format GL_RGBA16F where there are four components, each a 16-bit "half-precision" floating-point value.


### PR DESCRIPTION
## What problem(s) does this PR solve?

The docs say the opposite of the conversion that is actually performed. Also changes `color space` to `color encoding`.

## Additional information

Here is the conversion in the source:

https://github.com/godotengine/godot/blob/c939bf3791ce40ff70e0ee29f06486da1ebb6a84/servers/rendering/renderer_rd/shaders/tex_blit.glsl#L110-L112
