### PR TITLE
Inherit untyped override return types in GDScript exports

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1851,7 +1851,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			}
 		}
 	} else {
-		if (p_function->return_type != nullptr) {
+		const bool has_explicit_return_type = p_function->return_type != nullptr;
+		if (has_explicit_return_type) {
 			p_function->set_datatype(type_from_metatype(resolve_datatype(p_function->return_type)));
 		} else {
 			// In case the function is not typed, we can safely assume it's a Variant, so it's okay to mark as "inferred" here.
@@ -1863,6 +1864,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		}
 
 		// Fetch the parent signature to inherit return types for untyped overrides.
+		// Export templates need the inherited return type for runtime return conversion.
 		// Constructors can vary in signature.
 		GDScriptParser::DataType base_type = parser->current_class->base_type;
 		base_type.is_meta_type = false;
@@ -1872,12 +1874,12 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		BitField<MethodFlags> method_flags = {};
 		StringName native_base;
 #ifdef TOOLS_ENABLED
-		const bool should_check_parent_signature = !p_is_lambda;
+		const bool should_fetch_parent_signature = !p_is_lambda;
 #else
-		const bool should_check_parent_signature = !p_is_lambda && p_function->return_type == nullptr;
+		const bool should_fetch_parent_signature = !p_is_lambda && !has_explicit_return_type;
 #endif // TOOLS_ENABLED
-		if (should_check_parent_signature && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
-			if (p_function->return_type == nullptr) {
+		if (should_fetch_parent_signature && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
+			if (!has_explicit_return_type) {
 				// GH-118877. We decided to make an exception to maintain compatibility, since the problem can only be detected at runtime.
 #ifdef DISABLE_DEPRECATED
 				p_function->set_datatype(parent_return_type);
@@ -1898,7 +1900,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 #ifdef TOOLS_ENABLED
 			bool valid = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
 
-			if (p_function->return_type != nullptr) {
+			if (has_explicit_return_type) {
 				// Check return type covariance.
 				GDScriptParser::DataType return_type = p_function->get_datatype();
 				if (return_type.is_variant()) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1862,9 +1862,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			p_function->set_datatype(return_type);
 		}
 
-#ifdef TOOLS_ENABLED
-		// Check if the function signature matches the parent. If not it's an error since it breaks polymorphism.
-		// Not for the constructor which can vary in signature.
+		// Fetch the parent signature to inherit return types for untyped overrides.
+		// Constructors can vary in signature.
 		GDScriptParser::DataType base_type = parser->current_class->base_type;
 		base_type.is_meta_type = false;
 		GDScriptParser::DataType parent_return_type;
@@ -1872,9 +1871,12 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		int default_par_count = 0;
 		BitField<MethodFlags> method_flags = {};
 		StringName native_base;
-		if (!p_is_lambda && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
-			bool valid = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
-
+#ifdef TOOLS_ENABLED
+		const bool should_check_parent_signature = !p_is_lambda;
+#else
+		const bool should_check_parent_signature = !p_is_lambda && p_function->return_type == nullptr;
+#endif // TOOLS_ENABLED
+		if (should_check_parent_signature && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
 			if (p_function->return_type == nullptr) {
 				// GH-118877. We decided to make an exception to maintain compatibility, since the problem can only be detected at runtime.
 #ifdef DISABLE_DEPRECATED
@@ -1891,7 +1893,12 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 					p_function->set_datatype(parent_return_type);
 				}
 #endif // DISABLE_DEPRECATED
-			} else {
+			}
+
+#ifdef TOOLS_ENABLED
+			bool valid = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
+
+			if (p_function->return_type != nullptr) {
 				// Check return type covariance.
 				GDScriptParser::DataType return_type = p_function->get_datatype();
 				if (return_type.is_variant()) {
@@ -1977,8 +1984,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 				parser->push_warning(p_function, GDScriptWarning::NATIVE_METHOD_OVERRIDE, function_name, native_base);
 			}
 #endif // DEBUG_ENABLED
-		}
 #endif // TOOLS_ENABLED
+		}
 	}
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Closes #121047

Untyped GDScript overrides now inherit the parent method return type in export templates too, matching editor behavior.

The editor-only signature checks remain guarded by TOOLS_ENABLED.

If you want to verify,  you may add this piece of test code in modules/gdscript/tests/gdscript_test_runner_suite.h(generated by gpt5.5, prompt:`i've fixedd https://github.com/godotengine/godot/issues/121047 in this branch. plz generate a test to verify whether it successfully fixes the issue`)
```cpp
TEST_CASE("[Modules][GDScript] Untyped overrides inherit parent return type") {
	GDScriptLanguage::get_singleton()->init();
	Ref<GDScript> gdscript = memnew(GDScript);
	gdscript->set_source_code(R"(
extends RefCounted

class Base:
	func value(_arg: Variant) -> int:
		return 0

class Child extends Base:
	func value(arg: Variant):
		return arg

func get_child_value(arg: Variant) -> Variant:
	return Child.new().value(arg)
)");
	ERR_PRINT_OFF;
	const Error error = gdscript->reload();
	ERR_PRINT_ON;
	CHECK_MESSAGE(error == OK, "The script should parse successfully.");

	Ref<RefCounted> ref_counted = memnew(RefCounted);
	ref_counted->set_script(gdscript);

	Variant arg = String("not an integer");
	const Variant *args[] = { &arg };
	Callable::CallError call_error;

	ERR_PRINT_OFF;
	Variant result = ref_counted->callp("get_child_value", args, 1, call_error);
	ERR_PRINT_ON;

	CHECK_MESSAGE(call_error.error == Callable::CallError::CALL_OK, "The script function should be callable.");
	CHECK_MESSAGE(result.get_type() == Variant::INT, "The inherited return type should validate the override result.");
	CHECK_MESSAGE(int(result) == 0, "Invalid values should be replaced with the default int value.");
}
```