### PR TITLE
Use mono-spaced font for Bezier and Blend Shape animation track paths

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -287,6 +287,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 			const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 			const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+			const Ref<Font> source_font = get_theme_font(SNAME("source"), EditorStringName(EditorFonts));
+			const int source_font_size = get_theme_font_size(SNAME("source_size"), EditorStringName(EditorFonts));
 			const Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 
 			const Color h_line_color = get_theme_color(SNAME("h_line_color"), SNAME("AnimationBezierTrackEdit"));
@@ -499,6 +501,13 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 					}
 				}
 
+				Ref<Font> font_to_use = font;
+				int font_size_to_use = font_size;
+				if (EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols")) {
+					font_to_use = source_font;
+					font_size_to_use = source_font_size;
+				}
+
 				float remove_hpos = limit - h_separation - remove->get_width();
 				float lock_hpos = remove_hpos - h_separation - lock->get_width();
 				float visibility_hpos = lock_hpos - h_separation - visibility_visible->get_width();
@@ -515,7 +524,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 					path = path.replace_first(base_path, "");
 
 					Color cc = color;
-					TextLine text_buf = TextLine(path, font, font_size);
+					TextLine text_buf = TextLine(path, font_to_use, font_size_to_use);
 					text_buf.set_width(limit - margin - buttons_width - h_separation * 2);
 
 					Rect2 rect = Rect2(margin, vofs, solo_hpos - h_separation - solo->get_width(), text_buf.get_size().y + v_separation);

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2233,7 +2233,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					}
 
 					bool use_monospace_font = EDITOR_GET("interface/theme/use_monospace_font_for_editor_symbols");
-					if (animation->track_get_type(track) == Animation::TYPE_VALUE && use_monospace_font) {
+					if (use_monospace_font && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BEZIER)) {
 						font_to_use = source_font;
 						font_size_to_use = source_font_size;
 					}


### PR DESCRIPTION
When animation track paths were made to use a mono-spaced font, only the `VALUE` type of tracks were accepted, which means `BEZIER` types were ignored. This PR fixes that, and also makes the paths in the Bezier editor use them as well:

|Before|After|
|-|-|
|<img width="240" height="96" alt="Screenshot_20260707_131812" src="https://github.com/user-attachments/assets/bdcbfbe3-2791-4715-8e82-7b353687a92c" />|<img width="240" height="96" alt="Screenshot_20260707_131145" src="https://github.com/user-attachments/assets/58eef5c2-4a72-44b4-a153-29b1d107332c" />|

|Before|After|
|-|-|
|<img width="240" height="67" alt="Screenshot_20260707_131832" src="https://github.com/user-attachments/assets/4c3ed1e4-3445-4b7e-84b2-0f4bece8da41" />|<img width="240" height="63" alt="Screenshot_20260707_131132" src="https://github.com/user-attachments/assets/df329718-7dd8-4971-b358-e6cf64c489cf" />|