### PR TITLE
Remove clamping from `linear_to_srgb` functions of drawable textures.

### DIFF
--- a/drivers/gles3/shaders/tex_blit.glsl
+++ b/drivers/gles3/shaders/tex_blit.glsl
@@ -72,8 +72,6 @@ layout(std140) uniform MaterialUniforms{ //ubo:0
 #GLOBALS
 
 vec3 linear_to_srgb(vec3 color) {
-	// If going to srgb, clamp from 0 to 1.
-	color = clamp(color, vec3(0.0), vec3(1.0));
 	const vec3 a = vec3(0.055f);
 	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
 }

--- a/servers/rendering/renderer_rd/shaders/tex_blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/tex_blit.glsl
@@ -79,8 +79,6 @@ layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #GLOBALS
 
 vec3 linear_to_srgb(vec3 color) {
-	// If going to srgb, clamp from 0 to 1.
-	color = clamp(color, vec3(0.0), vec3(1.0));
 	const vec3 a = vec3(0.055f);
 	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

When the [DrawableTextures](https://github.com/godotengine/godot/pull/105701) PR was created, many of the `linear_to_srgb` shader functions had unnecessary clamping. It seems that this PR had copied those over, but was never updated to remove this clamping when this clamping was removed from the rest of Godot.

## Additional information

I'm not familiar with DrawableTextures specifically, but sRGB encoding actually handles values outside of the [0, 1] range perfectly fine, and these values can sometimes be useful. Any clamping can typically be done by the user if that's something they actually want, but doesn't need to be enforced by a linear to sRGB encoding.

CC @ColinSORourke 