### PR TITLE
Expose `Resource.set_path()` virtual function

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -112,6 +112,8 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		}
 	}
 
+	GDVIRTUAL_CALL(_set_path, p_path, p_take_over);
+
 	_resource_path_changed();
 }
 
@@ -779,6 +781,7 @@ void Resource::_bind_methods() {
 	GDVIRTUAL_BIND(_setup_local_to_scene);
 	GDVIRTUAL_BIND(_get_rid);
 	GDVIRTUAL_BIND(_reset_state);
+	GDVIRTUAL_BIND(_set_path, "path", "take_over");
 	GDVIRTUAL_BIND(_set_path_cache, "path");
 }
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -118,6 +118,7 @@ protected:
 
 	GDVIRTUAL0RC(RID, _get_rid);
 
+	GDVIRTUAL2C(_set_path, String, bool);
 	GDVIRTUAL1C(_set_path_cache, String);
 	GDVIRTUAL0(_reset_state);
 

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -26,6 +26,14 @@
 				For resources that store state in non-exported properties, such as via [method Object._validate_property] or [method Object._get_property_list], this method must be implemented to clear them.
 			</description>
 		</method>
+		<method name="_set_path" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="take_over" type="bool" />
+			<description>
+				Override this method to execute additional logic after either [member resource_path] is set or [method take_over_path] is called on this object.
+			</description>
+		</method>
 		<method name="_set_path_cache" qualifiers="virtual const">
 			<return type="void" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
## What problem(s) does this PR solve?

I am implementing my own texture type in user space, using the new drawable texture API. I would like to be able to do this:

https://github.com/godotengine/godot/blob/c939bf3791ce40ff70e0ee29f06486da1ebb6a84/scene/resources/compressed_texture.cpp#L95-L101

but the virtual function is not exposed.

Using this rendering server function allows the texture path to appear in the Video RAM debugger tab.

## Additional information

I'm not sure on whether the `const` qualifier is appropriate, but `_set_path_cache` is also is exposed as `const`.