### PR TITLE
Fix Editor crashing on Android 8 and lower

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
@@ -195,7 +195,6 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 	private val selectDropdownMenu: PopupMenu by lazy {
 		PopupMenu(context, selectDropdownButton).apply {
 			inflate(R.menu.select_dropdown_menu)
-			menu.setGroupDividerEnabled(true)
 			setOnMenuItemClickListener { item: MenuItem ->
 				when (item.itemId) {
 					R.id.menu_show_selection_visibility -> {


### PR DESCRIPTION
Crash log from the Editor instrumented test run on `Medium Phone, 6.4in/16cm (Arm), Virtual, API Level 26`

```
java.lang.NoSuchMethodError: No interface method setGroupDividerEnabled(Z)V in class Landroid/view/Menu; or its super classes (declaration of 'android.view.Menu' appears in /system/framework/framework.jar:classes2.dex)
     FATAL EXCEPTION: main
Process: org.godotengine.editor.v4.debug, PID: 7655
java.lang.NoSuchMethodError: No interface method setGroupDividerEnabled(Z)V in class Landroid/view/Menu; or its super classes (declaration of 'android.view.Menu' appears in /system/framework/framework.jar:classes2.dex)
	at org.godotengine.editor.embed.GameMenuFragment.selectDropdownMenu_delegate$lambda$21(GameMenuFragment.kt:198)
	at org.godotengine.editor.embed.GameMenuFragment.$r8$lambda$M2nBfPvKYbBLa3WTPdWVhXdYr9s(Unknown Source:0)
	at org.godotengine.editor.embed.GameMenuFragment$$ExternalSyntheticLambda21.invoke(D8$$SyntheticClass:0)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
	at org.godotengine.editor.embed.GameMenuFragment.getSelectDropdownMenu(GameMenuFragment.kt:195)
	at org.godotengine.editor.embed.GameMenuFragment.refreshGameMenu$android_editor_androidDebug(GameMenuFragment.kt:438)
	at org.godotengine.editor.embed.GameMenuFragment.onViewCreated(GameMenuFragment.kt:412)
	at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:608)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1685)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3319)
	at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:3237)
	at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1333)
```

The Android version guard for `menu.setGroupDividerEnabled(true)` was missing. This likely happened because when I was working on that PR, editor's minsdk was 29, and I later forgot to update this after it was reverted to 24.

I've removed the line entirely for now because it wasn't even being used, there are no two groups to display dividers between :-)