### PR TITLE
[CI] Fix Android Instrumented tests timeout issue

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -162,7 +162,7 @@ jobs:
             --app "$APP_APK" \
             --test "$TEST_APK" \
             --device model=MediumPhone.arm,version=26 \
-            --device model=starlte,version=29 \
+            --device model=java,version=30 \
             --device model=MediumPhone.arm,version=32 \
             --device model=MediumTablet.arm,version=35 \
             --device model=rango,version=36 \


### PR DESCRIPTION
Instrumented tests on `Galaxy S9` are taking too long to start and in some cases even more than 10 hours. It's probably due to device unavailability.

<img width="1454" height="813" alt="Screenshot From 2026-07-07 23-55-31" src="https://github.com/user-attachments/assets/53864d43-0d16-4463-9420-8411cf961410" />

Fix:-
Replacing it with `Moto G20`, we have used this device before and didn't get any device unavailability delays.