### PR TITLE
Add EditorSetting to allow auto-prefixing of "_" on Ctrl-dragged @onready variables

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1583,9 +1583,6 @@
 		<member name="text_editor/completion/add_string_name_literals" type="bool" setter="" getter="">
 			If [code]true[/code], uses [StringName] instead of [String] when appropriate for code autocompletion.
 		</member>
-		<member name="text_editor/completion/private_dragged_onready_variables" type="bool" setter="" getter="">
-			If [code]true[/code], prefixes an underscore on variables created by dropping nodes from the Scene Dock while holding [kbd]Ctrl[/kbd].
-		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
 			If [code]true[/code], automatically adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] (such as [code]-&gt; void[/code] and [code]: int[/code]) in many situations where it's possible to, including when:
 			- Accepting a suggestion from code autocompletion;
@@ -1613,6 +1610,9 @@
 		</member>
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
+		</member>
+		<member name="text_editor/completion/private_dragged_onready_variables" type="bool" setter="" getter="">
+			If [code]true[/code], prefixes an underscore on variables created by dropping nodes from the Scene Dock while holding [kbd]Ctrl[/kbd].
 		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1584,7 +1584,7 @@
 			If [code]true[/code], uses [StringName] instead of [String] when appropriate for code autocompletion.
 		</member>
 		<member name="text_editor/completion/private_dragged_onready_variables" type="bool" setter="" getter="">
-			If [code]true[/code], prefixes an underline on variables created by dropping nodes from the scene Dock while holding [kbd]Ctrl[/kbd].
+			If [code]true[/code], prefixes an underscore on variables created by dropping nodes from the Scene Dock while holding [kbd]Ctrl[/kbd].
 		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
 			If [code]true[/code], automatically adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] (such as [code]-&gt; void[/code] and [code]: int[/code]) in many situations where it's possible to, including when:

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1583,6 +1583,9 @@
 		<member name="text_editor/completion/add_string_name_literals" type="bool" setter="" getter="">
 			If [code]true[/code], uses [StringName] instead of [String] when appropriate for code autocompletion.
 		</member>
+		<member name="text_editor/completion/private_dragged_onready_variables" type="bool" setter="" getter="">
+			If [code]true[/code], prefixes an underline on variables created by dropping nodes from the scene Dock while holding [kbd]Ctrl[/kbd].
+		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
 			If [code]true[/code], automatically adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] (such as [code]-&gt; void[/code] and [code]: int[/code]) in many situations where it's possible to, including when:
 			- Accepting a suggestion from code autocompletion;

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2209,6 +2209,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 		if (member_drop_modifier_pressed) {
 			const bool use_type = EDITOR_GET("text_editor/completion/add_type_hints");
+			const bool set_private = EDITOR_GET("text_editor/completion/private_dragged_onready_variables");
 			add_new_line = !is_empty_line && drop_at_column != 0;
 
 			for (int i = 0; i < nodes.size(); i++) {
@@ -2228,6 +2229,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 				}
 
 				String variable_name = String(node->get_name()).to_snake_case().validate_unicode_identifier();
+				if (set_private) {
+					variable_name = variable_name.insert(0, "_");
+				}
 				if (use_type) {
 					StringName custom_class_name;
 					Ref<Script> node_script = node->get_script();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -879,7 +879,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
-	_initial_set("text_editor/completion/private_dragged_onready_variables", false, false);
+	_initial_set("text_editor/completion/private_dragged_onready_variables", false);
 	_initial_set("text_editor/completion/add_type_hints", true, true);
 	_initial_set("text_editor/completion/add_string_name_literals", false, true);
 	_initial_set("text_editor/completion/add_node_path_literals", false, true);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -879,6 +879,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
+	_initial_set("text_editor/completion/private_dragged_onready_variables", false, false);
 	_initial_set("text_editor/completion/add_type_hints", true, true);
 	_initial_set("text_editor/completion/add_string_name_literals", false, true);
 	_initial_set("text_editor/completion/add_node_path_literals", false, true);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/10953

## Additional information
- [x] Created new editor setting to handle the operation (defaults to false and is hidden as advanced).
- [x] Added draft documentation to `EditorSettings.xml`. For now reads as:
> If [code]true[/code], prefixes an underline on variables created by dropping nodes from the scene Dock while holding [kbd]Ctrl[/kbd]
<img width="1130" height="731" alt="{7E33BD9A-F389-40B8-8739-71E320A9BB33}" src="https://github.com/user-attachments/assets/70f240d2-d42c-487f-b033-4065b7d23d72" />

- [x] Implemented the code in `script_text_editor.cpp` that prefixes the underline.
<img width="1334" height="241" alt="{8A1CA550-F4E9-4C82-A10A-7B7E43F08AB5}" src="https://github.com/user-attachments/assets/c2ae99d8-8dfa-4859-ab61-ee20dcd2cfb4" />
---

This PR implements something that I'd appreciate in my daily work, as it saves time in a common operation. It is my first code contribution to Godot, so a bit nervous about it; apologies in advance if there is something obviously wrong. Used the contributing docs a lot and they're very well written and thorough!

Didn't use AI for this PR.