### PR TITLE
Style: Use math functions from `Math` namespace where possible

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4826,7 +4826,7 @@ Dictionary Image::compute_image_metrics(const Ref<Image> p_compared_image, bool 
 	image_metric_mean = CLAMP(sum / total_values, 0.0f, 255.0f);
 	image_metric_mean_squared = CLAMP(sum2 / total_values, 0.0f, 255.0f * 255.0f);
 
-	image_metric_root_mean_squared = std::sqrt(image_metric_mean_squared);
+	image_metric_root_mean_squared = Math::sqrt(image_metric_mean_squared);
 
 	if (!image_metric_root_mean_squared) {
 		image_metric_peak_snr = 1e+10f;

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -476,7 +476,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					if (rows[1][0] == 0 && rows[0][1] == 0 && rows[1][2] == 0 && rows[2][1] == 0 && rows[1][1] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
 						euler.x = 0;
-						euler.y = std::atan2(rows[0][2], rows[0][0]);
+						euler.y = Math::atan2(rows[0][2], rows[0][0]);
 						euler.z = 0;
 					} else {
 						euler.x = Math::atan2(-rows[1][2], rows[2][2]);
@@ -541,22 +541,22 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					// is this a pure X rotation?
 					if (rows[1][0] == 0 && rows[0][1] == 0 && rows[0][2] == 0 && rows[2][0] == 0 && rows[0][0] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
-						euler.x = std::atan2(-m12, rows[1][1]);
+						euler.x = Math::atan2(-m12, rows[1][1]);
 						euler.y = 0;
 						euler.z = 0;
 					} else {
-						euler.x = std::asin(-m12);
-						euler.y = std::atan2(rows[0][2], rows[2][2]);
-						euler.z = std::atan2(rows[1][0], rows[1][1]);
+						euler.x = Math::asin(-m12);
+						euler.y = Math::atan2(rows[0][2], rows[2][2]);
+						euler.z = Math::atan2(rows[1][0], rows[1][1]);
 					}
 				} else { // m12 == -1
 					euler.x = Math::PI * 0.5f;
-					euler.y = std::atan2(rows[0][1], rows[0][0]);
+					euler.y = Math::atan2(rows[0][1], rows[0][0]);
 					euler.z = 0;
 				}
 			} else { // m12 == 1
 				euler.x = -Math::PI * 0.5f;
-				euler.y = -std::atan2(rows[0][1], rows[0][0]);
+				euler.y = -Math::atan2(rows[0][1], rows[0][0]);
 				euler.z = 0;
 			}
 

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -282,7 +282,7 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 
 	real_t left, right, modeltranslation, ymax, xmax, frustumshift;
 
-	ymax = p_z_near * std::tan(Math::deg_to_rad(p_fovy_degrees / 2.0));
+	ymax = p_z_near * Math::tan(Math::deg_to_rad(p_fovy_degrees / 2.0));
 	xmax = ymax * p_aspect;
 	frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1422,7 +1422,7 @@ String String::num(double p_num, int p_decimals) {
 		if (abs_num > 10) {
 			// We want to align the digits to the above reasonable default, so we only
 			// need to subtract log10 for numbers with a positive power of ten.
-			p_decimals -= (int)std::floor(std::log10(abs_num));
+			p_decimals -= (int)Math::floor(std::log10(abs_num));
 		}
 	}
 	if (p_decimals > MAX_DECIMALS) {
@@ -1588,7 +1588,7 @@ String String::num_real(double p_num, bool p_trailing) {
 	// to subtract log10 for numbers with a positive power of ten magnitude.
 	const double abs_num = Math::abs(p_num);
 	if (abs_num > 10) {
-		decimals -= (int)std::floor(std::log10(abs_num));
+		decimals -= (int)Math::floor(std::log10(abs_num));
 	}
 
 	return num(p_num, decimals);
@@ -1611,7 +1611,7 @@ String String::num_real(float p_num, bool p_trailing) {
 	// to subtract log10 for numbers with a positive power of ten magnitude.
 	const float abs_num = Math::abs(p_num);
 	if (abs_num > 10) {
-		decimals -= (int)std::floor(std::log10(abs_num));
+		decimals -= (int)Math::floor(std::log10(abs_num));
 	}
 	return num(p_num, decimals);
 }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -758,7 +758,7 @@ struct _VariantCall {
 		String s;
 		if (p_instance->size() > 0) {
 			const uint8_t *r = p_instance->ptr();
-			s.append_utf16((const char16_t *)r, std::floor((double)p_instance->size() / (double)sizeof(char16_t)));
+			s.append_utf16((const char16_t *)r, Math::floor((double)p_instance->size() / (double)sizeof(char16_t)));
 		}
 		return s;
 	}
@@ -767,7 +767,7 @@ struct _VariantCall {
 		String s;
 		if (p_instance->size() > 0) {
 			const uint8_t *r = p_instance->ptr();
-			s.append_utf32(Span((const char32_t *)r, std::floor((double)p_instance->size() / (double)sizeof(char32_t))));
+			s.append_utf32(Span((const char32_t *)r, Math::floor((double)p_instance->size() / (double)sizeof(char32_t))));
 		}
 		return s;
 	}
@@ -777,9 +777,9 @@ struct _VariantCall {
 		if (p_instance->size() > 0) {
 			const uint8_t *r = p_instance->ptr();
 #ifdef WINDOWS_ENABLED
-			s.append_utf16((const char16_t *)r, std::floor((double)p_instance->size() / (double)sizeof(char16_t)));
+			s.append_utf16((const char16_t *)r, Math::floor((double)p_instance->size() / (double)sizeof(char16_t)));
 #else
-			s.append_utf32(Span((const char32_t *)r, std::floor((double)p_instance->size() / (double)sizeof(char32_t))));
+			s.append_utf32(Span((const char32_t *)r, Math::floor((double)p_instance->size() / (double)sizeof(char32_t))));
 #endif
 		}
 		return s;

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1988,7 +1988,7 @@ static String rtos_fix(double p_value, bool p_compat) {
 		return "0"; // Avoid negative zero (-0) being written, which may annoy git, svn, etc. for changes when they don't exist.
 	} else if (p_compat) {
 		// Write old inf_neg for compatibility.
-		if (std::isinf(p_value) && p_value < 0.0) {
+		if (Math::is_inf(p_value) && p_value < 0.0) {
 			return "inf_neg";
 		}
 	}

--- a/drivers/gles3/effects/cubemap_filter.cpp
+++ b/drivers/gles3/effects/cubemap_filter.cpp
@@ -92,13 +92,13 @@ CubemapFilter::~CubemapFilter() {
 Vector3 importance_sample_GGX(Vector2 xi, float roughness4) {
 	// Compute distribution direction
 	float phi = 2.0 * Math::PI * xi.x;
-	float cos_theta = std::sqrt((1.0 - xi.y) / (1.0 + (roughness4 - 1.0) * xi.y));
-	float sin_theta = std::sqrt(1.0 - cos_theta * cos_theta);
+	float cos_theta = Math::sqrt((1.0 - xi.y) / (1.0 + (roughness4 - 1.0) * xi.y));
+	float sin_theta = Math::sqrt(1.0 - cos_theta * cos_theta);
 
 	// Convert to spherical direction
 	Vector3 half_vector;
-	half_vector.x = sin_theta * std::cos(phi);
-	half_vector.y = sin_theta * std::sin(phi);
+	half_vector.x = sin_theta * Math::cos(phi);
+	half_vector.y = sin_theta * Math::sin(phi);
 	half_vector.z = cos_theta;
 
 	return half_vector;
@@ -182,7 +182,7 @@ void CubemapFilter::filter_radiance(GLuint p_source_cubemap, GLuint p_dest_cubem
 
 			float solid_angle_sample = 1.0 / (float(sample_count) * pdf + 0.0001);
 
-			float mip_level = MAX(0.5 * std::log2(solid_angle_sample / solid_angle_texel) + float(MAX(1, p_layer - 3)), 1.0);
+			float mip_level = MAX(0.5 * Math::log2(solid_angle_sample / solid_angle_texel) + float(MAX(1, p_layer - 3)), 1.0);
 
 			sample_directions[index * 4 + 3] = mip_level;
 			weight += light_vec.z;

--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -1827,7 +1827,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				float track_h = animation->bezier_track_interpolate(i, time);
 				float track_height = _bezier_h_to_pixel(track_h);
 
-				if (std::abs(mb->get_position().y - track_height) < 10) {
+				if (Math::abs(mb->get_position().y - track_height) < 10) {
 					set_animation_and_track(animation, i, read_only);
 					break;
 				}
@@ -1843,7 +1843,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (moving_selection_attempt && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		if (!read_only) {
-			if (moving_selection && (std::abs(moving_selection_offset.x) > CMP_EPSILON || std::abs(moving_selection_offset.y) > CMP_EPSILON)) {
+			if (moving_selection && (Math::abs(moving_selection_offset.x) > CMP_EPSILON || Math::abs(moving_selection_offset.y) > CMP_EPSILON)) {
 				// Commit it.
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 				undo_redo->create_action(TTR("Move Bezier Points"));
@@ -1983,7 +1983,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (scaling_selection && mb.is_valid() && !read_only && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		if (std::abs(scaling_selection_scale.x - 1) > CMP_EPSILON || std::abs(scaling_selection_scale.y - 1) > CMP_EPSILON) {
+		if (Math::abs(scaling_selection_scale.x - 1) > CMP_EPSILON || Math::abs(scaling_selection_scale.y - 1) > CMP_EPSILON) {
 			// Scale it.
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Scale Bezier Points"));
@@ -2137,7 +2137,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			float snapped_time = editor->snap_time(moving_selection_pivot + time_delta);
 			float time_offset = 0.0;
-			if (std::abs(moving_selection_offset.x) > CMP_EPSILON || (snapped_time > moving_selection_pivot && time_delta > CMP_EPSILON) || (snapped_time < moving_selection_pivot && time_delta < -CMP_EPSILON)) {
+			if (Math::abs(moving_selection_offset.x) > CMP_EPSILON || (snapped_time > moving_selection_pivot && time_delta > CMP_EPSILON) || (snapped_time < moving_selection_pivot && time_delta < -CMP_EPSILON)) {
 				time_offset = snapped_time - moving_selection_pivot;
 			}
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3289,7 +3289,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (!mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			moving_selection_attempt = false;
 			if (moving_selection && moving_selection_effective) {
-				if (std::abs(editor->get_moving_selection_offset()) > CMP_EPSILON) {
+				if (Math::abs(editor->get_moving_selection_offset()) > CMP_EPSILON) {
 					emit_signal(SNAME("move_selection_commit"));
 				}
 			} else if (select_single_attempt != -1) {
@@ -3372,7 +3372,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		float snapped_time = editor->snap_time(moving_selection_pivot + delta);
 
 		float offset = 0.0;
-		if (std::abs(editor->get_moving_selection_offset()) > CMP_EPSILON || (snapped_time > moving_selection_pivot && delta > CMP_EPSILON) || (snapped_time < moving_selection_pivot && delta < -CMP_EPSILON)) {
+		if (Math::abs(editor->get_moving_selection_offset()) > CMP_EPSILON || (snapped_time > moving_selection_pivot && delta > CMP_EPSILON) || (snapped_time < moving_selection_pivot && delta < -CMP_EPSILON)) {
 			offset = snapped_time - moving_selection_pivot;
 			moving_selection_effective = true;
 		}
@@ -7389,8 +7389,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 						if (is_using_angle) {
 							real_t a = from_v;
 							real_t b = to_v;
-							real_t to_diff = std::fmod(b - a, Math::TAU);
-							to_v = a + std::fmod(2.0 * to_diff, Math::TAU) - to_diff;
+							real_t to_diff = Math::fmod(b - a, static_cast<real_t>(Math::TAU));
+							to_v = a + Math::fmod(2.0 * to_diff, Math::TAU) - to_diff;
 						}
 						Variant delta_v = Animation::subtract_variant(to_v, from_v);
 						double duration = to_t - from_t;

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -957,7 +957,7 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 #ifndef ANDROID_ENABLED
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
 	if (magnify_gesture.is_valid()) {
-		_zoom_to(zoom_factor * std::pow(magnify_gesture->get_factor(), 0.25f));
+		_zoom_to(zoom_factor * Math::pow(static_cast<float>(magnify_gesture->get_factor()), 0.25f));
 		accept_event();
 		return;
 	}

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1022,7 +1022,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				Vector<float> tangents = d[Mesh::ARRAY_TANGENT];
 				for (int vert = 0; vert < normals.size(); vert++) {
 					Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
-					if (std::abs(tan.dot(normals[vert])) > 0.0001) {
+					if (Math::abs(tan.dot(normals[vert])) > 0.0001) {
 						// Tangent is not perpendicular to the normal, so we can't use compression.
 						mesh_flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 					}

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -454,7 +454,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 		if (bool(p_options["retarget/rest_fixer/normalize_position_tracks"])) {
 			int src_bone_idx = src_skeleton->find_bone(profile->get_scale_base_bone());
 			if (src_bone_idx >= 0) {
-				real_t motion_scale = std::abs(src_skeleton->get_bone_global_rest(src_bone_idx).origin.y);
+				real_t motion_scale = Math::abs(src_skeleton->get_bone_global_rest(src_bone_idx).origin.y);
 				if (motion_scale > 0) {
 					src_skeleton->set_motion_scale(motion_scale);
 				}

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -456,7 +456,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 					ERR_FAIL_COND_V(tangents.is_empty(), ERR_FILE_CORRUPT);
 					for (int vert = 0; vert < norms.size(); vert++) {
 						Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
-						if (std::abs(tan.dot(norms[vert])) > 0.0001) {
+						if (Math::abs(tan.dot(norms[vert])) > 0.0001) {
 							// Tangent is not perpendicular to the normal, so we can't use compression.
 							mesh_flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 						}

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -151,7 +151,7 @@ Control *EditorAudioStreamTooltipPlugin::make_tooltip_for_path(const String &p_r
 
 	double length = p_metadata.get("length", 0.0);
 	if (length >= 60.0) {
-		vb->add_child(memnew(Label(vformat(TTR("Length: %0dm %0ds"), int(length / 60.0), int(std::fmod(length, 60))))));
+		vb->add_child(memnew(Label(vformat(TTR("Length: %0dm %0ds"), int(length / 60.0), int(Math::fmod(length, 60))))));
 	} else if (length >= 1.0) {
 		vb->add_child(memnew(Label(vformat(TTR("Length: %0.1fs"), length))));
 	} else {

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -507,7 +507,7 @@ void Path3DGizmo::redraw() {
 					const int n = 36;
 					for (int i = 0; i <= n; i++) {
 						const float a = Math::TAU * i / n;
-						const Vector3 edge = std::sin(a) * side + std::cos(a) * up;
+						const Vector3 edge = Math::sin(a) * side + Math::cos(a) * up;
 						disk.append(pos + edge * disk_size);
 					}
 					add_vertices(disk, debug_material, Mesh::PRIMITIVE_LINE_STRIP);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -356,7 +356,7 @@ void CanvasItemEditor::_snap_other_nodes(
 
 	if (ci && !exception) {
 		Transform2D ci_transform = ci->get_screen_transform();
-		if (std::fmod(ci_transform.get_rotation() - p_transform_to_snap.get_rotation(), (real_t)360.0) == 0.0) {
+		if (Math::fmod(ci_transform.get_rotation() - p_transform_to_snap.get_rotation(), (real_t)360.0) == 0.0) {
 			if (ci->_edit_use_rect()) {
 				Point2 begin = ci_transform.xform(ci->_edit_get_rect().get_position());
 				Point2 end = ci_transform.xform(ci->_edit_get_rect().get_position() + ci->_edit_get_rect().get_size());
@@ -461,7 +461,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 				get_tree()->get_edited_scene_root());
 	}
 
-	if (((is_snap_active && snap_guides && (p_modes & SNAP_GUIDES)) || (p_forced_modes & SNAP_GUIDES)) && std::fmod(rotation, (real_t)360.0) == 0.0) {
+	if (((is_snap_active && snap_guides && (p_modes & SNAP_GUIDES)) || (p_forced_modes & SNAP_GUIDES)) && Math::fmod(rotation, (real_t)360.0) == 0.0) {
 		// Guides.
 		if (Node *scene = EditorNode::get_singleton()->get_edited_scene()) {
 			Array vguides = scene->get_meta("_edit_vertical_guides_", Array());
@@ -476,7 +476,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		}
 	}
 
-	if (((grid_snap_active && (p_modes & SNAP_GRID)) || (p_forced_modes & SNAP_GRID)) && std::fmod(rotation, (real_t)360.0) == 0.0) {
+	if (((grid_snap_active && (p_modes & SNAP_GRID)) || (p_forced_modes & SNAP_GRID)) && Math::fmod(rotation, (real_t)360.0) == 0.0) {
 		// Grid
 		Point2 offset = grid_offset;
 		if (snap_relative) {
@@ -3345,8 +3345,8 @@ void CanvasItemEditor::_draw_grid() {
 
 		if (snap_relative && selection.size() > 0) {
 			const Vector2 topleft = _get_encompassing_rect_from_list(selection).position;
-			real_grid_offset.x = std::fmod(topleft.x, grid_step.x * (real_t)Math::pow(2.0, grid_step_multiplier));
-			real_grid_offset.y = std::fmod(topleft.y, grid_step.y * (real_t)Math::pow(2.0, grid_step_multiplier));
+			real_grid_offset.x = Math::fmod(topleft.x, grid_step.x * (real_t)Math::pow(2.0, grid_step_multiplier));
+			real_grid_offset.y = Math::fmod(topleft.y, grid_step.y * (real_t)Math::pow(2.0, grid_step_multiplier));
 		} else {
 			real_grid_offset = grid_offset;
 		}
@@ -3494,8 +3494,8 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		viewport->draw_string(font, text_pos, ts->format_number(vformat("%.1f px", length_vector.length()), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 
 		if (draw_secondary_lines) {
-			const int horizontal_angle = std::round(180 * horizontal_angle_rad / Math::PI);
-			const int vertical_angle = std::round(180 * vertical_angle_rad / Math::PI);
+			const int horizontal_angle = Math::round(180 * horizontal_angle_rad / Math::PI);
+			const int vertical_angle = Math::round(180 * vertical_angle_rad / Math::PI);
 
 			Point2 text_pos2 = text_pos;
 			text_pos2.x = begin.x < text_pos.x ? MIN(text_pos.x - text_width, begin.x - text_width / 2) : MAX(text_pos.x + text_width, begin.x - text_width / 2);
@@ -3543,16 +3543,16 @@ void CanvasItemEditor::_draw_ruler_tool() {
 
 				Point2 text_pos2 = text_pos;
 				text_pos2.x = begin.x < text_pos.x ? MIN(text_pos.x - text_width, begin.x - text_width / 2) : MAX(text_pos.x + text_width, begin.x - text_width / 2);
-				viewport->draw_string_outline(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), std::round(length_vector.y / grid_step.y)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
-				viewport->draw_string(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), std::round(length_vector.y / grid_step.y)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_secondary_color);
+				viewport->draw_string_outline(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), Math::round(length_vector.y / grid_step.y)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
+				viewport->draw_string(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), Math::round(length_vector.y / grid_step.y)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_secondary_color);
 
 				text_pos2 = text_pos;
 				text_pos2.y = end.y < text_pos.y ? MIN(text_pos.y - text_height * 2, end.y + text_height / 2) : MAX(text_pos.y + text_height * 2, end.y + text_height / 2);
-				viewport->draw_string_outline(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), std::round(length_vector.x / grid_step.x)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
-				viewport->draw_string(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), std::round(length_vector.x / grid_step.x)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_secondary_color);
+				viewport->draw_string_outline(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), Math::round(length_vector.x / grid_step.x)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
+				viewport->draw_string(font, text_pos2, ts->format_number(vformat("%d " + TTR("units"), Math::round(length_vector.x / grid_step.x)), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_secondary_color);
 			} else {
-				viewport->draw_string_outline(font, text_pos, ts->format_number(vformat("%d " + TTR("units"), std::round((length_vector / grid_step).length())), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
-				viewport->draw_string(font, text_pos, ts->format_number(vformat("%d " + TTR("units"), std::round((length_vector / grid_step).length())), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
+				viewport->draw_string_outline(font, text_pos, ts->format_number(vformat("%d " + TTR("units"), Math::round((length_vector / grid_step).length())), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, outline_size, outline_color);
+				viewport->draw_string(font, text_pos, ts->format_number(vformat("%d " + TTR("units"), Math::round((length_vector / grid_step).length())), lang), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 			}
 		}
 	} else {

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -353,7 +353,7 @@ MainFrameTime MainTimerSync::advance_core(double p_physics_step, int p_physics_t
 
 	// simple determination of number of physics iteration
 	time_accum += ret.process_step;
-	ret.physics_steps = std::floor(time_accum * p_physics_ticks_per_second);
+	ret.physics_steps = Math::floor(time_accum * p_physics_ticks_per_second);
 
 	int min_typical_steps = typical_physics_steps[0];
 	int max_typical_steps = min_typical_steps + 1;
@@ -386,7 +386,7 @@ MainFrameTime MainTimerSync::advance_core(double p_physics_step, int p_physics_t
 
 	// try to keep it consistent with previous iterations
 	if (ret.physics_steps < min_typical_steps) {
-		const int max_possible_steps = std::floor((time_accum)*p_physics_ticks_per_second + get_physics_jitter_fix());
+		const int max_possible_steps = Math::floor((time_accum)*p_physics_ticks_per_second + get_physics_jitter_fix());
 		if (max_possible_steps < min_typical_steps) {
 			ret.physics_steps = max_possible_steps;
 			update_typical = true;
@@ -394,7 +394,7 @@ MainFrameTime MainTimerSync::advance_core(double p_physics_step, int p_physics_t
 			ret.physics_steps = min_typical_steps;
 		}
 	} else if (ret.physics_steps > max_typical_steps) {
-		const int min_possible_steps = std::floor((time_accum)*p_physics_ticks_per_second - get_physics_jitter_fix());
+		const int min_possible_steps = Math::floor((time_accum)*p_physics_ticks_per_second - get_physics_jitter_fix());
 		if (min_possible_steps > max_typical_steps) {
 			ret.physics_steps = min_possible_steps;
 			update_typical = true;
@@ -480,7 +480,7 @@ MainFrameTime MainTimerSync::advance_checked(double p_physics_step, int p_physic
 #endif
 
 	if (time_accum > p_physics_step) {
-		const int extra_physics_steps = std::floor(time_accum * p_physics_ticks_per_second);
+		const int extra_physics_steps = Math::floor(time_accum * p_physics_ticks_per_second);
 		time_accum -= extra_physics_steps * p_physics_step;
 		ret.physics_steps += extra_physics_steps;
 	}

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -999,7 +999,7 @@ Vector3 GodotSoftBody3D::_compute_area_windforce(const GodotArea3D *p_area, cons
 	const Vector3 &ws = p_area->get_wind_source();
 	real_t projection_on_tri_normal = vec3_dot(p_face->normal, wd);
 	real_t projection_toward_centroid = vec3_dot(p_face->centroid - ws, wd);
-	real_t attenuation_over_distance = std::pow(projection_toward_centroid, -waf);
+	real_t attenuation_over_distance = Math::pow(projection_toward_centroid, -waf);
 	real_t nodal_force_magnitude = wfm * 0.33333333333 * p_face->ra * projection_on_tri_normal * attenuation_over_distance;
 	return nodal_force_magnitude * p_face->normal;
 }

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -129,7 +129,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 			int e = ptr[3] - 128;
 
 			if (force_linear || (e < -15 || e > 15)) {
-				float exp = std::pow(2.0f, e);
+				float exp = Math::pow(2.0f, e);
 				Color c(ptr[0] * exp / 255.0, ptr[1] * exp / 255.0, ptr[2] * exp / 255.0);
 
 				if (force_linear) {

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -206,7 +206,7 @@ void MobileVRInterface::set_position_from_sensors() {
 			Vector3 axis = grav_adj.cross(down);
 			axis.normalize();
 
-			Basis drift_compensation(axis, std::acos(dot) * delta_time * 10);
+			Basis drift_compensation(axis, Math::acos(dot) * delta_time * 10);
 			orientation = drift_compensation * orientation;
 		};
 	};

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -94,8 +94,8 @@ private:
 
 	///@TODO a few support functions for trackers, most are math related and should likely be moved elsewhere
 	float floor_decimals(const float p_value, const float p_decimals) {
-		float power_of_10 = std::pow(10.0f, p_decimals);
-		return std::floor(p_value * power_of_10) / power_of_10;
+		float power_of_10 = Math::pow(10.0f, p_decimals);
+		return Math::floor(p_value * power_of_10) / power_of_10;
 	}
 
 	Vector3 floor_decimals(const Vector3 &p_vector, const float p_decimals) {

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -89,8 +89,8 @@ Error ImageLoaderSVG::create_image_from_utf8_buffer(Ref<Image> p_image, const ui
 	float fw, fh;
 	picture->size(&fw, &fh);
 
-	uint32_t width = MAX(1, std::round(fw * p_scale));
-	uint32_t height = MAX(1, std::round(fh * p_scale));
+	uint32_t width = MAX(1, Math::round(fw * p_scale));
+	uint32_t height = MAX(1, Math::round(fh * p_scale));
 
 	const uint32_t max_dimension = 16384;
 	if (width > max_dimension || height > max_dimension) {

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2238,7 +2238,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 					if (test_button == MouseButton::WHEEL_RIGHT || test_button == MouseButton::WHEEL_LEFT) {
 						// If this is a discrete scroll, specify how many "clicks" it did for this
 						// pointer frame.
-						mb->set_factor(std::abs(pd.discrete_scroll_vector_120.x / (float)120));
+						mb->set_factor(Math::abs(pd.discrete_scroll_vector_120.x / (float)120));
 					}
 
 					mb->set_button_mask(pd.pressed_button_mask);
@@ -4091,8 +4091,8 @@ void WaylandThread::window_state_set_buffer_scale(WindowState *p_ws, int p_buffe
 // must be scaled with away from zero half-rounding.
 Vector2i WaylandThread::scale_vector2i(const Vector2i &p_vector, double p_amount) {
 	// This snippet is tiny, I know, but this is done a lot.
-	int x = std::round(p_vector.x * p_amount);
-	int y = std::round(p_vector.y * p_amount);
+	int x = Math::round(p_vector.x * p_amount);
+	int y = Math::round(p_vector.y * p_amount);
 
 	return Vector2i(x, y);
 }

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1480,7 +1480,7 @@ int DisplayServerMacOS::screen_get_dpi(int p_screen) const {
 
 		float den2 = (displayPhysicalSize.width / 25.4f) * (displayPhysicalSize.width / 25.4f) + (displayPhysicalSize.height / 25.4f) * (displayPhysicalSize.height / 25.4f);
 		if (den2 > 0.0f) {
-			return std::ceil(std::sqrt(displayPixelSize.width * displayPixelSize.width + displayPixelSize.height * displayPixelSize.height) / std::sqrt(den2) * scale);
+			return Math::ceil(Math::sqrt(displayPixelSize.width * displayPixelSize.width + displayPixelSize.height * displayPixelSize.height) / Math::sqrt(den2) * scale);
 		}
 	}
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -915,11 +915,11 @@
 	if ([event phase] != NSEventPhaseNone || [event momentumPhase] != NSEventPhaseNone) {
 		[self processPanEvent:event dx:delta_x dy:delta_y];
 	} else {
-		if (std::abs(delta_x)) {
-			[self processScrollEvent:event button:(0 > delta_x ? MouseButton::WHEEL_RIGHT : MouseButton::WHEEL_LEFT) factor:std::abs(delta_x * 0.3)];
+		if (Math::abs(delta_x)) {
+			[self processScrollEvent:event button:(0 > delta_x ? MouseButton::WHEEL_RIGHT : MouseButton::WHEEL_LEFT) factor:Math::abs(delta_x * 0.3)];
 		}
-		if (std::abs(delta_y)) {
-			[self processScrollEvent:event button:(0 < delta_y ? MouseButton::WHEEL_UP : MouseButton::WHEEL_DOWN) factor:std::abs(delta_y * 0.3)];
+		if (Math::abs(delta_y)) {
+			[self processScrollEvent:event button:(0 < delta_y ? MouseButton::WHEEL_UP : MouseButton::WHEEL_DOWN) factor:Math::abs(delta_y * 0.3)];
 		}
 	}
 }

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -849,7 +849,7 @@ void GPUParticles2D::_draw_emission_gizmo() {
 				draw_circle(Vector2(), pm->get_emission_ring_radius(), emission_ring_color, false);
 			} else {
 				Vector2 a = Vector2(pm->get_emission_ring_height() / -2.0, pm->get_emission_ring_radius() / -1.0);
-				Vector2 b = Vector2(-a.x, MIN(a.y + std::tan((90.0 - pm->get_emission_ring_cone_angle()) * 0.01745329) * pm->get_emission_ring_height(), 0.0));
+				Vector2 b = Vector2(-a.x, MIN(a.y + Math::tan((90.0 - pm->get_emission_ring_cone_angle()) * 0.01745329) * pm->get_emission_ring_height(), 0.0));
 				Vector2 c = Vector2(b.x, -b.y);
 				Vector2 d = Vector2(a.x, -a.y);
 				if (ring_axis.is_equal_approx(Vector3(1.0, 0.0, 0.0))) {

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -121,12 +121,12 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_s
 
 	if (mirroring.x) {
 		real_t den = mirroring.x * p_scale;
-		new_ofs.x -= den * std::ceil(new_ofs.x / den);
+		new_ofs.x -= den * Math::ceil(new_ofs.x / den);
 	}
 
 	if (mirroring.y) {
 		real_t den = mirroring.y * p_scale;
-		new_ofs.y -= den * std::ceil(new_ofs.y / den);
+		new_ofs.y -= den * Math::ceil(new_ofs.y / den);
 	}
 
 	set_position(new_ofs);

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -85,13 +85,13 @@ public:
 		const Speaker *r = speakers.ptr();
 		real_t sum_squared_gains = 0.0;
 		for (unsigned int speaker_num = 0; speaker_num < (unsigned int)speakers.size(); speaker_num++) {
-			real_t initial_gain = 0.5 * std::pow(1.0 + r[speaker_num].direction.dot(source_direction), tightness) / r[speaker_num].effective_number_of_speakers;
+			real_t initial_gain = 0.5 * Math::pow(static_cast<real_t>(1.0) + r[speaker_num].direction.dot(source_direction), tightness) / r[speaker_num].effective_number_of_speakers;
 			r[speaker_num].squared_gain = initial_gain * initial_gain;
 			sum_squared_gains += r[speaker_num].squared_gain;
 		}
 
 		for (unsigned int speaker_num = 0; speaker_num < MIN(volume_count, (unsigned int)speakers.size()); speaker_num++) {
-			volumes[speaker_num] = std::sqrt(r[speaker_num].squared_gain / sum_squared_gains);
+			volumes[speaker_num] = Math::sqrt(r[speaker_num].squared_gain / sum_squared_gains);
 		}
 	}
 };

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -586,15 +586,15 @@ void NavigationObstacle3D::_update_fake_agent_radius_debug() {
 		float w;
 
 		v /= (rings + 1);
-		w = std::sin(Math::PI * v);
-		y = (radius)*std::cos(Math::PI * v);
+		w = Math::sin(Math::PI * v);
+		y = (radius)*Math::cos(Math::PI * v);
 
 		for (i = 0; i <= radial_segments; i++) {
 			float u = i;
 			u /= radial_segments;
 
-			x = std::sin(u * Math::TAU);
-			z = std::cos(u * Math::TAU);
+			x = Math::sin(u * Math::TAU);
+			z = Math::cos(u * Math::TAU);
 
 			Vector3 p = Vector3(x * radius * w, y, z * radius * w);
 			face_vertex_array.push_back(p);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -192,7 +192,7 @@ bool Control::_edit_use_rotation() const {
 
 void Control::_edit_set_pivot(const Point2 &p_pivot) {
 	Vector2 delta_pivot = p_pivot - get_pivot_offset();
-	Vector2 move = Vector2((std::cos(data.rotation) - 1.0) * delta_pivot.x - std::sin(data.rotation) * delta_pivot.y, std::sin(data.rotation) * delta_pivot.x + (std::cos(data.rotation) - 1.0) * delta_pivot.y);
+	Vector2 move = Vector2((Math::cos(data.rotation) - 1.0) * delta_pivot.x - Math::sin(data.rotation) * delta_pivot.y, Math::sin(data.rotation) * delta_pivot.x + (Math::cos(data.rotation) - 1.0) * delta_pivot.y);
 	set_position(get_position() + move);
 	set_pivot_offset(p_pivot);
 	set_pivot_offset_ratio(Vector2());
@@ -883,7 +883,7 @@ void Control::set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, 
 
 void Control::set_begin(const Point2 &p_point) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!std::isfinite(p_point.x) || !std::isfinite(p_point.y));
+	ERR_FAIL_COND(!Math::is_finite(p_point.x) || !Math::is_finite(p_point.y));
 	if (data.offset[0] == p_point.x && data.offset[1] == p_point.y) {
 		return;
 	}
@@ -1567,7 +1567,7 @@ void Control::_set_size(const Size2 &p_size) {
 
 void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!std::isfinite(p_size.x) || !std::isfinite(p_size.y));
+	ERR_FAIL_COND(!Math::is_finite(p_size.x) || !Math::is_finite(p_size.y));
 	Size2 new_size = p_size;
 	Size2 min = get_combined_minimum_size();
 	if (new_size.x < min.x) {

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -125,7 +125,7 @@ void GridContainer::_resort() {
 	}
 
 	int max_col = MIN(valid_controls_index, columns);
-	int max_row = std::ceil((float)valid_controls_index / (float)columns);
+	int max_row = Math::ceil((float)valid_controls_index / (float)columns);
 
 	// Consider all empty columns expanded.
 	for (int i = valid_controls_index; i < columns; i++) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1526,7 +1526,7 @@ void LineEdit::_notification(int p_what) {
 				Vector2 oofs = ofs;
 				for (int i = 0; i < gl_size; i++) {
 					for (int j = 0; j < glyphs[i].repeat; j++) {
-						if (std::ceil(oofs.x) >= x_ofs && (oofs.x + glyphs[i].advance) <= ofs_max) {
+						if (Math::ceil(oofs.x) >= x_ofs && (oofs.x + glyphs[i].advance) <= ofs_max) {
 							if (glyphs[i].font_rid != RID()) {
 								TS->font_draw_glyph_outline(glyphs[i].font_rid, ci, glyphs[i].font_size, outline_size, oofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, font_outline_color);
 							}
@@ -1541,7 +1541,7 @@ void LineEdit::_notification(int p_what) {
 			for (int i = 0; i < gl_size; i++) {
 				bool selected = selection.enabled && glyphs[i].start >= selection.begin && glyphs[i].end <= selection.end;
 				for (int j = 0; j < glyphs[i].repeat; j++) {
-					if (std::ceil(ofs.x) >= x_ofs && (ofs.x + glyphs[i].advance) <= ofs_max) {
+					if (Math::ceil(ofs.x) >= x_ofs && (ofs.x + glyphs[i].advance) <= ofs_max) {
 						if (glyphs[i].font_rid != RID()) {
 							TS->font_draw_glyph(glyphs[i].font_rid, ci, glyphs[i].font_size, ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, selected ? font_selected_color : font_color);
 						} else if (((glyphs[i].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) && ((glyphs[i].flags & TextServer::GRAPHEME_IS_EMBEDDED_OBJECT) != TextServer::GRAPHEME_IS_EMBEDDED_OBJECT)) {

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -118,13 +118,13 @@ void ProgressBar::_notification(int p_what) {
 				case FILL_BEGIN_TO_END:
 				case FILL_END_TO_BEGIN: {
 					int mp = theme_cache.fill_style->get_minimum_size().width;
-					int p = std::round(r * (get_size().width - mp));
+					int p = Math::round(r * (get_size().width - mp));
 					// We want FILL_BEGIN_TO_END to map to right to left when UI layout is RTL,
 					// and left to right otherwise. And likewise for FILL_END_TO_BEGIN.
 					bool right_to_left = mode == (is_layout_rtl() ? FILL_BEGIN_TO_END : FILL_END_TO_BEGIN);
 					if (p > 0) {
 						if (right_to_left) {
-							int p_remaining = std::round((1.0 - r) * (get_size().width - mp));
+							int p_remaining = Math::round((1.0 - r) * (get_size().width - mp));
 							draw_style_box(theme_cache.fill_style, Rect2(Point2(p_remaining, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
 						} else {
 							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
@@ -134,13 +134,13 @@ void ProgressBar::_notification(int p_what) {
 				case FILL_TOP_TO_BOTTOM:
 				case FILL_BOTTOM_TO_TOP: {
 					int mp = theme_cache.fill_style->get_minimum_size().height;
-					int p = std::round(r * (get_size().height - mp));
+					int p = Math::round(r * (get_size().height - mp));
 
 					if (p > 0) {
 						if (mode == FILL_TOP_TO_BOTTOM) {
 							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
 						} else {
-							int p_remaining = std::round((1.0 - r) * (get_size().height - mp));
+							int p_remaining = Math::round((1.0 - r) * (get_size().height - mp));
 							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, p_remaining), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
 						}
 					}

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -308,7 +308,7 @@ void Range::set_as_ratio(double p_value) {
 	} else {
 		double percent = (get_max() - get_min()) * p_value;
 		if (get_step() > 0) {
-			double steps = std::round(percent / get_step());
+			double steps = Math::round(percent / get_step());
 			v = steps * get_step() + get_min();
 		} else {
 			v = percent + get_min();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2774,9 +2774,9 @@ void RichTextLabel::_notification(int p_what) {
 					bool right_to_left = is_layout_rtl();
 					double r = loaded.load();
 					int mp = theme_cache.progress_fg_style->get_minimum_size().width;
-					int p = std::round(r * (p_size.width - mp));
+					int p = Math::round(r * (p_size.width - mp));
 					if (right_to_left) {
-						int p_remaining = std::round((1.0 - r) * (p_size.width - mp));
+						int p_remaining = Math::round((1.0 - r) * (p_size.width - mp));
 						draw_style_box(theme_cache.progress_fg_style, Rect2(p_pos + Point2(p_remaining, 0), Size2(p + theme_cache.progress_fg_style->get_minimum_size().width, p_size.height)));
 					} else {
 						draw_style_box(theme_cache.progress_fg_style, Rect2(p_pos, Size2(p + theme_cache.progress_fg_style->get_minimum_size().width, p_size.height)));

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -956,7 +956,7 @@ void TextEdit::_notification(int p_what) {
 				}
 			} else if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
-				double dist = std::abs(target_y);
+				double dist = Math::abs(target_y);
 				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_process_delta_time();
 
@@ -1214,7 +1214,7 @@ void TextEdit::_notification(int p_what) {
 				// Calculate viewport size and y offset.
 				int viewport_height = (draw_amount - 1) * minimap_line_height;
 				int control_height = _get_control_height() - viewport_height;
-				int viewport_offset_y = std::round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
+				int viewport_offset_y = Math::round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
 				// Calculate the first line.
 				int num_lines_before = std::round((viewport_offset_y) / minimap_line_height);
@@ -1696,7 +1696,7 @@ void TextEdit::_notification(int p_what) {
 									} else if (rect.position.x + rect.size.x > xmargin_end) {
 										rect.size.x = xmargin_end - rect.position.x;
 									}
-									rect.position.y += std::ceil(TS->shaped_text_get_ascent(rid)) + std::ceil(theme_cache.font->get_underline_position(theme_cache.font_size));
+									rect.position.y += Math::ceil(TS->shaped_text_get_ascent(rid)) + Math::ceil(theme_cache.font->get_underline_position(theme_cache.font_size));
 									rect.size.y = MAX(1, theme_cache.font->get_underline_thickness(theme_cache.font_size));
 									RS::get_singleton()->canvas_item_add_rect(text_ci, rect, highlight_underline_color);
 								}
@@ -5555,7 +5555,7 @@ int TextEdit::get_minimap_line_at_pos(const Point2i &p_pos) const {
 	// Calculate viewport size and y offset.
 	int viewport_height = (draw_amount - 1) * minimap_line_height;
 	int control_height = _get_control_height() - viewport_height;
-	int viewport_offset_y = std::round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
+	int viewport_offset_y = Math::round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
 	// Calculate the first line.
 	int num_lines_before = std::round((viewport_offset_y) / minimap_line_height);
@@ -9177,7 +9177,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 		// Set line ofs and wrap ofs.
 		bool draw_placeholder = _using_placeholder();
 
-		int v_scroll_i = std::floor(get_v_scroll());
+		int v_scroll_i = Math::floor(get_v_scroll());
 		int sc = 0;
 		int n_line;
 		for (n_line = 0; n_line < text.size(); n_line++) {
@@ -9204,13 +9204,13 @@ void TextEdit::_scroll_moved(double p_to_val) {
 double TextEdit::_get_visible_lines_offset() const {
 	double total = _get_control_height();
 	total /= (double)get_line_height();
-	total = total - std::floor(total);
+	total = total - Math::floor(total);
 	total = -CLAMP(total, 0.001, 1) + 1;
 	return total;
 }
 
 double TextEdit::_get_v_scroll_offset() const {
-	double val = get_v_scroll() - std::floor(get_v_scroll());
+	double val = get_v_scroll() - Math::floor(get_v_scroll());
 	return CLAMP(val, 0, 1);
 }
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -182,7 +182,7 @@ void SkeletonModification2DTwoBoneIK::_execute(float p_delta) {
 			angle_1 = -angle_1;
 		}
 
-		if (std::isnan(angle_0) || std::isnan(angle_1)) {
+		if (Math::is_nan(angle_0) || Math::is_nan(angle_1)) {
 			// We cannot solve for this angle! Do nothing to avoid setting the rotation (and scale) to NaN.
 		} else {
 			if (same_scale_sign) {
@@ -242,10 +242,10 @@ void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
 
 	if (flip_bend_direction) {
 		float angle = -(Math::PI * 0.5) + operation_bone_one->get_bone_angle();
-		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), std::sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
+		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), Math::sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
 	} else {
 		float angle = (Math::PI * 0.5) + operation_bone_one->get_bone_angle();
-		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), std::sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
+		stack->skeleton->draw_line(Vector2(0, 0), Vector2(Math::cos(angle), Math::sin(angle)) * (operation_bone_one->get_length() * 0.5), bone_ik_color, 2.0);
 	}
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4411,10 +4411,10 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 				t1.value = vt->values[i + 1].value;
 				t2.value = vt->values[i + 2].value;
 				if (is_using_angle) {
-					float diff1 = std::fmod(t1.value - t0.value, Math::TAU);
-					t1.value = t0.value + std::fmod(2.0 * diff1, Math::TAU) - diff1;
-					float diff2 = std::fmod(t2.value - t1.value, Math::TAU);
-					t2.value = t1.value + std::fmod(2.0 * diff2, Math::TAU) - diff2;
+					float diff1 = Math::fmod(t1.value - t0.value, static_cast<float>(Math::TAU));
+					t1.value = t0.value + Math::fmod(2.0f * diff1, static_cast<float>(Math::TAU)) - diff1;
+					float diff2 = Math::fmod(t2.value - t1.value, static_cast<float>(Math::TAU));
+					t2.value = t1.value + Math::fmod(2.0f * diff2, static_cast<float>(Math::TAU)) - diff2;
 					if (std::abs(std::abs(diff1) + std::abs(diff2)) >= Math::PI) {
 						break; // Rotation is more than 180 deg, keep key.
 					}
@@ -4475,8 +4475,8 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 				float val_0 = vt->values[0].value;
 				float val_1 = vt->values[1].value;
 				if (is_using_angle) {
-					float diff1 = std::fmod(val_1 - val_0, Math::TAU);
-					val_1 = val_0 + std::fmod(2.0 * diff1, Math::TAU) - diff1;
+					float diff1 = Math::fmod(val_1 - val_0, static_cast<float>(Math::TAU));
+					val_1 = val_0 + Math::fmod(2.0f * diff1, static_cast<float>(Math::TAU)) - diff1;
 				}
 				single_key = std::abs(val_0 - val_1) < p_allowed_precision_error;
 			} break;

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -387,7 +387,7 @@ void CameraAttributesPhysical::_update_frustum() {
 	Vector2i sensor_size = Vector2i(36, 24); // Matches high-end DSLR, could be made variable if there is demand.
 	float CoC = sensor_size.length() / 1500.0;
 
-	frustum_fov = Math::rad_to_deg(2 * std::atan(sensor_size.height / (2 * frustum_focal_length)));
+	frustum_fov = Math::rad_to_deg(2 * Math::atan(sensor_size.height / (2 * frustum_focal_length)));
 
 	// Based on https://en.wikipedia.org/wiki/Depth_of_field.
 	float u = MAX(frustum_focus_distance * 1000.0, frustum_focal_length + 1.0); // Focus distance expressed in mm and clamped to at least 1 mm away from lens.
@@ -448,8 +448,8 @@ void CameraAttributesPhysical::_update_auto_exposure() {
 	RS::get_singleton()->camera_attributes_set_auto_exposure(
 			get_rid(),
 			auto_exposure_enabled,
-			std::pow(2.0, auto_exposure_min) * (12.5 / exposure_sensitivity), // Convert from EV100 to Luminance
-			std::pow(2.0, auto_exposure_max) * (12.5 / exposure_sensitivity), // Convert from EV100 to Luminance
+			Math::pow(2.0f, auto_exposure_min) * (12.5 / exposure_sensitivity), // Convert from EV100 to Luminance
+			Math::pow(2.0f, auto_exposure_max) * (12.5 / exposure_sensitivity), // Convert from EV100 to Luminance
 			auto_exposure_speed,
 			auto_exposure_scale);
 	emit_changed();

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -2086,8 +2086,8 @@ void ParticleProcessMaterial::set_turbulence_noise_scale(float p_turbulence_nois
 	const float noise_frequency_when_slider_is_zero = 4.0;
 	const float max_slider_value = 10.0;
 	const float curve_exponent = 0.25;
-	const float curve_rescale = noise_frequency_when_slider_is_zero / std::pow(max_slider_value, curve_exponent);
-	float shader_turbulence_noise_scale = std::pow(p_turbulence_noise_scale, curve_exponent) * curve_rescale - noise_frequency_when_slider_is_zero;
+	const float curve_rescale = noise_frequency_when_slider_is_zero / Math::pow(max_slider_value, curve_exponent);
+	float shader_turbulence_noise_scale = Math::pow(p_turbulence_noise_scale, curve_exponent) * curve_rescale - noise_frequency_when_slider_is_zero;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->turbulence_noise_scale, shader_turbulence_noise_scale);
 }
 

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -108,9 +108,9 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 		} break;
 
 		case BANDPASS: {
-			p_coeffs->b0 = alpha * std::sqrt(Q + 1);
+			p_coeffs->b0 = alpha * Math::sqrt(Q + 1);
 			p_coeffs->b1 = 0.0;
-			p_coeffs->b2 = -alpha * std::sqrt(Q + 1);
+			p_coeffs->b2 = -alpha * Math::sqrt(Q + 1);
 			p_coeffs->a1 = -2.0 * cos_v;
 			p_coeffs->a2 = 1.0 - alpha;
 		} break;
@@ -195,19 +195,19 @@ float AudioFilterSW::get_response(float p_freq, Coeffs *p_coeffs) {
 
 	float cx = p_coeffs->b0, cy = 0.0;
 
-	cx += std::cos(freq) * p_coeffs->b1;
-	cy -= std::sin(freq) * p_coeffs->b1;
-	cx += std::cos(2 * freq) * p_coeffs->b2;
-	cy -= std::sin(2 * freq) * p_coeffs->b2;
+	cx += Math::cos(freq) * p_coeffs->b1;
+	cy -= Math::sin(freq) * p_coeffs->b1;
+	cx += Math::cos(2 * freq) * p_coeffs->b2;
+	cy -= Math::sin(2 * freq) * p_coeffs->b2;
 
 	float H = cx * cx + cy * cy;
 	cx = 1.0;
 	cy = 0.0;
 
-	cx -= std::cos(freq) * p_coeffs->a1;
-	cy += std::sin(freq) * p_coeffs->a1;
-	cx -= std::cos(2 * freq) * p_coeffs->a2;
-	cy += std::sin(2 * freq) * p_coeffs->a2;
+	cx -= Math::cos(freq) * p_coeffs->a1;
+	cy += Math::sin(freq) * p_coeffs->a1;
+	cx -= Math::cos(2 * freq) * p_coeffs->a2;
+	cy += Math::sin(2 * freq) * p_coeffs->a2;
 
 	H = H / (cx * cx + cy * cy);
 	return H;

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -86,7 +86,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 		if (v.cutoff == 0) {
 			continue;
 		}
-		float auxlp = std::exp(-Math::TAU * v.cutoff / mix_rate);
+		float auxlp = Math::exp(-Math::TAU * v.cutoff / mix_rate);
 		float c1 = 1.0 - auxlp;
 		float c2 = auxlp;
 		AudioFrame h = filter_h[vc];
@@ -106,9 +106,9 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 
 			float phase = (float)(local_cycles & AudioEffectChorus::CYCLES_MASK) / (float)(1 << AudioEffectChorus::CYCLES_FRAC);
 
-			float wave_delay = std::sin(phase * Math::TAU) * max_depth_frames;
+			float wave_delay = Math::sin(phase * Math::TAU) * max_depth_frames;
 
-			int wave_delay_frames = std::rint(std::floor(wave_delay));
+			int wave_delay_frames = std::rint(Math::floor(wave_delay));
 			float wave_delay_frac = wave_delay - (float)wave_delay_frames;
 
 			/** COMPUTE RINGBUFFER POS**/

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -38,17 +38,17 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 	float threshold = Math::db_to_linear(base->threshold);
 	float sample_rate = AudioServer::get_singleton()->get_mix_rate();
 
-	float ratatcoef = std::exp(-1 / (0.00001f * sample_rate));
-	float ratrelcoef = std::exp(-1 / (0.5f * sample_rate));
+	float ratatcoef = Math::exp(-1 / (0.00001f * sample_rate));
+	float ratrelcoef = Math::exp(-1 / (0.5f * sample_rate));
 	float attime = base->attack_us / 1000000.0;
 	float reltime = base->release_ms / 1000.0;
-	float atcoef = std::exp(-1 / (attime * sample_rate));
-	float relcoef = std::exp(-1 / (reltime * sample_rate));
+	float atcoef = Math::exp(-1 / (attime * sample_rate));
+	float relcoef = Math::exp(-1 / (reltime * sample_rate));
 
 	float makeup = Math::db_to_linear(base->gain);
 
 	float mix = base->mix;
-	float gr_meter_decay = std::exp(1 / (1 * sample_rate));
+	float gr_meter_decay = Math::exp(1 / (1 * sample_rate));
 
 	const AudioFrame *src = p_src_frames;
 

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -74,7 +74,7 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 	tap2_vol.right *= CLAMP(1.0 + base->tap_2_pan, 0, 1);
 
 	// feedback lowpass here
-	float lpf_c = std::exp(-Math::TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
+	float lpf_c = Math::exp(-Math::TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
 	float lpf_ic = 1.0 - lpf_c;
 
 	const AudioFrame *src = p_src_frames;

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -38,18 +38,18 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 	const float *src = (const float *)p_src_frames;
 	float *dst = (float *)p_dst_frames;
 
-	//float lpf_c=std::exp(-Math::TAU*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
-	float lpf_c = std::exp(-Math::TAU * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
+	//float lpf_c=Math::exp(-Math::TAU*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
+	float lpf_c = Math::exp(-Math::TAU * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
 	float lpf_ic = 1.0 - lpf_c;
 
 	float drive_f = base->drive;
 	float pregain_f = Math::db_to_linear(base->pre_gain);
 	float postgain_f = Math::db_to_linear(base->post_gain);
 
-	float atan_mult = std::pow(10, drive_f * drive_f * 3.0) - 1.0 + 0.001;
-	float atan_div = 1.0 / (std::atan(atan_mult) * (1.0 + drive_f * 8));
+	float atan_mult = Math::pow(10, drive_f * drive_f * 3.0) - 1.0 + 0.001;
+	float atan_div = 1.0 / (Math::atan(atan_mult) * (1.0 + drive_f * 8));
 
-	float lofi_mult = std::pow(2.0, 2.0 + (1.0 - drive_f) * 14); //goes from 16 to 2 bits
+	float lofi_mult = Math::pow(2.0, 2.0 + (1.0 - drive_f) * 14); //goes from 16 to 2 bits
 
 	for (int i = 0; i < p_frame_count * 2; i++) {
 		float out = undenormalize(src[i] * lpf_ic + lpf_c * h[i & 1]);
@@ -61,7 +61,7 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 		switch (base->mode) {
 			case AudioEffectDistortion::MODE_CLIP: {
 				float a_sign = a < 0 ? -1.0f : 1.0f;
-				a = std::pow(std::abs(a), 1.0001 - drive_f) * a_sign;
+				a = Math::pow(Math::abs(a), 1.0001f - drive_f) * a_sign;
 				if (a > 1.0) {
 					a = 1.0;
 				} else if (a < (-1.0)) {
@@ -70,23 +70,23 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 
 			} break;
 			case AudioEffectDistortion::MODE_ATAN: {
-				a = std::atan(a * atan_mult) * atan_div;
+				a = Math::atan(a * atan_mult) * atan_div;
 
 			} break;
 			case AudioEffectDistortion::MODE_LOFI: {
-				a = std::floor(a * lofi_mult + 0.5) / lofi_mult;
+				a = Math::floor(a * lofi_mult + 0.5) / lofi_mult;
 
 			} break;
 			case AudioEffectDistortion::MODE_OVERDRIVE: {
 				const double x = a * 0.686306;
-				const double z = 1 + std::exp(std::sqrt(std::abs(x)) * -0.75);
-				a = (std::exp(x) - std::exp(-x * z)) / (std::exp(x) + std::exp(-x));
+				const double z = 1 + Math::exp(Math::sqrt(Math::abs(x)) * -0.75);
+				a = (Math::exp(x) - Math::exp(-x * z)) / (Math::exp(x) + Math::exp(-x));
 			} break;
 			case AudioEffectDistortion::MODE_WAVESHAPE: {
 				float x = a;
 				float k = 2 * drive_f / (1.00001 - drive_f);
 
-				a = (1.0 + k) * x / (1.0 + k * std::abs(x));
+				a = (1.0 + k) * x / (1.0 + k * Math::abs(x));
 
 			} break;
 		}

--- a/servers/audio/effects/audio_effect_phaser.cpp
+++ b/servers/audio/effects/audio_effect_phaser.cpp
@@ -48,7 +48,7 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 			phase -= Math::TAU;
 		}
 
-		float d = dmin + (dmax - dmin) * ((std::sin(phase) + 1.f) / 2.f);
+		float d = dmin + (dmax - dmin) * ((Math::sin(phase) + 1.f) / 2.f);
 
 		//update filter coeffs
 		for (int j = 0; j < 6; j++) {

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -76,8 +76,8 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 		ur = 1.0;
 		ui = 0.0;
 		arg = Math::PI / (le2 >> 1);
-		wr = std::cos(arg);
-		wi = sign * std::sin(arg);
+		wr = Math::cos(arg);
+		wi = sign * Math::sin(arg);
 		for (j = 0; j < le2; j += 2) {
 			p1r = fftBuffer + j;
 			p1i = p1r + 1;

--- a/servers/audio/effects/reverb_filter.cpp
+++ b/servers/audio/effects/reverb_filter.cpp
@@ -88,7 +88,7 @@ void Reverb::process(float *p_src, float *p_dst, int p_frames) {
 	}
 
 	if (params.hpf > 0) {
-		float hpaux = std::exp(-Math::TAU * params.hpf * 6000 / params.mix_rate);
+		float hpaux = Math::exp(-Math::TAU * params.hpf * 6000 / params.mix_rate);
 		float hp_a1 = (1.0 + hpaux) / 2.0;
 		float hp_a2 = -(1.0 + hpaux) / 2.0;
 		float hp_b1 = hpaux;
@@ -290,7 +290,7 @@ void Reverb::update_parameters() {
 		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0 is enough)
 		auxdmp *= auxdmp;
 
-		c.damp = std::exp(-Math::TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
+		c.damp = Math::exp(-Math::TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
 	}
 }
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -960,8 +960,8 @@ static Vector2 compute_polyline_edge_offset_clamped(const Vector2 &p_segment_dir
 
 	bisector = (p_prev_segment_dir * p_segment_dir.length() - p_segment_dir * p_prev_segment_dir.length()).normalized();
 
-	float angle = std::atan2(bisector.cross(p_prev_segment_dir), bisector.dot(p_prev_segment_dir));
-	float sin_angle = std::sin(angle);
+	float angle = Math::atan2(bisector.cross(p_prev_segment_dir), bisector.dot(p_prev_segment_dir));
+	float sin_angle = Math::sin(angle);
 
 	if (!Math::is_zero_approx(sin_angle) && !p_segment_dir.is_equal_approx(p_prev_segment_dir)) {
 		length = 1.0f / sin_angle;

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -216,7 +216,7 @@ static FfxErrorCode create_resource_rd(FfxFsr2Interface *p_backend_interface, co
 
 	if (res_desc.mipCount == 0) {
 		// Mipmap count must be derived from the resource's dimensions.
-		res_desc.mipCount = uint32_t(1 + std::floor(std::log2(MAX(MAX(res_desc.width, res_desc.height), res_desc.depth))));
+		res_desc.mipCount = uint32_t(1 + Math::floor(std::log2(MAX(MAX(res_desc.width, res_desc.height), res_desc.depth))));
 	}
 
 	Vector<PackedByteArray> initial_data;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1172,7 +1172,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 			base_specialization.disable_fog = false;
 			base_specialization.use_fog_aerial_perspective = environment_get_fog_aerial_perspective(p_render_data->environment) > 0.0;
 			base_specialization.use_fog_sun_scatter = environment_get_fog_sun_scatter(p_render_data->environment) > 0.001;
-			base_specialization.use_fog_height_density = std::abs(environment_get_fog_height_density(p_render_data->environment)) >= 0.0001;
+			base_specialization.use_fog_height_density = Math::abs(environment_get_fog_height_density(p_render_data->environment)) >= 0.0001;
 			base_specialization.use_depth_fog = p_render_data->environment.is_valid() && environment_get_fog_mode(p_render_data->environment) == RSE::EnvironmentFogMode::ENV_FOG_MODE_DEPTH;
 		}
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -270,7 +270,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 			if (scaling_type == RSE::VIEWPORT_SCALING_3D_TYPE_TEMPORAL) {
 				// Implementation has been copied from ffxFsr2GetJitterPhaseCount.
 				// Also used for MetalFX Temporal scaling.
-				jitter_phase_count = uint32_t(8.0f * std::pow(float(target_width) / render_width, 2.0f));
+				jitter_phase_count = uint32_t(8.0f * Math::pow(float(target_width) / render_width, 2.0f));
 			} else if (use_taa) {
 				// Default jitter count for TAA.
 				jitter_phase_count = 16;
@@ -281,7 +281,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 
 			// At resolution scales lower than 1.0, use negative texture mipmap bias
 			// to compensate for the loss of sharpness.
-			const float texture_mipmap_bias = std::log2(MIN(scaling_3d_scale, 1.0)) + p_viewport->texture_mipmap_bias;
+			const float texture_mipmap_bias = Math::log2(MIN(scaling_3d_scale, 1.0)) + p_viewport->texture_mipmap_bias;
 
 			RenderSceneBuffersConfiguration rb_config;
 			rb_config.set_render_target(p_viewport->render_target);

--- a/tests/core/math/test_random_number_generator.cpp
+++ b/tests/core/math/test_random_number_generator.cpp
@@ -259,7 +259,7 @@ TEST_CASE_MAY_FAIL("[RandomNumberGenerator] randi_range bias check") {
 		int val = rng->randi_range(0, 1);
 		val == 0 ? zeros++ : ones++;
 	}
-	CHECK_MESSAGE(std::abs(zeros * 1.0 / ones - 1.0) < 0.1, "The ratio of zeros to ones should be nearly 1");
+	CHECK_MESSAGE(Math::abs(zeros * 1.0 / ones - 1.0) < 0.1, "The ratio of zeros to ones should be nearly 1");
 
 	int vals[10] = { 0 };
 	for (int i = 0; i < 1000000; i++) {
@@ -267,7 +267,7 @@ TEST_CASE_MAY_FAIL("[RandomNumberGenerator] randi_range bias check") {
 	}
 
 	for (int i = 0; i < 10; i++) {
-		CHECK_MESSAGE(std::abs(vals[i] / 1000000.0 - 0.1) < 0.01, "Each element should appear roughly 10% of the time");
+		CHECK_MESSAGE(Math::abs(vals[i] / 1000000.0 - 0.1) < 0.01, "Each element should appear roughly 10% of the time");
 	}
 }
 


### PR DESCRIPTION
This PR simply improves the style of the code base by using functions from the `Math` namespace consistently wherever possible. They are being used in most parts of the code base already but not everywhere, there are many cases where there are one or two uses of the standard library surrounded by functions of the `Math` namespace.
