### PR TITLE
Prevent signals with inherited connections from being disconnected with the delete key

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1397,7 +1397,7 @@ void ConnectionsDock::_tree_gui_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
 		if (ED_IS_SHORTCUT("connections_editor/disconnect", p_event)) {
 			item = tree->get_selected();
-			if (item && _get_item_type(*item) == TREE_ITEM_TYPE_CONNECTION) {
+			if (item && _get_item_type(*item) == TREE_ITEM_TYPE_CONNECTION && !item->has_meta("_inherited_connection")) {
 				Connection connection = item->get_metadata(0);
 				_disconnect(connection);
 				update_tree();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/111713

Users were able to delete signals with inherited connections by pressing `Delete` to bypass the disabled disconnect option in the signal connections dock.