### PR TITLE
Add filter_cutoff_min/max parameters to fuzzy search

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -298,7 +298,7 @@ void FuzzySearch::_sort_and_filter(Vector<Ref<FuzzySearchMatch>> &p_results) con
 		}
 
 		avg_score /= p_results.size();
-		float cull_score = MIN(filter_cutoff, Math::lerp(avg_score, max_score, filter_factor));
+		float cull_score = CLAMP(Math::lerp(avg_score, max_score, filter_factor), filter_cutoff_min, filter_cutoff_max);
 		remove_low_scores(p_results, cull_score);
 	}
 
@@ -444,8 +444,11 @@ void FuzzySearch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_filter_factor", "filter_factor"), &FuzzySearch::set_filter_factor);
 	ClassDB::bind_method(D_METHOD("get_filter_factor"), &FuzzySearch::get_filter_factor);
 
-	ClassDB::bind_method(D_METHOD("set_filter_cutoff", "filter_cutoff"), &FuzzySearch::set_filter_cutoff);
-	ClassDB::bind_method(D_METHOD("get_filter_cutoff"), &FuzzySearch::get_filter_cutoff);
+	ClassDB::bind_method(D_METHOD("set_filter_cutoff_max", "filter_cutoff_max"), &FuzzySearch::set_filter_cutoff_max);
+	ClassDB::bind_method(D_METHOD("get_filter_cutoff_max"), &FuzzySearch::get_filter_cutoff_max);
+
+	ClassDB::bind_method(D_METHOD("set_filter_cutoff_min", "filter_cutoff_min"), &FuzzySearch::set_filter_cutoff_min);
+	ClassDB::bind_method(D_METHOD("get_filter_cutoff_min"), &FuzzySearch::get_filter_cutoff_min);
 
 	ClassDB::bind_method(D_METHOD("search", "query", "target"), &FuzzySearch::search);
 	ClassDB::bind_method(D_METHOD("search_all", "query", "targets"), &FuzzySearch::_search_all_bind);
@@ -457,5 +460,6 @@ void FuzzySearch::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "case_sensitive"), "set_case_sensitive", "get_case_sensitive");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_low_scores"), "set_filter_low_scores", "get_filter_low_scores");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_factor"), "set_filter_factor", "get_filter_factor");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff"), "set_filter_cutoff", "get_filter_cutoff");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff_max"), "set_filter_cutoff_max", "get_filter_cutoff_max");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff_min"), "set_filter_cutoff_min", "get_filter_cutoff_min");
 }

--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -302,7 +302,7 @@ void FuzzySearch::_sort_and_filter(Vector<Ref<FuzzySearchMatch>> &p_results) con
 		}
 
 		avg_score /= p_results.size();
-		float cull_score = MIN(filter_cutoff, Math::lerp(avg_score, max_score, filter_factor));
+		float cull_score = CLAMP(Math::lerp(avg_score, max_score, filter_factor), filter_cutoff_min, filter_cutoff_max);
 		remove_low_scores(p_results, cull_score);
 	}
 
@@ -448,8 +448,11 @@ void FuzzySearch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_filter_factor", "filter_factor"), &FuzzySearch::set_filter_factor);
 	ClassDB::bind_method(D_METHOD("get_filter_factor"), &FuzzySearch::get_filter_factor);
 
-	ClassDB::bind_method(D_METHOD("set_filter_cutoff", "filter_cutoff"), &FuzzySearch::set_filter_cutoff);
-	ClassDB::bind_method(D_METHOD("get_filter_cutoff"), &FuzzySearch::get_filter_cutoff);
+	ClassDB::bind_method(D_METHOD("set_filter_cutoff_max", "filter_cutoff_max"), &FuzzySearch::set_filter_cutoff_max);
+	ClassDB::bind_method(D_METHOD("get_filter_cutoff_max"), &FuzzySearch::get_filter_cutoff_max);
+
+	ClassDB::bind_method(D_METHOD("set_filter_cutoff_min", "filter_cutoff_min"), &FuzzySearch::set_filter_cutoff_min);
+	ClassDB::bind_method(D_METHOD("get_filter_cutoff_min"), &FuzzySearch::get_filter_cutoff_min);
 
 	ClassDB::bind_method(D_METHOD("search", "query", "target"), &FuzzySearch::search);
 	ClassDB::bind_method(D_METHOD("search_all", "query", "targets"), &FuzzySearch::_search_all_bind);
@@ -461,5 +464,6 @@ void FuzzySearch::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "case_sensitive"), "set_case_sensitive", "get_case_sensitive");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_low_scores"), "set_filter_low_scores", "get_filter_low_scores");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_factor"), "set_filter_factor", "get_filter_factor");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff"), "set_filter_cutoff", "get_filter_cutoff");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff_max"), "set_filter_cutoff_max", "get_filter_cutoff_max");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "filter_cutoff_min"), "set_filter_cutoff_min", "get_filter_cutoff_min");
 }

--- a/core/string/fuzzy_search.h
+++ b/core/string/fuzzy_search.h
@@ -112,7 +112,8 @@ class FuzzySearch : public RefCounted {
 	bool case_sensitive = false;
 	bool filter_low_scores = true;
 	float filter_factor = 0.1f;
-	float filter_cutoff = 30.0f;
+	float filter_cutoff_max = 30.0f;
+	float filter_cutoff_min = -3.0f;
 
 	Vector<FuzzySearchToken> _get_tokens(const String &p_query) const;
 	void _sort_and_filter(Vector<Ref<FuzzySearchMatch>> &p_results) const;
@@ -156,8 +157,11 @@ public:
 	}
 	float get_filter_factor() const { return filter_factor; }
 
-	void set_filter_cutoff(float p_filter_cutoff) { filter_cutoff = p_filter_cutoff; }
-	float get_filter_cutoff() const { return filter_cutoff; }
+	void set_filter_cutoff_max(float p_filter_cutoff_max) { filter_cutoff_max = p_filter_cutoff_max; }
+	float get_filter_cutoff_max() const { return filter_cutoff_max; }
+
+	void set_filter_cutoff_min(float p_filter_cutoff_min) { filter_cutoff_min = p_filter_cutoff_min; }
+	float get_filter_cutoff_min() const { return filter_cutoff_min; }
 
 	Ref<FuzzySearchMatch> search(const String &p_query, const String &p_target) const;
 	Vector<Ref<FuzzySearchMatch>> search_all(const String &p_query, const PackedStringArray &p_targets) const;

--- a/core/string/fuzzy_search.h
+++ b/core/string/fuzzy_search.h
@@ -112,7 +112,8 @@ class FuzzySearch : public RefCounted {
 	bool case_sensitive = false;
 	bool filter_low_scores = true;
 	float filter_factor = 0.1f;
-	float filter_cutoff = 30.0f;
+	float filter_cutoff_max = 30.0f;
+	float filter_cutoff_min = -3.0f;
 
 	Vector<FuzzySearchToken> _get_tokens(const String &p_query) const;
 	void _sort_and_filter(Vector<Ref<FuzzySearchMatch>> &p_results) const;
@@ -147,8 +148,11 @@ public:
 	}
 	float get_filter_factor() const { return filter_factor; }
 
-	void set_filter_cutoff(float p_filter_cutoff) { filter_cutoff = p_filter_cutoff; }
-	float get_filter_cutoff() const { return filter_cutoff; }
+	void set_filter_cutoff_max(float p_filter_cutoff_max) { filter_cutoff_max = p_filter_cutoff_max; }
+	float get_filter_cutoff_max() const { return filter_cutoff_max; }
+
+	void set_filter_cutoff_min(float p_filter_cutoff_min) { filter_cutoff_min = p_filter_cutoff_min; }
+	float get_filter_cutoff_min() const { return filter_cutoff_min; }
 
 	Ref<FuzzySearchMatch> search(const String &p_query, const String &p_target) const;
 	Vector<Ref<FuzzySearchMatch>> search_all(const String &p_query, const PackedStringArray &p_targets) const;

--- a/doc/classes/FuzzySearch.xml
+++ b/doc/classes/FuzzySearch.xml
@@ -50,8 +50,11 @@
 		<member name="case_sensitive" type="bool" setter="set_case_sensitive" getter="get_case_sensitive" default="false">
 			Whether the query character casing should be matched exactly or not.
 		</member>
-		<member name="filter_cutoff" type="float" setter="set_filter_cutoff" getter="get_filter_cutoff" default="30.0">
-			Minimum score for filtering results returned by [method search_all].
+		<member name="filter_cutoff_max" type="float" setter="set_filter_cutoff_max" getter="get_filter_cutoff_max" default="30.0">
+			Maximum cutoff score to use when filtering results. Increasing this value will reduce the number of low-score results.
+		</member>
+		<member name="filter_cutoff_min" type="float" setter="set_filter_cutoff_min" getter="get_filter_cutoff_min" default="-3.0">
+			Minimum cutoff score to use when filtering results. Decreasing this value will increase the number of low-score results.
 		</member>
 		<member name="filter_factor" type="float" setter="set_filter_factor" getter="get_filter_factor" default="0.1">
 			Biases the filtering cutoff score between the average score and max score. Value should be between [code]0[/code] and [code]1[/code].


### PR DESCRIPTION
This PR adds `filter_cutoff_min` and renames `filter_cutoff` to `filter_cutoff_max` in the fuzzy matching code. Previously, only `filter_cutoff` was included so that relevant results would continue to be surfaced even if other results were very high scoring, but I was hesitant to include a lower bound to the cutoff score because I didn't want to omit decent results in short queries where one missed character might outweigh a short match. However, this allowed more low quality noise into the results. After considering some examples, I now think a lower bound in the range [-10, -3] improves some degenerate cases while not degrading/impacting normal cases. This also clarifies the docs for the parameters, of which before `filter_cutoff` was not clear about how it actually was used. It's still useful to vary the cutoff as if there are several strong matches, low quality matches without negative scores (eg, single character matches broken up along a path) can still be filtered out.

This alleviates the problem described in https://github.com/godotengine/godot-proposals/issues/15108 although I think it may be still worthwhile to change popupmenu to sort its filtered results. This does break one parameter name, but the feature was only landed in dev 1 as experimental and I truly don't think there is a single human being who is using it.

Without this change (from the proposal):

<img width="389" height="293" alt="image" src="https://github.com/user-attachments/assets/7955a749-edbc-4526-b768-4d5dff138942" />

With this change:

<img width="207" height="152" alt="Screenshot 2026-07-07 at 8 54 33 PM" src="https://github.com/user-attachments/assets/d4fbe86b-b05e-46e9-8930-175e2a615005" />

(NB: the results here aren't sorted, but coincidentally are in an order one might expect the sorted results to be)