### PR TITLE
Expose `ResourceLoader::get_resource_type` to scripting

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -138,6 +138,10 @@ ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	return ::ResourceLoader::get_resource_uid(p_path);
 }
 
+String ResourceLoader::get_resource_type(const String &p_path) {
+	return ::ResourceLoader::get_resource_type(p_path);
+}
+
 Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 	return ::ResourceLoader::list_directory(p_directory);
 }
@@ -157,6 +161,7 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cached_ref", "path"), &ResourceLoader::get_cached_ref);
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &ResourceLoader::get_resource_uid);
+	ClassDB::bind_method(D_METHOD("get_resource_type", "path"), &ResourceLoader::get_resource_type);
 	ClassDB::bind_method(D_METHOD("list_directory", "directory_path"), &ResourceLoader::list_directory);
 
 	BIND_ENUM_CONSTANT(THREAD_LOAD_INVALID_RESOURCE);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -84,6 +84,7 @@ public:
 	Ref<Resource> get_cached_ref(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");
 	ResourceUID::ID get_resource_uid(const String &p_path);
+	String get_resource_type(const String &p_path);
 
 	Vector<String> list_directory(const String &p_directory);
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -64,6 +64,13 @@
 				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
+		<method name="get_resource_type">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the resource type associated with a given resource path.
+			</description>
+		</method>
 		<method name="get_resource_uid">
 			<return type="int" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
Most `ResourceFormatLoader::get_resource_type` override implementations provide a lightweight way to return the resource's type without loading the resource's path. 

In our scripting language, we support `preload` just like GDScript. In this code path, we don't want to load our full script at this step, as this needs to be done at the right inheritance analysis position.  However, we need to know whether the resource is one of our language's scripts. If we were to call `ResourceLoader::load` to get the loaded class' class type, this would trigger the full load and deserialization of that script, which would cascade into its own parser and analysis phase. 

Exposing `ResourceLoader::get_resource_type` would delegate the call to all registered loaders and provide the same mechanism that GDScript's analyzer uses today.
