### PR TITLE
Expose all fields on `ScriptLanguageExtensionProfilingInfo` struct

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -348,7 +348,7 @@ void register_core_types() {
 
 	GDREGISTER_NATIVE_STRUCT(ObjectID, "uint64_t id = 0");
 	GDREGISTER_NATIVE_STRUCT(AudioFrame, "float left;float right");
-	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
+	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time;uint64_t internal_time");
 
 	worker_thread_pool = memnew(WorkerThreadPool);
 


### PR DESCRIPTION
All properties in `ScriptLanguageExtensionProfilingInfo` struct are exposed except for the most recent `internal_time`. This PR adds that field to the struct's property list so that `ScriptExtension` implementations can provide all profiling information back to the engine internals.