### PR TITLE
[DRAFT] Add option to build tracy-profiler client as a shared lib

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -229,6 +229,13 @@ opts.Add(
         True,
     )
 )
+opts.Add(
+    BoolVariable(
+        "tracy_as_shared",
+        "if profiling using tracy this option enables building tracy as a shared library so that gdextension can link and use the tracy api",
+        False,
+    )
+)
 
 
 # Advanced options
@@ -1170,6 +1177,9 @@ else:
     env["LIBSUFFIXES"] += [env["LIBSUFFIX"], env["SHLIBSUFFIX"]]
 env["LIBSUFFIX"] = suffix + env["LIBSUFFIX"]
 env["SHLIBSUFFIX"] = suffix + env["SHLIBSUFFIX"]
+
+# msvc exports sidecar name will be incorrect without this
+env["WINDOWSEXPSUFFIX"] = suffix + ".exp"
 
 env["OBJPREFIX"] = env["object_prefix"]
 env["SHOBJPREFIX"] = env["object_prefix"]

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -113,12 +113,21 @@ def configure_tracy_shared(env_tracy, profiler_path) -> bool:
             pass
 
     elif env["platform"] == "macos":
-        if methods.is_apple_clang(env):
-            # AppleClang
-            pass
-        elif methods.using_clang(env):
-            # Upstream Clang on macOS
-            pass
+        # Set install name so the engine binary (and GDExtensions) load via @rpath.
+        # platform/macos/detect.py already adds -rpath @executable_path/../Frameworks
+        # and -rpath @executable_path (so bin/ next to the unbundled binary also works).
+        dylib_node = tracylib[0]
+        dylib_name = pathlib.Path(str(dylib_node)).name
+        env_tracy.AddPostAction(
+            dylib_node,
+            f'install_name_tool -id "@rpath/{dylib_name}" "$TARGET"',
+        )
+
+        # Register for inclusion in the .app bundle. generate_bundle recreates the
+        # .app from a template (shutil.rmtree), so do not Install into Frameworks here.
+        if "extra_dylibs" not in env:
+            env["extra_dylibs"] = []
+        env["extra_dylibs"].extend(to_install)
 
     # libtarget fallback
     if not link_target:

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -56,6 +56,11 @@ def configure_instruments() -> bool:
 
 
 def configure_tracy_shared(env_tracy, profiler_path) -> bool:
+    # certain flags that we have inherited by cloning the env have to be removed.
+    if env["platform"] == "macos":
+        for f in [f for f in env["LINKFLAGS"] if "-stack_size" in f]:
+            env_tracy["LINKFLAGS"].remove(f)
+
     tracylib = env_tracy.add_shared_library("TracyClient", [str((profiler_path / "TracyClient.cpp").absolute())])
     link_target = None
     to_install = Flatten(tracylib)

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -57,34 +57,47 @@ def configure_instruments() -> bool:
 
 def configure_tracy_shared(env_tracy, profiler_path) -> bool:
     tracylib = env_tracy.add_shared_library("TracyClient", [str((profiler_path / "TracyClient.cpp").absolute())])
+    link_target = None
     to_install = Flatten(tracylib)
 
-    if env["platform"] == "windows":
-        if env.msvc and not methods.using_clang(env):
-            # These two defines control the visibility of symbols within the library
-            # and are required when fvisibility=hidden, which is the default on windows.
-            env_tracy.Append(CPPDEFINES=["TRACY_EXPORTS", "TRACY_IMPORTS"])
+    # These two defines control the visibility of symbols within the library
+    # and are required when fvisibility=hidden, which is the default on windows.
+    env_tracy.AppendUnique(CPPDEFINES=["TRACY_EXPORTS", "TRACY_IMPORTS"])
 
+    if env["platform"] == "windows":
+        if env.msvc and not methods.using_gcc(env):
+            # MSVC or Clang (with MSVC Frontend)
             # required on release build when msvc
-            env_tracy.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS", "/ENTRY:_DllMainCRTStartup", "/DLL"])
+            env_tracy.AppendUnique(LINKFLAGS=["/SUBSYSTEM:WINDOWS", "/ENTRY:_DllMainCRTStartup", "/DLL"])
+
+            # get the link target node
+            link_target = next((n for n in to_install if str(n).endswith(".lib")), None)
 
             # add the pdb to the list of files to install
             if env_tracy.get("debug_symbols"):
                 # Create PDB node with proper dependency because an immediate copy
                 # breaks due to windows file locking.
-                dll_node = next((n for n in to_install if str(n).endswith(".dll")), None)
-                if dll_node:
-                    pdb_node = env_tracy.File(env_tracy.subst("${TARGET.base}.pdb", target=dll_node))
+                if link_target:
+                    pdb_node = env_tracy.File(env_tracy.subst("${TARGET.base}.pdb", target=link_target))
                     to_install.append(pdb_node)
                     # Add explicit dependency so SCons knows PDB is produced by the link step
-                    env_tracy.Depends(pdb_node, dll_node)
+                    env_tracy.Depends(pdb_node, link_target)
+
+            # == LLVM / lld-link does not create an exp file, but scons has a node for it ==
+            if methods.using_clang(env) and env["LINK"] == "lld-link":  # or however you detect lld
+                # lld-link often does not emit .exp (or names it differently)
+                # Only keep files that actually exist
+                to_install = [
+                    f for f in to_install if env_tracy.File(f).exists() or str(f).endswith((".dll", ".lib", ".pdb"))
+                ]
 
         elif methods.using_clang(env):
-            # clang-cl (with MSVC frontend) or MinGW LLVM
+            # MinGW LLVM
             pass
         elif methods.using_gcc(env):
             # MinGW GCC
-            pass
+            # get the link target node
+            link_target = next((n for n in to_install if str(n).endswith(".a")), None)
 
     elif env["platform"] == "linuxbsd":
         if methods.using_clang(env):
@@ -102,9 +115,12 @@ def configure_tracy_shared(env_tracy, profiler_path) -> bool:
             # Upstream Clang on macOS
             pass
 
-    # Add the shared library to the godot dependencies.
-    env.Append(LIBS=["TracyClient"])
-    env.Append(LIBPATH=[tracylib[0].get_dir()])
+    # libtarget fallback
+    if not link_target:
+        link_target = tracylib[0]
+    # Add the shared library to the main Godot build environment
+    env.Append(LIBPATH=[link_target.get_dir()])
+    env.Append(LIBS=[link_target])
 
     # Install(copy) shared lib files [+ pdb] to the bin dir
     env.Install("#bin/", to_install)

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -112,7 +112,7 @@ def configure_tracy_shared(env_tracy, profiler_path) -> bool:
             # Linux + GCC (default)
             pass
 
-    elif env["platform"] == "macos":
+    elif env["platform"] in ["macos", "ios", "visionos"]:
         # Set install name so the engine binary (and GDExtensions) load via @rpath.
         # platform/macos/detect.py already adds -rpath @executable_path/../Frameworks
         # and -rpath @executable_path (so bin/ next to the unbundled binary also works).
@@ -132,9 +132,15 @@ def configure_tracy_shared(env_tracy, profiler_path) -> bool:
     # libtarget fallback
     if not link_target:
         link_target = tracylib[0]
-    # Add the shared library to the main Godot build environment
-    env.Append(LIBPATH=[link_target.get_dir()])
-    env.Append(LIBS=[link_target])
+
+    # Add the shared library to the main Godot build environment for actual linking.
+    # Apple-embedded platforms (ios/visionos) produce a static libgodot via
+    # libtool -static over env["LIBS"] — a dylib cannot be merged into that archive
+    # and only produces "is a dynamic library, not added to the static library".
+    # Ship the dylib next to bin/ (and via extra_dylibs) for the consumer/Xcode project.
+    if env["platform"] not in ("ios", "visionos"):
+        env.Append(LIBPATH=[link_target.get_dir()])
+        env.Append(LIBS=[link_target])
 
     # Install(copy) shared lib files [+ pdb] to the bin dir
     env.Install("#bin/", to_install)

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -7,6 +7,8 @@ import pathlib
 
 import profiling_builders
 
+import methods
+
 Import("env")
 
 env.add_source_files(env.core_sources, "*.cpp")
@@ -14,11 +16,10 @@ env.add_source_files(env.core_sources, "*.cpp")
 default_perfetto_install_dir = "../../thirdparty/perfetto"
 
 
-def find_perfetto_path(path: pathlib.Path) -> pathlib.Path:
+def find_perfetto_path(path: pathlib.Path) -> pathlib.Path | None:
     if not path.is_dir():
         print(f"Perfetto profiler path '{path.absolute()}' is invalid.")
-        Exit(255)
-
+        return None
     if (path / "sdk" / "perfetto.cc").is_file():
         # perfetto root directory.
         return path / "sdk"
@@ -27,82 +28,174 @@ def find_perfetto_path(path: pathlib.Path) -> pathlib.Path:
         return path
 
     print("Invalid perfetto profiler path. Unable to find perfetto.cc.")
-    Exit(255)
+    return None
 
 
-def find_tracy_path(path: pathlib.Path) -> pathlib.Path:
+def find_tracy_path(path: pathlib.Path) -> pathlib.Path | None:
     if not path.is_dir():
         print("profiler_path must point to a directory.")
-        Exit(255)
-
+        return None
     if (path / "public" / "TracyClient.cpp").is_file():
         # tracy root directory
         return path / "public"
     if (path / "TracyClient.cpp").is_file():
         # tracy public directory
         return path
-
     print("Invalid profiler_path. Unable to find TracyClient.cpp.")
-    Exit(255)
+    return None
+
+
+def configure_instruments() -> bool:
+    if env["profiler_sample_callstack"]:
+        print("profiler_sample_callstack ignored. Please configure callstack sampling in Instruments instead.")
+    if env["profiler_track_memory"]:
+        print("profiler_track_memory ignored. Please configure memory tracking in Instruments instead.")
+    if env["profiler_record_on_demand"]:
+        print("profiler_record_on_demand ignored. Instruments is always recording.")
+    return True
+
+
+def configure_tracy_shared(env_tracy, profiler_path) -> bool:
+    tracylib = env_tracy.add_shared_library("TracyClient", [str((profiler_path / "TracyClient.cpp").absolute())])
+    to_install = Flatten(tracylib)
+
+    if env["platform"] == "windows":
+        if env.msvc and not methods.using_clang(env):
+            # These two defines control the visibility of symbols within the library
+            # and are required when fvisibility=hidden, which is the default on windows.
+            env_tracy.Append(CPPDEFINES=["TRACY_EXPORTS", "TRACY_IMPORTS"])
+
+            # required on release build when msvc
+            env_tracy.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS", "/ENTRY:_DllMainCRTStartup", "/DLL"])
+
+            # add the pdb to the list of files to install
+            if env_tracy.get("debug_symbols"):
+                # Create PDB node with proper dependency because an immediate copy
+                # breaks due to windows file locking.
+                dll_node = next((n for n in to_install if str(n).endswith(".dll")), None)
+                if dll_node:
+                    pdb_node = env_tracy.File(env_tracy.subst("${TARGET.base}.pdb", target=dll_node))
+                    to_install.append(pdb_node)
+                    # Add explicit dependency so SCons knows PDB is produced by the link step
+                    env_tracy.Depends(pdb_node, dll_node)
+
+        elif methods.using_clang(env):
+            # clang-cl (with MSVC frontend) or MinGW LLVM
+            pass
+        elif methods.using_gcc(env):
+            # MinGW GCC
+            pass
+
+    elif env["platform"] == "linuxbsd":
+        if methods.using_clang(env):
+            # Linux + Clang
+            pass
+        else:
+            # Linux + GCC (default)
+            pass
+
+    elif env["platform"] == "macos":
+        if methods.is_apple_clang(env):
+            # AppleClang
+            pass
+        elif methods.using_clang(env):
+            # Upstream Clang on macOS
+            pass
+
+    # Add the shared library to the godot dependencies.
+    env.Append(LIBS=["TracyClient"])
+    env.Append(LIBPATH=[tracylib[0].get_dir()])
+
+    # Install(copy) shared lib files [+ pdb] to the bin dir
+    env.Install("#bin/", to_install)
+    return True
+
+
+def configure_tracy() -> bool:
+    if not env["profiler_path"]:
+        print("profiler_path must be set when using the tracy profiler. Aborting.")
+        return False
+
+    profiler_path: pathlib.Path | None = find_tracy_path(pathlib.Path(env["profiler_path"]))
+    if profiler_path is None:
+        return False
+
+    env.Prepend(CPPPATH=[str(profiler_path.absolute())])
+
+    # clone env so we dont pollute the build flags unnecessarily.
+    # The engine code relies on the generated core/profiling/profiling.gen.h
+    # to enable/disable tracy features.
+    env_tracy = env.Clone()
+    env_tracy.disable_warnings()
+    env_tracy.Append(CPPDEFINES=["TRACY_ENABLE"])
+
+    # == Call Stack Sampling ==
+    if env["profiler_sample_callstack"]:
+        if env["platform"] not in ("windows", "linuxbsd", "android"):
+            # Reference the feature matrix in the tracy documentation.
+            print("Tracy does not support call stack sampling on the target platform. Aborting.")
+            return False
+        # 62 is the maximum supported callstack depth reported by the tracy docs.
+        env_tracy.Append(CPPDEFINES=[("TRACY_CALLSTACK", 62)])
+
+    # == Profile on demand( this is the default) ==
+    if env["profiler_record_on_demand"]:
+        env_tracy.Append(CPPDEFINES=["TRACY_ON_DEMAND"])
+
+    # == Build Tracy as a shared library ==
+    # This allows GDExtenstion to link to the tracy shared library and use the
+    # its API directly.
+    if env["tracy_as_shared"]:
+        return configure_tracy_shared(env_tracy, profiler_path)
+    else:
+        # Otherwise compile tracy into the engine.
+        env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
+    return True
+
+
+def configure_perfetto() -> bool:
+    if env["profiler_path"]:
+        profiler_path = find_perfetto_path(pathlib.Path(env["profiler_path"]))
+    elif (default_perfetto_path := pathlib.Path(default_perfetto_install_dir)).is_dir():
+        profiler_path = find_perfetto_path(default_perfetto_path)
+    else:
+        print("Perfetto must be installed or profiler_path must be set when using the perfetto profiler. Aborting.")
+        return False
+
+    if profiler_path is None:
+        return False
+
+    env.Prepend(CPPPATH=[str(profiler_path.absolute())])
+
+    env_perfetto = env.Clone()
+    if env["profiler_sample_callstack"]:
+        print("Perfetto does not support call stack sampling. Aborting.")
+        Exit(255)
+    if env["profiler_track_memory"]:
+        print("Perfetto does not support memory tracking. Aborting.")
+        Exit(255)
+    if env["profiler_record_on_demand"]:
+        print("profiler_record_on_demand ignored. Perfetto is always recording.")
+    env_perfetto.disable_warnings()
+    env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
+    env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
+    return True
 
 
 if env["profiler"]:
-    if env["profiler"] == "instruments":
-        if env["profiler_sample_callstack"]:
-            print("profiler_sample_callstack ignored. Please configure callstack sampling in Instruments instead.")
-        if env["profiler_track_memory"]:
-            print("profiler_track_memory ignored. Please configure memory tracking in Instruments instead.")
-        if env["profiler_record_on_demand"]:
-            print("profiler_record_on_demand ignored. Instruments is always recording.")
-    elif env["profiler"] == "tracy":
-        if not env["profiler_path"]:
-            print("profiler_path must be set when using the tracy profiler. Aborting.")
-            Exit(255)
-        profiler_path = find_tracy_path(pathlib.Path(env["profiler_path"]))
-        env.Prepend(CPPPATH=[str(profiler_path.absolute())])
-
-        env_tracy = env.Clone()
-        env_tracy.Append(CPPDEFINES=["TRACY_ENABLE"])
-        if env["profiler_sample_callstack"]:
-            if env["platform"] not in ("windows", "linuxbsd", "android"):
-                # Reference the feature matrix in the tracy documentation.
-                print("Tracy does not support call stack sampling on this platform. Aborting.")
-                Exit(255)
-
-            # 62 is the maximum supported callstack depth reported by the tracy docs.
-            env_tracy.Append(CPPDEFINES=[("TRACY_CALLSTACK", 62)])
-        if env["profiler_track_memory"]:
-            env_tracy.Append(CPPDEFINES=["GODOT_PROFILER_TRACK_MEMORY"])
-        if env["profiler_record_on_demand"]:
-            env_tracy.Append(CPPDEFINES=["TRACY_ON_DEMAND"])
-        env_tracy.disable_warnings()
-        env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
-    elif env["profiler"] == "perfetto":
-        if env["profiler_path"]:
-            profiler_path = find_perfetto_path(pathlib.Path(env["profiler_path"]))
-        elif (default_perfetto_path := pathlib.Path(default_perfetto_install_dir)).is_dir():
-            profiler_path = find_perfetto_path(default_perfetto_path)
-        else:
-            print("Perfetto must be installed or profiler_path must be set when using the perfetto profiler. Aborting.")
-            Exit(255)
-
-        env.Prepend(CPPPATH=[str(profiler_path.absolute())])
-
-        env_perfetto = env.Clone()
-        if env["profiler_sample_callstack"]:
-            print("Perfetto does not support call stack sampling. Aborting.")
-            Exit(255)
-        if env["profiler_track_memory"]:
-            print("Perfetto does not support memory tracking. Aborting.")
-            Exit(255)
-        if env["profiler_record_on_demand"]:
-            print("profiler_record_on_demand ignored. Perfetto is always recording.")
-        env_perfetto.disable_warnings()
-        env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
-        env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
+    if env["profiler"] == "instruments" and not configure_instruments():
+        print("Failed to configure Instruments. Aborting.")
+        Exit(255)
+    elif env["profiler"] == "tracy" and not configure_tracy():
+        print("Failed to configure Tracy. Aborting.")
+        Exit(255)
+    elif env["profiler"] == "perfetto" and not configure_perfetto():
+        print("Failed to configure Perfetto. Aborting.")
+        Exit(255)
 elif env["profiler_path"]:
     print("profiler is required if profiler_path is set. Aborting.")
     Exit(255)
+
 
 env.CommandNoCache(
     "profiling.gen.h",
@@ -114,3 +207,8 @@ env.CommandNoCache(
     ],
     env.Run(profiling_builders.profiler_gen_builder),
 )
+
+# Copy generated header to bin/ for users to include into their GDExtension
+if env["profiler"] == "tracy" and env["tracy_as_shared"]:
+    gen_header = env.File("profiling.gen.h")
+    env.Install("#bin/", gen_header)

--- a/core/profiling/profiling.h
+++ b/core/profiling/profiling.h
@@ -47,8 +47,6 @@
 
 #include "core/string/string_name.h"
 
-#define TRACY_ENABLE
-
 GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4366) // The result of the unary operator may be unaligned.
 #include <tracy/Tracy.hpp>
 GODOT_MSVC_WARNING_POP

--- a/core/profiling/profiling_builders.py
+++ b/core/profiling/profiling_builders.py
@@ -3,19 +3,37 @@
 import methods
 
 
+def tracy_gen(file, env):
+    file.write("#define GODOT_USE_TRACY\n")
+    file.write("#define TRACY_ENABLE\n")
+
+    if env["profiler_sample_callstack"]:
+        file.write("#define TRACY_CALLSTACK 62\n")
+    else:
+        file.write("#define TRACY_NO_SAMPLING\n")
+
+    if env["profiler_track_memory"]:
+        file.write("#define GODOT_PROFILER_TRACK_MEMORY\n")
+
+    if env["profiler_record_on_demand"]:
+        file.write("#define TRACY_ON_DEMAND\n")
+
+
+def perfetto_gen(file, env):
+    file.write("#define GODOT_USE_PERFETTO\n")
+
+
+def instruments_gen(file, env):
+    file.write("#define GODOT_USE_INSTRUMENTS\n")
+    if env["profiler_sample_callstack"]:
+        file.write("#define INSTRUMENTS_SAMPLE_CALLSTACKS\n")
+
+
 def profiler_gen_builder(target, source, env):
     with methods.generated_wrapper(str(target[0])) as file:
         if env["profiler"] == "tracy":
-            file.write("#define GODOT_USE_TRACY\n")
-            if env["profiler_sample_callstack"]:
-                file.write("#define TRACY_CALLSTACK 62\n")
-            if env["profiler_track_memory"]:
-                file.write("#define GODOT_PROFILER_TRACK_MEMORY\n")
-            if env["profiler_record_on_demand"]:
-                file.write("#define TRACY_ON_DEMAND\n")
-        if env["profiler"] == "perfetto":
-            file.write("#define GODOT_USE_PERFETTO\n")
-        if env["profiler"] == "instruments":
-            file.write("#define GODOT_USE_INSTRUMENTS\n")
-            if env["profiler_sample_callstack"]:
-                file.write("#define INSTRUMENTS_SAMPLE_CALLSTACKS\n")
+            tracy_gen(file, env)
+        elif env["profiler"] == "perfetto":
+            perfetto_gen(file, env)
+        elif env["profiler"] == "instruments":
+            instruments_gen(file, env)

--- a/methods.py
+++ b/methods.py
@@ -103,10 +103,21 @@ def redirect_emitter(target, source, env):
             pass
         elif base_folder in path.parents:
             item = env.File(f"#bin/obj/{path.relative_to(base_folder)}")
-        elif (alt_base := Path(env.Dir(".").get_abspath()).resolve().parent) in path.parents:
-            item = env.File(f"#bin/obj/external/{path.relative_to(alt_base)}")
         else:
-            print_warning(f'Failed to redirect "{path}"')
+            try:
+                # Try common external bases (e.g., profiler_path parent)
+                alt_base = Path(env.Dir(".").get_abspath()).resolve().parent
+                if alt_base in path.parents:
+                    rel = path.relative_to(alt_base)
+                else:
+                    # Fallback: filename under external/
+                    rel = f"external/{path.name}"
+                item = env.File(f"#bin/obj/{rel}")
+            except (ValueError, RuntimeError, OSError) as e:
+                # ValueError = not a relative subpath
+                # Others = rare filesystem/env issues
+                print_warning(f'Failed to redirect "{path}": {e} — using default location')
+                # item remains the original (no redirect)
         redirected_targets.append(item)
     return redirected_targets, source
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -105,12 +105,14 @@ def configure(env: "SConsEnvironment"):
         env["APPLE_PLATFORM"] = "iossimulator"
         env.Append(ASFLAGS=["-mios-simulator-version-min=15.0"])
         env.Append(CCFLAGS=["-mios-simulator-version-min=15.0"])
+        env.Append(LINKFLAGS=["-mios-simulator-version-min=15.0"])
         env.Append(CPPDEFINES=["IOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         env["APPLE_PLATFORM"] = "ios"
         env.Append(ASFLAGS=["-miphoneos-version-min=15.0"])
         env.Append(CCFLAGS=["-miphoneos-version-min=15.0"])
+        env.Append(LINKFLAGS=["-miphoneos-version-min=15.0"])
     detect_darwin_sdk_path(env["APPLE_PLATFORM"], env)
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
@@ -129,6 +131,7 @@ def configure(env: "SConsEnvironment"):
             ).split()
         )
         env.Append(ASFLAGS=["-arch", "x86_64"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-isysroot", "$APPLE_SDK_PATH"])
     elif env["arch"] == "arm64":
         env.Append(
             CCFLAGS=(
@@ -139,6 +142,7 @@ def configure(env: "SConsEnvironment"):
             )
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-isysroot", "$APPLE_SDK_PATH"])
 
     # Temp fix for ABS/MAX/MIN macros in iOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -43,6 +43,16 @@ def generate_bundle(target, source, env):
             os.mkdir(app_dir + "/Contents/MacOS")
         if target_bin != "":
             shutil.copy(target_bin, app_dir + "/Contents/MacOS/Godot")
+
+        # Copy extra dylibs (e.g. TracyClient when tracy_as_shared=yes) into Frameworks.
+        # These are registered by the feature that builds them (eg. configure_tracy_shared in core/profiling/SCsub)
+        if env.get("extra_dylibs"):
+            frameworks_dir = os.path.join(app_dir, "Contents", "Frameworks")
+            os.makedirs(frameworks_dir, exist_ok=True)
+            for lib in env["extra_dylibs"]:
+                src = lib.get_abspath() if hasattr(lib, "get_abspath") else str(lib)
+                shutil.copy(src, frameworks_dir)
+
         if "mono" in env.module_version_string:
             shutil.copytree(env.Dir("#bin/GodotSharp").abspath, app_dir + "/Contents/Resources/GodotSharp")
         version = get_version_info("", True)

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -106,12 +106,14 @@ def configure(env: "SConsEnvironment"):
         env["APPLE_PLATFORM"] = "visionossimulator"
         env.Append(ASFLAGS=["-mtargetos=xros26.0-simulator"])
         env.Append(CCFLAGS=["-mtargetos=xros26.0-simulator"])
+        env.Append(LINKFLAGS=["-mtargetos=xros26.0-simulator"])
         env.Append(CPPDEFINES=["VISIONOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         env["APPLE_PLATFORM"] = "visionos"
         env.Append(ASFLAGS=["-mtargetos=xros26.0"])
         env.Append(CCFLAGS=["-mtargetos=xros26.0"])
+        env.Append(LINKFLAGS=["-mtargetos=xros26.0"])
     detect_darwin_sdk_path(env["APPLE_PLATFORM"], env)
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
@@ -126,6 +128,7 @@ def configure(env: "SConsEnvironment"):
             )
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-isysroot", "$APPLE_SDK_PATH"])
 
     # Temp fix for ABS/MAX/MIN macros in visionOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -723,6 +723,16 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
+    # Cross-compilation
+    host_is_64_bit = sys.maxsize > 2**32
+    if host_is_64_bit and env["arch"] == "x86_32":
+        env.Append(CCFLAGS=["-m32"])
+        env.Append(LINKFLAGS=["-m32"])
+    elif not host_is_64_bit and env["arch"] == "x86_64":
+        env.Append(CCFLAGS=["-m64"])
+        env.Append(LINKFLAGS=["-m64"])
+    # arm32/arm64 usually don't need explicit -m flags with the prefixed toolchain
+
     if env["arch"] == "x86_32":
         if env["use_static_cpp"]:
             env.Append(LINKFLAGS=["-static"])


### PR DESCRIPTION
This PR introduces a build option "tracy_as_shared"(subject to renaming) and appropriate changes to the build system to compile TracyClient as a shared library. The reason this needs to come from Godot itself is because building a GDExtension against the shared library needs to match exactly the build options the engine uses for tracy, or there will highly likely be errors.

**Motivation:**

Currently tracy-profiler can not be used to profile the engine and GDExtension simultaneously.
There are no known issues, or proposals addressing this that I found, however there have been a few discussions requesting, or lamenting this fact.

- **Forum posts:**
	- https://forum.godotengine.org/t/does-new-godot4-6-tracy-profiler-support-works-with-gdextension-dlls/132830/6
- ***Discord Chats:**
	- https://discord.com/channels/1235157165589794909/1259879534392774748/1518526225453285400
	- https://discord.com/channels/1235157165589794909/1235321874607771810/1498936198108811305
 
**Technical overview:**

Build system changes only primarily confined to the core/profiling build scripts. 
Conditionally create a shared library from the tracy source pointed to by the profiler_path
Copy the library, sidecar files, and the `profiling.gen.h` to the bin directory next to the godot binary.

Users who wish to build their GDExtension against the TracyClient shared library include the `profiling.gen.h` to match the build flags used in the engine.

**Testing:**

I have an example [godot-cpp-template](https://github.com/enetheru/godot-cpp-template/tree/godot-shared-tracy) demonstrating this using CMake, and will follow up with a Scons before taking this out of Draft.

**Discussion:**

As this work is guarded by a build option, I see no impact to existing users who use tracy to profile their games.

**Additional work:** 

Currently only tested on Windows with MSVC, soon to be tested with multiple toolchains on windows, Linux and MacOS.
Of particular concern to me is the ease of use. Getting a GDExtension built is difficult for most people as it is, I really don't want to make it harder, or add to the support burden.

If necessary I can write up a tutorial of sorts once I have the GDExtension SCons example, and have tested against multiple platform/toolchain combinations.

I also want to follow this up with additional work to make this unnecessary for the average user by adding profiling globals, or builtin objects to facilitate tracing. However this direct access to tracy is a better avenue for seasoned developers.

***PRChecklist:**

- AI used as a search engine and research tool. I actually like writing code, so handing it off to AI robs me of that joy.