### PR TITLE
Reload presets when export plugins are added and removed

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -213,12 +213,14 @@ void EditorExport::add_export_plugin(const Ref<EditorExportPlugin> &p_plugin) {
 	if (!export_plugins.has(p_plugin)) {
 		export_plugins.push_back(p_plugin);
 		should_update_presets = true;
+		should_reload_presets = true;
 	}
 }
 
 void EditorExport::remove_export_plugin(const Ref<EditorExportPlugin> &p_plugin) {
 	export_plugins.erase(p_plugin);
 	should_update_presets = true;
+	should_reload_presets = true;
 }
 
 Vector<Ref<EditorExportPlugin>> EditorExport::get_export_plugins() {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121091

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

`EditorExport::load_config()` is called once when the project is loaded (`NOTIFICATION_ENTER_TREE`) and again when `EditorExportPlatform`s are added and removed. This can happen before `EditorExportPlugin`s are loaded, causing `EditorExport::load_config()` to fail to show export options stored in the credentials file (usage = `PROPERTY_USAGE_SECRET`).

This PR fixes this issue by simply reloading export presets whenever export plugins are added and removed.

Note: This PR technically makes `should_reload_presets` and `should_update_presets` completely equivalent but to keep changes minimal I've intentionally refrained from merging the two flags into one.