### PR TITLE
Fix `GodotPhysicsDirectBodyState2D::get_velocity_at_local_position()` ignoring custom `center_of_mass`

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -321,7 +321,7 @@ public:
 	void integrate_velocities(real_t p_step);
 
 	_FORCE_INLINE_ Vector2 get_velocity_in_local_point(const Vector2 &rel_pos) const {
-		return linear_velocity + Vector2(-angular_velocity * rel_pos.y, angular_velocity * rel_pos.x);
+		return linear_velocity + Vector2(-angular_velocity * (rel_pos.y - center_of_mass.y), angular_velocity * (rel_pos.x - center_of_mass.x));
 	}
 
 	_FORCE_INLINE_ Vector2 get_motion() const {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/121086

## Additional information

Changes:
- `GodotPhysicsDirectBodyState2D::get_velocity_at_local_position()` now accounts for custom `center_of_mass` offset when adding angular velocity.
  - This may affect `CharacterBody2D::move_and_slide()`: [(character_body_2d.cpp#L65)](https://github.com/godotengine/godot/blob/e17f949f934246f8951f1a926f22b22514698cb3/scene/2d/physics/character_body_2d.cpp#L65)
  - This is consistent with how `CharacterBody3D::move_and_slide()` uses `GodotPhysicsDirectBodyState3D::get_velocity_at_local_position()`: [(character_body_3d.cpp#L82)](https://github.com/godotengine/godot/blob/e17f949f934246f8951f1a926f22b22514698cb3/scene/3d/physics/character_body_3d.cpp#L82)

Notes for reviewer:
- `CharacterBody2D::move_and_slide()` may be affected, but I could not figure out how to test that part.

## Author disclosure

I wrote this PR by myself.