### PR TITLE
Fix wrong accesibility name for next and previous button of EditorPaginator

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3829,7 +3829,7 @@ EditorPaginator::EditorPaginator() {
 	add_child(page_count_label);
 
 	next_page_button = memnew(Button);
-	prev_page_button->set_accessibility_name(TTRC("Next Page"));
+	next_page_button->set_accessibility_name(TTRC("Next Page"));
 	next_page_button->set_flat(true);
 	next_page_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPaginator::_next_page_button_pressed));
 	add_child(next_page_button);


### PR DESCRIPTION
While trying to understand how the EditorPaginator works I noticed that the accessibility name of the "Previous Page" Button is set to "Next Page" instead of the Button for "Next Page". This small fix sets the accessibility name of the correct Button.