### PR TITLE
Deduplicate Area2D/3D space override enum

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -66,7 +66,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
@@ -91,14 +91,14 @@
 			The distance at which the gravity strength is equal to [member gravity]. For example, on a planet 100 pixels in radius with a surface gravity of 4.0 px/s², set the [member gravity] to 4.0 and the unit distance to 100.0. The gravity will have falloff according to the inverse square law, so in the example, at 200 pixels from the center the gravity will be 1.0 px/s² (twice the distance, 1/4th the gravity), at 50 pixels it will be 16.0 px/s² (half the distance, 4x the gravity), and so on.
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
-		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
@@ -198,19 +198,19 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_DISABLED] instead.">
 			This area does not affect gravity/damping.
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_COMBINE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order).
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_COMBINE_REPLACE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order), ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_REPLACE] instead.">
 			This area replaces any gravity/damping, even the defaults, ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_REPLACE_COMBINE] instead.">
 			This area replaces any gravity/damping calculated so far (in [member priority] order), but keeps calculating the rest of the areas.
 		</constant>
 	</constants>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -66,7 +66,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
@@ -91,14 +91,14 @@
 			The distance at which the gravity strength is equal to [member gravity]. For example, on a planet 100 pixels in radius with a surface gravity of 4.0 px/s², set the [member gravity] to 4.0 and the unit distance to 100.0. The gravity will have falloff according to the inverse square law, so in the example, at 200 pixels from the center the gravity will be 1.0 px/s² (twice the distance, 1/4th the gravity), at 50 pixels it will be 16.0 px/s² (half the distance, 4× the gravity), and so on.
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
-		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/2d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area2D.SpaceOverride" default="0">
+		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="PhysicsServer2D.AreaSpaceOverrideMode" default="0">
 			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
@@ -198,19 +198,19 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_DISABLED] instead.">
 			This area does not affect gravity/damping.
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_COMBINE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order).
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_COMBINE_REPLACE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order), ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_REPLACE] instead.">
 			This area replaces any gravity/damping, even the defaults, ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride" deprecated="Use [constant PhysicsServer2D.AREA_SPACE_OVERRIDE_REPLACE_COMBINE] instead.">
 			This area replaces any gravity/damping calculated so far (in [member priority] order), but keeps calculating the rest of the areas.
 		</constant>
 	</constants>

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -69,7 +69,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
@@ -94,14 +94,14 @@
 			The distance at which the gravity strength is equal to [member gravity]. For example, on a planet 100 meters in radius with a surface gravity of 4.0 m/s², set the [member gravity] to 4.0 and the unit distance to 100.0. The gravity will have falloff according to the inverse square law, so in the example, at 200 meters from the center the gravity will be 1.0 m/s² (twice the distance, 1/4th the gravity), at 50 meters it will be 16.0 m/s² (half the distance, 4x the gravity), and so on.
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
-		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
@@ -229,19 +229,19 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_DISABLED] instead.">
 			This area does not affect gravity/damping.
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_COMBINE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order).
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_COMBINE_REPLACE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order), ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_REPLACE] instead.">
 			This area replaces any gravity/damping, even the defaults, ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_REPLACE_COMBINE] instead.">
 			This area replaces any gravity/damping calculated so far (in [member priority] order), but keeps calculating the rest of the areas.
 		</constant>
 	</constants>

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -69,7 +69,7 @@
 			The rate at which objects stop spinning in this area. Represents the angular velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
-		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="angular_damp_space_override" type="int" setter="set_angular_damp_space_override_mode" getter="get_angular_damp_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for angular damping calculations within this area.
 		</member>
 		<member name="audio_bus_name" type="StringName" setter="set_audio_bus_name" getter="get_audio_bus_name" default="&amp;&quot;Master&quot;">
@@ -94,14 +94,14 @@
 			The distance at which the gravity strength is equal to [member gravity]. For example, on a planet 100 meters in radius with a surface gravity of 4.0 m/s², set the [member gravity] to 4.0 and the unit distance to 100.0. The gravity will have falloff according to the inverse square law, so in the example, at 200 meters from the center the gravity will be 1.0 m/s² (twice the distance, 1/4th the gravity), at 50 meters it will be 16.0 m/s² (half the distance, 4× the gravity), and so on.
 			The above is true only when the unit distance is a positive number. When this is set to 0.0, the gravity will be constant regardless of distance.
 		</member>
-		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="gravity_space_override" type="int" setter="set_gravity_space_override_mode" getter="get_gravity_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for gravity calculations within this area.
 		</member>
 		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.1">
 			The rate at which objects stop moving in this area. Represents the linear velocity lost per second.
 			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
 		</member>
-		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="Area3D.SpaceOverride" default="0">
+		<member name="linear_damp_space_override" type="int" setter="set_linear_damp_space_override_mode" getter="get_linear_damp_space_override_mode" enum="PhysicsServer3D.AreaSpaceOverrideMode" default="0">
 			Override mode for linear damping calculations within this area.
 		</member>
 		<member name="monitorable" type="bool" setter="set_monitorable" getter="is_monitorable" default="true">
@@ -229,19 +229,19 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_DISABLED" value="0" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_DISABLED] instead.">
 			This area does not affect gravity/damping.
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE" value="1" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_COMBINE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order).
 		</constant>
-		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_COMBINE_REPLACE" value="2" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_COMBINE_REPLACE] instead.">
 			This area adds its gravity/damping values to whatever has been calculated so far (in [member priority] order), ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE" value="3" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_REPLACE] instead.">
 			This area replaces any gravity/damping, even the defaults, ignoring any lower priority areas.
 		</constant>
-		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride">
+		<constant name="SPACE_OVERRIDE_REPLACE_COMBINE" value="4" enum="SpaceOverride" deprecated="Use [constant PhysicsServer3D.AREA_SPACE_OVERRIDE_REPLACE_COMBINE] instead.">
 			This area replaces any gravity/damping calculated so far (in [member priority] order), but keeps calculating the rest of the areas.
 		</constant>
 	</constants>

--- a/misc/extension_api_validation/4.7-stable/GH-121102.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121102.txt
@@ -1,0 +1,18 @@
+GH-121102
+--------------
+
+Validate extension JSON: Error: Field 'classes/Area2D/methods/get_angular_damp_space_override_mode/return_value': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/get_gravity_space_override_mode/return_value': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/get_linear_damp_space_override_mode/return_value': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/set_angular_damp_space_override_mode/arguments/0': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/set_gravity_space_override_mode/arguments/0': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/set_linear_damp_space_override_mode/arguments/0': type changed value in new API, from "enum::Area2D.SpaceOverride" to "enum::PhysicsServer2D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/get_angular_damp_space_override_mode/return_value': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/get_gravity_space_override_mode/return_value': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/get_linear_damp_space_override_mode/return_value': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/set_angular_damp_space_override_mode/arguments/0': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/set_gravity_space_override_mode/arguments/0': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/set_linear_damp_space_override_mode/arguments/0': type changed value in new API, from "enum::Area3D.SpaceOverride" to "enum::PhysicsServer3D.AreaSpaceOverrideMode".
+
+Change Area2D/3D space override properties to use PhysicsServer2D/3D.AreaSpaceOverrideMode instead of Area2D/3D.SpaceOverride.
+Compatibility methods registered.

--- a/scene/2d/physics/area_2d.compat.inc
+++ b/scene/2d/physics/area_2d.compat.inc
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  area_2d.compat.inc                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "area_2d.h"
+
+#include "core/object/class_db.h"
+
+// Old enum properties for compatibility.
+
+void Area2D::_set_gravity_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_gravity_space_override_mode((PS2DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area2D::SpaceOverride Area2D::_get_gravity_space_override_mode_bind_compat_121102() const {
+	return (Area2D::SpaceOverride)get_gravity_space_override_mode();
+}
+
+void Area2D::_set_linear_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_linear_damp_space_override_mode((PS2DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area2D::SpaceOverride Area2D::_get_linear_damp_space_override_mode_bind_compat_121102() const {
+	return (Area2D::SpaceOverride)get_linear_damp_space_override_mode();
+}
+
+void Area2D::_set_angular_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_angular_damp_space_override_mode((PS2DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area2D::SpaceOverride Area2D::_get_angular_damp_space_override_mode_bind_compat_121102() const {
+	return (Area2D::SpaceOverride)get_angular_damp_space_override_mode();
+}
+
+void Area2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_gravity_space_override_mode", "mode"), &Area2D::_set_gravity_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_gravity_space_override_mode"), &Area2D::_get_gravity_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("set_linear_damp_space_override_mode", "mode"), &Area2D::_set_linear_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_linear_damp_space_override_mode"), &Area2D::_get_linear_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("set_angular_damp_space_override_mode", "mode"), &Area2D::_set_angular_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_angular_damp_space_override_mode"), &Area2D::_get_angular_damp_space_override_mode_bind_compat_121102);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "area_2d.h"
+#include "area_2d.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
@@ -36,12 +37,12 @@
 #include "servers/audio/audio_server.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
-void Area2D::set_gravity_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_gravity_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_gravity_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_gravity_space_override_mode() const {
 	return gravity_space_override;
 }
 
@@ -90,21 +91,21 @@ real_t Area2D::get_gravity() const {
 	return gravity;
 }
 
-void Area2D::set_linear_damp_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_linear_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	linear_damp_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_linear_damp_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_linear_damp_space_override_mode() const {
 	return linear_damp_space_override;
 }
 
-void Area2D::set_angular_damp_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_angular_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	angular_damp_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_angular_damp_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_angular_damp_space_override_mode() const {
 	return angular_damp_space_override;
 }
 
@@ -560,7 +561,7 @@ void Area2D::_validate_property(PropertyInfo &p_property) const {
 
 		p_property.hint_string = options;
 	} else if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
-		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (gravity_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
@@ -574,11 +575,11 @@ void Area2D::_validate_property(PropertyInfo &p_property) const {
 			}
 		}
 	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
-		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (linear_damp_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
-		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (angular_damp_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
@@ -673,11 +674,13 @@ void Area2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus_name", "get_audio_bus_name");
 
+#ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE_COMBINE);
+#endif // DISABLE_DEPRECATED
 }
 
 Area2D::Area2D() :

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "area_2d.h"
+#include "area_2d.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
@@ -36,12 +37,12 @@
 #include "servers/audio/audio_server.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
-void Area2D::set_gravity_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_gravity_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_gravity_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_gravity_space_override_mode() const {
 	return gravity_space_override;
 }
 
@@ -90,21 +91,21 @@ real_t Area2D::get_gravity() const {
 	return gravity;
 }
 
-void Area2D::set_linear_damp_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_linear_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	linear_damp_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_linear_damp_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_linear_damp_space_override_mode() const {
 	return linear_damp_space_override;
 }
 
-void Area2D::set_angular_damp_space_override_mode(SpaceOverride p_mode) {
+void Area2D::set_angular_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode) {
 	angular_damp_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area2D::SpaceOverride Area2D::get_angular_damp_space_override_mode() const {
+PS2DE::AreaSpaceOverrideMode Area2D::get_angular_damp_space_override_mode() const {
 	return angular_damp_space_override;
 }
 
@@ -549,7 +550,7 @@ void Area2D::_validate_property(PropertyInfo &p_property) const {
 		return;
 	}
 	if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
-		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (gravity_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
@@ -563,11 +564,11 @@ void Area2D::_validate_property(PropertyInfo &p_property) const {
 			}
 		}
 	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
-		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (linear_damp_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
-		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (angular_damp_space_override == PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
@@ -662,11 +663,13 @@ void Area2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_AUDIO_BUS), "set_audio_bus_name", "get_audio_bus_name");
 
+#ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE_COMBINE);
+#endif // DISABLE_DEPRECATED
 }
 
 Area2D::Area2D() :

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -39,6 +39,7 @@ class Area2D : public CollisionObject2D {
 public:
 	static constexpr AncestralClass static_ancestral_class = AncestralClass::AREA_2D;
 
+#ifndef DISABLE_DEPRECATED
 	enum SpaceOverride {
 		SPACE_OVERRIDE_DISABLED,
 		SPACE_OVERRIDE_COMBINE,
@@ -46,16 +47,17 @@ public:
 		SPACE_OVERRIDE_REPLACE,
 		SPACE_OVERRIDE_REPLACE_COMBINE
 	};
+#endif // DISABLE_DEPRECATED
 
 private:
-	SpaceOverride gravity_space_override = SPACE_OVERRIDE_DISABLED;
+	PS2DE::AreaSpaceOverrideMode gravity_space_override = PS2DE::AREA_SPACE_OVERRIDE_DISABLED;
 	Vector2 gravity_vec;
 	real_t gravity = 0.0;
 	bool gravity_is_point = false;
 	real_t gravity_point_unit_distance = 0.0;
 
-	SpaceOverride linear_damp_space_override = SPACE_OVERRIDE_DISABLED;
-	SpaceOverride angular_damp_space_override = SPACE_OVERRIDE_DISABLED;
+	PS2DE::AreaSpaceOverrideMode linear_damp_space_override = PS2DE::AREA_SPACE_OVERRIDE_DISABLED;
+	PS2DE::AreaSpaceOverrideMode angular_damp_space_override = PS2DE::AREA_SPACE_OVERRIDE_DISABLED;
 	real_t linear_damp = 0.1;
 	real_t angular_damp = 1.0;
 
@@ -139,9 +141,20 @@ protected:
 
 	virtual void _space_changed(const RID &p_new_space) override;
 
+#ifndef DISABLE_DEPRECATED
+	// Old enum properties for compatibility.
+	void _set_gravity_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_gravity_space_override_mode_bind_compat_121102() const;
+	void _set_linear_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_linear_damp_space_override_mode_bind_compat_121102() const;
+	void _set_angular_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_angular_damp_space_override_mode_bind_compat_121102() const;
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
-	void set_gravity_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_gravity_space_override_mode() const;
+	void set_gravity_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode);
+	PS2DE::AreaSpaceOverrideMode get_gravity_space_override_mode() const;
 
 	void set_gravity_is_point(bool p_enabled);
 	bool is_gravity_a_point() const;
@@ -158,11 +171,11 @@ public:
 	void set_gravity(real_t p_gravity);
 	real_t get_gravity() const;
 
-	void set_linear_damp_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_linear_damp_space_override_mode() const;
+	void set_linear_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode);
+	PS2DE::AreaSpaceOverrideMode get_linear_damp_space_override_mode() const;
 
-	void set_angular_damp_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_angular_damp_space_override_mode() const;
+	void set_angular_damp_space_override_mode(PS2DE::AreaSpaceOverrideMode p_mode);
+	PS2DE::AreaSpaceOverrideMode get_angular_damp_space_override_mode() const;
 
 	void set_linear_damp(real_t p_linear_damp);
 	real_t get_linear_damp() const;
@@ -198,4 +211,6 @@ public:
 	~Area2D();
 };
 
+#ifndef DISABLE_DEPRECATED
 VARIANT_ENUM_CAST(Area2D::SpaceOverride);
+#endif // DISABLE_DEPRECATED

--- a/scene/3d/physics/area_3d.compat.inc
+++ b/scene/3d/physics/area_3d.compat.inc
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  area_3d.compat.inc                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "area_3d.h"
+
+#include "core/object/class_db.h"
+
+// Old enum properties for compatibility.
+
+void Area3D::_set_gravity_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_gravity_space_override_mode((PS3DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area3D::SpaceOverride Area3D::_get_gravity_space_override_mode_bind_compat_121102() const {
+	return (Area3D::SpaceOverride)get_gravity_space_override_mode();
+}
+
+void Area3D::_set_linear_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_linear_damp_space_override_mode((PS3DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area3D::SpaceOverride Area3D::_get_linear_damp_space_override_mode_bind_compat_121102() const {
+	return (Area3D::SpaceOverride)get_linear_damp_space_override_mode();
+}
+
+void Area3D::_set_angular_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode) {
+	set_angular_damp_space_override_mode((PS3DE::AreaSpaceOverrideMode)p_mode);
+}
+
+Area3D::SpaceOverride Area3D::_get_angular_damp_space_override_mode_bind_compat_121102() const {
+	return (Area3D::SpaceOverride)get_angular_damp_space_override_mode();
+}
+
+void Area3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_gravity_space_override_mode", "mode"), &Area3D::_set_gravity_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_gravity_space_override_mode"), &Area3D::_get_gravity_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("set_linear_damp_space_override_mode", "mode"), &Area3D::_set_linear_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_linear_damp_space_override_mode"), &Area3D::_get_linear_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("set_angular_damp_space_override_mode", "mode"), &Area3D::_set_angular_damp_space_override_mode_bind_compat_121102);
+	ClassDB::bind_compatibility_method(D_METHOD("get_angular_damp_space_override_mode"), &Area3D::_get_angular_damp_space_override_mode_bind_compat_121102);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -29,18 +29,19 @@
 /**************************************************************************/
 
 #include "area_3d.h"
+#include "area_3d.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 
-void Area3D::set_gravity_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_gravity_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_gravity_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_gravity_space_override_mode() const {
 	return gravity_space_override;
 }
 
@@ -89,21 +90,21 @@ real_t Area3D::get_gravity() const {
 	return gravity;
 }
 
-void Area3D::set_linear_damp_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_linear_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	linear_damp_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_linear_damp_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_linear_damp_space_override_mode() const {
 	return linear_damp_space_override;
 }
 
-void Area3D::set_angular_damp_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_angular_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	angular_damp_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_angular_damp_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_angular_damp_space_override_mode() const {
 	return angular_damp_space_override;
 }
 
@@ -663,7 +664,7 @@ void Area3D::_validate_property(PropertyInfo &p_property) const {
 
 		p_property.hint_string = options;
 	} else if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
-		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (gravity_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
@@ -677,11 +678,11 @@ void Area3D::_validate_property(PropertyInfo &p_property) const {
 			}
 		}
 	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
-		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (linear_damp_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
-		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (angular_damp_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
@@ -808,11 +809,13 @@ void Area3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_amount", "get_reverb_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_uniformity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_uniformity", "get_reverb_uniformity");
 
+#ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE_COMBINE);
+#endif // DISABLE_DEPRECATED
 }
 
 Area3D::Area3D() :

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "area_3d.h"
+#include "area_3d.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
@@ -36,12 +37,12 @@
 #include "servers/audio/audio_server.h"
 #include "servers/physics_3d/physics_server_3d.h"
 
-void Area3D::set_gravity_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_gravity_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_gravity_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_gravity_space_override_mode() const {
 	return gravity_space_override;
 }
 
@@ -90,21 +91,21 @@ real_t Area3D::get_gravity() const {
 	return gravity;
 }
 
-void Area3D::set_linear_damp_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_linear_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	linear_damp_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_linear_damp_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_linear_damp_space_override_mode() const {
 	return linear_damp_space_override;
 }
 
-void Area3D::set_angular_damp_space_override_mode(SpaceOverride p_mode) {
+void Area3D::set_angular_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode) {
 	angular_damp_space_override = p_mode;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PS3DE::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE, p_mode);
 }
 
-Area3D::SpaceOverride Area3D::get_angular_damp_space_override_mode() const {
+PS3DE::AreaSpaceOverrideMode Area3D::get_angular_damp_space_override_mode() const {
 	return angular_damp_space_override;
 }
 
@@ -653,7 +654,7 @@ void Area3D::_validate_property(PropertyInfo &p_property) const {
 		return;
 	}
 	if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
-		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (gravity_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
@@ -667,11 +668,11 @@ void Area3D::_validate_property(PropertyInfo &p_property) const {
 			}
 		}
 	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
-		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (linear_damp_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
-		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
+		if (angular_damp_space_override == PS3DE::AREA_SPACE_OVERRIDE_DISABLED) {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
@@ -798,11 +799,13 @@ void Area3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_amount", "get_reverb_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_uniformity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_uniformity", "get_reverb_uniformity");
 
+#ifndef DISABLE_DEPRECATED
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_REPLACE_COMBINE);
+#endif // DISABLE_DEPRECATED
 }
 
 Area3D::Area3D() :

--- a/scene/3d/physics/area_3d.h
+++ b/scene/3d/physics/area_3d.h
@@ -37,6 +37,7 @@ class Area3D : public CollisionObject3D {
 	GDCLASS(Area3D, CollisionObject3D);
 
 public:
+#ifndef DISABLE_DEPRECATED
 	enum SpaceOverride {
 		SPACE_OVERRIDE_DISABLED,
 		SPACE_OVERRIDE_COMBINE,
@@ -44,16 +45,17 @@ public:
 		SPACE_OVERRIDE_REPLACE,
 		SPACE_OVERRIDE_REPLACE_COMBINE
 	};
+#endif // DISABLE_DEPRECATED
 
 private:
-	SpaceOverride gravity_space_override = SPACE_OVERRIDE_DISABLED;
+	PS3DE::AreaSpaceOverrideMode gravity_space_override = PS3DE::AREA_SPACE_OVERRIDE_DISABLED;
 	Vector3 gravity_vec;
 	real_t gravity = 0.0;
 	bool gravity_is_point = false;
 	real_t gravity_point_unit_distance = 0.0;
 
-	SpaceOverride linear_damp_space_override = SPACE_OVERRIDE_DISABLED;
-	SpaceOverride angular_damp_space_override = SPACE_OVERRIDE_DISABLED;
+	PS3DE::AreaSpaceOverrideMode linear_damp_space_override = PS3DE::AREA_SPACE_OVERRIDE_DISABLED;
+	PS3DE::AreaSpaceOverrideMode angular_damp_space_override = PS3DE::AREA_SPACE_OVERRIDE_DISABLED;
 	real_t angular_damp = 0.1;
 	real_t linear_damp = 0.1;
 
@@ -149,9 +151,20 @@ protected:
 
 	virtual void _space_changed(const RID &p_new_space) override;
 
+#ifndef DISABLE_DEPRECATED
+	// Old enum properties for compatibility.
+	void _set_gravity_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_gravity_space_override_mode_bind_compat_121102() const;
+	void _set_linear_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_linear_damp_space_override_mode_bind_compat_121102() const;
+	void _set_angular_damp_space_override_mode_bind_compat_121102(SpaceOverride p_mode);
+	SpaceOverride _get_angular_damp_space_override_mode_bind_compat_121102() const;
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
-	void set_gravity_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_gravity_space_override_mode() const;
+	void set_gravity_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode);
+	PS3DE::AreaSpaceOverrideMode get_gravity_space_override_mode() const;
 
 	void set_gravity_is_point(bool p_enabled);
 	bool is_gravity_a_point() const;
@@ -168,11 +181,11 @@ public:
 	void set_gravity(real_t p_gravity);
 	real_t get_gravity() const;
 
-	void set_linear_damp_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_linear_damp_space_override_mode() const;
+	void set_linear_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode);
+	PS3DE::AreaSpaceOverrideMode get_linear_damp_space_override_mode() const;
 
-	void set_angular_damp_space_override_mode(SpaceOverride p_mode);
-	SpaceOverride get_angular_damp_space_override_mode() const;
+	void set_angular_damp_space_override_mode(PS3DE::AreaSpaceOverrideMode p_mode);
+	PS3DE::AreaSpaceOverrideMode get_angular_damp_space_override_mode() const;
 
 	void set_angular_damp(real_t p_angular_damp);
 	real_t get_angular_damp() const;
@@ -229,4 +242,6 @@ public:
 	~Area3D();
 };
 
+#ifndef DISABLE_DEPRECATED
 VARIANT_ENUM_CAST(Area3D::SpaceOverride);
+#endif // DISABLE_DEPRECATED


### PR DESCRIPTION
As of PR #120983, it is safe to depend on the enums in the physics server, since they are now in a dedicated namespace. This means we can deduplicate the ones found in Area2D/3D, assuming that this doesn't break GDExtension.
