### PR TITLE
Fix leaks when opening EditorPropertyArray and EditorPropertyDictionary

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -415,6 +415,16 @@ void EditorPropertyArray::update_property() {
 			memdelete(container);
 			button_add_item = nullptr;
 			container = nullptr;
+			for (Slot &slot : slots) {
+				slot.prop->queue_free();
+				slot.reorder_button->queue_free();
+				slot.container->queue_free();
+				if (slot.edit_button) { // Either edit_button or remove_button has been created.
+					slot.edit_button->queue_free();
+				} else {
+					slot.remove_button->queue_free();
+				}
+			}
 			slots.clear();
 		}
 		return;
@@ -582,6 +592,16 @@ void EditorPropertyArray::update_property() {
 			memdelete(container);
 			button_add_item = nullptr;
 			container = nullptr;
+			for (Slot &slot : slots) {
+				slot.prop->queue_free();
+				slot.reorder_button->queue_free();
+				slot.container->queue_free();
+				if (slot.edit_button) { // Either edit_button or remove_button has been created.
+					slot.edit_button->queue_free();
+				} else {
+					slot.remove_button->queue_free();
+				}
+			}
 			slots.clear();
 		}
 	}
@@ -1299,6 +1319,18 @@ void EditorPropertyDictionary::update_property() {
 			button_add_item = nullptr;
 			container = nullptr;
 			add_panel = nullptr;
+			for (Slot &slot : slots) {
+				slot.prop->queue_free();
+				slot.container->queue_free();
+				if (slot.prop_key) { // prop_key might not have been created, and that's fine.
+					slot.prop_key->queue_free();
+				}
+				if (slot.edit_button) { // Either edit_button or remove_button has been created.
+					slot.edit_button->queue_free();
+				} else if (slot.remove_button) {
+					slot.remove_button->queue_free();
+				}
+			}
 			slots.clear();
 		}
 		return;
@@ -1515,6 +1547,18 @@ void EditorPropertyDictionary::update_property() {
 			button_add_item = nullptr;
 			container = nullptr;
 			add_panel = nullptr;
+			for (Slot &slot : slots) {
+				slot.prop->queue_free();
+				slot.container->queue_free();
+				if (slot.prop_key) { // prop_key might not have been created, and that's fine.
+					slot.prop_key->queue_free();
+				}
+				if (slot.edit_button) { // Either edit_button or remove_button has been created.
+					slot.edit_button->queue_free();
+				} else if (slot.remove_button) {
+					slot.remove_button->queue_free();
+				}
+			}
 			slots.clear();
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121031

## Additional information
When folding the `EditorPropertyArray` or `EditorPropertyDictionary` drop-down list, the slots are not being freed which leads to memory leaks.