### PR TITLE
[Polygon2D] Fix polygon list not being adjusted after vertex deletion

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -614,6 +614,30 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 						previous_colors.remove_at(closest);
 					}
 
+					Array polygons = node->get_polygons().duplicate(); // Copy because it's a reference.
+					for (int i = polygons.size() - 1; i >= 0; --i) {
+						Vector<int> points = polygons[i];
+
+						bool uses_removed_vertex = false;
+						bool modified = false;
+						for (int j = 0; j < points.size(); ++j) {
+							if (points[j] == closest) {
+								uses_removed_vertex = true;
+								break;
+							}
+							if (points[j] > closest) {
+								points.set(j, points[j] - 1);
+								modified = true;
+							}
+						}
+
+						if (uses_removed_vertex) {
+							polygons.remove_at(i);
+						} else if (modified) {
+							polygons[i] = points;
+						}
+					}
+
 					undo_redo->create_action(TTR("Remove Internal Vertex"));
 					undo_redo->add_do_method(node, "set_uv", previous_uv);
 					undo_redo->add_undo_method(node, "set_uv", node->get_uv());
@@ -621,6 +645,8 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					undo_redo->add_undo_method(node, "set_polygon", node->get_polygon());
 					undo_redo->add_do_method(node, "set_vertex_colors", previous_colors);
 					undo_redo->add_undo_method(node, "set_vertex_colors", node->get_vertex_colors());
+					undo_redo->add_do_method(node, "set_polygons", polygons);
+					undo_redo->add_undo_method(node, "set_polygons", node->get_polygons());
 					for (int i = 0; i < node->get_bone_count(); i++) {
 						Vector<float> bonew = node->get_bone_weights(i);
 						bonew.remove_at(closest);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, if we delete an internal vertex from a Polygon2D's Polygon editor, all polygons made in the 'Polygons' mode aren't adjusted alongside the vertex array. This means polygons using the vertex remain and polygons using an ID above the deleted ID will not decrement, breaking them.

Before:
<img width="678" height="608" alt="before" src="https://github.com/user-attachments/assets/4ef72518-28ce-494a-8189-4168c9e27464" />

After:
<img width="678" height="608" alt="after" src="https://github.com/user-attachments/assets/06068e4c-7bee-462b-8fdb-391221d3bcd4" />
