### PR TITLE
Set the Asset Store's default sorting to highest scored

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -2188,6 +2188,9 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 		sort->add_item(sort_text[i]);
 	}
 
+	// TODO: Remove this once "Relevance" sorting is fixed.
+	sort->select(SORT_REVIEWS);
+
 	search_hb2->add_child(sort);
 
 	sort->set_h_size_flags(Control::SIZE_EXPAND_FILL);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-asset-store/issues/450.

## Additional information

The server-side relevance sorting of assets is currently flawed, so we're temporarily setting the default to highest scored until it works properly.