### PR TITLE
Add `get_velocity_at_(local)_position()` to `RigidBody3D`

### DIFF
--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -122,6 +122,24 @@
 				Returns the inverse inertia tensor basis. This is used to calculate the angular acceleration resulting from a torque applied to the [RigidBody3D].
 			</description>
 		</method>
+		<method name="get_velocity_at_local_position" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="local_position" type="Vector3" />
+			<description>
+				Returns the body's velocity at the given relative position.
+				[param local_position] is the offset from the body origin in global coordinates.
+				See also [method get_velocity_at_position].
+			</description>
+		</method>
+		<method name="get_velocity_at_position" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="global_point" type="Vector3" />
+			<description>
+				Returns the body's velocity at the given global position.
+				This is equivalent to [code]get_velocity_at_local_position(global_point - global_position)[/code].
+				See also [method get_velocity_at_local_position].
+			</description>
+		</method>
 		<method name="set_axis_velocity">
 			<return type="void" />
 			<param index="0" name="axis_velocity" type="Vector3" />

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -731,6 +731,9 @@ void RigidBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_continuous_collision_detection", "enable"), &RigidBody3D::set_use_continuous_collision_detection);
 	ClassDB::bind_method(D_METHOD("is_using_continuous_collision_detection"), &RigidBody3D::is_using_continuous_collision_detection);
 
+	ClassDB::bind_method(D_METHOD("get_velocity_at_local_position", "local_position"), &RigidBody3D::get_velocity_at_local_position);
+	ClassDB::bind_method(D_METHOD("get_velocity_at_position", "global_point"), &RigidBody3D::get_velocity_at_position);
+
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody3D::set_axis_velocity);
 
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &RigidBody3D::apply_central_impulse);

--- a/scene/3d/physics/rigid_body_3d.h
+++ b/scene/3d/physics/rigid_body_3d.h
@@ -173,6 +173,14 @@ public:
 	void set_linear_velocity(const Vector3 &p_velocity);
 	Vector3 get_linear_velocity() const override;
 
+	_FORCE_INLINE_ Vector3 get_velocity_at_local_position(const Vector3 &p_position) const {
+		return linear_velocity + angular_velocity.cross(p_position + get_global_position() - to_global(center_of_mass));
+	}
+
+	_FORCE_INLINE_ Vector3 get_velocity_at_position(const Vector3 &p_position) const {
+		return linear_velocity + angular_velocity.cross(p_position - to_global(center_of_mass));
+	}
+
 	void set_axis_velocity(const Vector3 &p_axis);
 
 	void set_angular_velocity(const Vector3 &p_velocity);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot-proposals/issues/773
Closes https://github.com/godotengine/godot-proposals/issues/7480

Related PR:
- https://github.com/godotengine/godot/pull/121142

## Additional information

Changes:
- Adds `RigidBody3D.get_velocity_at_local_position()`.
- Adds `RigidBody3D.get_velocity_at_position()`.
  - Equivalent to `RigidBody3D.get_velocity_at_local_position(global_point - global_position)`.
- Adds relevant docs.

Test project:
[MRP_RigidBody3D.zip](https://github.com/user-attachments/files/29836336/MRP_RigidBody3D.zip)

Note for reviewers:
- I find `get_velocity_at_position()` more intuitive; `get_velocity_at_local_position()` requires subtracting `global_position` in the parameter, and then adds it back inside the function anyway.

## Author disclosure

I wrote this PR by myself.