### PR TITLE
OpenXR: Improve built-in marker tracking

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3599,27 +3599,13 @@
 			If [code]true[/code] we enable the render model extension if available.
 			[b]Note:[/b] This relates to the core OpenXR render model extension and has no relation to any vendor render model extensions.
 		</member>
-		<member name="xr/openxr/extensions/spatial_entity/april_tag_dict" type="int" setter="" getter="" default="&quot;3&quot;">
-			The April Tag marker types the built-in marker tracking is set to recognize (if April Tag marker tracking is available and enabled).
-		</member>
-		<member name="xr/openxr/extensions/spatial_entity/aruco_dict" type="int" setter="" getter="" default="&quot;15&quot;">
-			The ArUco marker types the built-in marker tracking is set to recognize (if ArUco marker tracking is available and enabled).
-		</member>
 		<member name="xr/openxr/extensions/spatial_entity/enable_builtin_anchor_detection" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], we enable the built-in logic for handling anchors. Godot will query (persistent) anchors and manage [OpenXRAnchorTracker] instances for you. If disabled you'll need to create your own spatial and persistence context and perform your own discovery queries.
 			[b]Note:[/b] This functionality requires that spatial anchors are supported and enabled.
 		</member>
-		<member name="xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], we enable the built-in logic for handling marker tracking. Godot will query markers and manage [OpenXRMarkerTracker] instances for you. If disabled you'll need to create your own spatial context and perform your own discovery queries.
-			[b]Note:[/b] This functionality requires that marker tracking is supported and enabled.
-		</member>
 		<member name="xr/openxr/extensions/spatial_entity/enable_builtin_plane_detection" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], we enable the built-in logic for handling plane detection. Godot will query detected planes (walls, floors, ceilings, etc.) and manage [OpenXRPlaneTracker] instances for you. If disabled you'll need to create your own spatial context and perform your own discovery queries.
 			[b]Note:[/b] This functionality requires that plane tracking is supported and enabled.
-		</member>
-		<member name="xr/openxr/extensions/spatial_entity/enable_marker_tracking" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], support for the marker tracking extension is requested. If supported, you will be able to query information about markers detected by the XR runtime, e.g. QR codes, aruca markers and april tags.
-			[b]Note:[/b] This requires that the OpenXR spatial entities and marker tracking extensions are supported by the XR runtime. If not supported this setting will be ignored. [member xr/openxr/extensions/spatial_entity/enabled] must be enabled for this setting to be used.
 		</member>
 		<member name="xr/openxr/extensions/spatial_entity/enable_persistent_anchors" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], support for the persistent anchors extension is requested. If supported, you will be able to store spatial anchors and they will be restored on application startup.
@@ -3636,6 +3622,20 @@
 		<member name="xr/openxr/extensions/spatial_entity/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], support for the spatial entity extension is requested. If supported, you will be able to access spatial information about the real environment around you. What information is available is dependent on additional extensions.
 			[b]Note:[/b] This requires that the OpenXR spatial entities extension is supported by the XR runtime. If not supported this setting will be ignored.
+		</member>
+		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/april_tag_dict" type="int" setter="" getter="" default="&quot;3&quot;">
+			The April Tag marker types the built-in marker tracking is set to recognize (if April Tag marker tracking is available and enabled).
+		</member>
+		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/aruco_dict" type="int" setter="" getter="" default="&quot;15&quot;">
+			The ArUco marker types the built-in marker tracking is set to recognize (if ArUco marker tracking is available and enabled).
+		</member>
+		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/enable" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], support for the marker tracking extension is requested. If supported, you will be able to query information about markers detected by the XR runtime, e.g., QR codes, ArUco markers, and April tags.
+			[b]Note:[/b] This requires that the OpenXR spatial entities and marker tracking extensions are supported by the XR runtime. If not supported this setting will be ignored. [member xr/openxr/extensions/spatial_entity/enabled] must be enabled for this setting to be used.
+		</member>
+		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types" type="int" setter="" getter="" default="0">
+			We enable the built-in logic for handling marker tracking for each selected marker type. Godot will query markers and manage [OpenXRMarkerTracker] instances for you. If disabled you'll need to create your own spatial context and perform your own discovery queries.
+			[b]Note:[/b] This functionality requires that marker tracking is supported and enabled.
 		</member>
 		<member name="xr/openxr/extensions/user_presence" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the user presence extension is enabled if available.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2813,6 +2813,26 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("xr/openxr/startup_alert", true);
 
 	// OpenXR project extensions settings.
+#ifndef DISABLE_DEPRECATED
+#define MOVE_PROJECT_SETTING(m_old_setting, m_new_setting) \
+	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting); \
+		ProjectSettings::get_singleton()->set_setting(m_new_setting, value); \
+		ProjectSettings::get_singleton()->clear(m_old_setting); \
+	}
+
+	MOVE_PROJECT_SETTING("xr/openxr/extensions/spatial_entity/enable_marker_tracking", "xr/openxr/extensions/spatial_entity/marker_tracking/enable");
+	MOVE_PROJECT_SETTING("xr/openxr/extensions/spatial_entity/aruco_dict", "xr/openxr/extensions/spatial_entity/marker_tracking/aruco_dict");
+	MOVE_PROJECT_SETTING("xr/openxr/extensions/spatial_entity/april_tag_dict", "xr/openxr/extensions/spatial_entity/marker_tracking/april_tag_dict");
+
+	if (!ProjectSettings::get_singleton()->has_setting("xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types") && ProjectSettings::get_singleton()->has_setting("xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking")) {
+		bool value = GLOBAL_GET("xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking");
+		ProjectSettings::get_singleton()->set_setting("xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types", value ? 15 : 0);
+		ProjectSettings::get_singleton()->clear("xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking");
+	}
+#undef MOVE_PROJECT_SETTING
+#endif // DISABLE_DEPRECATED
+
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/debug_utils", PROPERTY_HINT_ENUM, "Disabled,Error,Warning,Info,Verbose"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/debug_message_types", PROPERTY_HINT_FLAGS, "General,Validation,Performance,Conformance"), "15");
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/frame_synthesis", false);
@@ -2827,10 +2847,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/enable_builtin_anchor_detection", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/enable_plane_tracking", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/enable_builtin_plane_detection", false);
-	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/enable_marker_tracking", false);
-	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking", false);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/spatial_entity/aruco_dict", PROPERTY_HINT_ENUM, "4x4 50 IDs,4x4 100 IDs,4x4 250 IDs,4x4 1000 IDs,5x5 50 IDs,5x5 100 IDs,5x5 250 IDs,5x5 1000 IDs,6x6 50 IDs,6x6 100 IDs,6x6 250 IDs,6x6 1000 IDs,7x7 50 IDs,7x7 100 IDs,7x7 250 IDs,7x7 1000 IDs"), "15");
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/spatial_entity/april_tag_dict", PROPERTY_HINT_ENUM, "4x4H5,5x5H9,6x6H10,6x6H11"), "3");
+	GLOBAL_DEF_BASIC("xr/openxr/extensions/spatial_entity/marker_tracking/enable", false);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types", PROPERTY_HINT_FLAGS, "QR codes,Micro QR codes,ArUco markers,April tags"), 0);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/spatial_entity/marker_tracking/aruco_dict", PROPERTY_HINT_ENUM, "4x4 50 IDs,4x4 100 IDs,4x4 250 IDs,4x4 1000 IDs,5x5 50 IDs,5x5 100 IDs,5x5 250 IDs,5x5 1000 IDs,6x6 50 IDs,6x6 100 IDs,6x6 250 IDs,6x6 1000 IDs,7x7 50 IDs,7x7 100 IDs,7x7 250 IDs,7x7 1000 IDs"), "15");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/extensions/spatial_entity/marker_tracking/april_tag_dict", PROPERTY_HINT_ENUM, "4x4H5,5x5H9,6x6H10,6x6H11"), "3");
 	GLOBAL_DEF_RST_BASIC("xr/openxr/extensions/eye_gaze_interaction", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/render_model", false);
 	GLOBAL_DEF_BASIC("xr/openxr/extensions/user_presence", false);

--- a/misc/extension_api_validation/4.7-stable/GH-121123.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121123.txt
@@ -1,0 +1,6 @@
+GH-121123
+---------
+
+Validate extension JSON: Error: Field 'classes/OpenXRSpatialEntityExtension/methods/create_spatial_context/arguments': size changed value in new API, from 3 to 4.
+
+Added new optional `p_failure_callback` method to `create_spatial_context`.

--- a/modules/openxr/doc_classes/OpenXRMarkerTracker.xml
+++ b/modules/openxr/doc_classes/OpenXRMarkerTracker.xml
@@ -4,7 +4,7 @@
 		Spatial entity tracker for our spatial entity marker tracking extension.
 	</brief_description>
 	<description>
-		Spatial entity tracker for our OpenXR spatial entity marker tracking extension. These trackers identify entities in our real space detected by a visual marker such as a QRCode or Aruco code, and map their location to our virtual space.
+		Spatial entity tracker for our OpenXR spatial entity marker tracking extension. These trackers identify entities in our real space detected by a visual marker such as a QRCode or ArUco code, and map their location to our virtual space.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -29,7 +29,7 @@
 			The bounds size for this marker.
 		</member>
 		<member name="marker_id" type="int" setter="set_marker_id" getter="get_marker_id" default="0">
-			The marker ID for this marker, this is only returned for Aruco and April Tag markers. Call [method get_marker_data] for QRCode markers.
+			The marker ID for this marker, this is only returned for ArUco and April Tag markers. Call [method get_marker_data] for QRCode markers.
 		</member>
 		<member name="marker_type" type="int" setter="set_marker_type" getter="get_marker_type" enum="OpenXRSpatialComponentMarkerList.MarkerType" default="0">
 			The type of marker.

--- a/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationAruco.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationAruco.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRSpatialCapabilityConfigurationAruco" inherits="OpenXRSpatialCapabilityConfigurationBaseHeader" api_type="core" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Configuration header for Aruco markers.
+		Configuration header for ArUco markers.
 	</brief_description>
 	<description>
-		Configuration header for Aruco markers. Pass this to [method OpenXRSpatialEntityExtension.create_spatial_context] to create a spatial context that can detect Aruco markers.
+		Configuration header for ArUco markers. Pass this to [method OpenXRSpatialEntityExtension.create_spatial_context] to create a spatial context that can detect ArUco markers.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -19,58 +19,58 @@
 	</methods>
 	<members>
 		<member name="aruco_dict" type="int" setter="set_aruco_dict" getter="get_aruco_dict" enum="OpenXRSpatialCapabilityConfigurationAruco.ArucoDict" default="16">
-			Dictionary to use to decode Aruco markers.
+			Dictionary to use to decode ArUco markers.
 			[b]Note:[/b] Must be set before using this configuration to create a spatial context.
 		</member>
 	</members>
 	<constants>
 		<constant name="ARUCO_DICT_4X4_50" value="1" enum="ArucoDict">
-			4 by 4 pixel Aruco marker dictionary with 50 IDs.
+			4 by 4 pixel ArUco marker dictionary with 50 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_4X4_100" value="2" enum="ArucoDict">
-			4 by 4 pixel Aruco marker dictionary with 100 IDs.
+			4 by 4 pixel ArUco marker dictionary with 100 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_4X4_250" value="3" enum="ArucoDict">
-			4 by 4 pixel Aruco marker dictionary with 250 IDs.
+			4 by 4 pixel ArUco marker dictionary with 250 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_4X4_1000" value="4" enum="ArucoDict">
-			4 by 4 pixel Aruco marker dictionary with 1000 IDs.
+			4 by 4 pixel ArUco marker dictionary with 1000 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_5X5_50" value="5" enum="ArucoDict">
-			5 by 5 pixel Aruco marker dictionary with 50 IDs.
+			5 by 5 pixel ArUco marker dictionary with 50 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_5X5_100" value="6" enum="ArucoDict">
-			5 by 5 pixel Aruco marker dictionary with 100 IDs.
+			5 by 5 pixel ArUco marker dictionary with 100 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_5X5_250" value="7" enum="ArucoDict">
-			5 by 5 pixel Aruco marker dictionary with 250 IDs.
+			5 by 5 pixel ArUco marker dictionary with 250 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_5X5_1000" value="8" enum="ArucoDict">
-			5 by 5 pixel Aruco marker dictionary with 1000 IDs.
+			5 by 5 pixel ArUco marker dictionary with 1000 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_6X6_50" value="9" enum="ArucoDict">
-			6 by 6 pixel Aruco marker dictionary with 50 IDs.
+			6 by 6 pixel ArUco marker dictionary with 50 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_6X6_100" value="10" enum="ArucoDict">
-			6 by 6 pixel Aruco marker dictionary with 100 IDs.
+			6 by 6 pixel ArUco marker dictionary with 100 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_6X6_250" value="11" enum="ArucoDict">
-			6 by 6 pixel Aruco marker dictionary with 250 IDs.
+			6 by 6 pixel ArUco marker dictionary with 250 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_6X6_1000" value="12" enum="ArucoDict">
-			6 by 6 pixel Aruco marker dictionary with 1000 IDs.
+			6 by 6 pixel ArUco marker dictionary with 1000 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_7X7_50" value="13" enum="ArucoDict">
-			7 by 7 pixel Aruco marker dictionary with 50 IDs.
+			7 by 7 pixel ArUco marker dictionary with 50 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_7X7_100" value="14" enum="ArucoDict">
-			7 by 7 pixel Aruco marker dictionary with 100 IDs.
+			7 by 7 pixel ArUco marker dictionary with 100 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_7X7_250" value="15" enum="ArucoDict">
-			7 by 7 pixel Aruco marker dictionary with 250 IDs.
+			7 by 7 pixel ArUco marker dictionary with 250 IDs.
 		</constant>
 		<constant name="ARUCO_DICT_7X7_1000" value="16" enum="ArucoDict">
-			7 by 7 pixel Aruco marker dictionary with 1000 IDs.
+			7 by 7 pixel ArUco marker dictionary with 1000 IDs.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/doc_classes/OpenXRSpatialComponentMarkerList.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialComponentMarkerList.xml
@@ -21,7 +21,7 @@
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the marker ID for the marker at this [param index]. Only applicable for Aruco or April Tag markers.
+				Returns the marker ID for the marker at this [param index]. Only applicable for ArUco or April Tag markers.
 			</description>
 		</method>
 		<method name="get_marker_type" qualifiers="const">
@@ -43,7 +43,7 @@
 			Marker based on a micro QR code.
 		</constant>
 		<constant name="MARKER_TYPE_ARUCO" value="3" enum="MarkerType">
-			Marker based on an Aruco code.
+			Marker based on an ArUco code.
 		</constant>
 		<constant name="MARKER_TYPE_APRIL_TAG" value="4" enum="MarkerType">
 			Marker based on an April Tag.

--- a/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
@@ -23,10 +23,13 @@
 			<param index="0" name="capability_configurations" type="OpenXRSpatialCapabilityConfigurationBaseHeader[]" />
 			<param index="1" name="next" type="OpenXRStructureBase" default="null" />
 			<param index="2" name="user_callback" type="Callable" default="Callable()" />
+			<param index="3" name="failed_callback" type="Callable" default="Callable()" />
 			<description>
 				Creates a new spatial context that handles entities for the provided capability configurations. [param capability_configurations] is an array of [OpenXRSpatialCapabilityConfigurationBaseHeader] with the needed capability configuration data.
 				[param next] is an optional parameter that can contain additional information for creating our spatial context.
-				[b]Note:[/b] This is an asynchronous method and returns an [OpenXRFutureResult] object with which to track the status, discarding this object will not cancel the creation process. On success [param user_callback] will be called if specified. The result data for this function is the [RID] for our spatial context.
+				[b]Note:[/b] This is an asynchronous method and returns an [OpenXRFutureResult] object with which to track the status, discarding this object will not cancel the creation process.
+				On success [param user_callback] will be called if specified. The result data for this function is the [RID] for our spatial context - the argument will be the OpenXR result code (as an integer).
+				On failure [param failed_callback] will be called if specified. The OpenXR result code will be supplied as an integer - the arguments will be the OpenXR result code (as an integer) and a boolean indicating whether requesting the result failed, or the execution failed.
 			</description>
 		</method>
 		<method name="discover_spatial_entities">
@@ -242,7 +245,7 @@
 			Micro QR code based marker tracking capability.
 		</constant>
 		<constant name="CAPABILITY_MARKER_TRACKING_ARUCO_MARKER" value="1000743002" enum="Capability">
-			Aruco marker based marker tracking capability.
+			ArUco marker based marker tracking capability.
 		</constant>
 		<constant name="CAPABILITY_MARKER_TRACKING_APRIL_TAG" value="1000743003" enum="Capability">
 			April tag based marker tracking capability.
@@ -282,6 +285,24 @@
 		</constant>
 		<constant name="COMPONENT_TYPE_PERSISTENCE" value="1000763000" enum="ComponentType">
 			Component that provides the persisted UUID for a spatial entity. The corresponding list structure is [code]XrSpatialComponentPersistenceListEXT; the corresponding data structure is [code]XrSpatialPersistenceDataEXT[/code] (Added by the [code]XR_EXT_spatial_persistence[/code] extension).
+		</constant>
+		<constant name="TRACKING_UNSUPPORTED_CAPABILITY" value="-3" enum="TrackingState">
+			A capability supplied when creating the spatial context for tracking is unsupported.
+		</constant>
+		<constant name="TRACKING_NO_PERMISSION" value="-2" enum="TrackingState">
+			A permission required by the tracking logic is missing.
+		</constant>
+		<constant name="TRACKING_SETUP_FAILED" value="-1" enum="TrackingState">
+			Setup of the tracking logic failed, consult the logs for more details.
+		</constant>
+		<constant name="TRACKING_NOT_ACTIVE" value="0" enum="TrackingState">
+			Tracking is currently not active.
+		</constant>
+		<constant name="TRACKING_SETTING_UP" value="1" enum="TrackingState">
+			Tracking is being set up.
+		</constant>
+		<constant name="TRACKING_ENABLED" value="2" enum="TrackingState">
+			Tracking is enabled and running.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/doc_classes/OpenXRSpatialMarkerTrackingCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialMarkerTrackingCapability.xml
@@ -22,6 +22,12 @@
 				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
 			</description>
 		</method>
+		<method name="get_built_in_tracking_state">
+			<return type="int" enum="OpenXRSpatialEntityExtension.TrackingState" />
+			<description>
+				Returns the state of the built-in tracking system.
+			</description>
+		</method>
 		<method name="is_april_tag_supported">
 			<return type="bool" />
 			<description>
@@ -31,7 +37,7 @@
 		<method name="is_aruco_supported">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if Aruco marker tracking is supported by the current device.
+				Returns [code]true[/code] if ArUco marker tracking is supported by the current device.
 			</description>
 		</method>
 		<method name="is_micro_qrcode_supported">
@@ -44,6 +50,13 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if QR code marker tracking is supported by the current device.
+			</description>
+		</method>
+		<method name="start_built_in_tracking">
+			<return type="bool" />
+			<param index="0" name="marker_types" type="int" enum="OpenXRSpatialMarkerTrackingCapability.MarkerTypeFlags" is_bitfield="true" />
+			<description>
+				Starts the built-in marker tracking logic for the specified marker types. This will fail if built-in tracking is already enabled.
 			</description>
 		</method>
 		<method name="start_entity_discovery">
@@ -62,5 +75,26 @@
 				The returned [OpenXRFutureResult] is identical to the return from [method OpenXRSpatialEntityExtension.discover_spatial_entities].
 			</description>
 		</method>
+		<method name="stop_built_in_tracking">
+			<return type="void" />
+			<param index="0" name="clear_trackers" type="bool" default="true" />
+			<description>
+				Stops the built-in marker tracking logic.
+			</description>
+		</method>
 	</methods>
+	<constants>
+		<constant name="MARKER_QR_CODE" value="1" enum="MarkerTypeFlags" is_bitfield="true">
+			QR Code.
+		</constant>
+		<constant name="MARKER_MICRO_QR_CODE" value="2" enum="MarkerTypeFlags" is_bitfield="true">
+			Micro QR Code.
+		</constant>
+		<constant name="MARKER_ARUCO" value="4" enum="MarkerTypeFlags" is_bitfield="true">
+			ArUco marker.
+		</constant>
+		<constant name="MARKER_APRIL_TAG" value="8" enum="MarkerTypeFlags" is_bitfield="true">
+			April tag.
+		</constant>
+	</constants>
 </class>

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.compat.inc
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  openxr_spatial_entity_extension.compat.inc                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "openxr_spatial_entity_extension.h"
+
+#include "core/object/class_db.h"
+
+void OpenXRSpatialEntityExtension::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("create_spatial_context", "capability_configurations", "next", "user_callback"), &OpenXRSpatialEntityExtension::_create_spatial_context_bind_compat_121123, DEFVAL(Variant()), DEFVAL(Callable()));
+}
+
+Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::_create_spatial_context_bind_compat_121123(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback) {
+	return create_spatial_context(p_capability_configurations, p_next, p_user_callback, Callable());
+}
+
+#endif // DISABLE_DEPRECATED

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "openxr_spatial_entity_extension.h"
+#include "openxr_spatial_entity_extension.compat.inc"
 
 #include "../../openxr_api.h"
 #include "../../openxr_util.h"
@@ -50,7 +51,7 @@ void OpenXRSpatialEntityExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("supports_capability", "capability"), &OpenXRSpatialEntityExtension::_supports_capability);
 	ClassDB::bind_method(D_METHOD("supports_component_type", "capability", "component_type"), &OpenXRSpatialEntityExtension::_supports_component_type);
 
-	ClassDB::bind_method(D_METHOD("create_spatial_context", "capability_configurations", "next", "user_callback"), &OpenXRSpatialEntityExtension::create_spatial_context, DEFVAL(Variant()), DEFVAL(Callable()));
+	ClassDB::bind_method(D_METHOD("create_spatial_context", "capability_configurations", "next", "user_callback", "failed_callback"), &OpenXRSpatialEntityExtension::create_spatial_context, DEFVAL(Variant()), DEFVAL(Callable()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("get_spatial_context_ready", "spatial_context"), &OpenXRSpatialEntityExtension::get_spatial_context_ready);
 	ClassDB::bind_method(D_METHOD("free_spatial_context", "spatial_context"), &OpenXRSpatialEntityExtension::free_spatial_context);
 	ClassDB::bind_method(D_METHOD("get_spatial_context_handle", "spatial_context"), &OpenXRSpatialEntityExtension::_get_spatial_context_handle);
@@ -100,6 +101,13 @@ void OpenXRSpatialEntityExtension::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPONENT_TYPE_MARKER);
 	BIND_ENUM_CONSTANT(COMPONENT_TYPE_ANCHOR);
 	BIND_ENUM_CONSTANT(COMPONENT_TYPE_PERSISTENCE);
+
+	BIND_ENUM_CONSTANT(TRACKING_UNSUPPORTED_CAPABILITY);
+	BIND_ENUM_CONSTANT(TRACKING_NO_PERMISSION);
+	BIND_ENUM_CONSTANT(TRACKING_SETUP_FAILED);
+	BIND_ENUM_CONSTANT(TRACKING_NOT_ACTIVE);
+	BIND_ENUM_CONSTANT(TRACKING_SETTING_UP);
+	BIND_ENUM_CONSTANT(TRACKING_ENABLED);
 }
 
 OpenXRSpatialEntityExtension::OpenXRSpatialEntityExtension() {
@@ -369,7 +377,7 @@ bool OpenXRSpatialEntityExtension::on_event_polled(const XrEventDataBuffer &even
 ////////////////////////////////////////////////////////////////////////////
 // Spatial contexts
 
-Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::create_spatial_context(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback) {
+Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::create_spatial_context(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback, const Callable &p_failure_callback) {
 	if (!get_active()) {
 		return nullptr;
 	}
@@ -410,12 +418,12 @@ Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::create_spatial_context(con
 	}
 
 	// Create our future result
-	Ref<OpenXRFutureResult> future_result = future_api->register_future(future, callable_mp(this, &OpenXRSpatialEntityExtension::_on_context_creation_ready).bind(p_user_callback));
+	Ref<OpenXRFutureResult> future_result = future_api->register_future(future, callable_mp(this, &OpenXRSpatialEntityExtension::_on_context_creation_ready).bind(p_user_callback, p_failure_callback));
 
 	return future_result;
 }
 
-void OpenXRSpatialEntityExtension::_on_context_creation_ready(Ref<OpenXRFutureResult> p_future_result, const Callable &p_user_callback) {
+void OpenXRSpatialEntityExtension::_on_context_creation_ready(Ref<OpenXRFutureResult> p_future_result, const Callable &p_user_callback, const Callable &p_failure_callback) {
 	// Complete context creation...
 	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 	ERR_FAIL_NULL(openxr_api);
@@ -428,10 +436,18 @@ void OpenXRSpatialEntityExtension::_on_context_creation_ready(Ref<OpenXRFutureRe
 	};
 	XrResult result = xrCreateSpatialContextCompleteEXT(openxr_api->get_session(), p_future_result->get_future(), &completion);
 	if (XR_FAILED(result)) { // Did our xrCreateSpatialContextCompleteEXT call fail?
+		if (p_failure_callback.is_valid()) {
+			p_failure_callback.call(int(result), false);
+		}
+
 		// Log issue and fail.
 		ERR_FAIL_MSG("OpenXR: Failed to complete spatial context create future [" + openxr_api->get_error_string(result) + "]");
 	}
 	if (XR_FAILED(completion.futureResult)) { // Did our completion fail?
+		if (p_failure_callback.is_valid()) {
+			p_failure_callback.call(int(completion.futureResult), true);
+		}
+
 		// Log issue and fail.
 		ERR_FAIL_MSG("OpenXR: Failed to complete spatial context creation [" + openxr_api->get_error_string(completion.futureResult) + "]");
 	}

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
@@ -66,6 +66,15 @@ public:
 		COMPONENT_TYPE_PERSISTENCE = XR_SPATIAL_COMPONENT_TYPE_PERSISTENCE_EXT,
 	};
 
+	enum TrackingState {
+		TRACKING_UNSUPPORTED_CAPABILITY = -3,
+		TRACKING_NO_PERMISSION = -2,
+		TRACKING_SETUP_FAILED = -1,
+		TRACKING_NOT_ACTIVE = 0,
+		TRACKING_SETTING_UP = 1,
+		TRACKING_ENABLED = 2,
+	};
+
 	static OpenXRSpatialEntityExtension *get_singleton();
 
 	OpenXRSpatialEntityExtension();
@@ -84,7 +93,7 @@ public:
 	bool supports_component_type(XrSpatialCapabilityEXT p_capability, XrSpatialComponentTypeEXT p_component_type);
 
 	// Spatial contexts
-	Ref<OpenXRFutureResult> create_spatial_context(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback);
+	Ref<OpenXRFutureResult> create_spatial_context(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback = Callable(), const Callable &p_failure_callback = Callable());
 	bool get_spatial_context_ready(RID p_spatial_context) const;
 	void free_spatial_context(RID p_spatial_context);
 	XrSpatialContextEXT get_spatial_context_handle(RID p_spatial_context) const;
@@ -126,6 +135,10 @@ public:
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Ref<OpenXRFutureResult> _create_spatial_context_bind_compat_121123(const TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> &p_capability_configurations, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback);
+#endif
 
 private:
 	static OpenXRSpatialEntityExtension *singleton;
@@ -150,7 +163,7 @@ private:
 	};
 	mutable RID_Owner<SpatialContextData> spatial_context_owner;
 
-	void _on_context_creation_ready(Ref<OpenXRFutureResult> p_future_result, const Callable &p_user_callback);
+	void _on_context_creation_ready(Ref<OpenXRFutureResult> p_future_result, const Callable &p_user_callback, const Callable &p_failure_callback);
 	uint64_t _get_spatial_context_handle(RID p_spatial_context) const;
 
 	// Spatial query
@@ -218,3 +231,4 @@ private:
 
 VARIANT_ENUM_CAST(OpenXRSpatialEntityExtension::Capability);
 VARIANT_ENUM_CAST(OpenXRSpatialEntityExtension::ComponentType);
+VARIANT_ENUM_CAST(OpenXRSpatialEntityExtension::TrackingState);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -136,7 +136,7 @@ PackedInt64Array OpenXRSpatialCapabilityConfigurationMicroQrCode::_get_enabled_c
 // OpenXRSpatialCapabilityConfigurationAruco
 
 OpenXRSpatialCapabilityConfigurationAruco::OpenXRSpatialCapabilityConfigurationAruco() {
-	int aruco_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/aruco_dict");
+	int aruco_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/marker_tracking/aruco_dict");
 	set_aruco_dict((XrSpatialMarkerArucoDictEXT)(XR_SPATIAL_MARKER_ARUCO_DICT_4X4_50_EXT + aruco_dict));
 }
 
@@ -228,7 +228,7 @@ PackedInt64Array OpenXRSpatialCapabilityConfigurationAruco::_get_enabled_compone
 // OpenXRSpatialCapabilityConfigurationAprilTag
 
 OpenXRSpatialCapabilityConfigurationAprilTag::OpenXRSpatialCapabilityConfigurationAprilTag() {
-	int april_tag_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/april_tag_dict");
+	int april_tag_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/marker_tracking/april_tag_dict");
 	set_april_dict((XrSpatialMarkerAprilTagDictEXT)(XR_SPATIAL_MARKER_APRIL_TAG_DICT_16H5_EXT + april_tag_dict));
 }
 
@@ -366,6 +366,12 @@ uint32_t OpenXRSpatialComponentMarkerList::get_marker_id(int64_t p_index) const 
 	return marker_data[p_index].markerId;
 }
 
+XrSpatialBufferIdEXT OpenXRSpatialComponentMarkerList::get_marker_buffer_id(int64_t p_index) const {
+	ERR_FAIL_INDEX_V(p_index, marker_data.size(), XR_NULL_SPATIAL_BUFFER_ID_EXT);
+
+	return marker_data[p_index].data.bufferId;
+}
+
 Variant OpenXRSpatialComponentMarkerList::get_marker_data(RID p_snapshot, int64_t p_index) const {
 	ERR_FAIL_INDEX_V(p_index, marker_data.size(), Variant());
 
@@ -431,8 +437,14 @@ uint32_t OpenXRMarkerTracker::get_marker_id() const {
 	return marker_id;
 }
 
+void OpenXRMarkerTracker::set_marker_data_with_buffer_id(const Variant &p_data, XrSpatialBufferIdEXT p_buffer_id) {
+	marker_data = p_data;
+	marker_buffer_id = p_buffer_id;
+}
+
 void OpenXRMarkerTracker::set_marker_data(const Variant &p_data) {
 	marker_data = p_data;
+	marker_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
 }
 
 Variant OpenXRMarkerTracker::get_marker_data() const {
@@ -464,12 +476,21 @@ void OpenXRSpatialMarkerTrackingCapability::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("start_entity_discovery", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query", "user_callback"), &OpenXRSpatialMarkerTrackingCapability::start_entity_discovery, DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("do_entity_update", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query"), &OpenXRSpatialMarkerTrackingCapability::do_entity_update, DEFVAL(Variant()), DEFVAL(Variant()));
+
+	ClassDB::bind_method(D_METHOD("get_built_in_tracking_state"), &OpenXRSpatialMarkerTrackingCapability::get_built_in_tracking_state);
+	ClassDB::bind_method(D_METHOD("start_built_in_tracking", "marker_types"), &OpenXRSpatialMarkerTrackingCapability::start_built_in_tracking);
+	ClassDB::bind_method(D_METHOD("stop_built_in_tracking", "clear_trackers"), &OpenXRSpatialMarkerTrackingCapability::stop_built_in_tracking, DEFVAL(true));
+
+	BIND_BITFIELD_FLAG(MARKER_QR_CODE);
+	BIND_BITFIELD_FLAG(MARKER_MICRO_QR_CODE);
+	BIND_BITFIELD_FLAG(MARKER_ARUCO);
+	BIND_BITFIELD_FLAG(MARKER_APRIL_TAG);
 }
 
 HashMap<String, bool *> OpenXRSpatialMarkerTrackingCapability::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled") && GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_marker_tracking")) {
+	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled") && GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/marker_tracking/enable")) {
 		request_extensions[XR_EXT_SPATIAL_MARKER_TRACKING_EXTENSION_NAME] = &spatial_marker_tracking_ext;
 	}
 
@@ -486,19 +507,20 @@ void OpenXRSpatialMarkerTrackingCapability::on_session_created(const XrSession p
 
 	se_extension->connect(SNAME("spatial_discovery_recommended"), callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_on_spatial_discovery_recommended));
 
-	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_builtin_marker_tracking")) {
-		// Start by creating our spatial context
-		_create_spatial_context();
+	int marker_types = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types");
+	if (marker_types != 0) {
+		// Start our builtin tracking system.
+		start_built_in_tracking(marker_types);
 	}
 }
 
 void OpenXRSpatialMarkerTrackingCapability::on_session_destroyed() {
-	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-	ERR_FAIL_NULL(se_extension);
+	// Stop our built in tracking (if applicable), this will also clean up any markers previously detected.
+	stop_built_in_tracking();
+
+	// Free and unregister all our markers
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
-
-	// Free and unregister our anchors
 	for (const KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>>> &markers : marker_trackers) {
 		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker_tracker : markers.value) {
 			xr_server->remove_tracker(marker_tracker.value);
@@ -506,12 +528,9 @@ void OpenXRSpatialMarkerTrackingCapability::on_session_destroyed() {
 	}
 	marker_trackers.clear();
 
-	// Free our spatial context
-	if (spatial_context.is_valid()) {
-		se_extension->free_spatial_context(spatial_context);
-		spatial_context = RID();
-	}
-
+	// Disconnect our discovery
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL(se_extension);
 	se_extension->disconnect(SNAME("spatial_discovery_recommended"), callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_on_spatial_discovery_recommended));
 }
 
@@ -643,33 +662,91 @@ bool OpenXRSpatialMarkerTrackingCapability::is_april_tag_supported() {
 	return se_extension->supports_capability(XR_SPATIAL_CAPABILITY_MARKER_TRACKING_APRIL_TAG_EXT);
 }
 
+bool OpenXRSpatialMarkerTrackingCapability::start_built_in_tracking(BitField<MarkerTypeFlags> p_marker_types) {
+	ERR_FAIL_COND_V(builtin_tracking_state > 0, false);
+
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETTING_UP;
+
+	// Start by creating our spatial context
+	built_in_future = _create_spatial_context(p_marker_types);
+	if (built_in_future.is_null()) {
+		builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETUP_FAILED;
+		return false;
+	}
+
+	return true;
+}
+
+void OpenXRSpatialMarkerTrackingCapability::stop_built_in_tracking(bool p_clear_trackers) {
+	// Reset our tracking state
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NOT_ACTIVE;
+
+	// Cancel any discovery query
+	if (discovery_query_result.is_valid()) {
+		if (discovery_query_result->get_status() == OpenXRFutureResult::RESULT_RUNNING) {
+			discovery_query_result->cancel_future();
+		}
+
+		discovery_query_result.unref();
+	}
+
+	// If we have our future object, clean it up.
+	if (built_in_future.is_valid()) {
+		if (built_in_future->get_status() == OpenXRFutureResult::RESULT_RUNNING) {
+			built_in_future->cancel_future();
+		}
+
+		built_in_future.unref();
+	}
+
+	// If we have a spatial context, clean it up.
+	if (spatial_context.is_valid()) {
+		OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+		ERR_FAIL_NULL(se_extension);
+
+		if (p_clear_trackers && marker_trackers.has(spatial_context)) {
+			XRServer *xr_server = XRServer::get_singleton();
+			ERR_FAIL_NULL(xr_server);
+
+			// Free and unregister our markers
+			HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &markers = marker_trackers[spatial_context];
+			for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker : markers) {
+				xr_server->remove_tracker(marker.value);
+			}
+			marker_trackers.erase(spatial_context);
+		}
+
+		se_extension->free_spatial_context(spatial_context);
+		spatial_context = RID();
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Discovery logic
 
-Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_context() {
+Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_context(BitField<MarkerTypeFlags> p_marker_types) {
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL_V(se_extension, nullptr);
 
 	TypedArray<OpenXRSpatialCapabilityConfigurationBaseHeader> capability_configurations;
 
 	// Create our configuration objects.
-	// For now we enable all supported markers, will need to give some more user control over this.
-	if (is_qrcode_supported()) {
+	if (is_qrcode_supported() && p_marker_types.has_flag(MARKER_QR_CODE)) {
 		qrcode_configuration.instantiate();
 		capability_configurations.push_back(qrcode_configuration);
 	}
 
-	if (is_micro_qrcode_supported()) {
+	if (is_micro_qrcode_supported() && p_marker_types.has_flag(MARKER_MICRO_QR_CODE)) {
 		micro_qrcode_configuration.instantiate();
 		capability_configurations.push_back(micro_qrcode_configuration);
 	}
 
-	if (is_aruco_supported()) {
+	if (is_aruco_supported() && p_marker_types.has_flag(MARKER_ARUCO)) {
 		aruco_configuration.instantiate();
 		capability_configurations.push_back(aruco_configuration);
 	}
 
-	if (is_april_tag_supported()) {
+	if (is_april_tag_supported() && p_marker_types.has_flag(MARKER_APRIL_TAG)) {
 		april_tag_configuration.instantiate();
 		capability_configurations.push_back(april_tag_configuration);
 	}
@@ -679,12 +756,36 @@ Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_c
 		return nullptr;
 	}
 
-	return se_extension->create_spatial_context(capability_configurations, nullptr, callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_on_spatial_context_created));
+	return se_extension->create_spatial_context(capability_configurations, nullptr, callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_on_spatial_context_created), callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_on_spatial_context_creation_failed));
 }
 
 void OpenXRSpatialMarkerTrackingCapability::_on_spatial_context_created(RID p_spatial_context) {
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_ENABLED;
 	spatial_context = p_spatial_context;
 	need_discovery = true;
+
+	// We don't need our future anymore.
+	built_in_future.unref();
+}
+
+void OpenXRSpatialMarkerTrackingCapability::_on_spatial_context_creation_failed(int p_xr_result, bool p_is_completion_failure) {
+	XrResult result = XrResult(p_xr_result);
+
+	switch (result) {
+		case XR_ERROR_PERMISSION_INSUFFICIENT:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NO_PERMISSION;
+			break;
+		case XR_ERROR_SPATIAL_CAPABILITY_UNSUPPORTED_EXT:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_UNSUPPORTED_CAPABILITY;
+			break;
+		// We may wish to support additional error codes that are likely here.
+		default:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETUP_FAILED;
+			break;
+	}
+
+	// We don't need our future anymore.
+	built_in_future.unref();
 }
 
 void OpenXRSpatialMarkerTrackingCapability::_on_spatial_discovery_recommended(RID p_spatial_context) {
@@ -805,7 +906,12 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, RI
 					if (marker_list.is_valid()) {
 						marker_tracker->set_marker_type(marker_list->get_marker_type(i));
 						marker_tracker->set_marker_id(marker_list->get_marker_id(i));
-						marker_tracker->set_marker_data(marker_list->get_marker_data(p_snapshot, i));
+
+						// If the buffer id is the same, there is no new marker data.
+						XrSpatialBufferIdEXT buffer_id = marker_list->get_marker_buffer_id(i);
+						if (marker_tracker->get_marker_buffer_id() != buffer_id) {
+							marker_tracker->set_marker_data_with_buffer_id(marker_list->get_marker_data(p_snapshot, i), buffer_id);
+						}
 					}
 				}
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
@@ -33,6 +33,7 @@
 #include "../openxr_extension_wrapper.h"
 #include "../openxr_future_extension.h"
 #include "openxr_spatial_entities.h"
+#include "openxr_spatial_entity_extension.h"
 
 // QrCode marker tracking capability configuration
 class OpenXRSpatialCapabilityConfigurationQrCode : public OpenXRSpatialCapabilityConfigurationBaseHeader {
@@ -74,7 +75,7 @@ private:
 	PackedInt64Array _get_enabled_components() const;
 };
 
-// Aruco marker tracking capability configuration
+// ArUco marker tracking capability configuration
 class OpenXRSpatialCapabilityConfigurationAruco : public OpenXRSpatialCapabilityConfigurationBaseHeader {
 	GDCLASS(OpenXRSpatialCapabilityConfigurationAruco, OpenXRSpatialCapabilityConfigurationBaseHeader);
 
@@ -182,6 +183,7 @@ public:
 
 	MarkerType get_marker_type(int64_t p_index) const;
 	uint32_t get_marker_id(int64_t p_index) const;
+	XrSpatialBufferIdEXT get_marker_buffer_id(int64_t p_index) const;
 	Variant get_marker_data(RID p_snapshot, int64_t p_index) const;
 
 protected:
@@ -209,6 +211,9 @@ public:
 	void set_marker_id(uint32_t p_id);
 	uint32_t get_marker_id() const;
 
+	XrSpatialBufferIdEXT get_marker_buffer_id() { return marker_buffer_id; }
+
+	void set_marker_data_with_buffer_id(const Variant &p_data, XrSpatialBufferIdEXT p_buffer_id);
 	void set_marker_data(const Variant &p_data);
 	Variant get_marker_data() const;
 
@@ -220,6 +225,7 @@ private:
 
 	OpenXRSpatialComponentMarkerList::MarkerType marker_type = OpenXRSpatialComponentMarkerList::MarkerType::MARKER_TYPE_UNKNOWN;
 	uint32_t marker_id = 0;
+	XrSpatialBufferIdEXT marker_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
 	Variant marker_data;
 };
 
@@ -231,6 +237,13 @@ protected:
 	static void _bind_methods();
 
 public:
+	enum MarkerTypeFlags {
+		MARKER_QR_CODE = 1,
+		MARKER_MICRO_QR_CODE = 2,
+		MARKER_ARUCO = 4,
+		MARKER_APRIL_TAG = 8,
+	};
+
 	static OpenXRSpatialMarkerTrackingCapability *get_singleton();
 
 	OpenXRSpatialMarkerTrackingCapability();
@@ -251,11 +264,18 @@ public:
 	bool is_aruco_supported();
 	bool is_april_tag_supported();
 
+	OpenXRSpatialEntityExtension::TrackingState get_built_in_tracking_state() { return builtin_tracking_state; }
+	bool start_built_in_tracking(BitField<MarkerTypeFlags> p_marker_types);
+	void stop_built_in_tracking(bool p_clear_trackers = true);
+
 private:
 	static OpenXRSpatialMarkerTrackingCapability *singleton;
 	bool spatial_marker_tracking_ext = false;
 
+	OpenXRSpatialEntityExtension::TrackingState builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NOT_ACTIVE;
+	Ref<OpenXRFutureResult> built_in_future;
 	RID spatial_context;
+
 	bool need_discovery = false;
 	int discovery_cooldown = 0;
 	Ref<OpenXRFutureResult> discovery_query_result;
@@ -268,8 +288,9 @@ private:
 	Ref<OpenXRSpatialCapabilityConfigurationAprilTag> april_tag_configuration;
 
 	// Discovery logic
-	Ref<OpenXRFutureResult> _create_spatial_context();
+	Ref<OpenXRFutureResult> _create_spatial_context(BitField<MarkerTypeFlags> p_marker_types);
 	void _on_spatial_context_created(RID p_spatial_context);
+	void _on_spatial_context_creation_failed(int p_xr_result, bool p_is_completion_failure);
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 
@@ -278,3 +299,5 @@ private:
 	// Trackers; maps each Spatial Context RID to their marker entities and trackers
 	HashMap<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>>> marker_trackers;
 };
+
+VARIANT_BITFIELD_CAST(OpenXRSpatialMarkerTrackingCapability::MarkerTypeFlags);


### PR DESCRIPTION
This PR adds a few improvements that came out of testing the marker tracking implementation now that runtimes are starting to implement this functionality.

The improvements are:
- Being able to specify which marker types should be detected (if supported). Enabling all wastes precious compute which makes little sense when a developer designs their application to work with specific markers
- Being able to start/stop the built-in marker tracker logic. This specifically is introduced in case setup of marker tracking fails if the runtime requires privileges that have not yet been granted at the start. In this case the built in marker tracking can be started again from the vendor plugin when the correct privilege has been given. Sadly privileges are not standardised and we're enable to solve this cleanly in core. **Note:** if we're happy with this approach, we'll apply similar changes to anchor and plane tracking, but we'll make separate PRs for this.
- Caching the buffer id of the data associated with the marker. This prevents us from having to retrieve the data buffer when unchanged and thus prevents needless allocations especially considering marker data tends to be immutable once obtained. **Note:** we should make similar changes in plane tracking but that's for a separate PR.

Left over todos:
- [x] Stopping the built-in marker data logic does not clean up current markers. This may be a smart addition. 
- [x] Need to determine if it makes sense to check the old project setting and automatically convert it to the new setting. If we do not, this is a minor breaking change but a defendable one
- [x] Need to add a compatibility method for `OpenXRSpatialEntityExtension::create_spatial_context` as we added a new parameter.

For testing, this project can be used: https://github.com/BastiaanOlij/godot-spatial-markers-demo/tree/restrict_marker_types