### PR TITLE
Do not propagate window focus events from/to edited scene.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -528,7 +528,11 @@ void Viewport::_sub_window_remove(Window *p_window) {
 		} else {
 			new_focused_window = Object::cast_to<Window>(this);
 		}
-
+#ifdef TOOLS_ENABLED
+		if (new_focused_window && is_part_of_edited_scene() != new_focused_window->is_part_of_edited_scene()) {
+			new_focused_window = nullptr;
+		}
+#endif
 		if (new_focused_window) {
 			int new_focused_index = _sub_window_find(new_focused_window);
 			if (new_focused_index != -1) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121066
