### PR TITLE
Update `EditorHelp` pages after script rename

### DIFF
--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -360,11 +360,14 @@ void DocTools::remove_doc(const String &p_class_name) {
 }
 
 void DocTools::remove_script_doc_by_path(const String &p_path) {
+	LocalVector<String> to_remove;
 	for (KeyValue<String, DocData::ClassDoc> &E : class_list) {
 		if (E.value.is_script_doc && E.value.script_path == p_path) {
-			remove_doc(E.key);
-			return;
+			to_remove.push_back(E.key);
 		}
+	}
+	for (const String &E : to_remove) {
+		remove_doc(E);
 	}
 }
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2247,14 +2247,33 @@ void EditorFileSystem::_update_script_documentation() {
 				if (scr.is_null()) {
 					continue;
 				}
+
+				bool renamed = false;
+				// get_doc_class_name() returns the cached name, so the one before the rename
+				String old_prefix = scr->get_doc_class_name();
+				LocalVector<String> old_suffixes;
+				for (const DocData::ClassDoc &cd : scr->get_documentation()) {
+					if (cd.script_path != scr->get_path()) {
+						renamed = true;
+						should_reload_script = true;
+						old_suffixes.push_back(cd.name.trim_prefix(old_prefix));
+					}
+				}
+
 				if (should_reload_script) {
 					// Reloading the script from disk. Otherwise, the ResourceLoader::load will
 					// return the last loaded version of the script (without the modifications).
 					scr->reload_from_file();
 				}
+
+				String new_prefix = scr->get_doc_class_name();
 				for (const DocData::ClassDoc &cd : scr->get_documentation()) {
 					EditorHelp::add_doc(cd);
 					if (!first_scan) {
+						if (renamed && old_suffixes.has(cd.name.trim_prefix(new_prefix))) {
+							String suffix = cd.name.trim_prefix(new_prefix);
+							ScriptEditor::get_singleton()->replace_help_class(old_prefix + suffix, cd.name);
+						}
 						// Update the documentation in the Script Editor if it is open.
 						ScriptEditor::get_singleton()->update_doc(cd.name);
 					}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3630,6 +3630,19 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_save_layout();
 }
 
+void ScriptEditor::replace_help_class(const String &p_old_name, const String &p_new_name) {
+	if (p_old_name == p_new_name) {
+		return;
+	}
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
+		if (eh && eh->get_class() == p_old_name) {
+			eh->go_to_class(p_new_name);
+			return;
+		}
+	}
+}
+
 void ScriptEditor::update_doc(const String &p_name) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -509,6 +509,7 @@ public:
 	void notify_script_close(const Ref<Script> &p_script);
 	void notify_script_changed(const Ref<Script> &p_script);
 
+	void replace_help_class(const String &p_old_name, const String &p_new_name);
 	void goto_help(const String &p_desc) { _help_class_goto(p_desc); }
 	void update_doc(const String &p_name);
 	void clear_docs_from_script(const Ref<Script> &p_script);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Updates old doc cache when a script is renamed.

The only effect currently is the class name update for scripts without `class_name`, but if https://github.com/godotengine/godot-proposals/issues/14059 gets implemented, ensuring the script paths are valid is important.

Didn't create an issue for this, but I'm happy to create one if needed.

## Before

https://github.com/user-attachments/assets/abf43f1b-6ae0-489a-8fc9-b15e130ee6b6

## After

https://github.com/user-attachments/assets/b4c92e3e-d152-49ef-ab3b-50dc0de75e10

## Additional information

AI wasn't used.