### PR TITLE
Assign shortcut context for tile polygon shortcuts

### DIFF
--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -965,6 +965,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	button_advanced_menu->get_popup()->add_item(TTR("Flip Vertically"), FLIP_VERTICALLY, Key::V);
 	button_advanced_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &GenericTilePolygonEditor::_advanced_menu_item_pressed));
 	button_advanced_menu->set_focus_mode(FOCUS_ALL);
+	button_advanced_menu->set_shortcut_context(this);
 	toolbar->add_child(button_advanced_menu);
 
 	toolbar->add_child(memnew(VSeparator));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The shortcuts for transforming collision polygons in TileSet don't work correctly.

[Nagranie ekranu_20260709_122811.webm](https://github.com/user-attachments/assets/38bee8c6-d647-49fb-bd6d-e0932bfdd3cb)

Specifically, the H key conflicts with the toggle visibility shortcut and is handled by scene.

The PR assigns shortcut context for the transform menu, so its shortcuts are correctly handled.

[Nagranie ekranu_20260709_122956.webm](https://github.com/user-attachments/assets/27d79e2b-1894-44c6-b3d1-ecc1a01acf99)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
