### PR TITLE
Hide the ScriptEditor minimap in portrait mode on Android

### DIFF
--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -39,6 +39,8 @@
 #include "editor/editor_node.h"
 #include "editor/gui/editor_title_bar.h"
 #include "editor/run/editor_run_bar.h"
+#include "editor/script/script_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
 #include "main/main.h"
 #endif
 
@@ -96,12 +98,23 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runSc
 #endif
 }
 
-JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_toggleTitleBar(JNIEnv *p_env, jclass, jboolean p_visible) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_orientationChanged(JNIEnv *p_env, jclass, jboolean p_portrait) {
 #ifdef TOOLS_ENABLED
 	if (EditorNode::get_singleton() != nullptr) {
 		EditorTitleBar *title_bar = EditorNode::get_singleton()->get_title_bar();
 		if (title_bar != nullptr) {
-			title_bar->call_deferred("set_visible", p_visible);
+			// TODO: Enable for portrait once the title bar width is optimized.
+			title_bar->set_visible(!p_portrait);
+		}
+
+		if (ScriptEditor::get_singleton() != nullptr && EDITOR_GET("text_editor/appearance/minimap/show_minimap")) {
+			if (TextEditorBase *editor = Object::cast_to<TextEditorBase>(ScriptEditor::get_singleton()->get_current_editor())) {
+				if (CodeTextEditor *code_editor = editor->get_code_editor()) {
+					if (CodeEdit *text_editor = code_editor->get_text_editor()) {
+						text_editor->set_draw_minimap(!p_portrait);
+					}
+				}
+			}
 		}
 	}
 #endif

--- a/platform/android/editor/editor_utils_jni.h
+++ b/platform/android/editor/editor_utils_jni.h
@@ -34,5 +34,5 @@
 
 extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runScene(JNIEnv *p_env, jclass, jstring p_scene, jobjectArray p_scene_args);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_toggleTitleBar(JNIEnv *p_env, jclass, jboolean p_enable);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_orientationChanged(JNIEnv *p_env, jclass, jboolean p_portrait);
 }

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -211,6 +211,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	private var changingOrientationAllowed = false
 	private var distractionFreeModeEnabled = false
 	private var activeWorkspace: String? = null
+	private var currentOrientation = Configuration.ORIENTATION_UNDEFINED
 
 	override fun getGodotAppLayout() = R.layout.godot_editor_layout
 
@@ -281,9 +282,13 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	override fun onConfigurationChanged(newConfig: Configuration) {
 		super.onConfigurationChanged(newConfig)
 
-		// Show EditorTitleBar on small screens only in landscape due to width limitations in portrait.
-		// TODO: Enable for portrait once the title bar width is optimized.
-		EditorUtils.toggleTitleBar(isLargeScreen || newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
+		// Some editor parts are hidden on small screens due to width limitations in portrait.
+		if (!isLargeScreen && currentOrientation != newConfig.orientation) {
+			currentOrientation = newConfig.orientation
+			godot?.runOnRenderThread {
+				EditorUtils.orientationChanged(currentOrientation == Configuration.ORIENTATION_PORTRAIT)
+			}
+		}
 	}
 
 	override fun onDestroy() {

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/editor/utils/EditorUtils.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/editor/utils/EditorUtils.kt
@@ -40,5 +40,5 @@ object EditorUtils {
 	external fun runScene(scene: String, sceneArgs: Array<String>)
 
 	@JvmStatic
-	external fun toggleTitleBar(visible: Boolean)
+	external fun orientationChanged(isPortrait: Boolean)
 }


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/15148

This PR hides ScriptEditor's minimap on small screens Android devices due to width limitations in portrait.