### PR TITLE
Fix forgotten bracket typo

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -837,7 +837,7 @@
 			Performs bilinear separately on the two most-suited mipmap levels, then linearly interpolates between them.
 			It's slower than [constant INTERPOLATE_BILINEAR], but produces higher-quality results with far fewer aliasing artifacts.
 			If the image does not have mipmaps, they will be generated and used internally, but no mipmaps will be generated on the resulting image.
-			[b]Note:[/b] If you intend to scale multiple copies of the original image, it's better to call [method generate_mipmaps]] on it in advance, to avoid wasting processing power in generating them again and again.
+			[b]Note:[/b] If you intend to scale multiple copies of the original image, it's better to call [method generate_mipmaps] on it in advance, to avoid wasting processing power in generating them again and again.
 			On the other hand, if the image already has mipmaps, they will be used, and a new set will be generated for the resulting image.
 		</constant>
 		<constant name="INTERPOLATE_LANCZOS" value="4" enum="Interpolation">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

It's a typo in docs :) I think the `]` bracket shouldn't be there

<img width="1080" height="259" alt="Screenshot-Godot-001479" src="https://github.com/user-attachments/assets/e425aa5d-7bcf-4289-890d-5ec34af5235b" />
