### PR TITLE
Fix K2 lens distortion coefficient in GLES3 blit

### DIFF
--- a/drivers/gles3/effects/copy_effects.cpp
+++ b/drivers/gles3/effects/copy_effects.cpp
@@ -162,7 +162,7 @@ void CopyEffects::copy_with_lens_distortion(const Rect2 &p_rect, float p_layer, 
 	copy.shader.version_set_uniform(CopyShaderGLES3::LOD, 0.0, copy.shader_version, variant, specializations);
 	copy.shader.version_set_uniform(CopyShaderGLES3::EYE_CENTER, p_eye_center.x, p_eye_center.y, copy.shader_version, variant, specializations);
 	copy.shader.version_set_uniform(CopyShaderGLES3::K1, p_k1, copy.shader_version, variant, specializations);
-	copy.shader.version_set_uniform(CopyShaderGLES3::K2, p_k1, copy.shader_version, variant, specializations);
+	copy.shader.version_set_uniform(CopyShaderGLES3::K2, p_k2, copy.shader_version, variant, specializations);
 	copy.shader.version_set_uniform(CopyShaderGLES3::UPSCALE, p_upscale, copy.shader_version, variant, specializations);
 	copy.shader.version_set_uniform(CopyShaderGLES3::ASPECT_RATIO, p_aspect_ration, copy.shader_version, variant, specializations);
 


### PR DESCRIPTION
`CopyEffects::copy_with_lens_distortion` (`drivers/gles3/effects/copy_effects.cpp`) uploaded the `K2` shader uniform from `p_k1` instead of `p_k2`. `p_k2` was passed in and used nowhere else in the function.

The lens shader applies a two-term radial model (`drivers/gles3/shaders/effects/copy.glsl`):

```glsl
float distortion_scale = 1.0 + (k1 * radius_sq) + (k2 * radius_s4);
```

`k1` scales the r² term and `k2` scales the r⁴ term. With `K2` receiving `k1`, the r⁴ term used the wrong coefficient, so any lens profile with a nonzero `k2` produced an incorrect warp.

The caller passes the two coefficients separately and only takes this path when `k2` is set (`drivers/gles3/rasterizer_gles3.cpp`):

```cpp
if (p_blit.lens_distortion.apply && (p_blit.lens_distortion.k1 != 0.0 || p_blit.lens_distortion.k2)) {
    copy_effects->copy_with_lens_distortion(..., p_blit.lens_distortion.k1, p_blit.lens_distortion.k2, ...);
```

This runs on the XR/VR blit-to-screen path, once per eye per frame, on the Compatibility renderer.

I could not capture the visual result: it needs a headset, which I do not have.

Introduced in 37b7f577ad ("Fix GLES3 stereo output (sRGB + lens distortion)"), so this likely wants a 4.5 backport.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/121213*