### PR TITLE
Docs: Fix `Tween` documentation using `>` instead of `&gt`

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -397,11 +397,11 @@
 				[/gdscript]
 				[csharp]
 				Tween tween = CreateTween();
-				tween.TweenCallback(Callable.From(() => WalkTo(600.0f)));
+				tween.TweenCallback(Callable.From(() =&gt; WalkTo(600.0f)));
 				tween.TweenAwait(new Signal(this, SignalName.DestinationReached));
-				tween.TweenCallback(Callable.From(() => SayDialogue("Good day, sir!")));
+				tween.TweenCallback(Callable.From(() =&gt; SayDialogue("Good day, sir!")));
 				tween.TweenAwait(new Signal(this, SignalName.DialogueClosed));
-				tween.TweenCallback(Callable.From(() => WalkTo(0.0f)));
+				tween.TweenCallback(Callable.From(() =&gt; WalkTo(0.0f)));
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] If you are awaiting a signal from a callback called in the same [Tween], make sure the signal is emitted [i]after[/i] the await starts. If it can't be reasonably guaranteed, you can await and emit in the same step:


### PR DESCRIPTION
- Followup to #120887

## What problem(s) does this PR solve?

The above PR passed raw `>` instead of `&gt` in its example, and thus will cause documentation to desync. This wasn't caught, as the validation step requires building, which docs-only changes don't incur

## Additional information

Will setup a dedicated doc-only validation GHA after this PR is merged