### PR TITLE
Fix `gdscript_analyzer.cpp` compilation with `deprecated=no`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1880,7 +1880,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			if (p_function->return_type == nullptr) {
 				// GH-118877. We decided to make an exception to maintain compatibility, since the problem can only be detected at runtime.
 #ifdef DISABLE_DEPRECATED
-				p_function->set_datatype(parent_return_type);
+				p_function->return_type_constraint = parent_return_type;
 #else // !DISABLE_DEPRECATED
 				if (function_name == GDScriptLanguage::get_singleton()->strings._get_property_list && method_flags.has_flag(METHOD_FLAG_VIRTUAL)) {
 					GDScriptParser::DataType array_type;


### PR DESCRIPTION
This PR(#121064)'s modification seems to have missed a part in the `DISABLE_DEPRECATED` section, which causes a compilation error under `deprecated=no`.

I used the same approach as in this PR here, which should resolve the compilation error.