### PR TITLE
Add `get_velocity_at_(local)_position()` to `RigidBody2D`

### DIFF
--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -116,6 +116,24 @@
 				[b]Note:[/b] To retrieve the colliding bodies, use [method get_colliding_bodies].
 			</description>
 		</method>
+		<method name="get_velocity_at_local_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="local_position" type="Vector2" />
+			<description>
+				Returns the body's velocity at the given relative position.
+				[param local_position] is the offset from the body origin in global coordinates.
+				See also [method get_velocity_at_position].
+			</description>
+		</method>
+		<method name="get_velocity_at_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="global_point" type="Vector2" />
+			<description>
+				Returns the body's velocity at the given global position.
+				This is equivalent to [code]get_velocity_at_local_position(global_point - global_position)[/code].
+				See also [method get_velocity_at_local_position].
+			</description>
+		</method>
 		<method name="set_axis_velocity">
 			<return type="void" />
 			<param index="0" name="axis_velocity" type="Vector2" />

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -709,6 +709,9 @@ void RigidBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_continuous_collision_detection_mode", "mode"), &RigidBody2D::set_continuous_collision_detection_mode);
 	ClassDB::bind_method(D_METHOD("get_continuous_collision_detection_mode"), &RigidBody2D::get_continuous_collision_detection_mode);
 
+	ClassDB::bind_method(D_METHOD("get_velocity_at_local_position", "local_position"), &RigidBody2D::get_velocity_at_local_position);
+	ClassDB::bind_method(D_METHOD("get_velocity_at_position", "global_point"), &RigidBody2D::get_velocity_at_position);
+
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidBody2D::set_axis_velocity);
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &RigidBody2D::apply_central_impulse, Vector2());
 	ClassDB::bind_method(D_METHOD("apply_impulse", "impulse", "position"), &RigidBody2D::apply_impulse, Vector2());

--- a/scene/2d/physics/rigid_body_2d.h
+++ b/scene/2d/physics/rigid_body_2d.h
@@ -191,6 +191,16 @@ public:
 	void set_linear_velocity(const Vector2 &p_velocity);
 	Vector2 get_linear_velocity() const;
 
+	_FORCE_INLINE_ Vector2 get_velocity_at_local_position(const Vector2 &p_position) const {
+		const Vector2 com_to_pos = p_position + get_global_position() - to_global(center_of_mass);
+		return linear_velocity + Vector2(-angular_velocity * com_to_pos.y, angular_velocity * com_to_pos.x);
+	}
+
+	_FORCE_INLINE_ Vector2 get_velocity_at_position(const Vector2 &p_position) const {
+		const Vector2 com_to_pos = p_position - to_global(center_of_mass);
+		return linear_velocity + Vector2(-angular_velocity * com_to_pos.y, angular_velocity * com_to_pos.x);
+	}
+
 	void set_axis_velocity(const Vector2 &p_axis);
 
 	void set_angular_velocity(real_t p_velocity);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Follow up on https://github.com/godotengine/godot/pull/121122
~Requires https://github.com/godotengine/godot/pull/121100~ (merged)

## Additional information

Changes:
- Adds `RigidBody2D.get_velocity_at_local_position()`.
- Adds `RigidBody2D.get_velocity_at_position()`.
  - Equivalent to `RigidBody2D.get_velocity_at_local_position(global_point - global_position)`.
- Adds relevant docs.

Test project:
[MRP_RigidBody2D.zip](https://github.com/user-attachments/files/29861146/MRP_RigidBody2D.zip)

Note for reviewers:
- I find `get_velocity_at_position()` more intuitive; `get_velocity_at_local_position()` requires subtracting `global_position` in the parameter, and then adds it back inside the function anyway.

## Author disclosure

I wrote this PR by myself.
