### PR TITLE
CI: Validate documentation-only changes without incurring additional builds

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -28,3 +28,10 @@ clangd:
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"
   - "!platform/{android,ios,macos,visionos,web,windows}/**"
   - "platform/{android,ios,macos,visionos,web,windows}/{api,export}/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"
+
+# Determines if documentation changed in any capacity. Can't simply lump in with `!sources`, as
+#  a post-build validation step is required.
+documentation:
+  - doc/class.xsd
+  - doc/classes/*.xml
+  - modules/*/doc_classes/*.xml

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -45,3 +45,24 @@ jobs:
           CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
         with:
           extra-args: --files ${{ env.CHANGED_FILES }}
+
+      - name: Validate documentation-only changes - download artifact
+        id: download-artifact
+        if: steps.changed-files.outputs.documentation_any_changed == 'true' && steps.changed-files.outputs.sources_any_changed == 'false' && github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          name: linux-editor-mono
+          path: ./bin/
+          branch: ${{ github.event.repository.default_branch }}
+          workflow_search: true
+
+      - name: Validate documentation-only changes - test artifact
+        if: steps.download-artifact.outputs.found_artifact
+        run: |
+          # Execution perms weren't preserved; manually apply them.
+          chmod +x bin/godot.*
+          # Lifted from `linux_builds.sh`.
+          echo "Running --doctool to see if this changes the public API without updating the documentation."
+          echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
+          ./bin/godot.linuxbsd.editor.x86_64.mono --doctool --headless 2>&1 > /dev/null || true
+          git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'


### PR DESCRIPTION
## What problem(s) does this PR solve?

Ensures the issue in #121139 cannot happen again, by having any documentation-only PRs run the `doctool` test against the most recently built `linux-editor-mono` artifact

## Additional information

Adds no additional build time to PRs that aren't documentation-exclusive. Will only check for artifacts from the default branch, so it should be the most up-to-date version of documentation at any given time. Will have potential for brief desyncs when a PR is updated shortly after a push to the defualt branch, but that's easily sussed out

Ideally, we should have dedicated matrices built that can dynamically account for these build conditions and only run a single documentation build. Would require a larger-scale overhaul of the GHA structure before that could be realistically pursued