### PR TITLE
[Android] Play store crash investigations

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -230,6 +230,7 @@ void DisplayServerAndroid::emit_input_dialog_callback(String p_text) {
 }
 
 Error DisplayServerAndroid::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+	ERR_FAIL_COND_V(p_window_id != DisplayServerEnums::MAIN_WINDOW_ID, ERR_UNAVAILABLE);
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
 	ERR_FAIL_NULL_V(godot_java, FAILED);
 	file_picker_callback = p_callback;
@@ -437,18 +438,22 @@ bool DisplayServerAndroid::has_hardware_keyboard() const {
 }
 
 void DisplayServerAndroid::window_set_window_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	ERR_FAIL_COND(p_window != DisplayServerEnums::MAIN_WINDOW_ID);
 	window_event_callback = p_callable;
 }
 
 void DisplayServerAndroid::window_set_input_event_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	ERR_FAIL_COND(p_window != DisplayServerEnums::MAIN_WINDOW_ID);
 	input_event_callback = p_callable;
 }
 
 void DisplayServerAndroid::window_set_input_text_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	ERR_FAIL_COND(p_window != DisplayServerEnums::MAIN_WINDOW_ID);
 	input_text_callback = p_callable;
 }
 
 void DisplayServerAndroid::window_set_rect_changed_callback(const Callable &p_callable, DisplayServerEnums::WindowID p_window) {
+	ERR_FAIL_COND(p_window != DisplayServerEnums::MAIN_WINDOW_ID);
 	rect_changed_callback = p_callable;
 }
 
@@ -531,10 +536,12 @@ int64_t DisplayServerAndroid::window_get_native_handle(DisplayServerEnums::Handl
 }
 
 void DisplayServerAndroid::window_attach_instance_id(ObjectID p_instance, DisplayServerEnums::WindowID p_window) {
+	ERR_FAIL_COND(p_window != DisplayServerEnums::MAIN_WINDOW_ID);
 	window_attached_instance_id = p_instance;
 }
 
 ObjectID DisplayServerAndroid::window_get_attached_instance_id(DisplayServerEnums::WindowID p_window) const {
+	ERR_FAIL_COND_V(p_window != DisplayServerEnums::MAIN_WINDOW_ID, ObjectID());
 	return window_attached_instance_id;
 }
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -1044,6 +1044,7 @@ class Godot private constructor(val context: Context) {
 
 	fun onBackPressed() {
 		for (plugin in pluginRegistry.allPlugins) {
+			Log.v(TAG, "Invoking onMainBackPressed for plugin ${plugin.pluginName}")
 			plugin.onMainBackPressed()
 		}
 		runOnRenderThread { GodotLib.back() }

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
@@ -243,7 +243,7 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 
 				// Run queued event.
 				if (event != null) {
-					event?.run()
+					event.run()
 					continue
 				}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Adding guards to investigate a potential cause for https://github.com/godotengine/godot/issues/114800
  - This would help validate the theory that the window callbacks are updated when a non `MAIN` window is shown, rendering them stale by the time the app looses focus, leading to the crash. 
  - Given the issue is not reproducible by maintainers, validation of this theory would require a rollout to production, and a follow-up of the crash rate in the Google Play console.
- Adding logging statements to investigate https://github.com/godotengine/godot/issues/120638
  - The theory is that a plugin may be taking too long when `onBackPressed` is invoked, leading to the ANR. The log statement will allow developers to check what happens right before the ANR.

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
