### PR TITLE
Fix Output filter buttons width

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -113,16 +113,16 @@ void EditorLog::_update_theme() {
 
 	Button *button = type_filter_map[MSG_TYPE_STD]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Popup")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_ERROR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_WARNING]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusWarning")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_EDITOR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
@@ -146,8 +146,11 @@ void EditorLog::_editor_settings_changed() {
 void EditorLog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			_update_theme();
 			_load_state();
+		} break;
+
+		case NOTIFICATION_READY: {
+			_update_theme();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -108,20 +108,20 @@ void EditorLog::_update_theme() {
 	log->add_theme_font_size_override("mono_font_size", font_size);
 	log->end_bulk_theme_override();
 
-	const String wide_text = "MM";
+	const String wide_text = "0000";
 
 	Button *button = type_filter_map[MSG_TYPE_STD]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Popup")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_ERROR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_WARNING]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusWarning")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 	button = type_filter_map[MSG_TYPE_EDITOR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x, 0));
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
@@ -145,7 +145,6 @@ void EditorLog::_editor_settings_changed() {
 void EditorLog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			_update_theme();
 			_load_state();
 		} break;
 
@@ -157,8 +156,8 @@ void EditorLog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			_update_theme();
-			_rebuild_log();
+			callable_mp(this, &EditorLog::_update_theme).call_deferred();
+			callable_mp(this, &EditorLog::_rebuild_log).call_deferred();
 		} break;
 	}
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119357

## Additional information

Using 200% editor scale

Modern: Before/After

<img width="906" height="272" alt="Screenshot_20260709_235616" src="https://github.com/user-attachments/assets/61045d36-5678-493c-95e7-5dc08159fd87" />

<img width="906" height="272" alt="Screenshot_20260709_235501" src="https://github.com/user-attachments/assets/8fe930f2-9f07-4996-bb95-8b7e2910f4f1" />

Classic: Before
I switched from modern to classic and it looks like buttons got bigger when doing that.

<img width="906" height="272" alt="Screenshot_20260709_235749" src="https://github.com/user-attachments/assets/67b02646-923e-4556-881c-7f89669b9d87" />

Switching back to modern looks like this

<img width="906" height="272" alt="Screenshot_20260709_235814" src="https://github.com/user-attachments/assets/7b9e7509-20d3-445e-a8e1-1614b51d65df" />

After

<img width="906" height="272" alt="Screenshot_20260710_000032" src="https://github.com/user-attachments/assets/37303daa-3c51-4eab-bbb3-326387b16e90" />
