### PR TITLE
Ensure texture region size doesn't exceed texture size

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -4714,6 +4714,9 @@ void TileSetAtlasSource::set_texture_region_size(Vector2i p_tile_size) {
 	if (p_tile_size.x <= 0 || p_tile_size.y <= 0) {
 		WARN_PRINT("Atlas source tile_size should be strictly positive.");
 		texture_region_size = p_tile_size.maxi(1);
+	} else if (texture.is_valid() && (p_tile_size.x > texture->get_size().x || p_tile_size.y > texture->get_size().y)) {
+		WARN_PRINT("Atlas source tile_size should be less than the texture's size.");
+		texture_region_size = p_tile_size.min(texture->get_size());
 	} else {
 		texture_region_size = p_tile_size;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->



## What problem(s) does this PR solve?

- Prevents the engine from lagging out when attempting to make the texture region size greater than the texture's size by preventing it to go beyond that size.

### Before
<img width="1069" height="426" alt="Godot_v4 8-dev1_win64_Eea30NLnPq" src="https://github.com/user-attachments/assets/0443d743-5a69-4961-a56f-c1daafb315a1" />

### After
<img width="1073" height="425" alt="godot windows editor dev x86_64_A3OhrgdhFS" src="https://github.com/user-attachments/assets/637a5a7c-98d4-434f-8691-7300cb6a8339" />

## Additional information
I don't believe this is taking away any usefulness, I asked around to see if it not having a limit is useful in any way and it didn't seem to be. All it does is slow down the editor to a halt.
I did not use AI in writing this.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
