### PR TITLE
Add the ability to disable/enable playing in the Editor

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -548,5 +548,8 @@
 		<member name="movie_maker_enabled" type="bool" setter="set_movie_maker_enabled" getter="is_movie_maker_enabled">
 			If [code]true[/code], the Movie Maker mode is enabled in the editor. See [MovieWriter] for more information.
 		</member>
+		<member name="playing_enabled" type="bool" setter="set_playing_enabled" getter="is_playing_enabled">
+			If [code]false[/code], all buttons that allow playing, such as the play button and its hotkey, will be disabled and attempting to use them through hotkeys will not function.
+		</member>
 	</members>
 </class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -833,6 +833,14 @@ bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
 
+void EditorInterface::set_playing_enabled(bool p_enabled) {
+	EditorRunBar::get_singleton()->set_playing_enabled(p_enabled);
+}
+
+bool EditorInterface::is_playing_enabled() const {
+	return EditorRunBar::get_singleton()->is_playing_enabled();
+}
+
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
@@ -961,7 +969,10 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_movie_maker_enabled", "enabled"), &EditorInterface::set_movie_maker_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_playing_enabled", "enabled"), &EditorInterface::set_playing_enabled);
+	ClassDB::bind_method(D_METHOD("is_playing_enabled"), &EditorInterface::is_playing_enabled);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_maker_enabled"), "set_movie_maker_enabled", "is_movie_maker_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing_enabled"), "set_playing_enabled", "is_playing_enabled");
 }
 
 void EditorInterface::create() {

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -206,6 +206,9 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
+	void set_playing_enabled(bool p_enabled);
+	bool is_playing_enabled() const;
+
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -417,6 +417,9 @@ void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_p
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
 		return;
 	}
+	if (!is_playing_enabled()) {
+		return;
+	}
 
 	if (p_from_native) {
 		run_native->resume_run_native();
@@ -431,6 +434,9 @@ void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_p
 void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+	if (!is_playing_enabled()) {
 		return;
 	}
 
@@ -450,6 +456,9 @@ void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_pla
 void EditorRunBar::play_custom_scene(const String &p_custom, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+	if (!is_playing_enabled()) {
 		return;
 	}
 
@@ -521,6 +530,17 @@ void EditorRunBar::set_movie_maker_enabled(bool p_enabled) {
 
 bool EditorRunBar::is_movie_maker_enabled() const {
 	return movie_maker_enabled;
+}
+
+void EditorRunBar::set_playing_enabled(bool p_enabled) {
+	playing_enabled = p_enabled;
+	play_button->set_disabled(!p_enabled);
+	play_scene_button->set_disabled(!p_enabled);
+	play_custom_scene_button->set_disabled(!p_enabled);
+}
+
+bool EditorRunBar::is_playing_enabled() const {
+	return playing_enabled;
 }
 
 void EditorRunBar::update_profiler_autostart_indicator() {

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -87,6 +87,7 @@ class EditorRunBar : public MarginContainer {
 	PanelContainer *write_movie_panel = nullptr;
 	MenuButton *write_movie_button = nullptr;
 	bool movie_maker_enabled = false;
+	bool playing_enabled = true;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -136,6 +137,9 @@ public:
 
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
+
+	void set_playing_enabled(bool p_enabled);
+	bool is_playing_enabled() const;
 
 	void update_profiler_autostart_indicator();
 


### PR DESCRIPTION
Adds the ability to (ideally temporarily) disable all conventional methods of playing through the editor. This mostly means the Play button, Current Scene button, and Custom Scene button. Which includes their hotkeys.

This is called via `EditorInterface.playing_enabled`. (Naming is admittedly not the best, but I couldn't think of anything better)

## What problem(s) does this PR solve?
This PR does nothing by itself, it's a prerequisite for #121156, it still does have some uses by itself though. Such as..

Enabling plugins to have better UX, if you have a process that _needs_ to run prior to the user starting their game this will help prevent that. 
An example would be a plugin that downloads some arbitrary data or creates some arbitrary data (such as a json file containing game data), that may take longer than a single frame would benefit from temporarily disabling playing, as to make sure the user does not accidentally corrupt/break their game with no discernible cause. 

This also disables "Reload" functionality, as it's assumed if playing is disabled, reloading wouldn't be desirable either. (In the case of #121156 for instance)

A video example of "play" toggling

https://github.com/user-attachments/assets/52fd1f8c-dd42-47d3-beca-5b34b193d58e
