### PR TITLE
Fix crash in org.godotengine.godot.GodotActivity.updatePiPParams

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
@@ -248,8 +248,6 @@ abstract class GodotActivity : FragmentActivity(), GodotHost, PictureInPicturePr
 			} catch (e: NumberFormatException) {
 				Log.w(TAG, "Unable to parse viewport dimensions.", e)
 			}
-
-			runOnHostThread { updatePiPParams() }
 		}
 	}
 


### PR DESCRIPTION
Should fix this crash reported on Play Console:
https://play.google.com/console/u/0/developers/5310120689138741555/app/4972363226496209566/vitals/crashes/174db51bdcc102766d2681de5176fdbb/details?days=28
```
Exception java.lang.IllegalStateException:
  at android.os.Parcel.createExceptionOrNull (Parcel.java:3396)
  at android.os.Parcel.createException (Parcel.java:3372)
  at android.os.Parcel.readException (Parcel.java:3355)
  at android.os.Parcel.readException (Parcel.java:3297)
  at android.app.IActivityClientController$Stub$Proxy.setPictureInPictureParams (IActivityClientController.java:2388)
  at android.app.ActivityClient.setPictureInPictureParams (ActivityClient.java:457)
  at android.app.Activity.setPictureInPictureParams (Activity.java:3411)
  at org.godotengine.godot.GodotActivity.updatePiPParams (GodotActivity.kt:355)
  at org.godotengine.godot.GodotActivity.updatePiPParams$default (GodotActivity.kt:330)
  at org.godotengine.godot.GodotActivity.onGodotSetupCompleted$lambda$7 (GodotActivity.kt:252)
  at org.godotengine.godot.GodotActivity.$r8$lambda$h9xYV6ssYi8LMRmX1dLLthKEaQs (GodotActivity.kt)
  at org.godotengine.godot.GodotActivity$$ExternalSyntheticLambda5.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1070)
```

Crash is happening when `updatePiPParams` is called inside `onGodotSetupCompleted`. I think app is still not ready at this point, so we should instead call `updatePiPParams` inside `GodotMainLoopStarted`. However, there's also no reason to call `updatePiPParams` on app start. It is already called everytime app enters pip, https://github.com/godotengine/godot/blob/370b759037cf4bafd8f7904fc31551a5505efd22/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt#L360-L367

This PR removes calling `updatePiPParams` on app start.