### PR TITLE
[C#] Add asynchronous C# building

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -548,5 +548,8 @@
 		<member name="movie_maker_enabled" type="bool" setter="set_movie_maker_enabled" getter="is_movie_maker_enabled">
 			If [code]true[/code], the Movie Maker mode is enabled in the editor. See [MovieWriter] for more information.
 		</member>
+		<member name="playing_enabled" type="bool" setter="set_playing_enabled" getter="is_playing_enabled">
+			If [code]false[/code], all buttons that allow playing, such as the play button and its hotkey, will be disabled and attempting to use them through hotkeys will not function.
+		</member>
 	</members>
 </class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -833,6 +833,14 @@ bool EditorInterface::is_movie_maker_enabled() const {
 	return EditorRunBar::get_singleton()->is_movie_maker_enabled();
 }
 
+void EditorInterface::set_playing_enabled(bool p_enabled) {
+	EditorRunBar::get_singleton()->set_playing_enabled(p_enabled);
+}
+
+bool EditorInterface::is_playing_enabled() const {
+	return EditorRunBar::get_singleton()->is_playing_enabled();
+}
+
 void EditorInterface::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0) {
@@ -961,7 +969,10 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_movie_maker_enabled", "enabled"), &EditorInterface::set_movie_maker_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_playing_enabled", "enabled"), &EditorInterface::set_playing_enabled);
+	ClassDB::bind_method(D_METHOD("is_playing_enabled"), &EditorInterface::is_playing_enabled);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_maker_enabled"), "set_movie_maker_enabled", "is_movie_maker_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing_enabled"), "set_playing_enabled", "is_playing_enabled");
 }
 
 void EditorInterface::create() {

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -206,6 +206,9 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
+	void set_playing_enabled(bool p_enabled);
+	bool is_playing_enabled() const;
+
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -417,6 +417,9 @@ void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_p
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
 		return;
 	}
+	if (!is_playing_enabled()) {
+		return;
+	}
 
 	if (p_from_native) {
 		run_native->resume_run_native();
@@ -431,6 +434,9 @@ void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_p
 void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+	if (!is_playing_enabled()) {
 		return;
 	}
 
@@ -450,6 +456,9 @@ void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_pla
 void EditorRunBar::play_custom_scene(const String &p_custom, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
+		return;
+	}
+	if (!is_playing_enabled()) {
 		return;
 	}
 
@@ -521,6 +530,17 @@ void EditorRunBar::set_movie_maker_enabled(bool p_enabled) {
 
 bool EditorRunBar::is_movie_maker_enabled() const {
 	return movie_maker_enabled;
+}
+
+void EditorRunBar::set_playing_enabled(bool p_enabled) {
+	playing_enabled = p_enabled;
+	play_button->set_disabled(!p_enabled);
+	play_scene_button->set_disabled(!p_enabled);
+	play_custom_scene_button->set_disabled(!p_enabled);
+}
+
+bool EditorRunBar::is_playing_enabled() const {
+	return playing_enabled;
 }
 
 void EditorRunBar::update_profiler_autostart_indicator() {

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -87,6 +87,7 @@ class EditorRunBar : public MarginContainer {
 	PanelContainer *write_movie_panel = nullptr;
 	MenuButton *write_movie_button = nullptr;
 	bool movie_maker_enabled = false;
+	bool playing_enabled = true;
 
 	RunMode current_mode = RunMode::STOPPED;
 	String run_custom_filename;
@@ -136,6 +137,9 @@ public:
 
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
+
+	void set_playing_enabled(bool p_enabled);
+	bool is_playing_enabled() const;
 
 	void update_profiler_autostart_indicator();
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -243,7 +243,7 @@ namespace GodotTools.Build
         {
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to clean.
-            
+
             if (_buildInProgress != null)
                 return false;
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -222,10 +222,7 @@ namespace GodotTools.Build
                 return true; // No project to build.
 
             if (_buildInProgress != null)
-            {
-                //TODO: Toaster notif
                 return false;
-            }
 
             bool success;
             using (var pr = new EditorProgress("dotnet_build_project", "Building .NET project...", 1))
@@ -246,11 +243,10 @@ namespace GodotTools.Build
         {
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to clean.
+            
             if (_buildInProgress != null)
-            {
-                //TODO: Toaster notif
                 return false;
-            }
+
             bool success;
             using (var pr = new EditorProgress("dotnet_clean_project", "Cleaning .NET project...", 1))
             {
@@ -270,11 +266,10 @@ namespace GodotTools.Build
         {
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to publish.
+
             if (_buildInProgress != null)
-            {
-                //TODO: Toaster notif
                 return false;
-            }
+
             bool success;
             using (var pr = new EditorProgress("dotnet_publish_project", "Publishing .NET project...", 1))
             {
@@ -296,13 +291,8 @@ namespace GodotTools.Build
             bool success = await BuildAsync(buildInfo);
 
             if (!success)
-            {
                 ShowBuildErrorDialog("Failed to build project");
-            }
-            else
-            {
-                //TODO: Add toast notif
-            }
+
             return success;
         }
 
@@ -316,13 +306,8 @@ namespace GodotTools.Build
 
             bool success = await BuildAsync(buildInfo);
             if (!success)
-            {
                 ShowBuildErrorDialog("Failed to clean project");
-            }
-            else
-            {
-                //TODO: Toast notif
-            }
+
             return success;
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -221,6 +221,12 @@ namespace GodotTools.Build
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to build.
 
+            if (_buildInProgress != null)
+            {
+                //TODO: Toaster notif
+                return false;
+            }
+
             bool success;
             using (var pr = new EditorProgress("dotnet_build_project", "Building .NET project...", 1))
             {
@@ -240,7 +246,11 @@ namespace GodotTools.Build
         {
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to clean.
-
+            if (_buildInProgress != null)
+            {
+                //TODO: Toaster notif
+                return false;
+            }
             bool success;
             using (var pr = new EditorProgress("dotnet_clean_project", "Cleaning .NET project...", 1))
             {
@@ -258,6 +268,13 @@ namespace GodotTools.Build
 
         private static bool PublishProjectBlocking(BuildInfo buildInfo)
         {
+            if (!File.Exists(buildInfo.Project))
+                return true; // No project to publish.
+            if (_buildInProgress != null)
+            {
+                //TODO: Toaster notif
+                return false;
+            }
             bool success;
             using (var pr = new EditorProgress("dotnet_publish_project", "Publishing .NET project...", 1))
             {
@@ -265,6 +282,47 @@ namespace GodotTools.Build
                 success = Publish(buildInfo);
             }
 
+            return success;
+        }
+
+        private static async Task<bool> BuildProjectAsync(BuildInfo buildInfo)
+        {
+            if (!File.Exists(buildInfo.Project))
+                return true;
+
+            if (_buildInProgress != null)
+                return false;
+
+            bool success = await BuildAsync(buildInfo);
+
+            if (!success)
+            {
+                ShowBuildErrorDialog("Failed to build project");
+            }
+            else
+            {
+                //TODO: Add toast notif
+            }
+            return success;
+        }
+
+        private static async Task<bool> CleanProjectAsync(BuildInfo buildInfo)
+        {
+            if (!File.Exists(buildInfo.Project))
+                return true;
+
+            if (_buildInProgress != null)
+                return false;
+
+            bool success = await BuildAsync(buildInfo);
+            if (!success)
+            {
+                ShowBuildErrorDialog("Failed to clean project");
+            }
+            else
+            {
+                //TODO: Toast notif
+            }
             return success;
         }
 
@@ -332,6 +390,17 @@ namespace GodotTools.Build
             bool includeDebugSymbols = true
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
             platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+
+        public static async Task<bool> BuildProjectAsync(
+            string configuration,
+            string? platform = null,
+            bool rebuild = false
+            ) => await BuildProjectAsync(CreateBuildInfo(configuration, platform, rebuild));
+
+        public static async Task<bool> CleanProjectAsync(
+            string configuration,
+            string? platform = null
+        ) => await CleanProjectAsync(CreateBuildInfo(configuration, platform, rebuild: false, onlyClean: true));
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Godot;
 using GodotTools.Internals;
 using static GodotTools.Internals.Globals;
@@ -71,19 +72,25 @@ namespace GodotTools.Build
             }
         }
 
-        public void BuildProject()
+        public async Task BuildProject()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
                 return; // No project to build.
 
-            if (!BuildManager.BuildProjectBlocking("Debug"))
+            GodotSharpEditor.Instance.BuildStarted();
+
+            if (!await BuildManager.BuildProjectAsync("Debug"))
+            {
+                GodotSharpEditor.Instance.BuildEnded();
                 return; // Build failed.
+            }
 
             // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
 
             // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
+            GodotSharpEditor.Instance.BuildEnded();
 
             if (Internal.IsAssembliesReloadingNeeded())
             {
@@ -92,19 +99,25 @@ namespace GodotTools.Build
             }
         }
 
-        private void RebuildProject()
+        private async Task RebuildProject()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
                 return; // No project to build.
 
-            if (!BuildManager.BuildProjectBlocking("Debug", rebuild: true))
+            GodotSharpEditor.Instance.BuildStarted();
+
+            if (!await BuildManager.BuildProjectAsync("Debug", rebuild: false))
+            {
+                GodotSharpEditor.Instance.BuildEnded();
                 return; // Build failed.
+            }
 
             // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
 
             // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
+            GodotSharpEditor.Instance.BuildEnded();
 
             if (Internal.IsAssembliesReloadingNeeded())
             {
@@ -113,12 +126,14 @@ namespace GodotTools.Build
             }
         }
 
-        private void CleanProject()
+        private async Task CleanProject()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
                 return; // No project to build.
+            GodotSharpEditor.Instance.BuildStarted();
 
-            _ = BuildManager.CleanProjectBlocking("Debug");
+            _ = await BuildManager.CleanProjectAsync("Debug");
+            GodotSharpEditor.Instance.BuildEnded();
         }
 
         private void OpenLogsFolder() => OS.ShellOpen(
@@ -140,6 +155,7 @@ namespace GodotTools.Build
             };
 
             _problemsView.SetDiagnostics(new[] { diagnostic });
+            _buildMenuButton.Disabled = IsBuildingOngoing;
 
             UpdateBuildStateIcon();
         }
@@ -154,6 +170,7 @@ namespace GodotTools.Build
             _outputView.Clear();
 
             _problemsView.UpdateProblemsView();
+            _buildMenuButton.Disabled = IsBuildingOngoing;
 
             UpdateBuildStateIcon();
         }
@@ -167,6 +184,7 @@ namespace GodotTools.Build
             _problemsView.SetDiagnosticsFromFile(csvFile);
 
             _problemsView.UpdateProblemsView();
+            _buildMenuButton.Disabled = IsBuildingOngoing;
 
             UpdateBuildStateIcon();
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -53,23 +53,13 @@ namespace GodotTools.Build
 
         private void BuildMenuOptionPressed(long id)
         {
-            switch ((BuildMenuOptions)id)
+            _ = (BuildMenuOptions)id switch
             {
-                case BuildMenuOptions.BuildProject:
-                    BuildProject();
-                    break;
-
-                case BuildMenuOptions.RebuildProject:
-                    RebuildProject();
-                    break;
-
-                case BuildMenuOptions.CleanProject:
-                    CleanProject();
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(id), id, "Invalid build menu option");
-            }
+                BuildMenuOptions.BuildProject => BuildProject(),
+                BuildMenuOptions.RebuildProject => RebuildProject(),
+                BuildMenuOptions.CleanProject => CleanProject(),
+                _ => throw new ArgumentOutOfRangeException(nameof(id), id, "Invalid build menu option")
+            };
         }
 
         public async Task BuildProject()

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using GodotTools.Build;
 using GodotTools.Ides;
 using GodotTools.Ides.Rider;
@@ -44,8 +45,9 @@ namespace GodotTools
         private AcceptDialog _errorDialog;
         private ConfirmationDialog _confirmCreateSlnDialog;
 
-        private Button _bottomPanelBtn;
+        private HBoxContainer _toolBarBuildContainer;
         private Button _toolBarBuildButton;
+        private ProgressBar _toolBarBuildProgress;
 
         // TODO Use WeakReference once we have proper serialization.
         private WeakRef _exportPluginWeak;
@@ -143,7 +145,7 @@ namespace GodotTools
             }
         }
 
-        private void BuildProjectPressed()
+        private async Task BuildProjectPressed()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
@@ -151,7 +153,21 @@ namespace GodotTools
                     return; // Failed to create project.
             }
 
-            Instance.MSBuildPanel.BuildProject();
+            await Instance.MSBuildPanel.BuildProject();
+        }
+
+        public void BuildStarted()
+        {
+            EditorInterface.Singleton.SetPlayingEnabled(false);
+            _toolBarBuildProgress.Show();
+            _toolBarBuildButton.Disabled = true;
+        }
+
+        public void BuildEnded()
+        {
+            _toolBarBuildProgress.Hide();
+            _toolBarBuildButton.Disabled = false;
+            EditorInterface.Singleton.SetPlayingEnabled(true);
         }
 
         private enum MenuOptions
@@ -456,6 +472,44 @@ namespace GodotTools
             }
         }
 
+        private void SetupToolbar()
+        {
+            // Create a container specific for Dotnet, should additional elements be added they'll be grouped properly.
+            _toolBarBuildContainer = new HBoxContainer();
+            Internal.EditorPlugin_AddControlToEditorRunBar(_toolBarBuildContainer);
+
+            // Move Build container so it appears to the left of the Play button.
+            _toolBarBuildContainer.GetParent().MoveChild(_toolBarBuildContainer, 0);
+            _toolBarBuildContainer.GetParent().PrintTreePretty();
+
+            _toolBarBuildProgress = new ProgressBar
+            {
+                Indeterminate = true,
+                ShowBehindParent = true,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+                MouseFilter = Control.MouseFilterEnum.Ignore,
+            };
+
+            _toolBarBuildButton = new Button
+            {
+                Flat = false,
+                Icon = EditorInterface.Singleton.GetEditorTheme().GetIcon("BuildCSharp", "EditorIcons"),
+                FocusMode = Control.FocusModeEnum.None,
+                Shortcut = EditorDefShortcut("mono/build_solution", "Build Project".TTR(), (Key)KeyModifierMask.MaskAlt | Key.B),
+                ShortcutInTooltip = true,
+                ThemeTypeVariation = "RunBarButton",
+            };
+            EditorShortcutOverride("mono/build_solution", "macos", (Key)KeyModifierMask.MaskMeta | (Key)KeyModifierMask.MaskCtrl | Key.B);
+
+            _toolBarBuildButton.Pressed += () => _ = BuildProjectPressed();
+            _toolBarBuildContainer.AddChild(_toolBarBuildButton);
+
+            _toolBarBuildButton.AddChild(_toolBarBuildProgress);
+            _toolBarBuildProgress.SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
+            _toolBarBuildProgress.Hide();
+        }
+
         public override void _EnablePlugin()
         {
             base._EnablePlugin();
@@ -517,21 +571,7 @@ namespace GodotTools
 
             AddToolSubmenuItem("C#", _menuPopup);
 
-            _toolBarBuildButton = new Button
-            {
-                Flat = false,
-                Icon = EditorInterface.Singleton.GetEditorTheme().GetIcon("BuildCSharp", "EditorIcons"),
-                FocusMode = Control.FocusModeEnum.None,
-                Shortcut = EditorDefShortcut("mono/build_solution", "Build Project".TTR(), (Key)KeyModifierMask.MaskAlt | Key.B),
-                ShortcutInTooltip = true,
-                ThemeTypeVariation = "RunBarButton",
-            };
-            EditorShortcutOverride("mono/build_solution", "macos", (Key)KeyModifierMask.MaskMeta | (Key)KeyModifierMask.MaskCtrl | Key.B);
-
-            _toolBarBuildButton.Pressed += BuildProjectPressed;
-            Internal.EditorPlugin_AddControlToEditorRunBar(_toolBarBuildButton);
-            // Move Build button so it appears to the left of the Play button.
-            _toolBarBuildButton.GetParent().MoveChild(_toolBarBuildButton, 0);
+            SetupToolbar();
 
             EditorInterface.Singleton.GetCommandPalette().AddCommand("Build C# project".TTR(), "dotnet/build_solution", Callable.From(BuildProjectPressed), _toolBarBuildButton.Shortcut.GetAsText());
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -145,7 +145,7 @@ namespace GodotTools
             }
         }
 
-        private async Task BuildProjectPressed()
+        private void BuildProjectPressed()
         {
             if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
@@ -153,7 +153,7 @@ namespace GodotTools
                     return; // Failed to create project.
             }
 
-            await Instance.MSBuildPanel.BuildProject();
+            _ = Instance.MSBuildPanel.BuildProject();
         }
 
         public void BuildStarted()
@@ -501,7 +501,7 @@ namespace GodotTools
             };
             EditorShortcutOverride("mono/build_solution", "macos", (Key)KeyModifierMask.MaskMeta | (Key)KeyModifierMask.MaskCtrl | Key.B);
 
-            _toolBarBuildButton.Pressed += () => _ = BuildProjectPressed();
+            _toolBarBuildButton.Pressed += BuildProjectPressed;
             _toolBarBuildContainer.AddChild(_toolBarBuildButton);
 
             _toolBarBuildButton.AddChild(_toolBarBuildProgress);

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -480,7 +480,6 @@ namespace GodotTools
 
             // Move Build container so it appears to the left of the Play button.
             _toolBarBuildContainer.GetParent().MoveChild(_toolBarBuildContainer, 0);
-            _toolBarBuildContainer.GetParent().PrintTreePretty();
 
             _toolBarBuildProgress = new ProgressBar
             {


### PR DESCRIPTION
Intends to supersede: #91420
Requires: #121153

This adds asynchronous (background) building to C#, allowing a user to use the editor while their project builds.

## What problem(s) does this PR solve?
Resolves: https://github.com/godotengine/godot-proposals/issues/849

Currently, as many C# users may know, when building there is a popup that blocks the editor, preventing you from making any changes/navigating while the project builds. This isn't particularly fun when paired with #103657. As such this PR works to resolve it by having non-play builds work in the background, allowing a developer to get back to modifying whatever it is they want much quicker. 

This PR is based off of #91420, with the actual async logic itself being taken from it, as such I've added @CypherDoesStuff as a co-author, thank you for your work!
I have built upon it by adding additional feedback (as suggested in the original PR), this includes an indeterminate progress bar while the build is occurring and a temporary block on playing to ensure the user actually uses the up-to-date assembly.  

A demonstration of the PR:

https://github.com/user-attachments/assets/21880464-480b-4fb8-a88e-c4383f6cb948

## Additional information

As mentioned at the top, this relies on my previous PR to disable/enable playing, though I admit I did somewhat consider the path of just getting them by index (horrible). 

I've wrapped the toolbar additions into their own method to prevent _EnablePlugin from becoming _too_ monolithic, I've also wrapped all the dotnet stuff into it's own container, though this was a remnant from my various build feedback tests I've decided to keep it as I generally think it's probably good to have. 

I also considered adding a toast notification, this would be actually quite trivial, but in my testing I wasn't sure if users would enjoy being constantly barraged with "Dotnet build finished!". I considered having this be an editor setting, but I think the feedback you get seeing the toolbar temporarily disable and the progress bar begin should be enough.
The progress bar itself leaves a bit to be desired, it sort of expands beyond the bounds of the button which looks odd, but trying to make tiny changes such as these and needing to recompile it every time is time consuming, I'll likely keep thinking about it.

Playing the scene normally will still result in the pop-up, as the assembly does need to build before the game can start, this will be resolved with #93431 or similar. 

I'm aware that dotnet-gdextension is on the horizon, but from what I've experienced dotnet-gdext still has the pop-up. I would happily port this to dotnet-gdext once that becomes less painful to build, but for now my hope is that people use this in combination with the other great C# PRs. 

This PR is very much intended to be paired with #103657 and #93431 as the three of these combined really do improve the C# workflow, here's a demonstration of just how awesome it is:


https://github.com/user-attachments/assets/d5857b8e-d6d0-4789-bd85-9dbe14b0dff8

