### PR TITLE
Core: Apply `_WARN_UNUSED_` to `String`

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -490,7 +490,6 @@ public:
 Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links) {
 	List<String> dirs;
 
-	String curdir = get_current_dir();
 	list_dir_begin();
 	String n = get_next();
 	while (!n.is_empty()) {

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -575,7 +575,6 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 	int len = p_json.length();
 	Token token;
 	r_err_line = 0;
-	String aux_key;
 
 	Error err = _get_token(str, idx, len, token, r_err_line, r_err_str);
 	if (err) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2017,8 +2017,6 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 		return ERR_INVALID_DATA;
 	}
 
-	String aux;
-
 	int cstr_size = 0;
 	int str_size = 0;
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -261,7 +261,7 @@ using Char16String = CharStringT<char16_t>;
 /*  String                                                               */
 /*************************************************************************/
 
-class [[nodiscard]] String {
+class [[nodiscard]] _WARN_UNUSED_ String {
 	CowData<char32_t> _cowdata;
 	static constexpr char32_t _null = 0;
 	static constexpr char32_t _replacement_char = 0xfffd;

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -508,11 +508,11 @@ Error FileAccessUnix::_set_read_only_attribute(const String &p_file, bool p_ro) 
 PackedByteArray FileAccessUnix::_get_extended_attribute(const String &p_file, const String &p_attribute_name) {
 	ERR_FAIL_COND_V(p_attribute_name.is_empty(), PackedByteArray());
 
-	String file = fix_path(p_file);
 	PackedByteArray data;
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(WEB_ENABLED)
 	// Not supported.
 #elif defined(__APPLE__)
+	String file = fix_path(p_file);
 	CharString attr_name = p_attribute_name.utf8();
 	ssize_t attr_size = getxattr(file.utf8().get_data(), attr_name.get_data(), nullptr, 0, 0, 0);
 	if (attr_size <= 0) {
@@ -523,6 +523,7 @@ PackedByteArray FileAccessUnix::_get_extended_attribute(const String &p_file, co
 	attr_size = getxattr(file.utf8().get_data(), attr_name.get_data(), (void *)data.ptrw(), data.size(), 0, 0);
 	ERR_FAIL_COND_V_MSG(attr_size != data.size(), PackedByteArray(), "Failed to set extended attributes for: " + p_file);
 #else
+	String file = fix_path(p_file);
 	CharString attr_name = ("user." + p_attribute_name).utf8();
 	ssize_t attr_size = getxattr(file.utf8().get_data(), attr_name.get_data(), nullptr, 0);
 	if (attr_size <= 0) {
@@ -539,15 +540,16 @@ PackedByteArray FileAccessUnix::_get_extended_attribute(const String &p_file, co
 Error FileAccessUnix::_set_extended_attribute(const String &p_file, const String &p_attribute_name, const PackedByteArray &p_data) {
 	ERR_FAIL_COND_V(p_attribute_name.is_empty(), FAILED);
 
-	String file = fix_path(p_file);
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(WEB_ENABLED)
 	// Not supported.
 #elif defined(__APPLE__)
+	String file = fix_path(p_file);
 	int err = setxattr(file.utf8().get_data(), p_attribute_name.utf8().get_data(), (const void *)p_data.ptr(), p_data.size(), 0, 0);
 	if (err != 0) {
 		return FAILED;
 	}
 #else
+	String file = fix_path(p_file);
 	int err = setxattr(file.utf8().get_data(), ("user." + p_attribute_name).utf8().get_data(), (const void *)p_data.ptr(), p_data.size(), 0);
 	if (err != 0) {
 		return FAILED;
@@ -559,15 +561,16 @@ Error FileAccessUnix::_set_extended_attribute(const String &p_file, const String
 Error FileAccessUnix::_remove_extended_attribute(const String &p_file, const String &p_attribute_name) {
 	ERR_FAIL_COND_V(p_attribute_name.is_empty(), FAILED);
 
-	String file = fix_path(p_file);
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(WEB_ENABLED)
 	// Not supported.
 #elif defined(__APPLE__)
+	String file = fix_path(p_file);
 	int err = removexattr(file.utf8().get_data(), p_attribute_name.utf8().get_data(), 0);
 	if (err != 0) {
 		return FAILED;
 	}
 #else
+	String file = fix_path(p_file);
 	int err = removexattr(file.utf8().get_data(), ("user." + p_attribute_name).utf8().get_data());
 	if (err != 0) {
 		return FAILED;
@@ -578,10 +581,10 @@ Error FileAccessUnix::_remove_extended_attribute(const String &p_file, const Str
 
 PackedStringArray FileAccessUnix::_get_extended_attributes_list(const String &p_file) {
 	PackedStringArray ret;
-	String file = fix_path(p_file);
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(WEB_ENABLED)
 	// Not supported.
 #elif defined(__APPLE__)
+	String file = fix_path(p_file);
 	size_t size = listxattr(file.utf8().get_data(), nullptr, 0, 0);
 	if (size > 0) {
 		PackedByteArray data;
@@ -596,6 +599,7 @@ PackedStringArray FileAccessUnix::_get_extended_attributes_list(const String &p_
 		}
 	}
 #else
+	String file = fix_path(p_file);
 	size_t size = listxattr(file.utf8().get_data(), nullptr, 0);
 	if (size > 0) {
 		PackedByteArray data;

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -863,8 +863,6 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 }
 
 bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
-	String prev_path;
-
 	LocalVector<StringName> nodes = p_nodesm->get_node_list();
 
 	PopupMenu *nodes_menu = memnew(PopupMenu);

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -86,7 +86,6 @@ void EditorPerformanceProfiler::_update_monitor_value(Monitor *p_monitor, float 
 	const String label = EditorPerformanceProfiler::_format_label(p_value, p_monitor->type);
 	item->set_text(1, label);
 
-	String tooltip;
 	switch (p_monitor->type) {
 		case Performance::MONITOR_TYPE_MEMORY:
 		case Performance::MONITOR_TYPE_TIME: {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7199,8 +7199,6 @@ void EditorNode::reload_scene(const String &p_path) {
 }
 
 void EditorNode::find_all_instances_inheriting_path_in_node(Node *p_root, Node *p_node, const String &p_instance_path, HashSet<Node *> &p_instance_list) {
-	String scene_file_path = p_node->get_scene_file_path();
-
 	bool valid_instance_found = false;
 
 	// Attempt to find all the instances matching path we're going to reload.

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2208,8 +2208,6 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 		return ERR_SKIP;
 	}
 
-	String platform_name = get_platform_name();
-
 	String archive_path = p_path.get_basename() + ".xcarchive";
 	List<String> archive_args;
 	archive_args.push_back("-project");

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -416,8 +416,6 @@ void EditorFileSystem::_scan_filesystem() {
 	sources_changed.clear();
 	file_cache.clear();
 
-	String project = ProjectSettings::get_singleton()->get_resource_path();
-
 	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().path_join(CACHE_FILE_NAME);
 	{
 		Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::READ);
@@ -457,11 +455,7 @@ void EditorFileSystem::_scan_filesystem() {
 					// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
 					Vector<String> split = l.split("::", true, 8);
 					ERR_CONTINUE(split.size() < 9);
-					String name = split[0];
-					String file;
-
-					file = name;
-					name = cpath.path_join(name);
+					const String name = cpath.path_join(split[0]);
 
 					FileCache fc;
 					fc.type = split[1].get_slicec('/', 0);

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -683,7 +683,6 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 		if (f.is_valid()) {
 			f->store_32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
-				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
 				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());
 			}
 		}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3400,7 +3400,6 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		if (f.is_valid()) {
 			f->store_32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
-				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
 				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());
 			}
 		}

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -271,7 +271,6 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 		int face_index = preload_config.has("variation_face_index") ? preload_config["variation_face_index"].operator int() : 0;
 		Transform2D transform = preload_config.has("variation_transform") ? preload_config["variation_transform"].operator Transform2D() : Transform2D();
 		Vector2i size = preload_config.has("size") ? preload_config["size"].operator Vector2i() : Vector2i(16, 0);
-		String name = preload_config.has("name") ? preload_config["name"].operator String() : vformat("Configuration %d", i);
 
 		RID conf_rid = font->find_variation(variation, face_index, embolden, transform);
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5059,17 +5059,14 @@ void EditorInspector::update_tree() {
 		bool is_localized = property_name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED;
 		for (const KeyValue<String, HashMap<String, LocalVector<EditorProperty *>>> &KV : favorites_to_add) {
 			String section_name = KV.key;
-			String label;
 			String tooltip;
 			VBoxContainer *parent_vbox = favorites_vbox;
 			if (!section_name.is_empty()) {
 				favorites_groups_vbox->show();
 
 				if (is_localized) {
-					label = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 					tooltip = section_name;
 				} else {
-					label = section_name;
 					tooltip = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 				}
 
@@ -5106,10 +5103,8 @@ void EditorInspector::update_tree() {
 				VBoxContainer *vbox = parent_vbox;
 				if (!section_name.is_empty()) {
 					if (is_localized) {
-						label = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 						tooltip = section_name;
 					} else {
-						label = section_name;
 						tooltip = EditorPropertyNameProcessor::get_singleton()->translate_group_name(section_name);
 					}
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1708,8 +1708,6 @@ void EditorPropertySignal::_edit_pressed() {
 }
 
 void EditorPropertySignal::update_property() {
-	String type = base_type;
-
 	Signal signal = get_edited_property_value();
 
 	edit->set_text("Signal: " + signal.get_name());
@@ -1729,8 +1727,6 @@ EditorPropertySignal::EditorPropertySignal() {
 ///////////////////// CALLABLE /////////////////////////
 
 void EditorPropertyCallable::update_property() {
-	String type = base_type;
-
 	Callable callable = get_edited_property_value();
 
 	edit->set_text("Callable");

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -349,7 +349,6 @@ void PropertySelector::_item_selected() {
 		class_type = instance->get_class();
 	}
 
-	String text;
 	while (!class_type.is_empty()) {
 		if (properties) {
 			if (ClassDB::has_property(class_type, name, true)) {

--- a/editor/run/editor_run_native.cpp
+++ b/editor/run/editor_run_native.cpp
@@ -57,7 +57,6 @@ void EditorRunNative::_notification(int p_what) {
 						continue;
 					}
 					const int device_count = MIN(eep->get_options_count(), 9000);
-					String error;
 					if (device_count > 0) {
 						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
 						popup->set_item_disabled(-1, true);

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -224,8 +224,6 @@ void RunInstancesDialog::get_argument_list_for_instance(int p_idx, List<String> 
 		raw_custom_args = main_args_edit->get_text();
 	}
 
-	String exec = OS::get_singleton()->get_executable_path();
-
 	if (!raw_custom_args.is_empty()) {
 		// Allow the user to specify a command to run, similar to Steam's launch options.
 		// In this case, Godot will no longer be run directly; it's up to the underlying command
@@ -241,7 +239,6 @@ void RunInstancesDialog::get_argument_list_for_instance(int p_idx, List<String> 
 			// If nothing is placed before `%command%`, behave as if no placeholder was specified.
 			Vector<String> exec_args = _split_cmdline_args(raw_custom_args.substr(0, placeholder_pos));
 			if (exec_args.size() > 0) {
-				exec = exec_args[0];
 				exec_args.remove_at(0);
 
 				// Append the Godot executable name before we append executable arguments

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1074,8 +1074,6 @@ void Polygon2DEditor::_canvas_draw() {
 
 	Ref<Texture2D> base_tex = node->get_texture();
 
-	String warning;
-
 	Transform2D mtx;
 	mtx.columns[2] = -draw_offset * draw_zoom;
 	mtx.scale_basis(Vector2(draw_zoom, draw_zoom));

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3244,8 +3244,6 @@ Node3DEditor::Node3DEditor() {
 	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
 	main_flow->add_child(main_menu_hbox);
 
-	String sct;
-
 	tool_button[TOOL_MODE_TRANSFORM] = memnew(Button);
 	main_menu_hbox->add_child(tool_button[TOOL_MODE_TRANSFORM]);
 	tool_button[TOOL_MODE_TRANSFORM]->set_toggle_mode(true);

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -498,8 +498,6 @@ void Skeleton3DEditor::_insert_keys(const bool p_all_bones) {
 	bool scl_enabled = key_scale_button->is_pressed();
 
 	int bone_len = skeleton->get_bone_count();
-	Node *root = EditorNode::get_singleton()->get_tree()->get_root();
-	String path = String(root->get_path_to(skeleton));
 
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
 	te->make_insert_queue();

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1005,7 +1005,6 @@ void ScriptTextEditor::_update_errors() {
 
 		errors_panel->push_indent(1);
 		errors_panel->push_table(2);
-		String filename = KV.key.get_file();
 		for (const ScriptLanguage::ScriptError &err : KV.value) {
 			Dictionary click_meta;
 			click_meta["path"] = KV.key;

--- a/editor/settings/editor_folding.cpp
+++ b/editor/settings/editor_folding.cpp
@@ -208,7 +208,6 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 
-	String path = EditorPaths::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
 

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -635,7 +635,6 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 		Dictionary meta_data = commit_list->get_selected()->get_metadata(0);
 		String commit_id = meta_data[SNAME("commit_id")];
 		String commit_subtitle = meta_data[SNAME("commit_subtitle")];
-		String commit_date = meta_data[SNAME("commit_date")];
 		String commit_author = meta_data[SNAME("commit_author")];
 		String commit_date_string = meta_data[SNAME("commit_date_string")];
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1118,8 +1118,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	bool quiet_stdout = false;
 	int separate_thread_render = -1; // Tri-state: -1 = not set, 0 = false, 1 = true.
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	String remotefs;
 	String remotefs_pass;
+#endif
 
 	Vector<String> breakpoints;
 	bool delta_smoothing_override = false;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2578,9 +2578,9 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			p_return->void_return = true;
 			const GDScriptParser::DataType &return_type = p_return->return_value->type_constraint;
 			if (is_call && !return_type.is_hard_type()) {
+#ifdef DEBUG_ENABLED
 				String function_name = parser->current_function->identifier ? parser->current_function->identifier->name.string() : String("<anonymous function>");
 				String called_function_name = static_cast<GDScriptParser::CallNode *>(p_return->return_value)->function_name.string();
-#ifdef DEBUG_ENABLED
 				parser->push_warning(p_return, GDScriptWarning::UNSAFE_VOID_RETURN, function_name, called_function_name);
 #endif // DEBUG_ENABLED
 				mark_node_unsafe(p_return);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -961,7 +961,6 @@ static ScriptLanguage::CodeCompletionOption _calculate_string_insertion(const GD
 }
 
 static void _get_directory_contents(const GDScriptParser::Node *p_current, EditorFileSystemDirectory *p_dir, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_list, const StringName &p_required_type = StringName()) {
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 	const bool requires_type = !p_required_type.is_empty();
 
 	for (int i = 0; i < p_dir->get_file_count(); i++) {
@@ -3007,8 +3006,6 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	Variant base = p_base.value;
 	GDScriptParser::DataType base_type = p_base.type;
 	const StringName &method = p_call->function_name;
-
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 
 	const GDScriptParser::Node *existing_argument = p_call->arguments.size() > p_argidx ? p_call->arguments[p_argidx] : nullptr;
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -136,7 +136,6 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 				bool exists = fs->file_exists(scr_path);
 
 				if (exists) {
-					String value = const_val;
 					LSP::DocumentLink link;
 					link.target = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(scr_path);
 					link.range = GodotRange(GodotPosition(token.start_line, token.start_column), GodotPosition(token.end_line, token.end_column)).to_lsp();

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -93,7 +93,6 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 	Dictionary dict = p_param;
 	LSP::TextDocumentIdentifier doc;
 	doc.load(dict["textDocument"]);
-	String text = dict["text"];
 
 	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
 	Ref<GDScript> scr = ResourceLoader::load(path);

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -157,7 +157,9 @@ private:
 #endif
 
 		String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+#ifdef MACOS_ENABLED
 		String res_dir = OS::get_singleton()->get_bundle_resource_dir();
+#endif
 
 #ifdef TOOLS_ENABLED
 		String data_dir_root = exe_dir.path_join("GodotSharp");

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -184,8 +184,6 @@ TEST_CASE("[RegEx] Uninitialized use") {
 }
 
 TEST_CASE("[RegEx] Empty pattern") {
-	const String s = "Godot";
-
 	RegEx re;
 	CHECK(re.compile("") == OK);
 	CHECK(re.is_valid());

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -7221,11 +7221,12 @@ VisualShaderEditor::VisualShaderEditor() {
 	const String input_param_for_texture_blit_shader_mode = TTR("'%s' input parameter for blit shader mode.") + translation_gdsl;
 	const String input_param_for_light_shader_mode = TTR("'%s' input parameter for light shader mode.") + translation_gdsl;
 	const String input_param_for_vertex_shader_mode = TTR("'%s' input parameter for vertex shader mode.") + translation_gdsl;
-	const String input_param_for_start_shader_mode = TTR("'%s' input parameter for start shader mode.") + translation_gdsl;
-	const String input_param_for_process_shader_mode = TTR("'%s' input parameter for process shader mode.") + translation_gdsl;
 	const String input_param_for_collide_shader_mode = TTR("'%s' input parameter for collide shader mode." + translation_gdsl);
-	const String input_param_for_start_and_process_shader_mode = TTR("'%s' input parameter for start and process shader modes.") + translation_gdsl;
-	const String input_param_for_process_and_collide_shader_mode = TTR("'%s' input parameter for process and collide shader modes.") + translation_gdsl;
+	// TODO: Check if we are missing registrations for these.
+	// const String input_param_for_start_shader_mode = TTR("'%s' input parameter for start shader mode.") + translation_gdsl;
+	// const String input_param_for_process_shader_mode = TTR("'%s' input parameter for process shader mode.") + translation_gdsl;
+	// const String input_param_for_start_and_process_shader_mode = TTR("'%s' input parameter for start and process shader modes.") + translation_gdsl;
+	// const String input_param_for_process_and_collide_shader_mode = TTR("'%s' input parameter for process and collide shader modes.") + translation_gdsl;
 	const String input_param_for_vertex_and_fragment_shader_mode = TTR("'%s' input parameter for vertex and fragment shader modes.") + translation_gdsl;
 
 	// NODE3D INPUTS

--- a/modules/visual_shader/visual_shader.cpp
+++ b/modules/visual_shader/visual_shader.cpp
@@ -5621,7 +5621,6 @@ bool VisualShaderNodeVaryingGetter::has_output_port_preview(int p_port) const {
 
 String VisualShaderNodeVaryingGetter::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String from = varying_name;
-	String from2;
 
 	if (varying_name == "[None]" || p_for_preview) {
 		switch (varying_type) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1322,14 +1322,14 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 				iofs += 28;
 
 				for (uint32_t i = 0; i < attrcount; i++) {
-					uint32_t attr_nspace = decode_uint32(&p_manifest[iofs]);
+					// uint32_t attr_nspace = decode_uint32(&p_manifest[iofs]);
 					uint32_t attr_name = decode_uint32(&p_manifest[iofs + 4]);
 					uint32_t attr_value = decode_uint32(&p_manifest[iofs + 8]);
-					uint32_t attr_resid = decode_uint32(&p_manifest[iofs + 16]);
+					// uint32_t attr_resid = decode_uint32(&p_manifest[iofs + 16]);
 
-					const String value = (attr_value != 0xFFFFFFFF) ? string_table[attr_value] : "Res #" + itos(attr_resid);
+					// const String value = (attr_value != 0xFFFFFFFF) ? string_table[attr_value] : "Res #" + itos(attr_resid);
 					String attrname = string_table[attr_name];
-					const String nspace = (attr_nspace != 0xFFFFFFFF) ? string_table[attr_nspace] : "";
+					// const String nspace = (attr_nspace != 0xFFFFFFFF) ? string_table[attr_nspace] : "";
 
 					//replace project information
 					if (tname == "manifest" && attrname == "package") {
@@ -2472,7 +2472,6 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	String output;
 
 	bool remove_prev = EDITOR_GET("export/android/one_click_deploy_clear_previous_install");
-	String version_name = p_preset->get_version("version/name");
 	String package_name = p_preset->get("package/unique_name");
 
 	if (remove_prev) {
@@ -4139,11 +4138,6 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	((void)0)
 
 	zipFile unaligned_apk = zipOpen2(tmp_unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);
-
-	String cmdline = p_preset->get("command_line/extra_args");
-
-	String version_name = p_preset->get_version("version/name");
-	String package_name = p_preset->get("package/unique_name");
 
 	Vector<ABI> invalid_abis(enabled_abis);
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -504,7 +504,6 @@ Vector<String> OS_LinuxBSD::lspci_device_filter(Vector<String> vendor_device_id_
 
 Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_id_mapping, String check_column, String blacklist) const {
 	// NOTE: blacklist can be changed to `Vector<String>`, if the need arises.
-	const String sep = ":";
 	Vector<String> values;
 	for (const String &mapping : vendor_device_id_mapping) {
 		String device;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3329,7 +3329,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 		// Editing.
 		bool bring_up_editor = allow_reselect ? (c.selected && already_selected) : c.selected;
-		String editor_text = c.text;
 
 		switch (c.mode) {
 			case TreeItem::CELL_MODE_STRING: {
@@ -3408,7 +3407,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 						bring_up_editor = false;
 
 					} else {
-						editor_text = String::num(p_item->cells[col].val, Math::range_step_decimals(p_item->cells[col].step));
 						if (select_mode == SELECT_MULTI && get_viewport()->get_processed_events_count() == focus_in_id) {
 							bring_up_editor = false;
 						}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1359,8 +1359,6 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			get_path()));
 
 	int idx = sname.get_slicec('/', 1).to_int();
-	String what = sname.get_slicec('/', 2);
-
 	if (idx == surfaces.size()) {
 		//create
 		Dictionary d = p_value;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4986,7 +4986,6 @@ PropertyInfo ShaderLanguage::uniform_to_property_info(const ShaderNode::Uniform 
 			} else if (p_uniform.hint == ShaderLanguage::ShaderNode::Uniform::HINT_ENUM) {
 				pi.type = Variant::INT;
 				pi.hint = PROPERTY_HINT_ENUM;
-				String hint_string;
 				pi.hint_string = String(",").join(p_uniform.hint_enum_names);
 			} else {
 				pi.type = Variant::INT;

--- a/tests/core/crypto/test_hashing_context.cpp
+++ b/tests/core/crypto/test_hashing_context.cpp
@@ -69,7 +69,6 @@ TEST_CASE("[HashingContext] Default - MD5/SHA1/SHA256") {
 
 TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
 	HashingContext ctx;
-	const String s = "xyz";
 
 	const PackedByteArray s_byte_parts[] = {
 		String("x").to_ascii_buffer(),

--- a/tests/core/io/test_image.cpp
+++ b/tests/core/io/test_image.cpp
@@ -80,7 +80,9 @@ TEST_CASE("[Image] Instantiation") {
 TEST_CASE("[Image] Saving and loading") {
 	Ref<Image> image = memnew(Image(4, 4, false, Image::FORMAT_RGBA8));
 	const String save_path_png = TestUtils::get_temp_path("image.png");
+#ifdef TOOLS_ENABLED
 	const String save_path_exr = TestUtils::get_temp_path("image.exr");
+#endif // TOOLS_ENABLED
 
 	// Save PNG
 	Error err;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Gcc and clang now complain about unused `String`s. Inspired by https://github.com/godotengine/godot/pull/121157 (keeping as draft till https://github.com/godotengine/godot/pull/121157 is merged)
