### PR TITLE
Make it impossible to have more than one main thread, and don't release unnecessarily

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -88,6 +88,20 @@ void Thread::wait_to_finish() {
 	id = UNASSIGNED_ID;
 }
 
+void Thread::make_main_thread() {
+	if (caller_id == MAIN_ID) {
+		return; // We're already the main thread
+	}
+	CRASH_COND_MSG(!is_main_thread_assigned.set_if_clear(), "A second thread attempted to become the main thread.");
+	caller_id = MAIN_ID;
+}
+
+void Thread::release_main_thread() {
+	CRASH_COND_MSG(caller_id != MAIN_ID, "Trying to release main thread from a thread that isn't main.");
+	CRASH_COND(!is_main_thread_assigned.clear_if_set());
+	caller_id = id_counter.increment();
+}
+
 Error Thread::set_name(const String &p_name) {
 	if (platform_functions.set_name) {
 		return platform_functions.set_name(p_name);

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -107,14 +107,12 @@ private:
 
 	ID id = UNASSIGNED_ID;
 
+	static inline SafeFlag is_main_thread_assigned{ false };
 	static SafeNumeric<uint64_t> id_counter;
 	static thread_local ID caller_id;
 	THREADING_NAMESPACE::thread thread;
 
 	static void callback(ID p_caller_id, const Settings &p_settings, Thread::Callback p_callback, void *p_userdata);
-
-	static void make_main_thread() { caller_id = MAIN_ID; }
-	static void release_main_thread() { caller_id = id_counter.increment(); }
 
 public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
@@ -130,6 +128,8 @@ public:
 	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }
 
 	_FORCE_INLINE_ static bool is_main_thread() { return caller_id == MAIN_ID; } // Gain a tiny bit of perf here because there is no need to validate caller_id here, because only main thread will be set as 1.
+	static void make_main_thread();
+	static void release_main_thread();
 
 	static Error set_name(const String &p_name);
 
@@ -182,9 +182,6 @@ private:
 
 	static PlatformFunctions platform_functions;
 
-	static void make_main_thread() {}
-	static void release_main_thread() {}
-
 public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
 
@@ -193,6 +190,8 @@ public:
 	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }
 
 	_FORCE_INLINE_ static bool is_main_thread() { return true; }
+	static void make_main_thread() {}
+	static void release_main_thread() {}
 
 	static Error set_name(const String &p_name) { return ERR_UNAVAILABLE; }
 

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -164,8 +164,16 @@ public:
 		flag.store(true, std::memory_order_release);
 	}
 
+	_ALWAYS_INLINE_ bool set_if_clear() {
+		return !flag.exchange(true, std::memory_order_acq_rel);
+	}
+
 	_ALWAYS_INLINE_ void clear() {
 		flag.store(false, std::memory_order_release);
+	}
+
+	_ALWAYS_INLINE_ bool clear_if_set() {
+		return flag.exchange(false, std::memory_order_acq_rel);
 	}
 
 	_ALWAYS_INLINE_ void set_to(bool p_value) {

--- a/drivers/apple/thread_apple.cpp
+++ b/drivers/apple/thread_apple.cpp
@@ -62,6 +62,20 @@ void *Thread::thread_callback(void *p_data) {
 	return nullptr;
 }
 
+void Thread::make_main_thread() {
+	if (caller_id == MAIN_ID) {
+		return; // We're already the main thread
+	}
+	CRASH_COND_MSG(!is_main_thread_assigned.set_if_clear(), "A second thread attempted to become the main thread.");
+	caller_id = MAIN_ID;
+}
+
+void Thread::release_main_thread() {
+	CRASH_COND_MSG(caller_id != MAIN_ID, "Trying to release main thread from a thread that isn't main.");
+	CRASH_COND(!is_main_thread_assigned.clear_if_set());
+	caller_id = id_counter.increment();
+}
+
 Error Thread::set_name(const String &p_name) {
 	int err = pthread_setname_np(p_name.utf8().get_data());
 	return err == 0 ? OK : ERR_INVALID_PARAMETER;

--- a/drivers/apple/thread_apple.h
+++ b/drivers/apple/thread_apple.h
@@ -76,13 +76,11 @@ private:
 	ID id = UNASSIGNED_ID;
 	pthread_t pthread;
 
+	static inline SafeFlag is_main_thread_assigned{ false };
 	static SafeNumeric<uint64_t> id_counter;
 	static thread_local ID caller_id;
 
 	static void *thread_callback(void *p_data);
-
-	static void make_main_thread() { caller_id = MAIN_ID; }
-	static void release_main_thread() { caller_id = id_counter.increment(); }
 
 public:
 	_FORCE_INLINE_ static void yield() { pthread_yield_np(); }
@@ -96,6 +94,8 @@ public:
 	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }
 
 	_FORCE_INLINE_ static bool is_main_thread() { return caller_id == MAIN_ID; }
+	static void make_main_thread();
+	static void release_main_thread();
 
 	static Error set_name(const String &p_name);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2924,9 +2924,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	message_queue = memnew(MessageQueue);
 
-	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
-	set_current_thread_safe_for_nodes(false);
-
 #if defined(STEAMAPI_ENABLED)
 	if (editor || project_manager) {
 		steam_tracker = memnew(SteamTracker);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -745,6 +745,7 @@ void Main::test_cleanup() {}
 // are initialized here. This also combines `Main::setup2()` initialization.
 Error Main::test_setup() {
 	Thread::make_main_thread();
+
 	set_current_thread_safe_for_nodes(true);
 
 	OS::get_singleton()->initialize();
@@ -884,6 +885,8 @@ Error Main::test_setup() {
 void Main::test_cleanup() {
 	ERR_FAIL_COND(!_start_success);
 
+	Thread::make_main_thread();
+
 	// Printing in the usual way can become problematic during/after cleanup.
 	CoreGlobals::print_ready = false;
 
@@ -971,6 +974,8 @@ void Main::test_cleanup() {
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();
+
+	Thread::release_main_thread();
 }
 #endif // TESTS_ENABLED
 
@@ -3003,6 +3008,8 @@ error:
 
 	OS::get_singleton()->finalize_core();
 	locale = String();
+
+	Thread::release_main_thread();
 
 	return exit_err;
 }
@@ -5210,6 +5217,8 @@ void Main::force_redraw() {
  * The order matters as some of those steps are linked with each other.
  */
 void Main::cleanup(bool p_force) {
+	Thread::make_main_thread();
+
 	GodotProfileZone("cleanup");
 	OS::get_singleton()->benchmark_begin_measure("Shutdown", "Main::Cleanup");
 	if (!p_force) {
@@ -5395,4 +5404,6 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();
+
+	Thread::release_main_thread();
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -50,6 +50,8 @@
 #include "core/input/input.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
+#include "core/os/thread.h"
+#include "core/os/thread_safe.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/camera/camera_server.h"
@@ -229,6 +231,9 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env
 	if (err != OK) {
 		return false;
 	}
+
+	Thread::release_main_thread(); // setup2 will be called from another thread.
+	set_current_thread_safe_for_nodes(false);
 
 	TTS_Android::setup(p_godot_tts);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Should close https://github.com/godotengine/godot/issues/121083, but not yet tested

Two problems:
- There was previously no protection from multiple threads becoming the "main thread". If this had ever happened, hard to trace problems would ensue.
- The main-thread-ness was previously dropped on all platforms, although only Android actually switches. This leads to unnecessary complications in other setup configurations.

## Additional information

Awkward main-thread grabs now crash reliably instead of spuriously.
The main thread now stays main thread (in between `setup` and `setup2`) on all platforms that don't switch.
Main-thread-ness is now released after teardown.

#### Alternatives

https://github.com/godotengine/godot/issues/121083 could have been fixed in a variety of other ways:

- `GDType` could stop checking for main-thread-ness. I'd really like to avoid this since we're still churning `GDType` pretty hard, and a predictable setup + teardown without multi threading complexity is critical. `GDType` might later drop this, but only in exchange for other safety guards:
    - [PR #117443](https://github.com/godotengine/godot/pull/117443) could be used, but it would only tighten the vulnerable window, not erase it.
    - `GDType` could use mutexes (only during setup) instead. This might be worth doing anyway, but it would add complexity I'd rather discuss than add now.
- We could have tried to track down who creates the `GDType` between `setup` and `setup2`, but we've not quite established that this is illegal in the first place.

Practically, I think the fix presented here is a useful safety improvement for the lifecycle anyway, making it more predictable, so that's why I opted for it.