### PR TITLE
Add plugin selection, reload functionality, and custom status UI to plugin settings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -455,6 +455,8 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 			}
 
 			undo_redo->commit_action();
+		} else if (ED_IS_SHORTCUT("editor/reload_plugins", p_event)) {
+			reload_addon_plugins();
 		} else {
 			is_handled = false;
 		}
@@ -4583,6 +4585,48 @@ bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 	return addon_name_to_plugin.has("res://addons/" + p_addon + "/plugin.cfg");
 }
 
+void EditorNode::set_addon_plugin_selected(const String &p_addon, bool p_selected) {
+	if (p_selected) {
+		selected_addons.push_back(p_addon);
+	} else {
+		selected_addons.erase(p_addon);
+	}
+}
+
+bool EditorNode::is_addon_plugin_selected(const String &p_addon) const {
+	return selected_addons.has(p_addon);
+}
+
+bool EditorNode::has_addon_plugin_selection() const {
+	return !selected_addons.is_empty();
+}
+
+void EditorNode::reload_addon_plugins() {
+	if (!has_addon_plugin_selection()) {
+		return;
+	}
+
+	for (const String &addon : selected_addons) {
+		String addon_path = addon;
+		if (!addon_path.begins_with("res://")) {
+			addon_path = "res://addons/" + addon + "/plugin.cfg";
+		}
+		if (is_addon_plugin_enabled(addon_path)) {
+			EditorPlugin *plugin = addon_name_to_plugin.get(addon_path);
+			if (plugin) {
+				plugin->disable_plugin();
+			}
+			set_addon_plugin_enabled(addon_path, false);
+		}
+		set_addon_plugin_enabled(addon_path, true);
+		if (addon_name_to_plugin.has(addon_path)) {
+			addon_name_to_plugin[addon_path]->enable_plugin();
+		}
+	}
+	EditorToaster::get_singleton()->popup_str(TTR("Plugins reloaded."));
+	emit_signal(SNAME("addon_plugins_reloaded"));
+}
+
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
 	// When scene gets closed no node is edited anymore, so make sure the editors are notified before nodes are freed.
 	hide_unused_editors(SceneTreeDock::get_singleton());
@@ -7941,6 +7985,7 @@ void EditorNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("preview_locale_changed"));
 	ADD_SIGNAL(MethodInfo("resource_counter_changed"));
 	ADD_SIGNAL(MethodInfo("distraction_free_mode_changed", PropertyInfo(Variant::BOOL, "enabled")));
+	ADD_SIGNAL(MethodInfo("addon_plugins_reloaded"));
 }
 
 static Node *_resource_get_edited_scene() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -284,6 +284,7 @@ private:
 	bool _initializing_plugins = false;
 	HashMap<String, EditorPlugin *> addon_name_to_plugin;
 	LocalVector<String> pending_addons;
+	LocalVector<String> selected_addons;
 	HashMap<ObjectID, HashSet<EditorPlugin *>> active_plugins;
 	bool is_main_screen_editing = false;
 
@@ -817,6 +818,12 @@ public:
 
 	void set_addon_plugin_enabled(const String &p_addon, bool p_enabled, bool p_config_changed = false);
 	bool is_addon_plugin_enabled(const String &p_addon) const;
+
+	void set_addon_plugin_selected(const String &p_addon, bool p_selected);
+	bool is_addon_plugin_selected(const String &p_addon) const;
+	bool has_addon_plugin_selection() const;
+
+	void reload_addon_plugins();
 
 	void edit_node(Node *p_node);
 	void edit_resource(const Ref<Resource> &p_resource);

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -38,6 +38,7 @@
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
@@ -50,6 +51,7 @@ void EditorPluginSettings::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
+			EditorNode::get_singleton()->connect("addon_plugins_reloaded", callable_mp(this, &EditorPluginSettings::update_plugins));
 			plugin_config_dialog->connect("plugin_ready", callable_mp(EditorNode::get_singleton(), &EditorNode::_on_plugin_ready));
 			plugin_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 		} break;
@@ -64,6 +66,7 @@ void EditorPluginSettings::_notification(int p_what) {
 			if (Engine::get_singleton()->is_recovery_mode_hint()) {
 				recovery_mode_icon->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
 			}
+			update_plugins();
 		} break;
 	}
 }
@@ -102,8 +105,11 @@ void EditorPluginSettings::update_plugins() {
 				String description = cfg->get_value("plugin", "description");
 				String scr = cfg->get_value("plugin", "script");
 
+				bool is_selected = EditorNode::get_singleton()->is_addon_plugin_selected(path);
 				bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(path);
 				Color disabled_color = get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
+				Color status_enabled_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
+				Color status_disabled_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
 
 				const PackedInt32Array boundaries = TS->string_get_word_breaks(description, "", 80);
 				String wrapped_description;
@@ -122,22 +128,37 @@ void EditorPluginSettings::update_plugins() {
 				}
 				item->set_tooltip_text(COLUMN_NAME, vformat(TTR("Name: %s\nPath: %s\nMain Script: %s\n\n%s"), name, path, scr, wrapped_description));
 				item->set_metadata(COLUMN_NAME, path);
+
 				item->set_text(COLUMN_VERSION, version);
 				item->set_auto_translate_mode(COLUMN_VERSION, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_custom_font(COLUMN_VERSION, get_theme_font("source", EditorStringName(EditorFonts)));
+				item->set_text_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_CENTER);
 				item->set_metadata(COLUMN_VERSION, scr);
+
 				item->set_text(COLUMN_AUTHOR, author);
 				item->set_auto_translate_mode(COLUMN_AUTHOR, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_metadata(COLUMN_AUTHOR, description);
-				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CHECK);
-				item->set_text(COLUMN_STATUS, TTRC("On"));
-				item->set_checked(COLUMN_STATUS, is_enabled);
+
+				item->set_cell_mode(COLUMN_SELECT, TreeItem::CELL_MODE_CHECK);
+				item->set_checked(COLUMN_SELECT, is_selected);
+				item->set_metadata(COLUMN_SELECT, path);
+				item->set_editable(COLUMN_SELECT, true);
+
+				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CUSTOM);
+				item->set_downarrow(COLUMN_STATUS, false);
+				item->set_text(COLUMN_STATUS, is_enabled ? TTR("Enabled") : TTR("Disabled"));
+				item->set_text_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_CENTER);
+				item->set_custom_color(COLUMN_STATUS, is_enabled ? status_enabled_color : status_disabled_color);
+				item->set_custom_as_button(COLUMN_STATUS, true);
+				item->set_metadata(COLUMN_STATUS, is_enabled);
 				item->set_editable(COLUMN_STATUS, true);
+
 				item->add_button(COLUMN_EDIT, get_editor_theme_icon(SNAME("Edit")), BUTTON_PLUGIN_EDIT, false, TTRC("Edit Plugin"));
 			}
 		}
 	}
 
+	reload_plugin_button->set_disabled(!EditorNode::get_singleton()->has_addon_plugin_selection());
 	updating = false;
 }
 
@@ -148,23 +169,48 @@ void EditorPluginSettings::_plugin_activity_changed() {
 
 	TreeItem *ti = plugin_list->get_edited();
 	ERR_FAIL_NULL(ti);
-	bool checked = ti->is_checked(COLUMN_STATUS);
-	String name = ti->get_metadata(COLUMN_NAME);
+	int edited_column = plugin_list->get_selected_column();
 
-	EditorNode::get_singleton()->set_addon_plugin_enabled(name, checked, true);
+	if (edited_column == COLUMN_STATUS) {
+		bool enabled = ti->get_metadata(COLUMN_STATUS);
+		String name = ti->get_metadata(COLUMN_NAME);
 
-	bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(name);
+		EditorNode::get_singleton()->set_addon_plugin_enabled(name, !enabled, true);
 
-	if (is_enabled != checked) {
+		bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(name);
+
+		if (is_enabled != enabled) {
+			updating = true;
+			Color status_enabled_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
+			Color status_disabled_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			ti->set_text(COLUMN_STATUS, is_enabled ? TTR("Enabled") : TTR("Disabled"));
+			ti->set_custom_color(COLUMN_STATUS, is_enabled ? status_enabled_color : status_disabled_color);
+			ti->set_metadata(COLUMN_STATUS, is_enabled);
+			updating = false;
+		}
+		if (is_enabled) {
+			ti->clear_custom_color(COLUMN_NAME);
+		} else {
+			ti->set_custom_color(COLUMN_NAME, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+		}
+	} else if (edited_column == COLUMN_SELECT) {
 		updating = true;
-		ti->set_checked(COLUMN_STATUS, is_enabled);
+		bool selected = ti->is_checked(COLUMN_SELECT);
+		String path = ti->get_metadata(COLUMN_SELECT);
+		EditorNode::get_singleton()->set_addon_plugin_selected(path, selected);
+		reload_plugin_button->set_disabled(!EditorNode::get_singleton()->has_addon_plugin_selection());
 		updating = false;
 	}
-	if (is_enabled) {
-		ti->clear_custom_color(COLUMN_NAME);
-	} else {
-		ti->set_custom_color(COLUMN_NAME, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+}
+
+void EditorPluginSettings::_reload_plugins() {
+	if (updating) {
+		return;
 	}
+
+	updating = true;
+	EditorNode::get_singleton()->reload_addon_plugins();
+	updating = false;
 }
 
 void EditorPluginSettings::_create_clicked() {
@@ -245,6 +291,14 @@ EditorPluginSettings::EditorPluginSettings() {
 	label->set_theme_type_variation("HeaderSmall");
 	title_hb->add_child(label);
 	title_hb->add_spacer();
+
+	reload_plugin_button = memnew(Button(TTRC("Reload Plugins")));
+	reload_plugin_button->set_tooltip_text(TTRC("Reloads the selected plugins."));
+	reload_plugin_button->set_shortcut(ED_SHORTCUT("editor/reload_plugins", TTRC("Reload Selected Plugins"), KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::R));
+	reload_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPluginSettings::_reload_plugins));
+	reload_plugin_button->set_disabled(true);
+	title_hb->add_child(reload_plugin_button);
+
 	Button *create_plugin_button = memnew(Button(TTRC("Create New Plugin")));
 	create_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin_button);
@@ -253,33 +307,40 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list = memnew(Tree);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	plugin_list->set_theme_type_variation("TreeTable");
+
 	plugin_list->set_hide_folding(true);
 	plugin_list->set_columns(COLUMN_MAX);
 	plugin_list->set_column_titles_visible(true);
-	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Enabled"));
+
+	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Status"));
 	plugin_list->set_column_title(COLUMN_NAME, TTRC("Name"));
 	plugin_list->set_column_title(COLUMN_VERSION, TTRC("Version"));
 	plugin_list->set_column_title(COLUMN_AUTHOR, TTRC("Author"));
 	plugin_list->set_column_title(COLUMN_EDIT, TTRC("Edit"));
-	plugin_list->set_column_title_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_LEFT);
+
 	plugin_list->set_column_title_alignment(COLUMN_NAME, HORIZONTAL_ALIGNMENT_LEFT);
-	plugin_list->set_column_title_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_AUTHOR, HORIZONTAL_ALIGNMENT_LEFT);
-	plugin_list->set_column_title_alignment(COLUMN_EDIT, HORIZONTAL_ALIGNMENT_LEFT);
+
+	plugin_list->set_column_expand(COLUMN_SELECT, false);
 	plugin_list->set_column_expand(COLUMN_STATUS, false);
 	plugin_list->set_column_expand(COLUMN_NAME, true);
 	plugin_list->set_column_expand(COLUMN_VERSION, false);
 	plugin_list->set_column_expand(COLUMN_AUTHOR, false);
 	plugin_list->set_column_expand(COLUMN_EDIT, false);
+
+	plugin_list->set_column_clip_content(COLUMN_SELECT, true);
 	plugin_list->set_column_clip_content(COLUMN_STATUS, true);
 	plugin_list->set_column_clip_content(COLUMN_NAME, true);
 	plugin_list->set_column_clip_content(COLUMN_VERSION, true);
 	plugin_list->set_column_clip_content(COLUMN_AUTHOR, true);
 	plugin_list->set_column_clip_content(COLUMN_EDIT, true);
-	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 80 * EDSCALE);
+
+	plugin_list->set_column_custom_minimum_width(COLUMN_SELECT, 40 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_VERSION, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_AUTHOR, 250 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_EDIT, 40 * EDSCALE);
+
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed), CONNECT_DEFERRED);
 

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -38,6 +38,7 @@
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
@@ -50,6 +51,7 @@ void EditorPluginSettings::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
+			EditorNode::get_singleton()->connect("addon_plugins_reloaded", callable_mp(this, &EditorPluginSettings::update_plugins));
 			plugin_config_dialog->connect("plugin_ready", callable_mp(EditorNode::get_singleton(), &EditorNode::_on_plugin_ready));
 			plugin_list->connect("button_clicked", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 		} break;
@@ -64,6 +66,7 @@ void EditorPluginSettings::_notification(int p_what) {
 			if (Engine::get_singleton()->is_recovery_mode_hint()) {
 				recovery_mode_icon->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
 			}
+			update_plugins();
 		} break;
 	}
 }
@@ -102,8 +105,11 @@ void EditorPluginSettings::update_plugins() {
 				String description = cfg->get_value("plugin", "description");
 				String scr = cfg->get_value("plugin", "script");
 
+				bool is_selected = EditorNode::get_singleton()->is_addon_plugin_selected(path);
 				bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(path);
 				Color disabled_color = get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
+				Color status_enabled_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
+				Color status_disabled_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
 
 				const PackedInt32Array boundaries = TS->string_get_word_breaks(description, "", 80);
 				String wrapped_description;
@@ -122,23 +128,56 @@ void EditorPluginSettings::update_plugins() {
 				}
 				item->set_tooltip_text(COLUMN_NAME, vformat(TTR("Name: %s\nPath: %s\nMain Script: %s\n\n%s"), name, path, scr, wrapped_description));
 				item->set_metadata(COLUMN_NAME, path);
+
 				item->set_text(COLUMN_VERSION, version);
 				item->set_auto_translate_mode(COLUMN_VERSION, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_custom_font(COLUMN_VERSION, get_theme_font("source", EditorStringName(EditorFonts)));
+				item->set_text_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_CENTER);
 				item->set_metadata(COLUMN_VERSION, scr);
+
 				item->set_text(COLUMN_AUTHOR, author);
 				item->set_auto_translate_mode(COLUMN_AUTHOR, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_metadata(COLUMN_AUTHOR, description);
-				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CHECK);
-				item->set_text(COLUMN_STATUS, TTRC("On"));
-				item->set_checked(COLUMN_STATUS, is_enabled);
+
+				item->set_cell_mode(COLUMN_SELECT, TreeItem::CELL_MODE_CHECK);
+				item->set_checked(COLUMN_SELECT, is_selected);
+				item->set_metadata(COLUMN_SELECT, path);
+				item->set_editable(COLUMN_SELECT, true);
+				_update_plugin_tooltip(item, COLUMN_SELECT, is_selected);
+
+				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CUSTOM);
+				item->set_downarrow(COLUMN_STATUS, false);
+				item->set_text(COLUMN_STATUS, is_enabled ? TTR("Enabled") : TTR("Disabled"));
+				item->set_text_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_CENTER);
+				item->set_custom_color(COLUMN_STATUS, is_enabled ? status_enabled_color : status_disabled_color);
+				item->set_custom_as_button(COLUMN_STATUS, true);
+				item->set_metadata(COLUMN_STATUS, is_enabled);
 				item->set_editable(COLUMN_STATUS, true);
+				_update_plugin_tooltip(item, COLUMN_STATUS, is_enabled);
+
 				item->add_button(COLUMN_EDIT, get_editor_theme_icon(SNAME("Edit")), BUTTON_PLUGIN_EDIT, false, TTRC("Edit Plugin"));
 			}
 		}
 	}
 
+	reload_plugin_button->set_disabled(!EditorNode::get_singleton()->has_addon_plugin_selection());
 	updating = false;
+}
+
+void EditorPluginSettings::_update_plugin_tooltip(TreeItem *p_item, int p_column, bool p_state) {
+	if (p_column == COLUMN_STATUS) {
+		if (p_state) {
+			p_item->set_tooltip_text(COLUMN_STATUS, TTR("This plugin is enabled.\nClick to disable this plugin."));
+		} else {
+			p_item->set_tooltip_text(COLUMN_STATUS, TTR("This plugin is disabled.\nClick to enable this plugin."));
+		}
+	} else if (p_column == COLUMN_SELECT) {
+		if (p_state) {
+			p_item->set_tooltip_text(COLUMN_SELECT, TTR("This plugin is selected.\nSelected plugins will be reloaded when the \"Reload Plugins\" button is pressed.\nClick the checkbox to deselect this plugin."));
+		} else {
+			p_item->set_tooltip_text(COLUMN_SELECT, TTR("This plugin is not selected.\nSelected plugins will be reloaded when the \"Reload Plugins\" button is pressed.\nClick the checkbox to select this plugin."));
+		}
+	}
 }
 
 void EditorPluginSettings::_plugin_activity_changed() {
@@ -148,23 +187,50 @@ void EditorPluginSettings::_plugin_activity_changed() {
 
 	TreeItem *ti = plugin_list->get_edited();
 	ERR_FAIL_NULL(ti);
-	bool checked = ti->is_checked(COLUMN_STATUS);
-	String name = ti->get_metadata(COLUMN_NAME);
+	int edited_column = plugin_list->get_selected_column();
 
-	EditorNode::get_singleton()->set_addon_plugin_enabled(name, checked, true);
+	if (edited_column == COLUMN_STATUS) {
+		bool enabled = ti->get_metadata(COLUMN_STATUS);
+		String name = ti->get_metadata(COLUMN_NAME);
 
-	bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(name);
+		EditorNode::get_singleton()->set_addon_plugin_enabled(name, !enabled, true);
 
-	if (is_enabled != checked) {
+		bool is_enabled = EditorNode::get_singleton()->is_addon_plugin_enabled(name);
+
+		if (is_enabled != enabled) {
+			updating = true;
+			Color status_enabled_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
+			Color status_disabled_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			ti->set_text(COLUMN_STATUS, is_enabled ? TTR("Enabled") : TTR("Disabled"));
+			ti->set_custom_color(COLUMN_STATUS, is_enabled ? status_enabled_color : status_disabled_color);
+			ti->set_metadata(COLUMN_STATUS, is_enabled);
+			_update_plugin_tooltip(ti, COLUMN_STATUS, is_enabled);
+			updating = false;
+		}
+		if (is_enabled) {
+			ti->clear_custom_color(COLUMN_NAME);
+		} else {
+			ti->set_custom_color(COLUMN_NAME, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+		}
+	} else if (edited_column == COLUMN_SELECT) {
 		updating = true;
-		ti->set_checked(COLUMN_STATUS, is_enabled);
+		bool selected = ti->is_checked(COLUMN_SELECT);
+		String path = ti->get_metadata(COLUMN_SELECT);
+		EditorNode::get_singleton()->set_addon_plugin_selected(path, selected);
+		reload_plugin_button->set_disabled(!EditorNode::get_singleton()->has_addon_plugin_selection());
+		_update_plugin_tooltip(ti, COLUMN_SELECT, selected);
 		updating = false;
 	}
-	if (is_enabled) {
-		ti->clear_custom_color(COLUMN_NAME);
-	} else {
-		ti->set_custom_color(COLUMN_NAME, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+}
+
+void EditorPluginSettings::_reload_plugins() {
+	if (updating) {
+		return;
 	}
+
+	updating = true;
+	EditorNode::get_singleton()->reload_addon_plugins();
+	updating = false;
 }
 
 void EditorPluginSettings::_create_clicked() {
@@ -245,6 +311,14 @@ EditorPluginSettings::EditorPluginSettings() {
 	label->set_theme_type_variation("HeaderSmall");
 	title_hb->add_child(label);
 	title_hb->add_spacer();
+
+	reload_plugin_button = memnew(Button(TTRC("Reload Plugins")));
+	reload_plugin_button->set_tooltip_text(TTRC("Reloads the selected plugins."));
+	reload_plugin_button->set_shortcut(ED_SHORTCUT("editor/reload_plugins", TTRC("Reload Selected Plugins"), KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::R));
+	reload_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPluginSettings::_reload_plugins));
+	reload_plugin_button->set_disabled(true);
+	title_hb->add_child(reload_plugin_button);
+
 	Button *create_plugin_button = memnew(Button(TTRC("Create New Plugin")));
 	create_plugin_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin_button);
@@ -253,33 +327,40 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list = memnew(Tree);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	plugin_list->set_theme_type_variation("TreeTable");
+
 	plugin_list->set_hide_folding(true);
 	plugin_list->set_columns(COLUMN_MAX);
 	plugin_list->set_column_titles_visible(true);
-	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Enabled"));
+
+	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Status"));
 	plugin_list->set_column_title(COLUMN_NAME, TTRC("Name"));
 	plugin_list->set_column_title(COLUMN_VERSION, TTRC("Version"));
 	plugin_list->set_column_title(COLUMN_AUTHOR, TTRC("Author"));
 	plugin_list->set_column_title(COLUMN_EDIT, TTRC("Edit"));
-	plugin_list->set_column_title_alignment(COLUMN_STATUS, HORIZONTAL_ALIGNMENT_LEFT);
+
 	plugin_list->set_column_title_alignment(COLUMN_NAME, HORIZONTAL_ALIGNMENT_LEFT);
-	plugin_list->set_column_title_alignment(COLUMN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
 	plugin_list->set_column_title_alignment(COLUMN_AUTHOR, HORIZONTAL_ALIGNMENT_LEFT);
-	plugin_list->set_column_title_alignment(COLUMN_EDIT, HORIZONTAL_ALIGNMENT_LEFT);
+
+	plugin_list->set_column_expand(COLUMN_SELECT, false);
 	plugin_list->set_column_expand(COLUMN_STATUS, false);
 	plugin_list->set_column_expand(COLUMN_NAME, true);
 	plugin_list->set_column_expand(COLUMN_VERSION, false);
 	plugin_list->set_column_expand(COLUMN_AUTHOR, false);
 	plugin_list->set_column_expand(COLUMN_EDIT, false);
+
+	plugin_list->set_column_clip_content(COLUMN_SELECT, true);
 	plugin_list->set_column_clip_content(COLUMN_STATUS, true);
 	plugin_list->set_column_clip_content(COLUMN_NAME, true);
 	plugin_list->set_column_clip_content(COLUMN_VERSION, true);
 	plugin_list->set_column_clip_content(COLUMN_AUTHOR, true);
 	plugin_list->set_column_clip_content(COLUMN_EDIT, true);
-	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 80 * EDSCALE);
+
+	plugin_list->set_column_custom_minimum_width(COLUMN_SELECT, 40 * EDSCALE);
+	plugin_list->set_column_custom_minimum_width(COLUMN_STATUS, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_VERSION, 100 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_AUTHOR, 250 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(COLUMN_EDIT, 40 * EDSCALE);
+
 	plugin_list->set_hide_root(true);
 	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed), CONNECT_DEFERRED);
 

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -43,6 +43,7 @@ class EditorPluginSettings : public VBoxContainer {
 	};
 
 	enum {
+		COLUMN_SELECT,
 		COLUMN_STATUS,
 		COLUMN_NAME,
 		COLUMN_VERSION,
@@ -54,9 +55,11 @@ class EditorPluginSettings : public VBoxContainer {
 	PluginConfigDialog *plugin_config_dialog = nullptr;
 	TextureRect *recovery_mode_icon = nullptr;
 	Tree *plugin_list = nullptr;
+	Button *reload_plugin_button = nullptr;
 	bool updating = false;
 
 	void _plugin_activity_changed();
+	void _reload_plugins();
 	void _create_clicked();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 

--- a/editor/plugins/editor_plugin_settings.h
+++ b/editor/plugins/editor_plugin_settings.h
@@ -34,6 +34,7 @@
 
 class TextureRect;
 class Tree;
+class TreeItem;
 
 class EditorPluginSettings : public VBoxContainer {
 	GDCLASS(EditorPluginSettings, VBoxContainer);
@@ -43,6 +44,7 @@ class EditorPluginSettings : public VBoxContainer {
 	};
 
 	enum {
+		COLUMN_SELECT,
 		COLUMN_STATUS,
 		COLUMN_NAME,
 		COLUMN_VERSION,
@@ -54,9 +56,12 @@ class EditorPluginSettings : public VBoxContainer {
 	PluginConfigDialog *plugin_config_dialog = nullptr;
 	TextureRect *recovery_mode_icon = nullptr;
 	Tree *plugin_list = nullptr;
+	Button *reload_plugin_button = nullptr;
 	bool updating = false;
 
+	void _update_plugin_tooltip(TreeItem *p_item, int p_column, bool p_state);
 	void _plugin_activity_changed();
+	void _reload_plugins();
 	void _create_clicked();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1684,6 +1684,17 @@ bool TreeItem::is_custom_set_as_button(int p_column) const {
 	return cells[p_column].custom_button;
 }
 
+void TreeItem::set_downarrow(int p_column, bool p_enabled) {
+	ERR_FAIL_INDEX(p_column, cells.size());
+	cells.write[p_column].downarrow = p_enabled;
+	_changed_notify(p_column);
+}
+
+bool TreeItem::has_downarrow(int p_column) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), true);
+	return cells[p_column].downarrow;
+}
+
 void TreeItem::set_text_alignment(int p_column, HorizontalAlignment p_alignment) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
@@ -2700,33 +2711,37 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						break;
 					}
 
-					Ref<Texture2D> downarrow = theme_cache.select_arrow;
+					if (p_item->cells[i].downarrow) {
+						Ref<Texture2D> downarrow = theme_cache.select_arrow;
 
-					Rect2i ir = item_rect;
+						Rect2i ir = item_rect;
 
-					Point2i arrow_pos = item_rect.position;
-					arrow_pos.x += item_rect.size.x - downarrow->get_width();
-					arrow_pos.y += Math::floor(((item_rect.size.y - downarrow->get_height())) / 2.0);
-					ir.size.width -= downarrow->get_width();
+						Point2i arrow_pos = item_rect.position;
+						arrow_pos.x += item_rect.size.x - downarrow->get_width();
+						arrow_pos.y += Math::floor(((item_rect.size.y - downarrow->get_height())) / 2.0);
+						ir.size.width -= downarrow->get_width();
 
-					if (p_item->cells[i].custom_button) {
-						if (cache.hover_item == p_item && cache.hover_column == i) {
-							if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-								theme_cache.custom_button_pressed->draw(ci, ir);
+						if (p_item->cells[i].custom_button) {
+							if (cache.hover_item == p_item && cache.hover_column == i) {
+								if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
+									theme_cache.custom_button_pressed->draw(ci, ir);
+								} else {
+									theme_cache.custom_button_hover->draw(ci, ir);
+									cell_color = theme_cache.custom_button_font_highlight;
+								}
 							} else {
-								theme_cache.custom_button_hover->draw(ci, ir);
-								cell_color = theme_cache.custom_button_font_highlight;
+								theme_cache.custom_button->draw(ci, ir);
 							}
-						} else {
-							theme_cache.custom_button->draw(ci, ir);
+							ir.size -= theme_cache.custom_button->get_minimum_size();
+							ir.position += theme_cache.custom_button->get_offset();
 						}
-						ir.size -= theme_cache.custom_button->get_minimum_size();
-						ir.position += theme_cache.custom_button->get_offset();
+
+						draw_item_rect(p_item->cells[i], ir, cell_color, icon_col, outline_size, font_outline_color, ci);
+
+						downarrow->draw(ci, arrow_pos);
+					} else {
+						draw_item_rect(p_item->cells[i], item_rect, cell_color, icon_col, outline_size, font_outline_color, ci);
 					}
-
-					draw_item_rect(p_item->cells[i], ir, cell_color, icon_col, outline_size, font_outline_color, ci);
-
-					downarrow->draw(ci, arrow_pos);
 
 				} break;
 			}

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -99,6 +99,7 @@ private:
 		Color bg_color;
 		bool custom_button = false;
 		bool expand_right = false;
+		bool downarrow = true;
 		Color icon_color = Color(1, 1, 1);
 		Ref<StyleBox> custom_stylebox;
 
@@ -405,6 +406,9 @@ public:
 
 	void set_custom_as_button(int p_column, bool p_button);
 	bool is_custom_set_as_button(int p_column) const;
+
+	void set_downarrow(int p_column, bool p_enabled);
+	bool has_downarrow(int p_column) const;
 
 	void set_tooltip_text(int p_column, const String &p_tooltip);
 	String get_tooltip_text(int p_column) const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Alternative to https://github.com/godotengine/godot/pull/112086
- Closes https://github.com/godotengine/godot-proposals/issues/13308

## Additional information
This PR changes the status column title to `status` and removes the checkboxes; instead, it now relies on a button that resembles the real state, green and `Enabled` text when the addon is enabled, and red and `Disabled` text when the addon is disabled. Clicking on the button changes the status
A `downarrow` flag was added to `TreeItem` to be able to remove the `downarrow` icon when using a custom button. Methods:
```c++
void set_downarrow(int p_column, bool p_enabled);
bool has_downarrow(int p_column) const;
```
A new column is added that resembles selected addons with checkboxes (no title included)
A new `Reload Plugins` button has been added as well, with the default shortcut `Alt+Shift+R,` that accessible through the entire editor. To achieve it, I used `EditorNode::_shortcut_input`
I also centered the status, version, and edit columns.
## Overview:
When there are no selected addons, the reload button is disabled.
<img width="1505" height="911" alt="image" src="https://github.com/user-attachments/assets/30352c7e-d349-4be3-89b2-cb344a1b8924" />
After selecting addons, the reload button becomes enabled.
<img width="1505" height="911" alt="image" src="https://github.com/user-attachments/assets/2d7795f1-7107-4300-99ab-3858e247c3c7" />
After pressing `Reload Plugins`, disabled addons become enabled.
<img width="1505" height="911" alt="image" src="https://github.com/user-attachments/assets/5068f574-41b1-4978-afc6-06c82db30765" />
Pressing the status button changes the status of that addon.
<img width="1505" height="911" alt="image" src="https://github.com/user-attachments/assets/d6f83862-b22d-4df6-ae48-332649b2ca45" />
