### PR TITLE
GDScript: Remove type constraint from `PatternNode`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2044,24 +2044,6 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 	static_context = previous_static_context;
 }
 
-void GDScriptAnalyzer::decide_pattern_type(GDScriptParser::PatternNode &p_pattern, GDScriptParser::PatternNode *p_statement) {
-	if (p_statement == nullptr) {
-		return;
-	}
-
-	// Use return or nested suite type as this suite type.
-	// TODO: Only downgrades. As long as all of the downgraded vars are unused irrelevant.
-	if (p_pattern.type_constraint.is_set() && (p_pattern.type_constraint != p_statement->type_constraint)) {
-		// Mixed types.
-		// TODO: This could use the common supertype instead.
-		p_pattern.type_constraint.kind = GDScriptParser::DataType::VARIANT;
-		p_pattern.type_constraint.type_source = GDScriptParser::DataType::UNDETECTED;
-	} else {
-		p_pattern.type_constraint = p_statement->type_constraint;
-		p_pattern.type_constraint.type_source = GDScriptParser::DataType::INFERRED;
-	}
-}
-
 void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite, bool p_is_root) {
 	for (int i = 0; i < p_suite->statements.size(); i++) {
 		GDScriptParser::Node *stmt = p_suite->statements[i];
@@ -2478,20 +2460,16 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 		return;
 	}
 
-	GDScriptParser::DataType result;
-
 	switch (p_match_pattern->pattern_type) {
 		case GDScriptParser::PatternNode::PT_LITERAL:
 			if (p_match_pattern->literal) {
 				reduce_literal(p_match_pattern->literal);
-				result = p_match_pattern->literal->type_constraint;
 			}
 			break;
 		case GDScriptParser::PatternNode::PT_EXPRESSION:
 			if (p_match_pattern->expression) {
 				GDScriptParser::ExpressionNode *expr = p_match_pattern->expression;
 				reduce_expression(expr);
-				result = expr->type_constraint;
 				if (!expr->is_constant) {
 					while (expr && expr->type == GDScriptParser::Node::SUBSCRIPT) {
 						GDScriptParser::SubscriptNode *sub = static_cast<GDScriptParser::SubscriptNode *>(expr);
@@ -2507,7 +2485,8 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 				}
 			}
 			break;
-		case GDScriptParser::PatternNode::PT_BIND:
+		case GDScriptParser::PatternNode::PT_BIND: {
+			GDScriptParser::DataType result;
 			if (p_match_test != nullptr) {
 				result = p_match_test->type_constraint;
 			} else {
@@ -2520,13 +2499,11 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 				parser->push_warning(p_match_pattern->bind, GDScriptWarning::UNUSED_VARIABLE, p_match_pattern->bind->name);
 			}
 #endif // DEBUG_ENABLED
-			break;
+		} break;
 		case GDScriptParser::PatternNode::PT_ARRAY:
 			for (int i = 0; i < p_match_pattern->array.size(); i++) {
 				resolve_match_pattern(p_match_pattern->array[i], nullptr);
-				decide_pattern_type(*p_match_pattern, p_match_pattern->array[i]);
 			}
-			result = p_match_pattern->type_constraint;
 			break;
 		case GDScriptParser::PatternNode::PT_DICTIONARY:
 			for (int i = 0; i < p_match_pattern->dictionary.size(); i++) {
@@ -2539,18 +2516,13 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 
 				if (p_match_pattern->dictionary[i].value_pattern) {
 					resolve_match_pattern(p_match_pattern->dictionary[i].value_pattern, nullptr);
-					decide_pattern_type(*p_match_pattern, p_match_pattern->dictionary[i].value_pattern);
 				}
 			}
-			result = p_match_pattern->type_constraint;
 			break;
 		case GDScriptParser::PatternNode::PT_WILDCARD:
 		case GDScriptParser::PatternNode::PT_REST:
-			result.kind = GDScriptParser::DataType::VARIANT;
 			break;
 	}
-
-	p_match_pattern->type_constraint = result;
 }
 
 void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2059,24 +2059,6 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 	static_context = previous_static_context;
 }
 
-void GDScriptAnalyzer::decide_pattern_type(GDScriptParser::PatternNode &p_pattern, GDScriptParser::PatternNode *p_statement) {
-	if (p_statement == nullptr) {
-		return;
-	}
-
-	// Use return or nested suite type as this suite type.
-	// TODO: Only downgrades. As long as all of the downgraded vars are unused irrelevant.
-	if (p_pattern.type_constraint.is_set() && (p_pattern.type_constraint != p_statement->type_constraint)) {
-		// Mixed types.
-		// TODO: This could use the common supertype instead.
-		p_pattern.type_constraint.kind = GDScriptParser::DataType::VARIANT;
-		p_pattern.type_constraint.type_source = GDScriptParser::DataType::UNDETECTED;
-	} else {
-		p_pattern.type_constraint = p_statement->type_constraint;
-		p_pattern.type_constraint.type_source = GDScriptParser::DataType::INFERRED;
-	}
-}
-
 void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite, bool p_is_root) {
 	for (GDScriptParser::Node *stmt : p_suite->statements) {
 		// Apply annotations.
@@ -2518,20 +2500,16 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 		return;
 	}
 
-	GDScriptParser::DataType result;
-
 	switch (p_match_pattern->pattern_type) {
 		case GDScriptParser::PatternNode::PT_LITERAL:
 			if (p_match_pattern->literal) {
 				reduce_literal(p_match_pattern->literal);
-				result = p_match_pattern->literal->type_constraint;
 			}
 			break;
 		case GDScriptParser::PatternNode::PT_EXPRESSION:
 			if (p_match_pattern->expression) {
 				GDScriptParser::ExpressionNode *expr = p_match_pattern->expression;
 				reduce_expression(expr);
-				result = expr->type_constraint;
 				if (!expr->is_constant) {
 					while (expr && expr->type == GDScriptParser::Node::SUBSCRIPT) {
 						GDScriptParser::SubscriptNode *sub = static_cast<GDScriptParser::SubscriptNode *>(expr);
@@ -2547,7 +2525,8 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 				}
 			}
 			break;
-		case GDScriptParser::PatternNode::PT_BIND:
+		case GDScriptParser::PatternNode::PT_BIND: {
+			GDScriptParser::DataType result;
 			if (p_match_test != nullptr) {
 				result = p_match_test->type_constraint;
 			} else {
@@ -2557,13 +2536,11 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 #ifdef DEBUG_ENABLED
 			is_shadowing(p_match_pattern->bind, "pattern bind", true);
 #endif // DEBUG_ENABLED
-			break;
+		} break;
 		case GDScriptParser::PatternNode::PT_ARRAY:
 			for (GDScriptParser::PatternNode *element_pattern : p_match_pattern->array) {
 				resolve_match_pattern(element_pattern, nullptr);
-				decide_pattern_type(*p_match_pattern, element_pattern);
 			}
-			result = p_match_pattern->type_constraint;
 			break;
 		case GDScriptParser::PatternNode::PT_DICTIONARY:
 			for (const GDScriptParser::PatternNode::Pair &element_pattern : p_match_pattern->dictionary) {
@@ -2576,18 +2553,13 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 
 				if (element_pattern.value_pattern) {
 					resolve_match_pattern(element_pattern.value_pattern, nullptr);
-					decide_pattern_type(*p_match_pattern, element_pattern.value_pattern);
 				}
 			}
-			result = p_match_pattern->type_constraint;
 			break;
 		case GDScriptParser::PatternNode::PT_WILDCARD:
 		case GDScriptParser::PatternNode::PT_REST:
-			result.kind = GDScriptParser::DataType::VARIANT;
 			break;
 	}
-
-	p_match_pattern->type_constraint = result;
 }
 
 void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -68,8 +68,6 @@ class GDScriptAnalyzer {
 	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
 
-	void decide_pattern_type(GDScriptParser::PatternNode &p_pattern, GDScriptParser::PatternNode *p_statement);
-
 	void resolve_annotation(GDScriptParser::AnnotationNode *p_annotation);
 	void resolve_class_member(GDScriptParser::ClassNode *p_class, const StringName &p_name, const GDScriptParser::Node *p_source = nullptr);
 	void resolve_class_member(GDScriptParser::ClassNode *p_class, int p_index, const GDScriptParser::Node *p_source = nullptr);

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -68,8 +68,6 @@ class GDScriptAnalyzer {
 	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
 
-	void decide_pattern_type(GDScriptParser::PatternNode &p_pattern, GDScriptParser::PatternNode *p_statement);
-
 	void resolve_annotation(GDScriptParser::AnnotationNode *p_annotation);
 	void resolve_class_member(GDScriptParser::ClassNode *p_class, const StringName &p_name, const GDScriptParser::Node *p_source = nullptr);
 	void resolve_class_member(GDScriptParser::ClassNode *p_class, uint32_t p_index, const GDScriptParser::Node *p_source = nullptr);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1019,8 +1019,6 @@ public:
 	};
 
 	struct PatternNode : public Node {
-		DataType type_constraint;
-
 		enum Type {
 			PT_LITERAL,
 			PT_EXPRESSION,


### PR DESCRIPTION
## What problem(s) does this PR solve?

Thanks to https://github.com/godotengine/godot/pull/121064 it is now easy to verify, that the type information on `PatternNode`s is only ever read to update itself. Thus it serves no purpose and we can remove it.

- `PatternNode::type_constraint` is used in `decide_pattern_type`, but that function only updates `PatternNode::type_constraint`
- It is stored into `result` in `resolve_match_pattern` but `result` is only used to store it back into `PatternNode::type_constraint`
    - (`result` has one other usage, but that's in a branch where `PatternNode::type_constraint` is never stored into `result`)