### PR TITLE
Fix CSG module breaking on disable_physics_3d=yes builds

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -206,6 +206,7 @@ void CSGShape3D::set_collision_priority(real_t p_priority) {
 real_t CSGShape3D::get_collision_priority() const {
 	return collision_priority;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void CSGShape3D::set_autosmooth(bool p_smooth) {
 	autosmooth = p_smooth;
@@ -225,8 +226,6 @@ void CSGShape3D::set_smoothing_angle(const float p_angle) {
 float CSGShape3D::get_smoothing_angle() const {
 	return smoothing_angle;
 }
-
-#endif // PHYSICS_3D_DISABLED
 
 bool CSGShape3D::is_root_shape() const {
 	return !parent_shape;


### PR DESCRIPTION
Fixes CSG module breaking on disable_physics_3d=yes builds.

The CSG module had some of the newer autosmooth functions fall into an exclude  `PHYSICS_3D_DISABLED` block causing compile errors and fails when the physics stuff was removed.
