### PR TITLE
Vulkan: Disable MSAA discardable flag to prevent DMA page fault

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -4394,7 +4394,7 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 		rd_color_multisample_format.usage_bits = render_target_get_color_usage_bits(true);
 		RD::TextureView rd_view_multisample;
 		rd_color_multisample_format.is_resolve_buffer = false;
-		rd_color_multisample_format.is_discardable = true;
+		rd_color_multisample_format.is_discardable = false;
 		rt->color_multisample = RD::get_singleton()->texture_create(rd_color_multisample_format, rd_view_multisample);
 		ERR_FAIL_COND(rt->color_multisample.is_null());
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120637 

## Additional information

<b>Root Cause:</b> NVIDIA Nsight Aftermath reports_DMA_PageFault Error with the hardware error string: MMU fault detected during a GPU memory access. The failure consistently triggers during a downstream buffer-to-buffer copy (vkCmdCopyBuffer) inside RenderingDeviceDriverVulkan, when `rd_color_multisample_format.is_discardable = true;` on NVIDIA GPU.

I found that reverting commit 3cf0881c36 also prevents the crash. However, doing a pure revert would mark the single-sampled resolve destination target as discardable, which may cause rendering regressions on mobile and WebGPU targets that take DONT_CARE literally.

While setting `is_discardable = true (VK_ATTACHMENT_STORE_OP_DONT_CARE)` makes ideal architectural sense for a multisampled attachment to save VRAM bandwidth, leaving it as 'false' ensures that it at least wont crash. 

There is likely a better solution that preserves the intended optimization while avoiding the NVIDIA specific issue, but identifying that solution would require a deeper understanding of the rendering pipeline and attachment synchronization logic.

[aftermath-report.zip](https://github.com/user-attachments/files/29892710/aftermath-report.zip)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->


