### PR TITLE
Fix physics picking for touch events on mobile

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -903,8 +903,8 @@ void Viewport::_process_picking() {
 			pos = st->get_position();
 		}
 
-		if (!get_visible_rect().has_point(pos)) {
-			// Skip this event if the event position is outside of the viewport
+		if (!is_mouse && !get_visible_rect().has_point(pos)) {
+			// Skip this event if it is a touch event and the event position is outside of the viewport
 			continue;
 		}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -788,9 +788,9 @@ void Viewport::_process_picking() {
 	if (Object::cast_to<Window>(this) && Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		return;
 	}
-	if (!gui.mouse_in_viewport || gui.subwindow_over) {
-		// Clear picking events if the mouse has left the viewport or is over an embedded window.
-		// These are locations, that are expected to not trigger physics picking.
+	if (gui.subwindow_over) {
+		// Clear picking events if the mouse is over an embedded window.
+		// This location is expected to not trigger physics picking.
 		physics_picking_events.clear();
 		return;
 	}
@@ -886,6 +886,11 @@ void Viewport::_process_picking() {
 			is_mouse = true;
 		}
 
+		if (is_mouse && !gui.mouse_in_viewport) {
+			// Skip this event if it is a mouse event if the mouse is outside of the viewport
+			continue;
+		}
+
 		Ref<InputEventScreenDrag> sd = ev;
 
 		if (sd.is_valid()) {
@@ -896,6 +901,11 @@ void Viewport::_process_picking() {
 
 		if (st.is_valid()) {
 			pos = st->get_position();
+		}
+
+		if (!get_visible_rect().has_point(pos)) {
+			// Skip this event if the event position is outside of the viewport
+			continue;
 		}
 
 #ifndef PHYSICS_2D_DISABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #109615

## Additional information

Before my changes the `_process_picking()` function was returned early if the mouse was outside of the viewport. That caused all touch events to also be ignored if the mouse is outside of the viewport. From my testing this was an issue on mobile, but I haven't been able to test this on a pc, because I don't have a pc or laptop with a touchscreen. 

I've moved the "mouse outside of viewport" check into the `while (physics_picking_events.size())` loop and changed it to only check if the mouse was outside of the viewport if it is a mouse related event. Plus it now only skips that mouse event instead of the whole physics picking, because there can still be valid touch input events.

I've also added a check to skip an event if the position of the event is outside of the viewport to make sure that touch events are also ignored if they occur outside of the viewport. This is to keep the intent of why lines 791-796 were originally added intact (see PR #58610).

And for full disclosure, I haven't used AI for this fix.