### PR TITLE
Make `NoiseTexture2D.get_image()` return copy of image instead of shared instance

### DIFF
--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -396,5 +396,5 @@ RID NoiseTexture2D::get_rid() const {
 }
 
 Ref<Image> NoiseTexture2D::get_image() const {
-	return image;
+	return RenderingServer::get_singleton()->texture_2d_get(get_rid());
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121173

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Using the same MRP as in the linked issue, with this PR the printed results are:
```
ScatterNoise size: (256.0, 256.0)
Image 1 size: (256, 256)
Image 2 size: (256, 256)
Now resizing only image 2...
New Image 1 size (should be same): (256, 256)
New Image 2 size (should be resized): (512, 512)
```

---

Previously, the `NoiseTexture2D.get_image()` method simply returned the RID for the NoiseTexture2D. By modifying the texture associated with this RID, then, the original data used by the NoiseTexture2D itself would be modified (as well as any other "copies" that it had given out via other calls to `get_image()`).

With this PR, `NoiseTexture2D` uses the same approach as `CameraTexture`, and one very similar to `GradientTexture1D/2D` and `DPITexture` (specifically, using `RenderingServer.texture_2d_get()`). The former two were the reference I used to make the changes, and then afterwards I searched to realize that what I'd written ended up actually being the exact same code as `CameraTexture` 😄 

Thanks once again to henrikfalk on the Godot Engine Discord server for finding this bug in the first place, and also thanks to suzie from the server for taking a look at the source code and recognizing that it wasn't creating a new `Image` instance!