### PR TITLE
Editor: Fix collapsible property desync in inspector

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4613,7 +4613,10 @@ void EditorInspector::update_tree() {
 		Vector<String> components = path.split("/");
 		for (int i = 0; i < components.size(); i++) {
 			const String &component = components[i];
-			acc_path += (i > 0) ? "/" + component : component;
+
+			if (component != "") {
+				acc_path += (i > 0) ? "/" + component : String(doc_name) + "_" + component;
+			}
 
 			if (!vbox_per_path[root_vbox].has(acc_path)) {
 				// If the section does not exists, create it.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121096

## Additional information

It was determined that the desync was caused by `core\object\object.cpp`'s `editor_is_section_unfolded(string)` method, which just takes the string and checks in an array if it is collapsed.

This means that two sections with the same name will not be properly handled, and removing one from the array (uncollapsing) will make the next check for the other section think it is also uncollapsed.

I considered that the object collapse array itself might need to be refactored into a more sophisticated system, but given that I am not very fluent in CPP, and this is one of my first times touching Godot's engine core, I decided to just stick with the simple solution (which is also what the contributing docs recommend anyway) and appended the section name to the collapsable.

Now, a section with a `Collision` name will get its `doc_name` (`CharacterBody3D`, `PhysicsBody3D`, `Node2D`....) appended to it before creation, resulting in every section having the internal `acc_path` formatting of `DocName_SectionName` (like `Node3D_Transform`).

This creates unique names for every section so it gets correctly handled by the `object.cpp` array.

The if statement checking that `component` is not an empty string is because each category (`doc_name`s) has a nameless component for the uncollapsed section, and prefixing it with the doc_name made it access the section logic and be turned into a nameless collapsable section.

I have checked to ensure that the `acc_path` method-scoped variable is not used anywhere else and verified to my best effort that this causes no regressions or weird behaviors in other parts of the engine, but please review carefully since, as stated, I am just starting to fiddle with CPP and the engine code recently.

No AI was used in this PR whatsoever.

https://github.com/user-attachments/assets/cbb9d19e-0ebe-43f9-b6e0-877807c8427b

