### PR TITLE
SCons: Treat Tracy/Perfetto objects as children of `core/profiling`

### DIFF
--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -76,7 +76,7 @@ if env["profiler"]:
         if env["profiler_record_on_demand"]:
             env_tracy.Append(CPPDEFINES=["TRACY_ON_DEMAND"])
         env_tracy.disable_warnings()
-        env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
+        env.core_sources += [env_tracy.Object("TracyClient", str((profiler_path / "TracyClient.cpp").absolute()))]
     elif env["profiler"] == "perfetto":
         if env["profiler_path"]:
             profiler_path = find_perfetto_path(pathlib.Path(env["profiler_path"]))
@@ -99,7 +99,7 @@ if env["profiler"]:
             print("profiler_record_on_demand ignored. Perfetto is always recording.")
         env_perfetto.disable_warnings()
         env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
-        env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
+        env.core_sources += [env_perfetto.Object("perfetto", str((profiler_path / "perfetto.cc").absolute()))]
 elif env["profiler_path"]:
     print("profiler is required if profiler_path is set. Aborting.")
     Exit(255)


### PR DESCRIPTION
## What problem(s) does this PR solve?

Sidesteps the concern of an invalid external redirect by treating the sources as local instead. Now the build objects for Tracy and Perfetto will be chilling alongside wherever the build objects for the `core/profiling` directory ends up
