### PR TITLE
Capitalize project tags using EditorPropertyNameProcessor

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1408,6 +1408,10 @@ ProjectManager::ProjectManager() {
 
 	SceneTree::get_singleton()->get_root()->connect("files_dropped", callable_mp(this, &ProjectManager::_files_dropped));
 
+	// Used by tag display and QuickSettingsDialog.
+	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
+	add_child(epnp);
+
 	// Initialize UI.
 	{
 		int pm_root_dir = EDITOR_GET("interface/editor/localization/ui_layout_direction");

--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -30,6 +30,7 @@
 
 #include "project_tag.h"
 
+#include "editor/inspector/editor_property_name_processor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/button.h"
 #include "scene/gui/color_rect.h"
@@ -75,8 +76,9 @@ ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
 	button = memnew(Button);
 	add_child(button);
 	button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	button->set_text(p_text.capitalize());
-	button->set_tooltip_text(p_text.capitalize());
+	const String tag_text = EditorPropertyNameProcessor::get_singleton()->process_name(p_text, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+	button->set_text(tag_text);
+	button->set_tooltip_text(tag_text);
 	button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button->set_accessibility_name(vformat(TTR("Project Tag: %s"), p_text));
 	button->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -258,9 +258,6 @@ void QuickSettingsDialog::_show_full_settings() {
 		eidp.instantiate();
 		EditorInspector::add_inspector_plugin(eidp);
 
-		EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
-		add_child(epnp);
-
 		editor_settings_dialog = memnew(EditorSettingsDialog);
 		get_parent()->add_child(editor_settings_dialog);
 		editor_settings_dialog->connect("restart_requested", callable_mp(this, &QuickSettingsDialog::_request_restart));


### PR DESCRIPTION
This allows tags like `gui` to display as "GUI" instead of "Gui", similar to property names in the inspector.

- This closes https://github.com/godotengine/godot-proposals/issues/15167

## Preview

Tags from official demos:

Before | After
-|-
<img width="481" height="254" alt="Screenshot_20260710_211336" src="https://github.com/user-attachments/assets/9614fb29-c524-4837-944e-4a2c58132578" /> | <img width="481" height="254" alt="Screenshot_20260710_211406" src="https://github.com/user-attachments/assets/32f456d1-c8b1-446e-94ef-998d914331b7" />
