### PR TITLE
SCons: Remove warning from `redirect_emitter`

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -105,8 +105,6 @@ def redirect_emitter(target, source, env):
             item = env.File(f"#bin/obj/{path.relative_to(base_folder)}")
         elif (alt_base := Path(env.Dir(".").get_abspath()).resolve().parent) in path.parents:
             item = env.File(f"#bin/obj/external/{path.relative_to(alt_base)}")
-        else:
-            print_warning(f'Failed to redirect "{path}"')
         redirected_targets.append(item)
     return redirected_targets, source
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

The warning message from the redirection utility doesn't actually serve much of a purpose. It was initially intended for debugging when setting up the tool to make sure the base environment and modules were accounted for, but that's been battle-tested quite throughly by now. Anything that remains is explicitly external, and I've decided that's beyond the scope of this tool at this time. If we want to handle external redirects in some manner, then the warning can be reapplied if that system ends up failing somehow; not something we need to concern ourselves with at this time
