### PR TITLE
Avoid running `GetVolumeInformationW` on network drives

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -143,8 +143,14 @@ void DirAccessWindows::_update_drives() {
 			String drive = String::chr('A' + i) + ':';
 			String path = drive + '\\';
 			String label;
+			Char16String cs = path.utf16();
+			UINT type = GetDriveTypeW((LPCWSTR)cs.get_data());
+			if (type == DRIVE_REMOTE) {
+				drives.push_back(DriveInfo{ drive, "<network>" });
+				continue;
+			}
 			char16_t wlabel[4096];
-			if (GetVolumeInformationW((LPCWSTR)(path).utf16().get_data(), (LPWSTR)wlabel, 4096, nullptr, nullptr, nullptr, nullptr, 0)) {
+			if (GetVolumeInformationW((LPCWSTR)cs.get_data(), (LPWSTR)wlabel, 4096, nullptr, nullptr, nullptr, nullptr, 0)) {
 				label = String::utf16(wlabel);
 			}
 			drives.push_back(DriveInfo{ drive, label });


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #120649

## Additional information

checks whether a drive is a network drive before querying it with GetVolumeInformationW, which I have noticed hangs for about 8 seconds on disconnected network drives.

I don't know that this is the best way to resolve this, but it is a way.

I tested by launching godot editor with and without this change and without it it hangs for ~30 seconds and with it it opens right away
<img width="129" height="111" alt="image" src="https://github.com/user-attachments/assets/946fb815-4695-4cd2-9c85-1bee9feb4420" />


This is a continuation of #120666
I didn't find a satisfactory way to update the other one while still being a single commit.
any advice in this would be greatly appreciated, and I am happy to clean these up to fit the desired protocol.
I couldn't find anything speaking to it in the guidelines.
*edit* it's in there, https://contributing.godotengine.org/en/latest/pull_requests/creating_pull_requests.html#modifying-a-pull-request

I will also note here that I have never used godot's file dialog before, I always set it to native, and so didn't even know where these would be displayed.
This commit does fix the editor taking forever to open, but if you go and click on a network drive in "game" with the godot file dialog and then click on a ```<network>``` drive, it hangs for that ~8 seconds