### PR TITLE
Respect audio/driver/mix_rate in the Android OpenSL audio driver

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -80,7 +80,21 @@ void AudioDriverOpenSL::_buffer_callbacks(
 	ad->_buffer_callback(queueItf);
 }
 
+static int _fit_opensl_mix_rate(int p_mix_rate) {
+	// Sampling rates with SL_SAMPLINGRATE_* definitions in OpenSLES.h.
+	static const int supported_rates[] = { 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000, 192000 };
+	for (const int rate : supported_rates) {
+		if (p_mix_rate == rate) {
+			return p_mix_rate;
+		}
+	}
+	WARN_PRINT(vformat("%d Hz is not a mix rate supported by the OpenSL ES driver, falling back to 44100 Hz.", p_mix_rate));
+	return 44100;
+}
+
 Error AudioDriverOpenSL::init() {
+	mix_rate = _fit_opensl_mix_rate(_get_configured_mix_rate());
+
 	SLresult res;
 	SLEngineOption EngineOption[] = {
 		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
@@ -130,7 +144,7 @@ void AudioDriverOpenSL::start() {
 	/* Setup the format of the content in the buffer queue */
 	pcm.formatType = SL_DATAFORMAT_PCM;
 	pcm.numChannels = 2;
-	pcm.samplesPerSec = SL_SAMPLINGRATE_44_1;
+	pcm.samplesPerSec = SLuint32(mix_rate) * 1000; // Milli-hertz, matching SL_SAMPLINGRATE_* values.
 	pcm.bitsPerSample = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.containerSize = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.channelMask = SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
@@ -213,7 +227,7 @@ Error AudioDriverOpenSL::init_input_device() {
 	SLDataFormat_PCM format_pcm = {
 		SL_DATAFORMAT_PCM,
 		1,
-		SL_SAMPLINGRATE_44_1,
+		SLuint32(mix_rate) * 1000, // Milli-hertz, matching SL_SAMPLINGRATE_* values.
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_SPEAKER_FRONT_CENTER,
@@ -300,7 +314,7 @@ Error AudioDriverOpenSL::input_stop() {
 }
 
 int AudioDriverOpenSL::get_mix_rate() const {
-	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
+	return mix_rate;
 }
 
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -46,6 +46,7 @@ class AudioDriverOpenSL : public AudioDriver {
 
 	bool pause = false;
 
+	int mix_rate = 44100;
 	uint32_t buffer_size = 0;
 	int16_t *buffers[BUFFER_COUNT] = {};
 	int32_t *mixdown_buffer = nullptr;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes #39631 

## Additional information

`AudioDriverOpenSL` hardcodes 44100 Hz for both playback (`start()`) and capture (`init_input_device()`), and `get_mix_rate()` returns the constant — the documented `audio/driver/mix_rate` project setting is silently ignored on Android (#39631; also reported as #39612). The desktop drivers had the same defect fixed years ago (PulseAudio/ALSA now use `_get_configured_mix_rate()`); the Android driver never received the equivalent change, and the Oboe driver replacement that would have superseded it (#86776) was closed unmerged.

Beyond the setting being non-functional: most modern Android devices (including all Meta Quest headsets) run 48000 Hz natively, so the hardcoded 44.1 kHz forces Android's system resampler to run continuously in both directions for the app's lifetime. In instrumented long-session testing on Quest 3 (two devices, continuous voice calls, per-2-second stats on buffer fill / underruns / capture rate), we observed progressive audio corruption after several minutes that was provably outside the app layer and was cured by anything that restarts the OS audio streams. The same test on a patched engine running the streams at the native 48 kHz removed those resample stages. 

## Fix

- Read the rate once in `init()` via the existing `AudioDriver::_get_configured_mix_rate()` helper (same pattern as the desktop drivers).
- Validate it against the sampling rates OpenSL ES defines (`SL_SAMPLINGRATE_*`: 8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000, 192000); warn and fall back to 44100 Hz otherwise.
- Use the configured rate in the playback PCM format, the recorder PCM format, and `get_mix_rate()` (OpenSL takes milli-hertz, i.e. `rate * 1000`, matching the `SL_SAMPLINGRATE_*` constant values).

Default behavior is unchanged: `audio/driver/mix_rate` defaults to 44100.

## Testing

- Compile-tested for `platform=android target=template_debug arch=arm64` against `master`.
- Field-tested as a 4.7-stable backport on two Meta Quest 3 headsets with `audio/driver/mix_rate=48000`: `AudioServer.get_mix_rate()` reports 48000, microphone capture (`AudioStreamMicrophone` + `AudioEffectCapture`) delivers ~48000 frames/s, and 10-minute continuous two-way voice calls (WebRTC via a GDExtension) hold clean audio.

## AI Disclosure
I'm an old coder (check my repo) but I've picked up a contract with Anthropic (If you can't beat em join em) and one perk is unlimited fable right now...so, yeah I used it for diagnosis and composition but I've gone over every line.  It's a small fix, no slop, the Milli-hertz comments are relevant.  It passes clang-tidy and clang-format.  I am a human and I approve this message.