### PR TITLE
Don't override the rendering method when when CLI flag `--rendering-driver` is used

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2584,6 +2584,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				rendering_method = "dummy";
 			} else if (rendering_driver == "opengl3" || rendering_driver == "opengl3_angle" || rendering_driver == "opengl3_es") {
 				rendering_method = "gl_compatibility";
+			} else if (GLOBAL_GET("rendering/renderer/rendering_method") != "gl_compatibility") {
+				rendering_method = GLOBAL_GET("rendering/renderer/rendering_method");
 			} else {
 				rendering_method = "forward_plus";
 			}


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #115539

## Testing
Tested on Linux, Fedora 44 on master (91cb8e97688643bc00b7bede92c1d7b13716a22e) with this PR's changes.

## Summary of changes
When `--rendering-driver` is set to `vulkan`, `metal`, or `d3d12`, instead of forcing `forward_plus`, the rendering method from project settings is used. If the rendering method from project settings is `gl_compatibility` (incompatible, should we throw an error?), it uses `forward_plus`.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
