### PR TITLE
Reselect the edited node after drop without scrolling to it.

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1864,8 +1864,10 @@ void SceneTreeDock::_notification(int p_what) {
 			Node *node_edited = Object::cast_to<Node>(InspectorDock::get_inspector_singleton()->get_edited_object());
 			if (node_edited) {
 				editor_selection->clear();
-				editor_selection->add_node(node_edited);
-				scene_tree->set_selected(node_edited);
+				TreeItem *item = scene_tree->get_scene_tree()->get_item_with_metadata(node_edited->get_path());
+				if (item) {
+					scene_tree->get_scene_tree()->set_selected(item);
+				}
 			}
 		} break;
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121132

## Additional information

Use `Tree::set_selected()` directly to avoid `ensure_cursor_is_visible()` scrolling from `SceneTreeEditor::set_selected()`, so we still reselect the edited node properly to keep scene tree dock and inspector dock in sync (https://github.com/godotengine/godot/issues/112248) but we do not scroll back to it... @AdriaandeJongh if you want to test.