### PR TITLE
Add GDExtension `print_script_error` and `print_script_error_with_message`

### DIFF
--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -3975,6 +3975,101 @@
             "since": "4.1"
         },
         {
+            "name": "print_script_error",
+            "arguments": [
+                {
+                    "name": "p_description",
+                    "type": "const char*",
+                    "description": [
+                        "The code triggering the error."
+                    ]
+                },
+                {
+                    "name": "p_function",
+                    "type": "const char*",
+                    "description": [
+                        "The function name where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_file",
+                    "type": "const char*",
+                    "description": [
+                        "The file where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_line",
+                    "type": "int32_t",
+                    "description": [
+                        "The line where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_editor_notify",
+                    "type": "GDExtensionBool",
+                    "description": [
+                        "Whether or not to notify the editor."
+                    ]
+                }
+            ],
+            "description": [
+                "Logs a script error to Godot's built-in debugger and to the OS terminal."
+            ],
+            "since": "4.8"
+        },
+        {
+            "name": "print_script_error_with_message",
+            "arguments": [
+                {
+                    "name": "p_description",
+                    "type": "const char*",
+                    "description": [
+                        "The code triggering the error."
+                    ]
+                },
+                {
+                    "name": "p_message",
+                    "type": "const char*",
+                    "description": [
+                        "The message to show along with the error."
+                    ]
+                },
+                {
+                    "name": "p_function",
+                    "type": "const char*",
+                    "description": [
+                        "The function name where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_file",
+                    "type": "const char*",
+                    "description": [
+                        "The file where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_line",
+                    "type": "int32_t",
+                    "description": [
+                        "The line where the error occurred."
+                    ]
+                },
+                {
+                    "name": "p_editor_notify",
+                    "type": "GDExtensionBool",
+                    "description": [
+                        "Whether or not to notify the editor."
+                    ]
+                }
+            ],
+            "description": [
+                "Logs a script error with a message to Godot's built-in debugger and to the OS terminal."
+            ],
+            "since": "4.8"
+        },
+        {
             "name": "print_warning",
             "arguments": [
                 {


### PR DESCRIPTION
## What problem(s) does this PR solve?

This adds the GDExtension JSON mapping for `print_script_error` and `print_script_error_with_message` bindings that we are planning to add on godot-cpp side.

## Additional information

This is from a RChat discussion we had about the fact there is no way for scripting extensions written in GDExtension to use ERR_HANDLER_SCRIPT to report script-specific errors like GDScript does. This exposes the already present methods in gdextension_interface.cpp to the godot-cpp bindings.

This is needed for https://github.com/godotengine/godot-cpp/pull/2022