### PR TITLE
Show project name in bottom panel next to version

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -380,6 +380,7 @@ void EditorNode::_update_title() {
 		title = vformat("(*) %s", title);
 	}
 	DisplayServer::get_singleton()->window_set_title(title + String(" - ") + GODOT_VERSION_NAME);
+	bottom_panel->update_project_title();
 	if (project_title) {
 		project_title->set_text(title);
 	}

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_bottom_panel.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/docks/editor_dock.h"
@@ -285,6 +286,10 @@ void EditorBottomPanel::_on_button_visibility_changed(Button *p_button, EditorDo
 	}
 }
 
+void EditorBottomPanel::update_project_title() {
+	project_name_label->set_text(vformat("%s -", GLOBAL_GET("application/config/name")));
+}
+
 EditorBottomPanel::EditorBottomPanel() :
 		DockTabContainer(EditorDock::DOCK_SLOT_BOTTOM) {
 	layout = EditorDock::DOCK_LAYOUT_HORIZONTAL;
@@ -311,6 +316,10 @@ EditorBottomPanel::EditorBottomPanel() :
 	progress_indicator->set_v_size_flags(SIZE_SHRINK_CENTER);
 	progress_indicator->hide();
 	bottom_hbox->add_child(progress_indicator);
+
+	project_name_label = memnew(Label);
+	update_project_title();
+	bottom_hbox->add_child(project_name_label);
 
 	EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_BASIC));
 	// Fade out the version label to be less prominent, but still readable.

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -57,6 +57,7 @@ class EditorBottomPanel : public DockTabContainer {
 
 	HBoxContainer *bottom_hbox = nullptr;
 	EditorToaster *editor_toaster = nullptr;
+	Label *project_name_label = nullptr;
 	ProgressIndicator *progress_indicator = nullptr;
 	Button *pin_button = nullptr;
 	Button *expand_button = nullptr;
@@ -93,6 +94,7 @@ public:
 
 	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
 	void remove_item(Control *p_item);
+	void update_project_title();
 	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
 	void hide_bottom_panel();
 	void toggle_last_opened_bottom_panel();


### PR DESCRIPTION
## What problem(s) does this PR solve?

I am on hyprland, so I don't have the title bar at the top of the screen like windows does that says the project name. This PR makes the project name show next to the version info at the bottom of the screen. This is handy when I have ~5 Godot instances/ versions open.

Fixes https://github.com/godotengine/godot-proposals/issues/15171

https://github.com/user-attachments/assets/514238db-5353-4bfa-ab08-a9486da275e6

