### PR TITLE
Allow script tab shortcut to refocus script text input

### DIFF
--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -186,6 +186,10 @@ void EditorMainScreen::select(int p_index) {
 	ERR_FAIL_NULL(new_editor);
 
 	if (selected_plugin == new_editor) {
+		// This focuses the script area in case it did not have focus.
+		if (p_index == EDITOR_SCRIPT) {
+			selected_plugin->selected_notify();
+		}
 		return;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

If the script tab is already focused, but the user clicks in the scene tree, the text area no longer has focus. This PR allows the existing keybind that focuses the script editor tab to focus the text input area, even if the script tab was already focused.

Closes https://github.com/godotengine/godot-proposals/issues/14418


https://github.com/user-attachments/assets/d5c2e246-ccf2-4ec4-beda-9372c0b28f98

