### PR TITLE
Fix typo not checking got Japanese

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -181,7 +181,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 			var_suffix = { "TC", "HK", "SC", "KR", "JP" };
 		} else if (locale.begins_with("ko")) {
 			var_suffix = { "KR", "HK", "SC", "TC", "JP" };
-		} else if (locale.begins_with("ko")) {
+		} else if (locale.begins_with("ja")) {
 			var_suffix = { "JP", "HK", "KR", "SC", "TC" };
 		} else {
 			var_suffix = { "HK", "KR", "SC", "TC", "JP" };


### PR DESCRIPTION
~Removes an unnecessary duplicate else if statement.~
Fixes a typo during font registration where it would check twice for Korean and not for Japanese.
Closes #121217 

No AI was used in the making, ~though I suspect the author of the issue used AI due to a massive amount of issues in a very short time.~
