### PR TITLE
Fix copy paste error in macos mediaKeyEvent handler

### DIFF
--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -81,7 +81,7 @@ GodotApplication *GodotApp = nil;
 			keycode = Key::VOLUMEUP;
 		} break;
 		case NX_KEYTYPE_SOUND_DOWN: {
-			keycode = Key::VOLUMEUP;
+			keycode = Key::VOLUMEDOWN;
 		} break;
 		//NX_KEYTYPE_BRIGHTNESS_UP
 		//NX_KEYTYPE_BRIGHTNESS_DOWN


### PR DESCRIPTION
Fixes an (assumed) typo where both NX_KEYTYPE_SOUND_UP and NX_KEYTYPE_SOUND_DOWN were matched to Key::VOLUMEUP.

Closes #121205 

(I could not find any people having problems with their Volume Down keys, this PR was made as a direct response to #121205)

No AI was used in the making.