### PR TITLE
Fix RichTextLabel BBCode img height percent

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6288,7 +6288,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 						}
 						width = bbcode_value.substr(0, sep).to_float();
 						if (bbcode_value.substr(sep + 1).ends_with("%")) {
-							width_unit = IMAGE_UNIT_PERCENT;
+							height_unit = IMAGE_UNIT_PERCENT;
 						}
 						height = bbcode_value.substr(sep + 1).to_float();
 					}


### PR DESCRIPTION
Fix #121210.
Before:
<img width="876" height="330" alt="img2" src="https://github.com/user-attachments/assets/1bbdb787-e4cb-4b3a-acfa-9fa69f95bd87" />

After:
<img width="876" height="348" alt="img1" src="https://github.com/user-attachments/assets/0f04c464-7296-4ea9-b625-21ab8f3347b7" />
