### PR TITLE
Add proper instructions for using scene paint 2D

### DIFF
--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -83,6 +83,7 @@ void ScenePaint2DEditor::_edit(Object *p_object) {
 	}
 
 	_update_node(p_object);
+	_update_hint_label();
 }
 
 void ScenePaint2DEditor::_update_node(Object *p_object) {
@@ -245,6 +246,18 @@ bool ScenePaint2DEditor::_is_instance_valid() {
 void ScenePaint2DEditor::_update_draw_overlay() {
 	if (custom_overlay) {
 		custom_overlay->queue_redraw();
+	}
+}
+
+void ScenePaint2DEditor::_update_hint_label() {
+	if (!is_tool_selected) {
+		CanvasItemEditor::get_singleton()->get_viewport_control()->set_hint_label(String(), String());
+	} else if (!cache_node) {
+		CanvasItemEditor::get_singleton()->get_viewport_control()->set_hint_label(TTRC("Select a Node2D to enable painting."), TTRC("The node will be used as a parent for the painted scenes."));
+	} else if (!selected_scene) {
+		CanvasItemEditor::get_singleton()->get_viewport_control()->set_hint_label(TTRC("Pick a scene for painting."), vformat(TTR("Use the Scene Picker from the toolbar or %s+Click a 2D scene instance."), keycode_get_string(Key::CMD_OR_CTRL)));
+	} else {
+		CanvasItemEditor::get_singleton()->get_viewport_control()->set_hint_label(String(), String());
 	}
 }
 
@@ -595,6 +608,7 @@ void ScenePaint2DEditor::_scene_changed() {
 		cache_node = Object::cast_to<Node2D>(SceneTreeDock::get_singleton()->get_tree_editor()->get_selected());
 	}
 	_update_node();
+	_update_hint_label();
 }
 
 void ScenePaint2DEditor::_update_scene_picker(int p_mode, Control *p_control) {
@@ -745,6 +759,16 @@ void ScenePaint2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			advanced_settings_button->set_tooltip_text(TTR("Advanced Settings") + "\n" + TTR("Hold Alt while painting to temporarily switch to the previously used paint snap mode."));
+			if (toolbar->is_visible()) {
+				_update_hint_label();
+			}
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			// Dragging something into 2D viewport might override the label, so it needs to be restored.
+			if (toolbar->is_visible()) {
+				callable_mp(this, &ScenePaint2DEditor::_update_hint_label).call_deferred();
+			}
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -774,6 +798,8 @@ void ScenePaint2DEditor::_notification(int p_what) {
 
 void ScenePaint2DEditor::_set_picked_scene(Node2D *p_scene) {
 	selected_scene = p_scene;
+	_update_hint_label();
+
 	scene_picker_button->set_pressed(false);
 	input_tool = INPUT_TOOL_NONE;
 	if (!selected_scene) {
@@ -943,10 +969,18 @@ ScenePaint2DEditor::ScenePaint2DEditor() {
 }
 
 void ScenePaint2DEditorPlugin::_canvas_item_tool_changed(int p_tool) {
+	bool prev_selected = scene_paint_2d_editor->is_tool_selected;
 	scene_paint_2d_editor->is_tool_selected = (CanvasItemEditor::Tool)p_tool == CanvasItemEditor::TOOL_SCENE_PAINT;
+	if (!scene_paint_2d_editor->is_tool_selected && prev_selected) {
+		make_visible(false);
+		scene_paint_2d_editor->_update_hint_label();
+		return;
+	}
+
 	Node *selected_node = SceneTreeDock::get_singleton()->get_tree_editor()->get_selected();
 	if (!selected_node) {
 		make_visible(false);
+		scene_paint_2d_editor->_update_hint_label();
 		return;
 	}
 	scene_paint_2d_editor->_set_picked_scene(nullptr);

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.h
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.h
@@ -129,6 +129,7 @@ class ScenePaint2DEditor : public Control {
 
 	void _draw_overlay();
 	void _update_draw_overlay();
+	void _update_hint_label();
 
 	void _gui_input_viewport(const Ref<InputEvent> &p_event);
 	void _add_node_at_pos();

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5731,11 +5731,11 @@ CanvasItemEditor::CanvasItemEditor() {
 	panner->set_callbacks(callable_mp(this, &CanvasItemEditor::_pan_callback), callable_mp(this, &CanvasItemEditor::_zoom_callback));
 
 	viewport = memnew(CanvasItemEditorViewport(this));
-	viewport_scrollable->add_child(viewport);
 	viewport->set_mouse_filter(MOUSE_FILTER_PASS);
 	viewport->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	viewport->set_clip_contents(true);
 	viewport->set_focus_mode(FOCUS_ALL);
+	viewport_scrollable->add_child(viewport);
 	viewport->connect(SceneStringName(draw), callable_mp(this, &CanvasItemEditor::_draw_viewport));
 	viewport->connect(SceneStringName(gui_input), callable_mp(this, &CanvasItemEditor::_gui_input_viewport));
 	viewport->connect(SceneStringName(focus_exited), callable_mp(panner.ptr(), &ViewPanner::release_pan_key));
@@ -6192,7 +6192,7 @@ CanvasItemEditorPlugin::CanvasItemEditorPlugin() {
 }
 
 void CanvasItemEditorViewport::_on_mouse_exit() {
-	if (!texture_node_type_selector->is_visible()) {
+	if (!texture_node_type_selector->is_visible() && preview_node->get_parent()) {
 		_remove_preview();
 	}
 }
@@ -6533,7 +6533,12 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 	}
 }
 
-void CanvasItemEditorViewport::_show_tooltip(const String &p_title, const String &p_description) const {
+void CanvasItemEditorViewport::set_hint_label(const String &p_title, const String &p_description) const {
+	if (p_title.is_empty() && p_description.is_empty()) {
+		tooltip_panel->hide();
+		return;
+	}
+
 	tooltip_panel->set_text(
 			vformat("[font_size=%s][b][color=%s]%s[/color][/b][/font_size]\n%s",
 					get_theme_default_font_size() + 2,
@@ -6599,12 +6604,12 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 
 	String title = TTRN("Can't drop the file...", "Can't drop the files...", files.size());
 	if (!error_message.is_empty()) {
-		_show_tooltip(title, error_message);
+		set_hint_label(title, error_message);
 		canvas_item_editor->update_viewport();
 		return false;
 	}
 	if (instantiate_type == 0) {
-		_show_tooltip(title, TTR("This file format is not supported."));
+		set_hint_label(title, TTR("This file format is not supported."));
 		return false;
 	}
 
@@ -6660,7 +6665,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 	}
 	desc += "[/ul]";
 
-	_show_tooltip(title, desc);
+	set_hint_label(title, desc);
 
 	return true;
 }

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -201,7 +201,7 @@ private:
 	bool selection_menu_additive_selection = false;
 
 	Tool tool = TOOL_SELECT;
-	Control *viewport = nullptr;
+	CanvasItemEditorViewport *viewport = nullptr;
 	Control *viewport_scrollable = nullptr;
 
 	HScrollBar *h_scroll = nullptr;
@@ -604,7 +604,7 @@ public:
 
 	VSplitContainer *get_bottom_split();
 
-	Control *get_viewport_control() { return viewport; }
+	CanvasItemEditorViewport *get_viewport_control() { return viewport; }
 
 	Control *get_controls_container() { return controls_vb; }
 
@@ -695,14 +695,14 @@ class CanvasItemEditorViewport : public Control {
 	void _show_texture_node_type_selector();
 	void _update_theme();
 
-	void _show_tooltip(const String &p_title, const String &p_description) const;
-
 protected:
 	void _notification(int p_what);
 
 public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
+
+	void set_hint_label(const String &p_title, const String &p_description) const;
 
 	CanvasItemEditorViewport(CanvasItemEditor *p_canvas_item_editor);
 	~CanvasItemEditorViewport();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When you enable the 2D scene paint tool, literally nothing happens. Once you click anywhere, you get a message that you have to select a 2D node, then once you click again, you get info that you need a scene. That's like, not very friendly.

This PR adds instructions that show when paint tool is unconfigured.

[Nagranie ekranu_20260711_150020.webm](https://github.com/user-attachments/assets/cac0a2ac-63fb-4a22-a102-a49265316279)

The old on-click dialog is still there, but it's no longer required to learn the tool.

## Additional information

This reuses the same label used by drag and drop info. It may or may not cause problems.