### PR TITLE
[HTTPClient] Block on socket when reading data in blocking mode

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -145,6 +145,7 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection"), &HTTPClient::get_connection);
 	ClassDB::bind_method(D_METHOD("request_raw", "method", "url", "headers", "body"), &HTTPClient::_request_raw);
 	ClassDB::bind_method(D_METHOD("request", "method", "url", "headers", "body"), &HTTPClient::_request, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("shutdown"), &HTTPClient::shutdown);
 	ClassDB::bind_method(D_METHOD("close"), &HTTPClient::close);
 
 	ClassDB::bind_method(D_METHOD("has_response"), &HTTPClient::has_response);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -185,6 +185,7 @@ public:
 
 	virtual void set_blocking_mode(bool p_enable) = 0; // Useful mostly if running in a thread
 	virtual bool is_blocking_mode_enabled() const = 0;
+	virtual void shutdown() = 0;
 
 	virtual void set_read_chunk_size(int p_size) = 0;
 	virtual int get_read_chunk_size() const = 0;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -246,6 +246,12 @@ Error HTTPClientTCP::get_response_headers(List<String> *r_response) {
 	return OK;
 }
 
+void HTTPClientTCP::shutdown() {
+	if (tcp_connection.is_valid()) {
+		tcp_connection->shutdown();
+	}
+}
+
 void HTTPClientTCP::close() {
 	if (tcp_connection->get_status() != StreamPeerTCP::STATUS_NONE) {
 		tcp_connection->disconnect_from_host();

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -750,6 +750,12 @@ Error HTTPClientTCP::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_recei
 		int left = p_bytes;
 		r_received = 0;
 		while (left > 0) {
+			// Don't wait if there are already pending bytes.
+			// This might happen due to TLS buffers waiting for an EOF or having
+			// processed only partial information.
+			if (connection->get_available_bytes() == 0 && tcp_connection->get_available_bytes() == 0) {
+				err = tcp_connection->wait(NetSocket::POLL_TYPE_IN, -1);
+			}
 			err = connection->get_partial_data(p_buffer + r_received, left, read);
 			if (err == OK) {
 				r_received += read;

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -96,6 +96,7 @@ public:
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;
+	void shutdown() override;
 	void set_read_chunk_size(int p_size) override;
 	int get_read_chunk_size() const override;
 	Error poll() override;

--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -48,6 +48,12 @@ public:
 		POLL_TYPE_IN_OUT
 	};
 
+	enum ShutdownType : int32_t {
+		SHUTDOWN_TYPE_READ,
+		SHUTDOWN_TYPE_WRITE,
+		SHUTDOWN_TYPE_READ_WRITE,
+	};
+
 	enum Type : int32_t {
 		TYPE_NONE,
 		TYPE_TCP,
@@ -95,6 +101,7 @@ public:
 	};
 
 	virtual Error open(Family p_family, Type p_type, IP::Type &r_ip_type) = 0;
+	virtual void shutdown(ShutdownType p_flag = ShutdownType::SHUTDOWN_TYPE_READ_WRITE) = 0;
 	virtual void close() = 0;
 	virtual Error bind(Address p_addr) = 0;
 	virtual Error listen(int p_max_pending) = 0;

--- a/core/io/stream_peer_socket.cpp
+++ b/core/io/stream_peer_socket.cpp
@@ -196,6 +196,11 @@ Error StreamPeerSocket::wait(NetSocket::PollType p_type, int p_timeout) {
 	return _sock->poll(p_type, p_timeout);
 }
 
+void StreamPeerSocket::shutdown(NetSocket::ShutdownType p_type) {
+	ERR_FAIL_COND(_sock.is_null());
+	_sock->shutdown(p_type);
+}
+
 Error StreamPeerSocket::put_data(const uint8_t *p_data, int p_bytes) {
 	int total;
 	return write(p_data, p_bytes, total, true);

--- a/core/io/stream_peer_socket.h
+++ b/core/io/stream_peer_socket.h
@@ -80,6 +80,9 @@ public:
 	// Wait or check for writable, readable.
 	Error wait(NetSocket::PollType p_type, int p_timeout = 0);
 
+	// Shutdown one or both sides of the socket.
+	void shutdown(NetSocket::ShutdownType p_type = NetSocket::SHUTDOWN_TYPE_READ_WRITE);
+
 	// Read/Write from StreamPeer
 	Error put_data(const uint8_t *p_data, int p_bytes) override;
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -194,6 +194,14 @@
 				The proxy server is unset if [param host] is empty or [param port] is -1.
 			</description>
 		</method>
+		<method name="shutdown">
+			<return type="void" />
+			<description>
+				Shuts down the underlying connection without fully closing the [HTTPClient].
+				This is mostly useful when [member blocking_mode_enabled] is [code]true[/code] and the connection needs to be interrupted from a different thread.
+				[b]Note:[/b] This has no effect on platforms that do not support blocking mode (like the web platform).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="blocking_mode_enabled" type="bool" setter="set_blocking_mode" getter="is_blocking_mode_enabled" default="false">

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -348,6 +348,25 @@ Error NetSocketUnix::open(NetSocket::Family p_family, NetSocket::Type p_sock_typ
 	}
 }
 
+void NetSocketUnix::shutdown(ShutdownType p_flag) {
+	if (_sock == -1) {
+		return;
+	}
+	switch (p_flag) {
+		case ShutdownType::SHUTDOWN_TYPE_READ:
+			::shutdown(_sock, SHUT_RD);
+			return;
+		case ShutdownType::SHUTDOWN_TYPE_WRITE:
+			::shutdown(_sock, SHUT_WR);
+			return;
+		case ShutdownType::SHUTDOWN_TYPE_READ_WRITE:
+			::shutdown(_sock, SHUT_RDWR);
+			return;
+		default:
+			ERR_FAIL_MSG("Invalid shutdown flag");
+	}
+}
+
 void NetSocketUnix::close() {
 	if (_sock != -1) {
 		::close(_sock);

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -90,6 +90,7 @@ public:
 
 	virtual Error open(Family p_family, Type p_sock_type, IP::Type &r_ip_type) override;
 	virtual void close() override;
+	virtual void shutdown(ShutdownType p_flag) override;
 	virtual Error bind(Address p_addr) override;
 	virtual Error listen(int p_max_pending) override;
 	virtual Error connect_to_host(Address p_addr) override;

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -266,6 +266,25 @@ Error NetSocketWinSock::open(Family p_family, Type p_sock_type, IP::Type &ip_typ
 	return OK;
 }
 
+void NetSocketWinSock::shutdown(ShutdownType p_flag) {
+	if (_sock == INVALID_SOCKET) {
+		return;
+	}
+	switch (p_flag) {
+		case ShutdownType::SHUTDOWN_TYPE_READ:
+			::shutdown(_sock, SD_RECEIVE);
+			return;
+		case ShutdownType::SHUTDOWN_TYPE_WRITE:
+			::shutdown(_sock, SD_SEND);
+			return;
+		case ShutdownType::SHUTDOWN_TYPE_READ_WRITE:
+			::shutdown(_sock, SD_BOTH);
+			return;
+		default:
+			ERR_FAIL_MSG("Invalid shutdown flag");
+	}
+}
+
 void NetSocketWinSock::close() {
 	if (_sock != INVALID_SOCKET) {
 		closesocket(_sock);

--- a/drivers/windows/net_socket_winsock.h
+++ b/drivers/windows/net_socket_winsock.h
@@ -71,6 +71,7 @@ public:
 	static size_t _set_addr_storage(struct sockaddr_storage *p_addr, const IPAddress &p_ip, uint16_t p_port, IP::Type p_ip_type);
 
 	virtual Error open(Family p_family, Type p_sock_type, IP::Type &ip_type) override;
+	virtual void shutdown(ShutdownType p_flag) override;
 	virtual void close() override;
 	virtual Error bind(Address p_addr) override;
 	virtual Error listen(int p_max_pending) override;

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -113,6 +113,10 @@ Error HTTPClientWeb::request(Method p_method, const String &p_url, const Vector<
 	return OK;
 }
 
+void HTTPClientWeb::shutdown() {
+	// Not implemented since there is no blocking mode on the web.
+}
+
 void HTTPClientWeb::close() {
 	host = "";
 	port = -1;

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -87,6 +87,7 @@ public:
 	Error connect_to_host(const String &p_host, int p_port = -1, Ref<TLSOptions> p_tls_options = Ref<TLSOptions>()) override;
 	void set_connection(const Ref<StreamPeer> &p_connection) override;
 	Ref<StreamPeer> get_connection() const override;
+	void shutdown() override;
 	void close() override;
 	Status get_status() const override;
 	bool has_response() const override;

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -48,6 +48,7 @@ public:
 	}
 
 	virtual Error open(Family p_family, Type p_sock_type, IP::Type &ip_type) override { return ERR_UNAVAILABLE; }
+	virtual void shutdown(ShutdownType p_flag) override {}
 	virtual void close() override {}
 	virtual Error bind(Address p_addr) override { return ERR_UNAVAILABLE; }
 	virtual Error listen(int p_max_pending) override { return ERR_UNAVAILABLE; }

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -200,6 +200,9 @@ void HTTPRequest::cancel_request() {
 		set_process_internal(false);
 	} else {
 		thread_request_quit.set();
+		if (client.is_valid()) {
+			client->shutdown();
+		}
 		if (thread.is_started()) {
 			thread.wait_to_finish();
 		}

--- a/tests/core/io/test_stream_peer_tcp.cpp
+++ b/tests/core/io/test_stream_peer_tcp.cpp
@@ -57,6 +57,7 @@ public:
 	virtual Ref<NetSocket> accept(Address &r_addr) override;
 
 	virtual bool is_open() const override;
+	virtual void shutdown(ShutdownType p_flag) override {}
 	virtual int get_available_bytes() const override;
 	virtual Error get_socket_address(Address *r_ip) const override;
 


### PR DESCRIPTION
The threading model used by HTTPRequest and the way HTTPClient blocking mode is implemented, makes it really hard to implement efficient download loops, forcing us to rely on a very busy loop which doesn't actually block on the socket.

This is an attempt at making the HTTPClient actually block on the socket using [`shutdown`](https://man7.org/linux/man-pages/man2/shutdown.2.html) ([Win](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown)) to signal the downloading thread it should quit.

Fixes #33479
Fixes #35868
Fixes #119782

Closes #117749 .

Side Note
--

Reasoning on the thread safety of this implementation is non-trivial, but relies on the following constraints:

- The `tcp_connection` instance of the `HTTPClientTCP` never changes (i.e. never re-assigned after instantiation)
- The underlying `NetSocket` of the `tcp_connection` never changes (i.e. never re-assigned after instantiation)
- The call to `NetSocket::shutdown` thread-safe`*` (does not mutate the NetSocket state beside making the relevant socket syscall).
- The `HTTPRequest` never instantiate a new `HTTPClient` from the thread.


`*` There is a very scary blurb in the [MS docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown) about APCs and thread safety, but if I understand the MS-speak correctly what we are doing here should be fine.