### PR TITLE
Core: Fix doctool when passing `--quiet`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2169,6 +2169,10 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps"), "set_max_fps", "get_max_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
+
+	// Those default values need to be specified for the docs generator,
+	// to avoid using values from a `--quiet` run.
+	ADD_PROPERTY_DEFAULT("print_to_stdout", true);
 }
 
 ////// EngineDebugger //////


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a small discrepancy in the `print_to_stdout` property on `Engine`, which would assume a default value of `false` when running the doctool alongside `--quiet`
