### PR TITLE
Make generated doc data hash deterministic

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -1,5 +1,6 @@
 """Functions used to generate source files during build time"""
 
+import hashlib
 import os
 import os.path
 import subprocess
@@ -59,7 +60,7 @@ def make_doc_header(target, source, env):
 
     with methods.generated_wrapper(str(target[0])) as file:
         file.write(f"""\
-inline constexpr const char *_doc_data_hash = "{hash(buffer)}";
+inline constexpr const char *_doc_data_hash = "{hashlib.sha256(buffer).hexdigest()}";
 inline constexpr int _doc_data_compressed_size = {len(buffer)};
 inline constexpr int _doc_data_uncompressed_size = {decomp_size};
 inline constexpr const unsigned char _doc_data_compressed[] = {{


### PR DESCRIPTION
Python's build-in hash() is intentionally randomized between processes. This prevents Godot from building reproducibly since identical source input produces different hashed values each build. SHA-256 is used here as a deterministic alternative hash function.

ChatGPT Codex was prompted with the Debian build logs and `diffoscope` output and suggested a deterministic hash. I tested a patch and verified the Debian output packages are now byte-identical across builds.

## What problem(s) does this PR solve?

- Debian recently started requiring reproducible builds. This prevented Godot from being updated to 4.6.3 in Debian because of the doc hash mismatch across builds.

