### PR TITLE
Fix `Color::hash()` hashing the red component twice

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -242,7 +242,7 @@ struct [[nodiscard]] Color {
 
 	uint32_t hash() const {
 		uint32_t h = hash_murmur3_one_float(r);
-		h = hash_murmur3_one_float(r, h);
+		h = hash_murmur3_one_float(g, h);
 		h = hash_murmur3_one_float(b, h);
 		h = hash_murmur3_one_float(a, h);
 		return hash_fmix32(h);

--- a/tests/core/math/test_color.cpp
+++ b/tests/core/math/test_color.cpp
@@ -96,6 +96,13 @@ TEST_CASE("[Color] Operators") {
 			"Color negation should behave as expected (affecting the alpha channel, unlike `invert()`).");
 }
 
+TEST_CASE("[Color] Hash") {
+	const Color red = Color(1, 0, 0, 1);
+	const Color yellow = Color(1, 1, 0, 1);
+
+	CHECK(red.hash() != yellow.hash());
+}
+
 TEST_CASE("[Color] Reading methods") {
 	constexpr Color dark_blue = Color(0, 0, 0.5, 0.4);
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
Color::hash() function hashes component 'r' twice(r, r, b, a) instead of hashing all four components once (r, g, b, a)

- Closes #121189

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
