### PR TITLE
Allow the type names and property names of Theme resources to use valid Unicode characters

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -1868,7 +1868,7 @@ void ThemeItemEditorDialog::_open_rename_theme_item_dialog(Theme::DataType p_dat
 }
 
 void ThemeItemEditorDialog::_confirm_edit_theme_item() {
-	const String new_item_name = theme_item_name->get_text().strip_edges().validate_ascii_identifier();
+	const String new_item_name = theme_item_name->get_text().strip_edges().validate_unicode_identifier();
 
 	if (item_popup_mode == CREATE_THEME_ITEM) {
 		_add_theme_item(edit_item_data_type, new_item_name, edited_item_type);
@@ -3021,7 +3021,7 @@ void ThemeTypeEditor::_item_add_cbk(int p_data_type, Control *p_control) {
 		return;
 	}
 
-	const String item_name = le->get_text().strip_edges().validate_ascii_identifier();
+	const String item_name = le->get_text().strip_edges().validate_unicode_identifier();
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Add Theme Item"));
@@ -3190,7 +3190,7 @@ void ThemeTypeEditor::_item_rename_confirmed(int p_data_type, String p_item_name
 		return;
 	}
 
-	const String new_name = le->get_text().strip_edges().validate_ascii_identifier();
+	const String new_name = le->get_text().strip_edges().validate_unicode_identifier();
 	if (new_name == p_item_name) {
 		_item_rename_canceled(p_data_type, p_item_name, p_control);
 		return;

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -181,7 +181,7 @@ bool Theme::is_valid_type_name(const String &p_name) {
 	int len = p_name.length();
 	const char32_t *str = p_name.ptr();
 	for (int i = 0; i < len; i++) {
-		if (!is_ascii_identifier_char(str[i])) {
+		if (!is_unicode_identifier_continue(str[i])) {
 			return false;
 		}
 	}
@@ -195,7 +195,7 @@ bool Theme::is_valid_item_name(const String &p_name) {
 	int len = p_name.length();
 	const char32_t *str = p_name.ptr();
 	for (int i = 0; i < len; i++) {
-		if (!is_ascii_identifier_char(str[i])) {
+		if (!is_unicode_identifier_continue(str[i])) {
 			return false;
 		}
 	}
@@ -207,7 +207,7 @@ String Theme::validate_type_name(const String &p_name) {
 	int len = type_name.length();
 	char32_t *buffer = type_name.ptrw();
 	for (int i = 0; i < len; i++) {
-		if (!is_ascii_identifier_char(buffer[i])) {
+		if (!is_unicode_identifier_continue(buffer[i])) {
 			buffer[i] = '_';
 		}
 	}

--- a/tests/scene/test_theme.cpp
+++ b/tests/scene/test_theme.cpp
@@ -64,6 +64,7 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Good theme type names") {
 		"snake_cased_name",
 		"42",
 		"_Underscore_",
+		String::utf8("contains_汉字"),
 	};
 
 	SUBCASE("add_type") {
@@ -129,7 +130,6 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme type names") {
 		"With/Slash",
 		"With Space",
 		"With@various$symbols!",
-		String::utf8("contains_汉字"),
 	};
 
 	ERR_PRINT_OFF; // All these rightfully print errors.
@@ -194,6 +194,7 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Good theme item names") {
 		"snake_cased_name",
 		"42",
 		"_Underscore_",
+		String::utf8("contains_汉字"),
 	};
 
 	SUBCASE("set_theme_item") {
@@ -231,7 +232,6 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme item names") {
 		"With/Slash",
 		"With Space",
 		"With@various$symbols!",
-		String::utf8("contains_汉字"),
 	};
 
 	ERR_PRINT_OFF; // All these rightfully print errors.


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Allow the type names and property names of Theme resources to use valid Unicode characters.

## Additional information

By modifying the API, make Theme resources and related editors allow more relaxed Unicode characters in type names and property names.

The following video shows how to create Theme types and name attributes using Chinese characters.


https://github.com/user-attachments/assets/ad6c27bd-3aae-497c-b1a7-5b95eb3717c7

The following video shows the theme type variation used by scene tree nodes.


https://github.com/user-attachments/assets/58ff2812-37b4-44b7-983b-91c751e5f624



The following video shows the state of the game while it's running.


https://github.com/user-attachments/assets/90770131-8135-461e-9cd9-5307a658a2f5

To make testing easier, I provided the smallest game project to make code review easier.

[theme_test.zip](https://github.com/user-attachments/files/29930444/theme_test.zip)



<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
