### PR TITLE
Fix Script Editor zoom factor not being applied on editor start

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3290,6 +3290,9 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 	List<String> extensions = _get_recognized_extensions();
 
 	ScriptEditorNavigationMarker::get_singleton()->init_begin();
+
+	_set_script_zoom_factor(p_layout->get_value("ScriptEditor", "zoom_factor", 1.0f));
+
 	for (const Variant &v : scripts) {
 		String path = v;
 
@@ -3384,8 +3387,6 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 			EditorDebuggerNode::get_singleton()->set_breakpoint(E, (int)breakpoint + 1, true);
 		}
 	}
-
-	_set_script_zoom_factor(p_layout->get_value("ScriptEditor", "zoom_factor", 1.0f));
 
 	restoring_layout = false;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes #121250
Sometime between the 4.7-dev2 and dev3 cycle, zoom factor stopped getting applied to the script editor should the editor start with it displayed, only applying once visibility changes (such as moving to 2D view and then back to the script view) 

This applies the zoom just before the scripts are initialized, letting the edit method pull the correct value.

