### PR TITLE
Fix duplicate buffer deletion

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2906,8 +2906,8 @@ RasterizerCanvasGLES3::~RasterizerCanvasGLES3() {
 	glDeleteBuffers(1, &data.canvas_quad_vertices);
 	glDeleteVertexArrays(1, &data.canvas_quad_array);
 
-	glDeleteBuffers(1, &data.canvas_quad_vertices);
-	glDeleteVertexArrays(1, &data.canvas_quad_array);
+	glDeleteBuffers(1, &data.particle_quad_vertices);
+	glDeleteVertexArrays(1, &data.particle_quad_array);
 
 	GLES3::TextureStorage::get_singleton()->canvas_texture_free(default_canvas_texture);
 	memdelete_arr(state.instance_data_array);


### PR DESCRIPTION
Changed canvas to particle in duplicate quad_array/vertices buffer deletion
It was previously a duplicate deletion of canvas buffers in the destructor

## What problem(s) does this PR solve?

- Closes #121191 