### PR TITLE
Fix incorrect GDExtension library lookup in locateFile()

### DIFF
--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -314,7 +314,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 					return `${loadPath}.audio.position.worklet.js`;
 				} else if (path.endsWith('.js')) {
 					return `${loadPath}.js`;
-				} else if (path in gdext) {
+				} else if (gdext.indexOf(path) !== -1) {
 					return path;
 				} else if (path.endsWith('.side.wasm')) {
 					return `${loadPath}.side.wasm`;


### PR DESCRIPTION
## Summary

This pull request fixes the array membership check used by `locateFile()` when determining whether a requested file belongs to the configured GDExtension libraries.

The previous implementation used an incorrect membership test, which could cause GDExtension libraries to be misidentified during loading. This change replaces it with the correct lookup while preserving existing behavior for all other files.

## Changes

- Fix the GDExtension library membership check in `locateFile()`.
- Preserve existing behavior for non-GDExtension files.
- No API changes.
- No functional changes outside of the corrected lookup logic.

## Testing

- Built successfully.
- Verified the modified code compiles correctly.
- GitHub Actions passed except for one Linux job that appears to be failing due to an unrelated compiler/CI issue rather than this change.

## Responsibility

I have tested this change to the best of my ability and reviewed it carefully before submitting. I take responsibility for the implementation in this pull request and will address any feedback or requested changes during the review process.


## What problem(s) does this PR solve?

- Closes #
- Fixes incorrect detection of GDExtension libraries in `locateFile()`.
- Prevents valid GDExtension library paths from being handled incorrectly due to an improper array membership check.
- Ensures the runtime correctly distinguishes configured GDExtension libraries from other files during loading.


## Additional information

I'm a new contributor so maybe the code might not follow Godot's standards.