### PR TITLE
Fix incorrect slider joint parameter forwarding in PhysicalBone3D

### DIFF
--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -358,7 +358,7 @@ bool PhysicalBone3D::SliderJointData::_set(const StringName &p_name, const Varia
 	} else if ("joint_constraints/linear_limit_damping" == p_name) {
 		linear_limit_damping = p_value;
 		if (is_valid_slider) {
-			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_DAMPING, linear_limit_restitution);
+			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_DAMPING, linear_limit_damping);
 		}
 
 	} else if ("joint_constraints/angular_limit_upper" == p_name) {
@@ -382,7 +382,7 @@ bool PhysicalBone3D::SliderJointData::_set(const StringName &p_name, const Varia
 	} else if ("joint_constraints/angular_limit_restitution" == p_name) {
 		angular_limit_restitution = p_value;
 		if (is_valid_slider) {
-			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PS3DE::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS, angular_limit_softness);
+			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PS3DE::SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION, angular_limit_restitution);
 		}
 
 	} else if ("joint_constraints/angular_limit_damping" == p_name) {
@@ -1001,7 +1001,7 @@ void PhysicalBone3D::_reload_joint() {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_LOWER, sjd->linear_limit_lower);
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_SOFTNESS, sjd->linear_limit_softness);
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION, sjd->linear_limit_restitution);
-			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_DAMPING, sjd->linear_limit_restitution);
+			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_LINEAR_LIMIT_DAMPING, sjd->linear_limit_damping);
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_ANGULAR_LIMIT_UPPER, sjd->angular_limit_upper);
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_ANGULAR_LIMIT_LOWER, sjd->angular_limit_lower);
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(joint, PS3DE::SLIDER_JOINT_ANGULAR_LIMIT_SOFTNESS, sjd->angular_limit_softness);


### PR DESCRIPTION
## Summary

This pull request fixes several incorrect slider joint parameter assignments in `PhysicalBone3D` caused by copy-paste mistakes.

The affected code forwarded the wrong values or used the wrong `PhysicsServer3D` parameter when updating slider joint properties, causing some property changes to have no effect or modify the wrong underlying parameter.

AI is not used in this pull request.
## Changes

- Use `linear_limit_damping` when updating `SLIDER_JOINT_LINEAR_LIMIT_DAMPING`.
- Use `SLIDER_JOINT_ANGULAR_LIMIT_RESTITUTION` and `angular_limit_restitution` when updating the angular restitution property.
- Initialize `SLIDER_JOINT_LINEAR_LIMIT_DAMPING` using `linear_limit_damping` instead of `linear_limit_restitution`.

## Testing

- Built successfully.
- Verified the modified code compiles correctly.
- Verified that all affected changes are limited to `scene/3d/physics/physical_bone_3d.cpp`.
- GitHub Actions completed successfully.

## What problem(s) does this PR solve?
- Closes #121207 
- Fixes the **Linear Limit Damping** property incorrectly forwarding the restitution value to the physics server.
- Fixes the **Angular Limit Restitution** property incorrectly updating the softness parameter instead of the restitution parameter.
- Fixes newly created slider joints initializing the damping parameter with the restitution value.
- Ensures each exposed `PhysicalBone3D` slider joint property updates the corresponding `PhysicsServer3D` parameter as intended.

## Additional information

These are self-contained correctness fixes that address several copy-paste mistakes in slider joint parameter forwarding. The changes do not modify any public APIs or introduce new functionality; they only ensure that each property is forwarded to the correct physics parameter.