### PR TITLE
Update navigation scheme settings faster

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -93,6 +93,8 @@ void EditorSettingsDialog::_settings_property_edited() {
 	} else if (full_name == "editors/3d/navigation/navigation_scheme") {
 		update_3d_navigation_preset();
 		_update_shortcuts();
+		_update_dynamic_property_hints();
+		callable_mp(EditorSettings::get_singleton(), &EditorSettings::notify_changes).call_deferred();
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #99215 

## Additional information

The issue has a video that shows the problem well.

Changing the navigation scheme edits other settings related to it. On these settings the mouse button text changes instantly, but the modifier key text only updates after the timer triggers a save about a second later. 

Fixed it by just manually notifying changes after the new property hints are done. Call is deferred because otherwise it spits out errors about stuff being freed while emitting signals.