### PR TITLE
Enforce left qualifier alignment through `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -195,7 +195,7 @@ PackConstructorInitializers: NextLine
 # PenaltyIndentedWhitespace: 0
 # PenaltyReturnTypeOnItsOwnLine: 60
 # PointerAlignment: Right
-# QualifierAlignment: Leave
+QualifierAlignment: Left
 # ReferenceAlignment: Pointer
 # ReflowComments: true
 # RemoveBracesLLVM: false

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -90,3 +90,6 @@ a447ac95ec170ee117c2eae55f1bfff0d0cf0dce
 
 # Style: Apply `readability-identifier-naming` rules
 a3088fecf1837aa22fcf2bccae413598a2e91766
+
+# Style: Apply left qualifier alignment rule
+eb1b8e8edacc3c7449ea8ac894812720e7ee48bf

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3653,7 +3653,7 @@ static String _replace_common(const String &p_this, const String &p_key, const S
 	return new_string;
 }
 
-static String _replace_common(const String &p_this, char const *p_key, char const *p_with, bool p_case_insensitive) {
+static String _replace_common(const String &p_this, const char *p_key, const char *p_with, bool p_case_insensitive) {
 	size_t key_length = strlen(p_key);
 
 	if (key_length == 0 || p_this.is_empty()) {

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -665,7 +665,7 @@ private:
 		SamplerDescriptorHeapAllocation *sampler_descriptor_heap_alloc = nullptr;
 
 		struct DynamicBuffer {
-			BufferDynamicInfo const *info = nullptr;
+			const BufferDynamicInfo *info = nullptr;
 			uint32_t binding = UINT_MAX;
 		};
 

--- a/drivers/metal/metal3_objects.cpp
+++ b/drivers/metal/metal3_objects.cpp
@@ -362,7 +362,7 @@ void MDCommandBuffer::clear_color_texture(RDD::TextureID p_texture, RDD::Texture
 		uint32_t layerCnt = p_subresources.layer_count;
 		uint32_t layerEnd = layerStart + layerCnt;
 
-		MetalFeatures const &features = device_driver->get_device_properties().features;
+		const MetalFeatures &features = device_driver->get_device_properties().features;
 
 		// Iterate across mipmap levels and layers, and perform and empty render to clear each.
 		for (uint32_t mipLvl = mipLvlStart; mipLvl < mipLvlEnd; mipLvl++) {
@@ -462,7 +462,7 @@ void MDCommandBuffer::clear_depth_stencil_texture(RDD::TextureID p_texture, RDD:
 		uint32_t layerCnt = p_subresources.layer_count;
 		uint32_t layerEnd = layerStart + layerCnt;
 
-		MetalFeatures const &features = device_driver->get_device_properties().features;
+		const MetalFeatures &features = device_driver->get_device_properties().features;
 
 		// Iterate across mipmap levels and layers, and perform and empty render to clear each.
 		for (uint32_t mipLvl = mipLvlStart; mipLvl < mipLvlEnd; mipLvl++) {
@@ -778,7 +778,7 @@ void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> 
 	uint32_t stencil_value = 0;
 
 	for (uint32_t i = 0; i < p_attachment_clears.size(); i++) {
-		RDD::AttachmentClear const &attClear = p_attachment_clears[i];
+		const RDD::AttachmentClear &attClear = p_attachment_clears[i];
 		uint32_t attachment_index;
 		if (attClear.aspect.has_flag(RDD::TEXTURE_ASPECT_COLOR_BIT)) {
 			attachment_index = attClear.color_attachment;
@@ -786,7 +786,7 @@ void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> 
 			attachment_index = subpass.depth_stencil_reference.attachment;
 		}
 
-		MDAttachment const &mda = render.pass->attachments[attachment_index];
+		const MDAttachment &mda = render.pass->attachments[attachment_index];
 		if (attClear.aspect.has_flag(RDD::TEXTURE_ASPECT_COLOR_BIT)) {
 			key.set_color_format(attachment_index, mda.format);
 			clear_colors[attachment_index] = {
@@ -856,7 +856,7 @@ void MDCommandBuffer::_render_set_dirty_state() {
 		}
 	}
 
-	MDSubpass const &subpass = render.get_subpass();
+	const MDSubpass &subpass = render.get_subpass();
 	if (subpass.view_count > 1) {
 		uint32_t view_range[2] = { 0, subpass.view_count };
 		render.encoder->setVertexBytes(view_range, sizeof(view_range), VIEW_MASK_BUFFER_INDEX);
@@ -908,7 +908,7 @@ void MDCommandBuffer::_render_set_dirty_state() {
 }
 
 void ResourceTracker::merge_from(const ::ResourceUsageMap &p_from) {
-	for (KeyValue<StageResourceUsage, ::ResourceVector> const &keyval : p_from) {
+	for (const KeyValue<StageResourceUsage, ::ResourceVector> &keyval : p_from) {
 		ResourceVector *resources = _current.getptr(keyval.key);
 		if (resources == nullptr) {
 			resources = &_current.insert(keyval.key, ResourceVector())->value;
@@ -961,7 +961,7 @@ void ResourceTracker::merge_from(const ::ResourceUsageMap &p_from) {
 }
 
 void ResourceTracker::encode(MTL::RenderCommandEncoder *p_enc) {
-	for (KeyValue<StageResourceUsage, ResourceVector> const &keyval : _current) {
+	for (const KeyValue<StageResourceUsage, ResourceVector> &keyval : _current) {
 		if (keyval.value.is_empty()) {
 			continue;
 		}
@@ -989,7 +989,7 @@ void ResourceTracker::encode(MTL::RenderCommandEncoder *p_enc) {
 }
 
 void ResourceTracker::encode(MTL::ComputeCommandEncoder *p_enc) {
-	for (KeyValue<StageResourceUsage, ResourceVector> const &keyval : _current) {
+	for (const KeyValue<StageResourceUsage, ResourceVector> &keyval : _current) {
 		if (keyval.value.is_empty()) {
 			continue;
 		}
@@ -1088,9 +1088,9 @@ void MDCommandBuffer::render_next_subpass() {
 		render.current_subpass++;
 	}
 
-	MDFrameBuffer const &fb = *render.frameBuffer;
-	MDRenderPass const &pass = *render.pass;
-	MDSubpass const &subpass = render.get_subpass();
+	const MDFrameBuffer &fb = *render.frameBuffer;
+	const MDRenderPass &pass = *render.pass;
+	const MDSubpass &subpass = render.get_subpass();
 
 	NS::SharedPtr<MTL::RenderPassDescriptor> desc = NS::TransferPtr(MTL::RenderPassDescriptor::alloc()->init());
 
@@ -1123,7 +1123,7 @@ void MDCommandBuffer::render_next_subpass() {
 			}
 		}
 
-		MDAttachment const &attachment = pass.attachments[idx];
+		const MDAttachment &attachment = pass.attachments[idx];
 
 		MTL::Texture *tex = fb.get_texture(idx);
 		ERR_FAIL_NULL_MSG(tex, "Frame buffer color texture is null.");
@@ -1139,7 +1139,7 @@ void MDCommandBuffer::render_next_subpass() {
 	if (subpass.depth_stencil_reference.attachment != RDD::AttachmentReference::UNUSED) {
 		attachmentCount += 1;
 		uint32_t idx = subpass.depth_stencil_reference.attachment;
-		MDAttachment const &attachment = pass.attachments[idx];
+		const MDAttachment &attachment = pass.attachments[idx];
 		MTL::Texture *tex = fb.get_texture(idx);
 		ERR_FAIL_NULL_MSG(tex, "Frame buffer depth / stencil texture is null.");
 		if (attachment.type & MDAttachmentType::Depth) {
@@ -1200,7 +1200,7 @@ void MDCommandBuffer::render_draw(uint32_t p_vertex_count,
 
 	_render_set_dirty_state();
 
-	MDSubpass const &subpass = render.get_subpass();
+	const MDSubpass &subpass = render.get_subpass();
 	if (subpass.view_count > 1) {
 		p_instance_count *= subpass.view_count;
 	}
@@ -1276,7 +1276,7 @@ void MDCommandBuffer::render_draw_indexed(uint32_t p_index_count,
 
 	_render_set_dirty_state();
 
-	MDSubpass const &subpass = render.get_subpass();
+	const MDSubpass &subpass = render.get_subpass();
 	if (subpass.view_count > 1) {
 		p_instance_count *= subpass.view_count;
 	}
@@ -1642,7 +1642,7 @@ void MDCommandBuffer::_bind_uniforms_argument_buffers(MDUniformSet *p_set, MDSha
 		uint32_t dynamic_index = 0;
 
 		for (uint32_t i : shader_set.dynamic_uniforms) {
-			RDD::BoundUniform const &uniform = p_set->uniforms[i];
+			const RDD::BoundUniform &uniform = p_set->uniforms[i];
 			const UniformInfo &ui = shader_set.uniforms[i];
 			const UniformInfo::Indexes &idx = ui.arg_buffer;
 
@@ -1666,12 +1666,12 @@ void MDCommandBuffer::_bind_uniforms_argument_buffers(MDUniformSet *p_set, MDSha
 void MDCommandBuffer::_bind_uniforms_direct(MDUniformSet *p_set, MDShader *p_shader, DirectEncoder p_enc, uint32_t p_set_index, uint32_t p_dynamic_offsets) {
 	DEV_ASSERT(!p_shader->uses_argument_buffers);
 
-	UniformSet const &set = p_shader->sets[p_set_index];
+	const UniformSet &set = p_shader->sets[p_set_index];
 	DynamicOffsetLayout layout = p_shader->dynamic_offset_layout;
 	uint32_t dynamic_index = 0;
 
 	for (uint32_t i = 0; i < MIN(p_set->uniforms.size(), set.uniforms.size()); i++) {
-		RDD::BoundUniform const &uniform = p_set->uniforms[i];
+		const RDD::BoundUniform &uniform = p_set->uniforms[i];
 		const UniformInfo &ui = set.uniforms[i];
 		const UniformInfo::Indexes &indexes = ui.slot;
 
@@ -1798,7 +1798,7 @@ void MDCommandBuffer::_bind_uniforms_argument_buffers_compute(MDUniformSet *p_se
 		uint32_t dynamic_index = 0;
 
 		for (uint32_t i : shader_set.dynamic_uniforms) {
-			RDD::BoundUniform const &uniform = p_set->uniforms[i];
+			const RDD::BoundUniform &uniform = p_set->uniforms[i];
 			const UniformInfo &ui = shader_set.uniforms[i];
 			const UniformInfo::Indexes &idx = ui.arg_buffer;
 

--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -346,21 +346,21 @@ MTL::DepthStencilState *MDResourceCache::get_depth_stencil_state(bool p_use_dept
 MTLFmtCaps MDSubpass::getRequiredFmtCapsForAttachmentAt(uint32_t p_index) const {
 	MTLFmtCaps caps = kMTLFmtCapsNone;
 
-	for (RDD::AttachmentReference const &ar : input_references) {
+	for (const RDD::AttachmentReference &ar : input_references) {
 		if (ar.attachment == p_index) {
 			flags::set(caps, kMTLFmtCapsRead);
 			break;
 		}
 	}
 
-	for (RDD::AttachmentReference const &ar : color_references) {
+	for (const RDD::AttachmentReference &ar : color_references) {
 		if (ar.attachment == p_index) {
 			flags::set(caps, kMTLFmtCapsColorAtt);
 			break;
 		}
 	}
 
-	for (RDD::AttachmentReference const &ar : resolve_references) {
+	for (const RDD::AttachmentReference &ar : resolve_references) {
 		if (ar.attachment == p_index) {
 			flags::set(caps, kMTLFmtCapsResolve);
 			break;
@@ -378,7 +378,7 @@ void MDAttachment::linkToSubpass(const MDRenderPass &p_pass) {
 	firstUseSubpassIndex = UINT32_MAX;
 	lastUseSubpassIndex = 0;
 
-	for (MDSubpass const &subpass : p_pass.subpasses) {
+	for (const MDSubpass &subpass : p_pass.subpasses) {
 		MTLFmtCaps reqCaps = subpass.getRequiredFmtCapsForAttachmentAt(index);
 		if (reqCaps) {
 			firstUseSubpassIndex = MIN(subpass.subpass_index, firstUseSubpassIndex);
@@ -387,7 +387,7 @@ void MDAttachment::linkToSubpass(const MDRenderPass &p_pass) {
 	}
 }
 
-MTL::StoreAction MDAttachment::getMTLStoreAction(MDSubpass const &p_subpass,
+MTL::StoreAction MDAttachment::getMTLStoreAction(const MDSubpass &p_subpass,
 		bool p_is_rendering_entire_area,
 		bool p_has_resolve,
 		bool p_can_resolve,
@@ -440,7 +440,7 @@ void MDCommandBufferBase::render_set_viewport(VectorView<Rect2i> p_viewports) {
 	RenderStateBase &state = get_render_state_base();
 	state.viewports.resize(p_viewports.size());
 	for (uint32_t i = 0; i < p_viewports.size(); i += 1) {
-		Rect2i const &vp = p_viewports[i];
+		const Rect2i &vp = p_viewports[i];
 		state.viewports[i] = {
 			.originX = static_cast<double>(vp.position.x),
 			.originY = static_cast<double>(vp.position.y),
@@ -457,7 +457,7 @@ void MDCommandBufferBase::render_set_scissor(VectorView<Rect2i> p_scissors) {
 	RenderStateBase &state = get_render_state_base();
 	state.scissors.resize(p_scissors.size());
 	for (uint32_t i = 0; i < p_scissors.size(); i += 1) {
-		Rect2i const &vp = p_scissors[i];
+		const Rect2i &vp = p_scissors[i];
 		state.scissors[i] = {
 			.x = static_cast<NS::UInteger>(vp.position.x),
 			.y = static_cast<NS::UInteger>(vp.position.y),
@@ -480,12 +480,12 @@ void MDCommandBufferBase::render_set_blend_constants(const Color &p_constants) {
 void MDCommandBufferBase::_populate_vertices(simd::float4 *p_vertices, Size2i p_fb_size, VectorView<Rect2i> p_rects) {
 	uint32_t idx = 0;
 	for (uint32_t i = 0; i < p_rects.size(); i++) {
-		Rect2i const &rect = p_rects[i];
+		const Rect2i &rect = p_rects[i];
 		idx = _populate_vertices(p_vertices, idx, rect, p_fb_size);
 	}
 }
 
-uint32_t MDCommandBufferBase::_populate_vertices(simd::float4 *p_vertices, uint32_t p_index, Rect2i const &p_rect, Size2i p_fb_size) {
+uint32_t MDCommandBufferBase::_populate_vertices(simd::float4 *p_vertices, uint32_t p_index, const Rect2i &p_rect, Size2i p_fb_size) {
 	// Determine the positions of the four edges of the
 	// clear rectangle as a fraction of the attachment size.
 	float leftPos = (float)(p_rect.position.x) / (float)p_fb_size.width;
@@ -541,8 +541,8 @@ uint32_t MDCommandBufferBase::_populate_vertices(simd::float4 *p_vertices, uint3
 }
 
 void MDCommandBufferBase::_end_render_pass() {
-	MDFrameBuffer const &fb_info = *get_frame_buffer();
-	MDSubpass const &subpass = get_current_subpass();
+	const MDFrameBuffer &fb_info = *get_frame_buffer();
+	const MDSubpass &subpass = get_current_subpass();
 
 	PixelFormats &pf = device_driver->get_pixel_formats();
 
@@ -564,8 +564,8 @@ void MDCommandBufferBase::_end_render_pass() {
 }
 
 void MDCommandBufferBase::_render_clear_render_area() {
-	MDRenderPass const &pass = *get_render_pass();
-	MDSubpass const &subpass = get_current_subpass();
+	const MDRenderPass &pass = *get_render_pass();
+	const MDSubpass &subpass = get_current_subpass();
 	LocalVector<RDD::RenderPassClearValue> &clear_values = get_clear_values();
 
 	uint32_t ds_index = subpass.depth_stencil_reference.attachment;
@@ -589,7 +589,7 @@ void MDCommandBufferBase::_render_clear_render_area() {
 	}
 
 	if (clear_depth || clear_stencil) {
-		MDAttachment const &attachment = pass.attachments[ds_index];
+		const MDAttachment &attachment = pass.attachments[ds_index];
 		BitField<RDD::TextureAspectBits> bits = {};
 		if (clear_depth && attachment.type & MDAttachmentType::Depth) {
 			bits.set_flag(RDD::TEXTURE_ASPECT_DEPTH_BIT);
@@ -617,7 +617,7 @@ void MDCommandBufferBase::encode_push_constant_data(RDD::ShaderID p_shader, Vect
 				return;
 			}
 			push_constant_binding = shader->push_constants.binding;
-			void const *ptr = p_data.ptr();
+			const void *ptr = p_data.ptr();
 			push_constant_data_len = p_data.size() * sizeof(uint32_t);
 			DEV_ASSERT(push_constant_data_len <= sizeof(push_constant_data));
 			memcpy(push_constant_data, ptr, push_constant_data_len);

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -421,7 +421,7 @@ public:
 	 * @param p_subpass
 	 * @return
 	 */
-	_FORCE_INLINE_ bool isFirstUseOf(MDSubpass const &p_subpass) const {
+	_FORCE_INLINE_ bool isFirstUseOf(const MDSubpass &p_subpass) const {
 		return p_subpass.subpass_index == firstUseSubpassIndex;
 	}
 
@@ -430,20 +430,20 @@ public:
 	 * @param p_subpass
 	 * @return
 	 */
-	_FORCE_INLINE_ bool isLastUseOf(MDSubpass const &p_subpass) const {
+	_FORCE_INLINE_ bool isLastUseOf(const MDSubpass &p_subpass) const {
 		return p_subpass.subpass_index == lastUseSubpassIndex;
 	}
 
-	void linkToSubpass(MDRenderPass const &p_pass);
+	void linkToSubpass(const MDRenderPass &p_pass);
 
-	MTL::StoreAction getMTLStoreAction(MDSubpass const &p_subpass,
+	MTL::StoreAction getMTLStoreAction(const MDSubpass &p_subpass,
 			bool p_is_rendering_entire_area,
 			bool p_has_resolve,
 			bool p_can_resolve,
 			bool p_is_stencil) const;
 	bool configureDescriptor(MTL::RenderPassAttachmentDescriptor *p_desc,
 			PixelFormats &p_pf,
-			MDSubpass const &p_subpass,
+			const MDSubpass &p_subpass,
 			MTL::Texture *p_attachment,
 			bool p_is_rendering_entire_area,
 			bool p_has_resolve,
@@ -473,7 +473,7 @@ public:
 	}
 
 	/** Returns whether this attachment should be cleared in the subpass. */
-	bool shouldClear(MDSubpass const &p_subpass, bool p_is_stencil) const;
+	bool shouldClear(const MDSubpass &p_subpass, bool p_is_stencil) const;
 };
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0), visionos(2.0)) MDRenderPass {
@@ -672,7 +672,7 @@ protected:
 	virtual void end_render_encoding() = 0;
 
 	void _populate_vertices(simd::float4 *p_vertices, Size2i p_fb_size, VectorView<Rect2i> p_rects);
-	uint32_t _populate_vertices(simd::float4 *p_vertices, uint32_t p_index, Rect2i const &p_rect, Size2i p_fb_size);
+	uint32_t _populate_vertices(simd::float4 *p_vertices, uint32_t p_index, const Rect2i &p_rect, Size2i p_fb_size);
 	void _end_render_pass();
 	void _render_clear_render_area();
 

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -222,7 +222,7 @@ static const MTL::TextureType TEXTURE_TYPE[RDD::TEXTURE_TYPE_MAX] = {
 	MTL::TextureTypeCubeArray,
 };
 
-bool RenderingDeviceDriverMetal::is_valid_linear(TextureFormat const &p_format) const {
+bool RenderingDeviceDriverMetal::is_valid_linear(const TextureFormat &p_format) const {
 	MTLFormatType ft = pixel_formats->getFormatType(p_format.format);
 
 	return p_format.texture_type == TEXTURE_TYPE_2D // Linear textures must be 2D textures.
@@ -893,7 +893,7 @@ void RenderingDeviceDriverMetal::_swap_chain_release_buffers(SwapChain *p_swap_c
 }
 
 RDD::SwapChainID RenderingDeviceDriverMetal::swap_chain_create(RenderingContextDriver::SurfaceID p_surface) {
-	RenderingContextDriverMetal::Surface const *surface = (RenderingContextDriverMetal::Surface *)(p_surface);
+	const RenderingContextDriverMetal::Surface *surface = (RenderingContextDriverMetal::Surface *)(p_surface);
 	if (use_barriers) {
 		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
 		add_residency_set_to_main_queue(surface->get_residency_set());
@@ -1014,7 +1014,7 @@ RDD::FramebufferID RenderingDeviceDriverMetal::framebuffer_create(RenderPassID p
 	textures.resize(p_attachments.size());
 
 	for (uint32_t i = 0; i < p_attachments.size(); i += 1) {
-		MDAttachment const &a = pass->attachments[i];
+		const MDAttachment &a = pass->attachments[i];
 		MTL::Texture *tex = reinterpret_cast<MTL::Texture *>(p_attachments[i].id);
 		if (tex == nullptr) {
 #if DEV_ENABLED
@@ -1419,7 +1419,7 @@ RDD::UniformSetID RenderingDeviceDriverMetal::uniform_set_create(VectorView<Boun
 #undef ADD_USAGE
 
 		if (!use_barriers) {
-			for (KeyValue<MTL::Resource *, StageResourceUsage> const &keyval : bound_resources) {
+			for (const KeyValue<MTL::Resource *, StageResourceUsage> &keyval : bound_resources) {
 				ResourceVector *resources = set->usage_to_resources.getptr(keyval.value);
 				if (resources == nullptr) {
 					resources = &set->usage_to_resources.insert(keyval.value, ResourceVector())->value;
@@ -1643,7 +1643,7 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 	attachments.resize(p_attachments.size());
 
 	for (uint32_t i = 0; i < p_attachments.size(); i++) {
-		Attachment const &a = p_attachments[i];
+		const Attachment &a = p_attachments[i];
 		MDAttachment &mda = attachments.write[i];
 		MTL::PixelFormat format = pf.getMTLPixelFormat(a.format);
 		mda.format = format;
@@ -1827,7 +1827,7 @@ RenderingDeviceDriverMetal::Result<NS::SharedPtr<MTL::Function>> RenderingDevice
 	uint32_t j = 0;
 	while (i < constants.size() && j < p_specialization_constants.size()) {
 		MTL::FunctionConstant *curr = (MTL::FunctionConstant *)constants[i];
-		PipelineSpecializationConstant const &sc = p_specialization_constants[indexes[j]];
+		const PipelineSpecializationConstant &sc = p_specialization_constants[indexes[j]];
 		if (curr->index() == sc.constant_id) {
 			switch (curr->type()) {
 				case MTL::DataTypeBool:
@@ -1916,18 +1916,18 @@ RDD::PipelineID RenderingDeviceDriverMetal::render_pipeline_create(
 	NS::SharedPtr<MTL::RenderPipelineDescriptor> desc = NS::TransferPtr(MTL::RenderPipelineDescriptor::alloc()->init());
 
 	{
-		MDSubpass const &subpass = pass->subpasses[p_render_subpass];
+		const MDSubpass &subpass = pass->subpasses[p_render_subpass];
 		for (uint32_t i = 0; i < subpass.color_references.size(); i++) {
 			uint32_t attachment = subpass.color_references[i].attachment;
 			if (attachment != AttachmentReference::UNUSED) {
-				MDAttachment const &a = pass->attachments[attachment];
+				const MDAttachment &a = pass->attachments[attachment];
 				desc->colorAttachments()->object(i)->setPixelFormat(a.format);
 			}
 		}
 
 		if (subpass.depth_stencil_reference.attachment != AttachmentReference::UNUSED) {
 			uint32_t attachment = subpass.depth_stencil_reference.attachment;
-			MDAttachment const &a = pass->attachments[attachment];
+			const MDAttachment &a = pass->attachments[attachment];
 
 			if (a.type & MDAttachmentType::Depth) {
 				desc->setDepthAttachmentPixelFormat(a.format);
@@ -2558,8 +2558,8 @@ uint64_t RenderingDeviceDriverMetal::get_lazily_memory_used() {
 }
 
 uint64_t RenderingDeviceDriverMetal::limit_get(Limit p_limit) {
-	MetalDeviceProperties const &props = (*device_properties);
-	MetalLimits const &limits = props.limits;
+	const MetalDeviceProperties &props = (*device_properties);
+	const MetalLimits &limits = props.limits;
 	uint64_t safe_unbounded = ((uint64_t)1 << 30);
 #if defined(DEV_ENABLED)
 #define UNKNOWN(NAME) \

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -220,7 +220,7 @@ public:
 
 private:
 	// Returns true if the texture is a valid linear format.
-	bool is_valid_linear(TextureFormat const &p_format) const;
+	bool is_valid_linear(const TextureFormat &p_format) const;
 
 public:
 	virtual TextureID texture_create(const TextureFormat &p_format, const TextureView &p_view) override final;
@@ -537,7 +537,7 @@ public:
 	MTL::Device *get_device() const { return device; }
 	PixelFormats &get_pixel_formats() const { return *pixel_formats; }
 	MDResourceCache &get_resource_cache() const { return *resource_cache; }
-	MetalDeviceProperties const &get_device_properties() const { return *device_properties; }
+	const MetalDeviceProperties &get_device_properties() const { return *device_properties; }
 
 	_FORCE_INLINE_ uint32_t get_metal_buffer_index_for_vertex_attribute_binding(uint32_t p_binding) {
 		return (device_properties->limits.maxPerStageBufferCount - 1) - p_binding;

--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -702,7 +702,7 @@ bool RenderingShaderContainerMetal::_set_code_from_spirv(const ReflectShader &p_
 		}
 
 		if (!resources.stage_inputs.empty()) {
-			for (Resource const &res : resources.stage_inputs) {
+			for (const Resource &res : resources.stage_inputs) {
 				uint32_t binding = compiler.get_automatic_msl_resource_binding(res.id);
 				if (binding != (uint32_t)-1) {
 					stage_data.vertex_input_binding_mask |= 1 << binding;

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -546,7 +546,7 @@ private:
 		VkDescriptorPool vk_descriptor_pool = VK_NULL_HANDLE;
 		VkDescriptorPool vk_linear_descriptor_pool = VK_NULL_HANDLE;
 		DescriptorSetPools::Iterator pool_sets_it;
-		TightLocalVector<BufferInfo const *, uint32_t> dynamic_buffers;
+		TightLocalVector<const BufferInfo *, uint32_t> dynamic_buffers;
 	};
 
 	bool adreno_5xx_empty_descriptor_set_layout_workaround = false;

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -633,7 +633,7 @@ bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 
 		for (const String &file : files) {
 			int idx_in_dir;
-			EditorFileSystemDirectory const *dir = EditorFileSystem::get_singleton()->find_file(file, &idx_in_dir);
+			const EditorFileSystemDirectory *dir = EditorFileSystem::get_singleton()->find_file(file, &idx_in_dir);
 			if (!dir) {
 				return false;
 			}

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -206,7 +206,7 @@ class GameView : public VBoxContainer {
 	EmbeddedProcessBase *embedded_process = nullptr;
 	Label *state_label = nullptr;
 
-	int const DEFAULT_TIME_SCALE_INDEX = 5;
+	const int DEFAULT_TIME_SCALE_INDEX = 5;
 	Array time_scale_range = { 0.0625f, 0.125f, 0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 4.0f, 8.0f, 16.0f };
 	Array time_scale_label = { "1/16", "1/8", "1/4", "1/2", "3/4", "1.0", "1.25", "1.5", "1.75", "2.0", "4.0", "8.0", "16.0" };
 	int time_scale_index = DEFAULT_TIME_SCALE_INDEX;

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -190,8 +190,8 @@ protected:
 
 	//!@}
 
-	GodotGeneric6DOFJoint3D(GodotGeneric6DOFJoint3D const &) = delete;
-	void operator=(GodotGeneric6DOFJoint3D const &) = delete;
+	GodotGeneric6DOFJoint3D(const GodotGeneric6DOFJoint3D &) = delete;
+	void operator=(const GodotGeneric6DOFJoint3D &) = delete;
 
 	void buildLinearJacobian(
 			GodotJacobianEntry3D &jacLinear, const Vector3 &normalWorld,

--- a/modules/multiplayer/scene_rpc_interface.h
+++ b/modules/multiplayer/scene_rpc_interface.h
@@ -49,7 +49,7 @@ private:
 		MultiplayerPeer::TransferMode transfer_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
 		int channel = 0;
 
-		bool operator==(RPCConfig const &p_other) const {
+		bool operator==(const RPCConfig &p_other) const {
 			return name == p_other.name;
 		}
 	};

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -185,7 +185,7 @@ Rect2 NavRegion2D::get_bounds() const {
 	return iteration->get_bounds();
 }
 
-LocalVector<Nav2D::Polygon> const &NavRegion2D::get_polygons() const {
+const LocalVector<Nav2D::Polygon> &NavRegion2D::get_polygons() const {
 	RWLockRead read_lock(iteration_rwlock);
 	return iteration->get_navmesh_polygons();
 }

--- a/modules/navigation_2d/nav_region_2d.h
+++ b/modules/navigation_2d/nav_region_2d.h
@@ -99,7 +99,7 @@ public:
 	void set_navigation_mesh(Ref<NavigationPolygon> p_navigation_mesh);
 	Ref<NavigationPolygon> get_navigation_mesh() const { return navmesh; }
 
-	LocalVector<Nav2D::Polygon> const &get_polygons() const;
+	const LocalVector<Nav2D::Polygon> &get_polygons() const;
 
 	Nav2D::ClosestPointQueryResult get_closest_point_info(const Vector2 &p_point) const;
 	Vector2 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;

--- a/modules/navigation_3d/nav_region_3d.cpp
+++ b/modules/navigation_3d/nav_region_3d.cpp
@@ -203,7 +203,7 @@ AABB NavRegion3D::get_bounds() const {
 	return iteration->get_bounds();
 }
 
-LocalVector<Nav3D::Polygon> const &NavRegion3D::get_polygons() const {
+const LocalVector<Nav3D::Polygon> &NavRegion3D::get_polygons() const {
 	RWLockRead read_lock(iteration_rwlock);
 	return iteration->get_navmesh_polygons();
 }

--- a/modules/navigation_3d/nav_region_3d.h
+++ b/modules/navigation_3d/nav_region_3d.h
@@ -99,7 +99,7 @@ public:
 	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
 	Ref<NavigationMesh> get_navigation_mesh() const { return navmesh; }
 
-	LocalVector<Nav3D::Polygon> const &get_polygons() const;
+	const LocalVector<Nav3D::Polygon> &get_polygons() const;
 
 	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
 	Nav3D::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;

--- a/modules/openxr/openxr_util.cpp
+++ b/modules/openxr/openxr_util.cpp
@@ -189,7 +189,7 @@ XrUuid OpenXRUtil::xruuid_from_string(const String &p_uuid) {
 //              Paul Upchurch, Mathieu Desbrun
 //              Journal of Graphics Tools, Volume 16, Issue 1, 2012
 void OpenXRUtil::XrMatrix4x4f_CreateProjection(XrMatrix4x4f *result, const float tanAngleLeft, const float tanAngleRight,
-		const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ) {
+		const float tanAngleUp, const float tanAngleDown, const float nearZ, const float farZ) {
 	const float tanAngleWidth = tanAngleRight - tanAngleLeft;
 
 	// Set to tanAngleUp - tanAngleDown for a clip space with positive Y up.

--- a/modules/openxr/openxr_util.h
+++ b/modules/openxr/openxr_util.h
@@ -66,6 +66,6 @@ public:
 	} XrMatrix4x4f;
 
 	static void XrMatrix4x4f_CreateProjection(XrMatrix4x4f *result, const float tanAngleLeft, const float tanAngleRight,
-			const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ);
+			const float tanAngleUp, const float tanAngleDown, const float nearZ, const float farZ);
 	static void XrMatrix4x4f_CreateProjectionFov(XrMatrix4x4f *result, const XrFovf fov, const float nearZ, const float farZ);
 };

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3241,7 +3241,7 @@ void DisplayServerX11::_update_window_icon(WindowData &p_wd) {
 			const uint8_t *r = w_icon->get_data().ptr();
 
 			long *wr = &pd.write[2];
-			uint8_t const *pr = r;
+			const uint8_t *pr = r;
 
 			for (int i = 0; i < w * h; i++) {
 				long v = 0;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7763,7 +7763,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 
 	HMODULE comctl32 = LoadLibraryW(L"comctl32.dll");
 	if (comctl32) {
-		typedef BOOL(WINAPI * InitCommonControlsExPtr)(_In_ const INITCOMMONCONTROLSEX *picce);
+		typedef BOOL(WINAPI * InitCommonControlsExPtr)(const _In_ INITCOMMONCONTROLSEX *picce);
 		InitCommonControlsExPtr init_common_controls_ex = (InitCommonControlsExPtr)(void *)GetProcAddress(comctl32, "InitCommonControlsEx");
 
 		// Fails if the incorrect version was loaded. Probably not a big enough deal to print an error about.

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1947,7 +1947,7 @@ Vector<String> OS_Windows::get_system_font_path_for_text(const String &p_font_na
 
 	Vector<String> ret;
 	for (UINT32 i = 0; i < number_of_files; i++) {
-		void const *reference_key = nullptr;
+		const void *reference_key = nullptr;
 		UINT32 reference_key_size = 0;
 		ComAutoreleaseRef<IDWriteLocalFontFileLoader> loader;
 
@@ -2026,7 +2026,7 @@ String OS_Windows::get_system_font_path(const String &p_font_name, int p_weight,
 	}
 
 	for (UINT32 i = 0; i < number_of_files; i++) {
-		void const *reference_key = nullptr;
+		const void *reference_key = nullptr;
 		UINT32 reference_key_size = 0;
 		ComAutoreleaseRef<IDWriteLocalFontFileLoader> loader;
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2712,7 +2712,7 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	ERR_FAIL_NULL_V(p_start_node, nullptr);
 	ERR_FAIL_COND_V(!is_ancestor_of(p_start_node), p_start_node);
 
-	Node const *iterated_item = p_start_node;
+	const Node *iterated_item = p_start_node;
 	Node *node = p_start_node;
 
 	while (iterated_item->get_owner() && iterated_item->get_owner() != this) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -3005,7 +3005,7 @@ void RendererCanvasRenderRD::_canvas_texture_invalidation_callback(bool p_delete
 	}
 }
 
-void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasShaderData *p_shader_data, RenderingDevice::FramebufferFormatID p_framebuffer_format, Light *p_lights, Batch const *p_batch, RenderingServerTypes::RenderInfo *r_render_info) {
+void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasShaderData *p_shader_data, RenderingDevice::FramebufferFormatID p_framebuffer_format, Light *p_lights, const Batch *p_batch, RenderingServerTypes::RenderInfo *r_render_info) {
 	{
 		RendererRD::TextureStorage *ts = RendererRD::TextureStorage::get_singleton();
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -675,7 +675,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	inline RID _get_pipeline_specialization_or_ubershader(CanvasShaderData *p_shader_data, PipelineKey &r_pipeline_key, PushConstant &r_push_constant, RID p_mesh_instance = RID(), void *p_surface = nullptr, uint32_t p_surface_index = 0, RID *r_vertex_array = nullptr);
 	void _render_batch_items(RenderTarget p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer = false, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void _record_item_commands(const Item *p_item, RenderTarget p_render_target, const Transform2D &p_base_transform, Item *&r_current_clip, Light *p_lights, bool &r_batch_broken, bool &r_sdf_used, Batch *&r_current_batch);
-	void _render_batch(RD::DrawListID p_draw_list, CanvasShaderData *p_shader_data, RenderingDevice::FramebufferFormatID p_framebuffer_format, Light *p_lights, Batch const *p_batch, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
+	void _render_batch(RD::DrawListID p_draw_list, CanvasShaderData *p_shader_data, RenderingDevice::FramebufferFormatID p_framebuffer_format, Light *p_lights, const Batch *p_batch, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void _prepare_batch_texture_info(RID p_texture, TextureState &p_state, TextureInfo *p_info);
 
 	// non-UMA

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -2027,11 +2027,11 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 	return id;
 }
 
-static _ALWAYS_INLINE_ void _copy_region(uint8_t const *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_x, uint32_t p_src_y, uint32_t p_src_w, uint32_t p_src_h, uint32_t p_src_full_w, uint32_t p_dst_pitch, uint32_t p_unit_size) {
+static _ALWAYS_INLINE_ void _copy_region(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_x, uint32_t p_src_y, uint32_t p_src_w, uint32_t p_src_h, uint32_t p_src_full_w, uint32_t p_dst_pitch, uint32_t p_unit_size) {
 	uint32_t src_offset = (p_src_y * p_src_full_w + p_src_x) * p_unit_size;
 	uint32_t dst_offset = 0;
 	for (uint32_t y = p_src_h; y > 0; y--) {
-		uint8_t const *__restrict src = p_src + src_offset;
+		const uint8_t *__restrict src = p_src + src_offset;
 		uint8_t *__restrict dst = p_dst + dst_offset;
 		for (uint32_t x = p_src_w * p_unit_size; x > 0; x--) {
 			*dst = *src;


### PR DESCRIPTION
## What problem(s) does this PR solve?

C++ allows `const` qualifiers on either side of the type name:

```c++
const int a = 0;
// is equivalent to
int const a = 1;
```

In the parts of the codebase that I know, we usually use left qualifier alignment (the former). I think for readability and consistency purposes it is a good practice to stick with one style.

In https://github.com/godotengine/godot/pull/120891 I noticed right qualifier alignment being used. I don't think it is reasonable to expect reviewers to catch this all the time.

Clang format can enforce this for us using the `QualifierAlignment` rule, thus reducing stuff reviewers have to pay attention to.

## Additional information

Seeing that a lot of code that is currently in violation of this rule comes from platform code that I don't interact with, I'm more than happy to drop this PR if some maintainer says they prefer another style in their area. In that case I might look into enabling the rule exclusively for the GDScript module.
