### PR TITLE
Add safety check to `Animation::track_move_up` so negative indices don't crash it

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3883,7 +3883,7 @@ bool Animation::track_is_enabled(int p_track) const {
 }
 
 void Animation::track_move_up(int p_track) {
-	if (p_track < ((int)tracks.size() - 1)) {
+	if (p_track >= 0 && p_track < ((int)tracks.size() - 1)) {
 		SWAP(tracks[p_track], tracks[p_track + 1]);
 	}
 
@@ -3891,7 +3891,7 @@ void Animation::track_move_up(int p_track) {
 }
 
 void Animation::track_move_down(int p_track) {
-	if ((uint32_t)p_track < tracks.size()) {
+	if (p_track > 0 && (uint32_t)p_track < tracks.size()) {
 		SWAP(tracks[p_track], tracks[p_track - 1]);
 	}
 


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121261

## Additional information

There was no check for indices under 0, so I added it.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
