### PR TITLE
Fix incorrect margin height calculation in WindowWrapper

### DIFF
--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -306,8 +306,7 @@ Size2 WindowWrapper::get_margins_size() {
 	if (!margins) {
 		return Size2();
 	}
-
-	return Size2(margins->get_margin_size(SIDE_LEFT) + margins->get_margin_size(SIDE_RIGHT), margins->get_margin_size(SIDE_TOP) + margins->get_margin_size(SIDE_RIGHT));
+	return Size2(margins->get_margin_size(SIDE_LEFT) + margins->get_margin_size(SIDE_RIGHT), margins->get_margin_size(SIDE_TOP) + margins->get_margin_size(SIDE_BOTTOM));
 }
 
 Size2 WindowWrapper::get_margins_top_left() {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
Fixed a copy-paste error in `WindowWrapper::get_margins_size()` where `SIDE_RIGHT` was incorrectly used instead of `SIDE_BOTTOM` to calculate the Y-axis margin height.

- Closes #121216

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
