### PR TITLE
Fix out-of-bounds access on invalid binary resource string length

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -854,20 +854,28 @@ static void save_ustring(Ref<FileAccess> f, const String &p_string) {
 }
 
 static String get_ustring(Ref<FileAccess> f) {
-	int len = f->get_32();
+	uint32_t len = f->get_32();
+	if (len == 0) {
+		return String();
+	}
 	Vector<char> str_buf;
-	str_buf.resize(len);
+	if (str_buf.resize(len) != OK) {
+		return String();
+	}
 	f->get_buffer((uint8_t *)&str_buf[0], len);
 	return String::utf8(&str_buf[0], len);
 }
 
 String ResourceLoaderBinary::get_unicode_string() {
-	int len = f->get_32();
-	if (len > str_buf.size()) {
-		str_buf.resize(len);
-	}
+	uint32_t len = f->get_32();
 	if (len == 0) {
 		return String();
+	}
+	if (len > str_buf.size()) {
+		if (str_buf.resize(len) != OK) {
+			error = ERR_FILE_CORRUPT;
+			return String();
+		}
 	}
 	f->get_buffer((uint8_t *)&str_buf[0], len);
 	return String::utf8(&str_buf[0], len);


### PR DESCRIPTION
`ResourceLoaderBinary::get_unicode_string()` and the static `get_ustring()` read the string length with `int len = f->get_32()`. A stored length with bit 31 set becomes negative, so the `len > str_buf.size()` guard is skipped and the buffer is never resized. `len` is then widened to `uint64_t` for `FileAccess::get_buffer(uint8_t *, uint64_t)`, becoming a huge count. On the first call `str_buf` is empty, so `&str_buf[0]` aborts with an out-of-bounds index; after an earlier string has grown `str_buf`, `get_buffer` writes past it.

`get_unicode_string()` reads every string in the binary format (type, paths, the string table, property names), so a malformed `.res`/`.scn`/`.tres` reaches it immediately. `get_ustring()` is on the binary-to-text conversion path.

The length is now read as `uint32_t`, the zero case returns before any indexing, and a `resize` failure (an oversized length) sets `ERR_FILE_CORRUPT` and stops instead of reading into a buffer that is too small.

Repro: save a resource as `.res`, set the type-string length at byte offset 24 to `0xFFFFFFFF`, load it.

Before: `FATAL: Index p_index = 0 is out of bounds (size() = 0)`, the process crashes.
After: the load fails with an error and returns null; valid resources still load.
