### PR TITLE
Deprecate `ScriptEditorBase` signals

### DIFF
--- a/doc/classes/ScriptEditorBase.xml
+++ b/doc/classes/ScriptEditorBase.xml
@@ -24,60 +24,60 @@
 		</method>
 	</methods>
 	<signals>
-		<signal name="edited_script_changed">
+		<signal name="edited_script_changed" deprecated="This signal should only be used internally.">
 			<description>
 				Emitted after script validation.
 			</description>
 		</signal>
-		<signal name="go_to_help">
+		<signal name="go_to_help" deprecated="This signal should only be used internally. See [method ScriptEditor.goto_help] instead.">
 			<param index="0" name="what" type="String" />
 			<description>
 				Emitted when the user requests a specific documentation page.
 			</description>
 		</signal>
-		<signal name="go_to_method">
+		<signal name="go_to_method" deprecated="This signal should only be used internally.">
 			<param index="0" name="script" type="Object" />
 			<param index="1" name="method" type="String" />
 			<description>
 				Emitted when the user requests to view a specific method of a script, similar to [signal request_open_script_at_line].
 			</description>
 		</signal>
-		<signal name="name_changed">
+		<signal name="name_changed" deprecated="This signal should only be used internally.">
 			<description>
 				Emitted after script validation or when the edited resource has changed.
 			</description>
 		</signal>
-		<signal name="replace_in_files_requested">
+		<signal name="replace_in_files_requested" deprecated="This signal should only be used internally.">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the user request to find and replace text in the file system.
 			</description>
 		</signal>
-		<signal name="request_help">
+		<signal name="request_help" deprecated="This signal should only be used internally.">
 			<param index="0" name="topic" type="String" />
 			<description>
 				Emitted when the user requests contextual help.
 			</description>
 		</signal>
-		<signal name="request_open_script_at_line">
+		<signal name="request_open_script_at_line" deprecated="This signal should only be used internally. See [method EditorInterface.edit_script] instead.">
 			<param index="0" name="script" type="Object" />
 			<param index="1" name="line" type="int" />
 			<description>
 				Emitted when the user requests to view a specific line of a script, similar to [signal go_to_method].
 			</description>
 		</signal>
-		<signal name="request_save_history">
+		<signal name="request_save_history" deprecated="This signal should only be used internally.">
 			<description>
 				Emitted when the editor requests to save a new history navigation point.
 			</description>
 		</signal>
-		<signal name="request_save_previous_state">
+		<signal name="request_save_previous_state" deprecated="This signal should only be used internally.">
 			<param index="0" name="state" type="Dictionary" />
 			<description>
 				Emitted when the editor requests an update to its navigation point.
 			</description>
 		</signal>
-		<signal name="search_in_files_requested">
+		<signal name="search_in_files_requested" deprecated="This signal should only be used internally.">
 			<param index="0" name="text" type="String" />
 			<description>
 				Emitted when the user request to search text in the file system.

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -53,14 +53,18 @@ void ScriptEditorBase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditorBase::get_base_editor);
 
 	// First use in ScriptTextEditor.
-	ADD_SIGNAL(MethodInfo("request_save_history"));
 	ADD_SIGNAL(MethodInfo("_request_save_new_history", PropertyInfo(Variant::DICTIONARY, "state")));
-	ADD_SIGNAL(MethodInfo("request_save_previous_state", PropertyInfo(Variant::DICTIONARY, "state")));
+	ADD_SIGNAL(MethodInfo("_request_save_previous_state", PropertyInfo(Variant::DICTIONARY, "state")));
 	ADD_SIGNAL(MethodInfo("request_help", PropertyInfo(Variant::STRING, "topic")));
 	ADD_SIGNAL(MethodInfo("request_open_script_at_line", PropertyInfo(Variant::OBJECT, "script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("go_to_help", PropertyInfo(Variant::STRING, "what")));
 	ADD_SIGNAL(MethodInfo("replace_in_files_requested", PropertyInfo(Variant::STRING, "text")));
 	ADD_SIGNAL(MethodInfo("go_to_method", PropertyInfo(Variant::OBJECT, "script"), PropertyInfo(Variant::STRING, "method")));
+
+#ifndef DISABLE_DEPRECATED
+	ADD_SIGNAL(MethodInfo("request_save_history"));
+	ADD_SIGNAL(MethodInfo("request_save_previous_state", PropertyInfo(Variant::DICTIONARY, "state")));
+#endif
 }
 
 String ScriptEditorBase::get_name() {
@@ -543,7 +547,7 @@ void TextEditorBase::_emit_request_save_previous_state() {
 	Dictionary state = get_edit_state();
 	state["ensure_caret_visible"] = true;
 	previous_history_line = state["row"];
-	emit_signal(SNAME("request_save_previous_state"), state);
+	emit_signal(SNAME("_request_save_previous_state"), state);
 }
 
 void TextEditorBase::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -441,21 +441,6 @@ void ScriptEditor::_update_history_arrows() {
 	script_forward->set_disabled(history_pos >= history.size() - 1);
 }
 
-// For compatibility with the legacy exposed signal request_save_history.
-void ScriptEditor::_save_history(Control *p_control) {
-	Dictionary nav_state;
-	if (Object::cast_to<TextEditorBase>(p_control)) {
-		nav_state.merge(Object::cast_to<TextEditorBase>(p_control)->get_navigation_state());
-		nav_state["ensure_caret_visible"] = true;
-	} else if (Object::cast_to<EditorHelp>(p_control)) {
-		nav_state.merge(Object::cast_to<EditorHelp>(p_control)->get_state());
-	}
-	if (nav_state.is_empty() || !nav_state.has("row")) {
-		return;
-	}
-	_save_new_history(nav_state, p_control);
-}
-
 void ScriptEditor::_save_new_history(const Dictionary &p_state, Control *p_control) {
 	if (restoring_layout) {
 		return;
@@ -2422,9 +2407,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		teb->connect("request_help", callable_mp(this, &ScriptEditor::_help_search));
 		teb->connect("request_open_script_at_line", callable_mp(this, &ScriptEditor::_goto_script_line));
 		teb->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-		teb->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history).bind(teb));
 		teb->connect("_request_save_new_history", callable_mp(this, &ScriptEditor::_save_new_history).bind(teb));
-		teb->connect("request_save_previous_state", callable_mp(this, &ScriptEditor::_save_previous_state).bind(teb));
+		teb->connect("_request_save_previous_state", callable_mp(this, &ScriptEditor::_save_previous_state).bind(teb));
 		teb->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(false));
 		teb->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(true));
 		teb->connect("go_to_method", callable_mp(this, &ScriptEditor::script_goto_method));


### PR DESCRIPTION

## What problem(s) does this PR solve?

None of these were intended to be exposed, they are for communication from ScriptEditorBases to the ScriptEditor. The user cannot make either of these classes and should not emit or respond to any of these signals. So I am marking all of them as deprecated.
Previously it wasn't possible to have hidden signals so they were just exposed.


## Additional information

The ScriptEditor implements all the functionality for the signals so I don't think there is any use for connecting to them. It can't even be used to reliably determine when things happen, such as when the find in files opens, since there are other ways it can happen.
They shouldn't be emitted by the user either, but just in case I went through each of them.

The `search_in_files_requested` and `replace_in_files_requested` signals could be used to start find in files, but that is not a good way to do it. You had to hope that a ScriptEditorBase was open, get the first one, and then emit the signal on it.
It would be better to push the shortcut, with something like this:
```gdscript
var start_fif := InputEventShortcut.new()
start_fif.shortcut = EditorInterface.get_editor_settings().get_shortcut("editor/find_in_files")
EditorInterface.get_base_control().get_viewport().push_input(start_fif)
```
And then you could find the dialog to fill any of the fields you want.
Same with the `request_help` signal for the `editor/editor_help` shortcut.
If these are really wanted, they can be properly exposed as a method on `EditorInterface` in the future.

The `request_save_history` and `request_save_previous_state` signals could mess with the internal history state. `request_save_previous_state` especially since it takes a dictionary that is usually gotten from an unexposed method. It doesn't always check if the key exists either when it is used too. 
Since this affects the internal state and really shouldn't be exposed, I disconnected the signal and instead use a private one. The `request_save_history` compat is also removed. Related https://github.com/godotengine/godot/pull/119047/changes#r3213243849
The other signals don't really mess with internal state so I didn't bother to completely disconnect them, but I could.

The only thing emitting `edited_script_changed` does is remake the Signal connections dock tree, which should never be needed.
Emitting `name_changed` just updates the script list, which also should never be needed.
Emitting `go_to_help` is just `ScriptEditor.goto_help`.
Emitting `request_open_script_at_line` is just `EditorInterface.edit_script`. For emitting `go_to_method`, you can get the method position yourself and use `edit_script` as well.
