### PR TITLE
Use "Standard" syntax highlighter in CodeEditorBase instead of "Plain Text"

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -737,7 +737,7 @@ CodeEditorBase::CodeEditorBase() {
 	editor_box->add_child(code_editor);
 	editor_box->add_child(warnings_panel);
 
-	for (const Ref<EditorSyntaxHighlighter>& highlighter : highlighters) {
+	for (const Ref<EditorSyntaxHighlighter> &highlighter : highlighters) {
 		if (Object::cast_to<EditorStandardSyntaxHighlighter>(highlighter.ptr())) {
 			set_syntax_highlighter(highlighter);
 			break;

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -736,4 +736,11 @@ CodeEditorBase::CodeEditorBase() {
 	editor_box->set_v_size_flags(SIZE_EXPAND_FILL);
 	editor_box->add_child(code_editor);
 	editor_box->add_child(warnings_panel);
+
+	for (const Ref<EditorSyntaxHighlighter>& highlighter : highlighters) {
+		if (Object::cast_to<EditorStandardSyntaxHighlighter>(highlighter.ptr())) {
+			set_syntax_highlighter(highlighter);
+			break;
+		}
+	}
 }


### PR DESCRIPTION
This fixes ScriptLanguageExtensions code highlighting in the script code editor, broken in 2363720b5396c6db20503a9344bfd3f6252336bf.

## What problem(s) does this PR solve?

- Closes #121288