### PR TITLE
Fix crash in `GLTFNode.get_scene_node_path`

### DIFF
--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -212,6 +212,7 @@ void GLTFNode::set_additional_data(const StringName &p_extension_name, Variant p
 }
 
 NodePath GLTFNode::get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_skeletons) {
+	ERR_FAIL_COND_V_MSG(p_state.is_null(), NodePath(), "Cannot get scene node path because GLTFState is null.");
 	Vector<StringName> path;
 	Vector<StringName> subpath;
 	Ref<GLTFNode> current_gltf_node = this;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121267

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
