### PR TITLE
🤖 Fix BlitMaterial blend mode range check

### DIFF
--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,6 +80,8 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
+	ERR_FAIL_INDEX(int(p_blend_mode), BLEND_MODE_MAX);
+
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);
 	if (shader_set) {
@@ -110,10 +112,10 @@ RID BlitMaterial::get_rid() const {
 }
 
 Mutex BlitMaterial::shader_mutex;
-RID BlitMaterial::shader_cache[5];
+RID BlitMaterial::shader_cache[BLEND_MODE_MAX];
 
 void BlitMaterial::cleanup_shader() {
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < BLEND_MODE_MAX; i++) {
 		if (shader_cache[i].is_valid()) {
 			RS::get_singleton()->free_rid(shader_cache[i]);
 		}

--- a/scene/resources/blit_material.h
+++ b/scene/resources/blit_material.h
@@ -41,12 +41,13 @@ public:
 		BLEND_MODE_ADD,
 		BLEND_MODE_SUB,
 		BLEND_MODE_MUL,
-		BLEND_MODE_DISABLED
+		BLEND_MODE_DISABLED,
+		BLEND_MODE_MAX
 	};
 
 private:
 	static Mutex shader_mutex;
-	static RID shader_cache[5];
+	static RID shader_cache[BLEND_MODE_MAX];
 	static void _update_shader(BlendMode p_blend);
 	mutable bool shader_set = false;
 


### PR DESCRIPTION

> [!INFO]
> *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of Kunj Rathod.

## What changed

- Add a range check in `BlitMaterial::set_blend_mode()` so invalid enum values supplied through the binding path fail before indexing `shader_cache`.
- Replace hard-coded `5` shader-cache bounds with `BLEND_MODE_MAX` to keep the enum and cache size in sync.

## Duplicate-work check

I checked for existing open PRs with:

```bash
gh pr list -R godotengine/godot --state open --search '121263 OR BlitMaterial.set_blend_mode OR set_blend_mode blit_material' --json number,title,url,author
```

It returned `[]`.

## Testing

```bash
git diff --check
```

Passed with no whitespace errors.

```bash
. .venv/bin/activate && scons platform=macos target=template_debug tools=no tests=no vulkan=no angle=no accesskit=no -j4
```

Could not complete in this local environment because the macOS Command Line Tools C++ standard library headers are unavailable here (`fatal error: 'cstddef' file not found`). A standalone `clang++ -std=c++17 -fsyntax-only` check with `#include <cstddef>` fails the same way, so this is a local toolchain issue rather than an error specific to this patch.
