### PR TITLE
Fix GPUParticle3D TrailMesh sections not being updated correctly until scene is reloaded

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -286,12 +286,14 @@ void GPUParticles3D::set_draw_pass_mesh(int p_pass, const Ref<Mesh> &p_mesh) {
 
 	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
 		draw_passes.write[p_pass]->disconnect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
+		draw_passes.write[p_pass]->disconnect_changed(callable_mp((GPUParticles3D *)this, &GPUParticles3D::_skinning_changed));
 	}
 
 	draw_passes.write[p_pass] = p_mesh;
 
 	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
 		draw_passes.write[p_pass]->connect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings), CONNECT_DEFERRED);
+		draw_passes.write[p_pass]->connect_changed(callable_mp((GPUParticles3D *)this, &GPUParticles3D::_skinning_changed), CONNECT_DEFERRED);
 	}
 
 	RID mesh_rid;


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #121306 

## Additional information

Fixes trail sections not being properly updated until you reloaded the scene. For both `RibbonTrailMesh` and `TubeTrailMesh`.


https://github.com/user-attachments/assets/9178ba0b-e7d4-452a-b7dc-03d6cfab8cc9

