### PR TITLE
SCons: Improve redirect emitter for external source files

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -103,10 +103,21 @@ def redirect_emitter(target, source, env):
             pass
         elif base_folder in path.parents:
             item = env.File(f"#bin/obj/{path.relative_to(base_folder)}")
-        elif (alt_base := Path(env.Dir(".").get_abspath()).resolve().parent) in path.parents:
-            item = env.File(f"#bin/obj/external/{path.relative_to(alt_base)}")
         else:
-            print_warning(f'Failed to redirect "{path}"')
+            try:
+                # Try common external bases (e.g., profiler_path parent)
+                alt_base = Path(env.Dir(".").get_abspath()).resolve().parent
+                if alt_base in path.parents:
+                    rel = path.relative_to(alt_base)
+                else:
+                    # Fallback: filename under external/
+                    rel = f"external/{path.name}"
+                item = env.File(f"#bin/obj/{rel}")
+            except (ValueError, RuntimeError, OSError) as e:
+                # ValueError = not a relative subpath
+                # Others = rare filesystem/env issues
+                print_warning(f'Failed to redirect "{path}": {e} — using default location')
+                # item remains the original (no redirect)
         redirected_targets.append(item)
     return redirected_targets, source
 


### PR DESCRIPTION
Improve redirect emitter to put compile products into bin/obj/external/ if path is not an ancestor

- This resolves a warning emitted when compiling tracy/perfetto
- Keeps external source tree clean so re/multi-build wont be able to detect previous object files as built.

Discussed with @Repiteo and @Ivorforce in dev/buildsystem

Alternate solution: https://github.com/godotengine/godot/pull/121185

I prefer my solution because it resolves the issue at its source, instead of the call site.

The reason I want this is because when compiling against multiple architectures in macOS the compile products or tracy were remaining in the external source tree, and were not re-built, triggering errors for invalid architecture.

I also run a local build runner(on win mac and linux) for development that compiles against multiple toolchains and that triggers the problem too.

This is related to my work on tracing godot+gdextension: https://github.com/godotengine/godot/pull/121088

Possible improvements in the future might include better naming to handle collisions, though right now, only tracy and perfetto can possibly run into this as they are the only? external sources. If there is a desire to add more external sources this will probably be necessary at some point.

AI Disclosure: While AI may have been initially used to generate the snippet not a singe line of code, or comment escapes my scrutiny. The choice of using an exception is appropriate in the circumstance and is not tied to control flow.