### PR TITLE
SCons: Flags for building shared libaries on prefixed cross compile toolchains

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -723,6 +723,16 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
+    # Cross-compilation
+    host_is_64_bit = sys.maxsize > 2**32
+    if host_is_64_bit and env["arch"] == "x86_32":
+        env.Append(CCFLAGS=["-m32"])
+        env.Append(LINKFLAGS=["-m32"])
+    elif not host_is_64_bit and env["arch"] == "x86_64":
+        env.Append(CCFLAGS=["-m64"])
+        env.Append(LINKFLAGS=["-m64"])
+    # arm32/arm64 usually don't need explicit -m flags with the prefixed toolchain
+
     if env["arch"] == "x86_32":
         if env["use_static_cpp"]:
             env.Append(LINKFLAGS=["-static"])


### PR DESCRIPTION
Building Shared Libaries(mingw)
- llvm-mingw requires arch flags to link library when cross compiling for i686 on x86_64

This change is in support of https://github.com/godotengine/godot/pull/121088

Found when running through toolchain permutations on windows.

It has no effect on standard builds, as these flags are redundant with prefixed cross compile toolchains when compiling static libs or executables.

The code is a direct copy of the equivalent in the linuxbsd/detect.py:105