### PR TITLE
SCons: Support for building shared libaries on macOS, iOS, visionOS

### DIFF
--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -105,12 +105,14 @@ def configure(env: "SConsEnvironment"):
         env["APPLE_PLATFORM"] = "iossimulator"
         env.Append(ASFLAGS=["-mios-simulator-version-min=15.0"])
         env.Append(CCFLAGS=["-mios-simulator-version-min=15.0"])
+        env.Append(LINKFLAGS=["-mios-simulator-version-min=15.0"])
         env.Append(CPPDEFINES=["IOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         env["APPLE_PLATFORM"] = "ios"
         env.Append(ASFLAGS=["-miphoneos-version-min=15.0"])
         env.Append(CCFLAGS=["-miphoneos-version-min=15.0"])
+        env.Append(LINKFLAGS=["-miphoneos-version-min=15.0"])
     detect_darwin_sdk_path(env["APPLE_PLATFORM"], env)
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
@@ -129,6 +131,7 @@ def configure(env: "SConsEnvironment"):
             ).split()
         )
         env.Append(ASFLAGS=["-arch", "x86_64"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-isysroot", "$APPLE_SDK_PATH"])
     elif env["arch"] == "arm64":
         env.Append(
             CCFLAGS=(
@@ -139,6 +142,7 @@ def configure(env: "SConsEnvironment"):
             )
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-isysroot", "$APPLE_SDK_PATH"])
 
     # Temp fix for ABS/MAX/MIN macros in iOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -43,6 +43,15 @@ def generate_bundle(target, source, env):
             os.mkdir(app_dir + "/Contents/MacOS")
         if target_bin != "":
             shutil.copy(target_bin, app_dir + "/Contents/MacOS/Godot")
+
+        # Copy extra dylibs into Frameworks, these are registered by the feature that builds them
+        if env.get("extra_dylibs"):
+            frameworks_dir = os.path.join(app_dir, "Contents", "Frameworks")
+            os.makedirs(frameworks_dir, exist_ok=True)
+            for lib in env["extra_dylibs"]:
+                src = lib.get_abspath() if hasattr(lib, "get_abspath") else str(lib)
+                shutil.copy(src, frameworks_dir)
+
         if "mono" in env.module_version_string:
             shutil.copytree(env.Dir("#bin/GodotSharp").abspath, app_dir + "/Contents/Resources/GodotSharp")
         version = get_version_info("", True)

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -106,12 +106,14 @@ def configure(env: "SConsEnvironment"):
         env["APPLE_PLATFORM"] = "visionossimulator"
         env.Append(ASFLAGS=["-mtargetos=xros26.0-simulator"])
         env.Append(CCFLAGS=["-mtargetos=xros26.0-simulator"])
+        env.Append(LINKFLAGS=["-mtargetos=xros26.0-simulator"])
         env.Append(CPPDEFINES=["VISIONOS_SIMULATOR"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         env["APPLE_PLATFORM"] = "visionos"
         env.Append(ASFLAGS=["-mtargetos=xros26.0"])
         env.Append(CCFLAGS=["-mtargetos=xros26.0"])
+        env.Append(LINKFLAGS=["-mtargetos=xros26.0"])
     detect_darwin_sdk_path(env["APPLE_PLATFORM"], env)
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
@@ -126,6 +128,7 @@ def configure(env: "SConsEnvironment"):
             )
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-isysroot", "$APPLE_SDK_PATH"])
 
     # Temp fix for ABS/MAX/MIN macros in visionOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])


### PR DESCRIPTION
Building Shared Libaries(mac,ios,vision)
- Add mechanism to generate_bundle that adds libraries from *new* env["extra_dylibs"] to the app bundle.
- Add appropriate link flags for ios and visionos to support shared library generation

This is supporting work for https://github.com/godotengine/godot/pull/121088

## What does this solve?
### App Bundling
Shared files must be bundled with the application.
The bundling steps delete the .app folder and copy the fresh template each time. 
So simply copying any compile products to the correct folders will not work.
This PR adds a step to the bundling function that copies nodes in env["extra_dylibs"] to the app/Content/Frameworks folder.

An example of adding a shared library to the list from #121088
```python
    tracylib = env_tracy.add_shared_library("TracyClient", [str((profiler_path / "TracyClient.cpp").absolute())])

# <snip>

        # Set install name so the engine binary (and GDExtensions) load via @rpath.
        # platform/macos/detect.py already adds -rpath @executable_path/../Frameworks
        # and -rpath @executable_path (so bin/ next to the unbundled binary also works).
        dylib_node = tracylib[0]
        dylib_name = pathlib.Path(str(dylib_node)).name
        env_tracy.AddPostAction(
            dylib_node,
            f'install_name_tool -id "@rpath/{dylib_name}" "$TARGET"',
        )

        # Register for inclusion in the .app bundle. generate_bundle recreates the
        # .app from a template (shutil.rmtree), so do not Install into Frameworks here.
        if "extra_dylibs" not in env:
            env["extra_dylibs"] = []
        env["extra_dylibs"].extend(to_install)
```

### Flags and Sysroot
The link phase of building shared libraries does not automatically inherit the flags used when linking the executable, or static libs. there will be linking errors without sysroot as it will search the incorrect paths for standard libraries. and without target flags will attempt to build for the wrong architecture.

## Additional Work
I believe there is a separate bundling step for ios/visionos that is shared, which I have not included in this PR because I do not have the hardware to test such that he changes I would make would work. whereas the macos changes were developed on a M1 mac mini.

AI Disclosure: Was used to research what was needed.