### PR TITLE
Dismiss Symbol Tooltip on Key Press & Don't Show Symbol Tooltips from Behind Code Completion Popup

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -698,9 +698,12 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (symbol_tooltip_on_hover_enabled) {
+			Point2i last_symbol_tooltip_pos = symbol_tooltip_pos;
 			symbol_tooltip_pos = get_line_column_at_pos(mpos, false, false);
 			symbol_tooltip_word = get_lookup_word(symbol_tooltip_pos.y, symbol_tooltip_pos.x);
-			symbol_tooltip_timer->start();
+			if (symbol_tooltip_pos != last_symbol_tooltip_pos) {
+				symbol_tooltip_timer->start();
+			}
 		}
 
 		bool scroll_hovered = code_completion_scroll_rect.has_point(mpos);
@@ -761,6 +764,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (!k->is_pressed() || k->get_keycode() == Key::CTRL || k->get_keycode() == Key::ALT || k->get_keycode() == Key::SHIFT || k->get_keycode() == Key::META || k->get_keycode() == Key::CAPSLOCK) {
 		return;
 	}
+	symbol_tooltip_timer->stop();
 
 	// Allow unicode handling if:
 	// No modifiers are pressed (except Shift and CapsLock)
@@ -2818,7 +2822,8 @@ bool CodeEdit::is_symbol_tooltip_on_hover_enabled() const {
 void CodeEdit::_on_symbol_tooltip_timer_timeout() {
 	const int line = symbol_tooltip_pos.y;
 	const int column = symbol_tooltip_pos.x;
-	if (line >= 0 && column >= 0 && !symbol_tooltip_word.is_empty() && !Input::get_singleton()->is_anything_pressed()) {
+	bool is_mouse_over_code_completion_popup = code_completion_active && code_completion_rect.has_point(get_local_mouse_position());
+	if (line >= 0 && column >= 0 && !symbol_tooltip_word.is_empty() && !Input::get_singleton()->is_anything_pressed() && !is_mouse_over_code_completion_popup) {
 		emit_signal(SNAME("symbol_hovered"), symbol_tooltip_word, line, column);
 	}
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -696,9 +696,14 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (symbol_tooltip_on_hover_enabled) {
+			String last_symbol_tooltip_word = symbol_tooltip_word;
 			symbol_tooltip_pos = get_line_column_at_pos(mpos, false, false);
 			symbol_tooltip_word = get_lookup_word(symbol_tooltip_pos.y, symbol_tooltip_pos.x);
-			symbol_tooltip_timer->start();
+			if (symbol_tooltip_word != last_symbol_tooltip_word || (symbol_tooltip_word == last_symbol_tooltip_word && !symbol_tooltip_dismissed)) {
+				symbol_tooltip_dismissed = false;
+				last_symbol_tooltip_word = symbol_tooltip_word;
+				symbol_tooltip_timer->start();
+			}
 		}
 
 		bool scroll_hovered = code_completion_scroll_rect.has_point(mpos);
@@ -760,6 +765,10 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		return;
 	}
 
+	if (k->is_pressed()) {
+		symbol_tooltip_dismissed = true;
+	}
+
 	// Allow unicode handling if:
 	// No modifiers are pressed (except Shift and CapsLock)
 	bool allow_unicode_handling = !(k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
@@ -772,6 +781,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	if (code_completion_active) {
+		symbol_tooltip_dismissed = true;
 		if (k->is_action("ui_up", true)) {
 			if (code_completion_current_selected > 0) {
 				code_completion_current_selected--;
@@ -2815,7 +2825,8 @@ bool CodeEdit::is_symbol_tooltip_on_hover_enabled() const {
 void CodeEdit::_on_symbol_tooltip_timer_timeout() {
 	const int line = symbol_tooltip_pos.y;
 	const int column = symbol_tooltip_pos.x;
-	if (line >= 0 && column >= 0 && !symbol_tooltip_word.is_empty() && !Input::get_singleton()->is_anything_pressed()) {
+	bool is_mouse_over_code_completion_popup = code_completion_active && code_completion_rect.has_point(get_local_mouse_position());
+	if (line >= 0 && column >= 0 && !symbol_tooltip_word.is_empty() && !Input::get_singleton()->is_anything_pressed() && !symbol_tooltip_dismissed && !is_mouse_over_code_completion_popup) {
 		emit_signal(SNAME("symbol_hovered"), symbol_tooltip_word, line, column);
 	}
 }

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -247,6 +247,7 @@ private:
 
 	/* Symbol tooltip */
 	bool symbol_tooltip_on_hover_enabled = false;
+	bool symbol_tooltip_dismissed = false;
 	Point2i symbol_tooltip_pos; // Column and line.
 	String symbol_tooltip_word;
 	Timer *symbol_tooltip_timer = nullptr;


### PR DESCRIPTION
Supersedes #119263 
Closes #119213 
Closes #119215

Dismisses and suspends the symbol tooltip when any key on the keyboard is pressed, excluding modifier keys (Ctrl, Alt, Shift). The tooltip also doesn't show for symbols behind the autocomplete popup.

Examples:
old behaviour

https://github.com/user-attachments/assets/992e5910-d4dd-43d2-8ef3-1e9e30fdec86

new behaviour

https://github.com/user-attachments/assets/0478d63a-b564-41fe-8743-d4cc0353203f

