### PR TITLE
Clean up compatibility method internal names.

### DIFF
--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -38,7 +38,7 @@ Ref<FileAccess> FileAccess::_open_encrypted_bind_compat_98918(const String &p_pa
 	return open_encrypted(p_path, p_mode_flags, p_key, Vector<uint8_t>());
 }
 
-Ref<FileAccess> FileAccess::_create_temp_compat_114053(int p_mode_flags, const String &p_prefix, const String &p_extension, bool p_keep) {
+Ref<FileAccess> FileAccess::_create_temp_bind_compat_114053(int p_mode_flags, const String &p_prefix, const String &p_extension, bool p_keep) {
 	return _create_temp((ModeFlags)p_mode_flags, p_prefix, p_extension, p_keep);
 }
 
@@ -108,7 +108,7 @@ String FileAccess::get_as_text_bind_compat_110867(bool p_skip_cr) const {
 
 void FileAccess::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key"), &FileAccess::_open_encrypted_bind_compat_98918);
-	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("create_temp", "mode_flags", "prefix", "extension", "keep"), &FileAccess::_create_temp_compat_114053, DEFVAL(""), DEFVAL(""), DEFVAL(false));
+	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("create_temp", "mode_flags", "prefix", "extension", "keep"), &FileAccess::_create_temp_bind_compat_114053, DEFVAL(""), DEFVAL(""), DEFVAL(false));
 
 	ClassDB::bind_compatibility_method(D_METHOD("store_8", "value"), &FileAccess::store_8_bind_compat_78289);
 	ClassDB::bind_compatibility_method(D_METHOD("store_16", "value"), &FileAccess::store_16_bind_compat_78289);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -120,7 +120,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	static Ref<FileAccess> _open_encrypted_bind_compat_98918(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key);
-	static Ref<FileAccess> _create_temp_compat_114053(int p_mode_flags, const String &p_prefix = "", const String &p_extension = "", bool p_keep = false);
+	static Ref<FileAccess> _create_temp_bind_compat_114053(int p_mode_flags, const String &p_prefix = "", const String &p_extension = "", bool p_keep = false);
 
 	void store_8_bind_compat_78289(uint8_t p_dest);
 	void store_16_bind_compat_78289(uint16_t p_dest);

--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -47,7 +47,7 @@ Error Image::_compress_bind_compat_115003(CompressMode p_mode, CompressSource p_
 	return compress(p_mode, p_source, _astc_format_to_compress_profile(p_format));
 }
 
-Error Image::_compress_from_channels_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format) {
+Error Image::_compress_from_channels_bind_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format) {
 	return compress_from_channels(p_mode, p_channels, _astc_format_to_compress_profile(p_format));
 }
 
@@ -61,7 +61,7 @@ Error Image::_save_exr_bind_compat_117800(const String &p_path, bool p_grayscale
 
 void Image::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("compress", "mode", "source", "astc_format"), &Image::_compress_bind_compat_115003, DEFVAL(COMPRESS_SOURCE_GENERIC), DEFVAL(ASTC_FORMAT_4x4));
-	ClassDB::bind_compatibility_method(D_METHOD("compress_from_channels", "mode", "channels", "astc_format"), &Image::_compress_from_channels_compat_115003, DEFVAL(ASTC_FORMAT_4x4));
+	ClassDB::bind_compatibility_method(D_METHOD("compress_from_channels", "mode", "channels", "astc_format"), &Image::_compress_from_channels_bind_compat_115003, DEFVAL(ASTC_FORMAT_4x4));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_bind_compat_117800, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::_save_exr_to_buffer_bind_compat_117800, DEFVAL(false));
 }

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -277,7 +277,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	Error _compress_bind_compat_115003(CompressMode p_mode, CompressSource p_source, ASTCFormat p_format);
-	Error _compress_from_channels_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format);
+	Error _compress_from_channels_bind_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format);
 	Vector<uint8_t> _save_exr_to_buffer_bind_compat_117800(bool p_grayscale = false) const;
 	Error _save_exr_bind_compat_117800(const String &p_path, bool p_grayscale = false) const;
 

--- a/core/io/stream_peer_socket.compat.inc
+++ b/core/io/stream_peer_socket.compat.inc
@@ -45,12 +45,12 @@ enum class Status {
 
 VARIANT_ENUM_CAST(compat::StreamPeerTCP::Status);
 
-compat::StreamPeerTCP::Status StreamPeerSocket::_get_status_compat_107954() const {
+compat::StreamPeerTCP::Status StreamPeerSocket::_get_status_bind_compat_107954() const {
 	return (compat::StreamPeerTCP::Status)get_status();
 }
 
 void StreamPeerSocket::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("get_status"), &StreamPeerSocket::_get_status_compat_107954);
+	ClassDB::bind_compatibility_method(D_METHOD("get_status"), &StreamPeerSocket::_get_status_bind_compat_107954);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/core/io/stream_peer_socket.h
+++ b/core/io/stream_peer_socket.h
@@ -52,7 +52,7 @@ public:
 
 protected:
 #ifndef DISABLE_DEPRECATED
-	compat::StreamPeerTCP::Status _get_status_compat_107954() const;
+	compat::StreamPeerTCP::Status _get_status_bind_compat_107954() const;
 	static void _bind_compatibility_methods();
 #endif
 

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -148,7 +148,7 @@ void EditorDock::_bind_methods() {
 	GDVIRTUAL_BIND(_load_layout_from_config, "config", "section");
 
 #ifndef DISABLE_DEPRECATED
-	GDVIRTUAL_BIND_COMPAT(_update_layout_, "layout");
+	GDVIRTUAL_BIND_COMPAT(_update_layout_bind_compat_117080, "layout");
 #endif
 }
 

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -108,7 +108,7 @@ protected:
 	GDVIRTUAL2(_load_layout_from_config, Ref<ConfigFile>, const String &)
 
 #ifndef DISABLE_DEPRECATED
-	GDVIRTUAL1_COMPAT(_update_layout_, _update_layout, int)
+	GDVIRTUAL1_COMPAT(_update_layout_bind_compat_117080, _update_layout, int)
 #endif
 
 public:

--- a/editor/plugins/editor_plugin.compat.inc
+++ b/editor/plugins/editor_plugin.compat.inc
@@ -34,17 +34,17 @@
 
 #include "core/object/class_db.h"
 
-Button *EditorPlugin::_add_control_to_bottom_panel_compat_88081(Control *p_control, const String &p_title) {
+Button *EditorPlugin::_add_control_to_bottom_panel_bind_compat_88081(Control *p_control, const String &p_title) {
 	return add_control_to_bottom_panel(p_control, p_title, nullptr);
 }
 
-void EditorPlugin::_add_control_to_dock_compat_88081(DockSlot p_slot, Control *p_control) {
+void EditorPlugin::_add_control_to_dock_bind_compat_88081(DockSlot p_slot, Control *p_control) {
 	return add_control_to_dock(p_slot, p_control, nullptr);
 }
 
 void EditorPlugin::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_bottom_panel", "control", "title"), &EditorPlugin::_add_control_to_bottom_panel_compat_88081);
-	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_dock", "slot", "control"), &EditorPlugin::_add_control_to_dock_compat_88081);
+	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_bottom_panel", "control", "title"), &EditorPlugin::_add_control_to_bottom_panel_bind_compat_88081);
+	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_dock", "slot", "control"), &EditorPlugin::_add_control_to_dock_bind_compat_88081);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -146,8 +146,8 @@ protected:
 	GDVIRTUAL0(_disable_plugin)
 
 #ifndef DISABLE_DEPRECATED
-	Button *_add_control_to_bottom_panel_compat_88081(Control *p_control, const String &p_title);
-	void _add_control_to_dock_compat_88081(DockSlot p_slot, Control *p_control);
+	Button *_add_control_to_bottom_panel_bind_compat_88081(Control *p_control, const String &p_title);
+	void _add_control_to_dock_bind_compat_88081(DockSlot p_slot, Control *p_control);
 	static void _bind_compatibility_methods();
 
 	void add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut = nullptr);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.compat.inc
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.compat.inc
@@ -35,10 +35,10 @@
 #include "core/object/class_db.h"
 
 void OpenXRSpatialAnchorCapability::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("create_new_anchor", "transform", "spatial_context"), &OpenXRSpatialAnchorCapability::_create_new_anchor_compat_118128, DEFVAL(RID()));
+	ClassDB::bind_compatibility_method(D_METHOD("create_new_anchor", "transform", "spatial_context"), &OpenXRSpatialAnchorCapability::_create_new_anchor_bind_compat_118128, DEFVAL(RID()));
 }
 
-Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::_create_new_anchor_compat_118128(const Transform3D &p_transform, RID p_spatial_context) {
+Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::_create_new_anchor_bind_compat_118128(const Transform3D &p_transform, RID p_spatial_context) {
 	return create_new_anchor(p_transform, p_spatial_context, Ref<OpenXRStructureBase>());
 }
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
@@ -194,7 +194,7 @@ protected:
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	static void _bind_compatibility_methods();
-	Ref<OpenXRAnchorTracker> _create_new_anchor_compat_118128(const Transform3D &p_transform, RID p_spatial_context);
+	Ref<OpenXRAnchorTracker> _create_new_anchor_bind_compat_118128(const Transform3D &p_transform, RID p_spatial_context);
 #endif
 
 private:

--- a/scene/2d/tile_map.compat.inc
+++ b/scene/2d/tile_map.compat.inc
@@ -38,11 +38,11 @@ Rect2i TileMap::_get_used_rect_bind_compat_78328() {
 	return get_used_rect();
 }
 
-void TileMap::_set_quadrant_size_compat_81070(int p_quadrant_size) {
+void TileMap::_set_quadrant_size_bind_compat_81070(int p_quadrant_size) {
 	set_rendering_quadrant_size(p_quadrant_size);
 }
 
-int TileMap::_get_quadrant_size_compat_81070() const {
+int TileMap::_get_quadrant_size_bind_compat_81070() const {
 	return get_rendering_quadrant_size();
 }
 
@@ -58,8 +58,8 @@ TileMap::VisibilityMode TileMap::_get_navigation_visibility_mode_bind_compat_871
 
 void TileMap::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_used_rect"), &TileMap::_get_used_rect_bind_compat_78328);
-	ClassDB::bind_compatibility_method(D_METHOD("set_quadrant_size", "quadrant_size"), &TileMap::_set_quadrant_size_compat_81070);
-	ClassDB::bind_compatibility_method(D_METHOD("get_quadrant_size"), &TileMap::_get_quadrant_size_compat_81070);
+	ClassDB::bind_compatibility_method(D_METHOD("set_quadrant_size", "quadrant_size"), &TileMap::_set_quadrant_size_bind_compat_81070);
+	ClassDB::bind_compatibility_method(D_METHOD("get_quadrant_size"), &TileMap::_get_quadrant_size_bind_compat_81070);
 	ClassDB::bind_compatibility_method(D_METHOD("get_collision_visibility_mode"), &TileMap::_get_collision_visibility_mode_bind_compat_87115);
 #ifndef NAVIGATION_2D_DISABLED
 	ClassDB::bind_compatibility_method(D_METHOD("get_navigation_visibility_mode"), &TileMap::_get_navigation_visibility_mode_bind_compat_87115);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -103,8 +103,8 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	Rect2i _get_used_rect_bind_compat_78328();
-	void _set_quadrant_size_compat_81070(int p_quadrant_size);
-	int _get_quadrant_size_compat_81070() const;
+	void _set_quadrant_size_bind_compat_81070(int p_quadrant_size);
+	int _get_quadrant_size_bind_compat_81070() const;
 	VisibilityMode _get_collision_visibility_mode_bind_compat_87115();
 #ifndef NAVIGATION_2D_DISABLED
 	VisibilityMode _get_navigation_visibility_mode_bind_compat_87115();

--- a/scene/animation/animation_player.compat.inc
+++ b/scene/animation/animation_player.compat.inc
@@ -62,7 +62,7 @@ void AnimationPlayer::_seek_bind_compat_80813(double p_time, bool p_update) {
 	seek(p_time, p_update, false);
 }
 
-Vector<String> AnimationPlayer::_get_queue_compat_110767() {
+Vector<String> AnimationPlayer::_get_queue_bind_compat_110767() {
 	Vector<String> queue;
 	for (const Variant &E : get_queue()) {
 		queue.push_back(E);
@@ -70,27 +70,27 @@ Vector<String> AnimationPlayer::_get_queue_compat_110767() {
 	return queue;
 }
 
-String AnimationPlayer::_get_current_animation_compat_110767() const {
+String AnimationPlayer::_get_current_animation_bind_compat_110767() const {
 	return get_current_animation();
 }
 
-void AnimationPlayer::_set_current_animation_compat_110767(const String &p_animation) {
+void AnimationPlayer::_set_current_animation_bind_compat_110767(const String &p_animation) {
 	set_current_animation(p_animation);
 }
 
-String AnimationPlayer::_get_assigned_animation_compat_110767() const {
+String AnimationPlayer::_get_assigned_animation_bind_compat_110767() const {
 	return get_assigned_animation();
 }
 
-void AnimationPlayer::_set_assigned_animation_compat_110767(const String &p_animation) {
+void AnimationPlayer::_set_assigned_animation_bind_compat_110767(const String &p_animation) {
 	set_assigned_animation(p_animation);
 }
 
-String AnimationPlayer::_get_autoplay_compat_110767() const {
+String AnimationPlayer::_get_autoplay_bind_compat_110767() const {
 	return get_autoplay();
 }
 
-void AnimationPlayer::_set_autoplay_compat_110767(const String &p_name) {
+void AnimationPlayer::_set_autoplay_bind_compat_110767(const String &p_name) {
 	set_autoplay(p_name);
 }
 
@@ -102,13 +102,13 @@ void AnimationPlayer::_bind_compatibility_methods() {
 	ClassDB::bind_method(D_METHOD("set_root", "path"), &AnimationPlayer::_set_root_bind_compat_80813);
 	ClassDB::bind_method(D_METHOD("get_root"), &AnimationPlayer::_get_root_bind_compat_80813);
 
-	ClassDB::bind_compatibility_method(D_METHOD("get_queue"), &AnimationPlayer::_get_queue_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("get_current_animation"), &AnimationPlayer::_get_current_animation_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("set_current_animation", "animation"), &AnimationPlayer::_set_current_animation_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("get_assigned_animation"), &AnimationPlayer::_get_assigned_animation_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("set_assigned_animation", "animation"), &AnimationPlayer::_set_assigned_animation_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("get_autoplay"), &AnimationPlayer::_get_autoplay_compat_110767);
-	ClassDB::bind_compatibility_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::_set_autoplay_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_queue"), &AnimationPlayer::_get_queue_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_current_animation"), &AnimationPlayer::_get_current_animation_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_current_animation", "animation"), &AnimationPlayer::_set_current_animation_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_assigned_animation"), &AnimationPlayer::_get_assigned_animation_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_assigned_animation", "animation"), &AnimationPlayer::_set_assigned_animation_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_autoplay"), &AnimationPlayer::_get_autoplay_bind_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::_set_autoplay_bind_compat_110767);
 
 	ClassDB::bind_compatibility_method(D_METHOD("seek", "seconds", "update"), &AnimationPlayer::_seek_bind_compat_80813, DEFVAL(false));
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_PHYSICS);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -166,16 +166,16 @@ protected:
 	void _set_root_bind_compat_80813(const NodePath &p_root);
 	NodePath _get_root_bind_compat_80813() const;
 	void _seek_bind_compat_80813(double p_time, bool p_update = false);
-	void _play_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
-	void _play_backwards_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1);
+	void _play_bind_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
+	void _play_backwards_bind_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1);
 
-	Vector<String> _get_queue_compat_110767();
-	String _get_current_animation_compat_110767() const;
-	void _set_current_animation_compat_110767(const String &p_animation);
-	String _get_assigned_animation_compat_110767() const;
-	void _set_assigned_animation_compat_110767(const String &p_animation);
-	String _get_autoplay_compat_110767() const;
-	void _set_autoplay_compat_110767(const String &p_name);
+	Vector<String> _get_queue_bind_compat_110767();
+	String _get_current_animation_bind_compat_110767() const;
+	void _set_current_animation_bind_compat_110767(const String &p_animation);
+	String _get_assigned_animation_bind_compat_110767() const;
+	void _set_assigned_animation_bind_compat_110767(const String &p_animation);
+	String _get_autoplay_bind_compat_110767() const;
+	void _set_autoplay_bind_compat_110767(const String &p_name);
 
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/code_edit.compat.inc
+++ b/scene/gui/code_edit.compat.inc
@@ -38,13 +38,13 @@ String CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196() {
 	return get_text_for_symbol_lookup();
 }
 
-void CodeEdit::_add_code_completion_option_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+void CodeEdit::_add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
 	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location);
 }
 
 void CodeEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_text_for_symbol_lookup"), &CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196);
-	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_compat_84906, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_bind_compat_84906, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL), DEFVAL(LOCATION_OTHER));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -327,7 +327,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	String _get_text_for_symbol_lookup_bind_compat_73196();
-	void _add_code_completion_option_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
+	void _add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
 	static void _bind_compatibility_methods();
 #endif
 

--- a/scene/gui/popup_menu.compat.inc
+++ b/scene/gui/popup_menu.compat.inc
@@ -46,7 +46,7 @@ void PopupMenu::_clear_bind_compat_79965() {
 	clear(false);
 }
 
-void PopupMenu::_set_system_menu_root_compat_87452(const String &p_special) {
+void PopupMenu::_set_system_menu_root_bind_compat_87452(const String &p_special) {
 	if (p_special == "_dock") {
 		set_system_menu(NativeMenu::DOCK_MENU_ID);
 	} else if (p_special == "_apple") {
@@ -58,7 +58,7 @@ void PopupMenu::_set_system_menu_root_compat_87452(const String &p_special) {
 	}
 }
 
-String PopupMenu::_get_system_menu_root_compat_87452() const {
+String PopupMenu::_get_system_menu_root_bind_compat_87452() const {
 	switch (get_system_menu()) {
 		case NativeMenu::APPLICATION_MENU_ID:
 			return "_apple";
@@ -78,8 +78,8 @@ void PopupMenu::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("add_icon_shortcut", "texture", "shortcut", "id", "global"), &PopupMenu::_add_icon_shortcut_bind_compat_36493, DEFVAL(-1), DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("clear"), &PopupMenu::_clear_bind_compat_79965);
 
-	ClassDB::bind_compatibility_method(D_METHOD("set_system_menu_root", "special"), &PopupMenu::_set_system_menu_root_compat_87452);
-	ClassDB::bind_compatibility_method(D_METHOD("get_system_menu_root"), &PopupMenu::_get_system_menu_root_compat_87452);
+	ClassDB::bind_compatibility_method(D_METHOD("set_system_menu_root", "special"), &PopupMenu::_set_system_menu_root_bind_compat_87452);
+	ClassDB::bind_compatibility_method(D_METHOD("get_system_menu_root"), &PopupMenu::_get_system_menu_root_bind_compat_87452);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -291,8 +291,8 @@ protected:
 	void _add_icon_shortcut_bind_compat_36493(const Ref<Texture2D> &p_icon, const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
 	void _clear_bind_compat_79965();
 
-	void _set_system_menu_root_compat_87452(const String &p_special);
-	String _get_system_menu_root_compat_87452() const;
+	void _set_system_menu_root_bind_compat_87452(const String &p_special);
+	String _get_system_menu_root_bind_compat_87452() const;
 
 	static void _bind_compatibility_methods();
 #endif

--- a/scene/gui/split_container.compat.inc
+++ b/scene/gui/split_container.compat.inc
@@ -34,12 +34,12 @@
 
 #include "core/object/class_db.h"
 
-void SplitContainer::_clamp_split_offset_compat_90411() {
+void SplitContainer::_clamp_split_offset_bind_compat_90411() {
 	clamp_split_offset(0);
 }
 
 void SplitContainer::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("clamp_split_offset"), &SplitContainer::_clamp_split_offset_compat_90411);
+	ClassDB::bind_compatibility_method(D_METHOD("clamp_split_offset"), &SplitContainer::_clamp_split_offset_bind_compat_90411);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -183,7 +183,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
-	void _clamp_split_offset_compat_90411();
+	void _clamp_split_offset_bind_compat_90411();
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 

--- a/scene/gui/text_edit.compat.inc
+++ b/scene/gui/text_edit.compat.inc
@@ -34,7 +34,7 @@
 
 #include "core/object/class_db.h"
 
-void TextEdit::_set_selection_mode_compat_86978(SelectionMode p_mode, int p_line, int p_column, int p_caret) {
+void TextEdit::_set_selection_mode_bind_compat_86978(SelectionMode p_mode, int p_line, int p_column, int p_caret) {
 	set_selection_mode(p_mode);
 }
 
@@ -43,7 +43,7 @@ Point2i TextEdit::_get_line_column_at_pos_bind_compat_100913(const Point2i &p_po
 }
 
 void TextEdit::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::_set_selection_mode_compat_86978, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
+	ClassDB::bind_compatibility_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::_set_selection_mode_bind_compat_86978, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_compatibility_method(D_METHOD("get_line_column_at_pos", "position", "allow_out_of_bounds"), &TextEdit::_get_line_column_at_pos_bind_compat_100913, DEFVAL(true));
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -729,7 +729,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
-	void _set_selection_mode_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
+	void _set_selection_mode_bind_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	Point2i _get_line_column_at_pos_bind_compat_100913(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.compat.inc
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.compat.inc
@@ -34,27 +34,27 @@
 
 #include "core/object/class_db.h"
 
-RID RenderSceneBuffersRD::_get_color_texture_compat_80214() {
+RID RenderSceneBuffersRD::_get_color_texture_bind_compat_80214() {
 	return _get_color_texture(msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
-RID RenderSceneBuffersRD::_get_color_layer_compat_80214(const uint32_t p_layer) {
+RID RenderSceneBuffersRD::_get_color_layer_bind_compat_80214(const uint32_t p_layer) {
 	return _get_color_layer(p_layer, msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
-RID RenderSceneBuffersRD::_get_depth_texture_compat_80214() {
+RID RenderSceneBuffersRD::_get_depth_texture_bind_compat_80214() {
 	return _get_depth_texture(msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
-RID RenderSceneBuffersRD::_get_depth_layer_compat_80214(const uint32_t p_layer) {
+RID RenderSceneBuffersRD::_get_depth_layer_bind_compat_80214(const uint32_t p_layer) {
 	return _get_depth_layer(p_layer, msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
-RID RenderSceneBuffersRD::_get_velocity_texture_compat_80214() {
+RID RenderSceneBuffersRD::_get_velocity_texture_bind_compat_80214() {
 	return _get_velocity_texture(msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
-RID RenderSceneBuffersRD::_get_velocity_layer_compat_80214(const uint32_t p_layer) {
+RID RenderSceneBuffersRD::_get_velocity_layer_bind_compat_80214(const uint32_t p_layer) {
 	return _get_velocity_layer(p_layer, msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
 }
 
@@ -63,12 +63,12 @@ RID RenderSceneBuffersRD::_create_texture_bind_compat_98670(const StringName &p_
 }
 
 void RenderSceneBuffersRD::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("get_color_texture"), &RenderSceneBuffersRD::_get_color_texture_compat_80214);
-	ClassDB::bind_compatibility_method(D_METHOD("get_color_layer", "layer"), &RenderSceneBuffersRD::_get_color_layer_compat_80214);
-	ClassDB::bind_compatibility_method(D_METHOD("get_depth_texture"), &RenderSceneBuffersRD::_get_depth_texture_compat_80214);
-	ClassDB::bind_compatibility_method(D_METHOD("get_depth_layer", "layer"), &RenderSceneBuffersRD::_get_depth_layer_compat_80214);
-	ClassDB::bind_compatibility_method(D_METHOD("get_velocity_texture"), &RenderSceneBuffersRD::_get_velocity_texture_compat_80214);
-	ClassDB::bind_compatibility_method(D_METHOD("get_velocity_layer", "layer"), &RenderSceneBuffersRD::_get_velocity_layer_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_color_texture"), &RenderSceneBuffersRD::_get_color_texture_bind_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_color_layer", "layer"), &RenderSceneBuffersRD::_get_color_layer_bind_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_depth_texture"), &RenderSceneBuffersRD::_get_depth_texture_bind_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_depth_layer", "layer"), &RenderSceneBuffersRD::_get_depth_layer_bind_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_velocity_texture"), &RenderSceneBuffersRD::_get_velocity_texture_bind_compat_80214);
+	ClassDB::bind_compatibility_method(D_METHOD("get_velocity_layer", "layer"), &RenderSceneBuffersRD::_get_velocity_layer_bind_compat_80214);
 
 	ClassDB::bind_compatibility_method(D_METHOD("create_texture", "context", "name", "data_format", "usage_bits", "texture_samples", "size", "layers", "mipmaps", "unique"), &RenderSceneBuffersRD::_create_texture_bind_compat_98670);
 }

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -441,12 +441,12 @@ private:
 
 #ifndef DISABLE_DEPRECATED
 
-	RID _get_color_texture_compat_80214();
-	RID _get_color_layer_compat_80214(const uint32_t p_layer);
-	RID _get_depth_texture_compat_80214();
-	RID _get_depth_layer_compat_80214(const uint32_t p_layer);
-	RID _get_velocity_texture_compat_80214();
-	RID _get_velocity_layer_compat_80214(const uint32_t p_layer);
+	RID _get_color_texture_bind_compat_80214();
+	RID _get_color_layer_bind_compat_80214(const uint32_t p_layer);
+	RID _get_depth_texture_bind_compat_80214();
+	RID _get_depth_layer_bind_compat_80214(const uint32_t p_layer);
+	RID _get_velocity_texture_bind_compat_80214();
+	RID _get_velocity_layer_bind_compat_80214(const uint32_t p_layer);
 
 	RID _create_texture_bind_compat_98670(const StringName &p_context, const StringName &p_texture_name, const RD::DataFormat p_data_format, const uint32_t p_usage_bits, const RD::TextureSamples p_texture_samples, const Size2i p_size, const uint32_t p_layers, const uint32_t p_mipmaps, bool p_unique);
 

--- a/servers/rendering/rendering_device.compat.inc
+++ b/servers/rendering/rendering_device.compat.inc
@@ -163,7 +163,7 @@ RID RenderingDevice::_index_buffer_create_bind_compat_101561(uint32_t p_size_ind
 	return _index_buffer_create(p_size_indices, p_format, p_data, p_use_restart_indices, 0);
 }
 
-RID RenderingDevice::_texture_create_from_extension_compat_105570(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers) {
+RID RenderingDevice::_texture_create_from_extension_bind_compat_105570(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers) {
 	return texture_create_from_extension(p_type, p_format, p_samples, p_usage, p_image, p_width, p_height, p_depth, p_layers, 1);
 }
 
@@ -196,7 +196,7 @@ void RenderingDevice::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("vertex_buffer_create", "size_bytes", "data", "use_as_storage"), &RenderingDevice::_vertex_buffer_create_bind_compat_101561, DEFVAL(Vector<uint8_t>()), DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("index_buffer_create", "size_indices", "format", "data", "use_restart_indices"), &RenderingDevice::_index_buffer_create_bind_compat_101561, DEFVAL(Vector<uint8_t>()), DEFVAL(false));
 
-	ClassDB::bind_compatibility_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "usage_flags", "image", "width", "height", "depth", "layers"), &RenderingDevice::_texture_create_from_extension_compat_105570);
+	ClassDB::bind_compatibility_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "usage_flags", "image", "width", "height", "depth", "layers"), &RenderingDevice::_texture_create_from_extension_bind_compat_105570);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -94,7 +94,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	RID _shader_create_from_bytecode_bind_compat_79606(const Vector<uint8_t> &p_shader_binary);
-	RID _texture_create_from_extension_compat_105570(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers);
+	RID _texture_create_from_extension_bind_compat_105570(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers);
 	static void _bind_compatibility_methods();
 #endif
 

--- a/servers/rendering/rendering_server.compat.inc
+++ b/servers/rendering/rendering_server.compat.inc
@@ -62,7 +62,7 @@ void RenderingServer::_instance_reset_physics_interpolation_bind_compat_104269(R
 	WARN_PRINT_ONCE("instance_reset_physics_interpolation() is deprecated.");
 }
 
-void RenderingServer::_viewport_set_size_compat_115799(RID p_viewport, int p_width, int p_height) {
+void RenderingServer::_viewport_set_size_bind_compat_115799(RID p_viewport, int p_width, int p_height) {
 	viewport_set_size(p_viewport, p_width, p_height, 1);
 }
 
@@ -78,7 +78,7 @@ void RenderingServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("canvas_item_add_circle", "item", "pos", "radius", "color"), &RenderingServer::_canvas_item_add_circle_bind_compat_84523);
 	ClassDB::bind_compatibility_method(D_METHOD("instance_set_interpolated", "instance", "interpolated"), &RenderingServer::_instance_set_interpolated_bind_compat_104269);
 	ClassDB::bind_compatibility_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &RenderingServer::_instance_reset_physics_interpolation_bind_compat_104269);
-	ClassDB::bind_compatibility_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::_viewport_set_size_compat_115799);
+	ClassDB::bind_compatibility_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::_viewport_set_size_bind_compat_115799);
 	ClassDB::bind_compatibility_method(D_METHOD("particles_request_process_time", "particles", "process_time"), &RenderingServer::_particles_request_process_time_bind_compat_109142);
 }
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -95,7 +95,7 @@ protected:
 	void _canvas_item_add_circle_bind_compat_84523(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color);
 	void _instance_set_interpolated_bind_compat_104269(RID p_instance, bool p_interpolated);
 	void _instance_reset_physics_interpolation_bind_compat_104269(RID p_instance);
-	void _viewport_set_size_compat_115799(RID p_viewport, int p_width, int p_height);
+	void _viewport_set_size_bind_compat_115799(RID p_viewport, int p_width, int p_height);
 	void _particles_request_process_time_bind_compat_109142(RID p_particles, real_t p_request_process_time);
 
 	static void _bind_compatibility_methods();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes compatibility names that were not following common `_bind_compat_XXXXX` naming scheme.
