### PR TITLE
Fix saving manual triangles in BlendSpace2D

### DIFF
--- a/misc/extension_api_validation/4.7-stable/GH-121318.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121318.txt
@@ -1,0 +1,5 @@
+GH-121318
+--------------
+Validate extension JSON: API was removed: classes/AnimationNodeBlendSpace2D/properties/triangles
+
+The "triangles" property was moved from static ADD_PROPERTY registration into the dynamic _get_property_list() override, to allow it to serialize/deserialize together with blend_point_i/*, and prevent errors and dropped triangles on load. The property remains fully functional at runtime via _set/_get, only its static GDExtension reflection entry was removed.

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -371,10 +371,35 @@ void AnimationNodeBlendSpace2D::_set_triangles(const Vector<int> &p_triangles) {
 		return;
 	}
 	ERR_FAIL_COND(p_triangles.size() % 3 != 0);
+
+#ifndef DISABLE_DEPRECATED
+	for (int i = 0; i < p_triangles.size(); i += 3) {
+		if (p_triangles[i + 0] >= blend_points_used || p_triangles[i + 1] >= blend_points_used || p_triangles[i + 2] >= blend_points_used) {
+			// Blend points for this triangle haven't been deserialized yet, so retry after the rest of the file has loaded.
+			callable_mp(this, &AnimationNodeBlendSpace2D::_retry_set_triangles).call_deferred(p_triangles);
+			return;
+		}
+	}
+#endif // DISABLE_DEPRECATED
+
 	for (int i = 0; i < p_triangles.size(); i += 3) {
 		add_triangle(p_triangles[i + 0], p_triangles[i + 1], p_triangles[i + 2]);
 	}
 }
+
+#ifndef DISABLE_DEPRECATED
+void AnimationNodeBlendSpace2D::_retry_set_triangles(const Vector<int> &p_triangles) {
+	for (int i = 0; i < p_triangles.size(); i += 3) {
+		int x = p_triangles[i + 0];
+		int y = p_triangles[i + 1];
+		int z = p_triangles[i + 2];
+		if (x >= blend_points_used || y >= blend_points_used || z >= blend_points_used || has_triangle(x, y, z)) {
+			continue;
+		}
+		add_triangle(x, y, z);
+	}
+}
+#endif // DISABLE_DEPRECATED
 
 Vector<int> AnimationNodeBlendSpace2D::_get_triangles() const {
 	Vector<int> t;
@@ -411,6 +436,10 @@ bool AnimationNodeBlendSpace2D::_set(const StringName &p_name, const Variant &p_
 		}
 		return true;
 	}
+	if (prop == "triangles") {
+		_set_triangles(p_value);
+		return true;
+	}
 	return false;
 }
 
@@ -430,6 +459,10 @@ bool AnimationNodeBlendSpace2D::_get(const StringName &p_name, Variant &r_ret) c
 		}
 		return true;
 	}
+	if (prop == "triangles") {
+		r_ret = _get_triangles();
+		return true;
+	}
 	return false;
 }
 
@@ -439,6 +472,9 @@ void AnimationNodeBlendSpace2D::_get_property_list(List<PropertyInfo> *p_list) c
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, "blend_point_" + itos(i) + "/pos", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		p_list->push_back(PropertyInfo(Variant::STRING, "blend_point_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 	}
+
+	// This is here and not an ADD_PROPERTY in _bind_methods() because static properties apply before this list, so triangles would serialize before blend points and fail to resolve on deserialization.
+	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 }
 
 void AnimationNodeBlendSpace2D::_queue_auto_triangles() {
@@ -916,7 +952,6 @@ void AnimationNodeBlendSpace2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cyclic_length"), &AnimationNodeBlendSpace2D::get_cyclic_length);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_auto_triangles", "get_auto_triangles");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "triangles", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_triangles", "_get_triangles");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "min_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_min_space", "get_min_space");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "max_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_max_space", "get_max_space");

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -94,6 +94,10 @@ protected:
 	void _set_triangles(const Vector<int> &p_triangles);
 	Vector<int> _get_triangles() const;
 
+#ifndef DISABLE_DEPRECATED
+	void _retry_set_triangles(const Vector<int> &p_triangles);
+#endif // DISABLE_DEPRECATED
+
 	void _blend_triangle(const Vector2 &p_pos, const LocalVector<Vector2> &p_points, LocalVector<float> &r_weights);
 
 	bool auto_triangles = true;


### PR DESCRIPTION
Fixes #120616.
An oversight in #110369 didn't bring the `triangles` property into the new `_get`/`_set` path used by `node`, `path` and `name`, this PR does so.

Unfortunately, this PR will not be able to recover manual triangles saved with 4.7 while the regression was active. I don't think we should add code just for this slim period of time the regression was active, but if there's an opposing opinion, I can look into it.