### PR TITLE
GDScript: Check for soft function return types in various places

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1469,6 +1469,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 							return_datatype = getter_function->return_type->resolved_type;
 							return_datatype.is_meta_type = false;
 						}
+						return_datatype = return_datatype.as_hard_type();
 
 						if (getter_function->parameters.size() != 0 || return_datatype.has_no_type()) {
 							push_error(vformat(R"(Function "%s" cannot be used as getter because of its signature.)", getter_function->identifier->name), member.variable);
@@ -1512,8 +1513,8 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 				}
 
 				if (member.variable->type_constraint.is_variant() && has_valid_getter && has_valid_setter) {
-					if (!is_type_compatible(getter_function->return_type_constraint, setter_function->parameters[0]->type_constraint, true)) {
-						push_error(vformat(R"(Getter with type "%s" cannot be used along with setter of type "%s".)", getter_function->return_type_constraint.to_string(), setter_function->parameters[0]->type_constraint.to_string()), member.variable);
+					if (!is_type_compatible(getter_function->return_type_constraint.as_hard_type(), setter_function->parameters[0]->type_constraint, true)) {
+						push_error(vformat(R"(Getter with type "%s" cannot be used along with setter of type "%s".)", getter_function->return_type_constraint.to_string_strict(), setter_function->parameters[0]->type_constraint.to_string()), member.variable);
 					}
 				}
 			}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1475,6 +1475,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 							return_datatype = getter_function->return_type->resolved_type;
 							return_datatype.is_meta_type = false;
 						}
+						return_datatype = return_datatype.as_hard_type();
 
 						if (getter_function->parameters.size() != 0 || return_datatype.has_no_type()) {
 							push_error(vformat(R"(Function "%s" cannot be used as getter because of its signature.)", getter_function->identifier->name), member.variable);
@@ -1518,8 +1519,8 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 				}
 
 				if (member.variable->type_constraint.is_variant() && has_valid_getter && has_valid_setter) {
-					if (!is_type_compatible(getter_function->return_type_constraint, setter_function->parameters[0]->type_constraint, true)) {
-						push_error(vformat(R"(Getter with type "%s" cannot be used along with setter of type "%s".)", getter_function->return_type_constraint.to_string(), setter_function->parameters[0]->type_constraint.to_string()), member.variable);
+					if (!is_type_compatible(getter_function->return_type_constraint.as_hard_type(), setter_function->parameters[0]->type_constraint, true)) {
+						push_error(vformat(R"(Getter with type "%s" cannot be used along with setter of type "%s".)", getter_function->return_type_constraint.to_string_strict(), setter_function->parameters[0]->type_constraint.to_string()), member.variable);
 					}
 				}
 			}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -813,7 +813,7 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 		if (p_function->return_type_constraint.builtin_type == Variant::NIL) {
 			arghint = "void " + p_function->identifier->name + "(";
 		} else {
-			arghint = p_function->return_type_constraint.to_string() + " " + p_function->identifier->name + "(";
+			arghint = p_function->return_type_constraint.to_string_strict() + " " + p_function->identifier->name + "(";
 		}
 	}
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -831,10 +831,10 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 	if (p_just_args) {
 		arghint = "(";
 	} else {
-		if (p_function->return_type_constraint.builtin_type == Variant::NIL) {
+		if (p_function->return_type_constraint.is_hard_type() && p_function->return_type_constraint.builtin_type == Variant::NIL) {
 			arghint = "void " + p_function->identifier->name + "(";
 		} else {
-			arghint = p_function->return_type_constraint.to_string() + " " + p_function->identifier->name + "(";
+			arghint = p_function->return_type_constraint.to_string_strict() + " " + p_function->identifier->name + "(";
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -144,6 +144,16 @@ public:
 		_FORCE_INLINE_ bool is_variant() const { return kind == VARIANT || kind == RESOLVING || kind == UNRESOLVED; }
 		_FORCE_INLINE_ bool is_hard_type() const { return type_source > INFERRED; }
 
+		_FORCE_INLINE_ GDScriptParser::DataType as_hard_type() const {
+			if (!is_set() || has_no_type() || is_hard_type()) {
+				return *this;
+			}
+			DataType ret;
+			ret.type_source = ANNOTATED_INFERRED;
+			ret.kind = VARIANT;
+			return ret;
+		}
+
 		String to_string() const;
 		_FORCE_INLINE_ String to_string_strict() const { return is_hard_type() ? to_string() : "Variant"; }
 
@@ -762,7 +772,7 @@ public:
 		String extends_path;
 		Vector<IdentifierNode *> extends; // List for indexing: extends A.B.C
 		DataType base_type;
-		// Metatype that represents this class.
+		// Metatype that represents this class. Always contains a hard-type.
 		DataType self_type;
 		String fqcn; // Fully-qualified class name. Identifies uniquely any class in the project.
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -814,7 +814,7 @@ Dictionary ExtendGDScriptParser::dump_function_api(const GDScriptParser::Functio
 	ERR_FAIL_NULL_V(p_func, Dictionary());
 	Dictionary func;
 	func["name"] = p_func->identifier->name;
-	func["return_type"] = p_func->return_type_constraint.to_string();
+	func["return_type"] = p_func->return_type_constraint.to_string_strict();
 	func["rpc_config"] = p_func->rpc_config;
 	Array parameters;
 	for (int i = 0; i < p_func->parameters.size(); i++) {

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -811,7 +811,7 @@ Dictionary ExtendGDScriptParser::dump_function_api(const GDScriptParser::Functio
 	ERR_FAIL_NULL_V(p_func, Dictionary());
 	Dictionary func;
 	func["name"] = p_func->identifier->name;
-	func["return_type"] = p_func->return_type_constraint.to_string();
+	func["return_type"] = p_func->return_type_constraint.to_string_strict();
 	func["rpc_config"] = p_func->rpc_config;
 	Array parameters;
 	for (ParameterNode *param : p_func->parameters) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/properties.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/properties.gd
@@ -11,7 +11,7 @@ var prop_1: String:
 # Setter function has wrong argument type.
 # Getter function has wrong return type.
 var prop_2: String:
-	set = set_prop_2, get = get_prop_2
+	set = set_prop_int, get = get_prop_int
 
 # Inline setter parameter uses property type.
 var prop_3 := 0:
@@ -19,10 +19,46 @@ var prop_3 := 0:
 		var x: String = value
 		prop_3 = value
 
-func set_prop_2(value: int):
+# Untyped/variant is fine at compile time.
+var prop_4: String:
+	set = set_prop_untyped, get = get_prop_untyped
+
+var prop_5: String:
+	set = set_prop_variant, get = get_prop_variant
+
+# Mismatch in getter/setter type for untyped var.
+var prop6:
+	set = set_prop_int, get = get_prop_string
+
+var prop7: Variant:
+	set = set_prop_int, get = get_prop_string
+
+var prop8:
+	set = set_prop_untyped, get = get_prop_int
+
+var prop9:
+	set = set_prop_int, get = get_prop_variant
+
+
+func set_prop_int(value: int):
 	_prop = value
 
-func get_prop_2():
+func get_prop_int() -> int:
+	return _prop
+
+func get_prop_string() -> String:
+	return ""
+
+func set_prop_untyped(value):
+	_prop = value
+
+func get_prop_untyped():
+	return _prop
+
+func set_prop_variant(value: Variant):
+	_prop = value
+
+func get_prop_variant() -> Variant:
 	return _prop
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/errors/properties.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/properties.out
@@ -4,3 +4,5 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 13: Function with return type "int" cannot be used as getter for a property of type "String".
 >> ERROR at line 13: Function with argument type "int" cannot be used as setter for a property of type "String".
 >> ERROR at line 19: Cannot assign a value of type int to variable "x" with specified type String.
+>> ERROR at line 30: Getter with type "String" cannot be used along with setter of type "int".
+>> ERROR at line 33: Getter with type "String" cannot be used along with setter of type "int".


### PR DESCRIPTION
## What problem(s) does this PR solve?

The following code would previously not compile even though the getter is untyped:

```gdscript
var _prop: int
var prop: String: get = get_f

func get_f():
    return _prop
```

It now passes the analyzer. (Note: I think we have an issue with untyped getters were we are missing runtime checks somewhere, but that's nothing related to this change as the same also occurs with explicitly typing `get_f() -> Variant` which the analyzer already allows).

---

The following code would give wrong return type hints in the editor:

```gdscript
var _prop: int

func get_f():
    return _prop

func test():
    get_f()
```

<img width="265" height="235" alt="image" src="https://github.com/user-attachments/assets/a4c13435-611c-4fec-9b3f-c5a4e42739ce" />

It now correctly shows the actual type of the function:

<img width="265" height="235" alt="image" src="https://github.com/user-attachments/assets/cbe2c635-ee8e-4b62-b64e-5e17c7394ed1" />


## Additional information

Especially the first issue might seem like a non-issue when viewed in isolation. However when looking at the analyzer as a whole it is one of the few cases, where soft-types do have an actual effect on something compilation critical. So we need to get rid of that behaviour if we want to remove soft-types.
