### PR TITLE
Add Spinbox stepper mode

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -67,6 +67,9 @@
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
+		<member name="stepper_mode" type="int" setter="set_stepper_mode" getter="get_stepper_mode" enum="SpinBox.StepperMode" default="1">
+			Determines the layout of the up and down buttons.
+		</member>
 		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
 			Adds the specified suffix string after the numerical value of the [SpinBox].
 		</member>
@@ -75,6 +78,20 @@
 			[b]Note:[/b] If set to [code]true[/code], this will interfere with entering mathematical expressions in the [SpinBox]. The [SpinBox] will try to evaluate the expression as you type, which means symbols like a trailing [code]+[/code] are removed immediately by the expression being evaluated.
 		</member>
 	</members>
+	<constants>
+		<constant name="DISPLAY_NONE" value="0" enum="StepperMode">
+			No up and down buttons are drawn.
+		</constant>
+		<constant name="DISPLAY_VERTICALLY" value="1" enum="StepperMode">
+			Draws the up and down buttons stacked vertically.
+		</constant>
+		<constant name="DISPLAY_HORIZONTALLY" value="2" enum="StepperMode">
+			Draws the up and down buttons side‑by‑side on one side of the underlying [LineEdit].
+		</constant>
+		<constant name="DISPLAY_SPLIT_HORIZONTALLY" value="3" enum="StepperMode">
+			Draws the up and down buttons on opposite sides of the underlying [LineEdit].
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="down_disabled_icon_modulate" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.5)">
 			Down button icon modulation color, when the button is disabled.
@@ -101,7 +118,7 @@
 			Up button icon modulation color, when the button is being pressed.
 		</theme_item>
 		<theme_item name="buttons_vertical_separation" data_type="constant" type="int" default="0">
-			Vertical separation between the up and down buttons.
+			Separation between the up and down buttons.
 		</theme_item>
 		<theme_item name="buttons_width" data_type="constant" type="int" default="16">
 			Width of the up and down buttons. If smaller than any icon set on the buttons, the respective icon may overlap neighboring elements. If smaller than [code]0[/code], the width is automatically adjusted from the icon size.

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -203,8 +203,8 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_range_click_timeout() {
 	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-		Rect2 up_button_rc = Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height);
-		Rect2 down_button_rc = Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height);
+		Rect2 up_button_rc = Rect2(sizing_cache.up_button_x, 0, sizing_cache.buttons_width, sizing_cache.button_up_height);
+		Rect2 down_button_rc = Rect2(sizing_cache.down_button_x, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height);
 
 		Vector2 mpos = get_local_mouse_position();
 
@@ -275,8 +275,8 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 	bool mouse_on_up_button = false;
 	bool mouse_on_down_button = false;
 	if (mb.is_valid() || mm.is_valid()) {
-		Rect2 up_button_rc = Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height);
-		Rect2 down_button_rc = Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height);
+		Rect2 up_button_rc = Rect2(sizing_cache.up_button_x, 0, sizing_cache.buttons_width, sizing_cache.button_up_height);
+		Rect2 down_button_rc = Rect2(sizing_cache.down_button_x, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height);
 
 		mpos = me->get_position();
 
@@ -355,7 +355,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mm.is_valid() && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 		if (drag.enabled) {
-			drag.diff_y += mm->get_relative().y;
+			drag.diff_y += (stepper_mode == StepperMode::DISPLAY_VERTICALLY ? mm->get_relative().y : -mm->get_relative().x * (is_layout_rtl() ? -1 : 1));
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
 		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
@@ -391,34 +391,77 @@ void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
 }
 
 inline void SpinBox::_compute_sizes() {
-	int buttons_block_wanted_width = theme_cache.buttons_width + theme_cache.field_and_buttons_separation;
-	int buttons_block_icon_enforced_width = _get_widest_button_icon_width() + theme_cache.field_and_buttons_separation;
+	Size2i size = get_size();
+	bool rtl = is_layout_rtl();
 
 #ifndef DISABLE_DEPRECATED
 	const bool min_width_from_icons = theme_cache.set_min_buttons_width_from_icons || (theme_cache.buttons_width < 0);
 #else
 	const bool min_width_from_icons = theme_cache.buttons_width < 0;
 #endif
-	int w = min_width_from_icons != 0 ? MAX(buttons_block_icon_enforced_width, buttons_block_wanted_width) : buttons_block_wanted_width;
 
-	if (w != sizing_cache.buttons_block_width) {
-		line_edit->set_offset(SIDE_LEFT, 0);
-		line_edit->set_offset(SIDE_RIGHT, -w);
-		sizing_cache.buttons_block_width = w;
+	int btn_width = min_width_from_icons ? MAX(_get_widest_button_icon_width(), theme_cache.buttons_width) : theme_cache.buttons_width;
+	int block_width = btn_width + theme_cache.field_and_buttons_separation;
+	int left_ofs = 0;
+	int right_ofs = block_width;
+
+	sizing_cache.buttons_width = btn_width;
+	sizing_cache.field_and_buttons_separator_width = theme_cache.field_and_buttons_separation;
+	sizing_cache.up_button_x = rtl ? 0 : size.width - sizing_cache.buttons_width;
+
+	switch (stepper_mode) {
+		case StepperMode::DISPLAY_NONE: {
+			sizing_cache = {};
+			block_width = 0;
+			right_ofs = 0;
+		} break;
+
+		case StepperMode::DISPLAY_VERTICALLY: {
+			sizing_cache.buttons_vertical_separation = CLAMP(theme_cache.buttons_vertical_separation, 0, size.height);
+			sizing_cache.button_up_height = (size.height - sizing_cache.buttons_vertical_separation) / 2;
+			sizing_cache.button_down_height = size.height - sizing_cache.button_up_height - sizing_cache.buttons_vertical_separation;
+			sizing_cache.down_button_x = sizing_cache.up_button_x;
+			sizing_cache.second_button_top = size.height - sizing_cache.button_down_height;
+			sizing_cache.buttons_separator_x = sizing_cache.up_button_x;
+			sizing_cache.buttons_separator_top = sizing_cache.button_up_height;
+			sizing_cache.field_and_buttons_separator_left = rtl ? sizing_cache.buttons_width : size.width - block_width;
+		} break;
+
+		case StepperMode::DISPLAY_HORIZONTALLY: {
+			block_width += btn_width + theme_cache.buttons_vertical_separation;
+			sizing_cache.buttons_vertical_separation = theme_cache.buttons_vertical_separation;
+			sizing_cache.button_up_height = size.height;
+			sizing_cache.button_down_height = size.height;
+			sizing_cache.down_button_x = rtl ? sizing_cache.buttons_width + theme_cache.buttons_vertical_separation : sizing_cache.up_button_x - theme_cache.buttons_vertical_separation - sizing_cache.buttons_width;
+			sizing_cache.second_button_top = 0;
+			sizing_cache.buttons_separator_x = rtl ? sizing_cache.buttons_width : sizing_cache.down_button_x + sizing_cache.buttons_width;
+			sizing_cache.buttons_separator_top = 0;
+			sizing_cache.field_and_buttons_separator_left = rtl ? sizing_cache.down_button_x + sizing_cache.buttons_width : size.width - block_width;
+			right_ofs = block_width;
+
+		} break;
+
+		case StepperMode::DISPLAY_SPLIT_HORIZONTALLY: {
+			block_width += btn_width + sizing_cache.field_and_buttons_separator_width;
+			sizing_cache.buttons_vertical_separation = theme_cache.buttons_vertical_separation;
+			sizing_cache.button_up_height = size.height;
+			sizing_cache.button_down_height = size.height;
+			sizing_cache.down_button_x = rtl ? size.width - sizing_cache.buttons_width : 0;
+			sizing_cache.second_button_top = 0;
+			sizing_cache.buttons_separator_x = rtl ? size.width - sizing_cache.buttons_width : sizing_cache.buttons_width;
+			sizing_cache.buttons_separator_top = 0;
+			sizing_cache.field_and_buttons_separator_left = rtl ? sizing_cache.down_button_x + sizing_cache.buttons_width : size.width - sizing_cache.buttons_width - sizing_cache.field_and_buttons_separator_width;
+			left_ofs = btn_width + sizing_cache.field_and_buttons_separator_width;
+			right_ofs = left_ofs;
+		} break;
 	}
 
-	Size2i size = get_size();
+	line_edit->set_offset(SIDE_LEFT, left_ofs);
+	line_edit->set_offset(SIDE_RIGHT, -right_ofs);
 
-	sizing_cache.buttons_width = w - theme_cache.field_and_buttons_separation;
-	sizing_cache.buttons_vertical_separation = CLAMP(theme_cache.buttons_vertical_separation, 0, size.height);
-	sizing_cache.buttons_left = is_layout_rtl() ? 0 : size.width - sizing_cache.buttons_width;
-	sizing_cache.button_up_height = (size.height - sizing_cache.buttons_vertical_separation) / 2;
-	sizing_cache.button_down_height = size.height - sizing_cache.button_up_height - sizing_cache.buttons_vertical_separation;
-	sizing_cache.second_button_top = size.height - sizing_cache.button_down_height;
-
-	sizing_cache.buttons_separator_top = sizing_cache.button_up_height;
-	sizing_cache.field_and_buttons_separator_left = is_layout_rtl() ? sizing_cache.buttons_width : size.width - sizing_cache.buttons_block_width;
-	sizing_cache.field_and_buttons_separator_width = theme_cache.field_and_buttons_separation;
+	if (block_width != sizing_cache.buttons_block_width) {
+		sizing_cache.buttons_block_width = block_width;
+	}
 }
 
 inline int SpinBox::_get_widest_button_icon_width() {
@@ -443,6 +486,9 @@ void SpinBox::_notification(int p_what) {
 			_update_text(true);
 			_compute_sizes();
 
+			if (stepper_mode == StepperMode::DISPLAY_NONE) {
+				return;
+			}
 			Size2i size = get_size();
 
 			Ref<StyleBox> up_stylebox = theme_cache.up_base_stylebox;
@@ -483,18 +529,22 @@ void SpinBox::_notification(int p_what) {
 			}
 
 			// Compute center icon positions once we know which one is used.
-			int up_icon_left = sizing_cache.buttons_left + (sizing_cache.buttons_width - up_icon->get_width()) / 2;
+			int up_icon_left = sizing_cache.up_button_x + (sizing_cache.buttons_width - up_icon->get_width()) / 2;
 			int up_icon_top = (sizing_cache.button_up_height - up_icon->get_height()) / 2;
-			int down_icon_left = sizing_cache.buttons_left + (sizing_cache.buttons_width - down_icon->get_width()) / 2;
+			int down_icon_left = sizing_cache.down_button_x + (sizing_cache.buttons_width - down_icon->get_width()) / 2;
 			int down_icon_top = sizing_cache.second_button_top + (sizing_cache.button_down_height - down_icon->get_height()) / 2;
 
 			// Draw separators.
-			draw_style_box(theme_cache.up_down_buttons_separator, Rect2(sizing_cache.buttons_left, sizing_cache.buttons_separator_top, sizing_cache.buttons_width, sizing_cache.buttons_vertical_separation));
+			if (stepper_mode == StepperMode::DISPLAY_SPLIT_HORIZONTALLY) {
+				draw_style_box(theme_cache.field_and_buttons_separator, Rect2(sizing_cache.buttons_separator_x, 0, sizing_cache.field_and_buttons_separator_width, size.height));
+			} else {
+				draw_style_box(theme_cache.up_down_buttons_separator, Rect2(sizing_cache.buttons_separator_x, sizing_cache.buttons_separator_top, stepper_mode != StepperMode::DISPLAY_VERTICALLY ? sizing_cache.buttons_vertical_separation : sizing_cache.buttons_width, stepper_mode != StepperMode::DISPLAY_VERTICALLY ? size.height : sizing_cache.buttons_vertical_separation));
+			}
 			draw_style_box(theme_cache.field_and_buttons_separator, Rect2(sizing_cache.field_and_buttons_separator_left, 0, sizing_cache.field_and_buttons_separator_width, size.height));
 
 			// Draw buttons.
-			draw_style_box(up_stylebox, Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height));
-			draw_style_box(down_stylebox, Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height));
+			draw_style_box(up_stylebox, Rect2(sizing_cache.up_button_x, 0, sizing_cache.buttons_width, sizing_cache.button_up_height));
+			draw_style_box(down_stylebox, Rect2(sizing_cache.down_button_x, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height));
 
 #ifndef DISABLE_DEPRECATED
 			if (theme_cache.is_updown_assigned) {
@@ -662,6 +712,20 @@ void SpinBox::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+void SpinBox::set_stepper_mode(StepperMode p_mode) {
+	if (stepper_mode == p_mode) {
+		return;
+	}
+
+	stepper_mode = p_mode;
+	queue_redraw();
+	callable_mp((Control *)this, &Control::update_minimum_size).call_deferred();
+}
+
+SpinBox::StepperMode SpinBox::get_stepper_mode() const {
+	return stepper_mode;
+}
+
 void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "alignment"), &SpinBox::set_horizontal_alignment);
 	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &SpinBox::get_horizontal_alignment);
@@ -681,6 +745,8 @@ void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_select_all_on_focus"), &SpinBox::is_select_all_on_focus);
 	ClassDB::bind_method(D_METHOD("apply"), &SpinBox::apply);
 	ClassDB::bind_method(D_METHOD("get_line_edit"), &SpinBox::get_line_edit);
+	ClassDB::bind_method(D_METHOD("set_stepper_mode", "enable"), &SpinBox::set_stepper_mode);
+	ClassDB::bind_method(D_METHOD("get_stepper_mode"), &SpinBox::get_stepper_mode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
@@ -690,6 +756,12 @@ void SpinBox::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_arrow_step", PROPERTY_HINT_RANGE, "0,10000,0.0001,or_greater"), "set_custom_arrow_step", "get_custom_arrow_step");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "custom_arrow_round"), "set_custom_arrow_round", "is_custom_arrow_rounding");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_all_on_focus"), "set_select_all_on_focus", "is_select_all_on_focus");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stepper_mode", PROPERTY_HINT_ENUM, "None,Vertical,Horizontal,Split Horizontal"), "set_stepper_mode", "get_stepper_mode");
+
+	BIND_ENUM_CONSTANT(DISPLAY_NONE);
+	BIND_ENUM_CONSTANT(DISPLAY_VERTICALLY);
+	BIND_ENUM_CONSTANT(DISPLAY_HORIZONTALLY);
+	BIND_ENUM_CONSTANT(DISPLAY_SPLIT_HORIZONTALLY);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, buttons_vertical_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, field_and_buttons_separation);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -60,8 +60,11 @@ class SpinBox : public Range {
 		int buttons_left = 0;
 		int button_up_height = 0;
 		int button_down_height = 0;
+		int up_button_x = 0;
+		int down_button_x = 0;
 		int second_button_top = 0;
 		int buttons_separator_top = 0;
+		int buttons_separator_x = 0;
 		int field_and_buttons_separator_left = 0;
 		int field_and_buttons_separator_width = 0;
 	} sizing_cache;
@@ -149,10 +152,19 @@ class SpinBox : public Range {
 	void _mouse_exited();
 	void _update_buttons_state_for_current_value();
 
+	enum StepperMode {
+		DISPLAY_NONE,
+		DISPLAY_VERTICALLY,
+		DISPLAY_HORIZONTALLY,
+		DISPLAY_SPLIT_HORIZONTALLY
+	};
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _value_changed(double p_value) override;
 	void _validate_property(PropertyInfo &p_property) const;
+
+	StepperMode stepper_mode = DISPLAY_VERTICALLY;
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -187,5 +199,10 @@ public:
 	void set_custom_arrow_round(bool p_round);
 	bool is_custom_arrow_rounding() const;
 
+	void set_stepper_mode(StepperMode p_mode);
+	StepperMode get_stepper_mode() const;
+
 	SpinBox();
 };
+
+VARIANT_ENUM_CAST(SpinBox::StepperMode);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/discussions/9479, closes https://github.com/godotengine/godot-proposals/issues/11314, 

Related: https://github.com/godotengine/godot-proposals/issues/7412, https://github.com/godotengine/godot-proposals/issues/4584

## Additional information

Adds an option to switch how the up and down buttons is displayed.
None, Vertical (default), Horizontal and Split horizontal

I made this a while ago, but later saw that a PR got merged that used "buttons_vertical_separation", this was a bit unfortunate as this is now used for horizontal separation too in this PR. So I didn't finish it then. 
Maybe fine to use it for both anyways? 

The split mode draws the same stylebox on both side of the LineEdit. Maybe we should add a new stylebox field_and_buttons_separator_leading or something and use the current for trailing in this mode?

In horizontal modes you can drag horizontal instead of vertical.

[Screencast_20260713_153022.webm](https://github.com/user-attachments/assets/cd78afb3-418f-4930-a452-a8ed654c0aec)


<img width="785" height="248" alt="Screenshot_20260713_153104" src="https://github.com/user-attachments/assets/8c58f057-f2d9-4c0b-b660-6f30e9caa383" />
