### PR TITLE
Fix build error C2327 on `SelfList<CellData>` due to recurring VS bug

### DIFF
--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -120,7 +120,7 @@ public:
 				_FORCE_INLINE_ bool operator()(const T *p_a, const T *p_b) const { return compare(*p_a, *p_b); }
 			};
 			using Element = SelfList<T>;
-			SortList<Element, T *, &Element::_self, &Element::_prev, &Element::_next, PtrComparator> sorter;
+			SortList<Element, T *, _self_ref, _prev_ref, _next_ref, PtrComparator> sorter;
 			sorter.sort(_first, _last);
 		}
 
@@ -141,6 +141,10 @@ private:
 	T *_self = nullptr;
 	SelfList<T> *_next = nullptr;
 	SelfList<T> *_prev = nullptr;
+	// Specify pointers in variables to work around a VS 2022 bug (GH-121326).
+	static constexpr T *SelfList<T>::*_self_ref = &SelfList<T>::_self;
+	static constexpr SelfList<T> *SelfList<T>::*_prev_ref = &SelfList<T>::_prev;
+	static constexpr SelfList<T> *SelfList<T>::*_next_ref = &SelfList<T>::_next;
 
 public:
 	_FORCE_INLINE_ bool in_list() const { return _root; }


### PR DESCRIPTION
This is a recurring VS bug that causes a build failure, see issues #110124 and #117259.

VS 2022 is currently broken, I tested on 17.14.25, 17.14.28 and 17.14.33, and it's unlikely that MS is ever going to fix it. The linked issues are actually not resolved, it's just luck that they seemed to work with the particular versions of VS 2022 they were tested on at the time.

This affects 4.5 and above.

This is what the compiler error looks like:

```
1>core/templates/self_list.h(124): error C2327: 'SelfList<CellData>::_self': is not a type name, static, or enumerator
1>templates/self_list.h(124): note: see declaration of 'SelfList<CellData>::_self'
1>templates/self_list.h(124): note: the template instantiation context (the oldest one first) is
1>scene\2d\tile_map_layer.cpp(313): note: see reference to function template instantiation 'void SelfList<CellData>::List::sort_custom<CellDataYSortedXReversedComparator>(void)' being compiled
1>scene\2d\tile_map_layer.cpp(313): note: see the first reference to 'SelfList<CellData>::List::sort_custom' in 'TileMapLayer::_rendering_update'
1>core/templates/self_list.h(124): error C2327: 'SelfList<CellData>::_prev': is not a type name, static, or enumerator
1>core/templates/self_list.h(124): note: see declaration of 'SelfList<CellData>::_prev'
1>core/templates/self_list.h(124): error C2327: 'SelfList<CellData>::_next': is not a type name, static, or enumerator
1>core/templates/self_list.h(124): note: see declaration of 'SelfList<CellData>::_next'
```


## What problem(s) does this PR solve?

- Closes #110124 
- Closes #117259

