### PR TITLE
Fix BoneTwistDisperser stale joint update crash

### DIFF
--- a/scene/3d/bone_twist_disperser_3d.cpp
+++ b/scene/3d/bone_twist_disperser_3d.cpp
@@ -601,6 +601,8 @@ void BoneTwistDisperser3D::_make_joints_dirty(int p_index) {
 }
 
 void BoneTwistDisperser3D::_update_joints(int p_index) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+
 	Skeleton3D *sk = get_skeleton();
 	int current_bone = settings[p_index]->end_bone.bone;
 	int root_bone = settings[p_index]->root_bone.bone;


### PR DESCRIPTION
Fixes godotengine/godot#121264.

`BoneTwistDisperser3D::_make_joints_dirty()` defers `_update_joints(index)`. If settings are cleared before the deferred call runs, the saved index can be stale and `_update_joints()` dereferences `settings[p_index]` without re-validating it.

This adds the same index guard used by the other setting/joint helpers before `_update_joints()` reads the settings array.

Verification:

The `repro/Node.tscn` command below uses the MRP from godotengine/godot#121264. The final run is the post-fix behavior: it reports the guarded out-of-bounds error and exits cleanly instead of crashing.

```text
$ python3 -m SCons platform=macos target=template_debug dev_build=yes tools=no vulkan=no angle=no accesskit=no -j4
scons: done building targets.
INFO: Time elapsed: 00:05:19.87

$ python3 -m SCons platform=macos target=template_debug dev_build=yes tools=no vulkan=no angle=no accesskit=no disable_path_overrides=no -j4
scons: done building targets.
INFO: Time elapsed: 00:07:06.91

$ ./bin/godot.macos.template_debug.dev.arm64 --headless --path repro Node.tscn
Godot Engine v4.8.dev.custom_build.4efc6b49e (2026-07-13 18:51:09 UTC) - https://godotengine.org
ERROR: Index p_index = 60 is out of bounds ((int)settings.size() = 0).
   at: _update_joints (scene/3d/bone_twist_disperser_3d.cpp:604)
[exit code 0]
```

AI assistance disclosure: AI tools were used to help inspect the issue and draft this small change/PR text. I reviewed the resulting code and ran the verification locally.
