### PR TITLE
Style: Re-activate `modernize-use-default-member-init`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,17 +3,17 @@
 
 Checks:
   - -*
-  - performance-move-const-arg
   - bugprone-use-after-move
   - modernize-deprecated-headers
   - modernize-redundant-void-arg
   - modernize-use-bool-literals
-#  - modernize-use-default-member-init # TODO Re-activate
+  - modernize-use-default-member-init
   - modernize-use-nullptr
+  - performance-move-const-arg
   - readability-braces-around-statements
   - readability-identifier-naming
-  - readability-redundant-member-init
   - readability-operators-representation
+  - readability-redundant-member-init
 HeaderFileExtensions: ["", h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/


### PR DESCRIPTION
## What problem(s) does this PR solve?

Re-enables the final clang-tidy warning suppressed by #112785. I was prepared do so sweeping changes similar to #121327 after activating it, but it seems like everything is already using the rule anyway? I ran across the repo with `clangd-tidy` twice, and neither time did anything for `modernize-use-default-member-init` get picked up.

## Additional information

The clang-tidy checks themselves have been re-alphabetized, as that uniformity was lost somewhere down the line.
