### PR TITLE
Prevent crash when `CameraFeed.get_texture_tex_id` is passed a value out of `FeedImage` range.

### DIFF
--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -148,6 +148,8 @@ RID CameraFeed::get_texture(CameraServer::FeedImage p_which) {
 }
 
 uint64_t CameraFeed::get_texture_tex_id(CameraServer::FeedImage p_which) {
+	ERR_FAIL_COND_V_MSG(p_which >= 0 && p_which < CameraServer::FeedImage::FEED_IMAGES, 0, "Argument p_which must be a valid FeedImage type.");
+
 	return RenderingServer::get_singleton()->texture_get_native_handle(texture[p_which]);
 }
 

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -148,7 +148,7 @@ RID CameraFeed::get_texture(CameraServer::FeedImage p_which) {
 }
 
 uint64_t CameraFeed::get_texture_tex_id(CameraServer::FeedImage p_which) {
-	ERR_FAIL_COND_V_MSG(p_which >= 0 && p_which < CameraServer::FeedImage::FEED_IMAGES, 0, "Argument p_which must be a valid FeedImage type.");
+	ERR_FAIL_COND_V_MSG(p_which < 0 || p_which >= CameraServer::FeedImage::FEED_IMAGES, 0, "Argument p_which must be a valid FeedImage type.");
 
 	return RenderingServer::get_singleton()->texture_get_native_handle(texture[p_which]);
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121266 

Root cause, as far as I could find, is that there's no validation on the p_which arg of CameraFeed::get_texture_tex_id. To resolve this I:
- Added a helper function that confirms whether or not a given value is valud for the `FeedImage` enum.
- Added an `ERR_FAIL` macro that checks against the new helper, and has the function return a default value of `0` if the `p_which` value is invalid.

## Additional information

Root cause, as far as I could find, is that there's no validation on the p_which arg of CameraFeed::get_texture_tex_id. To resolve this I:
- Added a helper function that confirms whether or not a given value is valud for the `FeedImage` enum.
- Added an `ERR_FAIL` macro that checks against the new helper, and has the function return a default value of `0` if the `p_which` value is invalid.

Tested manually with on linux with the scons args helpfully provided by qarmin:
`scons -j$(nproc) platform=linuxbsd target=editor arch=x86_64 dev_build=yes use_asan=yes debug_symbols=yes optimize=none`

The error I added appears in the expected cases, and the heap-buffer-overflow error no longer appears whatsoever. Performed two out of range tests with integers, all three in range tests with integers, and enum tests with `RGBA` and `CBCR`.