### PR TITLE
🤖 Fix BlitMaterial blend mode validation

### DIFF
--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,6 +80,8 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
+	ERR_FAIL_INDEX(p_blend_mode, BLEND_MODE_MAX);
+
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);
 	if (shader_set) {
@@ -110,10 +112,10 @@ RID BlitMaterial::get_rid() const {
 }
 
 Mutex BlitMaterial::shader_mutex;
-RID BlitMaterial::shader_cache[5];
+RID BlitMaterial::shader_cache[BLEND_MODE_MAX];
 
 void BlitMaterial::cleanup_shader() {
-	for (int i = 0; i < 5; i++) {
+	for (int i = 0; i < BLEND_MODE_MAX; i++) {
 		if (shader_cache[i].is_valid()) {
 			RS::get_singleton()->free_rid(shader_cache[i]);
 		}

--- a/tests/scene/test_blit_material.cpp
+++ b/tests/scene/test_blit_material.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  blit_material.h                                                       */
+/*  test_blit_material.cpp                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,46 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "tests/test_macros.h"
 
-#include "scene/resources/material.h"
+TEST_FORCE_LINK(test_blit_material)
 
-class BlitMaterial : public Material {
-	GDCLASS(BlitMaterial, Material);
+#include "scene/resources/blit_material.h"
 
-public:
-	enum BlendMode {
-		BLEND_MODE_MIX,
-		BLEND_MODE_ADD,
-		BLEND_MODE_SUB,
-		BLEND_MODE_MUL,
-		BLEND_MODE_DISABLED,
-		BLEND_MODE_MAX
-	};
+namespace TestBlitMaterial {
 
-private:
-	static Mutex shader_mutex;
-	static RID shader_cache[BLEND_MODE_MAX];
-	static void _update_shader(BlendMode p_blend);
-	mutable bool shader_set = false;
+TEST_CASE("[SceneTree][BlitMaterial] Invalid blend modes are rejected") {
+	Ref<BlitMaterial> material;
+	material.instantiate();
+	material->set_blend_mode(BlitMaterial::BLEND_MODE_ADD);
 
-	BlendMode blend_mode = BLEND_MODE_MIX;
+	ERR_PRINT_OFF;
+	SUBCASE("Negative blend mode") {
+		material->set_blend_mode(static_cast<BlitMaterial::BlendMode>(-1));
+	}
+	SUBCASE("Blend mode above the valid range") {
+		material->set_blend_mode(static_cast<BlitMaterial::BlendMode>(static_cast<int>(BlitMaterial::BLEND_MODE_DISABLED) + 1));
+	}
+	ERR_PRINT_ON;
 
-protected:
-	static void _bind_methods();
+	CHECK(material->get_blend_mode() == BlitMaterial::BLEND_MODE_ADD);
+}
 
-public:
-	void set_blend_mode(BlendMode p_blend_mode);
-	BlendMode get_blend_mode() const;
-
-	virtual Shader::Mode get_shader_mode() const override;
-	virtual RID get_shader_rid() const override;
-	virtual RID get_rid() const override;
-
-	static void cleanup_shader();
-
-	BlitMaterial();
-	virtual ~BlitMaterial();
-};
-
-VARIANT_ENUM_CAST(BlitMaterial::BlendMode);
+} // namespace TestBlitMaterial


### PR DESCRIPTION
> [!INFO]
> *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of GitHub user @zbl1998-sdjn, to fix the range-checking bug reported in #121263. The user selected the issue and authorized submission; the agent inspected the current source and contribution rules, wrote the regression test before the fix, implemented the change, and ran the local verification below.

## What problem(s) does this PR solve?

- `BlitMaterial::set_blend_mode()` accepted values outside the valid enum range, stored the invalid value, and then used it to index `shader_cache`, causing an out-of-bounds access.

## Additional information

- Rejects negative and upper-bound invalid blend modes before mutating state or accessing the shader cache.
- Uses `BLEND_MODE_MAX` as the shared bound for the enum and shader cache.
- Adds a `[SceneTree][BlitMaterial]` regression test covering both invalid boundaries and verifying that the previous valid mode is preserved.

## Validation

- Before the fix, the new focused test failed both assertions (`-1 == 1` and `5 == 1`).
- `scons platform=windows target=editor dev_mode=yes module_text_server_fb_enabled=yes debug_symbols=no windows_subsystem=console d3d12=no angle=no accesskit=no -j8` (MSVC, warnings as errors): passed.
- `godot.windows.editor.x86_64.exe --test --test-case="*[BlitMaterial]*" --success`: 1 test case and 2 assertions passed.
- `godot.windows.editor.x86_64.exe --test`: 1,401 test cases and 421,376 assertions passed.
- A temporary GDScript reproduction matching the issue called `set_blend_mode(98)`: Godot rejected the value with `Index p_blend_mode = 98 is out of bounds (BLEND_MODE_MAX = 5)`, preserved the previous valid mode, and exited with code 0.
- `prek run --files scene/resources/blit_material.cpp scene/resources/blit_material.h tests/scene/test_blit_material.cpp`: all applicable hooks passed.
