### PR TITLE
Core: Optimize `HashMap` lookup

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -97,9 +97,8 @@ private:
 
 	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
 		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
-		const uint32_t distance_idx = p_idx - original_idx + p_capacity;
-		// At most p_capacity over 0, so we can use an if (faster than fastmod).
-		return distance_idx >= p_capacity ? distance_idx - p_capacity : distance_idx;
+		// We can use an if (faster than fastmod) to wrap around.
+		return p_idx >= original_idx ? p_idx - original_idx : p_idx - original_idx + p_capacity;
 	}
 
 	bool _lookup_idx(const TKey &p_key, uint32_t &r_idx) const {
@@ -110,25 +109,55 @@ private:
 	bool _lookup_idx_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_idx) const {
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t idx = fastmod(p_hash, capacity_inv, capacity);
-		uint32_t distance = 0;
+		const uint32_t starting_idx = fastmod(p_hash, capacity_inv, capacity);
 
+		// Extract first iteration of loop to skip probe length check.
+		if (_hashes[starting_idx] == EMPTY_HASH) {
+			return false;
+		}
+		if (_hashes[starting_idx] == p_hash && likely(Comparator::compare(_elements[starting_idx]->data.key, p_key))) {
+			r_idx = starting_idx;
+			return true;
+		}
+		// First loop: search until end then wrap around.
+		uint32_t idx;
+		for (idx = starting_idx + 1; idx < capacity; idx++) {
+			if (_hashes[idx] == EMPTY_HASH) {
+				return false;
+			}
+			if (_hashes[idx] != p_hash) {
+				const uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
+				// Stop search if we probed further than this element, which happens when
+				// we encountered the `original_idx` along the search.
+				// Since we didn't wrap, the interval is simply (starting_idx, idx]
+				if (original_idx > starting_idx && original_idx <= idx) {
+					return false;
+				}
+			} else if (likely(Comparator::compare(_elements[idx]->data.key, p_key))) {
+				r_idx = idx;
+				return true;
+			}
+		}
+		// Second loop: after wrap around, search from beginning.
+		idx = 0;
 		while (true) {
 			if (_hashes[idx] == EMPTY_HASH) {
 				return false;
 			}
-
-			if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
-				return false;
-			}
-
-			if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
+			if (_hashes[idx] != p_hash) {
+				const uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
+				// Stop search if we probed further than this element, which happens when
+				// we encountered the `original_idx` along the search.
+				// Since we wrapped around, the search path consists of two intervals
+				// (starting_idx, capacity) and [0, idx]
+				if (original_idx > starting_idx || original_idx <= idx) {
+					return false;
+				}
+			} else if (likely(Comparator::compare(_elements[idx]->data.key, p_key))) {
 				r_idx = idx;
 				return true;
 			}
-
-			_increment_mod(idx, capacity);
-			distance++;
+			idx++;
 		}
 	}
 

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -95,11 +95,12 @@ private:
 		}
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
-		const uint32_t distance_idx = p_idx - original_idx + p_capacity;
-		// At most p_capacity over 0, so we can use an if (faster than fastmod).
-		return distance_idx >= p_capacity ? distance_idx - p_capacity : distance_idx;
+	// Returns true when the probe length from `a` to `idx` is LESS THAN the probe length from `b` to `idx`.
+	_FORCE_INLINE_ static constexpr bool _probe_length_cmp(const uint32_t p_a, const uint32_t p_b, const uint32_t p_idx) {
+		if (unlikely(p_idx < p_b)) {
+			return likely(p_idx >= p_a) || p_b < p_a;
+		}
+		return p_b < p_a && likely(p_idx >= p_a);
 	}
 
 	bool _lookup_idx(const TKey &p_key, uint32_t &r_idx) const {
@@ -110,26 +111,39 @@ private:
 	bool _lookup_idx_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_idx) const {
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t idx = fastmod(p_hash, capacity_inv, capacity);
-		uint32_t distance = 0;
+		const uint32_t start_idx = fastmod(p_hash, capacity_inv, capacity);
+		uint32_t idx = start_idx;
 
+		if (_hashes[idx] == EMPTY_HASH) {
+			return false;
+		}
+		if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
+			r_idx = idx;
+			return true;
+		}
 		while (true) {
+			_increment_mod(idx, capacity);
 			if (_hashes[idx] == EMPTY_HASH) {
 				return false;
 			}
-
-			if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
-				return false;
-			}
-
-			if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
+			if (_hashes[idx] != p_hash) {
+				// Stop search if we probed further than this element.
+				if (_probe_length_cmp(fastmod(_hashes[idx], capacity_inv, capacity), start_idx, idx)) {
+					return false;
+				}
+			} else if (Comparator::compare(_elements[idx]->data.key, p_key)) {
 				r_idx = idx;
 				return true;
 			}
-
-			_increment_mod(idx, capacity);
-			distance++;
 		}
+	}
+
+	// Small helper for _insert_element
+	_FORCE_INLINE_ void _insert_empty_at(const uint32_t p_idx, const uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
+		_elements[p_idx] = p_value;
+		_hashes[p_idx] = p_hash;
+
+		_size++;
 	}
 
 	void _insert_element(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
@@ -137,29 +151,30 @@ private:
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
 		uint32_t hash = p_hash;
 		HashMapElement<TKey, TValue> *value = p_value;
-		uint32_t distance = 0;
-		uint32_t idx = fastmod(hash, capacity_inv, capacity);
 
+		uint32_t start_idx = fastmod(hash, capacity_inv, capacity);
+		uint32_t idx = start_idx;
+
+		if (_hashes[idx] == EMPTY_HASH) {
+			_insert_empty_at(idx, hash, value);
+			return;
+		}
+
+		// Keep going until empty slot found.
 		while (true) {
+			_increment_mod(idx, capacity);
 			if (_hashes[idx] == EMPTY_HASH) {
-				_elements[idx] = value;
-				_hashes[idx] = hash;
-
-				_size++;
-
+				_insert_empty_at(idx, hash, value);
 				return;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
-			if (existing_probe_len < distance) {
+			uint32_t new_start_idx = fastmod(_hashes[idx], capacity_inv, capacity);
+			if (_probe_length_cmp(new_start_idx, start_idx, idx)) {
 				SWAP(hash, _hashes[idx]);
 				SWAP(value, _elements[idx]);
-				distance = existing_probe_len;
+				start_idx = new_start_idx;
 			}
-
-			_increment_mod(idx, capacity);
-			distance++;
 		}
 	}
 
@@ -327,8 +342,10 @@ public:
 
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+
+		uint32_t next_idx = idx;
+		_increment_mod(next_idx, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && next_idx != fastmod(_hashes[next_idx], capacity_inv, capacity)) {
 			SWAP(_hashes[next_idx], _hashes[idx]);
 			SWAP(_elements[next_idx], _elements[idx]);
 			idx = next_idx;
@@ -375,8 +392,10 @@ public:
 		// Delete the old entries in _hashes and _elements.
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+
+		uint32_t next_idx = idx;
+		_increment_mod(next_idx, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && next_idx != fastmod(_hashes[next_idx], capacity_inv, capacity)) {
 			SWAP(_hashes[next_idx], _hashes[idx]);
 			SWAP(_elements[next_idx], _elements[idx]);
 			idx = next_idx;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -87,20 +87,6 @@ private:
 		return hash;
 	}
 
-	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {
-		r_idx++;
-		// `if` is faster than both fastmod and mod.
-		if (unlikely(r_idx == p_capacity)) {
-			r_idx = 0;
-		}
-	}
-
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
-		// We can use an if (faster than fastmod) to wrap around.
-		return p_idx >= original_idx ? p_idx - original_idx : p_idx - original_idx + p_capacity;
-	}
-
 	bool _lookup_idx(const TKey &p_key, uint32_t &r_idx) const {
 		return _elements != nullptr && _size > 0 && _lookup_idx_unchecked(p_key, _hash(p_key), r_idx);
 	}
@@ -109,55 +95,30 @@ private:
 	bool _lookup_idx_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_idx) const {
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		const uint32_t starting_idx = fastmod(p_hash, capacity_inv, capacity);
+		const uint32_t start_idx = fastmod(p_hash, capacity_inv, capacity);
+		uint32_t idx = start_idx;
 
-		// Extract first iteration of loop to skip probe length check.
-		if (_hashes[starting_idx] == EMPTY_HASH) {
+		if (_hashes[idx] == EMPTY_HASH) {
 			return false;
 		}
-		if (_hashes[starting_idx] == p_hash && likely(Comparator::compare(_elements[starting_idx]->data.key, p_key))) {
-			r_idx = starting_idx;
+		if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
+			r_idx = idx;
 			return true;
 		}
-		// First loop: search until end then wrap around.
-		uint32_t idx;
-		for (idx = starting_idx + 1; idx < capacity; idx++) {
-			if (_hashes[idx] == EMPTY_HASH) {
-				return false;
-			}
-			if (_hashes[idx] != p_hash) {
-				const uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
-				// Stop search if we probed further than this element, which happens when
-				// we encountered the `original_idx` along the search.
-				// Since we didn't wrap, the interval is simply (starting_idx, idx]
-				if (original_idx > starting_idx && original_idx <= idx) {
-					return false;
-				}
-			} else if (likely(Comparator::compare(_elements[idx]->data.key, p_key))) {
-				r_idx = idx;
-				return true;
-			}
-		}
-		// Second loop: after wrap around, search from beginning.
-		idx = 0;
 		while (true) {
+			increment_mod(idx, capacity);
 			if (_hashes[idx] == EMPTY_HASH) {
 				return false;
 			}
 			if (_hashes[idx] != p_hash) {
-				const uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
-				// Stop search if we probed further than this element, which happens when
-				// we encountered the `original_idx` along the search.
-				// Since we wrapped around, the search path consists of two intervals
-				// (starting_idx, capacity) and [0, idx]
-				if (original_idx > starting_idx || original_idx <= idx) {
+				// Stop search if we probed further than this element.
+				if (probe_length_cmp(fastmod(_hashes[idx], capacity_inv, capacity), start_idx, idx)) {
 					return false;
 				}
-			} else if (likely(Comparator::compare(_elements[idx]->data.key, p_key))) {
+			} else if (Comparator::compare(_elements[idx]->data.key, p_key)) {
 				r_idx = idx;
 				return true;
 			}
-			idx++;
 		}
 	}
 
@@ -166,30 +127,33 @@ private:
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
 		uint32_t hash = p_hash;
 		HashMapElement<TKey, TValue> *value = p_value;
-		uint32_t distance = 0;
-		uint32_t idx = fastmod(hash, capacity_inv, capacity);
 
+		uint32_t start_idx = fastmod(hash, capacity_inv, capacity);
+		uint32_t idx = start_idx;
+
+		if (_hashes[idx] == EMPTY_HASH) {
+			goto empty;
+		}
+
+		// Keep going until empty slot found.
 		while (true) {
+			increment_mod(idx, capacity);
 			if (_hashes[idx] == EMPTY_HASH) {
-				_elements[idx] = value;
-				_hashes[idx] = hash;
-
-				_size++;
-
-				return;
+				goto empty;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
-			if (existing_probe_len < distance) {
+			uint32_t new_start_idx = fastmod(_hashes[idx], capacity_inv, capacity);
+			if (probe_length_cmp(new_start_idx, start_idx, idx)) {
 				SWAP(hash, _hashes[idx]);
 				SWAP(value, _elements[idx]);
-				distance = existing_probe_len;
+				start_idx = new_start_idx;
 			}
-
-			_increment_mod(idx, capacity);
-			distance++;
 		}
+	empty:
+		_elements[idx] = value;
+		_hashes[idx] = hash;
+		_size++;
 	}
 
 	void _resize_and_rehash(uint32_t p_new_capacity_idx) {
@@ -356,12 +320,14 @@ public:
 
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+
+		uint32_t next_idx = idx;
+		increment_mod(next_idx, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && next_idx != fastmod(_hashes[next_idx], capacity_inv, capacity)) {
 			SWAP(_hashes[next_idx], _hashes[idx]);
 			SWAP(_elements[next_idx], _elements[idx]);
 			idx = next_idx;
-			_increment_mod(next_idx, capacity);
+			increment_mod(next_idx, capacity);
 		}
 
 		_hashes[idx] = EMPTY_HASH;
@@ -404,12 +370,14 @@ public:
 		// Delete the old entries in _hashes and _elements.
 		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
-		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
-		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+
+		uint32_t next_idx = idx;
+		increment_mod(next_idx, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && next_idx != fastmod(_hashes[next_idx], capacity_inv, capacity)) {
 			SWAP(_hashes[next_idx], _hashes[idx]);
 			SWAP(_elements[next_idx], _elements[idx]);
 			idx = next_idx;
-			_increment_mod(next_idx, capacity);
+			increment_mod(next_idx, capacity);
 		}
 
 		_hashes[idx] = EMPTY_HASH;

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -422,13 +422,12 @@ static _FORCE_INLINE_ uint32_t fastmod(const uint32_t p_n, const uint64_t p_c, c
 #endif // _MSC_VER
 }
 
-// Returns true when the probe length from `a_idx` to `idx` is LESS THAN the probe length from `b_idx`
-// to `idx`.
-static _FORCE_INLINE_ bool probe_length_cmp(uint32_t a_idx, uint32_t b_idx, uint32_t idx) {
-	if (unlikely(idx < b_idx)) {
-		return likely(idx >= a_idx) || b_idx < a_idx;
+// Returns true when the probe length from `a` to `idx` is LESS THAN the probe length from `b` to `idx`.
+static _FORCE_INLINE_ bool probe_length_cmp(const uint32_t p_a, const uint32_t p_b, const uint32_t p_idx) {
+	if (unlikely(p_idx < p_b)) {
+		return likely(p_idx >= p_a) || p_b < p_a;
 	}
-	return b_idx < a_idx && likely(idx >= a_idx);
+	return p_b < p_a && likely(p_idx >= p_a);
 }
 
 static _FORCE_INLINE_ constexpr void increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -421,3 +421,20 @@ static _FORCE_INLINE_ uint32_t fastmod(const uint32_t p_n, const uint64_t p_c, c
 #endif // __SIZEOF_INT128__
 #endif // _MSC_VER
 }
+
+// Returns true when the probe length from `a_idx` to `idx` is LESS THAN the probe length from `b_idx`
+// to `idx`.
+static _FORCE_INLINE_ bool probe_length_cmp(uint32_t a_idx, uint32_t b_idx, uint32_t idx) {
+	if (unlikely(idx < b_idx)) {
+		return likely(idx >= a_idx) || b_idx < a_idx;
+	}
+	return b_idx < a_idx && likely(idx >= a_idx);
+}
+
+static _FORCE_INLINE_ constexpr void increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {
+	r_idx++;
+	// `if` is faster than both fastmod and mod.
+	if (unlikely(r_idx == p_capacity)) {
+		r_idx = 0;
+	}
+}


### PR DESCRIPTION
Speeds up HashMap operations (lookup, insert, erase, replace-key) by avoiding probe length calculations. Calculating probe-length requires a `fastmod` and 2-3 additions. This PR explores a solution that replaces the arithmetic with boolean logic.

## Motivation

HashMaps are used extensively across the project. For example, in GDScript function calls, HashMap lookups account for 8% or more of overhead. It is also the data-structure backing the Variant type `Dictionary`.

<img width="1405" height="237" alt="image" src="https://github.com/user-attachments/assets/ff5282d4-a054-4883-8829-8ea833dc11b0" />
An extreme profiling example of a calling a function from a class with 30 functions.

## Explanation of Changes

<details open>
<summary><b>Short version</b></summary>

**For lookup and insert:** we never need to calculate the exact probe length, we just need to know if the current probe distance exceeds it. For this, we can do some casework given the starting index of both probes and the current index. We need to account for the case when we need to wrap around the end of the array when probing.

**For erase and replace:** we just need to check that the probe distance is non-zero. Equivalently, we can check that the hash start index is not equal to the current index.


Additionally we apply the optimization from `AHashMap` where the probe-distance is not checked for the starting index.

</details>

<details>
<summary>:flushed: <b>Long version 😅 </b></summary>

The theory is that within `_lookup_idx_unchecked`, `_get_probe_length` is the bottleneck operation.

### Part 1: Avoid the need to check `distance > _get_probe_length()`

Let's inspect the current lookup code (scrollable):

https://github.com/godotengine/godot/blob/2cd047c26db4f5bcb1b48500820a016451eb0a8d/core/templates/hash_map.h#L115-L138

We make two observations on the line 126 condition `distance > _get_probe_length(...)`

1. Since `_get_probe_length()` returns a `uint32_t`, the condition can never be true on the first iteration `distance = 0`.
2. If `_hashes[idx] == p_hash`, then the condition will also be false because `_get_probe_length()` essentially calculates `distance`.

So with this in mind, we can skip the call to `_get_probe_length()` in these two scenarios. For (1), we pull out the first iteration of the loop and remove the probe distance check. For (2), we reorder the if statement to check the probe distance only if there is no hash match.

```cpp
if (_hashes[idx] == EMPTY_HASH) {
	return false;
}
if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
	r_idx = idx;
	return true;
}
_increment_mod(idx, capacity);
uint32_t distance = 1;
while (true) {
	if (_hashes[idx] == EMPTY_HASH) {
		return false;
	}

	if (_hashes[idx] != p_hash) {
		if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
			return false;
		}
	} else if (Comparator::compare(_elements[idx]->data.key, p_key)) {
		r_idx = idx;
		return true;
	}

	_increment_mod(idx, capacity);
	distance++;
}
```

Nice. The changes now skip the probe length calculation on the first iteration and whenever we have a hash match. In most cases this is just 1-2 calls. This is strictly faster than the old implementation. This optimization already exists in `AHashMap`. 

### Part 2: Optimizing probe length

Let's look into `_get_probe_length`.

https://github.com/godotengine/godot/blob/2cd047c26db4f5bcb1b48500820a016451eb0a8d/core/templates/hash_map.h#L103-L108

Probe length is the rightwards distance from the hash's originating slot to the current index. 

```cpp
if (p_idx >= original_idx) {
    // Did not wrap, direct distance of original_idx -> p_idx
    return p_idx - original_idx;
}
// Length is combination of two intervals: original_idx -> p_capacity, 0 -> p_idx
// (p_capacity - original_idx) + (p_idx - 0)
return p_idx - original_idx + p_capacity;
```

This simplified version is equivalent and saves two operations in the first branch.

### Part 3: Beyond probe length

We observe that probe length is essentially calculating `(idx - original_idx) % capacity`. Additionally, `distance` is our manually incremented probe length. Going back to our `distance > _get_probe_length(...` check, if we substitute `distance` for probe length, we can do some sketchy math.

```cpp
distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
=> _get_probe_length(idx, p_hash, capacity, capacity_inv) > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
uint32_t start_idx = fastmod(p_hash, capacity_inv, capacity);
uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
=> (idx - start_idx) % capacity > (idx - original_idx) % capacity;
```

The modulo makes the math hard. If we were to ignore wrap-around, the condition would be  `idx - start_idx > idx - original_idx` which simplifies to `start_idx < original_idx`. 

**When we check `distance > _get_probe_length(...` we want to know if we have traveled further than the current element. Paraphrasing, we stop the search if the current element originates from a closer spot than where we started our search.**

We can replace the entire conditional with a new function:

```cpp
const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
if (idx >= start_idx) {
    // In this case, we did not wrap around yet. The search path is starting_idx -> idx
    // To exit the search, original_idx must be in between this interval.
    return original_idx > start_idx && original_idx <= idx;
}
// We wrapped around, the search path consists of two intervals: starting_idx -> capacity and 0 -> idx
return original_idx > start_idx || original_idx <= idx;
```

Aside: comment if you can find a way to simplify this function. I've found that the operands can be reordered while maintaining correctness due to transitive properties. 

Now we can replace our distance-probe length comparison with this new function call:

```diff
- uint32_t idx = fastmod(p_hash, capacity_inv, capacity);
+ const uint32_t start_idx = fastmod(p_hash, capacity_inv, capacity);
+ uint32_t idx = start_idx;
if (_hashes[idx] == EMPTY_HASH) {
	return false;
}
if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
	r_idx = idx;
	return true;
}
_increment_mod(idx, capacity);
- uint32_t distance = 1;
while (true) {
	if (_hashes[idx] == EMPTY_HASH) {
		return false;
	}

	if (_hashes[idx] != p_hash) {

-		if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
+		uint32_t original_idx = fastmod(_hashes[idx], capacity_inv, capacity);
+		if (_probe_length_cmp(start_idx, original_idx, idx)) {
			return false;
		}
	} else if (Comparator::compare(_elements[idx]->data.key, p_key)) {
		r_idx = idx;
		return true;
	}

	_increment_mod(idx, capacity);
-	distance++;
}
```

This is a huge improvement. We replaced 2-3 additions/subtractions with a comparison. 

### Part 4: Optimizing our probe length comparison function

Recall the function to determine if we should stop our search. After changing the names to make it general, we can see how simple the logic is.

```cpp
// Returns true if distance from b -> idx is LESS THAN a -> idx
if (idx >= a) {
    return b > a && b <= idx;
}
return b > a || b <= idx;
```

Aside: if we flip the first condition and swap the branches, the logic is that we need 2 of 3 conditions to be true. Let me know if you find a way to simplify this further or optimize the performance somehow.

We can move the order of the conditions. For performance, the goal is to trigger short-circuiting. Let's analyze our conditions:

| Condition | Meaning when `true` | Likelihood |
| --- | --- | --- |
| `idx >= a` | We did not wrap-around our search. | High |
| `b > a` | The index of the element at the current spot started probing at a higher index than the one we are searching for. | Medium |
| `b <= idx` | The element at the current spot did not wrap around. | High |

The first condition is mostly true, so we can keep it there. Next in the `&&`, we want the less likely condition first. `b > a` is less likely so it is already in the right place. Then in the last part, we want the likelier condition first, so we will swap the order. 

In my testing, huge performance gains came from adding `un/likely` labels to these conditions. So we finally end with:

```cpp
// Returns true if distance from b -> idx is LESS THAN a -> idx
if (likely(idx >= a)) {
    return b > a && likely(b <= idx);
}
return likely(b <= idx) || b > a;
```

Note: In the PR, some of these conditions are flipped, so it may look different but the logic is equivalent.

### Part 5: Insert, Erase and Replace-Key

Insertion uses probe-length the same way as lookup so that is a trivial change. But erase and replace use it differently.

```cpp
_get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0
```

Probe-length is only zero when the hash start index is the current one. 

```cpp
fastmod(_hashes[next_idx], capacity_inv, capacity) != next_idx
```

### Part 6: Inlining the if condition into control flow (not included)

**This part is no longer included for the sake of code brevity and because it adds 17.5KiB to the release build size for ~5% gain in lookups. I can add it back if this is deemed a worthy trade-off.**

Notice our implementation for `_probe_length_cmp` from *Part 3* has a key conditional:

```cpp
if (idx >= starting_idx) {
```

This determines if we haven't wrapped-around yet and is true most of the time. And once we wrap around it is always false. Since we know when this flip will happen, we can avoid checking it like it is a mystical unknown. Aside: `_increment_mod` also has a check and performs the wrap-around.

Let's inline this condition into control flow. The loop will be split into two, one before and one after wrapping. 

```cpp
// First iteration, no distance check
...
// Loop before wrapping
for (idx = starting_idx + 1; idx < capacity; idx++) {
	...
		const uint32_t original_idx = fastmod(_hashes[idx], p_capacity_inv, p_capacity);
		if (original_idx > starting_idx && original_idx <= idx) {
			return false;
		}
	...
}
...
// Loop after wrapping
idx = 0;
while (true) {
	...
		const uint32_t original_idx = fastmod(_hashes[idx], p_capacity_inv, p_capacity);
		if (original_idx > starting_idx || original_idx <= idx) {
			return false;
		}
	...
	idx++;
}
``` 

</details>

## Benchmarking

Despite a seemingly long history of hash map benchmarking, I didn't find anything I could easily run. I ended up pulling the changes from [the user-test PR](https://github.com/godotengine/godot/pull/110899) and writing test cases.

These benchmarks will not reflect practical results, but I think they are indicative of baseline atomic performance.

I don't know of any operation where `HashMap` lookup is the main bottleneck. I saw slight improvement from GDScript function calls but they are omitted due to high variance.

<details>
<summary>Scenarios</summary>

### F1: Found match on first element

```cpp
map[1] = 1;
// test
map.has(1);
```

### F3C: Found match on third element after 2 collisions.

```cpp
map[0] = 1;
map[12067897] = 1;
map[904256620] = 1;
// test
map.has(904256620);
```

### F3: Found match on third element (non-collisions). Starts at index 1, no wrap around.

```cpp
map[3];
map[7];
map[14];
// test
map.has(14);
```

### E4: Did not find element at 4th check

```cpp
map[0] = 1;
map[5] = 1;
map[10] = 1;
// test
map.has(11);
```

### W4: Finds element on 4th check. Latter 3 wrap around the end.

```cpp
w[2];
w[21];
w[38];
w[41];
// test
map.has(41);
```

### M128: Mixed - 128 found, 128 not found 66% load factor

```cpp
for(int i = 0; i < 128; i++) {
    map[i] = i;
}
// test
for(int i = 0; i < 1'000'000'000; i++) {
    map.has(i & 255);
}
```

### M1024: Mixed - 1024 found, 1024 not found, 66% load factor

```cpp
for(int i = 0; i < 1024; i++) {
    map[i] = i;
}
// test
for(int i = 0; i < 1'000'000'000; i++) {
    map.has(i & 2047);
}
```

### D100k: Duplicate a map of 100k elements 100 times.

```cpp
for(int i = 0; i < 100'000; i++) {
    map[i] = i;
}
// test
for(int i = 0; i < 100; i++) {
    HashMap<uint64_t, uint64_t> copy(map);
}
```

### E100k: Erase all 100k elements in random order.

See usertest.

-----

A case left out is when the first element is empty in which case this PR has no change.

</details>

<details>
<summary><code>usertest.cpp</code> Code</summary>

```cpp
#include "usertest.h"

#include "core/string/print_string.h"
#include "core/templates/hash_map.h"
#include "core/variant/variant.h"
#include <chrono>
#include <algorithm> // for shuffle
#include <vector>
#include <random>

// Allows easy swapping
#define XHashMap HashMap

void found1() {
    XHashMap<uint64_t, uint64_t> w;
    w[1ull] = 1ull;
    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 1000'000'000; i++) {
        x = w.has(1ull);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (!x) {
        print_line(x);
    }
}

// Found on 3rd probe with collisions
void found3c() {
    XHashMap<uint64_t, uint64_t> w;
    w[0ull] = 1;
    w[12067897ull] = 1;
    w[904256620ull] = 1;
    uint32_t b = HashMapHasherDefault::hash(0ull);
    if (b != HashMapHasherDefault::hash(12067897ull) ||
        b != HashMapHasherDefault::hash(904256620ull)) {
        print_line("Bad setup");
        return;
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 1000'000'000; i++) {
        x = w.has(904256620ull);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (!x) {
        print_line(x);
    }
}

void found3() {
    XHashMap<uint64_t, uint64_t> w(3);

    uint32_t count = 0;
    uint64_t last_element = 0;

    // 3, 7, 14 (search 14)
    for (uint64_t i = 0; i < 1000ull; i++) {
        if (HashMapHasherDefault::hash(i) % w.get_capacity() == 1) {
            w[i] = i;
            count++;
            if (count == 3) {
                last_element = i;
                break;
            }
        }
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 1000'000'000; i++) {
        x = w.has(last_element);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (!x) {
        print_line(x);
    }
}

void empty4() {
    XHashMap<uint64_t, uint64_t> w(3);
    
    uint32_t count = 0;
    uint64_t last_element = 0;

    // 3, 7, 14
    // search 19
    for (uint64_t i = 0; i < 1000ull; i++) {
        if (HashMapHasherDefault::hash(i) % w.get_capacity() == 1) {
            count++;
            if (count == 4) {
                last_element = i;
                break;
            } else {
                w[i] = i;
            }
        }
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 1000'000'000; i++) {
        x = w.has(last_element);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (x) {
        print_line(x);
    }
}

void mixed128() {
    XHashMap<uint32_t, uint32_t> w;

    for(int i = 0; i < 128; i++) {
        w[i] = i;
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (uint32_t i = 0; i < 1'000'000'000; i++) {
        x = w.has(i & 255u);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (x) {
        print_raw("");
    }
}

void mixed1024() {
    XHashMap<uint32_t, uint32_t> w;

    for(int i = 0; i < 1024; i++) {
        w[i] = i;
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (uint32_t i = 0; i < 1000'000'000; i++) {
        x = w.has(i & 2047u);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (x) {
        print_raw("");
    }
}

void wrap4() {
    XHashMap<uint64_t, uint64_t> w(6);
    // Fill with 4 elements
    uint64_t last_element = -1;
    uint64_t count = 0;

    if (w.get_capacity() != 13) {
        print_line("BAD SETUP: size");
        return;
    }

    // 2, 21, 38, 41
    for (uint64_t i = 0; i < 1000ull; i++) {
        if (HashMapHasherDefault::hash(i) % w.get_capacity() == 12) {
            w[i] = i;
            count++;
            if (count == 4) {
                last_element = i;
                break;
            }
        }
    }

    bool x;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 1000'000'000; i++) {
        x = w.has(last_element);
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (!x) {
        print_line(x);
    }
}

void duplicate100k() {
    XHashMap<uint64_t, uint64_t> w(100'000);

    for (uint64_t i = 0; i < 100'000; i++) {
        w[i] = i;
    }

    uint64_t x = 0;

    auto t = std::chrono::high_resolution_clock::now();

    for (int i = 0; i < 100; i++) {
        XHashMap<uint64_t, uint64_t> copy(w);
        x += copy.size();
    }

    auto t2 = std::chrono::high_resolution_clock::now();
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();

    print_line(duration / 1000.);

    if (!x) {
        print_line(x);
    }
}

void erase100k() {
    XHashMap<uint64_t, uint64_t> w(100'000);
    std::vector<uint64_t> elements;
    elements.reserve(100'000);

    for (uint64_t i = 0; i < 100'000; i++) {
        w[i] = i;
        elements.push_back(i);
    }

    uint32_t total_time = 0;

    std::mt19937 g;

    for (int i = 0; i < 100; i++) {
        XHashMap<uint64_t, uint64_t> copy(w);
        std::shuffle(elements.begin(), elements.end(), g);

        auto t = std::chrono::high_resolution_clock::now();

        for (uint64_t x: elements) {
            copy.erase(x);
        }

        auto t2 = std::chrono::high_resolution_clock::now();
        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t).count();
        total_time += duration;
    }

    print_line(total_time / 1000.);
}

// You can run this function by launching Godot with the --user-test argument.
bool run_usertest() {
	// print_line("No user test configured. User tests are a tool for engine developers. To add one, edit main/usertest/usertest.cpp and recompile the engine.");

    const int N = 4;

    print_line("F1");
    for (int n = 0; n < N; n++) {
        found1();
    }

    print_line("F3C");
    for (int n = 0; n < N; n++) {
        found3c();
    }

    print_line("F3");
    for (int n = 0; n < N; n++) {
        found3();
    }

    print_line("E4");
    for (int n = 0; n < N; n++) {
        empty4();
    }

    print_line("W4");
    for (int n = 0; n < N; n++) {
        wrap4();
    }

    print_line("M128");
    for (int n = 0; n < N; n++) {
        mixed128();
    }

    print_line("M1024");
    for (int n = 0; n < N; n++) {
        mixed1024();
    }

    print_line("D100k");
    for (int n = 0; n < N; n++) {
        duplicate100k();
    }

    print_line("E100k");
    for (int n = 0; n < N; n++) {
        erase100k();
    }

	// Return true to indicate success, false to indicate failure.
	return true;
}
```
</details>

For faster testing without rebuilding the whole engine every time, you can copy the implementation to another file, rename `HashMap` and `HashMapElement` and update the `#define XHashMap` in the usertest. You can skip pulling the PR changes this way.

-----

Run on Windows11, MinGW release templates, non-LTO. Each test is run 20 times, with N = 10<sup>9</sup> lookups per run. The 25th percentile is taken.

| Operation | Scenario | PR (s) | Master (s) | Diff (s) | Diff% |
| --- | --- | --- | --- | --- | --- |
| Lookup | F1 | 0.195 | 0.569 | -0.374 | -66% |
| Lookup | F3C | 1.479 | 1.854 | -0.385 | -21% |
| Lookup | F3 | 0.983 | 2.375 | -1.392 | -59% |
| Lookup | E4 | 1.283 | 1.719 | -0.436 | -25% |
| Lookup | W4 | 1.621 | 2.756 | -1.135 | -41% |
| Lookup | M128 | 1.632 | 2.240 | -0.608 | -27% |
| Lookup | M1024 | 1.635 | 2.263 | -0.628 | -28% |
| Insert (duplication) | D100k | 0.602 | 0.612 | -0.010 | -1.6% |
| Erase | E100k | 0.204 | 0.206 | -0.002 | -1.0% |

These results translate to a 0.4-0.6ns improvement per operation on my machine. The `insert` and `erase` changes are overshadowed by allocation/deallocation overhead, but it is good to know that we do not regress in performance there.

### Build size

On Windows 11, release templates built with MinGW using the command:

```
scons platform=windows target=template_release use_mingw=yes winrt=no accesskit=no angle=no
```

I noticed a 29KiB increase in binary size from this change.

## Bonus

The same profiled example from above sees a 5% decrease in portion of time spent in HashMap::find.

<img width="1403" height="258" alt="image" src="https://github.com/user-attachments/assets/42d93b29-101a-4c82-8d7c-8e9bfdc084db" />

## Future Work

Apply same change to `AHashMap` and `HashSet`. In my brief testing, `AHashMap` performance did not noticeably change.