### PR TITLE
Fix typo in `CameraFeedLinux._request_buffers()` rollback

### DIFF
--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -150,9 +150,7 @@ bool CameraFeedLinux::_request_buffers() {
 		buffers[i].start = mmap(nullptr, buffer.length, PROT_READ | PROT_WRITE, MAP_SHARED, file_descriptor, buffer.m.offset);
 
 		if (buffers[i].start == MAP_FAILED) {
-			for (unsigned int b = 0; b < i; b++) {
-				_unmap_buffers(i);
-			}
+			_unmap_buffers(i);
 			delete[] buffers;
 			ERR_FAIL_V_MSG(false, "Mapping buffers failed.");
 		}


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/121193#issuecomment-4946880070

If mapping of any buffer fails all previously mapped ones should be unmapped.
This PR fixes typo causing unmapping failure.
Now rollback on error is correct.