### PR TITLE
GDScript: Fix temporary cleanup after typed default arguments

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -128,6 +128,9 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 	}
 	int slot = pool.front()->get();
 	pool.pop_front();
+	// Reference-counted temporary types share a pool, so a reused slot may
+	// have different object containment than its previous value.
+	temporaries.write[slot].can_contain_object = p_type.can_contain_object();
 	used_temporaries.push_back(slot);
 	return slot;
 }

--- a/modules/gdscript/tests/scripts/runtime/features/temporary_cleanup_with_typed_default.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/temporary_cleanup_with_typed_default.gd
@@ -1,0 +1,21 @@
+# https://github.com/godotengine/godot/issues/121316
+
+class Tracked extends RefCounted:
+	func return_self() -> Tracked:
+		return self
+
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_PREDELETE:
+			print("released")
+
+func with_untyped_default(_values: Array = []) -> void:
+	Tracked.new().return_self()
+	print("after untyped")
+
+func with_typed_default(_values: Array[String] = []) -> void:
+	Tracked.new().return_self()
+	print("after typed")
+
+func test() -> void:
+	with_untyped_default()
+	with_typed_default()

--- a/modules/gdscript/tests/scripts/runtime/features/temporary_cleanup_with_typed_default.out
+++ b/modules/gdscript/tests/scripts/runtime/features/temporary_cleanup_with_typed_default.out
@@ -1,0 +1,4 @@
+released
+after untyped
+released
+after typed


### PR DESCRIPTION
## What problem(s) does this PR solve?

GDScript's bytecode generator pools all reference-counted temporary types in the same stack-slot pool. The slot's `can_contain_object` metadata was only initialized when the slot was first created, so a slot first used by a typed `Array[String]` default argument remained marked as unable to contain objects when it was later reused for a `RefCounted` method-chain temporary. As a result, the temporary was not cleared at the end of the statement.

- Closes #121316

## Additional information

This updates the slot metadata whenever a pooled temporary slot is reused, so end-of-statement cleanup reflects its current value. A GDScript integration regression test compares untyped and typed-array default arguments and verifies that both release the chained `RefCounted` before the following statement.

Verification:

- `python3 -m SCons platform=macos target=template_debug dev_build=yes vulkan=no angle=no accesskit=no disable_path_overrides=no tests=yes -j4` — build succeeded.
- Focused headless reproduction using the built engine — both untyped and typed-default cases printed `released` before their following `after ...` marker.
- `git diff --cached --check` — passed before commit.

**AI disclosure:** This contribution was implemented and tested by an autonomous AI coding agent on behalf of @rathodkunj2005. The agent inspected the issue, traced the temporary-slot metadata reuse, authored the focused fix and regression test, and ran the verification above.
