### PR TITLE
Display warning when editor shortcuts are conflicting

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -477,7 +477,7 @@ Array EditorSettingsDialog::_event_list_to_array_helper(const List<Ref<InputEven
 	return events;
 }
 
-TreeItem *EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const String &p_shortcut_identifier, const String &p_display, Array &p_events, bool p_allow_revert, bool p_is_action, bool p_is_collapsed) {
+TreeItem *EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const String &p_shortcut_identifier, const String &p_display, Array &p_events, bool p_allow_revert, bool p_is_action, bool p_is_collapsed, const PackedStringArray &p_duplicate_shortcuts) {
 	TreeItem *shortcut_item = shortcuts->create_item(p_parent);
 	shortcut_item->set_collapsed(p_is_collapsed);
 	shortcut_item->set_text(0, p_display);
@@ -504,6 +504,11 @@ TreeItem *EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, co
 	if (sc_text == "None") {
 		// Fade out unassigned shortcut labels for easier visual grepping.
 		shortcut_item->set_custom_color(1, get_theme_color(SceneStringName(font_color), SNAME("Label")) * Color(1, 1, 1, 0.5));
+	}
+
+	if (!p_duplicate_shortcuts.is_empty()) {
+		shortcut_item->add_button(1, get_editor_theme_icon(SNAME("NodeWarning")), SHORTCUT_CONFLICT);
+		shortcut_item->set_button_tooltip_text(1, -1, String(" ").join(p_duplicate_shortcuts));
 	}
 
 	if (p_allow_revert) {
@@ -652,7 +657,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		bool same_as_defaults = Shortcut::is_event_array_equal(default_events, action_events);
 		bool collapse = !collapsed.has(action_name) || (collapsed.has(action_name) && collapsed[action_name]);
 
-		TreeItem *item = _create_shortcut_treeitem(common_section, action_name, action_name, action_events, !same_as_defaults, true, collapse);
+		TreeItem *item = _create_shortcut_treeitem(common_section, action_name, action_name, action_events, !same_as_defaults, true, collapse, PackedStringArray());
 		item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED); // `ui_*` input action names are untranslatable identifiers.
 		if (!prev_selected_shortcut.is_empty() && action_name == prev_selected_shortcut) {
 			item->select(0);
@@ -716,7 +721,31 @@ void EditorSettingsDialog::_update_shortcuts() {
 		bool same_as_defaults = Shortcut::is_event_array_equal(original, shortcuts_array);
 		bool collapse = !collapsed.has(E) || (collapsed.has(E) && collapsed[E]);
 
-		TreeItem *shortcut_item = _create_shortcut_treeitem(section, E, sc->get_name(), shortcuts_array, !same_as_defaults, false, collapse);
+		String prefix = E;
+		{
+			int i = prefix.rfind("/");
+			if (i > -1) {
+				prefix = prefix.substr(0, i + 1);
+			}
+			print_line(prefix);
+		}
+
+		PackedStringArray dupes;
+		for (const String &E2 : slist) {
+			if (E2 == E || !E2.begins_with(prefix)) {
+				continue;
+			}
+
+			const Array events2 = EditorSettings::get_singleton()->get_shortcut(E2)->get_events();
+			for (const Variant &ev : events2) {
+				if (sc->matches_event(ev)) {
+					dupes.append(E2);
+					break;
+				}
+			}
+		}
+
+		TreeItem *shortcut_item = _create_shortcut_treeitem(section, E, sc->get_name(), shortcuts_array, !same_as_defaults, false, collapse, dupes);
 		if (!prev_selected_shortcut.is_empty() && sc->get_name() == prev_selected_shortcut) {
 			shortcut_item->select(0);
 		}

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -60,6 +60,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	// Shortcuts
 	enum ShortcutButton {
+		SHORTCUT_CONFLICT,
 		SHORTCUT_ADD,
 		SHORTCUT_EDIT,
 		SHORTCUT_ERASE,
@@ -91,7 +92,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _event_config_confirmed();
 	bool _is_in_project_manager() const;
 
-	TreeItem *_create_shortcut_treeitem(TreeItem *p_parent, const String &p_shortcut_identifier, const String &p_display, Array &p_events, bool p_allow_revert, bool p_is_common, bool p_is_collapsed);
+	TreeItem *_create_shortcut_treeitem(TreeItem *p_parent, const String &p_shortcut_identifier, const String &p_display, Array &p_events, bool p_allow_revert, bool p_is_common, bool p_is_collapsed, const PackedStringArray &p_duplicate_shortcuts);
 	Array _event_list_to_array_helper(const List<Ref<InputEvent>> &p_events);
 	void _update_builtin_action(const String &p_name, const Array &p_events);
 	void _update_shortcut_events(const String &p_path, const Array &p_events);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Inspired by https://github.com/godotengine/godot/issues/32619

When shortcuts within the same section have conflicting events, a warning is dispalyed.

<img width="1856" height="174" alt="image" src="https://github.com/user-attachments/assets/08a9b223-6342-4a1d-abb4-de858682bec7" />


## Additional information

Turns out we have some conflicts by default; resolving it would require some hard-coded list of allowed conflicts, but that's rather questionable.

Putting as draft for now.