### PR TITLE
Change default project setting `keep_screen_on` to `false`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1743,7 +1743,7 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF_BASIC("display/window/hdr/request_hdr_output", false);
 
-	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
+	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", false);
 	GLOBAL_DEF("animation/warnings/check_invalid_skeleton_modifier_node_paths", true);
 	GLOBAL_DEF("animation/warnings/check_invalid_track_paths", true);
 	GLOBAL_DEF("animation/warnings/check_angle_interpolation_type_conflicting", true);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -966,7 +966,7 @@
 			If [code]true[/code], allows HiDPI display on Windows, macOS, Android, iOS and Web. If [code]false[/code], the platform's low-DPI fallback will be used on HiDPI displays, which causes the window to be displayed in a blurry or pixelated manner (and can cause various window management bugs). Therefore, it is recommended to make your project scale to [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] instead of disabling this setting.
 			[b]Note:[/b] This setting has no effect on Linux as DPI-awareness fallbacks are not supported there.
 		</member>
-		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="true">
+		<member name="display/window/energy_saving/keep_screen_on" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], keeps the screen on (even in case of inactivity), so the screensaver does not take over. Works on desktop and mobile platforms.
 		</member>
 		<member name="display/window/frame_pacing/android/enable_frame_pacing" type="bool" setter="" getter="" default="true">


### PR DESCRIPTION
This PR changes the default project setting `display/window/energy_saving/keep_screen_on` to `false`
This aligns the default value to what seems to be the standard among game engines, as "do not inhibit sleep"

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15187

## Additional information

I think it's best to be "opt-in", as the majority of games do not have a reason to inhibit sleep, and to avoid any interference with the system's power-saving measures.