### PR TITLE
Fix inconsistent coloring of script members

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -1000,6 +1000,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (int i = 0; i < notice_list.size(); i++) {
 		comment_markers[notice_list[i]] = COMMENT_MARKER_NOTICE;
 	}
+
+	// Force the text edit to update its highlighting.
+	emit_changed();
 }
 
 void GDScriptSyntaxHighlighter::add_color_region(ColorRegion::Type p_type, const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only, bool p_r_prefix) {

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -31,6 +31,7 @@
 #include "gdscript_highlighter.h"
 
 #include "../gdscript.h"
+#include "../gdscript_parser.h"
 #include "../gdscript_tokenizer.h"
 
 #include "core/config/project_settings.h"
@@ -916,40 +917,62 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			}
 		}
 
-		List<PropertyInfo> scr_property_list;
-		scr->get_script_property_list(&scr_property_list);
-		for (const PropertyInfo &E : scr_property_list) {
-			String prop_name = E.name;
-			if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
-				continue;
+		// Direct members of the script, parsed from live text.
+		GDScriptParser parser;
+		parser.parse(text_edit->get_text(), scr->get_path(), false);
+		if (GDScriptParser::ClassNode *p_class = parser.get_tree()) {
+			using Member = GDScriptParser::ClassNode::Member;
+			for (Member &m : p_class->members) {
+				switch (m.type) {
+					case Member::Type::VARIABLE:
+					case Member::Type::SIGNAL:
+					case Member::Type::FUNCTION:
+					case Member::Type::CONSTANT:
+					case Member::Type::CLASS:
+						member_keywords[m.get_name()] = member_variable_color;
+						break;
+					default:; // skip
+				}
 			}
-			if (prop_name.contains_char('/')) {
-				continue;
-			}
-			member_keywords[prop_name] = member_variable_color;
 		}
 
-		List<MethodInfo> scr_signal_list;
-		scr->get_script_signal_list(&scr_signal_list);
-		for (const MethodInfo &E : scr_signal_list) {
-			member_keywords[E.name] = member_variable_color;
-		}
-
-		// For callables.
-		List<MethodInfo> scr_method_list;
-		scr->get_script_method_list(&scr_method_list);
-		for (const MethodInfo &E : scr_method_list) {
-			member_keywords[E.name] = member_variable_color;
-		}
-
-		Ref<Script> scr_class = scr;
-		while (scr_class.is_valid()) {
-			HashMap<StringName, Variant> scr_constant_list;
-			scr_class->get_constants(&scr_constant_list);
-			for (const KeyValue<StringName, Variant> &E : scr_constant_list) {
-				member_keywords[E.key.string()] = member_variable_color;
+		// Inherited members.
+		Ref<Script> ancestor_scr = scr->get_base_script();
+		if (ancestor_scr.is_valid()) {
+			List<PropertyInfo> scr_property_list;
+			ancestor_scr->get_script_property_list(&scr_property_list);
+			for (const PropertyInfo &E : scr_property_list) {
+				String prop_name = E.name;
+				if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
+					continue;
+				}
+				if (prop_name.contains_char('/')) {
+					continue;
+				}
+				member_keywords[prop_name] = member_variable_color;
 			}
-			scr_class = scr_class->get_base_script();
+
+			List<MethodInfo> scr_signal_list;
+			ancestor_scr->get_script_signal_list(&scr_signal_list);
+			for (const MethodInfo &E : scr_signal_list) {
+				member_keywords[E.name] = member_variable_color;
+			}
+
+			// For callables.
+			List<MethodInfo> scr_method_list;
+			ancestor_scr->get_script_method_list(&scr_method_list);
+			for (const MethodInfo &E : scr_method_list) {
+				member_keywords[E.name] = member_variable_color;
+			}
+
+			while (ancestor_scr.is_valid()) {
+				HashMap<StringName, Variant> scr_constant_list;
+				ancestor_scr->get_constants(&scr_constant_list);
+				for (const KeyValue<StringName, Variant> &E : scr_constant_list) {
+					member_keywords[E.key.string()] = member_variable_color;
+				}
+				ancestor_scr = ancestor_scr->get_base_script();
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

An attempt to fix https://github.com/godotengine/godot/issues/107941

Let me know if this is a good idea or not.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

I'm not sure this solution is something the maintainers would want, so creating it as draft until I know more. Also, I'm new to the codebase and so not sure I got everything correct.

From what I gathered, the root cause of the issue is that the highlighter uses data from the compiled script. Until the script is saved, the "live" changes are not highlighted correctly.

What this PR changes:
- Use a temporary gdscript parser instance to parse the "live" unsaved script to get up-to-date direct members. `_update_cache` is running periodically, and the validate pass already using a temp parser instance, so this approach doesn't seem totally wrong. If performance is an issue, we could potentially share the temp parser between the validation and cache updating.
- Continue using the compiled data for inherited members - getting this data from the parser is trickier and more expensive, and not really needed - it is a reasonable expectation that the ancestor script file has to be saved to affect its descendants.
- As a bonus, added an `emit_changed` at the end of `_update_cache` to let the text edit know it needs to update its highlighting. Otherwise it gets updated only after making a change (see the videos below). Not sure if this has any undesirable side effects or edge cases though.

I'd also want to add a functional test or at least a test scene that has a script with all possible highlights + inherited members, to verify no regressions.

_(I recommend hiding whitespaces in the diff, as the changes are smaller than they look)_

### Videos

Changes without `emit_changed` - notice how I need to make a change in order for the highlighting to update

https://github.com/user-attachments/assets/c8a73dcd-0509-4fbb-b98c-c9d09d9cc4df


with `emit_changed` - the highlighting updates without text changes

https://github.com/user-attachments/assets/0ee4a6b3-b7b9-4a33-96cf-0ebefa637e73

_AI disclosure: no generated code or text have been used in this PR_