### PR TITLE
Exclude current scene in instantiation quick open dialog

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -455,6 +455,7 @@
 			<return type="void" />
 			<param index="0" name="callback" type="Callable" />
 			<param index="1" name="base_types" type="StringName[]" default="[]" />
+			<param index="2" name="hidden_uids" type="PackedInt64Array" default="PackedInt64Array()" />
 			<description>
 				Pops up an editor dialog for quick selecting a resource file. The [param callback] must take a single argument of type [String] which will contain the path of the selected resource or be empty if the dialog is canceled. If [param base_types] is provided, the dialog will only show resources that match these types. Only types deriving from [Resource] are supported.
 			</description>

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -688,7 +688,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			EditorNode::get_singleton()->get_quick_open_dialog()->popup_dialog({ "PackedScene" }, callable_mp(this, &SceneTreeDock::_quick_open));
+			PackedInt64Array hidden_uids{};
+			if (const ResourceUID::ID scene_file_path = ResourceLoader::get_resource_uid(scene->get_scene_file_path()); scene_file_path != ResourceUID::INVALID_ID) {
+				hidden_uids.push_back(scene_file_path);
+			}
+
+			EditorNode::get_singleton()->get_quick_open_dialog()->popup_dialog({ "PackedScene" }, callable_mp(this, &SceneTreeDock::_quick_open), false, hidden_uids);
 			if (!p_confirm_override) {
 				emit_signal(SNAME("add_node_used"));
 			}

--- a/editor/editor_interface.compat.inc
+++ b/editor/editor_interface.compat.inc
@@ -34,6 +34,10 @@
 
 #include "core/object/class_db.h"
 
+void EditorInterface::_popup_quick_open_bind_compat_121354(const Callable &p_callback, const TypedArray<StringName> &p_base_types) {
+	popup_quick_open(p_callback, p_base_types, {});
+}
+
 void EditorInterface::_popup_node_selector_bind_compat_94323(const Callable &p_callback, const TypedArray<StringName> &p_valid_types) {
 	popup_node_selector(p_callback, p_valid_types, nullptr);
 }
@@ -47,6 +51,7 @@ void EditorInterface::_open_scene_from_path_bind_compat_90057(const String &scen
 }
 
 void EditorInterface::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("popup_quick_open", "callback", "valid_types"), &EditorInterface::_popup_quick_open_bind_compat_121354, DEFVAL(TypedArray<StringName>()));
 	ClassDB::bind_compatibility_method(D_METHOD("popup_node_selector", "callback", "valid_types"), &EditorInterface::_popup_node_selector_bind_compat_94323, DEFVAL(TypedArray<StringName>()));
 	ClassDB::bind_compatibility_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter"), &EditorInterface::_popup_property_selector_bind_compat_94323, DEFVAL(PackedInt32Array()));
 	ClassDB::bind_compatibility_method(D_METHOD("open_scene_from_path", "scene_path"), &EditorInterface::_open_scene_from_path_bind_compat_90057);

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -557,7 +557,7 @@ void EditorInterface::popup_method_selector(Object *p_object, const Callable &p_
 	method_selector->connect(SNAME("canceled"), callback.bind(String(), p_callback), CONNECT_DEFERRED);
 }
 
-void EditorInterface::popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types) {
+void EditorInterface::popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types, const PackedInt64Array &p_hidden_uids) {
 	StringName required_type = SNAME("Resource");
 	Vector<StringName> base_types;
 	if (p_base_types.is_empty()) {
@@ -572,7 +572,7 @@ void EditorInterface::popup_quick_open(const Callable &p_callback, const TypedAr
 
 	EditorQuickOpenDialog *quick_open = EditorNode::get_singleton()->get_quick_open_dialog();
 	quick_open->connect(SNAME("canceled"), callable_mp(this, &EditorInterface::_quick_open).bind(String(), p_callback));
-	quick_open->popup_dialog(base_types, callable_mp(this, &EditorInterface::_quick_open).bind(p_callback));
+	quick_open->popup_dialog(base_types, callable_mp(this, &EditorInterface::_quick_open).bind(p_callback), false, p_hidden_uids);
 }
 
 void EditorInterface::popup_create_dialog(const Callable &p_callback, const StringName &p_base_type, const String &p_current_type, const String &p_dialog_title, const TypedArray<StringName> &p_custom_type_blocklist) {
@@ -909,7 +909,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_node_selector", "callback", "valid_types", "current_value"), &EditorInterface::popup_node_selector, DEFVAL(TypedArray<StringName>()), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter", "current_value"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_method_selector", "object", "callback", "current_value"), &EditorInterface::popup_method_selector, DEFVAL(String()));
-	ClassDB::bind_method(D_METHOD("popup_quick_open", "callback", "base_types"), &EditorInterface::popup_quick_open, DEFVAL(TypedArray<StringName>()));
+	ClassDB::bind_method(D_METHOD("popup_quick_open", "callback", "base_types", "hidden_uids"), &EditorInterface::popup_quick_open, DEFVAL(TypedArray<StringName>()), DEFVAL(PackedInt64Array()));
 	ClassDB::bind_method(D_METHOD("popup_create_dialog", "callback", "base_type", "current_type", "dialog_title", "type_blocklist"), &EditorInterface::popup_create_dialog, DEFVAL(""), DEFVAL(""), DEFVAL(""), DEFVAL(TypedArray<StringName>()));
 
 	// Editor docks.

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -87,6 +87,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
+	void _popup_quick_open_bind_compat_121354(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>());
 	void _popup_node_selector_bind_compat_94323(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>());
 	void _popup_property_selector_bind_compat_94323(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array());
 	void _open_scene_from_path_bind_compat_90057(const String &scene_path);
@@ -154,7 +155,7 @@ public:
 	// Must use Vector<int> because exposing Vector<Variant::Type> is not supported.
 	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array(), const String &p_current_value = String());
 	void popup_method_selector(Object *p_object, const Callable &p_callback, const String &p_current_value = String());
-	void popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>());
+	void popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>(), const PackedInt64Array &p_hidden_uids = {});
 	void popup_create_dialog(const Callable &p_callback, const StringName &p_base_type = "", const String &p_current_type = "", const String &p_dialog_title = "", const TypedArray<StringName> &p_custom_type_blocklist = TypedArray<StringName>());
 
 	// Editor docks.

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -153,7 +153,7 @@ String EditorQuickOpenDialog::get_dialog_title(const Vector<StringName> &p_base_
 	return vformat(TTR("Select %s"), p_base_types[0]);
 }
 
-void EditorQuickOpenDialog::popup_dialog(const Vector<StringName> &p_base_types, const Callable &p_item_selected_callback, bool p_allow_type_switching) {
+void EditorQuickOpenDialog::popup_dialog(const Vector<StringName> &p_base_types, const Callable &p_item_selected_callback, bool p_allow_type_switching, const PackedInt64Array &p_hidden_uids) {
 	ERR_FAIL_COND(p_base_types.is_empty());
 	ERR_FAIL_COND(!p_item_selected_callback.is_valid());
 
@@ -163,12 +163,12 @@ void EditorQuickOpenDialog::popup_dialog(const Vector<StringName> &p_base_types,
 	allow_type_switching = p_allow_type_switching;
 
 	is_cycling_items = false;
-	container->init(p_base_types);
+	container->init(p_base_types, p_hidden_uids);
 	container->set_instant_preview_toggle_visible(false);
 	_finish_dialog_setup(p_base_types);
 }
 
-void EditorQuickOpenDialog::popup_dialog_for_property(const Vector<StringName> &p_base_types, Object *p_obj, const StringName &p_path, const Callable &p_item_selected_callback) {
+void EditorQuickOpenDialog::popup_dialog_for_property(const Vector<StringName> &p_base_types, Object *p_obj, const StringName &p_path, const Callable &p_item_selected_callback, const PackedInt64Array &p_hidden_uids) {
 	ERR_FAIL_NULL(p_obj);
 	ERR_FAIL_COND(p_base_types.is_empty());
 	ERR_FAIL_COND(!p_item_selected_callback.is_valid());
@@ -183,7 +183,7 @@ void EditorQuickOpenDialog::popup_dialog_for_property(const Vector<StringName> &
 	// the window.
 	initial_selection_performed = false;
 
-	container->init(p_base_types);
+	container->init(p_base_types, p_hidden_uids);
 	container->set_instant_preview_toggle_visible(true);
 	_finish_dialog_setup(p_base_types);
 }
@@ -507,9 +507,10 @@ void QuickOpenResultContainer::_ensure_result_vector_capacity() {
 	}
 }
 
-void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
+void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types, const PackedInt64Array &p_hidden_uids) {
 	_ensure_result_vector_capacity();
 	base_types = p_base_types;
+	hidden_uids = p_hidden_uids;
 
 	const int display_mode_behavior = EDITOR_GET("filesystem/quick_open_dialog/default_display_mode");
 	const bool adaptive_display_mode = (display_mode_behavior == 0);
@@ -733,6 +734,10 @@ QuickOpenResultCandidate QuickOpenResultCandidate::from_result(Ref<FuzzySearchMa
 
 void QuickOpenResultContainer::_add_candidate(QuickOpenResultCandidate &p_candidate) {
 	ERR_FAIL_COND(!ResourceUID::get_singleton()->has_id(p_candidate.uid));
+
+	if (hidden_uids.has(p_candidate.uid)) {
+		return;
+	}
 
 	StringName actual_type;
 	{

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -91,7 +91,7 @@ class QuickOpenResultContainer : public VBoxContainer {
 	};
 
 public:
-	void init(const Vector<StringName> &p_base_types);
+	void init(const Vector<StringName> &p_base_types, const PackedInt64Array &p_hidden_uids = {});
 	void handle_search_box_input(const Ref<InputEvent> &p_ie);
 	void set_query_and_update(const String &p_query);
 	void update_results();
@@ -116,6 +116,7 @@ private:
 	static constexpr int MAX_HISTORY_SIZE = 20;
 
 	Vector<StringName> base_types;
+	PackedInt64Array hidden_uids;
 	LocalVector<ResourceUID::ID> uids;
 	AHashMap<ResourceUID::ID, StringName> filetypes;
 	Vector<QuickOpenResultCandidate> candidates;
@@ -259,8 +260,8 @@ class EditorQuickOpenDialog : public AcceptDialog {
 	GDCLASS(EditorQuickOpenDialog, AcceptDialog);
 
 public:
-	void popup_dialog(const Vector<StringName> &p_base_types, const Callable &p_item_selected_callback, bool p_allow_type_switching = false);
-	void popup_dialog_for_property(const Vector<StringName> &p_base_types, Object *p_obj, const StringName &p_path, const Callable &p_item_selected_callback);
+	void popup_dialog(const Vector<StringName> &p_base_types, const Callable &p_item_selected_callback, bool p_allow_type_switching = false, const PackedInt64Array &p_hidden_uids = {});
+	void popup_dialog_for_property(const Vector<StringName> &p_base_types, Object *p_obj, const StringName &p_path, const Callable &p_item_selected_callback, const PackedInt64Array &p_hidden_uids = {});
 	EditorQuickOpenDialog();
 
 protected:


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The current scene is now excluded from the quick open dialog. This functionality is also exposed to EditorInterface.

- Closes godotengine/godot-proposals#15184

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
