### PR TITLE
[Docs] Add description to _is_valid_letter virtual method inside TextServerExtension class

### DIFF
--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1214,6 +1214,7 @@
 			<return type="bool" />
 			<param index="0" name="unicode" type="int" />
 			<description>
+				Returns [code]true[/code] if [param unicode] is a valid letter.
 			</description>
 		</method>
 		<method name="_load_support_data" qualifiers="virtual">


### PR DESCRIPTION
## Brief Description

Added a description to `_is_valid_letter` virtual method after noticing it lacked documentation via [doc-status](https://godotengine.github.io/doc-status/) website.

## Testing

I've compiled Godot with this patch, and Godot renders the newly added documentation without any issues.

<details><summary><h2>Screenshots</h2></summary>
<p>

<img width="1347" height="967" alt="image" src="https://github.com/user-attachments/assets/8fba87a9-ce9b-494c-ad0e-2c0817bea91e" />

</p>
</details> 
