### PR TITLE
Add global constants to Expression

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -30,6 +30,7 @@
 
 #include "expression.h"
 
+#include "core/core_constants.h"
 #include "core/object/class_db.h"
 
 Error Expression::_get_token(Token &r_token) {
@@ -716,11 +717,17 @@ Expression::ENode *Expression::_parse_expression() {
 						input->index = input_index;
 						expr = input;
 					} else {
-						NamedIndexNode *index = alloc_node<NamedIndexNode>();
-						SelfNode *self_node = alloc_node<SelfNode>();
-						index->base = self_node;
-						index->name = identifier;
-						expr = index;
+						if (StringName n = identifier; CoreConstants::is_global_constant(n)) {
+							ConstantNode *constant = alloc_node<ConstantNode>();
+							constant->value = CoreConstants::get_global_constant_value(CoreConstants::get_global_constant_index(n));
+							expr = constant;
+						} else {
+							NamedIndexNode *index = alloc_node<NamedIndexNode>();
+							SelfNode *self_node = alloc_node<SelfNode>();
+							index->base = self_node;
+							index->name = identifier;
+							expr = index;
+						}
 					}
 				}
 			} break;
@@ -743,41 +750,56 @@ Expression::ENode *Expression::_parse_expression() {
 
 				Variant::Type bt = Variant::Type(int(tk.value));
 				_get_token(tk);
-				if (tk.type != TK_PARENTHESIS_OPEN) {
+				if (tk.type != TK_PARENTHESIS_OPEN && tk.type != TK_PERIOD) {
 					_set_error("Expected '('");
 					return nullptr;
 				}
 
-				ConstructorNode *constructor = alloc_node<ConstructorNode>();
-				constructor->data_type = bt;
-
-				while (true) {
-					int cofs = str_ofs;
+				if (tk.type == TK_PERIOD) {
 					_get_token(tk);
-					if (tk.type == TK_PARENTHESIS_CLOSE) {
-						break;
-					}
-					str_ofs = cofs; //revert
-					//parse an expression
-					ENode *subexpr = _parse_expression();
-					if (!subexpr) {
+					if (tk.type != TK_IDENTIFIER) {
+						_set_error("Expected identifier");
 						return nullptr;
 					}
-
-					constructor->arguments.push_back(subexpr);
-
-					cofs = str_ofs;
-					_get_token(tk);
-					if (tk.type == TK_COMMA) {
-						//all good
-					} else if (tk.type == TK_PARENTHESIS_CLOSE) {
-						str_ofs = cofs;
-					} else {
-						_set_error("Expected ',' or ')'");
+					ConstantNode *constant = alloc_node<ConstantNode>();
+					bool is_valid;
+					constant->value = Variant::get_constant_value(bt, tk.value, &is_valid);
+					if (!is_valid) {
+						_set_error(vformat("Invalid constant name %s for type %s", String(tk.value), Variant::get_type_name(bt)));
 					}
-				}
+					expr = constant;
+				} else {
+					ConstructorNode *constructor = alloc_node<ConstructorNode>();
+					constructor->data_type = bt;
 
-				expr = constructor;
+					while (true) {
+						int cofs = str_ofs;
+						_get_token(tk);
+						if (tk.type == TK_PARENTHESIS_CLOSE) {
+							break;
+						}
+						str_ofs = cofs; //revert
+						//parse an expression
+						ENode *subexpr = _parse_expression();
+						if (!subexpr) {
+							return nullptr;
+						}
+
+						constructor->arguments.push_back(subexpr);
+
+						cofs = str_ofs;
+						_get_token(tk);
+						if (tk.type == TK_COMMA) {
+							//all good
+						} else if (tk.type == TK_PARENTHESIS_CLOSE) {
+							str_ofs = cofs;
+						} else {
+							_set_error("Expected ',' or ')'");
+						}
+					}
+
+					expr = constructor;
+				}
 
 			} break;
 			case TK_BUILTIN_FUNC: {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Re-adds global and Variant constant support to Expression. This script

```gdscript
@tool
extends EditorScript

func _run():
	var expr = Expression.new()
	for k in [
		"Color()",
		"Vector2()",
		"Color(1,1,1,1).darkened(0.5)",
		"Vector2(0,0).distance_to(Vector2(1,1))",
		# the following won't work
		"KEY_ESCAPE",
		"Color.WHITE",
		"Vector2.ZERO",
		"Color.WHITE.darkened(0.5)",
		"Vector2.ZERO.distance_to(Vector2.ONE)",
		]:
		if expr.parse(k) == OK:
			prints("\"%s\": %s" % [k, expr.execute()])
		else:
			print("(ERROR) \"%s\": %s" % [k, expr.get_error_text()])


```

now works correctly. On master:

```gdscript
"Color()": (0.0, 0.0, 0.0, 1.0)
"Vector2()": (0.0, 0.0)
"Color(1,1,1,1).darkened(0.5)": (0.5, 0.5, 0.5, 1.0)
"Vector2(0,0).distance_to(Vector2(1,1))": 1.41421353816986
  ERROR: self can't be used because instance is null (not passed)
"KEY_ESCAPE": <null>
(ERROR) "Color.WHITE": Expected '('
(ERROR) "Vector2.ZERO": Expected '('
(ERROR) "Color.WHITE.darkened(0.5)": Expected '('
(ERROR) "Vector2.ZERO.distance_to(Vector2.ONE)": Expected '('
```

This PR:

```gdscript
"Color()": (0.0, 0.0, 0.0, 1.0)
"Vector2()": (0.0, 0.0)
"Color(1,1,1,1).darkened(0.5)": (0.5, 0.5, 0.5, 1.0)
"Vector2(0,0).distance_to(Vector2(1,1))": 1.41421353816986
"KEY_ESCAPE": 4194305
"Color.WHITE": (1.0, 1.0, 1.0, 1.0)
"Vector2.ZERO": (0.0, 0.0)
"Color.WHITE.darkened(0.5)": (0.5, 0.5, 0.5, 1.0)
"Vector2.ZERO.distance_to(Vector2.ONE)": 1.41421353816986
```

- Closes #60066

## Additional information

Constant resolving could be pushed to execution time, but I think this is fine

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/106542*