### PR TITLE
[Resource] Disallow setting overriding cached path if resource is already cached with different load path.

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -120,7 +120,11 @@ String Resource::get_path() const {
 }
 
 void Resource::set_path_cache(const String &p_path) {
-	path_cache = p_path;
+	if (path_cache != p_path) {
+		ERR_FAIL_COND_MSG(!path_cache.is_empty() && !p_path.is_empty() && ResourceCache::has(path_cache), vformat("This resource is already cached with path '%s'.", path_cache));
+		path_cache = p_path;
+	}
+
 	GDVIRTUAL_CALL(_set_path_cache, p_path);
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121287

## Additional information

Should prevent dangling resource cache entities and overwriting cache without removing old entities when using cached path override.

I think this condition should never happen during normal use, but it's possible I have missed some special case.