### PR TITLE
Fix VoxelGIData save extension and shared file dialog path resolution

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1902,7 +1902,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	}
 	// Lowest provided extension priority.
 	List<String>::Element *res_element = preferred.find("res");
-	if (res_element) {
+	if (res_element && !p_resource->is_class("VoxelGIData")) {
 		preferred.move_to_back(res_element);
 	}
 
@@ -1925,9 +1925,12 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 				const String ext = resource_path.get_extension().to_lower();
 				if (extensions.find(ext) == nullptr) {
 					file->set_current_path(resource_path.replacen("." + ext, "." + extensions.front()->get()));
+				} else {
+					file->set_current_path(resource_path);
 				}
 			}
 		} else {
+			file->set_current_dir(p_resource->get_path().get_base_dir());
 			file->set_current_file(new_resource_name_snake_case);
 		}
 	} else if (!preferred.is_empty()) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1902,6 +1902,8 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	}
 	// Lowest provided extension priority.
 	List<String>::Element *res_element = preferred.find("res");
+	// VoxelGIData should favor being saved to binary `.res` to reduce file size,
+	// so keep that extension as the preferred one.
 	if (res_element && !p_resource->is_class("VoxelGIData")) {
 		preferred.move_to_back(res_element);
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121325
- Fixes `VoxelGIData` defaulting to the `.tres` extension when saved from the Inspector via "Save As" now correctly defaults to `.res`.
- Fixes the shared save file dialog retaining the previous scene's filename, path, and `.tscn` extension when saving resources.


## Additional information

- Bypasses `res` extension deprioritization in `EditorNode::save_resource_as` for `VoxelGIData`.
- Ensures `file->set_current_path()` is called when saving resources with recognized extensions, and `file->set_current_dir()` is called for built-in subresources, resetting the shared dialog's state.