### PR TITLE
Add `pressed` style to Tree

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -578,8 +578,11 @@
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The tint of text outline of the item.
 		</theme_item>
+		<theme_item name="font_pressed_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Text [Color] used when the item is pressed and selected.
+		</theme_item>
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
-			Text [Color] used when the item is selected.
+			Text [Color] used when the item is selected and not pressed.
 		</theme_item>
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 0.25)">
 			[Color] of the guideline.
@@ -767,6 +770,12 @@
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background style for the [Tree].
+		</theme_item>
+		<theme_item name="pressed_selected" data_type="style" type="StyleBox">
+			[StyleBox] for pressed and selected items, used when the [Tree] is not being focused.
+		</theme_item>
+		<theme_item name="pressed_selected_focus" data_type="style" type="StyleBox">
+			[StyleBox] for pressed and selected items, used when the [Tree] is being focused.
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -615,6 +615,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("font_hovered_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_color);
 			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.mono_color_font);
+			p_theme->set_color("font_pressed_selected_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_selected_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
 			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
@@ -694,6 +695,13 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 			p_theme->set_stylebox("hovered_selected", "Tree", style_tree_hover_selected);
 			p_theme->set_stylebox("hovered_selected_focus", "Tree", style_tree_hover_selected);
+
+			Ref<StyleBoxFlat> style_tree_pressed_selected = style_tree_selected->duplicate();
+			style_tree_pressed_selected->set_bg_color(p_config.highlight_color * Color(1, 1, 1, 1.4));
+			style_tree_pressed_selected->set_border_width_all(0);
+
+			p_theme->set_stylebox("pressed_selected", "Tree", style_tree_pressed_selected);
+			p_theme->set_stylebox("pressed_selected_focus", "Tree", style_tree_pressed_selected);
 
 			p_theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
 			p_theme->set_stylebox("selected", "Tree", style_tree_selected);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -640,6 +640,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("font_hovered_color", "Tree", p_config.font_hover_color);
 			p_theme->set_color("font_hovered_dimmed_color", "Tree", p_config.font_hover_color);
 			p_theme->set_color("font_hovered_selected_color", "Tree", p_config.mono_color_font);
+			p_theme->set_color("font_pressed_selected_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_selected_color", "Tree", p_config.mono_color_font);
 			p_theme->set_color("font_disabled_color", "Tree", p_config.font_disabled_color);
 			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
@@ -715,6 +716,9 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 			p_theme->set_stylebox("hovered_selected", "Tree", style_tree_hovered_selected);
 			p_theme->set_stylebox("hovered_selected_focus", "Tree", p_config.focus_style);
+
+			p_theme->set_stylebox("pressed_selected", "Tree", style_tree_hovered_selected);
+			p_theme->set_stylebox("pressed_selected_focus", "Tree", p_config.focus_style);
 
 			// Cursor is drawn on top of the item so it needs to be transparent.
 			Ref<StyleBoxFlat> style_tree_cursor = p_config.base_style->duplicate();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -137,6 +137,11 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->cache.hover_item = nullptr;
 		}
 
+		if (tree->cache.pressed_item == this) {
+			tree->cache.pressed_item = nullptr;
+			tree->cache.pressed_column = -1;
+		}
+
 		if (tree->selected_item == this) {
 			for (int i = 0; i < tree->selected_item->cells.size(); i++) {
 				tree->selected_item->cells.write[i].selected = false;
@@ -2366,6 +2371,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 		int skip2 = 0;
 
 		bool is_row_hovered = (!cache.hover_header_row && cache.hover_item == p_item);
+		bool is_row_pressed = is_row_hovered && cache.pressed_item == p_item && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT);
 		bool should_draw_row_rect = select_mode == SELECT_ROW;
 
 		for (int i = 0; i < columns.size(); i++) {
@@ -2377,6 +2383,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			bool is_col_hovered = cache.hover_column == i;
 			bool is_cell_hovered = is_row_hovered && is_col_hovered;
 			bool is_cell_button_hovered = is_cell_hovered && cache.hover_button_index_in_column != -1;
+			bool is_cell_pressed = is_row_pressed && cache.pressed_column == i;
 			int item_width = get_column_width(i);
 
 			if (i == 0) {
@@ -2458,7 +2465,13 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					row_rect = convert_rtl_rect(row_rect);
 
 					if (p_item->cells[0].selected) {
-						if (is_row_hovered) {
+						if (is_row_pressed) {
+							if (has_focus(true)) {
+								theme_cache.pressed_selected_focus->draw(sb_ci, row_rect);
+							} else {
+								theme_cache.pressed_selected->draw(sb_ci, row_rect);
+							}
+						} else if (is_row_hovered) {
 							if (has_focus(true)) {
 								theme_cache.hovered_selected_focus->draw(sb_ci, row_rect);
 							} else {
@@ -2502,7 +2515,13 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					p_item->focus_rect = Rect2(r.position, r.size);
 					r = convert_rtl_rect(r);
 					if (p_item->cells[i].selected) {
-						if (is_cell_hovered) {
+						if (is_cell_pressed) {
+							if (has_focus(true)) {
+								theme_cache.pressed_selected_focus->draw(sb_ci, r);
+							} else {
+								theme_cache.pressed_selected->draw(sb_ci, r);
+							}
+						} else if (is_cell_hovered) {
 							if (has_focus(true)) {
 								theme_cache.hovered_selected_focus->draw(sb_ci, r);
 							} else {
@@ -2559,7 +2578,23 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			} else {
 				bool draw_as_hover = !drop_mode_flags && (select_mode == SELECT_ROW ? is_row_hovered : is_cell_hovered);
 				bool draw_as_hover_dim = draw_as_hover && is_cell_button_hovered;
-				cell_color = p_item->cells[i].selected && draw_as_hover ? theme_cache.font_hovered_selected_color : (p_item->cells[i].selected ? theme_cache.font_selected_color : (draw_as_hover_dim ? theme_cache.font_hovered_dimmed_color : (draw_as_hover ? theme_cache.font_hovered_color : theme_cache.font_color)));
+				bool draw_as_pressed = !drop_mode_flags && (select_mode == SELECT_ROW ? is_row_pressed : is_cell_pressed);
+
+				if (p_item->cells[i].selected) {
+					if (draw_as_pressed) {
+						cell_color = theme_cache.font_pressed_selected_color;
+					} else if (draw_as_hover) {
+						cell_color = theme_cache.font_hovered_selected_color;
+					} else {
+						cell_color = theme_cache.font_selected_color;
+					}
+				} else if (draw_as_hover_dim) {
+					cell_color = theme_cache.font_hovered_dimmed_color;
+				} else if (draw_as_hover) {
+					cell_color = theme_cache.font_hovered_color;
+				} else {
+					cell_color = theme_cache.font_color;
+				}
 			}
 
 			Color font_outline_color = theme_cache.font_outline_color;
@@ -4240,6 +4275,9 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (mb->get_button_index() == MouseButton::LEFT) {
+				cache.pressed_item = nullptr;
+				cache.pressed_column = -1;
+
 				if (single_select_defer) {
 					select_single_item(single_select_defer, root, single_select_defer_column);
 					single_select_defer = nullptr;
@@ -4359,6 +4397,12 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				blocked++;
 				propagate_mouse_event(pos + theme_cache.offset, 0, 0, x_limit + theme_cache.offset.width, mb->is_double_click(), root, mb->get_button_index(), mb);
 				blocked--;
+
+				if (mb->get_button_index() == MouseButton::LEFT) {
+					cache.pressed_item = get_item_at_position(mb->get_position());
+					cache.pressed_column = get_column_at_position(mb->get_position());
+					queue_redraw();
+				}
 
 				if (pressing_for_editor) {
 					pressing_pos = mb->get_position();
@@ -7558,6 +7602,8 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, hovered_dimmed);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, hovered_selected);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, hovered_selected_focus);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, pressed_selected);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, pressed_selected_focus);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, selected);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, selected_focus);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, Tree, cursor);
@@ -7588,6 +7634,7 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_hovered_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_hovered_dimmed_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_hovered_selected_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_pressed_selected_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_selected_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, font_disabled_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, Tree, drop_on_item_color);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -634,6 +634,8 @@ private:
 		Ref<StyleBox> hovered_dimmed;
 		Ref<StyleBox> hovered_selected;
 		Ref<StyleBox> hovered_selected_focus;
+		Ref<StyleBox> pressed_selected;
+		Ref<StyleBox> pressed_selected_focus;
 		Ref<StyleBox> selected;
 		Ref<StyleBox> selected_focus;
 		Ref<StyleBox> cursor;
@@ -666,6 +668,7 @@ private:
 		Color font_hovered_color;
 		Color font_hovered_dimmed_color;
 		Color font_hovered_selected_color;
+		Color font_pressed_selected_color;
 		Color font_selected_color;
 		Color font_disabled_color;
 		Color guide_color;
@@ -732,7 +735,9 @@ private:
 		Point2 click_pos;
 
 		TreeItem *hover_item = nullptr;
+		TreeItem *pressed_item = nullptr;
 		int hover_column = -1;
+		int pressed_column = -1;
 		int hover_button_index_in_column = -1;
 
 		bool rtl = false;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -112,6 +112,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Color style_normal_color = Color(0.1, 0.1, 0.1, 0.6);
 	const Color style_hover_color = Color(0.225, 0.225, 0.225, 0.6);
 	const Color style_hover_selected_color = Color(1, 1, 1, 0.4);
+	const Color style_pressed_selected_color = Color(1, 1, 1, 0.5);
 	const Color style_pressed_color = Color(0, 0, 0, 0.6);
 	const Color style_disabled_color = Color(0.1, 0.1, 0.1, 0.3);
 	const Color style_focus_color = Color(1, 1, 1, 0.75);
@@ -885,6 +886,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("hovered_dimmed", "Tree", make_flat_stylebox(Color(1, 1, 1, 0.03)));
 	theme->set_stylebox("hovered_selected", "Tree", make_flat_stylebox(style_hover_selected_color));
 	theme->set_stylebox("hovered_selected_focus", "Tree", make_flat_stylebox(style_hover_selected_color));
+	theme->set_stylebox("pressed_selected", "Tree", make_flat_stylebox(style_pressed_selected_color));
+	theme->set_stylebox("pressed_selected_focus", "Tree", make_flat_stylebox(style_pressed_selected_color));
 	theme->set_stylebox("selected", "Tree", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("selected_focus", "Tree", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("cursor", "Tree", focus);
@@ -922,6 +925,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_hovered_color", "Tree", control_font_hover_color);
 	theme->set_color("font_hovered_dimmed_color", "Tree", control_font_color);
 	theme->set_color("font_hovered_selected_color", "Tree", control_font_pressed_color);
+	theme->set_color("font_pressed_selected_color", "Tree", control_font_pressed_color);
 	theme->set_color("font_selected_color", "Tree", control_font_pressed_color);
 	theme->set_color("font_disabled_color", "Tree", control_font_disabled_color);
 	theme->set_color("font_outline_color", "Tree", Color(0, 0, 0));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Implements a part of https://github.com/godotengine/godot-proposals/issues/13112

## Additional information
Adds new theme font color and styleboxes to `Tree` for the `pressed` state. Clicked items of a `Tree` are now highlighted and change back to normal once we release the mouse button. It gives the items visual feedback when clicked and makes the UI feel more responsive.

https://github.com/user-attachments/assets/2221cb47-1d89-4fea-90a3-3aa77ef79a72

<details>
<summary>Video of editor with classic theme</summary>

https://github.com/user-attachments/assets/799476bf-0774-4cb4-88a9-2514bd0ed2a6

https://github.com/user-attachments/assets/6c84a77f-e3c7-4df3-856b-fea8bae87a8a

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
