### PR TITLE
Fix "unknown version" string being translated for no reason

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -336,7 +336,7 @@ void ProjectListItemControl::set_unsupported_features(PackedStringArray p_featur
 					project_different_version->set_focus_mode(FOCUS_ACCESSIBILITY);
 					project_different_version->set_tooltip_text(project_version_tooltip_text);
 					project_different_version->show();
-				} else if (p_features[i] == TTR("Unknown version")) {
+				} else if (p_features[i] == "u-ver") {
 					unknown_version = true;
 					project_different_version->hide();
 				}
@@ -849,7 +849,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 			unsupported_features.push_back("3.x");
 			project_version = "3.x";
 		} else {
-			unsupported_features.push_back(TTR("Unknown version"));
+			unsupported_features.push_back("u-ver");
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When projects is invalid or missing, Project Manager inserts a translated `Unknown version` string as unsupported feature. This string is never displayed, there is no reason to translate it, or even make readable.

While this bug does do anything right now, it affects #120958

## Additional information

I changed the string to something short, since the actual content does not matter.