### PR TITLE
Security: Add bounds checks to prevent integer underflow in packet size validation

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -583,7 +583,7 @@ Error SceneReplicationInterface::on_spawn_receive(int p_from, const uint8_t *p_b
 	ofs += 4;
 	uint32_t name_len = decode_uint32(&p_buffer[ofs]);
 	ofs += 4;
-	ERR_FAIL_COND_V_MSG(name_len + (sync_len * 4) > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA, vformat("Invalid spawn packet size: %d, wants: %d", p_buffer_len, ofs + name_len + (sync_len * 4)));
+	ERR_FAIL_COND_V_MSG(ofs > p_buffer_len || name_len + (sync_len * 4) > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA, vformat("Invalid spawn packet size: %d, wants: %d", p_buffer_len, ofs + name_len + (sync_len * 4)));
 	List<uint32_t> sync_ids;
 	for (uint32_t i = 0; i < sync_len; i++) {
 		sync_ids.push_back(decode_uint32(&p_buffer[ofs]));
@@ -604,10 +604,10 @@ Error SceneReplicationInterface::on_spawn_receive(int p_from, const uint8_t *p_b
 	Node *node = nullptr;
 	if (scene_id == MultiplayerSpawner::INVALID_ID) {
 		// Custom spawn.
-		ERR_FAIL_COND_V(p_buffer_len - ofs < 4, ERR_INVALID_DATA);
+		ERR_FAIL_COND_V(ofs + 4 > p_buffer_len, ERR_INVALID_DATA);
 		uint32_t arg_size = decode_uint32(&p_buffer[ofs]);
 		ofs += 4;
-		ERR_FAIL_COND_V(arg_size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
+		ERR_FAIL_COND_V(ofs > p_buffer_len || arg_size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
 		Variant v;
 		Error err = MultiplayerAPI::decode_and_decompress_variant(v, &p_buffer[ofs], arg_size, nullptr, false);
 		ERR_FAIL_COND_V(err != OK, err);
@@ -773,7 +773,7 @@ Error SceneReplicationInterface::on_delta_receive(int p_from, const uint8_t *p_b
 		ofs += 8;
 		uint32_t size = decode_uint32(&p_buffer[ofs]);
 		ofs += 4;
-		ERR_FAIL_COND_V(size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
+		ERR_FAIL_COND_V(ofs > p_buffer_len || size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
 		MultiplayerSynchronizer *sync = _find_synchronizer(p_from, net_id);
 		Node *node = sync ? sync->get_root_node() : nullptr;
 		if (!sync || sync->get_multiplayer_authority() != p_from || !node) {
@@ -865,7 +865,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		ofs += 4;
 		uint32_t size = decode_uint32(&p_buffer[ofs]);
 		ofs += 4;
-		ERR_FAIL_COND_V(size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
+		ERR_FAIL_COND_V(ofs > p_buffer_len || size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
 		MultiplayerSynchronizer *sync = _find_synchronizer(p_from, net_id);
 		if (!sync) {
 			// Not received yet.


### PR DESCRIPTION
## Summary

The `on_spawn_receive`, `on_delta_receive`, and `on_sync_receive` functions perform unsigned arithmetic (`p_buffer_len - ofs`) that can underflow if `ofs` exceeds `p_buffer_len`. A malicious client can craft packets that bypass size validation, leading to out-of-bounds memory access.

## Fix

Added explicit bounds checks (`ofs > p_buffer_len || ...`) before each unsigned subtraction to ensure the offset never exceeds the buffer length before performing safe arithmetic.

## Files Changed

- `modules/multiplayer/scene_replication_interface.cpp`