### PR TITLE
GDScript: Fix not releasing `RefCounted` temporary at end of statement

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -109,7 +109,7 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 			case Variant::PACKED_COLOR_ARRAY:
 			case Variant::PACKED_VECTOR4_ARRAY:
 			case Variant::VARIANT_MAX:
-				// Arrays, dictionaries, and objects are reference counted, so we don't use the pool for them.
+				// Arrays, dictionaries, and objects are reference counted, so we use the same pool for them.
 				temp_type = Variant::NIL;
 				break;
 		}
@@ -121,7 +121,7 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 
 	List<int> &pool = temporaries_pool[temp_type];
 	if (pool.is_empty()) {
-		StackSlot new_temp(temp_type, p_type.can_contain_object());
+		StackSlot new_temp(temp_type, temp_type == Variant::NIL);
 		int idx = temporaries.size();
 		pool.push_back(idx);
 		temporaries.push_back(new_temp);

--- a/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.gd
@@ -1,0 +1,19 @@
+class TestRefCounted:
+	extends RefCounted
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_PREDELETE:
+			print("    TestRefCounted released")
+
+func test() -> void:
+	test1()
+	test2()
+
+func test1(_a: Array = []) -> void:
+	print("test1 (untyped Array default)")
+	var _count = TestRefCounted.new().get_reference_count()
+	print("    end of statement")
+
+func test2(_a: Array[String] = []) -> void:
+	print("test2 (typed Array[String] default)")
+	var _count = TestRefCounted.new().get_reference_count()
+	print("    end of statement")

--- a/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.out
+++ b/modules/gdscript/tests/scripts/runtime/features/release_at_end_of_statement.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+test1 (untyped Array default)
+    TestRefCounted released
+    end of statement
+test2 (typed Array[String] default)
+    TestRefCounted released
+    end of statement


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121316

## Summary of changes
The bug occured, because the `can_contain_object` field was not updated when a `StackSlot` was reused.
An untyped `Array` always returns `true` in `GDScriptDataType::can_contain_object`.
A typed `Array[String]` would relay the `can_contain_object` call to the inner type, which in this case, returns `false`.
A temporary is only cleared when `can_contain_object` is true.
This PR updates the `can_contain_object` field when a `StackSlot` is reused.

## Additional information
Added a GDScript feature test. It's a slightly modified version of the MRP.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
