### PR TITLE
Guard BlitMaterial blend mode range

### DIFF
--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,6 +80,8 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
+	ERR_FAIL_INDEX_MSG(p_blend_mode, 5, vformat("Invalid blend mode: %d.", p_blend_mode));
+
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);
 	if (shader_set) {


### PR DESCRIPTION
## What problem(s) does this PR solve?


`BlitMaterial.set_blend_mode()` accepts integer values from scripts without validating that they are valid `BlendMode` values. Invalid values can therefore be used to index the shader cache out of bounds.

## Additional information

This adds a range check before updating the material's internal blend mode.

Validated by compiling `scene/resources/blit_material.cpp` and running the issue's minimal reproduction project. The invalid value now reports an error and exits normally instead of accessing the shader cache out of bounds.

AI disclosure: Codex was used to help analyze the issue, explain the relevant engine code and error macro conventions, run the build and reproduction steps, and prepare this draft pull request. The code and pull request text will be manually reviewed and edited by the contributor before marking it ready for review.
