### PR TITLE
Fix sticky snap when focus lost

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -626,6 +626,10 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 	}
 }
 
+void Node3DEditor::_update_snap_input() {
+	snap_key_enabled = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
+}
+
 void Node3DEditor::_snap_changed() {
 	snap_translate_value = snap_translate->get_value();
 	snap_rotate_value = snap_rotate->get_value();
@@ -2299,7 +2303,7 @@ void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	snap_key_enabled = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
+	_update_snap_input();
 }
 
 void Node3DEditor::_sun_environ_settings_pressed() {
@@ -2439,6 +2443,8 @@ void Node3DEditor::_notification(int p_what) {
 			SceneTreeDock::get_singleton()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
 			editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditor::_selection_changed));
 
+			get_window()->connect("focus_entered", callable_mp(this, &Node3DEditor::_update_snap_input));
+
 			_update_preview_environment();
 
 			sun_state->set_custom_minimum_size(sun_vb->get_combined_minimum_size());
@@ -2455,6 +2461,7 @@ void Node3DEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			get_window()->disconnect("focus_entered", callable_mp(this, &Node3DEditor::_update_snap_input));
 			_finish_indicators();
 		} break;
 

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -243,6 +243,7 @@ private:
 	SpinBox *settings_znear = nullptr;
 	SpinBox *settings_zfar = nullptr;
 
+	void _update_snap_input();
 	void _snap_changed();
 	void _snap_update();
 	void _update_vertex_snap_tooltips();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #90320 

Fixes the sticky snap behavior that can happen when the window loses focus.

## Additional information

Typically when a shortcut spawns a new window.

It would cause the Node Editor Plugin unfocused and causes it to lose the snap key released event.

It can happen quite frequently when adding a new nodes, or saving a new file with a shortcut.

**The warning message in the video is just show the snap toggle is now being properly updated.** 


https://github.com/user-attachments/assets/78f30b11-17cb-4cb0-bc86-ae24be46d1f5

Here is how it was previously for reference:

https://github.com/user-attachments/assets/ebc51084-2b8d-4d8e-84ba-a2f182e503ac

