### PR TITLE
Add range check in `BlitMaterial::set_blend_mode`

### DIFF
--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,6 +80,8 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
+	ERR_FAIL_INDEX_MSG(p_blend_mode, 5, vformat("Invalid blend mode: %d.", p_blend_mode));
+
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);
 	if (shader_set) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121263 

Fix crash when give a invalid blend mode to BlitMaterial.set_blend_mode()

## Additional information
Test: Run MRP from the issue and got the this result:
```
ERROR: Invalid blend mode: 98.
   at: set_blend_mode (scene/resources/blit_material.cpp:83)
   GDScript backtrace:
       [0] _process (res://node.gd:9)
```
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

AI disclosure: Codex was used to help analyze the issue, explain the relevant engine code and error macro conventions, run the build and reproduction steps.
