### PR TITLE
Add `ZIPReader.decompress`

### DIFF
--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -52,6 +52,14 @@
 				Closes the underlying resources used by this instance.
 			</description>
 		</method>
+		<method name="decompress" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="input_path" type="String" />
+			<param index="1" name="output_path" type="String" />
+			<description>
+				Opens the zip archive at the given [param input_path] and decompresses it to [param output_path].
+			</description>
+		</method>
 		<method name="file_exists">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -31,6 +31,8 @@
 #include "zip_reader.h"
 
 #include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/class_db.h"
 
@@ -160,6 +162,104 @@ int ZIPReader::get_compression_level(const String &p_path, bool p_case_sensitive
 	return level;
 }
 
+Error ZIPReader::decompress(const String &p_input_path, const String &p_output_path) {
+	int err = UNZ_OK;
+	Error gdErr = OK;
+
+	// Open the zip file.
+	ZIPReader zip_reader = ZIPReader();
+	gdErr = zip_reader.open(p_input_path);
+	if (gdErr != OK) {
+		return gdErr;
+	}
+
+	// Create an output directory.
+	DirAccess::make_dir_recursive_absolute(p_output_path);
+	Ref<DirAccess> output_directory = DirAccess::open(p_output_path, &gdErr);
+	if (output_directory.is_null()) {
+		return gdErr;
+	}
+
+	// Go to the first file in the zip file.
+	err = unzGoToFirstFile(zip_reader.uzf);
+	ERR_FAIL_COND_V(err != UNZ_OK, ERR_FILE_CORRUPT);
+
+	// Read each file in the zip file.
+	while (true) {
+		// Open the current file in the zip file.
+		err = unzOpenCurrentFile(zip_reader.uzf);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "Could not open file within zip archive.");
+
+		// Read the file info for the current file in the zip file.
+		unz_file_info64 file_info;
+		String file_path;
+		err = godot_unzip_get_current_file_info(zip_reader.uzf, file_info, file_path);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "Unable to read file information from zip archive.");
+
+		// Replace back-slashes with forward-slashes.
+		file_path = file_path.replace_char('\\', '/');
+
+		// Ensure the file path doesn't escape the output directory.
+		String simplified_file_path = file_path.simplify_path();
+		bool is_malicious_path = simplified_file_path.is_absolute_path() || simplified_file_path == ".." || simplified_file_path.begins_with("../");
+		ERR_FAIL_COND_V_MSG(is_malicious_path, ERR_FILE_CORRUPT, "Extracting a ZIP entry would create a file/directory outside the output directory.");
+
+		// The current file is a directory.
+		if (file_path.ends_with("/")) {
+			// Create the output sub directory.
+			gdErr = output_directory->make_dir_recursive(file_path.trim_suffix("/"));
+			if (gdErr != OK) {
+				return gdErr;
+			}
+		}
+		// The current file is a file.
+		else {
+			// Create a sub directory for the output file.
+			gdErr = output_directory->make_dir_recursive(file_path.get_base_dir());
+			if (gdErr != OK) {
+				return gdErr;
+			}
+			// Create an output file.
+			Ref<FileAccess> output_file = FileAccess::open(p_output_path.path_join(file_path), FileAccess::WRITE, &gdErr);
+			if (output_file.is_null()) {
+				return gdErr;
+			}
+
+			// Read each chunk of the current file in the zip file.
+			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			while (true) {
+				// Read a chunk of the current file in the zip file.
+				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer, sizeof(buffer));
+				ERR_FAIL_COND_V_MSG(bytes_read < 0, ERR_FILE_CORRUPT, "IO/zlib error reading file from zip archive.");
+
+				// Reached the end of the current file in the zip file.
+				if (bytes_read == 0) {
+					break;
+				}
+
+				// Write the current chunk to the output file.
+				bool write_err = output_file->store_buffer(buffer, bytes_read);
+				ERR_FAIL_COND_V(!write_err, ERR_FILE_CANT_WRITE);
+			}
+		}
+
+		// Close the current file in the zip file.
+		err = unzCloseCurrentFile(zip_reader.uzf);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "CRC error reading file from zip archive.");
+
+		// Go to the next file in the zip file.
+		err = unzGoToNextFile(zip_reader.uzf);
+
+		// Reached the end of the list of files in the zip file.
+		if (err != UNZ_OK) {
+			break;
+		}
+	}
+
+	// The zip file was successfully extracted.
+	return OK;
+}
+
 ZIPReader::ZIPReader() {}
 
 ZIPReader::~ZIPReader() {
@@ -175,4 +275,6 @@ void ZIPReader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("read_file", "path", "case_sensitive"), &ZIPReader::read_file, DEFVAL(Variant(true)));
 	ClassDB::bind_method(D_METHOD("file_exists", "path", "case_sensitive"), &ZIPReader::file_exists, DEFVAL(Variant(true)));
 	ClassDB::bind_method(D_METHOD("get_compression_level", "path", "case_sensitive"), &ZIPReader::get_compression_level, DEFVAL(Variant(true)));
+
+	ClassDB::bind_static_method("ZIPReader", D_METHOD("decompress", "input_path", "output_path"), &ZIPReader::decompress);
 }

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -226,10 +226,11 @@ Error ZIPReader::decompress(const String &p_input_path, const String &p_output_p
 			}
 
 			// Read each chunk of the current file in the zip file.
-			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			LocalVector<uint8_t> buffer;
+			buffer.resize(64 * 1024); // 64KiB buffer
 			while (true) {
 				// Read a chunk of the current file in the zip file.
-				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer, sizeof(buffer));
+				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer.ptr(), buffer.size());
 				ERR_FAIL_COND_V_MSG(bytes_read < 0, ERR_FILE_CORRUPT, "IO/zlib error reading file from zip archive.");
 
 				// Reached the end of the current file in the zip file.
@@ -238,7 +239,7 @@ Error ZIPReader::decompress(const String &p_input_path, const String &p_output_p
 				}
 
 				// Write the current chunk to the output file.
-				bool write_err = output_file->store_buffer(buffer, bytes_read);
+				bool write_err = output_file->store_buffer(buffer.ptr(), bytes_read);
 				ERR_FAIL_COND_V(!write_err, ERR_FILE_CANT_WRITE);
 			}
 		}

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -53,6 +53,8 @@ public:
 	bool file_exists(const String &p_path, bool p_case_sensitive);
 	int get_compression_level(const String &p_path, bool p_case_sensitive);
 
+	static Error decompress(const String &p_input_path, const String &p_output_path);
+
 	ZIPReader();
 	~ZIPReader();
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Partially closes https://github.com/godotengine/godot-proposals/issues/12777

Implements `ZIPReader.decompress` (but not `ZIPPacker.compress`).
Edit: Implemented `ZIPPacker.compress` in https://github.com/godotengine/godot/pull/121430.

You can use it like this:
```gdscript
var err: Error = ZIPReader.decompress("res://example-dir.zip", "res://example-output")
```

The key advantages of this approach:
- Much simpler than manually decompressing each file
- Does not load each file into memory - reads them in 64KiB chunks instead

## Additional information

I have tested the pull request works for extracting ZIP files, including nested and empty directories.

There are a few things I would like to discuss:
1. Is 64KiB the best size for the buffer?
2. I have added a check to ensure the extracted directory doesn't escape the output directory (in the case of malicious ZIPs which use absolute paths or `..`). Is my check enough?
3. Would the method be better placed in a dedicated `ZIPAccess` class?

Demo: [zip-high-level-demo.zip](https://github.com/user-attachments/files/30019748/zip-high-level-demo.zip)

## Related discussion

I have also noticed that Godot is using `unzOpen2` and `zlib_filefunc_def` when it could be using `unzOpen2_64` and `zlib_filefunc64_def`. As a result, Godot errors if the ZIP file is more than 2GiB. Is there something stopping us from upgrading to the 64-bit versions?

## AI disclosure

I did not use AI to write the pull request, but I used AI to check my work and identify mistakes.