### PR TITLE
Dxchel/remove range no modify fail

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -557,14 +557,13 @@ void TextEdit::Text::remove_range(int p_from_line, int p_to_line) {
 		}
 		total_visible_line_count -= text_line.line_count;
 	}
+	ERR_FAIL_COND(total_visible_line_count < 0); // BUG
 
 	int diff = p_to_line - p_from_line;
 	for (int i = p_to_line + 1; i < text.size(); i++) {
 		text.write[i - diff] = text[i];
 	}
 	text.resize(text.size() - diff);
-
-	ERR_FAIL_COND(total_visible_line_count < 0); // BUG
 }
 
 void TextEdit::Text::add_gutter(int p_at) {


### PR DESCRIPTION
Just a small change for the text object to not be modified and left in an inconsistent state

AI not used for the fix or workflows, only used to search for silent bugs in code with no issue open.

- Closes #121383

## Additional information