### PR TITLE
Fix FindInFiles handling of unicode identifiers

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -74,10 +74,10 @@ static bool find_next(const String &p_line, const String &p_pattern, int p_from,
 		r_out_end = end;
 
 		if (p_whole_words) {
-			if (begin > 0 && is_ascii_identifier_char(p_line[begin - 1])) {
+			if (begin > 0 && !is_symbol(p_line[begin - 1])) {
 				continue;
 			}
-			if (end < p_line.size() && is_ascii_identifier_char(p_line[end])) {
+			if (end < p_line.length() && !is_symbol(p_line[end])) {
 				continue;
 			}
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

FindInFiles does not properly handle unicode identifiers. When "Whole Words" is enabled, it may still match partial words if they contain unicode chars. The script editor's search handles it correctly.

<img width="1732" height="431" alt="image" src="https://github.com/user-attachments/assets/91907aa5-da2b-4fa8-9b50-35f59fb5852e" />


## Additional information

The fix is based on
https://github.com/godotengine/godot/blob/ccb8004960b1638f5532048db6c33a0bf5f0769e/scene/gui/text_edit.cpp#L5322-L5323