### PR TITLE
Add shortcut for create new folder in file dialog

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -856,6 +856,10 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_filedialog_show_hidden", inputs);
 
 	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::N | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT));
+	default_builtin_cache.insert("ui_filedialog_new_folder", inputs);
+
+	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::F | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_filedialog_find", inputs);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1366,6 +1366,10 @@
 		<member name="input/ui_filedialog_focus_path.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to focus path edit field in [FileDialog].
 		</member>
+		<member name="input/ui_filedialog_new_folder" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to create a new folder in a [FileDialog].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_filedialog_refresh" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to refresh the contents of the current directory of a [FileDialog].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2350,6 +2350,7 @@ FileDialog::FileDialog() {
 		customization_flags[i] = true;
 	}
 
+	action_shortcuts[ITEM_MENU_NEW_FOLDER] = Shortcut::make_from_action("ui_filedialog_new_folder");
 	action_shortcuts[ITEM_MENU_DELETE] = Shortcut::make_from_action("ui_filedialog_delete");
 	action_shortcuts[ITEM_MENU_GO_UP] = Shortcut::make_from_action("ui_filedialog_up_one_level");
 	action_shortcuts[ITEM_MENU_REFRESH] = Shortcut::make_from_action("ui_filedialog_refresh");
@@ -2431,6 +2432,7 @@ FileDialog::FileDialog() {
 	make_dir_button = memnew(Button);
 	make_dir_button->set_theme_type_variation(SceneStringName(FlatButton));
 	make_dir_button->set_tooltip_text(ETR("Create a new folder."));
+	make_dir_button->set_shortcut(action_shortcuts[ITEM_MENU_NEW_FOLDER]);
 	make_dir_container->add_child(make_dir_button);
 	make_dir_button->connect(SceneStringName(pressed), callable_mp(this, &FileDialog::_make_dir));
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR adds the standard Ctrl + Shift + N shortcut to the file dialog box to create a new folder. This is a very common operation when navigating the file dialog and now creating a file in a new folder can be done entirely without the touching mouse.

https://github.com/user-attachments/assets/e669b234-54c4-4337-8a93-4ee6728f28b3
