### PR TITLE
Android editor: Enable screen orientation change on large screens and in Project Manager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -112,6 +112,7 @@ void ProjectManager::_notification(int p_what) {
 			_select_main_view(MAIN_VIEW_PROJECTS);
 			_update_list_placeholder();
 			_titlebar_resized();
+			_update_compact_mode(true);
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -145,6 +146,7 @@ void ProjectManager::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_RESIZED: {
 			project_list->resize_project_titles();
+			_update_compact_mode();
 		} break;
 	}
 }
@@ -180,8 +182,18 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 
 // Main layout.
 
+// Hides certain parts of the Project Manager when window width gets smaller than combined_minimum_size.
+void ProjectManager::_update_compact_mode(bool p_reset_threshold) {
+	if (p_reset_threshold) {
+		compact_mode_threshold = root_container->get_combined_minimum_size().width;
+	}
+
+	bool compact_mode = get_size().width < compact_mode_threshold;
+	project_list_sidebar->set_visible(!compact_mode);
+}
+
 void ProjectManager::_update_size_limits() {
-	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
+	const Size2 minimum_size = Size2(480, 300) * EDSCALE;
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
@@ -1669,7 +1681,7 @@ ProjectManager::ProjectManager() {
 			}
 
 			// The side bar with the edit, run, rename, etc. buttons.
-			VBoxContainer *project_list_sidebar = memnew(VBoxContainer);
+			project_list_sidebar = memnew(VBoxContainer);
 			project_list_sidebar->set_custom_minimum_size(Size2(120, 120) * EDSCALE);
 			project_list_hbox->add_child(project_list_sidebar);
 

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -93,6 +93,10 @@ class ProjectManager : public Control {
 	Button *title_bar_logo = nullptr;
 	HBoxContainer *main_view_toggles = nullptr;
 	Button *quick_settings_button = nullptr;
+	VBoxContainer *project_list_sidebar = nullptr;
+
+	int compact_mode_threshold = 0;
+	void _update_compact_mode(bool p_reset_threshold = false);
 
 	enum MainViewTab {
 		MAIN_VIEW_PROJECTS,

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -375,8 +375,9 @@ float DisplayServerAndroid::screen_get_scale(int p_screen) const {
 	// Update the scale to avoid cropping.
 	Size2i screen_size = screen_get_size(p_screen);
 	if (screen_size != Size2i()) {
-		float width_scale = screen_size.width / (float)OS_Android::DEFAULT_WINDOW_WIDTH;
-		float height_scale = screen_size.height / (float)OS_Android::DEFAULT_WINDOW_HEIGHT;
+		bool is_portrait = screen_size.height > screen_size.width;
+		float width_scale = screen_size.width / (float)(is_portrait ? OS_Android::DEFAULT_WINDOW_HEIGHT : OS_Android::DEFAULT_WINDOW_WIDTH);
+		float height_scale = screen_size.height / (float)(is_portrait ? OS_Android::DEFAULT_WINDOW_WIDTH : OS_Android::DEFAULT_WINDOW_HEIGHT);
 		screen_scale = MIN(screen_scale, MIN(width_scale, height_scale));
 	}
 

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
             android:exported="false"
             android:icon="@mipmap/themed_icon"
             android:launchMode="singleInstancePerTask"
-            android:screenOrientation="userLandscape">
+            android:screenOrientation="user">
             <layout
                 android:defaultWidth="@dimen/editor_default_window_width"
                 android:defaultHeight="@dimen/editor_default_window_height" />

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -277,6 +277,13 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 		// Add the game menu bar.
 		setupGameMenuBar()
+
+		if (!isLargeScreen) {
+			// Lock the editor screen orientation to landscape on small screens.
+			changingOrientationAllowed = true
+			requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+			changingOrientationAllowed = false
+		}
 	}
 
 	override fun onConfigurationChanged(newConfig: Configuration) {
@@ -720,7 +727,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	/**
 	 * The Godot Android Editor sets its own orientation via its AndroidManifest
 	 */
-	protected open fun overrideOrientationRequest() = !changingOrientationAllowed
+	protected open fun overrideOrientationRequest() = isLargeScreen || godot?.isProjectManagerHint() == true || !changingOrientationAllowed
 
 	protected open fun overrideVolumeButtons() = false
 
@@ -939,12 +946,16 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			}
 		}
 
-		toggleScriptEditorOrientation()
+		if (!isLargeScreen) {
+			toggleScriptEditorOrientation()
+		}
 	}
 
 	override fun onDistractionFreeModeChanged(enabled: Boolean) {
 		distractionFreeModeEnabled = enabled
-		toggleScriptEditorOrientation()
+		if (!isLargeScreen) {
+			toggleScriptEditorOrientation()
+		}
 	}
 
 	private fun toggleScriptEditorOrientation() {

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -278,7 +278,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		// Add the game menu bar.
 		setupGameMenuBar()
 
-		if (!isLargeScreen) {
+		if (!isLargeScreen && !isNativeXRDevice(applicationContext) && godot?.isEditorHint() == true) {
 			// Lock the editor screen orientation to landscape on small screens.
 			changingOrientationAllowed = true
 			requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE


### PR DESCRIPTION
- First commit enables screen orientation change on large screens devices like foldables, tablets, chromebooks.
    - It's already enabled forcefully on large devices running Android 16 or higher because those [ignore orientation locks](https://developer.android.com/about/versions/16/behavior-changes-16#ignore-orientation). So, we are now allowing orientation change on all large devices, according to some testings, editor is usable in portrait in these form factors.

- Second commit enables in Project Manager on all devices, fix the `DisplayServer.screen_get_scale()` logic for portrait, and optimizes Project manager for compact layout
    - Hides the Project Manager's side panel when the window is not wide enough. All the panel options are still accessible via right-click context menu.

https://github.com/user-attachments/assets/464f3f08-4371-4569-9947-f267f1b215ec


https://github.com/user-attachments/assets/89dc78a6-284b-42ca-8e73-4ccf9f144371


