### PR TITLE
Fix `LookAtModifier3D.is_interpolating()` value is inverted

### DIFF
--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -19,7 +19,7 @@
 		<method name="is_interpolating" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if time-based interpolation is running. If [code]true[/code], it is equivalent to [method get_interpolation_remaining] returning [code]0.0[/code].
+				Returns [code]true[/code] if time-based interpolation is running. If [code]false[/code], it is equivalent to [method get_interpolation_remaining] returning [code]0.0[/code].
 				This is useful to determine whether a [LookAtModifier3D] can be removed safely.
 			</description>
 		</method>

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -393,7 +393,7 @@ float LookAtModifier3D::get_interpolation_remaining() const {
 }
 
 bool LookAtModifier3D::is_interpolating() const {
-	return Math::is_zero_approx(remaining);
+	return !Math::is_zero_approx(remaining);
 }
 
 // General API.


### PR DESCRIPTION
The method name does not match its implementation. The documentation mentions true twice, but that was not intended. I did not notice this because the method is not used internally.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/121421*