### PR TITLE
Fix gizmo & Add `use_rest_for_limitation` to IterateIK/LookAtModifier

### DIFF
--- a/doc/classes/IKModifier3D.xml
+++ b/doc/classes/IKModifier3D.xml
@@ -40,6 +40,7 @@
 		<member name="mutable_bone_axes" type="bool" setter="set_mutable_bone_axes" getter="are_bone_axes_mutable" default="true">
 			If [code]true[/code], the solver retrieves the bone axis from the bone pose every frame.
 			If [code]false[/code], the solver retrieves the bone axis from the bone rest and caches it, which increases performance slightly, but position changes in the bone pose made before processing this [IKModifier3D] are ignored.
+			[b]Note:[/b] The rendered gizmo's forward vector (a line between parent and child joints) will only respect the bone pose when this modifier is active.
 		</member>
 	</members>
 </class>

--- a/doc/classes/IterateIK3D.xml
+++ b/doc/classes/IterateIK3D.xml
@@ -45,7 +45,7 @@
 				Rotation is done in the local space which is constructed by the bone direction (in general parent to child) as the +Y axis and [method get_joint_limitation_right_axis_vector] as the +X axis.
 				If the +X and +Y axes are not orthogonal, the +X axis is implicitly modified to make it orthogonal.
 				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the reference pose using the shortest arc that rotates the +Y axis of the reference pose to match the bone direction.
-				In here, the reference pose is the bone pose immediately before processing IK.
+				In here, the reference pose is the bone rest or bone pose immediately before processing IK depend on the [method is_joint_using_rest_for_limitation].
 			</description>
 		</method>
 		<method name="get_joint_rotation_axis" qualifiers="const">
@@ -70,6 +70,14 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the target node that the end bone is trying to reach.
+			</description>
+		</method>
+		<method name="is_joint_using_rest_for_limitation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<description>
+				Returns whether the limitation at [param joint] in the bone chain's joint list is applied based on the [method Skeleton3D.get_bone_rest].
 			</description>
 		</method>
 		<method name="set_joint_limitation">
@@ -122,6 +130,7 @@
 				The axes are based on the reference pose's space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
 				In here, the reference pose is the bone pose immediately before processing IK.
 				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [ChainIK3D] does not factor in twisting forces.
+				[b]Note:[/b] Since [IterateIK3D] never modifies the twist, the twist is not fixed by [method set_joint_rotation_axis] even if [method is_joint_using_rest_for_limitation] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_rotation_axis_vector">
@@ -133,6 +142,17 @@
 				Sets the rotation axis vector for the specified joint in the bone chain.
 				This vector is normalized by an internal process and represents the axis around which the bone chain can rotate.
 				If the vector length is [code]0[/code], it is considered synonymous with [constant SkeletonModifier3D.ROTATION_AXIS_ALL].
+			</description>
+		</method>
+		<method name="set_joint_use_rest_for_limitation">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<param index="2" name="enabled" type="bool" />
+			<description>
+				Sets whether the limitation and the rotation axis at [param joint] in the bone chain's joint list are applied based on the [method Skeleton3D.get_bone_rest]. See also [method set_joint_rotation_axis].
+				[b]Note:[/b] The limitation is applied to the rotation computed by this modifier. If the reference pose is rotated around the same axis, the limitation behaves as if it also limits the rotation of the reference pose. A rotation that this modifier does not change, such as the twist, is not limited.
+				[b]Note:[/b] The rendered gizmo's limitation shape will only respect the reference pose when this option is [code]false[/code] and the modifier is active.
 			</description>
 		</method>
 		<method name="set_target_node">

--- a/doc/classes/IterateIK3D.xml
+++ b/doc/classes/IterateIK3D.xml
@@ -45,7 +45,7 @@
 				Rotation is done in the local space which is constructed by the bone direction (in general parent to child) as the +Y axis and [method get_joint_limitation_right_axis_vector] as the +X axis.
 				If the +X and +Y axes are not orthogonal, the +X axis is implicitly modified to make it orthogonal.
 				Also, if the length of [method get_joint_limitation_right_axis_vector] is zero, the space is created by rotating the reference pose using the shortest arc that rotates the +Y axis of the reference pose to match the bone direction.
-				In here, the reference pose is the bone pose immediately before processing IK.
+				In here, the reference pose is the bone rest or bone pose immediately before processing IK depending on the [method is_joint_using_rest_for_limitation].
 			</description>
 		</method>
 		<method name="get_joint_rotation_axis" qualifiers="const">
@@ -70,6 +70,14 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the target node that the end bone is trying to reach.
+			</description>
+		</method>
+		<method name="is_joint_using_rest_for_limitation" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<description>
+				Returns whether the limitation at [param joint] in the bone chain's joint list is applied based on the [method Skeleton3D.get_bone_rest].
 			</description>
 		</method>
 		<method name="set_joint_limitation">
@@ -122,6 +130,7 @@
 				The axes are based on the reference pose's space, if [param axis] is [constant SkeletonModifier3D.ROTATION_AXIS_CUSTOM], you can specify any axis.
 				In here, the reference pose is the bone pose immediately before processing IK.
 				[b]Note:[/b] The rotation axis and the forward vector shouldn't be colinear to avoid unintended rotation since [ChainIK3D] does not factor in twisting forces.
+				[b]Note:[/b] Since [IterateIK3D] never modifies the twist, the twist is not fixed by [method set_joint_rotation_axis] even if [method is_joint_using_rest_for_limitation] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_joint_rotation_axis_vector">
@@ -133,6 +142,17 @@
 				Sets the rotation axis vector for the specified joint in the bone chain.
 				This vector is normalized by an internal process and represents the axis around which the bone chain can rotate.
 				If the vector length is [code]0[/code], it is considered synonymous with [constant SkeletonModifier3D.ROTATION_AXIS_ALL].
+			</description>
+		</method>
+		<method name="set_joint_use_rest_for_limitation">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="joint" type="int" />
+			<param index="2" name="enabled" type="bool" />
+			<description>
+				Sets whether the limitation and the rotation axis at [param joint] in the bone chain's joint list are applied based on the [method Skeleton3D.get_bone_rest]. See also [method set_joint_rotation_axis].
+				[b]Note:[/b] The limitation is applied to the rotation computed by this modifier. If the reference pose is rotated around the same axis, the limitation behaves as if it also limits the rotation of the reference pose. A rotation that this modifier does not change, such as the twist, is not limited.
+				[b]Note:[/b] The rendered gizmo's limitation shape will only respect the reference pose when this option is [code]false[/code] and the modifier is active.
 			</description>
 		</method>
 		<method name="set_target_node">

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -90,10 +90,10 @@
 		</member>
 		<member name="primary_rotation_axis" type="int" setter="set_primary_rotation_axis" getter="get_primary_rotation_axis" enum="Vector3.Axis" default="1">
 			The axis of the first rotation. This [SkeletonModifier3D] works by compositing the rotation by Euler angles to prevent to rotate the [member forward_axis].
+			[b]Note:[/b] Since [LookAtModifier3D] never modifies the twist when [member use_secondary_rotation] is [code]false[/code] and [member relative] is [code]true[/code], the twist is not fixed even if [member use_rest_for_limitation] is [code]true[/code].
 		</member>
 		<member name="relative" type="bool" setter="set_relative" getter="is_relative" default="false">
 			The relative option. If [code]true[/code], the rotation is applied relative to the pose. If [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [LookAtModifier3D]'s result.
-			[b]Note:[/b] This option affects the base angle for [member use_angle_limitation]. Since the [LookAtModifier3D] relies strongly on Euler rotation, the axis that determines the limitation and the actual rotation are strongly tied together.
 		</member>
 		<member name="secondary_damp_threshold" type="float" setter="set_secondary_damp_threshold" getter="get_secondary_damp_threshold">
 			The threshold to start damping for [member secondary_limit_angle].
@@ -115,7 +115,7 @@
 		</member>
 		<member name="symmetry_limitation" type="bool" setter="set_symmetry_limitation" getter="is_limitation_symmetry">
 			If [code]true[/code], the limitations are spread from the bone symmetrically.
-			If [code]false[/code], the limitation can be specified separately for each side of the bone rest.
+			If [code]false[/code], the limitation can be specified separately for each side of the reference pose. In here, the reference pose is the bone pose immediately before processing this modifier.
 		</member>
 		<member name="target_node" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
 			The [NodePath] to the node that is the target for the look at modification. This node is what the modification will rotate the bone to.
@@ -127,6 +127,11 @@
 			If [code]true[/code], limits the amount of rotation. For example, this helps to prevent a character's neck from rotating 360 degrees.
 			[b]Note:[/b] As with [AnimationTree] blending, interpolation is provided that favors [method Skeleton3D.get_bone_rest] or [method Skeleton3D.get_bone_pose] depends on the [member relative] option. This means that interpolation does not select the shortest path in some cases.
 			[b]Note:[/b] Some values for [member transition_type] (such as [constant Tween.TRANS_BACK], [constant Tween.TRANS_ELASTIC], and [constant Tween.TRANS_SPRING]) may exceed the limitations. If interpolation occurs while overshooting the limitations, the result might not respect the bone rest.
+		</member>
+		<member name="use_rest_for_limitation" type="bool" setter="set_use_rest_for_limitation" getter="is_using_rest_for_limitation">
+			If [code]true[/code], the angle limitation and the rotation axes are applied based on the [method Skeleton3D.get_bone_rest].
+			If [code]false[/code], the angle limitation is applied based on the reference pose. In here, the reference pose is the bone pose immediately before processing this modifier.
+			[b]Note:[/b] The limitation is applied to the rotation computed by this modifier. If the reference pose is rotated around the same axis, the limitation behaves as if it also limits the rotation of the reference pose. A rotation that this modifier does not change, such as the twist, is not limited.
 		</member>
 		<member name="use_secondary_rotation" type="bool" setter="set_use_secondary_rotation" getter="is_using_secondary_rotation" default="true">
 			If [code]true[/code], provides rotation by two axes.

--- a/scene/3d/iterate_ik_3d.cpp
+++ b/scene/3d/iterate_ik_3d.cpp
@@ -63,6 +63,8 @@ bool IterateIK3D::_set(const StringName &p_path, const Variant &p_value) {
 				} else {
 					return false;
 				}
+			} else if (prop == "use_rest_for_limitation") {
+				set_joint_use_rest_for_limitation(which, idx, p_value);
 			} else {
 				return false;
 			}
@@ -103,6 +105,8 @@ bool IterateIK3D::_get(const StringName &p_path, Variant &r_ret) const {
 				} else {
 					return false;
 				}
+			} else if (prop == "use_rest_for_limitation") {
+				r_ret = is_joint_using_rest_for_limitation(which, idx);
 			} else {
 				return false;
 			}
@@ -126,6 +130,7 @@ void IterateIK3D::_get_property_list(List<PropertyInfo> *p_list) const {
 			props.push_back(PropertyInfo(Variant::INT, joint_path + "limitation/right_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_secondary_direction()));
 			props.push_back(PropertyInfo(Variant::VECTOR3, joint_path + "limitation/right_axis_vector"));
 			props.push_back(PropertyInfo(Variant::QUATERNION, joint_path + "limitation/rotation_offset"));
+			props.push_back(PropertyInfo(Variant::BOOL, joint_path + "use_rest_for_limitation"));
 		}
 	}
 
@@ -145,6 +150,9 @@ void IterateIK3D::_validate_dynamic_prop(PropertyInfo &p_property) const {
 		// Joints option.
 		if (split[2] == "joints" && split.size() > 4) {
 			if (split[4] == "rotation_axis_vector" && get_joint_rotation_axis(which, joint) != ROTATION_AXIS_CUSTOM) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
+			if (split[4] == "use_rest_for_limitation" && get_joint_limitation(which, joint).is_null() && get_joint_rotation_axis(which, joint) == ROTATION_AXIS_ALL) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 			if (split[4] == "limitation" && split.size() > 5) {
@@ -258,12 +266,14 @@ Vector3 IterateIK3D::get_joint_rotation_axis_vector(int p_index, int p_joint) co
 	return joint_settings[p_joint]->get_rotation_axis_vector();
 }
 
+#ifdef TOOLS_ENABLED
 Quaternion IterateIK3D::get_joint_limitation_space(int p_index, int p_joint, const Vector3 &p_forward) const {
 	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Quaternion());
 	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), Quaternion());
 	return joint_settings[p_joint]->get_limitation_space(p_forward);
 }
+#endif // TOOLS_ENABLED
 
 void IterateIK3D::set_joint_limitation(int p_index, int p_joint, const Ref<JointLimitation3D> &p_limitation) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
@@ -327,6 +337,21 @@ Quaternion IterateIK3D::get_joint_limitation_rotation_offset(int p_index, int p_
 	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), Quaternion());
 	return joint_settings[p_joint]->limitation_rotation_offset;
+}
+
+void IterateIK3D::set_joint_use_rest_for_limitation(int p_index, int p_joint, bool p_enabled) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
+	joint_settings[p_joint]->use_rest_for_limitation = p_enabled;
+	_update_joint_limitation(p_index, p_joint);
+}
+
+bool IterateIK3D::is_joint_using_rest_for_limitation(int p_index, int p_joint) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), false);
+	return joint_settings[p_joint]->use_rest_for_limitation;
 }
 
 void IterateIK3D::_set_joint_count(int p_index, int p_count) {
@@ -396,6 +421,8 @@ void IterateIK3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joint_limitation_right_axis_vector", "index", "joint"), &IterateIK3D::get_joint_limitation_right_axis_vector);
 	ClassDB::bind_method(D_METHOD("set_joint_limitation_rotation_offset", "index", "joint", "offset"), &IterateIK3D::set_joint_limitation_rotation_offset);
 	ClassDB::bind_method(D_METHOD("get_joint_limitation_rotation_offset", "index", "joint"), &IterateIK3D::get_joint_limitation_rotation_offset);
+	ClassDB::bind_method(D_METHOD("set_joint_use_rest_for_limitation", "index", "joint", "enabled"), &IterateIK3D::set_joint_use_rest_for_limitation);
+	ClassDB::bind_method(D_METHOD("is_joint_using_rest_for_limitation", "index", "joint"), &IterateIK3D::is_joint_using_rest_for_limitation);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_iterations", PROPERTY_HINT_RANGE, "0,100,or_greater"), "set_max_iterations", "get_max_iterations");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_distance", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater"), "set_min_distance", "get_min_distance");
@@ -509,6 +536,34 @@ void IterateIK3D::_update_bone_axis(Skeleton3D *p_skeleton, int p_index) {
 #endif // TOOLS_ENABLED
 }
 
+#ifdef TOOLS_ENABLED
+void IterateIK3D::_update_limitation_gizmo(Skeleton3D *p_skeleton, int p_index) {
+	IterateIK3DSetting *setting = iterate_settings[p_index];
+	bool changed = false;
+	for (uint32_t j = 0; j < setting->joints.size(); j++) {
+		IterateIK3DJointSetting *joint_setting = setting->joint_settings[j];
+		IKModifier3DSolverInfo *solver_info = setting->solver_info_list[j];
+		if (!joint_setting || joint_setting->limitation.is_null() || !solver_info) {
+			continue;
+		}
+		Quaternion offset;
+		if (!joint_setting->use_rest_for_limitation) {
+			int bone = setting->joints[j].bone;
+			if (bone >= 0 && bone < p_skeleton->get_bone_count()) {
+				offset = p_skeleton->get_bone_rest(bone).basis.get_rotation_quaternion().inverse() * solver_info->current_lrest;
+			}
+		}
+		if (!joint_setting->limitation_gizmo_offset.is_equal_approx(offset)) {
+			joint_setting->limitation_gizmo_offset = offset;
+			changed = true;
+		}
+	}
+	if (changed) {
+		_make_gizmo_dirty();
+	}
+}
+#endif // TOOLS_ENABLED
+
 void IterateIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
 	min_distance_squared = min_distance * min_distance;
 	for (uint32_t i = 0; i < settings.size(); i++) {
@@ -517,7 +572,11 @@ void IterateIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
 		if (!target || iterate_settings[i]->chain.is_empty()) {
 			continue; // Abort.
 		}
-		iterate_settings[i]->cache_current_joint_rotations(p_skeleton); // Iterate over first to detect parent (outside of the chain) bone pose changes.
+		iterate_settings[i]->cache_current_joint_rotations(p_skeleton, Math::PI); // Iterate over first to detect parent (outside of the chain) bone pose changes.
+
+#ifdef TOOLS_ENABLED
+		_update_limitation_gizmo(p_skeleton, i);
+#endif // TOOLS_ENABLED
 
 		Vector3 destination = cached_space.affine_inverse().xform(target->get_global_transform_interpolated().origin);
 		_process_joints(p_delta, p_skeleton, iterate_settings[i], destination);

--- a/scene/3d/iterate_ik_3d.cpp
+++ b/scene/3d/iterate_ik_3d.cpp
@@ -63,6 +63,8 @@ bool IterateIK3D::_set(const StringName &p_path, const Variant &p_value) {
 				} else {
 					return false;
 				}
+			} else if (prop == "use_rest_for_limitation") {
+				set_joint_use_rest_for_limitation(which, idx, p_value);
 			} else {
 				return false;
 			}
@@ -103,6 +105,8 @@ bool IterateIK3D::_get(const StringName &p_path, Variant &r_ret) const {
 				} else {
 					return false;
 				}
+			} else if (prop == "use_rest_for_limitation") {
+				r_ret = is_joint_using_rest_for_limitation(which, idx);
 			} else {
 				return false;
 			}
@@ -126,6 +130,7 @@ void IterateIK3D::_get_property_list(List<PropertyInfo> *p_list) const {
 			props.push_back(PropertyInfo(Variant::INT, joint_path + "limitation/right_axis", PROPERTY_HINT_ENUM, SkeletonModifier3D::get_hint_secondary_direction()));
 			props.push_back(PropertyInfo(Variant::VECTOR3, joint_path + "limitation/right_axis_vector"));
 			props.push_back(PropertyInfo(Variant::QUATERNION, joint_path + "limitation/rotation_offset"));
+			props.push_back(PropertyInfo(Variant::BOOL, joint_path + "use_rest_for_limitation"));
 		}
 	}
 
@@ -145,6 +150,9 @@ void IterateIK3D::_validate_dynamic_prop(PropertyInfo &p_property) const {
 		// Joints option.
 		if (split[2] == "joints" && split.size() > 4) {
 			if (split[4] == "rotation_axis_vector" && get_joint_rotation_axis(which, joint) != ROTATION_AXIS_CUSTOM) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
+			if (split[4] == "use_rest_for_limitation" && get_joint_limitation(which, joint).is_null() && get_joint_rotation_axis(which, joint) == ROTATION_AXIS_ALL) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 			if (split[4] == "limitation" && split.size() > 5) {
@@ -258,12 +266,14 @@ Vector3 IterateIK3D::get_joint_rotation_axis_vector(int p_index, int p_joint) co
 	return joint_settings[p_joint]->get_rotation_axis_vector();
 }
 
+#ifdef TOOLS_ENABLED
 Quaternion IterateIK3D::get_joint_limitation_space(int p_index, int p_joint, const Vector3 &p_forward) const {
 	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Quaternion());
 	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), Quaternion());
 	return joint_settings[p_joint]->get_limitation_space(p_forward);
 }
+#endif // TOOLS_ENABLED
 
 void IterateIK3D::set_joint_limitation(int p_index, int p_joint, const Ref<JointLimitation3D> &p_limitation) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
@@ -327,6 +337,21 @@ Quaternion IterateIK3D::get_joint_limitation_rotation_offset(int p_index, int p_
 	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
 	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), Quaternion());
 	return joint_settings[p_joint]->limitation_rotation_offset;
+}
+
+void IterateIK3D::set_joint_use_rest_for_limitation(int p_index, int p_joint, bool p_enabled) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	ERR_FAIL_INDEX(p_joint, (int)joint_settings.size());
+	joint_settings[p_joint]->use_rest_for_limitation = p_enabled;
+	_update_joint_limitation(p_index, p_joint);
+}
+
+bool IterateIK3D::is_joint_using_rest_for_limitation(int p_index, int p_joint) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
+	const LocalVector<IterateIK3DJointSetting *> &joint_settings = iterate_settings[p_index]->joint_settings;
+	ERR_FAIL_INDEX_V(p_joint, (int)joint_settings.size(), false);
+	return joint_settings[p_joint]->use_rest_for_limitation;
 }
 
 void IterateIK3D::_set_joint_count(int p_index, int p_count) {
@@ -396,6 +421,8 @@ void IterateIK3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joint_limitation_right_axis_vector", "index", "joint"), &IterateIK3D::get_joint_limitation_right_axis_vector);
 	ClassDB::bind_method(D_METHOD("set_joint_limitation_rotation_offset", "index", "joint", "offset"), &IterateIK3D::set_joint_limitation_rotation_offset);
 	ClassDB::bind_method(D_METHOD("get_joint_limitation_rotation_offset", "index", "joint"), &IterateIK3D::get_joint_limitation_rotation_offset);
+	ClassDB::bind_method(D_METHOD("set_joint_use_rest_for_limitation", "index", "joint", "enabled"), &IterateIK3D::set_joint_use_rest_for_limitation);
+	ClassDB::bind_method(D_METHOD("is_joint_using_rest_for_limitation", "index", "joint"), &IterateIK3D::is_joint_using_rest_for_limitation);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_iterations", PROPERTY_HINT_RANGE, "0,100,or_greater"), "set_max_iterations", "get_max_iterations");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_distance", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater"), "set_min_distance", "get_min_distance");
@@ -509,6 +536,34 @@ void IterateIK3D::_update_bone_axis(Skeleton3D *p_skeleton, int p_index) {
 #endif // TOOLS_ENABLED
 }
 
+#ifdef TOOLS_ENABLED
+void IterateIK3D::_update_limitation_gizmo(Skeleton3D *p_skeleton, int p_index) {
+	IterateIK3DSetting *setting = iterate_settings[p_index];
+	bool changed = false;
+	for (uint32_t j = 0; j < setting->joints.size(); j++) {
+		IterateIK3DJointSetting *joint_setting = setting->joint_settings[j];
+		IKModifier3DSolverInfo *solver_info = setting->solver_info_list[j];
+		if (!joint_setting || joint_setting->limitation.is_null() || !solver_info) {
+			continue;
+		}
+		Quaternion offset;
+		if (!joint_setting->use_rest_for_limitation) {
+			int bone = setting->joints[j].bone;
+			if (bone >= 0 && bone < p_skeleton->get_bone_count()) {
+				offset = p_skeleton->get_bone_rest(bone).basis.get_rotation_quaternion().inverse() * solver_info->current_lrest;
+			}
+		}
+		if (!joint_setting->limitation_gizmo_offset.is_equal_approx(offset)) {
+			joint_setting->limitation_gizmo_offset = offset;
+			changed = true;
+		}
+	}
+	if (changed) {
+		_make_gizmo_dirty();
+	}
+}
+#endif // TOOLS_ENABLED
+
 void IterateIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
 	min_distance_squared = min_distance * min_distance;
 	for (uint32_t i = 0; i < settings.size(); i++) {
@@ -518,6 +573,10 @@ void IterateIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
 			continue; // Abort.
 		}
 		iterate_settings[i]->cache_current_joint_rotations(p_skeleton); // Iterate over first to detect parent (outside of the chain) bone pose changes.
+
+#ifdef TOOLS_ENABLED
+		_update_limitation_gizmo(p_skeleton, i);
+#endif // TOOLS_ENABLED
 
 		Vector3 destination = cached_space.affine_inverse().xform(target->get_global_transform_interpolated().origin);
 		_process_joints(p_delta, p_skeleton, iterate_settings[i], destination);

--- a/scene/3d/iterate_ik_3d.h
+++ b/scene/3d/iterate_ik_3d.h
@@ -45,6 +45,8 @@ public:
 		SecondaryDirection limitation_right_axis = SECONDARY_DIRECTION_NONE;
 		Vector3 limitation_right_axis_vector = Vector3(1, 0, 0);
 		Quaternion limitation_rotation_offset;
+		Quaternion limitation_offset_delta;
+		bool use_rest_for_limitation = false;
 
 		// Rotation axis.
 		Vector3 get_rotation_axis_vector() const {
@@ -100,19 +102,24 @@ public:
 			return ret;
 		}
 
+#ifdef TOOLS_ENABLED
+		Quaternion limitation_gizmo_offset;
 		Quaternion get_limitation_space(const Vector3 &p_local_forward) const {
 			if (limitation.is_null()) {
 				return Quaternion();
 			}
-			return limitation->make_space(p_local_forward, get_limitation_right_axis_vector(), limitation_rotation_offset);
+			return limitation_gizmo_offset * limitation->make_space(p_local_forward, get_limitation_right_axis_vector(), limitation_rotation_offset);
 		}
+#endif // TOOLS_ENABLED
 
 		// Get rotation around normal vector (normal vector is rotation axis).
 		Vector3 get_projected_rotation(const Quaternion &p_offset, const Vector3 &p_vector) const {
 			ERR_FAIL_COND_V(rotation_axis == ROTATION_AXIS_ALL, p_vector);
 			const double ALMOST_ONE = 1.0 - CMP_EPSILON;
 			Vector3 axis = get_rotation_axis_vector().normalized();
-			Vector3 local_vector = p_offset.xform_inv(p_vector);
+			// If use_rest_for_limitation is enabled, reference pose is bone_rest instead of the bone_pose immediately before processing IK.
+			Quaternion offset = p_offset * limitation_offset_delta;
+			Vector3 local_vector = offset.xform_inv(p_vector);
 			double length = local_vector.length();
 			Vector3 projected = snap_vector_to_plane(axis, local_vector.normalized());
 			if (!Math::is_zero_approx(length)) {
@@ -121,19 +128,20 @@ public:
 			if (Math::abs(local_vector.normalized().dot(axis)) > ALMOST_ONE) {
 				return p_vector;
 			}
-			return p_offset.xform(projected);
+			return offset.xform(projected);
 		}
 
 		// Get limited rotation from forward axis in local rest space.
 		Vector3 get_limited_rotation(const Quaternion &p_offset, const Vector3 &p_vector, const Vector3 &p_forward) const {
 			ERR_FAIL_COND_V(limitation.is_null(), p_vector);
-			Vector3 local_vector = p_offset.xform_inv(p_vector);
+			Quaternion offset = p_offset * limitation_offset_delta;
+			Vector3 local_vector = offset.xform_inv(p_vector);
 			float length = local_vector.length();
 			if (Math::is_zero_approx(length)) {
 				return p_vector;
 			}
 			Vector3 limited = limitation->solve(p_forward, get_limitation_right_axis_vector(), limitation_rotation_offset, local_vector.normalized()) * length;
-			return p_offset.xform(limited);
+			return offset.xform(limited);
 		}
 
 		~IterateIK3DJointSetting() {
@@ -167,11 +175,32 @@ public:
 				solver_info->current_lrest = p_skeleton->get_bone_pose(joints[HEAD].bone).basis.get_rotation_quaternion();
 				solver_info->current_grest = parent_gpose * solver_info->current_lrest;
 				solver_info->current_grest.normalize();
+				// If the joint's use_rest_for_limitation is true, cancel relative bone_pose from the bone_rest.
+				if (joint_settings[HEAD]->use_rest_for_limitation) {
+					joint_settings[HEAD]->limitation_offset_delta = (solver_info->current_lrest.inverse() * p_skeleton->get_bone_rest(joints[HEAD].bone).basis.get_rotation_quaternion()).normalized();
+				} else {
+					joint_settings[HEAD]->limitation_offset_delta = Quaternion();
+				}
 				Vector3 from = solver_info->forward_vector;
 				Vector3 to = solver_info->current_grest.xform_inv(solver_info->current_vector).normalized();
 				Quaternion prev = solver_info->current_lpose;
 				if (joint_settings[HEAD]->rotation_axis == ROTATION_AXIS_ALL) {
 					solver_info->current_lpose = solver_info->current_lrest * get_swing(Quaternion(from, to), from);
+				} else if (joint_settings[HEAD]->use_rest_for_limitation) {
+					Quaternion pose_from_rest = joint_settings[HEAD]->limitation_offset_delta.inverse();
+					Vector3 axis = joint_settings[HEAD]->get_rotation_axis_vector().normalized();
+					Vector3 to_rest = snap_vector_to_plane(axis, pose_from_rest.xform(to));
+					if (to_rest.is_zero_approx()) {
+						to_rest = from;
+					} else {
+						to_rest.normalize();
+					}
+					Quaternion twist;
+					if (!from.is_zero_approx()) {
+						Vector3 forward_nrm = from.normalized();
+						twist = Quaternion(forward_nrm, get_roll_angle(pose_from_rest, forward_nrm));
+					}
+					solver_info->current_lpose = solver_info->current_lrest * joint_settings[HEAD]->limitation_offset_delta * get_from_to_rotation_by_axis(from, to_rest, axis) * twist;
 				} else {
 					// To stabilize rotation path especially nearely 180deg.
 					solver_info->current_lpose = solver_info->current_lrest * get_from_to_rotation_by_axis(from, to, joint_settings[HEAD]->get_rotation_axis_vector().normalized());
@@ -268,6 +297,9 @@ protected:
 
 	virtual void _make_simulation_dirty(int p_index) override;
 	virtual void _update_bone_axis(Skeleton3D *p_skeleton, int p_index) override;
+#ifdef TOOLS_ENABLED
+	void _update_limitation_gizmo(Skeleton3D *p_skeleton, int p_index);
+#endif // TOOLS_ENABLED
 
 	virtual void _process_ik(Skeleton3D *p_skeleton, double p_delta) override;
 	void _process_joints(double p_delta, Skeleton3D *p_skeleton, IterateIK3DSetting *p_setting, const Vector3 &p_target_destination);
@@ -321,11 +353,12 @@ public:
 	Vector3 get_joint_limitation_right_axis_vector(int p_index, int p_joint) const;
 	void set_joint_limitation_rotation_offset(int p_index, int p_joint, const Quaternion &p_offset);
 	Quaternion get_joint_limitation_rotation_offset(int p_index, int p_joint) const;
+	void set_joint_use_rest_for_limitation(int p_index, int p_joint, bool p_enabled);
+	bool is_joint_using_rest_for_limitation(int p_index, int p_joint) const;
 
 	// Helper.
-	Quaternion get_joint_limitation_space(int p_index, int p_joint, const Vector3 &p_forward) const;
-
 #ifdef TOOLS_ENABLED
+	Quaternion get_joint_limitation_space(int p_index, int p_joint, const Vector3 &p_forward) const;
 	virtual Vector3 get_bone_vector(int p_index, int p_joint) const override;
 #endif // TOOLS_ENABLED
 

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -61,7 +61,7 @@ void LookAtModifier3D::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if ((!use_angle_limitation &&
-				(p_property.name == "symmetry_limitation" || p_property.name.ends_with("limit_angle") || p_property.name.ends_with("damp_threshold"))) ||
+				(p_property.name == "symmetry_limitation" || p_property.name == "use_rest_for_limitation" || p_property.name.ends_with("limit_angle") || p_property.name.ends_with("damp_threshold"))) ||
 			(!use_secondary_rotation && p_property.name.begins_with("secondary_")) ||
 			(!symmetry_limitation && (p_property.name == "primary_limit_angle" || p_property.name == "primary_damp_threshold" || p_property.name == "secondary_limit_angle" || p_property.name == "secondary_damp_threshold")) ||
 			(symmetry_limitation && (p_property.name.begins_with("primary_positive") || p_property.name.begins_with("primary_negative") || p_property.name.begins_with("secondary_positive") || (p_property.name.begins_with("secondary_negative"))))) {
@@ -288,6 +288,14 @@ bool LookAtModifier3D::is_limitation_symmetry() const {
 	return symmetry_limitation;
 }
 
+void LookAtModifier3D::set_use_rest_for_limitation(bool p_enabled) {
+	use_rest_for_limitation = p_enabled;
+}
+
+bool LookAtModifier3D::is_using_rest_for_limitation() const {
+	return use_rest_for_limitation;
+}
+
 void LookAtModifier3D::set_primary_limit_angle(float p_angle) {
 	primary_limit_angle = p_angle;
 }
@@ -440,6 +448,8 @@ void LookAtModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_using_angle_limitation"), &LookAtModifier3D::is_using_angle_limitation);
 	ClassDB::bind_method(D_METHOD("set_symmetry_limitation", "enabled"), &LookAtModifier3D::set_symmetry_limitation);
 	ClassDB::bind_method(D_METHOD("is_limitation_symmetry"), &LookAtModifier3D::is_limitation_symmetry);
+	ClassDB::bind_method(D_METHOD("set_use_rest_for_limitation", "enabled"), &LookAtModifier3D::set_use_rest_for_limitation);
+	ClassDB::bind_method(D_METHOD("is_using_rest_for_limitation"), &LookAtModifier3D::is_using_rest_for_limitation);
 
 	ClassDB::bind_method(D_METHOD("set_primary_limit_angle", "angle"), &LookAtModifier3D::set_primary_limit_angle);
 	ClassDB::bind_method(D_METHOD("get_primary_limit_angle"), &LookAtModifier3D::get_primary_limit_angle);
@@ -497,6 +507,7 @@ void LookAtModifier3D::_bind_methods() {
 
 	ADD_GROUP("Angle Limitation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_angle_limitation"), "set_use_angle_limitation", "is_using_angle_limitation");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_rest_for_limitation"), "set_use_rest_for_limitation", "is_using_rest_for_limitation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "symmetry_limitation"), "set_symmetry_limitation", "is_limitation_symmetry");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "primary_limit_angle", PROPERTY_HINT_RANGE, "0,360,0.01,radians_as_degrees"), "set_primary_limit_angle", "get_primary_limit_angle");
@@ -542,6 +553,15 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 	is_within_limitations = true;
 	Vector3 prev_forward_vector = forward_vector;
 	Quaternion destination;
+	Quaternion interpolation_rest = bone_rest.basis.get_rotation_quaternion();
+	Quaternion bone_rest_rotation;
+	Quaternion current_twist;
+	if (use_rest_for_limitation) {
+		bone_rest_rotation = skeleton->get_bone_rest(bone).basis.get_rotation_quaternion();
+		Vector3 forward_axis_vector = get_vector_from_bone_axis(forward_axis);
+		Quaternion pose_from_rest = (bone_rest_rotation.inverse() * bone_rest.basis.get_rotation_quaternion()).normalized();
+		current_twist = Quaternion(forward_axis_vector, get_roll_angle(pose_from_rest, forward_axis_vector));
+	}
 	Node3D *target = Object::cast_to<Node3D>(get_node_or_null(target_node));
 	if (!target) {
 		destination = skeleton->get_bone_pose_rotation(bone);
@@ -564,6 +584,12 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 		if (forward_vector_nrm.abs().is_equal_approx(get_vector_from_axis(primary_rotation_axis))) {
 			destination = skeleton->get_bone_pose_rotation(bone);
 			forward_vector = Vector3(0, 0, 0); // The zero-vector to be used for checking in the line immediately below to avoid animation glitch.
+		} else if (use_rest_for_limitation) {
+			Transform3D rest_transform = bone_rest;
+			rest_transform.basis = Basis(bone_rest_rotation);
+			destination = (look_at_with_axes(rest_transform).basis.get_rotation_quaternion() * current_twist).normalized();
+			forward_vector = bone_rest_rotation.xform_inv(forward_vector_nrm);
+			interpolation_rest = bone_rest_rotation * current_twist;
 		} else {
 			destination = look_at_with_axes(bone_rest).basis.get_rotation_quaternion();
 			forward_vector = bone_rest.basis.xform_inv(forward_vector_nrm); // Forward vector in the "current" bone rest.
@@ -601,18 +627,20 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 	// Do time-based interpolation.
 	if (remaining > 0) {
 		remaining = MAX(0, remaining - time_step * p_delta);
+		Quaternion from = from_q * from_twist.inverse() * current_twist;
 		if (is_flippable) {
 			// Interpolate through the rest same as AnimationTree blending for preventing to penetrate the bone into the body.
-			Quaternion rest = bone_rest.basis.get_rotation_quaternion();
+			Quaternion rest = interpolation_rest;
 			float weight = Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0);
-			destination = Animation::interpolate_via_rest(Animation::interpolate_via_rest(rest, from_q, 1 - weight, rest), destination, weight, rest);
+			destination = Animation::interpolate_via_rest(Animation::interpolate_via_rest(rest, from, 1 - weight, rest), destination, weight, rest);
 		} else {
-			destination = from_q.slerp(destination, Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0));
+			destination = from.slerp(destination, Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0));
 		}
 	}
 
 	skeleton->set_bone_pose_rotation(bone, destination);
 	prev_q = destination;
+	prev_twist = current_twist;
 }
 
 bool LookAtModifier3D::is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, Vector3::Axis p_flipping_axis, Vector3::Axis p_check_axis, bool p_check_plane) const {
@@ -794,5 +822,6 @@ void LookAtModifier3D::init_transition() {
 		return;
 	}
 	from_q = prev_q;
+	from_twist = prev_twist;
 	remaining = 1.0;
 }

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -61,10 +61,12 @@ void LookAtModifier3D::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if ((!use_angle_limitation &&
-				(p_property.name == "symmetry_limitation" || p_property.name.ends_with("limit_angle") || p_property.name.ends_with("damp_threshold"))) ||
+				(p_property.name == "symmetry_limitation" || p_property.name == "use_rest_for_limitation" || p_property.name.ends_with("limit_angle") || p_property.name.ends_with("damp_threshold"))) ||
 			(!use_secondary_rotation && p_property.name.begins_with("secondary_")) ||
 			(!symmetry_limitation && (p_property.name == "primary_limit_angle" || p_property.name == "primary_damp_threshold" || p_property.name == "secondary_limit_angle" || p_property.name == "secondary_damp_threshold")) ||
 			(symmetry_limitation && (p_property.name.begins_with("primary_positive") || p_property.name.begins_with("primary_negative") || p_property.name.begins_with("secondary_positive") || (p_property.name.begins_with("secondary_negative"))))) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	} else if (p_property.name == "use_rest_for_limitation" && !relative) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
@@ -288,6 +290,14 @@ bool LookAtModifier3D::is_limitation_symmetry() const {
 	return symmetry_limitation;
 }
 
+void LookAtModifier3D::set_use_rest_for_limitation(bool p_enabled) {
+	use_rest_for_limitation = p_enabled;
+}
+
+bool LookAtModifier3D::is_using_rest_for_limitation() const {
+	return use_rest_for_limitation;
+}
+
 void LookAtModifier3D::set_primary_limit_angle(float p_angle) {
 	primary_limit_angle = p_angle;
 }
@@ -440,6 +450,8 @@ void LookAtModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_using_angle_limitation"), &LookAtModifier3D::is_using_angle_limitation);
 	ClassDB::bind_method(D_METHOD("set_symmetry_limitation", "enabled"), &LookAtModifier3D::set_symmetry_limitation);
 	ClassDB::bind_method(D_METHOD("is_limitation_symmetry"), &LookAtModifier3D::is_limitation_symmetry);
+	ClassDB::bind_method(D_METHOD("set_use_rest_for_limitation", "enabled"), &LookAtModifier3D::set_use_rest_for_limitation);
+	ClassDB::bind_method(D_METHOD("is_using_rest_for_limitation"), &LookAtModifier3D::is_using_rest_for_limitation);
 
 	ClassDB::bind_method(D_METHOD("set_primary_limit_angle", "angle"), &LookAtModifier3D::set_primary_limit_angle);
 	ClassDB::bind_method(D_METHOD("get_primary_limit_angle"), &LookAtModifier3D::get_primary_limit_angle);
@@ -497,6 +509,7 @@ void LookAtModifier3D::_bind_methods() {
 
 	ADD_GROUP("Angle Limitation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_angle_limitation"), "set_use_angle_limitation", "is_using_angle_limitation");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_rest_for_limitation"), "set_use_rest_for_limitation", "is_using_rest_for_limitation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "symmetry_limitation"), "set_symmetry_limitation", "is_limitation_symmetry");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "primary_limit_angle", PROPERTY_HINT_RANGE, "0,360,0.01,radians_as_degrees"), "set_primary_limit_angle", "get_primary_limit_angle");
@@ -542,6 +555,15 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 	is_within_limitations = true;
 	Vector3 prev_forward_vector = forward_vector;
 	Quaternion destination;
+	Quaternion interpolation_rest = bone_rest.basis.get_rotation_quaternion();
+	Quaternion bone_rest_rotation;
+	Quaternion current_twist;
+	if (use_rest_for_limitation) {
+		bone_rest_rotation = skeleton->get_bone_rest(bone).basis.get_rotation_quaternion();
+		Vector3 forward_axis_vector = get_vector_from_bone_axis(forward_axis);
+		Quaternion pose_from_rest = (bone_rest_rotation.inverse() * bone_rest.basis.get_rotation_quaternion()).normalized();
+		current_twist = Quaternion(forward_axis_vector, get_roll_angle(pose_from_rest, forward_axis_vector));
+	}
 	Node3D *target = Object::cast_to<Node3D>(get_node_or_null(target_node));
 	if (!target) {
 		destination = skeleton->get_bone_pose_rotation(bone);
@@ -564,6 +586,12 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 		if (forward_vector_nrm.abs().is_equal_approx(get_vector_from_axis(primary_rotation_axis))) {
 			destination = skeleton->get_bone_pose_rotation(bone);
 			forward_vector = Vector3(0, 0, 0); // The zero-vector to be used for checking in the line immediately below to avoid animation glitch.
+		} else if (use_rest_for_limitation) {
+			Transform3D rest_transform = bone_rest;
+			rest_transform.basis = Basis(bone_rest_rotation);
+			destination = (look_at_with_axes(rest_transform).basis.get_rotation_quaternion() * current_twist).normalized();
+			forward_vector = bone_rest_rotation.xform_inv(forward_vector_nrm);
+			interpolation_rest = bone_rest_rotation * current_twist;
 		} else {
 			destination = look_at_with_axes(bone_rest).basis.get_rotation_quaternion();
 			forward_vector = bone_rest.basis.xform_inv(forward_vector_nrm); // Forward vector in the "current" bone rest.
@@ -601,18 +629,20 @@ void LookAtModifier3D::_process_modification(double p_delta) {
 	// Do time-based interpolation.
 	if (remaining > 0) {
 		remaining = MAX(0, remaining - time_step * p_delta);
+		Quaternion from = from_q * from_twist.inverse() * current_twist;
 		if (is_flippable) {
 			// Interpolate through the rest same as AnimationTree blending for preventing to penetrate the bone into the body.
-			Quaternion rest = bone_rest.basis.get_rotation_quaternion();
+			Quaternion rest = interpolation_rest;
 			float weight = Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0);
-			destination = Animation::interpolate_via_rest(Animation::interpolate_via_rest(rest, from_q, 1 - weight, rest), destination, weight, rest);
+			destination = Animation::interpolate_via_rest(Animation::interpolate_via_rest(rest, from, 1 - weight, rest), destination, weight, rest);
 		} else {
-			destination = from_q.slerp(destination, Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0));
+			destination = from.slerp(destination, Tween::run_equation(transition_type, ease_type, 1 - remaining, 0.0, 1.0, 1.0));
 		}
 	}
 
 	skeleton->set_bone_pose_rotation(bone, destination);
 	prev_q = destination;
+	prev_twist = current_twist;
 }
 
 bool LookAtModifier3D::is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, Vector3::Axis p_flipping_axis, Vector3::Axis p_check_axis, bool p_check_plane) const {
@@ -794,5 +824,6 @@ void LookAtModifier3D::init_transition() {
 		return;
 	}
 	from_q = prev_q;
+	from_twist = prev_twist;
 	remaining = 1.0;
 }

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -71,6 +71,7 @@ private:
 
 	bool use_angle_limitation = false;
 	bool symmetry_limitation = true;
+	bool use_rest_for_limitation = false;
 
 	float primary_limit_angle = Math::TAU;
 	float primary_damp_threshold = 1.0f;
@@ -91,6 +92,8 @@ private:
 	// For time-based interpolation.
 	Quaternion from_q;
 	Quaternion prev_q;
+	Quaternion from_twist;
+	Quaternion prev_twist;
 
 	float remaining = 0;
 	float time_step = 1.0;
@@ -155,6 +158,8 @@ public:
 	bool is_using_angle_limitation() const;
 	void set_symmetry_limitation(bool p_enabled);
 	bool is_limitation_symmetry() const;
+	void set_use_rest_for_limitation(bool p_enabled);
+	bool is_using_rest_for_limitation() const;
 
 	void set_primary_limit_angle(float p_angle);
 	float get_primary_limit_angle() const;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/119664

## Additional information

The issue with #119664 was that the internal processing did not match the Gizmo. This PR ensures that the Gizmo now matches.

Before:
<img width="493" height="357" alt="image" src="https://github.com/user-attachments/assets/71acd168-de9d-4fe9-93fc-abf0dc8f15a6" />

After fix:
<img width="536" height="382" alt="image" src="https://github.com/user-attachments/assets/7ce70dc0-9c61-425a-9b01-39387ad608e2" />

Also, this PR adds an option to set the limitations mentioned in #119664 to the rest based; the `use_rest_for_limitation` option to `IterateIK3D` and `LookAtModifier3D`. This allows Limitation to use the static `bone_rest` space instead of the `bone_pose` space immediately before the IK is processed.

<img width="517" height="190" alt="image" src="https://github.com/user-attachments/assets/0acd74b5-af66-4590-8747-1700e42a9dc2" />

<img width="444" height="358" alt="image" src="https://github.com/user-attachments/assets/87dbade3-b7f6-4fd2-91c1-1b385bfc00f1" />

[adjusted-ik-3d-demo.zip](https://github.com/user-attachments/files/30034528/adjusted-ik-3d-demo.zip)

To maintain backward compatibility, the default value is `false`. Incidentally, this option has an impact particularly when pre-aiming is being performed.

For example, the [adjusted-ik-3d-demo.zip](https://godotengine.org/storage/blog/inverse-kinematics-returns-to-godot-4-6/adjusted-ik-3d-demo.zip) in https://godotengine.org/article/inverse-kinematics-returns-to-godot-4-6/ performs pre-aiming, and this pre-aiming serves the role of providing behavior similar to a pole. Therefore, it makes sense that there are use cases where this option is set to false.

The essence of implementing this option is simply to have `bone_rest.inverted() * bone_pose` taken into account in limitation's space. And I have added documentation clarifying that `use_rest_for_limitation` refers to the limitation space relative to the result calculated within this Modifier. If one wishes to limit pre input pose, it is the role of a separate Modifier (like PoseResetter) or an option (such as `relative=false` in `LookAtModifier3D`).