### PR TITLE
Fix JacobianIK limitation method and clarify IK tip reachability

### DIFF
--- a/doc/classes/IterateIK3D.xml
+++ b/doc/classes/IterateIK3D.xml
@@ -7,6 +7,7 @@
 		Base class of [SkeletonModifier3D] to approach the goal by repeating small rotations.
 		Each bone chain (setting) has one effector, which is processed in order of the setting list. You can set some limitations for each joint.
 		[b]Note:[/b] All the methods in this class take an [code]index[/code] parameter. This parameter specifies which setting list entry to return if the IK has multiple entries (e.g. [code]settings/&lt;index&gt;/target_node[/code]).
+		[b]Note:[/b] When [method set_joint_rotation_axis] or [method set_joint_limitation] is set, the IK tip may not reach the target. This occurs because IK calculates the path through iterations, and in some cases, it may hit a limit during the process and fail to resolve. In some cases, this can be resolved by splitting the IK into several [SkeletonModifier3D]s and setting the iteration order manually.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/3d/jacobian_ik_3d.cpp
+++ b/scene/3d/jacobian_ik_3d.cpp
@@ -61,11 +61,15 @@ void JacobianIK3D::_solve_iteration(double p_delta, Skeleton3D *p_skeleton, Iter
 			p_setting->update_chain_coordinate_fw(p_skeleton, j, current_head + to_rot.xform(to_tail));
 
 			int k = j - 1;
+			IKModifier3DSolverInfo *limited_joint_solver_info = p_setting->solver_info_list[k];
+			if (!limited_joint_solver_info) {
+				continue;
+			}
 			if (p_setting->joint_settings[k]->rotation_axis != ROTATION_AXIS_ALL) {
-				p_setting->update_chain_coordinate_fw(p_skeleton, j, p_setting->chain[k] + p_setting->joint_settings[k]->get_projected_rotation(solver_info->current_grest, p_setting->chain[j] - p_setting->chain[k]));
+				p_setting->update_chain_coordinate_fw(p_skeleton, j, p_setting->chain[k] + p_setting->joint_settings[k]->get_projected_rotation(limited_joint_solver_info->current_grest, p_setting->chain[j] - p_setting->chain[k]));
 			}
 			if (p_setting->joint_settings[k]->limitation.is_valid()) {
-				p_setting->update_chain_coordinate_fw(p_skeleton, j, p_setting->chain[k] + p_setting->joint_settings[k]->get_limited_rotation(solver_info->current_grest, p_setting->chain[j] - p_setting->chain[k], solver_info->forward_vector));
+				p_setting->update_chain_coordinate_fw(p_skeleton, j, p_setting->chain[k] + p_setting->joint_settings[k]->get_limited_rotation(limited_joint_solver_info->current_grest, p_setting->chain[j] - p_setting->chain[k], limited_joint_solver_info->forward_vector));
 			}
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/116042

## Additional information

This PR fixes an issue where the joint used as a reference for obtaining the rest was incorrect when applying limitations in `JacobianIK3D`. While this does not fully resolve the issue in https://github.com/godotengine/godot/issues/116042, it improves reachability when using limitations in some cases that involve joints with different rests. In any case, I have added documentation here regarding the unreachability of the IK tip, so https://github.com/godotengine/godot/issues/116042 will be closed.

JacobianIK disabled:
<img width="249" height="257" alt="image" src="https://github.com/user-attachments/assets/40981c1a-51a7-45b6-b8f6-16e07116545b" />

JacobianIK enabled (before):
<img width="477" height="455" alt="image" src="https://github.com/user-attachments/assets/997409ad-7c71-4e92-a0e4-3b1c84e855b2" />

JacobianIK enabled (after this PR):
<img width="477" height="456" alt="image" src="https://github.com/user-attachments/assets/dbd84b39-4145-4518-ac21-b6512e947500" />

[adjusted-ik-3d-demo.zip](https://github.com/user-attachments/files/30034528/adjusted-ik-3d-demo.zip)
