### PR TITLE
TAA Rewrite based on SMAA's Temporal Reprojection

### DIFF
--- a/servers/rendering/renderer_rd/effects/taa.cpp
+++ b/servers/rendering/renderer_rd/effects/taa.cpp
@@ -48,7 +48,7 @@ TAA::~TAA() {
 	taa_shader.version_free(shader_version);
 }
 
-void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far) {
+void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far, Vector2 jitter) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -59,35 +59,29 @@ void TAA::resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_pr
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RSE::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RSE::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-	float base_variance = 1.1f;
-	float base_variance_min = 0.75f;
-	float base_variance_max = 1.00f;
-	float variance_scale = 1080.0f / p_resolution.height; // 1080p taken as baseline for calculation, as this is most commonly used resolution
-
 	TAAResolvePushConstant push_constant;
 	memset(&push_constant, 0, sizeof(TAAResolvePushConstant));
 	push_constant.resolution_width = p_resolution.width;
 	push_constant.resolution_height = p_resolution.height;
-	push_constant.disocclusion_threshold = 2.5f; // If velocity changes by less than this amount of texels we can retain the accumulation buffer.
-	push_constant.variance_dynamic = CLAMP(base_variance * variance_scale, base_variance_min, base_variance_max); // Variance dynamically scales based on resolution
+	push_constant.jitter_x = jitter.x;
+	push_constant.jitter_y = jitter.y;
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, pipeline);
 
-	RD::Uniform u_frame_source(RD::UNIFORM_TYPE_IMAGE, 0, { p_frame });
+	RD::Uniform u_frame_source(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, { default_sampler, p_frame });
 	RD::Uniform u_depth(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 1, { default_sampler, p_depth });
-	RD::Uniform u_velocity(RD::UNIFORM_TYPE_IMAGE, 2, { p_velocity });
-	RD::Uniform u_prev_velocity(RD::UNIFORM_TYPE_IMAGE, 3, { p_prev_velocity });
-	RD::Uniform u_history(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 4, { default_sampler, p_history });
-	RD::Uniform u_frame_dest(RD::UNIFORM_TYPE_IMAGE, 5, { p_temp });
+	RD::Uniform u_velocity(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 2, { default_sampler, p_velocity });
+	RD::Uniform u_history(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 3, { default_sampler, p_history });
+	RD::Uniform u_frame_dest(RD::UNIFORM_TYPE_IMAGE, 4, { p_temp });
 
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_frame_source, u_depth, u_velocity, u_prev_velocity, u_history, u_frame_dest), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, uniform_set_cache->get_cache(shader, 0, u_frame_source, u_depth, u_velocity, u_history, u_frame_dest), 0);
 	RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(TAAResolvePushConstant));
 	RD::get_singleton()->compute_list_dispatch_threads(compute_list, p_resolution.width, p_resolution.height, 1);
 	RD::get_singleton()->compute_list_end();
 }
 
-void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_format, float p_z_near, float p_z_far) {
+void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_format, float p_z_near, float p_z_far, Vector2 jitter) {
 	CopyEffects *copy_effects = CopyEffects::get_singleton();
 
 	uint32_t view_count = p_render_buffers->get_view_count();
@@ -100,8 +94,6 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 
 		p_render_buffers->create_texture(SNAME("taa"), SNAME("history"), p_format, usage_bits);
 		p_render_buffers->create_texture(SNAME("taa"), SNAME("temp"), p_format, usage_bits);
-
-		p_render_buffers->create_texture(SNAME("taa"), SNAME("prev_velocity"), RD::DATA_FORMAT_R16G16_SFLOAT, usage_bits);
 
 		just_allocated = true;
 	}
@@ -118,7 +110,7 @@ void TAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_f
 		if (!just_allocated) {
 			RID depth_texture = p_render_buffers->get_depth_texture(v);
 			RID taa_temp = p_render_buffers->get_texture_slice(SNAME("taa"), SNAME("temp"), v, 0);
-			resolve(internal_texture, taa_temp, depth_texture, velocity_buffer, taa_prev_velocity, taa_history, Size2(internal_size.x, internal_size.y), p_z_near, p_z_far);
+			resolve(internal_texture, taa_temp, depth_texture, velocity_buffer, taa_prev_velocity, taa_history, Size2(internal_size.x, internal_size.y), p_z_near, p_z_far, jitter);
 			copy_effects->copy_to_rect(taa_temp, internal_texture, Rect2(0, 0, internal_size.x, internal_size.y));
 		}
 

--- a/servers/rendering/renderer_rd/effects/taa.h
+++ b/servers/rendering/renderer_rd/effects/taa.h
@@ -40,21 +40,21 @@ public:
 	TAA();
 	~TAA();
 
-	void process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_format, float p_z_near, float p_z_far);
+	void process(Ref<RenderSceneBuffersRD> p_render_buffers, RD::DataFormat p_format, float p_z_near, float p_z_far, Vector2 jitter);
 
 private:
 	struct TAAResolvePushConstant {
 		float resolution_width;
 		float resolution_height;
-		float disocclusion_threshold;
-		float variance_dynamic;
+		float jitter_x;
+		float jitter_y;
 	};
 
 	TaaResolveShaderRD taa_shader;
 	RID shader_version;
 	RID pipeline;
 
-	void resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far);
+	void resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far, Vector2 jitter);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2538,7 +2538,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		} else if (using_taa) {
 			RD::get_singleton()->draw_command_begin_label("TAA");
 			RENDER_TIMESTAMP("TAA");
-			taa->process(rb, rb->get_base_data_format(), p_render_data->scene_data->z_near, p_render_data->scene_data->z_far);
+			Vector2 jitter = p_render_data->scene_data->taa_jitter * Vector2(rb->get_internal_size()) * 0.5f;
+			taa->process(rb, rb->get_base_data_format(), p_render_data->scene_data->z_near, p_render_data->scene_data->z_far, jitter);
 			RD::get_singleton()->draw_command_end_label();
 		}
 	}

--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -19,6 +19,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////////
 // File changes (yyyy-mm-dd)
+// 2026-07-14: Rene Prašnikar: Total shader rewrite, simplified the shader, new "all-in" anti-ghosting strategy introduced
 // 2025-11-05: Jakub Brzyski: Added dynamic variance, base variance value adjusted to reduce ghosting
 // 2022-05-06: Panos Karabelas: first commit
 // 2020-12-05: Joan Fons: convert to Vulkan and Godot
@@ -30,20 +31,15 @@
 
 #VERSION_DEFINES
 
-// Based on Spartan Engine's TAA implementation (without TAA upscale).
-// <https://github.com/PanosK92/SpartanEngine/blob/a8338d0609b85dc32f3732a5c27fb4463816a3b9/Data/shaders/temporal_antialiasing.hlsl>
+// Based on SMAA's Temporal Reprojection (This is NOT SMAA T2x)
+// https://github.com/iryoku/smaa/blob/master/SMAA.hlsl
 
-#define GROUP_SIZE 8
-#define FLT_MIN 0.00000001
-#define FLT_MAX 32767.0
 #define RPC_9 0.11111111111
 #define RPC_16 0.0625
 
-#define DISOCCLUSION_SCALE 0.01 // Scale the weight of this pixel calculated as (change in velocity - threshold) * scale.
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
-layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) in;
-
-layout(rgba16f, set = 0, binding = 0) uniform restrict readonly image2D color_buffer;
+layout(set = 0, binding = 0) uniform sampler2D color_buffer;
 layout(set = 0, binding = 1) uniform sampler2D depth_buffer;
 layout(rg16f, set = 0, binding = 2) uniform restrict readonly image2D velocity_buffer;
 layout(rg16f, set = 0, binding = 3) uniform restrict readonly image2D last_velocity_buffer;
@@ -52,12 +48,12 @@ layout(rgba16f, set = 0, binding = 5) uniform restrict writeonly image2D output_
 
 layout(push_constant, std430) uniform Params {
 	vec2 resolution;
-	float disocclusion_threshold; // 0.1 / max(params.resolution.x, params.resolution.y)
-	float variance_dynamic;
+	vec2 jitter;
 }
 params;
 
-const ivec2 kOffsets3x3[9] = {
+const ivec2 numpad[10] = {
+	ivec2(0, 0),
 	ivec2(-1, -1),
 	ivec2(0, -1),
 	ivec2(1, -1),
@@ -69,317 +65,69 @@ const ivec2 kOffsets3x3[9] = {
 	ivec2(1, 1),
 };
 
-/*------------------------------------------------------------------------------
-						THREAD GROUP SHARED MEMORY (LDS)
-------------------------------------------------------------------------------*/
-
-const int kBorderSize = 1;
-const int kGroupSize = GROUP_SIZE;
-const int kTileDimension = kGroupSize + kBorderSize * 2;
-const int kTileDimension2 = kTileDimension * kTileDimension;
-
-vec3 reinhard(vec3 hdr) {
-	return hdr / (hdr + 1.0);
-}
-vec3 reinhard_inverse(vec3 sdr) {
-	return sdr / (1.0 - sdr);
-}
-
-float get_depth(ivec2 thread_id) {
-	return texelFetch(depth_buffer, thread_id, 0).r;
-}
-
-shared vec3 tile_color[kTileDimension][kTileDimension];
-shared float tile_depth[kTileDimension][kTileDimension];
-
-vec3 load_color(uvec2 group_thread_id) {
-	group_thread_id += kBorderSize;
-	return tile_color[group_thread_id.x][group_thread_id.y];
-}
-
-void store_color(uvec2 group_thread_id, vec3 color) {
-	tile_color[group_thread_id.x][group_thread_id.y] = color;
-}
-
-float load_depth(uvec2 group_thread_id) {
-	group_thread_id += kBorderSize;
-	return tile_depth[group_thread_id.x][group_thread_id.y];
-}
-
-void store_depth(uvec2 group_thread_id, float depth) {
-	tile_depth[group_thread_id.x][group_thread_id.y] = depth;
-}
-
-void store_color_depth(uvec2 group_thread_id, ivec2 thread_id) {
-	// out of bounds clamp
-	thread_id = clamp(thread_id, ivec2(0, 0), ivec2(params.resolution) - ivec2(1, 1));
-
-	store_color(group_thread_id, imageLoad(color_buffer, thread_id).rgb);
-	store_depth(group_thread_id, get_depth(thread_id));
-}
-
-void populate_group_shared_memory(uvec2 group_id, uint group_index) {
-	// Populate group shared memory
-	ivec2 group_top_left = ivec2(group_id) * kGroupSize - kBorderSize;
-	if (group_index < (kTileDimension2 >> 2)) {
-		ivec2 group_thread_id_1 = ivec2(group_index % kTileDimension, group_index / kTileDimension);
-		ivec2 group_thread_id_2 = ivec2((group_index + (kTileDimension2 >> 2)) % kTileDimension, (group_index + (kTileDimension2 >> 2)) / kTileDimension);
-		ivec2 group_thread_id_3 = ivec2((group_index + (kTileDimension2 >> 1)) % kTileDimension, (group_index + (kTileDimension2 >> 1)) / kTileDimension);
-		ivec2 group_thread_id_4 = ivec2((group_index + kTileDimension2 * 3 / 4) % kTileDimension, (group_index + kTileDimension2 * 3 / 4) / kTileDimension);
-
-		store_color_depth(group_thread_id_1, group_top_left + group_thread_id_1);
-		store_color_depth(group_thread_id_2, group_top_left + group_thread_id_2);
-		store_color_depth(group_thread_id_3, group_top_left + group_thread_id_3);
-		store_color_depth(group_thread_id_4, group_top_left + group_thread_id_4);
-	}
-
-	// Wait for group threads to load store data.
-	groupMemoryBarrier();
-	barrier();
-}
-
-/*------------------------------------------------------------------------------
-								VELOCITY
-------------------------------------------------------------------------------*/
-
-void depth_test_min(uvec2 pos, inout float min_depth, inout uvec2 min_pos) {
-	float depth = load_depth(pos);
-
-	if (depth < min_depth) {
-		min_depth = depth;
-		min_pos = pos;
-	}
-}
-
-// Returns velocity with closest depth (3x3 neighborhood)
-void get_closest_pixel_velocity_3x3(in uvec2 group_pos, uvec2 group_top_left, out vec2 velocity) {
-	float min_depth = 1.0;
-	uvec2 min_pos = group_pos;
-
-	depth_test_min(group_pos + kOffsets3x3[0], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[1], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[2], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[3], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[4], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[5], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[6], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[7], min_depth, min_pos);
-	depth_test_min(group_pos + kOffsets3x3[8], min_depth, min_pos);
-
-	// Velocity out
-	velocity = imageLoad(velocity_buffer, ivec2(group_top_left + min_pos)).xy;
-}
-
-/*------------------------------------------------------------------------------
-							  HISTORY SAMPLING
-------------------------------------------------------------------------------*/
-
-vec3 sample_catmull_rom_9(sampler2D stex, vec2 uv, vec2 resolution) {
-	// Source: https://gist.github.com/TheRealMJP/c83b8c0f46b63f3a88a5986f4fa982b1
-	// License: https://gist.github.com/TheRealMJP/bc503b0b87b643d3505d41eab8b332ae
-
-	// We're going to sample a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
-	// down the sample location to get the exact center of our "starting" texel. The starting texel will be at
-	// location [1, 1] in the grid, where [0, 0] is the top left corner.
-	vec2 sample_pos = uv * resolution;
-	vec2 texPos1 = floor(sample_pos - 0.5f) + 0.5f;
-
-	// Compute the fractional offset from our starting texel to our original sample location, which we'll
-	// feed into the Catmull-Rom spline function to get our filter weights.
-	vec2 f = sample_pos - texPos1;
-
-	// Compute the Catmull-Rom weights using the fractional offset that we calculated earlier.
-	// These equations are pre-expanded based on our knowledge of where the texels will be located,
-	// which lets us avoid having to evaluate a piece-wise function.
-	vec2 w0 = f * (-0.5f + f * (1.0f - 0.5f * f));
-	vec2 w1 = 1.0f + f * f * (-2.5f + 1.5f * f);
-	vec2 w2 = f * (0.5f + f * (2.0f - 1.5f * f));
-	vec2 w3 = f * f * (-0.5f + 0.5f * f);
-
-	// Work out weighting factors and sampling offsets that will let us use bilinear filtering to
-	// simultaneously evaluate the middle 2 samples from the 4x4 grid.
-	vec2 w12 = w1 + w2;
-	vec2 offset12 = w2 / (w1 + w2);
-
-	// Compute the final UV coordinates we'll use for sampling the texture
-	vec2 texPos0 = texPos1 - 1.0f;
-	vec2 texPos3 = texPos1 + 2.0f;
-	vec2 texPos12 = texPos1 + offset12;
-
-	texPos0 /= resolution;
-	texPos3 /= resolution;
-	texPos12 /= resolution;
-
-	vec3 result = vec3(0.0f, 0.0f, 0.0f);
-
-	result += textureLod(stex, vec2(texPos0.x, texPos0.y), 0.0).xyz * w0.x * w0.y;
-	result += textureLod(stex, vec2(texPos12.x, texPos0.y), 0.0).xyz * w12.x * w0.y;
-	result += textureLod(stex, vec2(texPos3.x, texPos0.y), 0.0).xyz * w3.x * w0.y;
-
-	result += textureLod(stex, vec2(texPos0.x, texPos12.y), 0.0).xyz * w0.x * w12.y;
-	result += textureLod(stex, vec2(texPos12.x, texPos12.y), 0.0).xyz * w12.x * w12.y;
-	result += textureLod(stex, vec2(texPos3.x, texPos12.y), 0.0).xyz * w3.x * w12.y;
-
-	result += textureLod(stex, vec2(texPos0.x, texPos3.y), 0.0).xyz * w0.x * w3.y;
-	result += textureLod(stex, vec2(texPos12.x, texPos3.y), 0.0).xyz * w12.x * w3.y;
-	result += textureLod(stex, vec2(texPos3.x, texPos3.y), 0.0).xyz * w3.x * w3.y;
-
-	return max(result, 0.0f);
-}
-
-/*------------------------------------------------------------------------------
-							  HISTORY CLIPPING
-------------------------------------------------------------------------------*/
-
-// Based on "Temporal Reprojection Anti-Aliasing" - https://github.com/playdeadgames/temporal
-vec3 clip_aabb(vec3 aabb_min, vec3 aabb_max, vec3 p, vec3 q) {
-	vec3 r = q - p;
-	vec3 rmax = (aabb_max - p.xyz);
-	vec3 rmin = (aabb_min - p.xyz);
-
-	if (r.x > rmax.x + FLT_MIN) {
-		r *= (rmax.x / r.x);
-	}
-	if (r.y > rmax.y + FLT_MIN) {
-		r *= (rmax.y / r.y);
-	}
-	if (r.z > rmax.z + FLT_MIN) {
-		r *= (rmax.z / r.z);
-	}
-
-	if (r.x < rmin.x - FLT_MIN) {
-		r *= (rmin.x / r.x);
-	}
-	if (r.y < rmin.y - FLT_MIN) {
-		r *= (rmin.y / r.y);
-	}
-	if (r.z < rmin.z - FLT_MIN) {
-		r *= (rmin.z / r.z);
-	}
-
-	return p + r;
-}
-
-// Clip history to the neighbourhood of the current sample
-vec3 clip_history_3x3(uvec2 group_pos, vec3 color_history, vec2 velocity_closest) {
-	// Sample a 3x3 neighbourhood
-	vec3 s1 = load_color(group_pos + kOffsets3x3[0]);
-	vec3 s2 = load_color(group_pos + kOffsets3x3[1]);
-	vec3 s3 = load_color(group_pos + kOffsets3x3[2]);
-	vec3 s4 = load_color(group_pos + kOffsets3x3[3]);
-	vec3 s5 = load_color(group_pos + kOffsets3x3[4]);
-	vec3 s6 = load_color(group_pos + kOffsets3x3[5]);
-	vec3 s7 = load_color(group_pos + kOffsets3x3[6]);
-	vec3 s8 = load_color(group_pos + kOffsets3x3[7]);
-	vec3 s9 = load_color(group_pos + kOffsets3x3[8]);
-
-	// Compute min and max (with an adaptive box size, which greatly reduces ghosting)
-	vec3 color_avg = (s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9) * RPC_9;
-	vec3 color_avg2 = ((s1 * s1) + (s2 * s2) + (s3 * s3) + (s4 * s4) + (s5 * s5) + (s6 * s6) + (s7 * s7) + (s8 * s8) + (s9 * s9)) * RPC_9;
-	// Use variance clipping as described in https://developer.download.nvidia.com/gameworks/events/GDC2016/msalvi_temporal_supersampling.pdf
-	float box_size = mix(0.0f, params.variance_dynamic, smoothstep(0.02f, 0.0f, length(velocity_closest)));
-	vec3 dev = sqrt(abs(color_avg2 - (color_avg * color_avg))) * box_size;
-	vec3 color_min = color_avg - dev;
-	vec3 color_max = color_avg + dev;
-
-	// Variance clipping
-	vec3 color = clip_aabb(color_min, color_max, clamp(color_avg, color_min, color_max), color_history);
-
-	// Clamp to prevent NaNs
-	color = clamp(color, FLT_MIN, FLT_MAX);
-
-	return color;
-}
-
-/*------------------------------------------------------------------------------
-									TAA
-------------------------------------------------------------------------------*/
-
-const vec3 lumCoeff = vec3(0.299f, 0.587f, 0.114f);
-
-float luminance(vec3 color) {
-	return max(dot(color, lumCoeff), 0.0001f);
-}
-
-// This is "velocity disocclusion" as described by https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/.
-// We use texel space, so our scale and threshold differ.
-float get_factor_disocclusion(vec2 uv_reprojected, vec2 velocity) {
-	vec2 velocity_previous = imageLoad(last_velocity_buffer, ivec2(uv_reprojected * params.resolution)).xy;
-	vec2 velocity_texels = velocity * params.resolution;
-	vec2 prev_velocity_texels = velocity_previous * params.resolution;
-	float disocclusion = length(prev_velocity_texels - velocity_texels) - params.disocclusion_threshold;
-	return clamp(disocclusion * DISOCCLUSION_SCALE, 0.0, 1.0);
-}
-
-vec3 temporal_antialiasing(uvec2 pos_group_top_left, uvec2 pos_group, uvec2 pos_screen, vec2 uv, sampler2D tex_history) {
-	// Get the velocity of the current pixel
-	vec2 velocity = imageLoad(velocity_buffer, ivec2(pos_screen)).xy;
-
-	// Get reprojected uv
+vec4 temporal_antialiasing(vec2 uv, ivec2 screen) {
+	vec2 velocity = imageLoad(velocity_buffer, screen).xy;
 	vec2 uv_reprojected = uv + velocity;
+	vec2 velocity_previous = imageLoad(last_velocity_buffer, ivec2(uv_reprojected * params.resolution)).xy;
 
-	// Get input color
-	vec3 color_input = load_color(pos_group);
+	vec2 jitter = params.jitter / params.resolution;
 
-	// Get history color (catmull-rom reduces a lot of the blurring that you get under motion)
-	vec3 color_history = sample_catmull_rom_9(tex_history, uv_reprojected, params.resolution).rgb;
+	float d1 = textureLodOffset(depth_buffer, uv, 0.0, numpad[1]).r;
+	float d2 = textureLodOffset(depth_buffer, uv, 0.0, numpad[2]).r;
+	float d3 = textureLodOffset(depth_buffer, uv, 0.0, numpad[3]).r;
+	float d4 = textureLodOffset(depth_buffer, uv, 0.0, numpad[4]).r;
+	float d5 = textureLodOffset(depth_buffer, uv, 0.0, numpad[5]).r;
+	float d6 = textureLodOffset(depth_buffer, uv, 0.0, numpad[6]).r;
+	float d7 = textureLodOffset(depth_buffer, uv, 0.0, numpad[7]).r;
+	float d8 = textureLodOffset(depth_buffer, uv, 0.0, numpad[8]).r;
+	float d9 = textureLodOffset(depth_buffer, uv, 0.0, numpad[9]).r;
 
-	// Clip history to the neighbourhood of the current sample (fixes a lot of the ghosting).
-	vec2 velocity_closest = vec2(0.0); // This is best done by using the velocity with the closest depth.
-	get_closest_pixel_velocity_3x3(pos_group, pos_group_top_left, velocity_closest);
-	color_history = clip_history_3x3(pos_group, color_history, velocity_closest);
+	float depth_avg = (d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9) * RPC_9;
 
-	// Compute blend factor
-	float blend_factor = RPC_16; // We want to be able to accumulate as many jitter samples as we generated, that is, 16.
-	{
-		// If re-projected UV is out of screen, converge to current color immediately.
-		float factor_screen = any(lessThan(uv_reprojected, vec2(0.0))) || any(greaterThan(uv_reprojected, vec2(1.0))) ? 1.0 : 0.0;
+	vec3 s1 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[1]).rgb;
+	vec3 s2 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[2]).rgb;
+	vec3 s3 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[3]).rgb;
+	vec3 s4 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[4]).rgb;
+	vec3 s5 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[5]).rgb;
+	vec3 s6 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[6]).rgb;
+	vec3 s7 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[7]).rgb;
+	vec3 s8 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[8]).rgb;
+	vec3 s9 = textureLodOffset(color_buffer, uv + jitter, 0.0, numpad[9]).rgb;
 
-		// Increase blend factor when there is disocclusion (fixes a lot of the remaining ghosting).
-		float factor_disocclusion = get_factor_disocclusion(uv_reprojected, velocity);
+	vec3 s_min = min(s1, min(s2, min(s3, min(s4, min(s5, min(s6, min(s7, min(s8, s9))))))));
+	vec3 s_max = max(s1, max(s2, max(s3, max(s4, max(s5, max(s6, max(s7, max(s8, s9))))))));
 
-		// Add to the blend factor
-		blend_factor = clamp(blend_factor + factor_screen + factor_disocclusion, 0.0, 1.0);
+	vec3 current = textureLod(color_buffer, uv, 0.0).rgb;
+
+	vec3 previous = textureLod(history_buffer, uv_reprojected, 0.0).rgb;
+
+	float delta = length(velocity * velocity - velocity_previous * velocity_previous) / 5.0;
+	float weight = 0.5 * clamp(1.0 - sqrt(delta) * 30.0, 0.0, 1.0);
+
+	vec3 color_resolved = mix(current, previous, weight);
+
+	vec3 clip = clamp(color_resolved, s_min, s_max);
+
+	if (length(color_resolved - clip) > 0.0) {
+		color_resolved = current;
 	}
 
-	// Resolve
-	vec3 color_resolved = vec3(0.0);
-	{
-		// Tonemap
-		color_history = reinhard(color_history);
-		color_input = reinhard(color_input);
-
-		// Reduce flickering
-		float lum_color = luminance(color_input);
-		float lum_history = luminance(color_history);
-		float diff = abs(lum_color - lum_history) / max(lum_color, max(lum_history, 1.001));
-		diff = 1.0 - diff;
-		diff = diff * diff;
-		blend_factor = mix(0.0, blend_factor, diff);
-
-		// Lerp/blend
-		color_resolved = mix(color_history, color_input, blend_factor);
-
-		// Inverse tonemap
-		color_resolved = reinhard_inverse(color_resolved);
+	if (depth_avg == 0) {
+		color_resolved = s5;
 	}
 
-	return color_resolved;
+	return vec4(color_resolved, d5 * 10000.0);
 }
 
 void main() {
-	populate_group_shared_memory(gl_WorkGroupID.xy, gl_LocalInvocationIndex);
-
 	// Out of bounds check
 	if (any(greaterThanEqual(vec2(gl_GlobalInvocationID.xy), params.resolution))) {
 		return;
 	}
 
-	const uvec2 pos_group = gl_LocalInvocationID.xy;
-	const uvec2 pos_group_top_left = gl_WorkGroupID.xy * kGroupSize - kBorderSize;
-	const uvec2 pos_screen = gl_GlobalInvocationID.xy;
+	const ivec2 screen = ivec2(gl_GlobalInvocationID.xy);
 	const vec2 uv = (gl_GlobalInvocationID.xy + 0.5f) / params.resolution;
 
-	vec3 result = temporal_antialiasing(pos_group_top_left, pos_group, pos_screen, uv, history_buffer);
-	imageStore(output_buffer, ivec2(gl_GlobalInvocationID.xy), vec4(result, 1.0));
+	vec4 result = temporal_antialiasing(uv, screen);
+	imageStore(output_buffer, screen, result);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/67332
- Partially Resolves https://github.com/godotengine/godot/issues/69492 (No effect on FSR)
- Mostly Resolves TAA edge problems (expanding and contracting depending on motion)
- Resolves instances of Dark Ringing around bright objects in motion (caused by catmull-rom history sampling)

## Additional information

This is mostly based off my understanding of https://github.com/iryoku/smaa/blob/master/SMAA.hlsl with the addition of Background Detection which resolves smearing backgrounds and lack of transparency support.
The Edge problems seem to be similarly improved upon, and as there's no catmull-rom, there is no dark ringing around bright objects, which can be seen in this sample

<img width="324" height="156" alt="Screenshot 2026-07-15 085307 a" src="https://github.com/user-attachments/assets/ee4815bd-8fb0-4ebb-b89d-8a034aec027a" />

Unlike https://github.com/godotengine/godot/pull/121368 this isn't doing anything very exotic, however Both PRs are slightly less stable compared to Native FSR 2.2 in static scenes, which I guess is due to FSR's pixel locking helping it out.

I do not have a reference for how DLAA from the RTX branch handles itself to compare, as I'm sadly not on an RTX GPU, so I do not know how normal this level of stability is for TAA that does not completely break apart the moment you look at wrong like the current one.

No AI was used at any point of developing these changes.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->