### PR TITLE
Add range check in `BlitMaterial::set_blend_mode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ $RECYCLE.BIN/
 *.msp
 *.lnk
 *.generated.props
+/TestProjCommands.docx

--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,6 +80,12 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
+
+	if (p_blend_mode < 0 || p_blend_mode >= BLEND_MODE_DISABLED) {
+		ERR_PRINT("Invalid blend mode.");
+		return;
+	}
+
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);
 	if (shader_set) {

--- a/scene/resources/blit_material.cpp
+++ b/scene/resources/blit_material.cpp
@@ -80,11 +80,7 @@ void BlitMaterial::_update_shader(BlendMode p_blend) {
 }
 
 void BlitMaterial::set_blend_mode(BlendMode p_blend_mode) {
-
-	if (p_blend_mode < 0 || p_blend_mode >= BLEND_MODE_DISABLED) {
-		ERR_PRINT("Invalid blend mode.");
-		return;
-	}
+	ERR_FAIL_INDEX_MSG(p_blend_mode, BLEND_MODE_DISABLED, "Invalid blend mode.");
 
 	blend_mode = p_blend_mode;
 	_update_shader(blend_mode);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
--> No AI was used in this fix

## What problem(s) does this PR solve?

- Closes #121263 

## Additional information

Ran test program and got the following output:

Vulkan 1.3.271 - Forward+ - Using Device #0: Intel - Intel(R) Iris(R) Xe Graphics

ERROR: Invalid blend mode.
   at: BlitMaterial::set_blend_mode (scene\resources\blit_material.cpp:85)
   GDScript backtrace (most recent call first):
       [0] _process (res://Node.gd:8)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
