### PR TITLE
Remove changing scene checks in EditorInterface

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -707,17 +707,10 @@ void EditorInterface::edit_script(const Ref<Script> &p_script, int p_line, int p
 }
 
 void EditorInterface::open_scene_from_path(const String &scene_path, bool p_set_inherited) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
-		return;
-	}
 	EditorNode::get_singleton()->open_scene(scene_path, false, p_set_inherited);
 }
 
 void EditorInterface::reload_scene_from_path(const String &scene_path) {
-	if (EditorNode::get_singleton()->is_changing_scene()) {
-		return;
-	}
-
 	EditorNode::get_singleton()->reload_scene(scene_path);
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120594

## Additional information

#116905 made changing scenes more reliable. In the MRP from the issue, the script tries to open scene in `_ready()`, which runs when the node enters tree while changing scene, hence the condition was blocking it.

The condition traces back to when the method was originally added. I didn't spot any problems after removing it, chances are it's no longer needed.
