### PR TITLE
SCons: Apple build changes to support new containers

### DIFF
--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -14,7 +14,8 @@ def get_name():
 
 
 def can_build():
-    if sys.platform == "darwin" or ("OSXCROSS_IOS" in os.environ):
+    # OSXCROSS_IOS kept for compatibility with previous build-containers.
+    if sys.platform == "darwin" or "APPLE_LLVM_CROSS" in os.environ or "OSXCROSS_IOS" in os.environ:
         return True
 
     return False

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -99,10 +99,6 @@ def configure(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
-    # Save this in environment for use by other modules
-    if "OSXCROSS_ROOT" in os.environ:
-        env["osxcross"] = True
-
     # CPU architecture.
     if env["arch"] == "arm64":
         print("Building for macOS 13.0+.")
@@ -133,7 +129,7 @@ def configure(env: "SConsEnvironment"):
     if ccache_path != "":
         ccache_path = ccache_path + " "
 
-    if "osxcross" in env:  # osxcross toolchain (cctools-port wrappers)
+    if "OSXCROSS_ROOT" in os.environ:  # osxcross toolchain (cctools-port wrappers)
         root = os.environ.get("OSXCROSS_ROOT", "")
         if env["arch"] == "arm64":
             basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -14,7 +14,7 @@ def get_name():
 
 
 def can_build():
-    if sys.platform == "darwin" or ("OSXCROSS_VISIONOS" in os.environ):
+    if sys.platform == "darwin" or "APPLE_LLVM_CROSS" in os.environ:
         return True
 
     return False
@@ -77,10 +77,6 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-flto"])
 
     ## Compiler configuration
-
-    # Save this in environment for use by other modules
-    if "OSXCROSS_VISIONOS" in os.environ:
-        env["osxcross"] = True
 
     env["ENV"]["PATH"] = env["APPLE_TOOLCHAIN_PATH"] + "/Developer/usr/bin/:" + env["ENV"]["PATH"]
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up to #121255, addressing some review feedback from changes to build-containers and godot-build-scripts.

## Additional information

Needs testing.

It's not clear whether the `APPLE_LLVM_CROSS` path requires `env["osxcross"]` to be defined.

Fully dropped the `OSXCROSS_VISIONOS` gate for visionOS as we don't have containers that make use of it anymore. `OSXCROSS_IOS` is kept as previous containers (e.g. used for 4.7) make use of it to compile for iOS.