### PR TITLE
Add cut, copy, paste & duplicate to AnimationTree editors

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -80,11 +80,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 	}
 
-	const float pm = POINT_MARGIN * EDSCALE;
-
-	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
-	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
-
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
@@ -121,11 +116,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				menu->set_item_metadata(idx, E);
 			}
 
-			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (clipb.is_valid()) {
-				menu->add_separator();
-				menu->add_item(TTR("Paste"), MENU_PASTE);
-			}
+			_add_standard_context_menu_items(menu, selected_point >= 0, copy_item.node.is_valid());
+
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
@@ -133,13 +125,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->reset_size();
 			menu->popup();
 
-			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size).x;
-			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-			add_point_pos += blend_space->get_min_space();
-
-			if (snap->is_pressed()) {
-				add_point_pos = Math::snapped(add_point_pos, blend_space->get_snap());
-			}
+			add_point_pos = _map_to_blend_space(mb->get_position().x);
 		}
 	}
 
@@ -225,12 +211,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	// *set* the blend
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		float blend_pos = (mb->get_position().x - pm) / inner_size.x;
-		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
-		blend_pos += blend_space->get_min_space();
-
+		float blend_pos = _map_to_blend_space(mb->get_position().x);
 		tree->set(get_blend_position_path(), blend_pos);
-
 		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
 	}
@@ -243,6 +225,11 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
+
+		const float pm = POINT_MARGIN * EDSCALE;
+		const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+		const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 		// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
 		drag_ofs = ((mm->get_position() - drag_from) / inner_size) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
 		blend_space_draw->queue_redraw();
@@ -250,12 +237,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		float blend_pos = (mm->get_position().x - pm) / inner_size.x;
-		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
-		blend_pos += blend_space->get_min_space();
-
+		float blend_pos = _map_to_blend_space(mm->get_position().x);
 		tree->set(get_blend_position_path(), blend_pos);
-
 		blend_space_draw->queue_redraw();
 	}
 
@@ -511,6 +494,76 @@ String AnimationNodeBlendSpace1DEditor::_get_safe_name(const Ref<AnimationNodeBl
 	return final_name;
 }
 
+float AnimationNodeBlendSpace1DEditor::_map_to_blend_space(float p_mouse) {
+	const float pm = POINT_MARGIN * EDSCALE;
+	const float inner_size = blend_space_draw->get_size().x - pm * 2; // Inner size, for coordinate math.
+
+	float mapped = (p_mouse - pm) / inner_size;
+	mapped *= (blend_space->get_max_space() - blend_space->get_min_space());
+	mapped += blend_space->get_min_space();
+
+	if (snap->is_pressed()) {
+		mapped = Math::snapped(mapped, blend_space->get_snap());
+	}
+
+	return mapped;
+}
+
+Ref<AnimationRootNode> AnimationNodeBlendSpace1DEditor::_dup_copy_point() {
+	if (selected_point >= 0 && selected_point < blend_space->get_blend_point_count()) {
+		return blend_space->get_blend_point_node(selected_point)->duplicate();
+	}
+	return nullptr;
+}
+
+void AnimationNodeBlendSpace1DEditor::_dup_paste_point(Ref<AnimationNode> node, float p_position, const String &p_name) {
+	if (node.is_valid()) {
+		String base_name = p_name.is_empty() ? node->get_class().replace_first("AnimationNode", "") : p_name;
+		String name = _get_safe_name(blend_space, base_name);
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node->duplicate(), p_position, -1, name);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+		undo_redo->add_undo_method(this, "_update_space");
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_duplicate_point(float p_position) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Duplicate BlendSpace1D Point"));
+		_dup_paste_point(node, p_position, blend_space->get_blend_point_name(selected_point));
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_copy_point(bool p_cut) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		copy_item.name = blend_space->get_blend_point_name(selected_point);
+		copy_item.node = node;
+	}
+	if (node.is_valid() && p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendSpace1D Point"));
+		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", node->duplicate(), blend_space->get_blend_point_position(selected_point), -1, copy_item.name);
+		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_paste_point(float p_position) {
+	if (copy_item.node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Paste BlendSpace1D Point"));
+		_dup_paste_point(copy_item.node, p_position, copy_item.name);
+		undo_redo->commit_action();
+	}
+}
+
 void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	Ref<AnimationRootNode> node;
 	if (p_index == MENU_LOAD_FILE) {
@@ -525,8 +578,21 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_point(true);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_point(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
+		_paste_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		_duplicate_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DELETE) {
+		_erase_selected();
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -947,6 +1013,33 @@ void AnimationNodeBlendSpace1DEditor::_show_indices_with_cooldown() {
 	show_indices = true;
 	index_focus_cooldown_timer->start();
 	blend_space_draw->queue_redraw();
+}
+
+void AnimationNodeBlendSpace1DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_point(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_point(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position().x));
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position().x));
+		}
+	}
 }
 
 AnimationNodeBlendSpace1DEditor *AnimationNodeBlendSpace1DEditor::singleton = nullptr;

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -70,25 +70,15 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			accept_event();
 			return;
 		}
-
-		if (tool_select->is_pressed() && k->get_keycode() == Key::KEY_DELETE) {
-			if (selected_point != -1) {
-				if (!read_only) {
-					_erase_selected();
-				}
-				accept_event();
-			}
-		}
 	}
-
-	const float pm = POINT_MARGIN * EDSCALE;
-
-	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
-	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
 
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
+		if (editing_point != -1 && inline_editor && !inline_editor->get_rect().has_point(mb->get_position())) {
+			_finish_inline_edit();
+		}
+
 		if (!read_only) {
 			menu->clear(false);
 			animations_menu->clear();
@@ -98,7 +88,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			ClassDB::get_inheriters_from_class(SNAME("AnimationRootNode"), classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
-			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
+			menu->add_submenu_node_item(TTR("Animation"), animations_menu);
 
 			const LocalVector<StringName> &animation_list = tree->get_sorted_animation_list();
 			if (animation_list.is_empty()) {
@@ -118,15 +108,12 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				}
 
 				int idx = menu->get_item_count();
-				menu->add_item(vformat(TTR("Add %s"), name), idx);
+				menu->add_item(name, idx);
 				menu->set_item_metadata(idx, E);
 			}
 
-			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (clipb.is_valid()) {
-				menu->add_separator();
-				menu->add_item(TTR("Paste"), MENU_PASTE);
-			}
+			_add_standard_context_menu_items(menu, selected_point >= 0, copy_item.node.is_valid());
+
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
@@ -134,13 +121,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->reset_size();
 			menu->popup();
 
-			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size).x;
-			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-			add_point_pos += blend_space->get_min_space();
-
-			if (snap->is_pressed()) {
-				add_point_pos = Math::snapped(add_point_pos, blend_space->get_snap());
-			}
+			add_point_pos = _map_to_blend_space(mb->get_position().x);
 		}
 	}
 
@@ -226,12 +207,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	// *set* the blend
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		float blend_pos = (mb->get_position().x - pm) / inner_size.x;
-		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
-		blend_pos += blend_space->get_min_space();
-
+		float blend_pos = _map_to_blend_space(mb->get_position().x);
 		tree->set(get_blend_position_path(), blend_pos);
-
 		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
 	}
@@ -244,6 +221,11 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
+
+		const float pm = POINT_MARGIN * EDSCALE;
+		const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+		const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 		// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
 		drag_ofs = ((mm->get_position() - drag_from) / inner_size) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
 		blend_space_draw->queue_redraw();
@@ -251,12 +233,8 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		float blend_pos = (mm->get_position().x - pm) / inner_size.x;
-		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
-		blend_pos += blend_space->get_min_space();
-
+		float blend_pos = _map_to_blend_space(mm->get_position().x);
 		tree->set(get_blend_position_path(), blend_pos);
-
 		blend_space_draw->queue_redraw();
 	}
 
@@ -514,6 +492,78 @@ String AnimationNodeBlendSpace1DEditor::_get_safe_name(const Ref<AnimationNodeBl
 	return final_name;
 }
 
+float AnimationNodeBlendSpace1DEditor::_map_to_blend_space(float p_mouse) {
+	const float pm = POINT_MARGIN * EDSCALE;
+	const float inner_size = blend_space_draw->get_size().x - pm * 2; // Inner size, for coordinate math.
+
+	float mapped = (p_mouse - pm) / inner_size;
+	mapped *= (blend_space->get_max_space() - blend_space->get_min_space());
+	mapped += blend_space->get_min_space();
+
+	if (snap->is_pressed()) {
+		mapped = Math::snapped(mapped, blend_space->get_snap());
+	}
+
+	return mapped;
+}
+
+Ref<AnimationRootNode> AnimationNodeBlendSpace1DEditor::_dup_copy_point() {
+	if (selected_point >= 0 && selected_point < blend_space->get_blend_point_count()) {
+		return blend_space->get_blend_point_node(selected_point)->duplicate();
+	}
+	return nullptr;
+}
+
+void AnimationNodeBlendSpace1DEditor::_dup_paste_point(Ref<AnimationNode> node, float p_position, const String &p_name) {
+	if (node.is_valid()) {
+		String base_name = p_name.is_empty() ? node->get_class().replace_first("AnimationNode", "") : p_name;
+		String name = _get_safe_name(blend_space, base_name);
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node->duplicate(), p_position, -1, name);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+		undo_redo->add_undo_method(this, "_update_space");
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_duplicate_point(float p_position) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Duplicate BlendSpace1D Point"));
+		_dup_paste_point(node, p_position, blend_space->get_blend_point_name(selected_point));
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_copy_point(bool p_cut) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		copy_item.name = blend_space->get_blend_point_name(selected_point);
+		copy_item.node = node;
+	}
+	if (node.is_valid() && p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendSpace1D Point"));
+		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", node->duplicate(), blend_space->get_blend_point_position(selected_point), selected_point, copy_item.name);
+		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->commit_action();
+
+		_set_selected_point(-1);
+	}
+}
+
+void AnimationNodeBlendSpace1DEditor::_paste_point(float p_position) {
+	if (copy_item.node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Paste BlendSpace1D Point"));
+		_dup_paste_point(copy_item.node, p_position, copy_item.name);
+		undo_redo->commit_action();
+	}
+}
+
 void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	Ref<AnimationRootNode> node;
 	if (p_index == MENU_LOAD_FILE) {
@@ -528,8 +578,27 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_point(!read_only);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_point(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
+		if (!read_only) {
+			_paste_point(add_point_pos);
+		}
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		if (!read_only) {
+			_duplicate_point(add_point_pos);
+		}
+		return;
+	} else if (p_index == MENU_DELETE) {
+		if (!read_only) {
+			_erase_selected();
+		}
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -766,6 +835,8 @@ void AnimationNodeBlendSpace1DEditor::_open_editor() {
 		Ref<AnimationNode> an = blend_space->get_blend_point_node(selected_point);
 		ERR_FAIL_COND(an.is_null());
 		AnimationTreeEditor::get_singleton()->enter_editor(blend_space->get_blend_point_name(selected_point));
+
+		_set_selected_point(-1);
 	}
 }
 
@@ -810,6 +881,8 @@ void AnimationNodeBlendSpace1DEditor::edit(const Ref<AnimationNode> &p_node) {
 		read_only = EditorNode::get_singleton()->is_resource_read_only(blend_space);
 
 		_update_space();
+
+		callable_mp((Control *)blend_space_draw, &Control::grab_focus).call_deferred(false);
 	}
 
 	tool_create->set_disabled(read_only);
@@ -950,6 +1023,44 @@ void AnimationNodeBlendSpace1DEditor::_show_indices_with_cooldown() {
 	show_indices = true;
 	index_focus_cooldown_timer->start();
 	blend_space_draw->queue_redraw();
+}
+
+void AnimationNodeBlendSpace1DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("animation_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_point(!read_only);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_point(false);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/paste", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_paste_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position().x));
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/duplicate", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_duplicate_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position().x));
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/delete", p_event)) {
+			accept_event();
+			if (selected_point != -1) {
+				if (!read_only) {
+					_erase_selected();
+				}
+			}
+		}
+	}
 }
 
 AnimationNodeBlendSpace1DEditor *AnimationNodeBlendSpace1DEditor::singleton = nullptr;

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -141,11 +141,20 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
+	float _map_to_blend_space(float p_mouse);
+
+	struct CopyItem {
+		Ref<AnimationRootNode> node;
+		String name;
 	};
+
+	CopyItem copy_item;
+
+	Ref<AnimationRootNode> _dup_copy_point();
+	void _dup_paste_point(Ref<AnimationNode> node, float p_position, const String &p_name);
+	void _duplicate_point(float p_position);
+	void _copy_point(bool p_cut);
+	void _paste_point(float p_position);
 
 	StringName get_blend_position_path() const;
 	String _get_safe_name(const Ref<AnimationNodeBlendSpace1D> &p_blend_space, const String &p_name);
@@ -159,5 +168,6 @@ public:
 	void refresh_editor() { _update_space(); }
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	AnimationNodeBlendSpace1DEditor();
 };

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -62,6 +62,76 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
 	blend_space_draw->queue_redraw();
 }
 
+Vector2 AnimationNodeBlendSpace2DEditor::_map_to_blend_space(const Vector2 &p_mouse) {
+	const float pm = POINT_MARGIN * EDSCALE;
+	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
+	Vector2 mapped = ((p_mouse - margin_ofs) / inner_size);
+	mapped.y = 1.0 - mapped.y;
+	mapped *= (blend_space->get_max_space() - blend_space->get_min_space());
+	mapped += blend_space->get_min_space();
+
+	if (snap->is_pressed()) {
+		mapped = mapped.snapped(blend_space->get_snap());
+	}
+
+	return mapped;
+}
+
+Ref<AnimationRootNode> AnimationNodeBlendSpace2DEditor::_dup_copy_point() {
+	if (selected_point >= 0 && selected_point < blend_space->get_blend_point_count()) {
+		return blend_space->get_blend_point_node(selected_point)->duplicate();
+	}
+	return nullptr;
+}
+
+void AnimationNodeBlendSpace2DEditor::_dup_paste_point(Ref<AnimationNode> node, const Vector2 &p_position, const String &p_name) {
+	String base_name = p_name.is_empty() ? node->get_class().replace_first("AnimationNode", "") : p_name;
+	String name = _get_safe_name(blend_space, base_name);
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node->duplicate(), p_position, -1, name);
+	undo_redo->add_do_method(this, "_update_space");
+	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_undo_method(this, "_update_space");
+}
+
+void AnimationNodeBlendSpace2DEditor::_duplicate_point(const Vector2 &p_position) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Duplicate BlendSpace2D Point"));
+		_dup_paste_point(node, p_position, blend_space->get_blend_point_name(selected_point));
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_copy_point(bool p_cut) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		copy_item.name = blend_space->get_blend_point_name(selected_point);
+		copy_item.node = node;
+	}
+	if (node.is_valid() && p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendSpace2D Point"));
+		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", node->duplicate(), blend_space->get_blend_point_position(selected_point), -1, copy_item.name);
+		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_paste_point(const Vector2 &p_position) {
+	if (copy_item.node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Paste BlendSpace2D Point"));
+		_dup_paste_point(copy_item.node, p_position, copy_item.name);
+		undo_redo->commit_action();
+	}
+}
+
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_space.is_valid()) {
 		blend_space->disconnect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
@@ -93,6 +163,33 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	interpolation->set_disabled(read_only);
 }
 
+void AnimationNodeBlendSpace2DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_point(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_point(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+		}
+	}
+}
+
 StringName AnimationNodeBlendSpace2DEditor::get_blend_position_path() const {
 	StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + "blend_position";
 	return path;
@@ -121,11 +218,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			}
 		}
 	}
-
-	const float pm = POINT_MARGIN * EDSCALE;
-
-	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
-	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
 
 	Ref<InputEventMouseButton> mb = p_event;
 
@@ -162,11 +254,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				menu->set_item_metadata(idx, E);
 			}
 
-			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (clipb.is_valid()) {
-				menu->add_separator();
-				menu->add_item(TTR("Paste"), MENU_PASTE);
-			}
+			_add_standard_context_menu_items(menu, selected_point >= 0, copy_item.node.is_valid());
+
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
@@ -174,14 +263,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->reset_size();
 			menu->popup();
 
-			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size);
-			add_point_pos.y = 1.0 - add_point_pos.y;
-			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-			add_point_pos += blend_space->get_min_space();
-
-			if (snap->is_pressed()) {
-				add_point_pos = add_point_pos.snapped(blend_space->get_snap());
-			}
+			add_point_pos = _map_to_blend_space(mb->get_position());
 		}
 	}
 
@@ -319,13 +401,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		Vector2 blend_pos = ((mb->get_position() - margin_ofs) / inner_size);
-		blend_pos.y = 1.0 - blend_pos.y;
-		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-		blend_pos += blend_space->get_min_space();
-
+		Vector2 blend_pos = _map_to_blend_space(mb->get_position());
 		tree->set(get_blend_position_path(), blend_pos);
-
 		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
 	}
@@ -339,6 +416,10 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
 		if (!read_only) {
+			const float pm = POINT_MARGIN * EDSCALE;
+			const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+			const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 			// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
 			drag_ofs = ((mm->get_position() - drag_from) / inner_size) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
 		}
@@ -356,13 +437,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		Vector2 blend_pos = ((mm->get_position() - margin_ofs) / inner_size);
-		blend_pos.y = 1.0 - blend_pos.y;
-		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-		blend_pos += blend_space->get_min_space();
-
+		Vector2 blend_pos = _map_to_blend_space(mb->get_position());
 		tree->set(get_blend_position_path(), blend_pos);
-
 		blend_space_draw->queue_redraw();
 	}
 
@@ -426,8 +502,21 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_point(true);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_point(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
+		_paste_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		_duplicate_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DELETE) {
+		_erase_selected();
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -63,6 +63,78 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
 	blend_space_draw->queue_redraw();
 }
 
+Vector2 AnimationNodeBlendSpace2DEditor::_map_to_blend_space(const Vector2 &p_mouse) {
+	const float pm = POINT_MARGIN * EDSCALE;
+	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
+	Vector2 mapped = ((p_mouse - margin_ofs) / inner_size);
+	mapped.y = 1.0 - mapped.y;
+	mapped *= (blend_space->get_max_space() - blend_space->get_min_space());
+	mapped += blend_space->get_min_space();
+
+	if (snap->is_pressed()) {
+		mapped = mapped.snapped(blend_space->get_snap());
+	}
+
+	return mapped;
+}
+
+Ref<AnimationRootNode> AnimationNodeBlendSpace2DEditor::_dup_copy_point() {
+	if (selected_point >= 0 && selected_point < blend_space->get_blend_point_count()) {
+		return blend_space->get_blend_point_node(selected_point)->duplicate();
+	}
+	return nullptr;
+}
+
+void AnimationNodeBlendSpace2DEditor::_dup_paste_point(Ref<AnimationNode> node, const Vector2 &p_position, const String &p_name) {
+	String base_name = p_name.is_empty() ? node->get_class().replace_first("AnimationNode", "") : p_name;
+	String name = _get_safe_name(blend_space, base_name);
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node->duplicate(), p_position, -1, name);
+	undo_redo->add_do_method(this, "_update_space");
+	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_undo_method(this, "_update_space");
+}
+
+void AnimationNodeBlendSpace2DEditor::_duplicate_point(const Vector2 &p_position) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Duplicate BlendSpace2D Point"));
+		_dup_paste_point(node, p_position, blend_space->get_blend_point_name(selected_point));
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_copy_point(bool p_cut) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		copy_item.name = blend_space->get_blend_point_name(selected_point);
+		copy_item.node = node;
+	}
+	if (node.is_valid() && p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendSpace2D Point"));
+		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", node->duplicate(), blend_space->get_blend_point_position(selected_point), selected_point, copy_item.name);
+		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->commit_action();
+
+		_set_selected_point(-1);
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_paste_point(const Vector2 &p_position) {
+	if (copy_item.node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Paste BlendSpace2D Point"));
+		_dup_paste_point(copy_item.node, p_position, copy_item.name);
+		undo_redo->commit_action();
+	}
+}
+
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_space.is_valid()) {
 		blend_space->disconnect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
@@ -75,6 +147,8 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 
 		blend_space->connect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
 		_update_space();
+
+		callable_mp((Control *)blend_space_draw, &Control::grab_focus).call_deferred(false);
 	}
 
 	tool_create->set_disabled(read_only);
@@ -92,6 +166,44 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	sync->set_disabled(read_only);
 	cyclic_length_value->set_editable(!read_only);
 	interpolation->set_disabled(read_only);
+}
+
+void AnimationNodeBlendSpace2DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("animation_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_point(!read_only);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_point(false);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/paste", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_paste_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/duplicate", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_duplicate_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/delete", p_event)) {
+			accept_event();
+			if (selected_point != -1 || selected_triangle != -1) {
+				if (!read_only) {
+					_erase_selected();
+				}
+			}
+		}
+	}
 }
 
 StringName AnimationNodeBlendSpace2DEditor::get_blend_position_path() const {
@@ -112,25 +224,15 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			accept_event();
 			return;
 		}
-
-		if (tool_select->is_pressed() && k->get_keycode() == Key::KEY_DELETE) {
-			if (selected_point != -1 || selected_triangle != -1) {
-				if (!read_only) {
-					_erase_selected();
-				}
-				accept_event();
-			}
-		}
 	}
-
-	const float pm = POINT_MARGIN * EDSCALE;
-
-	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
-	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
 
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
+		if (editing_point != -1 && inline_editor && !inline_editor->get_rect().has_point(mb->get_position())) {
+			_finish_inline_edit();
+		}
+
 		if (!read_only) {
 			menu->clear(false);
 			animations_menu->clear();
@@ -140,7 +242,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
-			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
+			menu->add_submenu_node_item(TTR("Animation"), animations_menu);
 
 			const LocalVector<StringName> &animation_list = tree->get_sorted_animation_list();
 			if (animation_list.is_empty()) {
@@ -159,15 +261,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 					continue; // nope
 				}
 				int idx = menu->get_item_count();
-				menu->add_item(vformat(TTR("Add %s"), name), idx);
+				menu->add_item(name, idx);
 				menu->set_item_metadata(idx, E);
 			}
 
-			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (clipb.is_valid()) {
-				menu->add_separator();
-				menu->add_item(TTR("Paste"), MENU_PASTE);
-			}
+			_add_standard_context_menu_items(menu, selected_point >= 0, copy_item.node.is_valid());
+
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
@@ -175,14 +274,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->reset_size();
 			menu->popup();
 
-			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size);
-			add_point_pos.y = 1.0 - add_point_pos.y;
-			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-			add_point_pos += blend_space->get_min_space();
-
-			if (snap->is_pressed()) {
-				add_point_pos = add_point_pos.snapped(blend_space->get_snap());
-			}
+			add_point_pos = _map_to_blend_space(mb->get_position());
 		}
 	}
 
@@ -320,13 +412,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		Vector2 blend_pos = ((mb->get_position() - margin_ofs) / inner_size);
-		blend_pos.y = 1.0 - blend_pos.y;
-		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-		blend_pos += blend_space->get_min_space();
-
+		Vector2 blend_pos = _map_to_blend_space(mb->get_position());
 		tree->set(get_blend_position_path(), blend_pos);
-
 		dragging_blend_position = true;
 		blend_space_draw->queue_redraw();
 	}
@@ -340,6 +427,10 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
 		if (!read_only) {
+			const float pm = POINT_MARGIN * EDSCALE;
+			const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+			const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 			// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
 			drag_ofs = ((mm->get_position() - drag_from) / inner_size) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
 		}
@@ -357,13 +448,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		Vector2 blend_pos = ((mm->get_position() - margin_ofs) / inner_size);
-		blend_pos.y = 1.0 - blend_pos.y;
-		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-		blend_pos += blend_space->get_min_space();
-
+		Vector2 blend_pos = _map_to_blend_space(mm->get_position());
 		tree->set(get_blend_position_path(), blend_pos);
-
 		blend_space_draw->queue_redraw();
 	}
 
@@ -427,8 +513,27 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_point(!read_only);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_point(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
+		if (!read_only) {
+			_paste_point(add_point_pos);
+		}
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		if (!read_only) {
+			_duplicate_point(add_point_pos);
+		}
+		return;
+	} else if (p_index == MENU_DELETE) {
+		if (!read_only) {
+			_erase_selected();
+		}
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -1036,6 +1141,8 @@ void AnimationNodeBlendSpace2DEditor::_open_editor() {
 		Ref<AnimationNode> an = blend_space->get_blend_point_node(selected_point);
 		ERR_FAIL_COND(an.is_null());
 		AnimationTreeEditor::get_singleton()->enter_editor(blend_space->get_blend_point_name(selected_point));
+
+		_set_selected_point(-1);
 	}
 }
 

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -156,13 +156,22 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
+	void _blend_space_changed();
+
+	Vector2 _map_to_blend_space(const Vector2 &p_mouse);
+
+	struct CopyItem {
+		Ref<AnimationRootNode> node;
+		String name;
 	};
 
-	void _blend_space_changed();
+	CopyItem copy_item;
+
+	Ref<AnimationRootNode> _dup_copy_point();
+	void _dup_paste_point(Ref<AnimationNode> node, const Vector2 &p_position, const String &p_name);
+	void _duplicate_point(const Vector2 &p_position);
+	void _copy_point(bool p_cut);
+	void _paste_point(const Vector2 &p_position);
 
 protected:
 	void _notification(int p_what);
@@ -173,5 +182,6 @@ public:
 	void refresh_editor() { _update_space(); }
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	AnimationNodeBlendSpace2DEditor();
 };

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -79,8 +79,13 @@ void AnimationNodeBlendTreeEditor::remove_custom_type(const Ref<Script> &p_scrip
 }
 
 void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) {
+	if (graph->is_inside_tree()) {
+		popup_menu_point = graph->get_local_mouse_position();
+	}
+
 	add_node->get_popup()->clear();
 	add_node->get_popup()->reset_size();
+
 	for (int i = 0; i < add_options.size(); i++) {
 		if (p_has_input_ports && add_options[i].input_port_count == 0) {
 			continue;
@@ -88,13 +93,22 @@ void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) 
 		add_node->get_popup()->add_item(add_options[i].name, i);
 	}
 
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-	if (clipb.is_valid()) {
-		add_node->get_popup()->add_separator();
-		add_node->get_popup()->add_item(TTR("Paste"), MENU_PASTE);
+	bool can_copy = false;
+	for (int i = 0; i < graph->get_child_count(false); ++i) {
+		GraphNode *graph_node = Object::cast_to<GraphNode>(graph->get_child(i, false));
+		if (graph_node && graph_node->is_selected()) {
+			can_copy = true;
+			break;
+		}
 	}
+
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(add_node->get_popup(), can_copy, can_paste);
+
 	add_node->get_popup()->add_separator();
 	add_node->get_popup()->add_item(TTR("Load..."), MENU_LOAD_FILE);
+
 	use_position_from_popup_menu = false;
 }
 
@@ -392,6 +406,176 @@ void AnimationNodeBlendTreeEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeBlendTreeEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<Ref<GraphEdit::Connection>> &r_connections) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		Vector2 position = blend_tree->get_node_position(graph_element->get_name());
+		if (position.x < top_left.x) {
+			top_left.x = position.x;
+		}
+		if (position.y < top_left.y) {
+			top_left.y = position.y;
+		}
+	}
+
+	HashSet<StringName> nodes;
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		Ref<AnimationNode> node = blend_tree->get_node(graph_element->get_name());
+		if (!node.is_valid()) {
+			continue;
+		}
+
+		Ref<AnimationNodeOutput> output(node);
+		if (output.is_valid()) { // Can't duplicate output.
+			continue;
+		}
+
+		Vector2 position = blend_tree->get_node_position(graph_element->get_name());
+
+		CopyItem item;
+		item.name = graph_element->get_name();
+		item.node = node->duplicate();
+		item.position = position - top_left;
+
+		r_items.push_back(item);
+
+		nodes.insert(graph_element->get_name());
+	}
+
+	Vector<Ref<GraphEdit::Connection>> node_connections = graph->get_connections();
+	for (const Ref<GraphEdit::Connection> &E : node_connections) {
+		if (nodes.has(E->from_node) && nodes.has(E->to_node)) {
+			r_connections.push_back(*E);
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_dup_paste_nodes(List<CopyItem> &p_items, const List<Ref<GraphEdit::Connection>> &p_connections, const Vector2 &p_position, bool p_duplicate) {
+	if (p_items.is_empty()) {
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (p_duplicate) {
+		undo_redo->create_action(TTR("Duplicate AnimationTree Node(s)"));
+	} else {
+		undo_redo->create_action(TTR("Paste AnimationTree Node(s)"));
+	}
+
+	HashMap<StringName, StringName> connection_remap;
+	HashSet<StringName> added_set;
+
+	float scale = graph->get_zoom();
+	Vector2 position = graph->get_scroll_offset() / scale + p_position / scale;
+
+	for (CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		connection_remap[item.name] = name;
+		// Must duplicate node again for multiple pastes.
+		undo_redo->add_do_method(blend_tree.ptr(), "add_node", name, item.node->duplicate(), item.position + position);
+		added_set.insert(name);
+	}
+
+	for (const Ref<GraphEdit::Connection> &E : p_connections) {
+		undo_redo->add_do_method(blend_tree.ptr(), "connect_node", String(connection_remap[E->to_node]), E->to_port, String(connection_remap[E->from_node]));
+		undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", connection_remap[E->to_node], E->to_port);
+	}
+
+	for (const CopyItem &item : p_items) {
+		undo_redo->add_undo_method(blend_tree.ptr(), "remove_node", connection_remap[item.name]);
+	}
+
+	undo_redo->add_do_method(this, "update_graph");
+	undo_redo->add_undo_method(this, "update_graph");
+
+	undo_redo->commit_action();
+
+	// Select the new nodes so that the user can easily move them away.
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (graph_element) {
+			graph_element->set_selected(added_set.has(graph_element->get_name()));
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_duplicate_nodes(const Vector2 &p_position) {
+	List<CopyItem> items;
+	List<Ref<GraphEdit::Connection>> node_connections;
+	_dup_copy_nodes(items, node_connections);
+
+	if (items.is_empty()) {
+		return;
+	}
+
+	_dup_paste_nodes(items, node_connections, p_position, true);
+}
+
+void AnimationNodeBlendTreeEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_connections_buffer.clear();
+}
+
+void AnimationNodeBlendTreeEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+
+	_dup_copy_nodes(copy_items_buffer, copy_connections_buffer);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendTree Node(s)"));
+
+		TypedArray<StringName> names;
+		for (const CopyItem &E : copy_items_buffer) {
+			names.push_back(E.name);
+		}
+
+		_delete_nodes_request(names);
+		//update_graph();
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_paste_nodes(const Vector2 &p_position) {
+	if (!copy_items_buffer.is_empty()) {
+		_dup_paste_nodes(copy_items_buffer, copy_connections_buffer, p_position, false);
+	}
+}
+
+String AnimationNodeBlendTreeEditor::_deduplicate_node_name(const String &p_name) {
+	int base = 1;
+	String name = p_name;
+	while (blend_tree->has_node(name)) {
+		base++;
+		name = p_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	Ref<AnimationNode> anode;
 
@@ -410,10 +594,22 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		anode = file_loaded;
 		file_loaded.unref();
 		base_name = anode->get_class();
+	} else if (p_idx == MENU_DUPLICATE) {
+		_duplicate_nodes(popup_menu_point);
+		return;
+	} else if (p_idx == MENU_CUT) {
+		_copy_nodes(true);
+		return;
+	} else if (p_idx == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_idx == MENU_PASTE) {
-		anode = EditorSettings::get_singleton()->get_resource_clipboard();
-		ERR_FAIL_COND(anode.is_null());
-		base_name = anode->get_class();
+		_paste_nodes(popup_menu_point);
+		return;
+	} else if (p_idx == MENU_DELETE) {
+		_delete_nodes_request({});
+		update_graph();
+		return;
 	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_NULL(an);
@@ -1156,13 +1352,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 		return; //nothing to do
 	}
 
-	const String &base_name = new_name;
-	int base = 1;
-	String name = base_name;
-	while (blend_tree->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	String name = _deduplicate_node_name(new_name);
 
 	String base_path = AnimationTreeEditor::get_singleton()->get_base_path();
 
@@ -1252,6 +1442,33 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	add_node->set_disabled(read_only);
 	graph->set_show_arrange_button(!read_only);
+}
+
+void AnimationNodeBlendTreeEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_nodes(graph->get_local_mouse_position());
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_nodes(graph->get_local_mouse_position());
+		}
+	}
 }
 
 AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -79,22 +79,40 @@ void AnimationNodeBlendTreeEditor::remove_custom_type(const Ref<Script> &p_scrip
 }
 
 void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) {
+	if (graph->is_inside_tree()) {
+		popup_menu_point = graph->get_local_mouse_position();
+	}
+
 	add_node->get_popup()->clear();
 	add_node->get_popup()->reset_size();
+
 	for (int i = 0; i < add_options.size(); i++) {
+		if (add_options[i].is_separator) {
+			add_node->get_popup()->add_separator();
+			continue;
+		}
 		if (p_has_input_ports && add_options[i].input_port_count == 0) {
 			continue;
 		}
 		add_node->get_popup()->add_item(add_options[i].name, i);
 	}
 
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-	if (clipb.is_valid()) {
-		add_node->get_popup()->add_separator();
-		add_node->get_popup()->add_item(TTR("Paste"), MENU_PASTE);
+	bool can_copy = false;
+	for (int i = 0; i < graph->get_child_count(false); ++i) {
+		GraphNode *graph_node = Object::cast_to<GraphNode>(graph->get_child(i, false));
+		if (graph_node && graph_node->is_selected()) {
+			can_copy = true;
+			break;
+		}
 	}
+
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(add_node->get_popup(), can_copy, can_paste);
+
 	add_node->get_popup()->add_separator();
 	add_node->get_popup()->add_item(TTR("Load..."), MENU_LOAD_FILE);
+
 	use_position_from_popup_menu = false;
 }
 
@@ -393,6 +411,194 @@ void AnimationNodeBlendTreeEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeBlendTreeEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<Ref<GraphEdit::Connection>> &r_connections) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		top_left = top_left.min(blend_tree->get_node_position(graph_element->get_name()));
+	}
+
+	HashSet<StringName> nodes;
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		Ref<AnimationNode> node = blend_tree->get_node(graph_element->get_name());
+		if (!node.is_valid()) {
+			continue;
+		}
+
+		Ref<AnimationNodeOutput> output(node);
+		if (output.is_valid()) {
+			// Track output node just to preserve its connection, if present.
+			nodes.insert(graph_element->get_name());
+			continue;
+		}
+
+		Vector2 position = blend_tree->get_node_position(graph_element->get_name());
+
+		CopyItem item;
+		item.name = graph_element->get_name();
+		item.node = node->duplicate();
+		item.position = position - top_left;
+
+		r_items.push_back(item);
+
+		nodes.insert(graph_element->get_name());
+	}
+
+	Vector<Ref<GraphEdit::Connection>> node_connections = graph->get_connections();
+	for (const Ref<GraphEdit::Connection> &E : node_connections) {
+		if (nodes.has(E->from_node) && nodes.has(E->to_node)) {
+			r_connections.push_back(*E);
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_dup_paste_nodes(List<CopyItem> &p_items, const List<Ref<GraphEdit::Connection>> &p_connections, const Vector2 &p_position, bool p_duplicate) {
+	if (p_items.is_empty()) {
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (p_duplicate) {
+		undo_redo->create_action(TTR("Duplicate AnimationTree Node(s)"));
+	} else {
+		undo_redo->create_action(TTR("Paste AnimationTree Node(s)"));
+	}
+
+	HashMap<StringName, StringName> connection_remap;
+	HashSet<StringName> added_set;
+
+	connection_remap[SceneStringName(output)] = SceneStringName(output);
+
+	float scale = graph->get_zoom();
+	Vector2 position = graph->get_scroll_offset() / scale + p_position / scale;
+
+	for (CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		connection_remap[item.name] = name;
+		// Must duplicate node again for multiple pastes.
+		undo_redo->add_do_method(blend_tree.ptr(), "add_node", name, item.node->duplicate(), item.position + position);
+		added_set.insert(name);
+	}
+
+	LocalVector<AnimationNodeBlendTree::NodeConnection> existing_connections;
+	blend_tree->get_node_connections(&existing_connections);
+
+	for (const Ref<GraphEdit::Connection> &E : p_connections) {
+		StringName from = connection_remap[E->from_node];
+		StringName to = connection_remap[E->to_node];
+		int to_port = E->to_port;
+
+		if (to == SceneStringName(output)) {
+			bool port_occupied = false;
+			for (const AnimationNodeBlendTree::NodeConnection &C : existing_connections) {
+				if (C.input_node == to && C.input_index == to_port) {
+					port_occupied = true;
+					break;
+				}
+			}
+			if (port_occupied) {
+				continue; // Skip already taken Output port.
+			}
+		}
+
+		undo_redo->add_do_method(blend_tree.ptr(), "connect_node", String(to), to_port, String(from));
+		undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", to, to_port);
+	}
+
+	for (const CopyItem &item : p_items) {
+		undo_redo->add_undo_method(blend_tree.ptr(), "remove_node", connection_remap[item.name]);
+	}
+
+	undo_redo->add_do_method(this, "update_graph");
+	undo_redo->add_undo_method(this, "update_graph");
+
+	undo_redo->commit_action();
+
+	// Select the new nodes so that the user can easily move them away.
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (graph_element) {
+			graph_element->set_selected(added_set.has(graph_element->get_name()));
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_duplicate_nodes(const Vector2 &p_position) {
+	List<CopyItem> items;
+	List<Ref<GraphEdit::Connection>> node_connections;
+	_dup_copy_nodes(items, node_connections);
+
+	if (items.is_empty()) {
+		return;
+	}
+
+	_dup_paste_nodes(items, node_connections, p_position, true);
+}
+
+void AnimationNodeBlendTreeEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_connections_buffer.clear();
+}
+
+void AnimationNodeBlendTreeEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+
+	_dup_copy_nodes(copy_items_buffer, copy_connections_buffer);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendTree Node(s)"));
+
+		TypedArray<StringName> names;
+		for (const CopyItem &E : copy_items_buffer) {
+			names.push_back(E.name);
+		}
+
+		_delete_nodes_request(names);
+		//update_graph();
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_paste_nodes(const Vector2 &p_position) {
+	if (!copy_items_buffer.is_empty()) {
+		_dup_paste_nodes(copy_items_buffer, copy_connections_buffer, p_position, false);
+	}
+}
+
+String AnimationNodeBlendTreeEditor::_deduplicate_node_name(const String &p_name) {
+	int base = 1;
+	String name = p_name;
+	while (blend_tree->has_node(name)) {
+		base++;
+		name = p_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	Ref<AnimationNode> anode;
 
@@ -411,10 +617,28 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		anode = file_loaded;
 		file_loaded.unref();
 		base_name = anode->get_class();
+	} else if (p_idx == MENU_CUT) {
+		_copy_nodes(!read_only);
+		return;
+	} else if (p_idx == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_idx == MENU_PASTE) {
-		anode = EditorSettings::get_singleton()->get_resource_clipboard();
-		ERR_FAIL_COND(anode.is_null());
-		base_name = anode->get_class();
+		if (!read_only) {
+			_paste_nodes(popup_menu_point);
+		}
+		return;
+	} else if (p_idx == MENU_DUPLICATE) {
+		if (!read_only) {
+			_duplicate_nodes(popup_menu_point);
+		}
+		return;
+	} else if (p_idx == MENU_DELETE) {
+		if (!read_only) {
+			_delete_nodes_request({});
+			update_graph();
+		}
+		return;
 	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_NULL(an);
@@ -1044,6 +1268,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
+			add_node->set_button_icon(get_editor_theme_icon(SNAME("ListSelect")));
 			if (is_visible_in_tree()) {
 				update_graph();
 			}
@@ -1157,13 +1382,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 		return; //nothing to do
 	}
 
-	const String &base_name = new_name;
-	int base = 1;
-	String name = base_name;
-	while (blend_tree->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	String name = _deduplicate_node_name(new_name);
 
 	String base_path = AnimationTreeEditor::get_singleton()->get_base_path();
 
@@ -1249,10 +1468,43 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 		blend_tree->connect("node_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_changed));
 
 		update_graph();
+
+		callable_mp((Control *)graph, &Control::grab_focus).call_deferred(false);
 	}
 
 	add_node->set_disabled(read_only);
 	graph->set_show_arrange_button(!read_only);
+}
+
+void AnimationNodeBlendTreeEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("animation_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(!read_only);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/paste", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_paste_nodes(graph->get_local_mouse_position());
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/duplicate", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_duplicate_nodes(graph->get_local_mouse_position());
+			}
+		}
+	}
 }
 
 AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
@@ -1262,6 +1514,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	graph = memnew(GraphEdit);
 	add_child(graph);
+	graph->add_theme_style_override("panel_focus", memnew(StyleBoxEmpty));
 	graph->add_valid_right_disconnect_type(0);
 	graph->add_valid_left_disconnect_type(0);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1285,7 +1538,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	add_node = memnew(MenuButton);
 	graph->get_menu_hbox()->add_child(add_node);
-	add_node->set_text(TTR("Add Node..."));
+	add_node->set_tooltip_text(TTR("Manage blend tree nodes."));
+	add_node->set_accessibility_name(TTRC("Menu"));
 	graph->get_menu_hbox()->move_child(add_node, 0);
 	add_node->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationNodeBlendTreeEditor::_add_node));
 	add_node->get_popup()->connect("popup_hide", callable_mp(this, &AnimationNodeBlendTreeEditor::_popup_hide), CONNECT_DEFERRED);
@@ -1293,19 +1547,25 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_node->set_disabled(read_only);
 
 	add_options.push_back(AddOption("Animation", "AnimationNodeAnimation"));
-	add_options.push_back(AddOption("OneShot", "AnimationNodeOneShot", 2));
+	add_options.push_back(AddOption("BlendSpace1D", "AnimationNodeBlendSpace1D"));
+	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
+	add_options.push_back(AddOption("BlendTree", "AnimationNodeBlendTree"));
+	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
+
+	AddOption sep;
+	sep.is_separator = true;
+	add_options.push_back(sep);
+
 	add_options.push_back(AddOption("Add2", "AnimationNodeAdd2", 2));
 	add_options.push_back(AddOption("Add3", "AnimationNodeAdd3", 3));
 	add_options.push_back(AddOption("Blend2", "AnimationNodeBlend2", 2));
 	add_options.push_back(AddOption("Blend3", "AnimationNodeBlend3", 3));
+	add_options.push_back(AddOption("OneShot", "AnimationNodeOneShot", 2));
 	add_options.push_back(AddOption("Sub2", "AnimationNodeSub2", 2));
-	add_options.push_back(AddOption("TimeSeek", "AnimationNodeTimeSeek", 1));
 	add_options.push_back(AddOption("TimeScale", "AnimationNodeTimeScale", 1));
+	add_options.push_back(AddOption("TimeSeek", "AnimationNodeTimeSeek", 1));
 	add_options.push_back(AddOption("Transition", "AnimationNodeTransition"));
-	add_options.push_back(AddOption("BlendTree", "AnimationNodeBlendTree"));
-	add_options.push_back(AddOption("BlendSpace1D", "AnimationNodeBlendSpace1D"));
-	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
-	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
+
 	_update_options_menu();
 	filter_dialog = memnew(AcceptDialog);
 	add_child(filter_dialog);

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -142,14 +142,28 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
-	};
-
 	Ref<EditorInspectorPluginAnimationNodeAnimation> animation_node_inspector_plugin;
 	Ref<Tween> pan_to_tween;
+
+	Vector2 popup_menu_point;
+
+	struct CopyItem {
+		Ref<AnimationNode> node;
+		StringName name;
+		Vector2 position;
+	};
+
+	List<CopyItem> copy_items_buffer;
+	List<Ref<GraphEdit::Connection>> copy_connections_buffer;
+
+	void _dup_copy_nodes(List<CopyItem> &r_items, List<Ref<GraphEdit::Connection>> &r_connections);
+	void _dup_paste_nodes(List<CopyItem> &p_items, const List<Ref<GraphEdit::Connection>> &p_connections, const Vector2 &p_position, bool p_duplicate);
+	void _duplicate_nodes(const Vector2 &p_position);
+	void _copy_nodes(bool p_cut);
+	void _paste_nodes(const Vector2 &p_position);
+	void _clear_copy_buffer();
+
+	String _deduplicate_node_name(const String &p_name);
 
 protected:
 	void _notification(int p_what);
@@ -165,6 +179,8 @@ public:
 
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	void update_graph();
 	void update_graph_immediately();

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -79,11 +79,14 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 		String name;
 		String type;
 		Ref<Script> script;
-		int input_port_count;
-		AddOption(const String &p_name = String(), const String &p_type = String(), int p_input_port_count = 0) :
-				name(p_name),
-				type(p_type),
-				input_port_count(p_input_port_count) {
+		int input_port_count = 0;
+		bool is_separator = false;
+
+		AddOption() {}
+		AddOption(const String &p_name, const String &p_type, int p_input_port_count = 0) {
+			name = p_name;
+			type = p_type;
+			input_port_count = p_input_port_count;
 		}
 	};
 
@@ -142,14 +145,28 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
-	};
-
 	Ref<EditorInspectorPluginAnimationNodeAnimation> animation_node_inspector_plugin;
 	Ref<Tween> pan_to_tween;
+
+	Vector2 popup_menu_point;
+
+	struct CopyItem {
+		Ref<AnimationNode> node;
+		StringName name;
+		Vector2 position;
+	};
+
+	List<CopyItem> copy_items_buffer;
+	List<Ref<GraphEdit::Connection>> copy_connections_buffer;
+
+	void _dup_copy_nodes(List<CopyItem> &r_items, List<Ref<GraphEdit::Connection>> &r_connections);
+	void _dup_paste_nodes(List<CopyItem> &p_items, const List<Ref<GraphEdit::Connection>> &p_connections, const Vector2 &p_position, bool p_duplicate);
+	void _duplicate_nodes(const Vector2 &p_position);
+	void _copy_nodes(bool p_cut);
+	void _paste_nodes(const Vector2 &p_position);
+	void _clear_copy_buffer();
+
+	String _deduplicate_node_name(const String &p_name);
 
 protected:
 	void _notification(int p_what);
@@ -165,6 +182,8 @@ public:
 
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	void update_graph();
 	void update_graph_immediately();

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -44,6 +44,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/main/viewport.h"
@@ -814,6 +815,37 @@ String AnimationNodeStateMachineEditor::get_tooltip(const Point2 &p_pos) const {
 	return tooltip_text;
 }
 
+void AnimationNodeStateMachineEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_nodes(_map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_nodes();
+		}
+	}
+}
+
+Vector2 AnimationNodeStateMachineEditor::_map_to_state_machine(const Vector2 &p_position) {
+	return p_position / EDSCALE + state_machine->get_graph_offset();
+}
+
 void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
@@ -848,18 +880,20 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 		menu->add_item(vformat(TTR("Add %s"), name), idx);
 		menu->set_item_metadata(idx, class_name);
 	}
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 
-	if (clipb.is_valid()) {
-		menu->add_separator();
-		menu->add_item(TTR("Paste"), MENU_PASTE);
-	}
+	bool can_copy = !selected_nodes.is_empty();
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(menu, can_copy, can_paste);
+
 	menu->add_separator();
 	menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
 	menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	menu->reset_size();
 	menu->popup();
-	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
+
+	add_node_pos = _map_to_state_machine(p_position);
 }
 
 bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
@@ -916,6 +950,131 @@ void AnimationNodeStateMachineEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeStateMachineEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<CopyTransition> &r_transitions) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (const StringName &node_name : selected_nodes) {
+		if (node_name == SceneStringName(Start) || node_name == SceneStringName(End)) {
+			continue;
+		}
+
+		Vector2 position = state_machine->get_node_position(node_name);
+		if (position.x < top_left.x) {
+			top_left.x = position.x;
+		}
+		if (position.y < top_left.y) {
+			top_left.y = position.y;
+		}
+	}
+
+	for (const StringName &node_name : selected_nodes) {
+		if (node_name == SceneStringName(Start) || node_name == SceneStringName(End)) {
+			continue;
+		}
+
+		Vector2 position = state_machine->get_node_position(node_name);
+		r_items.push_back({
+				state_machine->get_node(node_name)->duplicate(),
+				node_name,
+				position - top_left,
+		});
+
+		Vector<int> transitions = state_machine->find_transition_from(node_name);
+		for (int index : transitions) {
+			StringName to = state_machine->get_transition_to(index);
+			if (selected_nodes.has(to)) {
+				Ref<AnimationNodeStateMachineTransition> transition = state_machine->get_transition(index)->duplicate();
+				r_transitions.push_back({ node_name, to, transition });
+			}
+		}
+	}
+}
+
+void AnimationNodeStateMachineEditor::_dup_paste_nodes(const List<CopyItem> &p_items, const List<CopyTransition> &p_transitions, const Vector2 &p_position) {
+	updating = true;
+
+	HashMap<StringName, StringName> remap;
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	for (const CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		remap[item.name] = name;
+		// Must duplicate node again for multiple pastes.
+		if (item.node.is_valid()) {
+			undo_redo->add_do_method(state_machine.ptr(), "add_node", name, item.node->duplicate(), p_position + item.position);
+			undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
+		}
+	}
+
+	for (const CopyTransition &item : p_transitions) {
+		StringName from = remap[item.from];
+		StringName to = remap[item.to];
+		// Must duplicate node again for multiple pastes.
+		if (item.transition.is_valid()) {
+			undo_redo->add_do_method(state_machine.ptr(), "add_transition", from, to, item.transition->duplicate());
+			undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", from, to);
+		}
+	}
+
+	undo_redo->add_do_method(this, "_update_graph");
+	undo_redo->add_undo_method(this, "_update_graph");
+
+	updating = false;
+}
+
+void AnimationNodeStateMachineEditor::_duplicate_nodes() {
+	// Don't destroy copy state, use separate buffer.
+	List<CopyItem> items;
+	List<CopyTransition> transitions;
+	_dup_copy_nodes(items, transitions);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Duplicate State Machine Node(s) and Transition(s)"));
+
+	_dup_paste_nodes(items, transitions, _map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+	_dup_copy_nodes(copy_items_buffer, copy_transitions_buffer);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut State Machine Node(s)"));
+
+		_erase_selected(true);
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeStateMachineEditor::_paste_nodes(const Vector2 &p_position) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Paste State Machine Node(s) and Transition(s)"));
+	_dup_paste_nodes(copy_items_buffer, copy_transitions_buffer, p_position);
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_transitions_buffer.clear();
+}
+
+String AnimationNodeStateMachineEditor::_deduplicate_node_name(const String &p_base_name) {
+	int base = 1;
+	String name = p_base_name;
+	while (state_machine->has_node(name)) {
+		base++;
+		name = p_base_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	String base_name;
 	Ref<AnimationRootNode> node;
@@ -932,9 +1091,23 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_nodes(true);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
-
+		_paste_nodes(add_node_pos);
+		return;
+	} else if (p_index == MENU_DELETE) {
+		if (!read_only) {
+			_erase_selected(false);
+		}
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		_duplicate_nodes();
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -956,46 +1129,24 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		base_name = node->get_class().replace_first("AnimationNode", "");
 	}
 
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
-
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
-	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
-	connecting_to_node = name;
-	_add_transition(true);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
-	undo_redo->commit_action();
-	updating = false;
-
-	state_machine_draw->queue_redraw();
+	_add_node_and_transition(base_name, node);
 }
 
 void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 	Ref<AnimationNodeAnimation> anim;
 	anim.instantiate();
-
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = String(animations_to_add[p_index]).validate_node_name();
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	_add_node_and_transition(animations_to_add[p_index], anim);
+}
+
+void AnimationNodeStateMachineEditor::_add_node_and_transition(const String &p_base_name, Ref<AnimationNode> node) {
+	String name = _deduplicate_node_name(p_base_name);
 
 	updating = true;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, anim, add_node_pos);
+	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
 	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
 	connecting_to_node = name;
 	_add_transition(true);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -44,6 +44,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/main/viewport.h"
@@ -72,6 +73,8 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 		connected_nodes.clear();
 		_update_mode();
 		_update_graph();
+
+		callable_mp((Control *)state_machine_draw, &Control::grab_focus).call_deferred(false);
 	}
 
 	if (read_only) {
@@ -218,16 +221,6 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(_get_root_playback_path(node_directory));
 	if (playback.is_null()) {
 		return;
-	}
-
-	Ref<InputEventKey> k = p_event;
-	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->get_keycode() == Key::KEY_DELETE && !k->is_echo()) {
-		if (selected_node != StringName() || !selected_nodes.is_empty() || selected_transition_to != StringName() || selected_transition_from != StringName()) {
-			if (!read_only) {
-				_erase_selected();
-			}
-			accept_event();
-		}
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -811,6 +804,48 @@ String AnimationNodeStateMachineEditor::get_tooltip(const Point2 &p_pos) const {
 	return tooltip_text;
 }
 
+void AnimationNodeStateMachineEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("animation_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(!read_only);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/paste", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_paste_nodes(_map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/duplicate", p_event)) {
+			accept_event();
+			if (!read_only) {
+				_duplicate_nodes();
+			}
+		} else if (ED_IS_SHORTCUT("animation_tree_editor/delete", p_event)) {
+			accept_event();
+			if (!selected_node.is_empty() || !selected_nodes.is_empty() || !selected_transition_to.is_empty() || !selected_transition_from.is_empty()) {
+				if (!read_only) {
+					_erase_selected(false);
+				}
+			}
+		}
+	}
+}
+
+Vector2 AnimationNodeStateMachineEditor::_map_to_state_machine(const Vector2 &p_position) {
+	return p_position / EDSCALE + state_machine->get_graph_offset();
+}
+
 void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
@@ -822,7 +857,7 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	animations_to_add.clear();
 
 	LocalVector<StringName> animation_names = tree->get_sorted_animation_list();
-	menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
+	menu->add_submenu_node_item(TTR("Animation"), animations_menu);
 	if (animation_names.is_empty()) {
 		menu->set_item_disabled(-1, true);
 	} else {
@@ -842,21 +877,23 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 			continue; // nope
 		}
 		int idx = menu->get_item_count();
-		menu->add_item(vformat(TTR("Add %s"), name), idx);
+		menu->add_item(name, idx);
 		menu->set_item_metadata(idx, class_name);
 	}
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 
-	if (clipb.is_valid()) {
-		menu->add_separator();
-		menu->add_item(TTR("Paste"), MENU_PASTE);
-	}
+	bool can_copy = !selected_nodes.is_empty();
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(menu, can_copy, can_paste);
+
 	menu->add_separator();
 	menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
 	menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	menu->reset_size();
 	menu->popup();
-	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
+
+	add_node_pos = _map_to_state_machine(p_position);
 }
 
 bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
@@ -913,6 +950,135 @@ void AnimationNodeStateMachineEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeStateMachineEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<CopyTransition> &r_transitions) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (const StringName &node_name : selected_nodes) {
+		if (node_name == SceneStringName(Start) || node_name == SceneStringName(End)) {
+			continue;
+		}
+
+		top_left = top_left.min(state_machine->get_node_position(node_name));
+	}
+
+	for (const StringName &node_name : selected_nodes) {
+		// Do not duplicate Start/End states...
+		if (node_name != SceneStringName(Start) && node_name != SceneStringName(End)) {
+			Vector2 position = state_machine->get_node_position(node_name);
+			r_items.push_back({
+					state_machine->get_node(node_name)->duplicate(),
+					node_name,
+					position - top_left,
+			});
+		}
+
+		// ...but still collect all outgoing transitions.
+		Vector<int> transitions = state_machine->find_transition_from(node_name);
+		for (int index : transitions) {
+			StringName to = state_machine->get_transition_to(index);
+			if (selected_nodes.has(to)) {
+				Ref<AnimationNodeStateMachineTransition> transition = state_machine->get_transition(index)->duplicate();
+				r_transitions.push_back({ node_name, to, transition });
+			}
+		}
+	}
+}
+
+void AnimationNodeStateMachineEditor::_dup_paste_nodes(const List<CopyItem> &p_items, const List<CopyTransition> &p_transitions, const Vector2 &p_position) {
+	updating = true;
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	HashMap<StringName, StringName> remap;
+
+	remap[SceneStringName(Start)] = SceneStringName(Start);
+	remap[SceneStringName(End)] = SceneStringName(End);
+
+	for (const CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		remap[item.name] = name;
+		// Must duplicate node again for multiple pastes.
+		if (item.node.is_valid()) {
+			undo_redo->add_do_method(state_machine.ptr(), "add_node", name, item.node->duplicate(), p_position + item.position);
+			undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
+		}
+	}
+
+	for (const CopyTransition &item : p_transitions) {
+		StringName from = remap[item.from];
+		StringName to = remap[item.to];
+
+		// In practice, only really avoids overwriting Start -> End.
+		if (state_machine->has_transition(from, to)) {
+			continue;
+		}
+
+		// Must duplicate node again for multiple pastes.
+		if (item.transition.is_valid()) {
+			undo_redo->add_do_method(state_machine.ptr(), "add_transition", from, to, item.transition->duplicate());
+			undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", from, to);
+		}
+	}
+
+	undo_redo->add_do_method(this, "_update_graph");
+	undo_redo->add_undo_method(this, "_update_graph");
+
+	updating = false;
+}
+
+void AnimationNodeStateMachineEditor::_duplicate_nodes() {
+	// Don't destroy copy state, use separate buffer.
+	List<CopyItem> items;
+	List<CopyTransition> transitions;
+	_dup_copy_nodes(items, transitions);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Duplicate State Machine Node(s) and Transition(s)"));
+
+	_dup_paste_nodes(items, transitions, _map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+	_dup_copy_nodes(copy_items_buffer, copy_transitions_buffer);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut State Machine Node(s)"));
+
+		_erase_selected(true);
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeStateMachineEditor::_paste_nodes(const Vector2 &p_position) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Paste State Machine Node(s) and Transition(s)"));
+	_dup_paste_nodes(copy_items_buffer, copy_transitions_buffer, p_position);
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_transitions_buffer.clear();
+}
+
+String AnimationNodeStateMachineEditor::_deduplicate_node_name(const String &p_base_name) {
+	int base = 1;
+	String name = p_base_name;
+	while (state_machine->has_node(name)) {
+		base++;
+		name = p_base_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	String base_name;
 	Ref<AnimationRootNode> node;
@@ -929,9 +1095,27 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_nodes(!read_only);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
-
+		if (!read_only) {
+			_paste_nodes(add_node_pos);
+		}
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		if (!read_only) {
+			_duplicate_nodes();
+		}
+		return;
+	} else if (p_index == MENU_DELETE) {
+		if (!read_only) {
+			_erase_selected(false);
+		}
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -953,46 +1137,24 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		base_name = node->get_class().replace_first("AnimationNode", "");
 	}
 
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
-
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
-	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
-	connecting_to_node = name;
-	_add_transition(true);
-	undo_redo->add_do_method(this, "_update_graph");
-	undo_redo->add_undo_method(this, "_update_graph");
-	undo_redo->commit_action();
-	updating = false;
-
-	state_machine_draw->queue_redraw();
+	_add_node_and_transition(base_name, node);
 }
 
 void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 	Ref<AnimationNodeAnimation> anim;
 	anim.instantiate();
-
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = String(animations_to_add[p_index]).validate_node_name();
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	_add_node_and_transition(animations_to_add[p_index], anim);
+}
+
+void AnimationNodeStateMachineEditor::_add_node_and_transition(const String &p_base_name, Ref<AnimationNode> node) {
+	String name = _deduplicate_node_name(p_base_name);
 
 	updating = true;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, anim, add_node_pos);
+	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
 	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
 	connecting_to_node = name;
 	_add_transition(true);
@@ -1215,9 +1377,6 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		travel_path = playback->get_travel_path();
 	}
 
-	if (state_machine_draw->has_focus(true)) {
-		state_machine_draw->draw_rect(Rect2(Point2(), state_machine_draw->get_size()), theme_cache.focus_color, false);
-	}
 	int sep = 3 * EDSCALE;
 
 	LocalVector<StringName> nodes = state_machine->get_node_list();

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -177,6 +177,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	void _add_menu_type(int p_index);
 	void _add_animation_type(int p_index);
+	void _add_node_and_transition(const String &p_base_name, Ref<AnimationNode> node);
 	void _connect_to(int p_index);
 	void _reconnect_transition();
 	void _select_transition(const StringName &p_from, const StringName &p_to);
@@ -280,16 +281,36 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
-	};
-
 	HashSet<StringName> connected_nodes;
 	void _update_connected_nodes(const StringName &p_node);
 
 	Ref<StyleBox> _adjust_stylebox_opacity(Ref<StyleBox> p_style, float p_opacity);
+
+	Vector2 popup_menu_point;
+
+	struct CopyItem {
+		Ref<AnimationNode> node;
+		StringName name;
+		Vector2 position;
+	};
+
+	struct CopyTransition {
+		StringName from;
+		StringName to;
+		Ref<AnimationNodeStateMachineTransition> transition;
+	};
+
+	List<CopyItem> copy_items_buffer;
+	List<CopyTransition> copy_transitions_buffer;
+
+	void _dup_copy_nodes(List<CopyItem> &r_items, List<CopyTransition> &r_transitions);
+	void _dup_paste_nodes(const List<CopyItem> &r_items, const List<CopyTransition> &p_transitions, const Vector2 &p_position);
+	void _duplicate_nodes();
+	void _copy_nodes(bool p_cut);
+	void _paste_nodes(const Vector2 &p_position);
+	void _clear_copy_buffer();
+	String _deduplicate_node_name(const String &p_base_name);
+	Vector2 _map_to_state_machine(const Vector2 &p_position);
 
 protected:
 	void _notification(int p_what);
@@ -303,6 +324,8 @@ public:
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	AnimationNodeStateMachineEditor();
 };

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -41,10 +41,12 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
+#include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -272,6 +274,30 @@ void AnimationTreeEditor::_update_error_message() {
 
 	error_button->set_text(itos(count));
 	error_button->show();
+}
+
+void AnimationTreeNodeEditorPlugin::_add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste) {
+	if (p_can_copy) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Cut"), MENU_CUT);
+		p_menu->add_item(TTR("Copy"), MENU_COPY);
+		p_menu->add_item(TTR("Duplicate"), MENU_DUPLICATE);
+	}
+	if (p_can_paste) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Paste"), MENU_PASTE);
+	}
+	if (p_can_copy) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Delete"), MENU_DELETE);
+	}
+}
+
+AnimationTreeNodeEditorPlugin::AnimationTreeNodeEditorPlugin() {
+	set_process_shortcut_input(true);
+	set_shortcut_context(this);
+
+	set_focus_mode(FOCUS_ALL);
 }
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
@@ -572,6 +598,11 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	add_plugin(memnew(AnimationNodeBlendSpace1DEditor));
 	add_plugin(memnew(AnimationNodeBlendSpace2DEditor));
 	add_plugin(memnew(AnimationNodeStateMachineEditor));
+
+	ED_SHORTCUT("blend_tree_editor/cut", TTR("Cut"), KeyModifierMask::CMD_OR_CTRL | Key::X);
+	ED_SHORTCUT("blend_tree_editor/copy", TTR("Copy"), KeyModifierMask::CMD_OR_CTRL | Key::C);
+	ED_SHORTCUT("blend_tree_editor/paste", TTR("Paste"), KeyModifierMask::CMD_OR_CTRL | Key::V);
+	ED_SHORTCUT("blend_tree_editor/duplicate", TTR("Duplicate"), KeyModifierMask::CMD_OR_CTRL | Key::D);
 
 	error_scroll = memnew(ScrollContainer);
 	error_scroll->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -41,10 +41,12 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
+#include "scene/gui/popup_menu.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -274,6 +276,30 @@ void AnimationTreeEditor::_update_error_message() {
 	error_button->set_text(itos(count));
 	error_button->show();
 	status_bar->show();
+}
+
+void AnimationTreeNodeEditorPlugin::_add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste) {
+	if (p_can_copy) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Cut"), MENU_CUT);
+		p_menu->add_item(TTR("Copy"), MENU_COPY);
+		p_menu->add_item(TTR("Duplicate"), MENU_DUPLICATE);
+	}
+	if (p_can_paste) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Paste"), MENU_PASTE);
+	}
+	if (p_can_copy) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Delete"), MENU_DELETE);
+	}
+}
+
+AnimationTreeNodeEditorPlugin::AnimationTreeNodeEditorPlugin() {
+	set_process_shortcut_input(true);
+	set_shortcut_context(this);
+
+	set_focus_mode(FOCUS_ALL);
 }
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
@@ -575,6 +601,12 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	add_plugin(memnew(AnimationNodeBlendSpace1DEditor));
 	add_plugin(memnew(AnimationNodeBlendSpace2DEditor));
 	add_plugin(memnew(AnimationNodeStateMachineEditor));
+
+	ED_SHORTCUT("animation_tree_editor/cut", TTR("Cut"), KeyModifierMask::CMD_OR_CTRL | Key::X);
+	ED_SHORTCUT("animation_tree_editor/copy", TTR("Copy"), KeyModifierMask::CMD_OR_CTRL | Key::C);
+	ED_SHORTCUT("animation_tree_editor/paste", TTR("Paste"), KeyModifierMask::CMD_OR_CTRL | Key::V);
+	ED_SHORTCUT("animation_tree_editor/duplicate", TTR("Duplicate"), KeyModifierMask::CMD_OR_CTRL | Key::D);
+	ED_SHORTCUT("animation_tree_editor/delete", TTR("Delete"), Key::KEY_DELETE);
 
 	error_scroll = memnew(ScrollContainer);
 	error_scroll->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -44,9 +44,25 @@ class RichTextLabel;
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);
 
+protected:
+	enum {
+		MENU_LOAD_FILE = 1000,
+		MENU_PASTE = 1001,
+		MENU_LOAD_FILE_CONFIRM = 1002,
+		MENU_DUPLICATE = 1003,
+		MENU_CUT = 1004,
+		MENU_COPY = 1005,
+		MENU_DELETE = 1006,
+		MENU_USER_ID
+	};
+
+	void _add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste);
+
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
+
+	AnimationTreeNodeEditorPlugin();
 
 private:
 	String last_error_key;

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -44,9 +44,25 @@ class RichTextLabel;
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);
 
+protected:
+	enum {
+		MENU_LOAD_FILE = 1000,
+		MENU_LOAD_FILE_CONFIRM = 1001,
+		MENU_CUT = 1002,
+		MENU_COPY = 1003,
+		MENU_PASTE = 1004,
+		MENU_DUPLICATE = 1005,
+		MENU_DELETE = 1006,
+		MENU_USER_ID
+	};
+
+	void _add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste);
+
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
+
+	AnimationTreeNodeEditorPlugin();
 
 private:
 	String last_error_key;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8146.
Salvages https://github.com/godotengine/godot/pull/83518.

### Fixes from original PR
- Makes `_map_to_blend_space` use the correct soft margin introduced for BlendSpaces in #117498, and uses it in more places.
- Correctly accounts for BlendSpace names, introduced in #110369.
- Adds missing handlers for Paste, Duplicate and Delete in BlendSpace2D's context menu.
- Cleans up rebase artifacts from over the years, like [this](https://github.com/godotengine/godot/pull/83518/changes#diff-20f8883cec070b2c166812fc3ddfbf7365daf08eb3ee7393466fd32ceaf04f9cR203-R207) and [this](https://github.com/godotengine/godot/pull/83518/changes#diff-c765c1efe91a9021d590c76eb331f83540e927f1af006176b70c695e1b894ae4R266-R269).

### Changes from original PR
- Removes Ctrl+Drag to duplicate. While it is a nice have, managing its state is error-prone, and could conflict with modifier behaviours across the many available tools in each type of editor. It is also platform-specific; in macOS, duplication is usually done with Option (Alt). I don't think it's too much trouble to have users just use Duplicate via shortcut or menu instead, at least until all editors are fully-feature complete and Ctrl is definitely not better suited elsewhere.
- Rearranges Cut, Copy, Duplicate, Paste and Delete to be in the same order as SceneTreeDock's context menu.

### Planned follow-up PRs
- When a copy or cut operation takes place, in addition to the rich buffer that is saved for that editor type (with data like connections for BlendTree and transitions for StateMachine) a more general-purpose buffer could be piped up to the AnimationTree or stored in the clipboard, so that pasting from any Root node type to another becomes possible.
- Changing "Paste" to "Paste as Unique," and adding a normal Paste that holds a linked resource.
- Hooking into the new context menu and providing a "Copy as Path" option for each node, for use as `"parameters/.../.../..."` in code.