### PR TITLE
Remove SVG support from the Asset Store

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1261,8 +1261,6 @@ void EditorAssetLibrary::_image_update(void *p_image_queue) {
 			parsed_image = Image::_webp_mem_loader_func(r, len);
 		} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
 			parsed_image = Image::_bmp_mem_loader_func(r, len);
-		} else if (Image::_svg_scalable_mem_loader_func) {
-			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0);
 		}
 
 		if (parsed_image.is_null()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

As per https://github.com/godotengine/godot-asset-store-tracker/issues/237 SVG will not be supported in the new Asset Store. So the editor handling it, is not necessary. This will get rid of some annoying error spam when other invalid images slip through moderation.

## Additional information

- Adding this was actually one of my first contributions: https://github.com/godotengine/godot/pull/70317
