### PR TITLE
Core: Add null checks to `memdelete` functions

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -156,6 +156,9 @@ _ALWAYS_INLINE_ bool predelete_handler(void *) {
 
 template <typename T>
 void memdelete(T *p_class) {
+	if (unlikely(p_class == nullptr)) {
+		return;
+	}
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
@@ -168,6 +171,9 @@ void memdelete(T *p_class) {
 
 template <typename T, typename A>
 void memdelete_allocator(T *p_class) {
+	if (unlikely(p_class == nullptr)) {
+		return;
+	}
 	if (!predelete_handler(p_class)) {
 		return; // doesn't want to be deleted
 	}
@@ -177,13 +183,6 @@ void memdelete_allocator(T *p_class) {
 
 	A::free(p_class);
 }
-
-#define memdelete_notnull(m_v) \
-	{ \
-		if (m_v) { \
-			memdelete(m_v); \
-		} \
-	}
 
 #define memnew_arr(m_class, m_count) memnew_arr_template<m_class>(m_count)
 

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -396,12 +396,12 @@ struct RenderTarget {
 		RID velocity_depth;
 
 		struct FBOCacheEntry {
-			GLuint fbo;
-			GLuint color;
-			GLuint depth;
+			GLuint fbo = 0;
+			GLuint color = 0;
+			GLuint depth = 0;
 			Size2i size;
 			Vector<GLuint> allocated_textures;
-			bool depth_has_stencil;
+			bool depth_has_stencil = false;
 		};
 		RBMap<uint32_t, FBOCacheEntry> fbo_cache;
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1274,7 +1274,7 @@ void EditorSelection::_node_removed(Node *p_node) {
 	}
 
 	Object *meta = selection[nid];
-	memdelete_notnull(meta);
+	memdelete(meta);
 	selection.erase(nid);
 	changed = true;
 	node_list_changed = true;
@@ -1312,7 +1312,7 @@ void EditorSelection::remove_node(Node *p_node) {
 	changed = true;
 	node_list_changed = true;
 	Object *meta = selection[nid];
-	memdelete_notnull(meta);
+	memdelete(meta);
 	selection.erase(nid);
 
 	p_node->disconnect(SceneStringName(tree_exiting), callable_mp(this, &EditorSelection::_node_removed));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2383,7 +2383,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 }
 
 void EditorNode::_close_save_scene_progress() {
-	memdelete_notnull(save_scene_progress);
+	memdelete(save_scene_progress);
 	save_scene_progress = nullptr;
 }
 
@@ -8268,7 +8268,7 @@ void EditorNode::_update_main_menu_type() {
 		memdelete(main_menu_button);
 		main_menu_button = nullptr;
 	}
-	memdelete_notnull(menu_btn_spacer);
+	memdelete(menu_btn_spacer);
 	menu_btn_spacer = nullptr;
 
 	// Create new menu.

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1025,7 +1025,7 @@ bool EditorFileSystem::_update_scan_actions() {
 		}
 	}
 
-	memdelete_notnull(ep);
+	memdelete(ep);
 
 	if (_scan_extensions()) {
 		//needs editor restart
@@ -2181,7 +2181,7 @@ void EditorFileSystem::_update_script_classes() {
 			}
 		}
 
-		memdelete_notnull(ep);
+		memdelete(ep);
 
 		update_script_paths.clear();
 	}
@@ -2278,7 +2278,7 @@ void EditorFileSystem::_update_script_documentation() {
 		}
 	}
 
-	memdelete_notnull(ep);
+	memdelete(ep);
 
 	update_script_paths_documentation.clear();
 }
@@ -2353,7 +2353,7 @@ void EditorFileSystem::_update_scene_groups() {
 			}
 		}
 
-		memdelete_notnull(ep);
+		memdelete(ep);
 		update_scene_paths.clear();
 	}
 
@@ -3416,7 +3416,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	ResourceUID::get_singleton()->update_cache(); // After reimporting, update the cache.
 	_save_filesystem_cache();
 
-	memdelete_notnull(ep);
+	memdelete(ep);
 
 	_process_update_pending();
 
@@ -3432,7 +3432,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 		emit_signal(SNAME("filesystem_changed"));
 	}
 	emit_signal(SNAME("resources_reimported"), reloads);
-	memdelete_notnull(ep);
+	memdelete(ep);
 }
 
 Error EditorFileSystem::reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters) {
@@ -3628,7 +3628,7 @@ Error EditorFileSystem::copy_directory(const String &p_from, const String &p_to)
 				ep->step(tuple.key.get_file(), i++, false);
 			}
 		}
-		memdelete_notnull(ep);
+		memdelete(ep);
 	}
 
 	// Now remap any internal dependencies (within the folder) to use the new files.
@@ -3647,7 +3647,7 @@ Error EditorFileSystem::copy_directory(const String &p_from, const String &p_to)
 				ep->step(tuple.key.get_file(), i++, false);
 			}
 		}
-		memdelete_notnull(ep);
+		memdelete(ep);
 	}
 
 	EditorFileSystemDirectory *efd = get_filesystem_path(p_to);

--- a/modules/gdscript/language_server/scene_cache.cpp
+++ b/modules/gdscript/language_server/scene_cache.cpp
@@ -167,7 +167,7 @@ void SceneCache::unload(const String &p_script_path) {
 	if (!cache.has(p_script_path)) {
 		return;
 	}
-	memdelete_notnull(cache[p_script_path]);
+	memdelete(cache[p_script_path]);
 	cache.erase(p_script_path);
 	LOG_LSP("Cache cleared for path:", p_script_path);
 }
@@ -179,7 +179,7 @@ void SceneCache::clear() {
 	}
 	script_path_queue.clear();
 	for (const KeyValue<String, Node *> &E : cache) {
-		memdelete_notnull(E.value);
+		memdelete(E.value);
 	}
 	cache.clear();
 	LOG_LSP("Cache cleared.");

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -102,7 +102,7 @@ GDScriptLanguageProtocol *initialize(const String &p_root) {
 	init_language(absolute_root);
 
 	// Recreate the singleton for each test, to ensure a clean state.
-	memdelete_notnull(GDScriptLanguageProtocol::get_singleton());
+	memdelete(GDScriptLanguageProtocol::get_singleton());
 	GDScriptLanguageProtocol *proto = memnew(GDScriptLanguageProtocol);
 	TestGDScriptLanguageProtocolInitializer::setup_client();
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -2231,7 +2231,7 @@ void GridMapEditorPlugin::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			EditorDockManager::get_singleton()->remove_dock(grid_map_editor);
-			memdelete_notnull(grid_map_editor);
+			memdelete(grid_map_editor);
 			grid_map_editor = nullptr;
 		} break;
 	}


### PR DESCRIPTION
- Supersedes #121295

## What problem(s) does this PR solve?

Given `free(nullptr)` and `operator delete(nullptr)` act as no-ops, it's reasonable to say that `memdelete(nullptr)` should do the same. This PR adds a silent, early return to `memdelete` and `memdelete_allocator` when passing a null pointer.

## Additional information

Discussed in the [07/15/2026 Core meeting](https://docs.google.com/document/d/1y4ce-S1qlm90n6-r2xdIokUKqKJCWcfOCuVJA3pyh-A/edit?tab=t.0#heading=h.m4yti8co7vnl). The now-redundant `memdelete_notnull` has been removed, and any existing references were converted to `memdelete`.