### PR TITLE
Style: Trim simple null `memdelete` conditionals

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -191,9 +191,7 @@ void EngineDebugger::deinitialize() {
 }
 
 EngineDebugger::~EngineDebugger() {
-	if (script_debugger) {
-		memdelete(script_debugger);
-	}
+	memdelete(script_debugger);
 	script_debugger = nullptr;
 	singleton = nullptr;
 }

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -395,7 +395,5 @@ LocalDebugger::LocalDebugger() {
 
 LocalDebugger::~LocalDebugger() {
 	unregister_profiler("scripts");
-	if (scripts_profiler) {
-		memdelete(scripts_profiler);
-	}
+	memdelete(scripts_profiler);
 }

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1225,9 +1225,7 @@ bool Expression::_compile_expression() {
 
 	if (error_set) {
 		root = nullptr;
-		if (nodes) {
-			memdelete(nodes);
-		}
+		memdelete(nodes);
 		nodes = nullptr;
 		return true;
 	}
@@ -1481,9 +1479,7 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 
 	if (error_set) {
 		root = nullptr;
-		if (nodes) {
-			memdelete(nodes);
-		}
+		memdelete(nodes);
 		nodes = nullptr;
 		return ERR_INVALID_PARAMETER;
 	}
@@ -1523,7 +1519,5 @@ void Expression::_bind_methods() {
 }
 
 Expression::~Expression() {
-	if (nodes) {
-		memdelete(nodes);
-	}
+	memdelete(nodes);
 }

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -125,9 +125,7 @@ protected:
 		Type type = TYPE_INPUT;
 
 		virtual ~ENode() {
-			if (next) {
-				memdelete(next);
-			}
+			memdelete(next);
 		}
 	};
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -180,9 +180,7 @@ bool Object::_predelete() {
 
 	// Destruction order starts with the most derived class, and progresses towards the base Object class:
 	// Script subclasses -> GDExtension subclasses -> C++ subclasses -> Object
-	if (script_instance) {
-		memdelete(script_instance);
-	}
+	memdelete(script_instance);
 	script_instance = nullptr;
 
 	if (_extension) {
@@ -1000,9 +998,7 @@ void Object::set_script_instance(ScriptInstance *p_instance) {
 		return;
 	}
 
-	if (script_instance) {
-		memdelete(script_instance);
-	}
+	memdelete(script_instance);
 
 	script_instance = p_instance;
 }
@@ -2366,9 +2362,7 @@ Object::~Object() {
 		memfree(_instance_bindings);
 	}
 
-	if (signal_mutex) {
-		memdelete(signal_mutex);
-	}
+	memdelete(signal_mutex);
 }
 
 bool predelete_handler(Object *p_object) {

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -44,9 +44,7 @@ void UndoRedo::Operation::delete_reference() {
 		ref.unref();
 	} else {
 		Object *obj = ObjectDB::get_instance(object);
-		if (obj) {
-			memdelete(obj);
-		}
+		memdelete(obj);
 	}
 }
 

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -672,9 +672,7 @@ WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_ca
 		group->done_semaphore.post();
 		group->tasks_used = 0;
 		p_tasks = 0;
-		if (p_template_userdata) {
-			memdelete(p_template_userdata);
-		}
+		memdelete(p_template_userdata);
 
 	} else {
 		group->tasks_used = p_tasks;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -75,9 +75,7 @@ double OS::get_unix_time() const {
 }
 
 void OS::_set_logger(CompositeLogger *p_logger) {
-	if (_logger) {
-		memdelete(_logger);
-	}
+	memdelete(_logger);
 	_logger = p_logger;
 }
 
@@ -835,8 +833,6 @@ OS::OS() {
 }
 
 OS::~OS() {
-	if (_logger) {
-		memdelete(_logger);
-	}
+	memdelete(_logger);
 	singleton = nullptr;
 }

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -439,9 +439,7 @@ void unregister_core_types() {
 
 	memdelete(resource_uid);
 
-	if (ip) {
-		memdelete(ip);
-	}
+	memdelete(ip);
 
 	if constexpr (GD_IS_CLASS_ENABLED(Image)) {
 		ResourceLoader::remove_resource_format_loader(resource_format_image);

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -77,9 +77,7 @@ void Array::_unref() const {
 	}
 
 	if (_p->refcount.unref()) {
-		if (_p->read_only) {
-			memdelete(_p->read_only);
-		}
+		memdelete(_p->read_only);
 		memdelete(_p);
 	}
 	_p = nullptr;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -351,12 +351,8 @@ Dictionary Dictionary::merged(const Dictionary &p_dictionary, bool p_overwrite) 
 void Dictionary::_unref() const {
 	ERR_FAIL_NULL(_p);
 	if (_p->refcount.unref()) {
-		if (_p->read_only) {
-			memdelete(_p->read_only);
-		}
-		if (_p->typed_fallback) {
-			memdelete(_p->typed_fallback);
-		}
+		memdelete(_p->read_only);
+		memdelete(_p->typed_fallback);
 		memdelete(_p);
 	}
 	_p = nullptr;

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -191,14 +191,9 @@ void OS_AppleEmbedded::initialize_modules() {
 
 void OS_AppleEmbedded::deinitialize_modules() {
 #ifdef SDL_ENABLED
-	if (joypad_sdl) {
-		memdelete(joypad_sdl);
-	}
+	memdelete(joypad_sdl);
 #endif
-
-	if (apple_embedded) {
-		memdelete(apple_embedded);
-	}
+	memdelete(apple_embedded);
 }
 
 void OS_AppleEmbedded::set_main_loop(MainLoop *p_main_loop) {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2251,9 +2251,7 @@ void MaterialStorage::shader_free(RID p_rid) {
 	}
 
 	//clear data if exists
-	if (shader->data) {
-		memdelete(shader->data);
-	}
+	memdelete(shader->data);
 	shader_owner.free(p_rid);
 }
 

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1023,9 +1023,7 @@ void TextureStorage::texture_free(RID p_texture) {
 	ERR_FAIL_NULL(t);
 	ERR_FAIL_COND(t->is_render_target);
 
-	if (t->canvas_texture) {
-		memdelete(t->canvas_texture);
-	}
+	memdelete(t->canvas_texture);
 
 	bool must_free_data = false;
 	if (t->is_proxy) {

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2775,17 +2775,9 @@ RenderingDeviceDriverMetal::~RenderingDeviceDriverMetal() {
 		memdelete(kv.value);
 	}
 
-	if (shader_container_format != nullptr) {
-		memdelete(shader_container_format);
-	}
-
-	if (pixel_formats != nullptr) {
-		memdelete(pixel_formats);
-	}
-
-	if (device_properties != nullptr) {
-		memdelete(device_properties);
-	}
+	memdelete(shader_container_format);
+	memdelete(pixel_formats);
+	memdelete(device_properties);
 }
 
 #pragma mark - Initialization

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8698,12 +8698,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 }
 
 AnimationTrackEditor::~AnimationTrackEditor() {
-	if (key_edit) {
-		memdelete(key_edit);
-	}
-	if (multi_key_edit) {
-		memdelete(multi_key_edit);
-	}
+	memdelete(key_edit);
+	memdelete(multi_key_edit);
 }
 
 // AnimationTrackKeyEditEditorPlugin.

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1914,9 +1914,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				}
 			}
 
-			if (description) {
-				memdelete(description);
-			}
+			memdelete(description);
 
 			description = memnew(EditorAssetLibraryItemDescription);
 			add_child(description);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1015,9 +1015,7 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 
 void EditorData::clear_edited_scenes() {
 	for (int i = 0; i < edited_scene.size(); i++) {
-		if (edited_scene[i].root) {
-			memdelete(edited_scene[i].root);
-		}
+		memdelete(edited_scene[i].root);
 	}
 	edited_scene.clear();
 	SceneTree::get_singleton()->set_edited_scene_root(nullptr);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -595,9 +595,7 @@ void EditorLog::deinit() {
 }
 
 EditorLog::~EditorLog() {
-	if (bbcode_parser) {
-		memdelete(bbcode_parser);
-	}
+	memdelete(bbcode_parser);
 
 	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
 		// MSG_TYPE_STD_RICH is connected to the std_filter button, so we do this

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1116,9 +1116,7 @@ void EditorFileSystem::scan() {
 		scanning = true;
 		scan_total = 0;
 		_scan_filesystem();
-		if (filesystem) {
-			memdelete(filesystem);
-		}
+		memdelete(filesystem);
 		//file_type_cache.clear();
 		filesystem = new_filesystem;
 		new_filesystem = nullptr;
@@ -1752,12 +1750,8 @@ void EditorFileSystem::_notification(int p_what) {
 				set_process(false);
 			}
 
-			if (filesystem) {
-				memdelete(filesystem);
-			}
-			if (new_filesystem) {
-				memdelete(new_filesystem);
-			}
+			memdelete(filesystem);
+			memdelete(new_filesystem);
 			filesystem = nullptr;
 			new_filesystem = nullptr;
 		} break;
@@ -1801,9 +1795,7 @@ void EditorFileSystem::_notification(int p_what) {
 				} else if (!scanning && thread.is_started()) {
 					set_process(false);
 
-					if (filesystem) {
-						memdelete(filesystem);
-					}
+					memdelete(filesystem);
 					filesystem = new_filesystem;
 					new_filesystem = nullptr;
 					thread.wait_to_finish();
@@ -3819,9 +3811,7 @@ EditorFileSystem::EditorFileSystem() {
 }
 
 EditorFileSystem::~EditorFileSystem() {
-	if (filesystem) {
-		memdelete(filesystem);
-	}
+	memdelete(filesystem);
 	filesystem = nullptr;
 	ResourceSaver::set_get_resource_id_for_path(nullptr);
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -940,36 +940,22 @@ void Main::test_cleanup() {
 	EngineDebugger::deinitialize();
 	OS::get_singleton()->finalize();
 
-	if (packed_data) {
-		memdelete(packed_data);
-	}
-	if (translation_server) {
-		memdelete(translation_server);
-	}
-	if (tsman) {
-		memdelete(tsman);
-	}
+	memdelete(packed_data);
+	memdelete(translation_server);
+	memdelete(tsman);
 #ifndef PHYSICS_3D_DISABLED
-	if (physics_server_3d_manager) {
-		memdelete(physics_server_3d_manager);
-	}
+	memdelete(physics_server_3d_manager);
 #endif // PHYSICS_3D_DISABLED
 #ifndef PHYSICS_2D_DISABLED
-	if (physics_server_2d_manager) {
-		memdelete(physics_server_2d_manager);
-	}
+	memdelete(physics_server_2d_manager);
 #endif // PHYSICS_2D_DISABLED
-	if (globals) {
-		memdelete(globals);
-	}
+	memdelete(globals);
 
 	unregister_core_driver_types();
 	unregister_core_extensions();
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 
-	if (engine) {
-		memdelete(engine);
-	}
+	memdelete(engine);
 
 	unregister_core_types();
 
@@ -2966,44 +2952,28 @@ error:
 
 	EngineDebugger::deinitialize();
 
-	if (performance) {
-		memdelete(performance);
-	}
-	if (input_map) {
-		memdelete(input_map);
-	}
-	if (translation_server) {
-		memdelete(translation_server);
-	}
-	if (globals) {
-		memdelete(globals);
-	}
-	if (packed_data) {
-		memdelete(packed_data);
-	}
+	memdelete(performance);
+	memdelete(input_map);
+	memdelete(translation_server);
+	memdelete(globals);
+	memdelete(packed_data);
 
 	unregister_core_driver_types();
 	unregister_core_extensions();
 
-	if (engine) {
-		memdelete(engine);
-	}
+	memdelete(engine);
 
 	unregister_core_types();
 
 	OS::get_singleton()->_cmdline.clear();
 	OS::get_singleton()->_user_args.clear();
 
-	if (message_queue) {
-		memdelete(message_queue);
-	}
+	memdelete(message_queue);
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup");
 
 #if defined(STEAMAPI_ENABLED)
-	if (steam_tracker) {
-		memdelete(steam_tracker);
-	}
+	memdelete(steam_tracker);
 #endif
 
 	OS::get_singleton()->finalize_core();
@@ -3392,29 +3362,19 @@ Error Main::setup2(bool p_show_boot_logo) {
 		if (err != OK || display_server == nullptr) {
 			ERR_PRINT("Unable to create DisplayServer, all display drivers failed.\nUse \"--headless\" command line argument to run the engine in headless mode if this is desired (e.g. for continuous integration).");
 
-			if (display_server) {
-				memdelete(display_server);
-			}
+			memdelete(display_server);
 
 			GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 			uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 			unregister_server_types();
 
-			if (input) {
-				memdelete(input);
-			}
-			if (tsman) {
-				memdelete(tsman);
-			}
+			memdelete(input);
+			memdelete(tsman);
 #ifndef PHYSICS_3D_DISABLED
-			if (physics_server_3d_manager) {
-				memdelete(physics_server_3d_manager);
-			}
+			memdelete(physics_server_3d_manager);
 #endif // PHYSICS_3D_DISABLED
 #ifndef PHYSICS_2D_DISABLED
-			if (physics_server_2d_manager) {
-				memdelete(physics_server_2d_manager);
-			}
+			memdelete(physics_server_2d_manager);
 #endif // PHYSICS_2D_DISABLED
 
 			return err;
@@ -4381,9 +4341,7 @@ int Main::start() {
 			Object *obj = ClassDB::instantiate(instance_type);
 			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
 			if (!script_loop) {
-				if (obj) {
-					memdelete(obj);
-				}
+				memdelete(obj);
 				OS::get_singleton()->alert(vformat("Can't load the script \"%s\" as it doesn't inherit from SceneTree or MainLoop.", script));
 				ERR_FAIL_V_MSG(EXIT_FAILURE, vformat("Can't load the script \"%s\" as it doesn't inherit from SceneTree or MainLoop.", script));
 			}
@@ -4405,9 +4363,7 @@ int Main::start() {
 			Object *obj = ClassDB::instantiate(script_base);
 			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
 			if (!script_loop) {
-				if (obj) {
-					memdelete(obj);
-				}
+				memdelete(obj);
 				OS::get_singleton()->alert("Error: Invalid MainLoop script base type: " + script_base);
 				ERR_FAIL_V_MSG(EXIT_FAILURE, vformat("The global class %s does not inherit from SceneTree or MainLoop.", main_loop_type));
 			}
@@ -5322,9 +5278,7 @@ void Main::cleanup(bool p_force) {
 	EngineDebugger::deinitialize();
 
 #ifndef XR_DISABLED
-	if (xr_server) {
-		memdelete(xr_server);
-	}
+	memdelete(xr_server);
 #endif // XR_DISABLED
 
 	if (audio_server) {
@@ -5332,46 +5286,26 @@ void Main::cleanup(bool p_force) {
 		memdelete(audio_server);
 	}
 
-	if (camera_server) {
-		memdelete(camera_server);
-	}
+	memdelete(camera_server);
 
 	OS::get_singleton()->finalize();
 
 	finalize_display();
 
-	if (input) {
-		memdelete(input);
-	}
+	memdelete(input);
 
-	if (packed_data) {
-		memdelete(packed_data);
-	}
-	if (performance) {
-		memdelete(performance);
-	}
-	if (input_map) {
-		memdelete(input_map);
-	}
-	if (translation_server) {
-		memdelete(translation_server);
-	}
-	if (tsman) {
-		memdelete(tsman);
-	}
+	memdelete(packed_data);
+	memdelete(performance);
+	memdelete(input_map);
+	memdelete(translation_server);
+	memdelete(tsman);
 #ifndef PHYSICS_3D_DISABLED
-	if (physics_server_3d_manager) {
-		memdelete(physics_server_3d_manager);
-	}
+	memdelete(physics_server_3d_manager);
 #endif // PHYSICS_3D_DISABLED
 #ifndef PHYSICS_2D_DISABLED
-	if (physics_server_2d_manager) {
-		memdelete(physics_server_2d_manager);
-	}
+	memdelete(physics_server_2d_manager);
 #endif // PHYSICS_2D_DISABLED
-	if (globals) {
-		memdelete(globals);
-	}
+	memdelete(globals);
 
 	if (OS::get_singleton()->is_restart_on_exit_set()) {
 		//attempt to restart with arguments
@@ -5385,18 +5319,14 @@ void Main::cleanup(bool p_force) {
 	memdelete(message_queue);
 
 #if defined(STEAMAPI_ENABLED)
-	if (steam_tracker) {
-		memdelete(steam_tracker);
-	}
+	memdelete(steam_tracker);
 #endif
 
 	unregister_core_driver_types();
 	unregister_core_extensions();
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 
-	if (engine) {
-		memdelete(engine);
-	}
+	memdelete(engine);
 
 	unregister_core_types();
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -487,9 +487,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 	if (!dirty) {
 		return brush;
 	}
-	if (brush) {
-		memdelete(brush);
-	}
+	memdelete(brush);
 	brush = nullptr;
 	CSGBrush *n = _build_brush();
 	HashMap<int32_t, Ref<Material>> mesh_materials;
@@ -522,9 +520,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 	}
 	if (!manifolds.empty()) {
 		manifold::Manifold manifold_result = manifold::Manifold::BatchBoolean(manifolds, current_op);
-		if (n) {
-			memdelete(n);
-		}
+		memdelete(n);
 		n = memnew(CSGBrush);
 		_unpack_manifold(manifold_result, mesh_materials, n);
 	}

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -130,13 +130,8 @@ void GDScriptParserRef::clear() {
 
 	clearing = false;
 
-	if (lanalyzer != nullptr) {
-		memdelete(lanalyzer);
-	}
-
-	if (lparser != nullptr) {
-		memdelete(lparser);
-	}
+	memdelete(lanalyzer);
+	memdelete(lparser);
 }
 
 GDScriptParserRef::~GDScriptParserRef() {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2725,15 +2725,9 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	p_script->static_variables.clear();
 
-	if (p_script->implicit_initializer) {
-		memdelete(p_script->implicit_initializer);
-	}
-	if (p_script->implicit_ready) {
-		memdelete(p_script->implicit_ready);
-	}
-	if (p_script->static_initializer) {
-		memdelete(p_script->static_initializer);
-	}
+	memdelete(p_script->implicit_initializer);
+	memdelete(p_script->implicit_ready);
+	memdelete(p_script->static_initializer);
 
 	p_script->member_functions.clear();
 	p_script->member_indices.clear();

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -181,13 +181,8 @@ void uninitialize_gdscript_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		ScriptServer::unregister_language(script_language_gd);
 
-		if (gdscript_cache) {
-			memdelete(gdscript_cache);
-		}
-
-		if (script_language_gd) {
-			memdelete(script_language_gd);
-		}
+		memdelete(gdscript_cache);
+		memdelete(script_language_gd);
 
 		ResourceLoader::remove_resource_format_loader(resource_loader_gd);
 		resource_loader_gd.unref();

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -216,9 +216,7 @@ static void test_directory(const String &p_dir) {
 			CHECK(expected_call_hint == call_hint);
 			CHECK(expected_forced == forced);
 
-			if (scene) {
-				memdelete(scene);
-			}
+			memdelete(scene);
 		}
 		next = dir->get_next();
 	}

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -754,10 +754,6 @@ GodotBody2D::GodotBody2D() :
 }
 
 GodotBody2D::~GodotBody2D() {
-	if (fi_callback_data) {
-		memdelete(fi_callback_data);
-	}
-	if (direct_state) {
-		memdelete(direct_state);
-	}
+	memdelete(fi_callback_data);
+	memdelete(direct_state);
 }

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -833,10 +833,6 @@ GodotBody3D::GodotBody3D() :
 }
 
 GodotBody3D::~GodotBody3D() {
-	if (fi_callback_data) {
-		memdelete(fi_callback_data);
-	}
-	if (direct_state) {
-		memdelete(direct_state);
-	}
+	memdelete(fi_callback_data);
+	memdelete(direct_state);
 }

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1438,9 +1438,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_TEXTURES
 			FREE_BUFFERS
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
+			memdelete(rcd);
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1457,9 +1455,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 		memdelete(rd);
 
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
+		memdelete(rcd);
 	}
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
@@ -1657,9 +1653,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		FREE_RASTER_RESOURCES
 		memdelete(rd);
 
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
+		memdelete(rcd);
 
 		compute_shader->print_errors("compute_shader");
 	}
@@ -1704,9 +1698,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_RASTER_RESOURCES
 			FREE_COMPUTE_RESOURCES
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
+			memdelete(rcd);
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1765,9 +1757,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_RASTER_RESOURCES
 			FREE_COMPUTE_RESOURCES
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
+			memdelete(rcd);
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1890,9 +1880,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 							FREE_RASTER_RESOURCES
 							FREE_COMPUTE_RESOURCES
 							memdelete(rd);
-							if (rcd != nullptr) {
-								memdelete(rcd);
-							}
+							memdelete(rcd);
 							return BAKE_ERROR_USER_ABORTED;
 						}
 					}
@@ -1989,9 +1977,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				FREE_RASTER_RESOURCES
 				FREE_COMPUTE_RESOURCES
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
+				memdelete(rcd);
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -2038,9 +2024,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 								FREE_RASTER_RESOURCES
 								FREE_COMPUTE_RESOURCES
 								memdelete(rd);
-								if (rcd != nullptr) {
-									memdelete(rcd);
-								}
+								memdelete(rcd);
 								return BAKE_ERROR_USER_ABORTED;
 							}
 						}
@@ -2067,9 +2051,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
+				memdelete(rcd);
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -2156,9 +2138,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 						rd->free_rid(light_probe_buffer);
 					}
 					memdelete(rd);
-					if (rcd != nullptr) {
-						memdelete(rcd);
-					}
+					memdelete(rcd);
 					return BAKE_ERROR_USER_ABORTED;
 				}
 			}
@@ -2199,9 +2179,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
+				memdelete(rcd);
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -2276,9 +2254,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		FREE_COMPUTE_RESOURCES
 		memdelete(rd);
 
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
+		memdelete(rcd);
 
 		blendseams_shader->print_errors("blendseams_shader");
 	}
@@ -2464,9 +2440,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	memdelete(rd);
 
-	if (rcd != nullptr) {
-		memdelete(rcd);
-	}
+	memdelete(rcd);
 
 	return BAKE_OK;
 }

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -71,9 +71,7 @@ void uninitialize_mono_module(ModuleInitializationLevel p_level) {
 
 	ScriptServer::unregister_language(script_language_cs);
 
-	if (script_language_cs) {
-		memdelete(script_language_cs);
-	}
+	memdelete(script_language_cs);
 
 	if constexpr (GD_IS_CLASS_ENABLED(CSharpScript)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_cs);
@@ -82,7 +80,5 @@ void uninitialize_mono_module(ModuleInitializationLevel p_level) {
 		resource_saver_cs.unref();
 	}
 
-	if (_godotsharp) {
-		memdelete(_godotsharp);
-	}
+	memdelete(_godotsharp);
 }

--- a/modules/navigation_3d/register_types.cpp
+++ b/modules/navigation_3d/register_types.cpp
@@ -82,8 +82,6 @@ void uninitialize_navigation_3d_module(ModuleInitializationLevel p_level) {
 	}
 
 #ifndef DISABLE_DEPRECATED
-	if (_nav_mesh_generator) {
-		memdelete(_nav_mesh_generator);
-	}
+	memdelete(_nav_mesh_generator);
 #endif // DISABLE_DEPRECATED
 }

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1868,13 +1868,9 @@ void OpenXRAPI::cleanup_extension_wrappers() {
 #ifndef DISABLE_DEPRECATED
 		// Fix crash when the extension wrapper comes from GDExtension.
 		OpenXRExtensionWrapperExtension *gdextension_extension_wrapper = dynamic_cast<OpenXRExtensionWrapperExtension *>(extension_wrapper);
-		if (gdextension_extension_wrapper) {
-			memdelete(gdextension_extension_wrapper);
-		} else
+		memdelete(gdextension_extension_wrapper);
 #endif
-		{
-			memdelete(extension_wrapper);
-		}
+		memdelete(extension_wrapper);
 	}
 	registered_extension_wrappers.clear();
 }

--- a/modules/raycast/register_types.cpp
+++ b/modules/raycast/register_types.cpp
@@ -53,9 +53,7 @@ void uninitialize_raycast_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	if (raycast_occlusion_cull) {
-		memdelete(raycast_occlusion_cull);
-	}
+	memdelete(raycast_occlusion_cull);
 #ifdef TOOLS_ENABLED
 	StaticRaycasterEmbree::free();
 #endif

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -569,9 +569,7 @@ class TextServerAdvanced : public TextServerExtension {
 					ubidi_close(bidi_iter[i]);
 				}
 			}
-			if (script_iter) {
-				memdelete(script_iter);
-			}
+			memdelete(script_iter);
 			if (hb_buffer) {
 				hb_buffer_destroy(hb_buffer);
 			}

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -856,9 +856,7 @@ DisplayServerAndroid::~DisplayServerAndroid() {
 	}
 
 #if defined(RD_ENABLED)
-	if (rendering_device) {
-		memdelete(rendering_device);
-	}
+	memdelete(rendering_device);
 
 	free_vulkan_global_context();
 #endif

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -4504,8 +4504,6 @@ EditorExportPlatformAndroid::~EditorExportPlatformAndroid() {
 #ifndef ANDROID_ENABLED
 	_stop_check_for_changes_poll_thread();
 #else
-	if (android_editor_gradle_runner) {
-		memdelete(android_editor_gradle_runner);
-	}
+	memdelete(android_editor_gradle_runner);
 #endif
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -101,9 +101,7 @@ static void _terminate(JNIEnv *env, bool p_restart = false) {
 	// Unregister android plugins
 	unregister_plugins_singletons();
 
-	if (java_class_wrapper) {
-		memdelete(java_class_wrapper);
-	}
+	memdelete(java_class_wrapper);
 	if (input_handler) {
 		delete input_handler;
 	}

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -43,9 +43,7 @@ void unregister_plugins_singletons() {
 	for (const KeyValue<String, JNISingleton *> &E : jni_singletons) {
 		Engine::get_singleton()->remove_singleton(E.key);
 
-		if (E.value) {
-			memdelete(E.value);
-		}
+		memdelete(E.value);
 	}
 	jni_singletons.clear();
 }

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -254,9 +254,7 @@ bool OS_LinuxBSD::is_sandboxed() const {
 }
 
 void OS_LinuxBSD::finalize() {
-	if (main_loop) {
-		memdelete(main_loop);
-	}
+	memdelete(main_loop);
 	main_loop = nullptr;
 
 #ifdef ALSAMIDI_ENABLED
@@ -264,9 +262,7 @@ void OS_LinuxBSD::finalize() {
 #endif
 
 #ifdef SDL_ENABLED
-	if (joypad_sdl) {
-		memdelete(joypad_sdl);
-	}
+	memdelete(joypad_sdl);
 #endif
 }
 
@@ -275,9 +271,7 @@ MainLoop *OS_LinuxBSD::get_main_loop() const {
 }
 
 void OS_LinuxBSD::delete_main_loop() {
-	if (main_loop) {
-		memdelete(main_loop);
-	}
+	memdelete(main_loop);
 	main_loop = nullptr;
 }
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -2599,31 +2599,18 @@ DisplayServerWayland::~DisplayServerWayland() {
 
 	// Destroy all drivers.
 #ifdef RD_ENABLED
-	if (rendering_device) {
-		memdelete(rendering_device);
-	}
-
-	if (rendering_context) {
-		memdelete(rendering_context);
-	}
+	memdelete(rendering_device);
+	memdelete(rendering_context);
 #endif
 
 #ifdef SPEECHD_ENABLED
-	if (tts) {
-		memdelete(tts);
-	}
+	memdelete(tts);
 #endif
 
 #ifdef DBUS_ENABLED
-	if (portal_desktop) {
-		memdelete(portal_desktop);
-	}
-	if (screensaver) {
-		memdelete(screensaver);
-	}
-	if (atspi_monitor) {
-		memdelete(atspi_monitor);
-	}
+	memdelete(portal_desktop);
+	memdelete(screensaver);
+	memdelete(atspi_monitor);
 #endif
 }
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1169,9 +1169,7 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 
 			for (struct zwp_tablet_tool_v2 *tool : ss->tablet_tools) {
 				TabletToolState *state = wp_tablet_tool_get_state(tool);
-				if (state) {
-					memdelete(state);
-				}
+				memdelete(state);
 
 				zwp_tablet_tool_v2_destroy(tool);
 			}
@@ -1236,9 +1234,7 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 
 					for (struct zwp_tablet_tool_v2 *tool : ss->tablet_tools) {
 						TabletToolState *state = wp_tablet_tool_get_state(tool);
-						if (state) {
-							memdelete(state);
-						}
+						memdelete(state);
 
 						zwp_tablet_tool_v2_destroy(tool);
 					}
@@ -3262,9 +3258,7 @@ void WaylandThread::_wp_tablet_tool_on_removed(void *data, struct zwp_tablet_too
 	if (E && E->get()) {
 		struct zwp_tablet_tool_v2 *tool = E->get();
 		TabletToolState *state = wp_tablet_tool_get_state(tool);
-		if (state) {
-			memdelete(state);
-		}
+		memdelete(state);
 
 		zwp_tablet_tool_v2_destroy(tool);
 		ss->tablet_tools.erase(E);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -7579,21 +7579,13 @@ DisplayServerX11::~DisplayServerX11() {
 	}
 
 #ifdef SPEECHD_ENABLED
-	if (tts) {
-		memdelete(tts);
-	}
+	memdelete(tts);
 #endif
 
 #ifdef DBUS_ENABLED
-	if (screensaver) {
-		memdelete(screensaver);
-	}
-	if (portal_desktop) {
-		memdelete(portal_desktop);
-	}
-	if (atspi_monitor) {
-		memdelete(atspi_monitor);
-	}
+	memdelete(screensaver);
+	memdelete(portal_desktop);
+	memdelete(atspi_monitor);
 #endif
 }
 

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -66,9 +66,7 @@ void EmbeddedDebugger::initialize(DisplayServerMacOSEmbedded *p_ds) {
 }
 
 void EmbeddedDebugger::deinitialize() {
-	if (singleton) {
-		memdelete(singleton);
-	}
+	memdelete(singleton);
 }
 
 #ifdef DEBUG_ENABLED

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -239,9 +239,7 @@ void OS_MacOS::finalize() {
 	delete_main_loop();
 
 #ifdef SDL_ENABLED
-	if (joypad_sdl) {
-		memdelete(joypad_sdl);
-	}
+	memdelete(joypad_sdl);
 #endif
 }
 

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -90,9 +90,7 @@ bool OS_Web::main_loop_iterate() {
 }
 
 void OS_Web::delete_main_loop() {
-	if (main_loop) {
-		memdelete(main_loop);
-	}
+	memdelete(main_loop);
 	main_loop = nullptr;
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -8309,9 +8309,7 @@ DisplayServerWindows::~DisplayServerWindows() {
 	}
 
 #ifdef SDL_ENABLED
-	if (joypad_sdl) {
-		memdelete(joypad_sdl);
-	}
+	memdelete(joypad_sdl);
 #endif
 	touch_state.clear();
 
@@ -8400,9 +8398,7 @@ DisplayServerWindows::~DisplayServerWindows() {
 		gl_manager_native = nullptr;
 	}
 #endif
-	if (tts) {
-		memdelete(tts);
-	}
+	memdelete(tts);
 
 	OleUninitialize();
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -347,9 +347,7 @@ void OS_Windows::initialize() {
 }
 
 void OS_Windows::delete_main_loop() {
-	if (main_loop) {
-		memdelete(main_loop);
-	}
+	memdelete(main_loop);
 	main_loop = nullptr;
 }
 
@@ -378,9 +376,7 @@ void OS_Windows::finalize() {
 	driver_midi.close();
 #endif
 
-	if (main_loop) {
-		memdelete(main_loop);
-	}
+	memdelete(main_loop);
 
 	main_loop = nullptr;
 }
@@ -2770,9 +2766,7 @@ bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_dr
 	}
 
 #ifdef GLES3_ENABLED
-	if (test_gl_manager_native) {
-		memdelete(test_gl_manager_native);
-	}
+	memdelete(test_gl_manager_native);
 #endif
 
 	DestroyWindow(hWnd);

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -115,7 +115,5 @@ TTS_Windows::TTS_Windows() {
 }
 
 TTS_Windows::~TTS_Windows() {
-	if (driver) {
-		memdelete(driver);
-	}
+	memdelete(driver);
 }

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -814,9 +814,7 @@ RigidBody2D::RigidBody2D() :
 }
 
 RigidBody2D::~RigidBody2D() {
-	if (contact_monitor) {
-		memdelete(contact_monitor);
-	}
+	memdelete(contact_monitor);
 }
 
 void RigidBody2D::_reload_physics_characteristics() {

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -266,9 +266,7 @@ private:
 		GenProbesOctree *children[8] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 		~GenProbesOctree() {
 			for (int i = 0; i < 8; i++) {
-				if (children[i] != nullptr) {
-					memdelete(children[i]);
-				}
+				memdelete(children[i]);
 			}
 		}
 	};

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -1099,9 +1099,7 @@ void PhysicalBone3D::set_joint_type(JointType p_joint_type) {
 		return;
 	}
 
-	if (joint_data) {
-		memdelete(joint_data);
-	}
+	memdelete(joint_data);
 	joint_data = nullptr;
 	switch (p_joint_type) {
 		case JOINT_TYPE_PIN:
@@ -1292,9 +1290,7 @@ PhysicalBone3D::PhysicalBone3D() :
 }
 
 PhysicalBone3D::~PhysicalBone3D() {
-	if (joint_data) {
-		memdelete(joint_data);
-	}
+	memdelete(joint_data);
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free_rid(joint);
 }

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -833,7 +833,5 @@ RigidBody3D::RigidBody3D() :
 }
 
 RigidBody3D::~RigidBody3D() {
-	if (contact_monitor) {
-		memdelete(contact_monitor);
-	}
+	memdelete(contact_monitor);
 }

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -228,9 +228,7 @@ FabrikInverseKinematic::Task *FabrikInverseKinematic::create_simple_task(Skeleto
 }
 
 void FabrikInverseKinematic::free_task(Task *p_task) {
-	if (p_task) {
-		memdelete(p_task);
-	}
+	memdelete(p_task);
 }
 
 void FabrikInverseKinematic::set_goal(Task *p_task, const Transform3D &p_goal) {

--- a/scene/3d/spline_ik_3d.cpp
+++ b/scene/3d/spline_ik_3d.cpp
@@ -201,9 +201,7 @@ void SplineIK3D::_init_joints(Skeleton3D *p_skeleton, int p_index) {
 		return;
 	}
 	for (uint32_t i = 0; i < setting->solver_info_list.size(); i++) {
-		if (setting->solver_info_list[i]) {
-			memdelete(setting->solver_info_list[i]);
-		}
+		memdelete(setting->solver_info_list[i]);
 	}
 	setting->solver_info_list.clear();
 	setting->solver_info_list.resize_initialized(setting->joints.size());

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -102,9 +102,7 @@ void SceneDebugger::initialize() {
 }
 
 void SceneDebugger::deinitialize() {
-	if (singleton) {
-		memdelete(singleton);
-	}
+	memdelete(singleton);
 }
 
 #ifdef DEBUG_ENABLED

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -5223,9 +5223,7 @@ Control::Control() {
 Control::~Control() {
 	memdelete(data.theme_owner);
 
-	if (data.offset_transform != nullptr) {
-		memdelete(data.offset_transform);
-	}
+	memdelete(data.offset_transform);
 
 	// Resources need to be disconnected.
 	for (KeyValue<StringName, Ref<Texture2D>> &E : data.theme_icon_override) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -7724,9 +7724,7 @@ Tree::Tree() {
 }
 
 Tree::~Tree() {
-	if (root) {
-		memdelete(root);
-	}
+	memdelete(root);
 	RenderingServer::get_singleton()->free_rid(drop_indicator_ci);
 	RenderingServer::get_singleton()->free_rid(content_ci);
 	RenderingServer::get_singleton()->free_rid(custom_ci);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1628,9 +1628,7 @@ void SceneTree::_flush_delete_queue() {
 
 	while (delete_queue.size()) {
 		Object *obj = ObjectDB::get_instance(delete_queue.front()->get());
-		if (obj) {
-			memdelete(obj);
-		}
+		memdelete(obj);
 		delete_queue.pop_front();
 	}
 }
@@ -1674,9 +1672,7 @@ void SceneTree::_flush_scene_change() {
 	if (prev_scene_id.is_valid()) {
 		// Might have already been freed externally.
 		Node *prev_scene = ObjectDB::get_instance<Node>(prev_scene_id);
-		if (prev_scene) {
-			memdelete(prev_scene);
-		}
+		memdelete(prev_scene);
 		prev_scene_id = ObjectID();
 	}
 
@@ -2229,16 +2225,12 @@ SceneTree::SceneTree() {
 SceneTree::~SceneTree() {
 	if (prev_scene_id.is_valid()) {
 		Node *prev_scene = ObjectDB::get_instance<Node>(prev_scene_id);
-		if (prev_scene) {
-			memdelete(prev_scene);
-		}
+		memdelete(prev_scene);
 		prev_scene_id = ObjectID();
 	}
 	if (pending_new_scene_id.is_valid()) {
 		Node *pending_new_scene = ObjectDB::get_instance<Node>(pending_new_scene_id);
-		if (pending_new_scene) {
-			memdelete(pending_new_scene);
-		}
+		memdelete(pending_new_scene);
 		pending_new_scene_id = ObjectID();
 	}
 	if (root) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2522,9 +2522,7 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	ERR_FAIL_COND(p_control->get_parent() != nullptr);
 
 	Control *drag_preview = _gui_get_drag_preview();
-	if (drag_preview) {
-		memdelete(drag_preview);
-	}
+	memdelete(drag_preview);
 	p_control->set_as_top_level(true);
 	p_control->set_position(gui.last_mouse_pos);
 	p_base->get_root_parent_control()->add_child(p_control); // Add as child of viewport.

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -245,9 +245,7 @@ bool PropertyListHelper::property_get_revert(const String &p_property, Variant &
 void PropertyListHelper::clear() {
 	if (is_initialized()) {
 		memdelete(array_length_getter);
-		if (property_filter) {
-			memdelete(property_filter);
-		}
+		memdelete(property_filter);
 
 		for (const KeyValue<String, Property> &E : property_list) {
 			if (E.value.setter) {

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -395,9 +395,7 @@ void ServersDebugger::initialize() {
 }
 
 void ServersDebugger::deinitialize() {
-	if (singleton) {
-		memdelete(singleton);
-	}
+	memdelete(singleton);
 }
 
 Error ServersDebugger::_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured) {

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -497,9 +497,7 @@ public:
 			for (int i = 0; i < blocks.size(); i++) {
 				memfree(blocks[i].memory);
 			}
-			if (copy_back_buffer) {
-				memdelete(copy_back_buffer);
-			}
+			memdelete(copy_back_buffer);
 		}
 	};
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1885,43 +1885,21 @@ void RendererSceneRenderRD::init() {
 }
 
 RendererSceneRenderRD::~RendererSceneRenderRD() {
-	if (forward_id_storage) {
-		memdelete(forward_id_storage);
-	}
+	memdelete(forward_id_storage);
 
-	if (bokeh_dof) {
-		memdelete(bokeh_dof);
-	}
-	if (copy_effects) {
-		memdelete(copy_effects);
-	}
-	if (debug_effects) {
-		memdelete(debug_effects);
-	}
-	if (luminance) {
-		memdelete(luminance);
-	}
-	if (smaa) {
-		memdelete(smaa);
-	}
-	if (tone_mapper) {
-		memdelete(tone_mapper);
-	}
-	if (vrs) {
-		memdelete(vrs);
-	}
-	if (fsr) {
-		memdelete(fsr);
-	}
+	memdelete(bokeh_dof);
+	memdelete(copy_effects);
+	memdelete(debug_effects);
+	memdelete(luminance);
+	memdelete(smaa);
+	memdelete(tone_mapper);
+	memdelete(vrs);
+	memdelete(fsr);
 #ifdef METAL_ENABLED
-	if (mfx_spatial) {
-		memdelete(mfx_spatial);
-	}
+	memdelete(mfx_spatial);
 #endif
 
-	if (resolve_effects) {
-		memdelete(resolve_effects);
-	}
+	memdelete(resolve_effects);
 
 	if (sky.sky_scene_state.uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sky.sky_scene_state.uniform_set)) {
 		RD::get_singleton()->free_rid(sky.sky_scene_state.uniform_set);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1549,9 +1549,7 @@ RID LightStorage::reflection_atlas_create() {
 void LightStorage::reflection_atlas_free(RID p_ref_atlas) {
 	reflection_atlas_set_size(p_ref_atlas, 0, 0);
 	ReflectionAtlas *ra = reflection_atlas_owner.get_or_null(p_ref_atlas);
-	if (ra->cluster_builder) {
-		memdelete(ra->cluster_builder);
-	}
+	memdelete(ra->cluster_builder);
 	reflection_atlas_owner.free(p_ref_atlas);
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2189,9 +2189,7 @@ void MaterialStorage::shader_free(RID p_rid) {
 		}
 
 		//clear data if exists
-		if (shader->data) {
-			memdelete(shader->data);
-		}
+		memdelete(shader->data);
 	}
 
 	if (shader->embedded) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -68,9 +68,7 @@ void TextureStorage::Texture::cleanup() {
 	if (RD::get_singleton()->texture_is_valid(rd_texture)) {
 		RD::get_singleton()->free_rid(rd_texture);
 	}
-	if (canvas_texture) {
-		memdelete(canvas_texture);
-	}
+	memdelete(canvas_texture);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -4548,9 +4548,7 @@ RendererSceneCull::~RendererSceneCull() {
 	}
 	scene_cull_result_threads.clear();
 
-	if (dummy_occlusion_culling) {
-		memdelete(dummy_occlusion_culling);
-	}
+	memdelete(dummy_occlusion_culling);
 
 	if (light_culler) {
 		memdelete(light_culler);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -607,12 +607,8 @@ public:
 		}
 
 		~Instance() {
-			if (base_data) {
-				memdelete(base_data);
-			}
-			if (custom_aabb) {
-				memdelete(custom_aabb);
-			}
+			memdelete(base_data);
+			memdelete(custom_aabb);
 		}
 	};
 

--- a/tests/core/io/test_resource.cpp
+++ b/tests/core/io/test_resource.cpp
@@ -249,9 +249,7 @@ public:
 
 	virtual ~DuplicateGuineaPigData() {
 		Object *obj_ptr = obj.get_validated_object();
-		if (obj_ptr) {
-			memdelete(obj_ptr);
-		}
+		memdelete(obj_ptr);
 	}
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -296,9 +296,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			MessageQueue::get_singleton()->flush();
 		}
 
-		if (SceneTree::get_singleton()) {
-			memdelete(SceneTree::get_singleton());
-		}
+		memdelete(SceneTree::get_singleton());
 
 #ifndef NAVIGATION_3D_DISABLED
 		if (navigation_server_3d) {
@@ -330,25 +328,15 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		}
 #endif // PHYSICS_2D_DISABLED
 
-		if (Input::get_singleton()) {
-			memdelete(Input::get_singleton());
-		}
+		memdelete(Input::get_singleton());
 
 		if (RenderingServer::get_singleton()) {
 			ThemeDB::get_singleton()->finalize_theme();
 		}
 
-		if (AccessibilityServer::get_singleton()) {
-			memdelete(AccessibilityServer::get_singleton());
-		}
-
-		if (DisplayServer::get_singleton()) {
-			memdelete(DisplayServer::get_singleton());
-		}
-
-		if (InputMap::get_singleton()) {
-			memdelete(InputMap::get_singleton());
-		}
+		memdelete(AccessibilityServer::get_singleton());
+		memdelete(DisplayServer::get_singleton());
+		memdelete(InputMap::get_singleton());
 
 		if (AudioServer::get_singleton()) {
 			AudioServer::get_singleton()->finish();


### PR DESCRIPTION
- Requires #121416

## What problem(s) does this PR solve?

An optional, stylistic followup to the above PR, aiming to trim any now-redundant conditionals that only check for a non-null pointer *and* only call `memdelete` if passed.

## Additional information

Discussed in the [07/15/2026 Core meeting](https://docs.google.com/document/d/1y4ce-S1qlm90n6-r2xdIokUKqKJCWcfOCuVJA3pyh-A/edit?tab=t.0#heading=h.m4yti8co7vnl). The significantly higher code churn incurred by this pass warranted a separate PR and discussion.