### PR TITLE
Hide sticky TreeItems when dragging in `Tree`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5639,7 +5639,7 @@ void Tree::_notification(int p_what) {
 			}
 
 			sticky_stack_end = 0;
-			if (root) {
+			if (root && !drop_mode_flags) {
 				sticky_list.clear();
 				Vector2 stick_ofs;
 				Vector2 last_ofs = stick_ofs;


### PR DESCRIPTION
Closes #121024 as a bug, by applying @TokageItLab's recommendation of hiding sticky TreeItems during drag.

Getting them to work with each other probably won't be as straightforward as I thought due to the need for scrolling up when dragging near the top edge, but it can always be worked out and attempted as an enhancement later.

This is visually and functionally fine for now.

https://github.com/user-attachments/assets/61966447-0d0f-47b4-a510-faed55591590