### PR TITLE
Apply `_WARN_UNUSED_` to remaining `Variant` types

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1690,7 +1690,6 @@ Variant ClassDB::class_get_property(RequiredParam<Object> rp_object, const Strin
 
 Error ClassDB::class_set_property(RequiredParam<Object> rp_object, const StringName &p_property, const Variant &p_value) const {
 	EXTRACT_PARAM_OR_FAIL_V(p_object, rp_object, ERR_INVALID_PARAMETER);
-	Variant ret;
 	bool valid;
 	if (!::ClassDB::set_property(p_object, p_property, p_value, &valid)) {
 		return ERR_UNAVAILABLE;

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -32,7 +32,7 @@
 
 #include "core/string/ustring.h"
 
-struct [[nodiscard]] IPAddress {
+struct [[nodiscard]] _WARN_UNUSED_ IPAddress {
 private:
 	union {
 		uint8_t field8[16];

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -39,7 +39,7 @@
 // Note that NodePath is (effectively) const: If you hold a NodePath,
 // you can expect it to remain unchanged, even if you make copies of
 // it. This is achieved through copy-on-write (CoW).
-class [[nodiscard]] NodePath {
+class [[nodiscard]] _WARN_UNUSED_ NodePath {
 	struct Data {
 		SafeRefCount refcount;
 		Vector<StringName> path;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -37,7 +37,7 @@
 
 class Main;
 
-class [[nodiscard]] StringName {
+class [[nodiscard]] _WARN_UNUSED_ StringName {
 	struct Table;
 
 	struct _Data {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -44,7 +44,7 @@ class Variant;
 struct ArrayPrivate;
 struct ContainerType;
 
-class Array {
+class _WARN_UNUSED_ Array {
 	mutable ArrayPrivate *_p;
 	void _ref(const Array &p_from) const;
 	void _unref() const;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -43,7 +43,7 @@ struct ContainerTypeValidate;
 struct DictionaryPrivate;
 struct StringLikeVariantComparator;
 
-class Dictionary {
+class _WARN_UNUSED_ Dictionary {
 	mutable DictionaryPrivate *_p;
 
 	void _ref(const Dictionary &p_from) const;

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -33,7 +33,7 @@
 #include "core/variant/type_info.h"
 
 template <typename T>
-class TypedArray : public Array {
+class _WARN_UNUSED_ TypedArray : public Array {
 public:
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");

--- a/core/variant/typed_dictionary.h
+++ b/core/variant/typed_dictionary.h
@@ -33,7 +33,7 @@
 #include "core/variant/type_info.h"
 
 template <typename K, typename V>
-class TypedDictionary : public Dictionary {
+class _WARN_UNUSED_ TypedDictionary : public Dictionary {
 public:
 	_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {
 		ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign a dictionary with different element types.");

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -91,7 +91,7 @@ typedef Vector<Vector3> PackedVector3Array;
 typedef Vector<Color> PackedColorArray;
 typedef Vector<Vector4> PackedVector4Array;
 
-class Variant {
+class _WARN_UNUSED_ Variant {
 public:
 	// If this changes the table in variant_op must be updated
 	enum Type {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -572,7 +572,6 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*p_method)(T *, P...), void *p_base,
 			Callable::CallError ce; \
 			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce); \
 			if (m_has_return) { \
-				m_return_type r = ret; \
 				PtrToArg<m_return_type>::encode(ret, r_ret); \
 			} \
 		} \

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1540,8 +1540,6 @@ void AnimationPlayerEditor::_current_animation_changed(const StringName &p_name)
 			}
 		}
 
-		StringName library_name = player->find_animation_library(anim);
-
 		bool animation_is_readonly = EditorNode::get_singleton()->is_resource_read_only(anim);
 
 		track_editor->set_animation(anim, animation_is_readonly);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -740,9 +740,6 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				bool is_start_closer = dist_to_start < dist_to_end;
 
 				if ((near_start || near_end) && d < closest_d_highlight) {
-					StringName from_node = transition_lines[i].from_node;
-					StringName to_node = transition_lines[i].to_node;
-
 					bool is_start_endpoint = near_start && (is_start_closer || !near_end);
 					closest_d_highlight = d;
 					closest_for_highlight = i;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -869,8 +869,6 @@ bool AnimationMultiTrackKeyEdit::_set(const StringName &p_name, const Variant &p
 						}
 					}
 
-					Variant prev = animation->track_get_key_value(track, key);
-
 					if (!setting) {
 						if (mergeable) {
 							undo_redo->create_action(TTR("Animation Multi Change Call"), UndoRedo::MERGE_ENDS);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -2637,7 +2637,7 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 
 		bool is_valid_revert = false;
 		if (can_revert && revert_rect.has_point(pos)) {
-			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, related_enable_property, &is_valid_revert);
+			EditorPropertyRevert::get_property_revert_value(object, related_enable_property, &is_valid_revert);
 			ERR_FAIL_COND(!is_valid_revert);
 		}
 		if (is_valid_revert || (checkable && check_rect.has_point(pos))) {

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -1710,11 +1710,9 @@ void EditorPropertyLocalizableString::update_property() {
 		for (int i = 0; i < amount; i++) {
 			String prop_name;
 			Variant key;
-			Variant value;
 
 			prop_name = "indices/" + itos(i + offset);
 			key = dict.get_key_at_index(i + offset);
-			value = dict.get_value_at_index(i + offset);
 
 			EditorProperty *prop = memnew(EditorPropertyText);
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1139,7 +1139,6 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 			material->set_name(vformat("material_%s", itos(material_i)));
 		}
 		material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-		Dictionary material_extensions;
 
 		if (fbx_material->pbr.base_color.has_value) {
 			Color albedo = _material_color(fbx_material->pbr.base_color, fbx_material->pbr.base_factor);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1735,7 +1735,7 @@ void GDScriptInstance::validate_property(PropertyInfo &p_property) const {
 				const Variant *args[1] = { &property };
 
 				Callable::CallError err;
-				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
+				E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
 				if (err.error == Callable::CallError::CALL_OK) {
 					p_property = PropertyInfo::from_dict(property);
 					return;

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -583,7 +583,6 @@ Array _get_or_create_state_shapes_in_state(const Ref<GLTFState> &p_state) {
 GLTFShapeIndex _export_node_shape(const Ref<GLTFState> &p_state, const Ref<GLTFPhysicsShape> &p_physics_shape) {
 	Array state_shapes = _get_or_create_state_shapes_in_state(p_state);
 	GLTFShapeIndex size = state_shapes.size();
-	Dictionary shape_property;
 	Dictionary shape_dict = p_physics_shape->to_dictionary();
 	for (GLTFShapeIndex i = 0; i < size; i++) {
 		Dictionary other = state_shapes[i];

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -1296,7 +1296,6 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 					Dictionary t;
 					Vector<Vector3> varr = array_morph[Mesh::ARRAY_VERTEX];
 					Vector<Vector3> src_varr = array[Mesh::ARRAY_VERTEX];
-					Array mesh_arrays = import_mesh->get_surface_arrays(surface_i);
 					if (varr.size() && varr.size() == src_varr.size()) {
 						if (shape_mode == ArrayMesh::BlendShapeMode::BLEND_SHAPE_MODE_NORMALIZED) {
 							const int max_idx = src_varr.size();
@@ -5968,7 +5967,6 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> p_state) {
 		Ref<Skin> skin = mi->get_skin();
 		Ref<GLTFSkin> gltf_skin;
 		gltf_skin.instantiate();
-		Array json_joints;
 		if (p_state->skeleton3d_to_gltf_skeleton.has(godot_skeleton->get_instance_id())) {
 			// This is a skinned mesh. If the mesh has no ARRAY_WEIGHTS or ARRAY_BONES, it will be invisible.
 			const GLTFSkeletonIndex skeleton_gltf_i = p_state->skeleton3d_to_gltf_skeleton[godot_skeleton->get_instance_id()];

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -184,8 +184,6 @@ bool WinRTUtils::window_has_display_info(const WinRTWindowData *p_data) {
 
 void WinRTUtils::window_get_advanced_color_info(const WinRTWindowData *p_data, bool &r_hdr_supported, float &r_min_luminance, float &r_max_luminance, float &r_max_average_luminance, float &r_sdr_white_level) {
 	if (p_data && p_data->has_disp_info) {
-		Dictionary info;
-
 		AdvancedColorInfo adv_info = p_data->disp_info.GetAdvancedColorInfo();
 
 		r_hdr_supported = (adv_info.CurrentAdvancedColorKind() == AdvancedColorKind::HighDynamicRange);

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -521,7 +521,6 @@ void GraphEditArranger::_place_block(const StringName &p_v, float p_delta, const
 	}
 
 	StringName predecessor;
-	StringName successor;
 	Vector2 pos = r_node_positions[p_v];
 
 	if (pos.y == FLT_MAX) {

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -975,7 +975,6 @@ void SurfaceTool::create_from_blend_shape(const Ref<Mesh> &p_existing, int p_sur
 	clear();
 	primitive = p_existing->surface_get_primitive_type(p_surface);
 	Array arr = p_existing->surface_get_blend_shape_arrays(p_surface);
-	Array blend_shape_names;
 	int32_t shape_idx = -1;
 	for (int32_t i = 0; i < p_existing->get_blend_shape_count(); i++) {
 		String name = p_existing->get_blend_shape_name(i);

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -1416,9 +1416,17 @@ TEST_CASE("[String] match") {
 
 TEST_CASE("[String] IPVX address to string") {
 	IPAddress ip0("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+	CHECK(ip0.is_valid());
+
 	IPAddress ip(0x0123, 0x4567, 0x89ab, 0xcdef, true);
+	CHECK(ip.is_valid());
+
 	IPAddress ip2("fe80::52e5:49ff:fe93:1baf");
+	CHECK(ip2.is_valid());
+
 	IPAddress ip3("::ffff:192.168.0.1");
+	CHECK(ip3.is_valid());
+
 	String ip4 = "192.168.0.1";
 	CHECK(ip4.is_valid_ip_address());
 

--- a/tests/core/variant/test_variant.cpp
+++ b/tests/core/variant/test_variant.cpp
@@ -1335,11 +1335,11 @@ TEST_CASE("[Variant] Assignment To Vec3 from Bool,Int,Float,String,Vec2,Vec2i,Ve
 
 	Variant projection_v = Projection();
 	vec3_v = Vector3(2.2f, 3.5f, 5.3f);
-	quaternion_v = vec3_v;
-	CHECK(quaternion_v == Variant(Vector3(2.2f, 3.5f, 5.3f)));
+	projection_v = vec3_v;
+	CHECK(projection_v == Variant(Vector3(2.2f, 3.5f, 5.3f)));
 	vec3_v = Vector3(-5.4f, -7.9f, -2.1f);
-	quaternion_v = vec3_v;
-	CHECK(quaternion_v.get_type() == Variant::VECTOR3);
+	projection_v = vec3_v;
+	CHECK(projection_v.get_type() == Variant::VECTOR3);
 
 	Variant rid_v = RID();
 	vec3_v = Vector3(2.2f, 3.5f, 5.3f);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -1211,8 +1211,6 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		SIGNAL_WATCH(text_edit, "lines_edited_from");
 		SIGNAL_WATCH(text_edit, "caret_changed");
 
-		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
-
 		SUBCASE("[TextEdit] select all") {
 			// Select when there is no text does not select.
 			text_edit->select_all();

--- a/tests/scene/test_timer.cpp
+++ b/tests/scene/test_timer.cpp
@@ -171,7 +171,6 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->process(0.05);
 
-		Array signal_args = { {} };
 		SIGNAL_CHECK_FALSE(SNAME("timeout"));
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
@@ -197,7 +196,6 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 
 		SceneTree::get_singleton()->physics_process(0.05);
 
-		Array signal_args = { {} };
 		SIGNAL_CHECK_FALSE(SNAME("timeout"));
 
 		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));


### PR DESCRIPTION
## What problem(s) does this PR solve?

gcc and clang now warn about some more `Variant` types being unused.

Not as much stuff in violation as for the other ones, but I think those types are still common enough to warrant warning about unused occurrences.
