### PR TITLE
Rename `method` parameter to `callable` in many Array methods

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2649,9 +2649,9 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, back, sarray(), varray());
 	bind_method(Array, pick_random, sarray(), varray());
 	bind_method(Array, find, sarray("what", "from"), varray(0));
-	bind_method(Array, find_custom, sarray("method", "from"), varray(0));
+	bind_method(Array, find_custom, sarray("callable", "from"), varray(0));
 	bind_method(Array, rfind, sarray("what", "from"), varray(-1));
-	bind_method(Array, rfind_custom, sarray("method", "from"), varray(-1));
+	bind_method(Array, rfind_custom, sarray("callable", "from"), varray(-1));
 	bind_method(Array, count, sarray("value"), varray());
 	bind_method(Array, has, sarray("value"), varray());
 	bind_method(Array, pop_back, sarray(), varray());
@@ -2666,11 +2666,11 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, duplicate, sarray("deep"), varray(false));
 	bind_method(Array, duplicate_deep, sarray("deep_subresources_mode"), varray(RESOURCE_DEEP_DUPLICATE_INTERNAL));
 	bind_method(Array, slice, sarray("begin", "end", "step", "deep"), varray(INT_MAX, 1, false));
-	bind_method(Array, filter, sarray("method"), varray());
-	bind_method(Array, map, sarray("method"), varray());
-	bind_method(Array, reduce, sarray("method", "accum"), varray(Variant()));
-	bind_method(Array, any, sarray("method"), varray());
-	bind_method(Array, all, sarray("method"), varray());
+	bind_method(Array, filter, sarray("callable"), varray());
+	bind_method(Array, map, sarray("callable"), varray());
+	bind_method(Array, reduce, sarray("callable", "accum"), varray(Variant()));
+	bind_method(Array, any, sarray("callable"), varray());
+	bind_method(Array, all, sarray("callable"), varray());
 	bind_method(Array, max, sarray(), varray());
 	bind_method(Array, min, sarray(), varray());
 	bind_method(Array, is_typed, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -166,10 +166,10 @@
 	<methods>
 		<method name="all" qualifiers="const">
 			<return type="bool" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
 				Calls the given [Callable] on each element in the array and returns [code]true[/code] if the [Callable] returns [code]true[/code] for [i]all[/i] elements in the array. If the [Callable] returns [code]false[/code] for one array element or more, this method returns [code]false[/code].
-				The [param method] should take one [Variant] parameter (the current array element) and return a [bool].
+				The [param callable] should take one [Variant] parameter (the current array element) and return a [bool].
 				[codeblocks]
 				[gdscript]
 				func greater_than_5(number):
@@ -213,10 +213,10 @@
 		</method>
 		<method name="any" qualifiers="const">
 			<return type="bool" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
 				Calls the given [Callable] on each element in the array and returns [code]true[/code] if the [Callable] returns [code]true[/code] for [i]one or more[/i] elements in the array. If the [Callable] returns [code]false[/code] for all elements in the array, this method returns [code]false[/code].
-				The [param method] should take one [Variant] parameter (the current array element) and return a [bool].
+				The [param callable] should take one [Variant] parameter (the current array element) and return a [bool].
 				[codeblock]
 				func greater_than_5(number):
 					return number &gt; 5
@@ -387,10 +387,10 @@
 		</method>
 		<method name="filter" qualifiers="const">
 			<return type="Array" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
 				Calls the given [Callable] on each element in the array and returns a new, filtered [Array].
-				The [param method] receives one of the array elements as an argument, and should return [code]true[/code] to add the element to the filtered array, or [code]false[/code] to exclude it.
+				The [param callable] receives one of the array elements as an argument, and should return [code]true[/code] to add the element to the filtered array, or [code]false[/code] to exclude it.
 				[codeblock]
 				func is_even(number):
 					return number % 2 == 0
@@ -416,12 +416,12 @@
 		</method>
 		<method name="find_custom" qualifiers="const">
 			<return type="int" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<param index="1" name="from" type="int" default="0" />
 			<description>
-				Returns the index of the [b]first[/b] element in the array that causes [param method] to return [code]true[/code], or [code]-1[/code] if there are none. The search's start can be specified with [param from], continuing to the end of the array.
-				[param method] is a callable that takes an element of the array, and returns a [bool].
-				[b]Note:[/b] If you just want to know whether the array contains [i]anything[/i] that satisfies [param method], use [method any].
+				Returns the index of the [b]first[/b] element in the array that causes [param callable] to return [code]true[/code], or [code]-1[/code] if there are none. The search's start can be specified with [param from], continuing to the end of the array.
+				[param callable] takes an element of the array and returns a [bool].
+				[b]Note:[/b] If you just want to know whether the array contains [i]anything[/i] that satisfies [param callable], use [method any].
 				[codeblocks]
 				[gdscript]
 				func is_even(number):
@@ -559,10 +559,10 @@
 		</method>
 		<method name="map" qualifiers="const">
 			<return type="Array" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
-				Calls the given [Callable] for each element in the array and returns a new array filled with values returned by the [param method].
-				The [param method] should take one [Variant] parameter (the current array element) and can return any [Variant].
+				Calls the given [Callable] for each element in the array and returns a new array filled with values returned by the [param callable].
+				The [param callable] should take one [Variant] parameter (the current array element) and can return any [Variant].
 				[codeblock]
 				func double(number):
 					return number * 2
@@ -644,11 +644,11 @@
 		</method>
 		<method name="reduce" qualifiers="const">
 			<return type="Variant" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<param index="1" name="accum" type="Variant" default="null" />
 			<description>
 				Calls the given [Callable] for each element in array, accumulates the result in [param accum], then returns it.
-				The [param method] takes two arguments: the current value of [param accum] and the current array element. If [param accum] is [code]null[/code] (as by default), the iteration will start from the second element, with the first one used as initial value of [param accum].
+				The [param callable] takes two arguments: the current value of [param accum] and the current array element. If [param accum] is [code]null[/code] (as by default), the iteration will start from the second element, with the first one used as initial value of [param accum].
 				[codeblock]
 				func sum(accum, number):
 					return accum + number
@@ -719,10 +719,10 @@
 		</method>
 		<method name="rfind_custom" qualifiers="const">
 			<return type="int" />
-			<param index="0" name="method" type="Callable" />
+			<param index="0" name="callable" type="Callable" />
 			<param index="1" name="from" type="int" default="-1" />
 			<description>
-				Returns the index of the [b]last[/b] element of the array that causes [param method] to return [code]true[/code], or [code]-1[/code] if there are none. The search's start can be specified with [param from], continuing to the beginning of the array. This method is the reverse of [method find_custom].
+				Returns the index of the [b]last[/b] element of the array that causes [param callable] to return [code]true[/code], or [code]-1[/code] if there are none. The search's start can be specified with [param from], continuing to the beginning of the array. This method is the reverse of [method find_custom].
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
Guess who forgot to make a PR **8 months ago**. I think it was because I wanted to tweak the surrounding documentation, but it wasn't strictly necessary for the purposes of this PR.
Similar to https://github.com/godotengine/godot/pull/113217

The title is self-explanatory. This PR renames the `method` parameter to `callable` in many Array methods. It does _not_ change the signatures of the underlying C++ methods ~~in order to reduce some diff noise, unless requested~~ **because it was already changed to `p_callable`**.

## What problem(s) does this PR solve?

Array's `filter`, `map`, `all` etc. These methods were added at a time where **Callable** was being figured out (early Godot `4.0`). It doesn't take much to realize why the parameter's name is disgusting, but I will nonetheless:
- It's exceedingly misleading.
- It implies that only methods can be passed.
- If not the above, it implies that all "callables" are referred to as "methods".
	- "_[param method] is a callable that_" 🤢 
- It muddies the context between "this method" and "the parameter named `method`"

Possible alternative names include `callback`.