### PR TITLE
[Docs] Improve description of resize method inside all PackedArray classes

### DIFF
--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -450,8 +450,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]0[/code].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -149,8 +149,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [constant Color.BLACK].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -150,8 +150,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]0.0[/code].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -151,8 +151,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]0.0[/code].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -145,8 +145,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]0[/code].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -146,8 +146,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]0[/code].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -152,8 +152,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [code]""[/code] (an empty string).
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -155,8 +155,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [constant Vector2.ZERO].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -154,8 +154,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [constant Vector3.ZERO].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -154,8 +154,9 @@
 			<return type="int" />
 			<param index="0" name="new_size" type="int" />
 			<description>
-				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size. Calling [method resize] once and assigning the new values is faster than adding new elements one by one.
+				Sets the array's number of elements to [param new_size]. If [param new_size] is smaller than the array's current size, the elements at the end are removed. If [param new_size] is larger, new default elements are added with a value of [constant Vector4.ZERO].
 				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the size is negative, or [constant ERR_OUT_OF_MEMORY] if allocations fail. Use [method size] to find the actual size of the array after resize.
+				[b]Note:[/b] Calling this method once and assigning the new values is faster than calling [method push_back] for every new element.
 			</description>
 		</method>
 		<method name="reverse">


### PR DESCRIPTION
## Commit Description

- Copied the first paragraph from Array.resize description, as well as the note about performance comparison between resize then adding versus using append method.
- Validated the default values returned by Godot for every PackedArray type through a simple script which asserts the default values written in these changes.

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-docs/issues/12148

## Additional information

About the script noted in the second point, I haven't shared it inside the commit message.. because final version is way longer then I anticipated (could be shorter, but it's functional and does a lot of validation, which's good), so I'll share it in the PR body.

```gdscript
extends Node

func _init() -> void:
	test_packed_array(PackedByteArray())
	test_packed_array(PackedStringArray())
	test_packed_array(PackedInt32Array())
	test_packed_array(PackedInt64Array())
	test_packed_array(PackedFloat32Array())
	test_packed_array(PackedFloat64Array())
	test_packed_array(PackedColorArray())
	test_packed_array(PackedVector2Array())
	test_packed_array(PackedVector3Array())
	test_packed_array(PackedVector4Array())

func test_packed_array(packed_arr: Variant, grow_amount: int = 10) -> void:
	# Validate packed_arr parameter, as it's a Variant and could be of many different possible types
	var valid_packed_arr_types: Array[int] = [
		TYPE_PACKED_BYTE_ARRAY,
		TYPE_PACKED_COLOR_ARRAY,
		TYPE_PACKED_FLOAT32_ARRAY,
		TYPE_PACKED_FLOAT64_ARRAY,
		TYPE_PACKED_INT32_ARRAY,
		TYPE_PACKED_INT64_ARRAY,
		TYPE_PACKED_STRING_ARRAY,
		TYPE_PACKED_VECTOR2_ARRAY,
		TYPE_PACKED_VECTOR3_ARRAY,
		TYPE_PACKED_VECTOR4_ARRAY,
	]
	assert(typeof(packed_arr) in valid_packed_arr_types, "parameter 'packed_arr' is not a valid packed array type. Got %s" % [type_string(typeof(packed_arr))])
	
	# Set the expected default value which used to validate what Godot returns to us after
	# an packed_arr.resize(new_size) call (where 'new_size' > packed_arr.size())
	var expected_default_val: Variant = 0
	match typeof(packed_arr):
		TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY:
			expected_default_val = 0
		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY:
			expected_default_val = 0.0
		TYPE_PACKED_STRING_ARRAY:
			expected_default_val = ""
		TYPE_PACKED_COLOR_ARRAY:
			expected_default_val = Color.BLACK
		TYPE_PACKED_VECTOR2_ARRAY:
			expected_default_val = Vector2.ZERO
		TYPE_PACKED_VECTOR3_ARRAY:
			expected_default_val = Vector3.ZERO
		TYPE_PACKED_VECTOR4_ARRAY:
			expected_default_val = Vector4.ZERO
	
	print("---------------------------------------------")
	prints("expected_default_val (%s)" % type_string(typeof(packed_arr)), "=", "\"\"" if typeof(expected_default_val) == TYPE_STRING else expected_default_val)
	prints("Got as input         (%s): " % type_string(typeof(packed_arr)), packed_arr)
	var err: Error = packed_arr.resize(packed_arr.size() + grow_amount) as Error
	if err != Error.OK:
		print("Failed to resize packed_arr, error code: %d, error msg: %s" % [err, error_string(err)])
	for i: int in range(packed_arr.size()):
		assert(packed_arr[i] == expected_default_val,"Oops, packed_arr[{0}] isn't what was expected, got: {1}, expected: {2}".format([i, packed_arr[i], expected_default_val]))
	prints("after resize         (%s): " % type_string(typeof(packed_arr)), packed_arr)
	print("---------------------------------------------")
	print()
```