### PR TITLE
Add `ZIPPacker.compress`

### DIFF
--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -46,6 +46,16 @@
 				It will fail if there is no open file.
 			</description>
 		</method>
+		<method name="compress" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="input_paths" type="PackedStringArray" />
+			<param index="1" name="output_path" type="String" />
+			<param index="2" name="compression_level" type="int" default="-1" />
+			<param index="3" name="append" type="int" enum="ZIPPacker.ZipAppend" default="0" />
+			<description>
+				Creates a zip archive at the given [param output_path] containing the files/directories specified in [param input_paths].
+			</description>
+		</method>
 		<method name="open">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />

--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -52,6 +52,14 @@
 				Closes the underlying resources used by this instance.
 			</description>
 		</method>
+		<method name="decompress" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="input_path" type="String" />
+			<param index="1" name="output_path" type="String" />
+			<description>
+				Opens the zip archive at the given [param input_path] and decompresses it to [param output_path].
+			</description>
+		</method>
 		<method name="file_exists">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -31,6 +31,9 @@
 #include "zip_packer.h"
 #include "zip_packer.compat.inc"
 
+#include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/class_db.h"
 #include "core/os/time.h"
@@ -195,6 +198,131 @@ Error ZIPPacker::add_directory(const String &p_path, BitField<FileAccess::UnixPe
 	return OK;
 }
 
+Error ZIPPacker::compress(const PackedStringArray &p_input_paths, const String &p_output_path, int p_compression_level, ZipAppend p_append) {
+	int err = UNZ_OK;
+	Error gdErr = OK;
+
+	// Open the zip file.
+	ZIPPacker zip_packer = ZIPPacker();
+	zip_packer.set_compression_level(p_compression_level);
+	gdErr = zip_packer.open(p_output_path, p_append);
+	if (gdErr != OK) {
+		return gdErr;
+	}
+
+	// Create a queue of pending input paths to check.
+	struct PendingPath {
+		String input_path;
+		String output_path;
+	};
+	LocalVector<PendingPath> pending_paths;
+	pending_paths.reserve((int32_t)p_input_paths.size());
+	for (const String &input_path : p_input_paths) {
+		pending_paths.push_back({ input_path,
+				input_path.trim_suffix("/").trim_suffix("\\").get_file() });
+	}
+
+	// Write each file/directory to the zip file.
+	while (!pending_paths.is_empty()) {
+		// Get the current file/directory to write to the zip file.
+		PendingPath current_path = pending_paths[pending_paths.size() - 1];
+		pending_paths.remove_at(pending_paths.size() - 1);
+
+		// The current file/directory is a directory.
+		if (DirAccess::dir_exists_absolute(current_path.input_path)) {
+			// Open the current directory.
+			Ref<DirAccess> current_dir = DirAccess::open(current_path.input_path, &gdErr);
+			if (current_dir.is_null()) {
+				return gdErr;
+			}
+
+			// Start listing the files in the current directory.
+			gdErr = current_dir->list_dir_begin();
+			if (gdErr != OK) {
+				return gdErr;
+			}
+
+			// Add each file/directory in the current directory to the queue.
+			while (true) {
+				String next_in_dir = current_dir->get_next();
+				if (next_in_dir.is_empty()) {
+					break;
+				}
+				if (next_in_dir == "." || next_in_dir == "..") {
+					continue;
+				}
+				pending_paths.push_back({ current_path.input_path.path_join(next_in_dir),
+						current_path.output_path.path_join(next_in_dir) });
+			}
+
+			// Stop listing the files in the current directory.
+			current_dir->list_dir_end();
+
+			// Add a slash to the end of the directory path in the zip file.
+			if (!current_path.output_path.ends_with("/") && !current_path.output_path.ends_with("\\")) {
+				current_path.output_path += '/';
+			}
+
+			// Get the last modified time of the current directory.
+			uint64_t last_modified_time = 0; // TODO: There is currently no DirAccess::get_modified_time method.
+
+			// Write the current directory to the zip file.
+			gdErr = zip_packer.start_file(current_path.output_path, 0644, last_modified_time);
+			if (gdErr != OK) {
+				return gdErr;
+			}
+
+			// Finish writing the current directory to the zip file.
+			gdErr = zip_packer.close_file();
+			if (gdErr != OK) {
+				return gdErr;
+			}
+		}
+		// The current file/directory is a file.
+		else {
+			// Open the current file.
+			Ref<FileAccess> current_file = FileAccess::open(current_path.input_path, FileAccess::ModeFlags::READ, &gdErr);
+			if (current_file.is_null()) {
+				return gdErr;
+			}
+
+			// Get the last modified time of the current file.
+			uint64_t last_modified_time = FileAccess::get_modified_time(current_path.input_path);
+
+			// Start writing the current file to the zip file.
+			gdErr = zip_packer.start_file(current_path.output_path, 0644, last_modified_time);
+			if (gdErr != OK) {
+				return gdErr;
+			}
+
+			// Write each chunk of the current file to the zip file.
+			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			while (!current_file->eof_reached()) {
+				// Read a chunk of the current file.
+				uint64_t bytes_read = current_file->get_buffer(buffer, sizeof(buffer));
+
+				// Reached the end of the current file.
+				if (bytes_read == 0) {
+					break;
+				}
+
+				// Write the current chunk to the output file in the zip file.
+				err = zipWriteInFileInZip(zip_packer.zf, buffer, bytes_read);
+				ERR_FAIL_COND_V(err != ZIP_OK, ERR_FILE_CANT_WRITE);
+			}
+
+			// Finish writing the current file to the zip file.
+			gdErr = zip_packer.close_file();
+			if (gdErr != OK) {
+				return gdErr;
+			}
+		}
+	}
+
+	// The zip file was successfully created.
+	return OK;
+}
+
 void ZIPPacker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open", "path", "append"), &ZIPPacker::open, DEFVAL(Variant(APPEND_CREATE)));
 	ClassDB::bind_method(D_METHOD("set_compression_level", "compression_level"), &ZIPPacker::set_compression_level);
@@ -205,6 +333,8 @@ void ZIPPacker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("write_file", "data"), &ZIPPacker::write_file);
 	ClassDB::bind_method(D_METHOD("close_file"), &ZIPPacker::close_file);
 	ClassDB::bind_method(D_METHOD("close"), &ZIPPacker::close);
+
+	ClassDB::bind_static_method("ZIPPacker", D_METHOD("compress", "input_paths", "output_path", "compression_level", "append"), &ZIPPacker::compress, DEFVAL(COMPRESSION_DEFAULT), DEFVAL(APPEND_CREATE));
 
 	BIND_ENUM_CONSTANT(APPEND_CREATE);
 	BIND_ENUM_CONSTANT(APPEND_CREATEAFTER);

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -296,10 +296,11 @@ Error ZIPPacker::compress(const PackedStringArray &p_input_paths, const String &
 			}
 
 			// Write each chunk of the current file to the zip file.
-			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			LocalVector<uint8_t> buffer;
+			buffer.resize(64 * 1024); // 64KiB buffer
 			while (!current_file->eof_reached()) {
 				// Read a chunk of the current file.
-				uint64_t bytes_read = current_file->get_buffer(buffer, sizeof(buffer));
+				uint64_t bytes_read = current_file->get_buffer(buffer.ptr(), buffer.size());
 
 				// Reached the end of the current file.
 				if (bytes_read == 0) {
@@ -307,7 +308,7 @@ Error ZIPPacker::compress(const PackedStringArray &p_input_paths, const String &
 				}
 
 				// Write the current chunk to the output file in the zip file.
-				err = zipWriteInFileInZip(zip_packer.zf, buffer, bytes_read);
+				err = zipWriteInFileInZip(zip_packer.zf, buffer.ptr(), bytes_read);
 				ERR_FAIL_COND_V(err != ZIP_OK, ERR_FILE_CANT_WRITE);
 			}
 

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -77,6 +77,8 @@ public:
 
 	Error add_directory(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions = 0755, uint64_t p_modified_time = 0);
 
+	static Error compress(const PackedStringArray &p_input_paths, const String &p_output_path, int p_compression_level = COMPRESSION_DEFAULT, ZipAppend p_append = ZipAppend::APPEND_CREATE);
+
 	ZIPPacker();
 	~ZIPPacker();
 };

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -31,6 +31,8 @@
 #include "zip_reader.h"
 
 #include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/class_db.h"
 
@@ -160,6 +162,104 @@ int ZIPReader::get_compression_level(const String &p_path, bool p_case_sensitive
 	return level;
 }
 
+Error ZIPReader::decompress(const String &p_input_path, const String &p_output_path) {
+	int err = UNZ_OK;
+	Error gdErr = OK;
+
+	// Open the zip file.
+	ZIPReader zip_reader = ZIPReader();
+	gdErr = zip_reader.open(p_input_path);
+	if (gdErr != OK) {
+		return gdErr;
+	}
+
+	// Create an output directory.
+	DirAccess::make_dir_recursive_absolute(p_output_path);
+	Ref<DirAccess> output_directory = DirAccess::open(p_output_path, &gdErr);
+	if (output_directory.is_null()) {
+		return gdErr;
+	}
+
+	// Go to the first file in the zip file.
+	err = unzGoToFirstFile(zip_reader.uzf);
+	ERR_FAIL_COND_V(err != UNZ_OK, ERR_FILE_CORRUPT);
+
+	// Read each file in the zip file.
+	while (true) {
+		// Open the current file in the zip file.
+		err = unzOpenCurrentFile(zip_reader.uzf);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "Could not open file within zip archive.");
+
+		// Read the file info for the current file in the zip file.
+		unz_file_info64 file_info;
+		String file_path;
+		err = godot_unzip_get_current_file_info(zip_reader.uzf, file_info, file_path);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "Unable to read file information from zip archive.");
+
+		// Replace back-slashes with forward-slashes.
+		file_path = file_path.replace_char('\\', '/');
+
+		// Ensure the file path doesn't escape the output directory.
+		String simplified_file_path = file_path.simplify_path();
+		bool is_malicious_path = simplified_file_path.is_absolute_path() || simplified_file_path == ".." || simplified_file_path.begins_with("../");
+		ERR_FAIL_COND_V_MSG(is_malicious_path, ERR_FILE_CORRUPT, "Extracting a ZIP entry would create a file/directory outside the output directory.");
+
+		// The current file is a directory.
+		if (file_path.ends_with("/")) {
+			// Create the output sub directory.
+			gdErr = output_directory->make_dir_recursive(file_path.trim_suffix("/"));
+			if (gdErr != OK) {
+				return gdErr;
+			}
+		}
+		// The current file is a file.
+		else {
+			// Create a sub directory for the output file.
+			gdErr = output_directory->make_dir_recursive(file_path.get_base_dir());
+			if (gdErr != OK) {
+				return gdErr;
+			}
+			// Create an output file.
+			Ref<FileAccess> output_file = FileAccess::open(p_output_path.path_join(file_path), FileAccess::WRITE, &gdErr);
+			if (output_file.is_null()) {
+				return gdErr;
+			}
+
+			// Read each chunk of the current file in the zip file.
+			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			while (true) {
+				// Read a chunk of the current file in the zip file.
+				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer, sizeof(buffer));
+				ERR_FAIL_COND_V_MSG(bytes_read < 0, ERR_FILE_CORRUPT, "IO/zlib error reading file from zip archive.");
+
+				// Reached the end of the current file in the zip file.
+				if (bytes_read == 0) {
+					break;
+				}
+
+				// Write the current chunk to the output file.
+				bool write_err = output_file->store_buffer(buffer, bytes_read);
+				ERR_FAIL_COND_V(!write_err, ERR_FILE_CANT_WRITE);
+			}
+		}
+
+		// Close the current file in the zip file.
+		err = unzCloseCurrentFile(zip_reader.uzf);
+		ERR_FAIL_COND_V_MSG(err != UNZ_OK, ERR_FILE_CORRUPT, "CRC error reading file from zip archive.");
+
+		// Go to the next file in the zip file.
+		err = unzGoToNextFile(zip_reader.uzf);
+
+		// Reached the end of the list of files in the zip file.
+		if (err != UNZ_OK) {
+			break;
+		}
+	}
+
+	// The zip file was successfully extracted.
+	return OK;
+}
+
 ZIPReader::ZIPReader() {}
 
 ZIPReader::~ZIPReader() {
@@ -175,4 +275,6 @@ void ZIPReader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("read_file", "path", "case_sensitive"), &ZIPReader::read_file, DEFVAL(Variant(true)));
 	ClassDB::bind_method(D_METHOD("file_exists", "path", "case_sensitive"), &ZIPReader::file_exists, DEFVAL(Variant(true)));
 	ClassDB::bind_method(D_METHOD("get_compression_level", "path", "case_sensitive"), &ZIPReader::get_compression_level, DEFVAL(Variant(true)));
+
+	ClassDB::bind_static_method("ZIPReader", D_METHOD("decompress", "input_path", "output_path"), &ZIPReader::decompress);
 }

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -226,10 +226,11 @@ Error ZIPReader::decompress(const String &p_input_path, const String &p_output_p
 			}
 
 			// Read each chunk of the current file in the zip file.
-			uint8_t buffer[64 * 1024]; // 64KiB buffer
+			LocalVector<uint8_t> buffer;
+			buffer.resize(64 * 1024); // 64KiB buffer
 			while (true) {
 				// Read a chunk of the current file in the zip file.
-				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer, sizeof(buffer));
+				int bytes_read = unzReadCurrentFile(zip_reader.uzf, buffer.ptr(), buffer.size());
 				ERR_FAIL_COND_V_MSG(bytes_read < 0, ERR_FILE_CORRUPT, "IO/zlib error reading file from zip archive.");
 
 				// Reached the end of the current file in the zip file.
@@ -238,7 +239,7 @@ Error ZIPReader::decompress(const String &p_input_path, const String &p_output_p
 				}
 
 				// Write the current chunk to the output file.
-				bool write_err = output_file->store_buffer(buffer, bytes_read);
+				bool write_err = output_file->store_buffer(buffer.ptr(), bytes_read);
 				ERR_FAIL_COND_V(!write_err, ERR_FILE_CANT_WRITE);
 			}
 		}

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -53,6 +53,8 @@ public:
 	bool file_exists(const String &p_path, bool p_case_sensitive);
 	int get_compression_level(const String &p_path, bool p_case_sensitive);
 
+	static Error decompress(const String &p_input_path, const String &p_output_path);
+
 	ZIPReader();
 	~ZIPReader();
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fully closes https://github.com/godotengine/godot-proposals/issues/12777.

This pull request includes https://github.com/godotengine/godot/pull/121380 (adds `ZIPReader.decompress`), but doesn't actually depend on it. They are intended to be merged together though.

Implements `ZIPPacker.compress`.

You can use it like this:
```gdscript
var err: Error = ZIPPacker.compress(["res://example-output"], "res://example-output.zip",
	ZIPPacker.COMPRESSION_BEST, # Optional parameter
	ZIPPacker.APPEND_CREATE # Optional parameter
)
```

Similar to the other one, the key advantages of this approach are:
- Much simpler than manually compressing each file
- Does not load each file into memory - writes them in 64KiB chunks instead

## Additional information

I have tested the pull request works for creating ZIP files, including nested and empty directories.

Demo: [zip-high-level-demo.zip](https://github.com/user-attachments/files/30067205/zip-high-level-demo.zip)

## AI disclosure

I did not use AI to write the pull request, but I used AI to check my work and identify mistakes.