### PR TITLE
[3.x] Fix `CowData` `Span` constructor.

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -61,7 +61,7 @@ class CowData {
 	friend class VMap;
 
 private:
-	mutable T *_ptr;
+	mutable T *_ptr = nullptr;
 
 	// internal helpers
 
@@ -187,7 +187,7 @@ public:
 
 	int find(const T &p_val, int p_from = 0) const;
 
-	_FORCE_INLINE_ CowData();
+	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
 	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
 	_FORCE_INLINE_ explicit CowData(Span<T> p_span);
@@ -374,11 +374,6 @@ void CowData<T>::_ref(const CowData &p_from) {
 	if (p_from._get_refcount()->conditional_increment() > 0) { // could reference
 		_ptr = p_from._ptr;
 	}
-}
-
-template <class T>
-CowData<T>::CowData() {
-	_ptr = nullptr;
 }
 
 template <typename T>


### PR DESCRIPTION
_ptr must be set to `nullptr` before use of the object.

## What problem(s) does this PR solve?

Godot locks up if you attempt to use the span constructor, because `resize()` depends on `_ptr` being set to NULL, otherwise it reads uninitialized data and treats it as a safenumeric.

## Additional information

Regression from #120812
I don't think this was occurring in the wild, as I've only just started trying to use this constructor from another in progress PR.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
