### PR TITLE
Fix editor custom font variation resetting to defaults randomly

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1702,7 +1702,7 @@ void CodeTextEditor::_update_font_ligatures() {
 			} break;
 		}
 		Vector<String> variation_tags = String(EDITOR_GET("interface/editor/fonts/code_font_custom_variations")).split(",");
-		Dictionary variations_mono;
+		Dictionary variations_mono = fc->get_variation_opentype();
 		for (int i = 0; i < variation_tags.size(); i++) {
 			Vector<String> subtag_a = variation_tags[i].split("=");
 			if (subtag_a.size() == 2) {

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -77,7 +77,7 @@ void ThemeDB::initialize_theme() {
 
 	Ref<Font> project_font;
 	if (!project_font_path.is_empty()) {
-		project_font = ResourceLoader::load(project_font_path);
+		project_font = ResourceLoader::load(project_font_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE);
 		if (project_font.is_valid()) {
 			set_fallback_font(project_font);
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121419 

## Additional information

First PR so be a little more skeptical about this one! :D
This issue is the result of two separate bugs: 
1.  The editor changes the custom project font file using "interface/editor/fonts/code_font_custom_variations" (instead of doing it temporarily for the session).
2. "interface/editor/fonts/code_font_custom_variations" overrides the whole variation.opentype, and not just the specific tags it had been supplied. This ended up changing everything to default automatically because it was empty.