### PR TITLE
Speed up PNG MovieWriter by saving with `PNG_IMAGE_FLAG_FAST`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2830,11 +2830,15 @@ Error Image::save_jpg(const String &p_path, float p_quality) const {
 }
 
 Vector<uint8_t> Image::save_png_to_buffer() const {
+	return _save_png_to_buffer();
+}
+
+Vector<uint8_t> Image::_save_png_to_buffer(bool p_fast) const {
 	if (save_png_buffer_func == nullptr) {
 		return Vector<uint8_t>();
 	}
 
-	return save_png_buffer_func(Ref<Image>((Image *)this));
+	return save_png_buffer_func(Ref<Image>((Image *)this), p_fast);
 }
 
 Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -44,7 +44,7 @@ class Image;
 // Function pointer prototypes.
 
 typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img);
-typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img);
+typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img, bool p_fast);
 
 typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality);
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
@@ -387,6 +387,7 @@ public:
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Error save_dds(const String &p_path) const;
 	Vector<uint8_t> save_png_to_buffer() const;
+	Vector<uint8_t> _save_png_to_buffer(bool p_fast = false) const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false, bool p_color_image = false, float p_max_value = -1.0f) const;
 	Vector<uint8_t> save_dds_to_buffer() const;

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -125,7 +125,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, 
 	return OK;
 }
 
-Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
+Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer, bool p_fast) {
 	Ref<Image> source_image = p_image->duplicate();
 
 	if (source_image->is_compressed()) {
@@ -139,6 +139,9 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	png_img.version = PNG_IMAGE_VERSION;
 	png_img.width = source_image->get_width();
 	png_img.height = source_image->get_height();
+	if (p_fast) {
+		png_img.flags = PNG_IMAGE_FLAG_FAST;
+	}
 
 	switch (source_image->get_format()) {
 		case Image::FORMAT_L8:

--- a/drivers/png/png_driver_common.h
+++ b/drivers/png/png_driver_common.h
@@ -39,5 +39,6 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, 
 
 // Append p_image, as a png, to p_buffer.
 // Contents of p_buffer is unspecified if error returned.
-Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer);
+// p_fast is only used internally by the PNGWAV MovieWriter to allow for faster saving, by prioritizing speed over compression.
+Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer, bool p_fast = false);
 } // namespace PNGDriverCommon

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -65,9 +65,9 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	return OK;
 }
 
-Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img) {
+Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img, bool p_fast) {
 	Vector<uint8_t> buffer;
-	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
+	Error err = PNGDriverCommon::image_to_png(p_img, buffer, p_fast);
 	ERR_FAIL_COND_V_MSG(err, Vector<uint8_t>(), "Can't convert image to PNG.");
 	return buffer;
 }

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -38,7 +38,7 @@ class ResourceSaverPNG : public ResourceFormatSaver {
 
 public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img);
-	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
+	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, bool p_fast = false);
 
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -144,7 +144,7 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 Error MovieWriterPNGWAV::write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) {
 	ERR_FAIL_COND_V(f_wav.is_null(), ERR_UNCONFIGURED);
 
-	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer();
+	Vector<uint8_t> png_buffer = p_image->_save_png_to_buffer(true);
 
 	Ref<FileAccess> fi = FileAccess::open(base_path + zeros_str(frame_count) + ".png", FileAccess::WRITE);
 	fi->store_buffer(png_buffer.ptr(), png_buffer.size());


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
Simpler version of https://github.com/godotengine/godot/pull/117943
**Check that PR for more information.**

This PR uses a PNG flag that prioritizes speed over compression, if saving PNG via the PNGWAV MovieWriter.
Based on this PR: https://github.com/godotengine/godot/pull/74324
Related to https://github.com/godotengine/godot-proposals/discussions/14534

If needed, this could eventually become an option for normal `save_png()` and `save_png_to_buffer()` calls. Perhaps with an enum constant parameter, or a project setting. In a recent core meeting, it was decided to implement this with no public-facing API for now.