### PR TITLE
Document best practices for exposing the FSR sharpness project setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3419,7 +3419,8 @@
 			[b]Note:[/b] Changing this property requires a restart to take effect.
 		</member>
 		<member name="rendering/scaling_3d/fsr_sharpness" type="float" setter="" getter="" default="0.2">
-			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.
+			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from [code]0.0[/code] (sharpest) to [code]2.0[/code] (no sharpening). Values above [code]2.0[/code] don't make a visible difference.
+			[b]Note:[/b] For consistency with established games, projects' settings menus should expose this value in inverted fashion, typically with a [code]0[/code] to [code]10[/code] scale where [code]0[/code] is the least sharp and [code]10[/code] is the sharpest. This can be achieved using [code]remap(fsr_sharpness, 2.0, 0.0, 0.0, 10.0)[/code] where [code]fsr_sharpness[/code] is this setting's value. Use [code]remap(fsr_sharpness, 0.0, 10.0, 2.0, 0.0)[/code] to convert back to this setting's value.
 		</member>
 		<member name="rendering/scaling_3d/mode" type="int" setter="" getter="" default="0">
 			Sets the scaling 3D mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially-aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. On particularly low-end GPUs, the added cost of FSR may not be worth it (compared to using bilinear scaling with a slightly higher resolution scale to match performance).

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4312,7 +4312,8 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="sharpness" type="float" />
 			<description>
-				Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.
+				Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from [code]0.0[/code] (sharpest) to [code]2.0[/code] (no sharpening). Values above [code]2.0[/code] don't make a visible difference.
+				[b]Note:[/b] For consistency with established games, projects' settings menus should expose this value in inverted fashion, typically with a [code]0[/code] to [code]10[/code] scale where [code]0[/code] is the least sharp and [code]10[/code] is the sharpest. This can be achieved using [code]remap(fsr_sharpness, 2.0, 0.0, 0.0, 10.0)[/code] where [code]fsr_sharpness[/code] is this setting's value. Use [code]remap(fsr_sharpness, 0.0, 10.0, 2.0, 0.0)[/code] to convert back to this setting's value.
 			</description>
 		</method>
 		<method name="viewport_set_global_canvas_transform">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -345,8 +345,9 @@
 			Disable 3D rendering (but keep 2D rendering).
 		</member>
 		<member name="fsr_sharpness" type="float" setter="set_fsr_sharpness" getter="get_fsr_sharpness" default="0.2">
-			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.
+			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from [code]0.0[/code] (sharpest) to [code]2.0[/code] (no sharpening). Values above [code]2.0[/code] don't make a visible difference.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/scaling_3d/fsr_sharpness] project setting.
+			[b]Note:[/b] For consistency with established games, projects' settings menus should expose this value in inverted fashion, typically with a [code]0[/code] to [code]10[/code] scale where [code]0[/code] is the least sharp and [code]10[/code] is the sharpest. This can be achieved using [code]remap(fsr_sharpness, 2.0, 0.0, 0.0, 10.0)[/code] where [code skip-lint]fsr_sharpness[/code] is this property's value. Use [code]remap(fsr_sharpness, 0.0, 10.0, 2.0, 0.0)[/code] to convert back to this setting's value.
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.


### PR DESCRIPTION
In-game menus often use a 0-10 scale where 0 is least sharp and 10 is the sharpest. However, many Godot projects expose the current setting as-is, which is counterintuitive for players and doesn't match established games or AMD's recommendations.
