### PR TITLE
`AHashMap`: Skip look-up if map was allocated but cleared

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -123,15 +123,15 @@ private:
 	}
 
 	bool _lookup_idx(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
+		if (unlikely(_size == 0)) {
+			return false; // Failed lookups, size is 0.
 		}
 		return _lookup_idx_with_hash(p_key, r_element_idx, r_meta_idx, _hash(p_key));
 	}
 
 	bool _lookup_idx_with_hash(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx, uint32_t p_hash) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
+		if (unlikely(_elements == nullptr || _size == 0)) {
+			return false; // Failed lookups, no _elements or size is 0.
 		}
 
 		uint32_t meta_idx = p_hash & _capacity_mask;

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -97,15 +97,15 @@ private:
 	}
 
 	bool _lookup_idx(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
+		if (unlikely(_size == 0)) {
+			return false; // Failed lookups, size is 0.
 		}
 		return _lookup_idx_with_hash(p_key, r_element_idx, r_meta_idx, _hash(p_key));
 	}
 
 	bool _lookup_idx_with_hash(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx, uint32_t p_hash) const {
-		if (unlikely(_elements == nullptr)) {
-			return false; // Failed lookups, no _elements.
+		if (unlikely(_size == 0)) {
+			return false; // Failed lookups, size is 0.
 		}
 
 		uint32_t meta_idx = p_hash & _capacity_mask;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Prevents `AHashMap` look-ups from using the slow path if it has been allocated but contains zero elements.

`_elements` being valid alone is not enough to assure the map has elements. This is a problem if an `AHashMap` allocates at any point, but then we call `clear()` later: any subsequent look-ups with no elements inserted will still go for the slow path because it ignores whether size is 0 (something `HashMap` doesn't).

In this case, `_size == 0` has the same cost as `_elements == nullptr` and is more trustworthy to determine if the map doesn't have elements.

## Benchmarks

### Test machine specs
CachyOS Linux #1 SMP PREEMPT_DYNAMIC Fri, 28 Aug 2026 17:20:10 +0000 on Wayland - Wayland display driver, Multi-window, 1 monitor - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 1650 (nvidia; 610.57.04) - 11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz (12 threads) - 15.39 GiB memory - PulseAudio (44100 Hz, Stereo/mono)


### User test

I built the engine with the following `usertest.cpp` (courtesy of #110899):

```cpp
#include "usertest.h"

#include "core/os/os.h"
#include "core/string/print_string.h"
#include "core/templates/a_hash_map.h"
#include "core/templates/hash_map.h"
#include "core/variant/variant.h"

bool run_usertest() {
	// Our containers.
	LocalVector<StringName> keys;
	HashMap<StringName, int> l_map;
	AHashMap<StringName, int> a_map;

	keys.reserve(UINT8_MAX);
	for (uint8_t i = 0; i < UINT8_MAX; i++) {
		StringName name = StringName(String::num(i));
		keys.push_back(name);
		l_map.insert(name, i);
		a_map.insert(name, i);
	}

	// Just to reduce chances of the compiler doing something funny.
	l_map.has(keys[0]);
	a_map.has(keys[0]);
	
	// Now clear everything.
	l_map.clear();
	a_map.clear();

	// Measurements for HashMap.
	uint64_t l_start = OS::get_singleton()->get_ticks_usec();

	for (uint8_t i = 0; i < UINT8_MAX; i++) {
		for (uint8_t j = 0; j < UINT8_MAX; j++) {
			for (uint8_t k = 0; k < UINT8_MAX; k++) {
				for (const StringName &key : keys) {
					l_map.has(key);
				}
			}
		}
	}

	uint64_t l_end = OS::get_singleton()->get_ticks_usec();

	printf("Cleared HashMap lookup time: %ld usec.\n", l_end - l_start);

	// AHashMap's turn.
	uint64_t a_start = OS::get_singleton()->get_ticks_usec();

	for (uint8_t i = 0; i < UINT8_MAX; i++) {
		for (uint8_t j = 0; j < UINT8_MAX; j++) {
			for (uint8_t k = 0; k < UINT8_MAX; k++) {
				for (const StringName &key : keys) {
					a_map.has(key);
				}
			}
		}
	}
	uint64_t a_end = OS::get_singleton()->get_ticks_usec();

	printf("Cleared AHashMap lookup time: %ld usec.\n", a_end - a_start);
	return true;
}
```

Numbers are in microseconds. **Lower is better**.

- Build command: `scons -j8 target=editor production=yes user_test=yes`
- Ran with `--user-test`
- Desired outcome: `AHashMap`'s time should be relatively close to `HashMap`'s.

#### Before PR

`AHashMap` takes much more time because, while the map is empty, it still performs the slower look-up, while `HashMap` is already aware of the size and skips it completely:

|Run|HashMap|AHashMap|
|-|-|-|
|1|1176487|1704429|
|2|1174431|1702146|
|3|1213348|1721474|
|4|1184910|1799984|

#### After PR

When `AHashMap` does check the size and confirms it's 0, it returns much earlier:

|Run|HashMap|AHashMap|
|-|-|-|
|1|1185593|1088929|
|2|1222962|1079796|
|3|1191604|1078624|
|4|1197091|1081186|

### Method maps

> This is just an experiment and may not be valid for this PR. If that's the case, you still have the one above to consider.

When making #112129, I left method maps out of the PR because it somehow bottlenecked Gaijin's Bunnymark (in which `ClassDB::get_property` is the hottest path). Later, #117599 does a similar thing on the same maps, and I found it also bottlenecks in a similar way.

Out of curiosity, I decided to try this change over the latter mentioned PR. These are the results:

- Build command: `scons -j8 target=template_release production=yes`
- Test project: [bunnymark_custom.tar.gz](https://github.com/user-attachments/files/30069206/bunnymark_custom.tar.gz)

Numbers are FPS printed at the end. **Higher is better**.

|Run|#117599 reverted|#117599|#117599 + this PR|
|-|-|-|-|
|1|164.13|160.00|162.93|
|2|163.40|158.53|162.53|
|3|163.60|157.67|164.80|
|4|164.47|156.47|167.40|

None of #117599's individual cases were faster than itself combined with this or it reverted. It could be a coincidence, but experimenting was worth it.

> After further testing, I found that it's an improvement only in builds with `target=template_release` *and* `production=yes` (LTO + `o3`). Otherwise it is a tiny regression.

## Extra notes

The two specific changes aren't random. I've recompiled the template several times with multiple alternatives to find an outcome that is the best both for the user test above and the #117599 stress test.

`_elements == nullptr || _size == 0` in `_lookup_idx` somehow made the #117599 test above much slower than it already was. Since `_size == 0` effectively guarantees the map is empty and has the same cost as `_elements == nullptr`, I went with the former. 
**Edit**: Per request, I went with `_size == 0` on both.

Additionally, the size check in `_lookup_idx_with_hash` is what effectively made the #117599 test faster and had little to no impact in my user test. Still checking if `_elements` is valid as that function tries to access it (although there should be virtually no situations where `_elements` is invalid while `_size` is not 0, maybe it could be faster?).