### PR TITLE
Tweak viewport resolution display in View Information panel in the 3D editor

### DIFF
--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -127,7 +127,7 @@ Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resou
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());
-	Label *label = memnew(Label(vformat(TTR(U"Dimensions: %d × %d"), dimensions.x, dimensions.y)));
+	Label *label = memnew(Label(vformat(TTR(U"Dimensions: %d×%d"), dimensions.x, dimensions.y)));
 	vb->add_child(label);
 
 	TextureRect *tr = memnew(TextureRect);

--- a/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -97,8 +97,8 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_notification(int p_what) {
 			}
 
 			String text;
-			text += vformat(TTR("Subdivisions: %s"), vformat(U"%d × %d × %d", size.x, size.y, size.z)) + "\n";
-			text += vformat(TTR("Cell size: %s"), vformat(U"%.3f × %.3f × %.3f", extents.x / size.x, extents.y / size.y, extents.z / size.z)) + "\n";
+			text += vformat(TTR("Subdivisions: %s"), vformat(U"%d×%d×%d", size.x, size.y, size.z)) + "\n";
+			text += vformat(TTR("Cell size: %s"), vformat(U"%.3f×%.3f×%.3f", extents.x / size.x, extents.y / size.y, extents.z / size.z)) + "\n";
 			text += vformat(TTR("Video RAM size: %s MB (%s)"), String::num(size_mb, 2), size_quality);
 
 			// Only update the tooltip when needed to avoid constant redrawing.

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3678,14 +3678,14 @@ void Node3DEditorViewport::_notification(int p_what) {
 			}
 
 			if (show_info) {
-				const String viewport_size = vformat(U"%d × %d", viewport->get_size().x * viewport->get_scaling_3d_scale(), viewport->get_size().y * viewport->get_scaling_3d_scale());
+				const String viewport_size = vformat(U"%d×%d", viewport->get_size().x * viewport->get_scaling_3d_scale(), viewport->get_size().y * viewport->get_scaling_3d_scale());
 				String text;
 				text += vformat(TTR("X: %s"), rtos(current_camera->get_position().x).pad_decimals(1)) + "\n";
 				text += vformat(TTR("Y: %s"), rtos(current_camera->get_position().y).pad_decimals(1)) + "\n";
 				text += vformat(TTR("Z: %s"), rtos(current_camera->get_position().z).pad_decimals(1)) + "\n";
 				text += "\n";
 				text += vformat(
-						TTR("Size: %s (%.1fMP)") + "\n",
+						TTR("Size: %s (%.1f MPix)") + "\n",
 						viewport_size,
 						viewport->get_size().x * viewport->get_size().y * Math::pow(viewport->get_scaling_3d_scale(), 2) * 0.000001);
 

--- a/editor/scene/3d/voxel_gi_editor_plugin.cpp
+++ b/editor/scene/3d/voxel_gi_editor_plugin.cpp
@@ -123,8 +123,8 @@ void VoxelGIEditorPlugin::_notification(int p_what) {
 			}
 
 			String text;
-			text += vformat(TTR("Subdivisions: %s"), vformat(U"%d × %d × %d", cell_size.x, cell_size.y, cell_size.z)) + "\n";
-			text += vformat(TTR("Cell size: %s"), vformat(U"%.3f × %.3f × %.3f", half_size.x / cell_size.x, half_size.y / cell_size.y, half_size.z / cell_size.z)) + "\n";
+			text += vformat(TTR("Subdivisions: %s"), vformat(U"%d×%d×%d", cell_size.x, cell_size.y, cell_size.z)) + "\n";
+			text += vformat(TTR("Cell size: %s"), vformat(U"%.3f×%.3f×%.3f", half_size.x / cell_size.x, half_size.y / cell_size.y, half_size.z / cell_size.z)) + "\n";
 			text += vformat(TTR("Video RAM size: %s MB (%s)"), String::num(size_mb, 2), size_quality);
 
 			// Only update the tooltip when needed to avoid constant redrawing.


### PR DESCRIPTION
- Use MPix for the megapixel unit, which is more self-explanatory and also used in the [documentation](https://docs.godotengine.org/en/stable/tutorials/3d/resolution_scaling.html#rendering-scale).
- Remove space in the resolution around the `×` symbol to compensate for the longer unit name.
  - For consistency, the space is also removed in other locations of the editor that used spaces.

## Preview

Before | After
-|-
<img width="231" height="245" alt="Image" src="https://github.com/user-attachments/assets/1a88ee53-d593-4da8-a5ab-c280be91b060" /> | <img width="231" height="245" alt="Image" src="https://github.com/user-attachments/assets/3f940032-545c-471f-a6b2-56ad76833945" />