### PR TITLE
Fix crash capturing script backtraces when ScriptBacktrace is disabled by build profile

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -273,6 +273,15 @@ Error ScriptServer::unregister_language(const ScriptLanguage *p_language) {
 }
 
 void ScriptServer::init_languages() {
+	// Make sure ScriptBacktrace's class is registered in ClassDB before backtraces can be
+	// captured: error macros may capture backtraces while the calling thread holds the
+	// ClassDB lock, and lazily registering the class at that point would upgrade a read
+	// lock to a write lock and crash. This is only reachable when a build profile has
+	// disabled the class, which skips its registration on startup. Must be called outside
+	// `languages_mutex` to avoid lock-order inversion with the error path, which holds
+	// the ClassDB lock while capturing backtraces.
+	ScriptBacktrace::initialize_class();
+
 	{ // Load global classes.
 		global_classes_clear();
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
**Reproduction:**
At build time, put `ScriptBacktrace` into `disabled_classes` in the file passed to scons as `build_profile`, and add a node whose type is also in `disabled_classes` to a scene.

**Cause of the crash:**
A read-to-write lock upgrade in ClassDB. When ClassDB meets a disabled class type during scene instantiation, it calls the `_err_print_error` macro while holding the read lock. Inside, it calls into ScriptServer, and if this is the first call, it enters ScriptBacktrace's class registration, which then tries to take the write lock in ClassDB, and the lock upgrade causes the crash.

**Fix:**
Call ScriptBacktrace's class registration early in `ScriptServer::init_languages()`, so that when the same situation happens later, the registration will not run again.

**Other fix considered:**
Adjust the logic in ClassDB to release the lock before calling the `_err_print_error` macro. That change would be bigger, so I chose the current approach.
