### PR TITLE
Fix CharacterBody2D BVH performance issue

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -565,8 +565,7 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 		real_t rot = new_transform.get_rotation() - get_transform().get_rotation();
 		angular_velocity = constant_angular_velocity + std::remainder(rot, 2.0 * Math::PI) / p_step;
 
-		do_motion = true;
-
+		do_motion = continuous_cd_mode != PS2DE::CCD_MODE_DISABLED;
 	} else {
 		if (!omit_force_integration) {
 			//overridden by direct state query
@@ -624,7 +623,7 @@ void GodotBody2D::integrate_velocities(real_t p_step) {
 	}
 
 	if (mode == PS2DE::BODY_MODE_KINEMATIC) {
-		_set_transform(new_transform, false);
+		_set_transform(new_transform, continuous_cd_mode == PS2DE::CCD_MODE_DISABLED);
 		_set_inv_transform(new_transform.affine_inverse());
 		if (contacts.is_empty() && linear_velocity == Vector2() && angular_velocity == 0) {
 			set_active(false); //stopped moving, deactivate


### PR DESCRIPTION
Character bodies (PS2DE::BODY_MODE_KINEMATIC) were incorrectly expanding their AABBs to incorporate next frame motion. This should only happen if CCD is turned on. If CCD is not turned on, all the extra broad phase hits are wasted, since narrow phase will not consider motion unless CCD is on.

## What problem(s) does this PR solve?

- Closes #83835

This should improve CharacterBody2D performance and performance consistency. In addition to the broad phase cost, the narrow phase is currently being fed excess candidate collisions that are costly to test and discard there.

Current performance may be suffering in circumstances with high velocity, diagonal movement or teleporting.

## Additional information

To confirm this someone could:

Review the narrow phase collision testing in godot_body_pair_2d.cpp to confirm that unless CCD is enabled, motion will be ignored and the body will collide based on it's `transform` position, not `new_transform` or `transform + motion`. 

Also review godot_area_pair_2d.cpp to confirm that areas do not respect motion or CCD, but merely collide based on `transform` position.

Also confirm that a RigidBody2D set to FREEZE_MODE_KINEMATIC (making it PS2DE::BODY_MODE_KINEMATIC in the engine) will still support CCD if that is enabled.

I can't think of any other areas of code that might be relevant. I have tested on my own game and a number of the CharacterBody2D samples in godot-demo-projects.