### PR TITLE
Don't include `physics_server_2d.h` in `world_2d.h` and same for 3D

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -75,6 +75,10 @@
 #include "servers/physics_3d/physics_server_3d_types.h"
 #include "servers/rendering/rendering_server.h"
 
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_3d/direct_states/physics_direct_space_state_3d.h"
+#endif // PHYSICS_3D_DISABLED
+
 using namespace Node3DEditorConstants;
 
 Node3DEditorSelectedItem::~Node3DEditorSelectedItem() {

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -47,6 +47,10 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/curve.h"
 
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_3d/direct_states/physics_direct_space_state_3d.h"
+#endif // PHYSICS_3D_DISABLED
+
 String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -40,6 +40,7 @@
 #include "scene/resources/surface_tool.h"
 
 #ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_3d/physics_server_3d.h"
 #include "servers/rendering/rendering_server.h" // Only used for debug collision shapes.
 #endif // PHYSICS_3D_DISABLED
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -51,6 +51,7 @@
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/3d/sphere_shape_3d.h"
 #include "scene/resources/physics_material.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -40,10 +40,11 @@
 #include "scene/resources/world_2d.h"
 #include "servers/audio/audio_server.h"
 #include "servers/audio/audio_stream.h"
-#include "servers/physics_2d/direct_states/physics_direct_space_state_2d.h"
 
 #ifndef PHYSICS_2D_DISABLED
 #include "scene/2d/physics/area_2d.h"
+#include "servers/physics_2d/direct_states/physics_direct_space_state_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 #endif // PHYSICS_2D_DISABLED
 
 void AudioStreamPlayer2D::_notification(int p_what) {

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/class_db.h"
 #include "scene/resources/world_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 
 void CollisionObject2D::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -36,6 +36,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/world_2d.h"
 #include "servers/physics_2d/direct_states/physics_direct_space_state_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 
 void RayCast2D::set_target_position(const Vector2 &p_point) {
 	target_position = p_point;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -43,6 +43,7 @@
 
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/area_3d.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 // Based on "A Novel Multichannel Panning Method for Standard and Arbitrary Loudspeaker Configurations" by Ramy Sadek and Chris Kyriakakis (2004)

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -38,6 +38,10 @@
 #include "scene/main/viewport.h"
 #include "servers/rendering/rendering_server.h"
 
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_3d/physics_server_3d.h"
+#endif // PHYSICS_3D_DISABLED
+
 void Camera3D::_update_audio_listener_state() {
 }
 

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -34,6 +34,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
+#include "servers/physics_3d/physics_server_3d.h"
 
 void Area3D::set_gravity_space_override_mode(SpaceOverride p_mode) {
 	gravity_space_override = p_mode;

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -36,6 +36,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/mesh.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #include "servers/rendering/rendering_server.h"
 
 void CollisionObject3D::_notification(int p_what) {

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -34,6 +34,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/shape_3d.h"
+#include "servers/physics_3d/physics_server_3d_enums.h"
 
 class CollisionObject3D : public Node3D {
 	GDCLASS(CollisionObject3D, Node3D);

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -35,6 +35,7 @@
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/mesh.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #include "servers/rendering/rendering_server.h"
 
 void RayCast3D::set_target_position(const Vector3 &p_point) {

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -37,6 +37,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/mesh.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #include "servers/rendering/rendering_server.h"
 
 void ShapeCast3D::_notification(int p_what) {

--- a/scene/3d/physics/shape_cast_3d.h
+++ b/scene/3d/physics/shape_cast_3d.h
@@ -33,6 +33,7 @@
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/material.h"
+#include "servers/physics_3d/physics_server_3d_types.h"
 
 class CollisionObject3D;
 

--- a/scene/3d/physics/spring_arm_3d.cpp
+++ b/scene/3d/physics/spring_arm_3d.cpp
@@ -35,6 +35,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/shape_3d.h"
+#include "servers/physics_3d/direct_states/physics_direct_space_state_3d.h"
 
 void SpringArm3D::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -61,6 +61,7 @@
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
+#include "servers/physics_3d/direct_states/physics_direct_space_state_3d.h"
 #endif // PHYSICS_3D_DISABLED
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -72,6 +72,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #ifndef PHYSICS_2D_DISABLED
 #include "scene/2d/physics/collision_object_2d.h"
 #include "servers/physics_2d/direct_states/physics_direct_space_state_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -77,6 +77,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_object_3d.h"
+#include "servers/physics_3d/physics_server_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef XR_DISABLED

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
@@ -34,6 +34,10 @@
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/world_2d.h"
 
+#ifndef PHYSICS_2D_DISABLED
+#include "servers/physics_2d/physics_server_2d.h"
+#endif // PHYSICS_2D_DISABLED
+
 bool SkeletonModification2DJiggle::_set(const StringName &p_path, const Variant &p_value) {
 	String path = p_path;
 

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -41,6 +41,10 @@
 #include "servers/navigation_3d/navigation_server_3d.h"
 #endif // NAVIGATION_3D_DISABLED
 
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/physics_3d/physics_server_3d.h"
+#endif // PHYSICS_3D_DISABLED
+
 void World3D::_register_camera(Camera3D *p_camera) {
 	cameras.insert(p_camera);
 }

--- a/scene/resources/3d/world_3d.h
+++ b/scene/resources/3d/world_3d.h
@@ -34,7 +34,7 @@
 #include "scene/resources/environment.h"
 
 #ifndef PHYSICS_3D_DISABLED
-#include "servers/physics_3d/physics_server_3d.h"
+class PhysicsDirectSpaceState3D;
 #endif // PHYSICS_3D_DISABLED
 
 class CameraAttributes;

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -39,6 +39,10 @@
 #include "servers/navigation_2d/navigation_server_2d.h"
 #endif // NAVIGATION_2D_DISABLED
 
+#ifndef PHYSICS_2D_DISABLED
+#include "servers/physics_2d/physics_server_2d.h"
+#endif // PHYSICS_2D_DISABLED
+
 RID World2D::get_canvas() const {
 	return canvas;
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -33,7 +33,7 @@
 #include "core/io/resource.h"
 
 #ifndef PHYSICS_2D_DISABLED
-#include "servers/physics_2d/physics_server_2d.h"
+class PhysicsDirectSpaceState2D;
 #endif // PHYSICS_2D_DISABLED
 
 class VisibleOnScreenNotifier2D;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This change might improve compile times, since `physics_server_2d.h` isn't small and `world_2d.h` is included in a ton of places. I am not sure though, since I have not benchmarked it.

The main motivation for submitting this PR is that I was getting this warning from `clangd-tidy`:

<img width="950" height="350" alt="Screenshot 2026-07-16 at 1 51 21 AM" src="https://github.com/user-attachments/assets/87eebd7a-d4bb-4395-8b51-ef8a1e21be54" />

## Additional information

https://github.com/aaronfranke/godot/actions/runs/29461470481/job/87505739258

The CI fails here even though the only change in the commit that CI is running on is the addition of a comment:

https://github.com/aaronfranke/godot/commit/c51a32d4bcd3401fb62350c8e0fbd7234cf433ed#diff-401fe5486e156fdcfcf97874b0b2f6547d407b101f00160f41695f67aff91ff6R43

In order to fix the problem, this PR replaces the `physics_server_2d.h` include with a forward declaration of `class PhysicsDirectSpaceState2D;` which is vastly simpler than including the entire PhysicsServer2D header, though it does require that several other files be updated to explicitly include `physics_server_2d.h`.