### PR TITLE
Fix combination of MSAA 2D, screen-space AA and bilinear upscaling breaking 3D rendering.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -773,7 +773,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			// Note that this is cached so we only create the texture the first time.
 			dest_fb_format = rb->get_base_data_format();
 			RID dest_texture = rb->create_texture(SNAME("Tonemapper"), SNAME("destination"), dest_fb_format, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT, RD::TEXTURE_SAMPLES_1, color_size, 0, 1, true, true);
-			dest_fb = FramebufferCacheRD::get_singleton()->get_cache(dest_texture);
+			dest_fb = FramebufferCacheRD::get_singleton()->get_cache_multiview(rb->get_view_count(), dest_texture);
 			tonemap.dest_texture_size = color_size;
 		} else {
 			// If we do a nearest or bilinear upscale, we just render into our render target and our shader will upscale automatically.
@@ -878,7 +878,12 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			// This is only necessary if screen-space antialiasing is active, otherwise this happens automatically during tonemapping.
 			RID source_texture = rb->get_texture(use_smaa ? SNAME("SMAA") : SNAME("Tonemapper"), SNAME("destination"));
 			RID dest_texture = texture_storage->render_target_get_rd_texture(render_target);
-			RID dest_fb = FramebufferCacheRD::get_singleton()->get_cache(dest_texture);
+
+			// Create an explicit pass, since the automatic pass in "framebuffer_create" can incorrectly put the texture as a resolve attachment.
+			RD::FramebufferPass pass;
+			pass.color_attachments.push_back(0);
+
+			RID dest_fb = FramebufferCacheRD::get_singleton()->get_cache_multipass(Vector<RID>{ dest_texture }, Vector<RD::FramebufferPass>{ pass }, rb->get_view_count());
 			copy_effects->copy_to_fb_rect(source_texture, dest_fb, Rect2i(Point2i(), rb->get_target_size()), false, false, false, false, RID(), rb->get_view_count() > 1, false, false, false, Rect2(), 1.0, scale_mode != RSE::VIEWPORT_SCALING_3D_MODE_NEAREST);
 		}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120470

With the combination in the PR title, the 2D MSAA resolve buffer can be used as the target for the bilinear upscale operation. However, since this texture has the "is_resolve_buffer" set to `true`, it'd always get assigned as a resolve attachment in `framebuffer_create`'s [automatic pass](https://github.com/godotengine/godot/blob/49f68a134ec7997dda2eb5b92a1f43eb37273498/servers/rendering/rendering_device.cpp#L3637). To solve this, we explicitly create the pass and attach the texture as a color attachment.

## Additional information

Multiview was also failing with this, so I tried to fix it, but I'm not sure if the solution here is correct for it, since `dest_is_msaa_2d` [cannot ever be true for multiview](https://github.com/godotengine/godot/blob/49f68a134ec7997dda2eb5b92a1f43eb37273498/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp#L494), it seems...?