### PR TITLE
Fix time limit in `EditorResourcePreview::_idle_callback`

### DIFF
--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -438,10 +438,21 @@ void EditorResourcePreview::_idle_callback() {
 		return;
 	}
 
+	static uint64_t prev_process_frame = 0;
+	static uint64_t spent_frame_msec = 0;
+
+	uint64_t current_process_frame = Engine::get_singleton()->get_process_frames();
+	if (current_process_frame != prev_process_frame) {
+		prev_process_frame = current_process_frame;
+		spent_frame_msec = 0;
+	}
+
 	// Process preview tasks, trying to leave a little bit of responsiveness worst case.
-	uint64_t start = OS::get_singleton()->get_ticks_msec();
-	while (!singleton->queue.is_empty() && OS::get_singleton()->get_ticks_msec() - start < 100) {
+	while (!singleton->queue.is_empty() && spent_frame_msec < 100) {
+		uint64_t start_msec = OS::get_singleton()->get_ticks_msec();
 		singleton->_iterate();
+		uint64_t end_msec = OS::get_singleton()->get_ticks_msec();
+		spent_frame_msec += end_msec - start_msec;
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121458.

## Additional information

This changes `EditorResourcePreview::_idle_callback` to not use a function-local 100 ms timer to limit its `_iterate` calls, but instead have that timer persist for the entirety of that process frame, meaning it resets when it finds itself at a new process frame.

This seems to take care of the problem of it potentially spending this 100 ms time across multiple idle callback invocations in a single engine iteration, which otherwise sort of defeated the purpose of having this explicit time limit to begin with.

Here's what profiling the web editor on a low-spec Chromebook looks like with this change. The frames are now on the order of 100-ish ms each rather than a second-ish long, with the editor feeling more responsive than before as well:

<img width="1920" height="693" alt="Screenshot 2026-07-16 16 18 30" src="https://github.com/user-attachments/assets/193f8676-be38-4a44-bab8-a8bbf37bef82" />
<img width="1920" height="693" alt="Screenshot 2026-07-16 16 18 47" src="https://github.com/user-attachments/assets/a7508add-554d-4664-95bc-a21bbc4047f6" />

I'd say 100 ms per frame still doesn't feel great in terms of responsiveness when the work gets spread over this amount of time, and should maybe be lowered even more, but that's for a separate PR.