### PR TITLE
Editor: Fix autocomplete icon for `CODE_COMPLETION_KIND_CLASS`

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1061,10 +1061,11 @@ Ref<Texture2D> CodeTextEditor::_get_completion_icon(const ScriptLanguage::CodeCo
 	Ref<Texture2D> tex;
 	switch (p_option.kind) {
 		case ScriptLanguage::CODE_COMPLETION_KIND_CLASS: {
-			if (has_theme_icon(p_option.display, EditorStringName(EditorIcons))) {
-				tex = get_editor_theme_icon(p_option.display);
+			const String formatted_class_name = p_option.display.unquote();
+			if (has_theme_icon(formatted_class_name, EditorStringName(EditorIcons))) {
+				tex = get_editor_theme_icon(formatted_class_name);
 			} else {
-				tex = EditorNode::get_singleton()->get_class_icon(p_option.display);
+				tex = EditorNode::get_singleton()->get_class_icon(formatted_class_name);
 				if (tex.is_null()) {
 					tex = get_editor_theme_icon(SNAME("Object"));
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121452

## Additional information

Fix an error where the GDScript editor will not properly display icons for classes that have been returned from the language server and are enclosed in double quotes.

As discussed with @HolonProduction in #121452 this adds the ability to the GDScript editor to get class icons for class autocompletions that have been returned from the language server and include quotation marks.

I did so by using an additional `formatted_class` `String` instead of directly using `p_class` in the icon retrieval logic. If I detect a class name enclosed in double quotes, I remove them from the `p_class`, otherwise, the logic stays the same.

This gives the desired result of keeping the double quotes while being able to display the icons, and only the icon logic is changed.

This issue did not only affect `export_tool_button` like the issue mentions, but also every other autocompletion that was being returned in anotations as a `CODE_COMPLETION_KIND_CLASS`, like `@export_node_path`.

I have tested that this and other code completions work and show their icons properly.

No AI was used in this PR whatsoever.

<img width="580" height="252" alt="image" src="https://github.com/user-attachments/assets/9144221d-0cf5-4c98-860b-eeb9855f4e44" />