### PR TITLE
Replace 0x7 mouse button check with explicit value

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3421,6 +3421,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		current_menu_option = (MenuOptions)p_option;
 	}
 
+	constexpr int button_mask_full = int(MouseButtonMask::LEFT | MouseButtonMask::RIGHT | MouseButtonMask::MIDDLE | MouseButtonMask::MB_XBUTTON1 | MouseButtonMask::MB_XBUTTON2);
+
 	switch (p_option) {
 		case SCENE_NEW_SCENE: {
 			new_scene();
@@ -3625,7 +3627,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 
 		case SCENE_UNDO: {
-			if ((int)Input::get_singleton()->get_mouse_button_mask() & 0x7) {
+			if ((int)Input::get_singleton()->get_mouse_button_mask() & button_mask_full) {
 				log->add_message(TTR("Can't undo while mouse buttons are pressed."), EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -3650,7 +3652,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case SCENE_REDO: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			if ((int)Input::get_singleton()->get_mouse_button_mask() & 0x7) {
+			if ((int)Input::get_singleton()->get_mouse_button_mask() & button_mask_full) {
 				log->add_message(TTR("Can't redo while mouse buttons are pressed."), EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				if (!undo_redo->redo()) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Replaces hard-coded `0x7` check in EditorNode with an explicit bitmask value for all mouse buttons.
