### PR TITLE
Improve 2D editor node paste

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1000,8 +1000,6 @@ void CanvasItemEditor::_selection_menu_hide() {
 }
 
 void CanvasItemEditor::_add_node_pressed(int p_result) {
-	List<Node *> nodes_to_move;
-
 	switch (p_result) {
 		case ADD_NODE: {
 			SceneTreeDock::get_singleton()->open_add_child_dialog();
@@ -1010,11 +1008,28 @@ void CanvasItemEditor::_add_node_pressed(int p_result) {
 			SceneTreeDock::get_singleton()->open_instance_child_dialog();
 		} break;
 		case ADD_PASTE: {
-			nodes_to_move = SceneTreeDock::get_singleton()->paste_nodes();
-			[[fallthrough]];
-		}
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action_for_history(TTR("Paste Node(s) at Position"), EditorNode::get_editor_data().get_current_edited_scene_history_id());
+
+			List<Node *> pasted_nodes = SceneTreeDock::get_singleton()->paste_nodes();
+			if (pasted_nodes.is_empty()) {
+				_reset_create_position();
+				return;
+			}
+
+			for (Node *node : pasted_nodes) {
+				CanvasItem *ci = Object::cast_to<CanvasItem>(node);
+				if (ci) {
+					Transform2D xform = ci->get_global_transform_with_canvas().affine_inverse() * ci->get_transform();
+					undo_redo->add_do_method(ci, "_edit_set_position", xform.xform(node_create_position));
+					undo_redo->add_undo_method(ci, "_edit_set_position", ci->_edit_get_position());
+				}
+			}
+			undo_redo->commit_action();
+			_reset_create_position();
+		} break;
 		case ADD_MOVE: {
-			nodes_to_move = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
+			List<Node *> nodes_to_move = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
 			if (nodes_to_move.is_empty()) {
 				return;
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Mainly fix for "Paste Node(s) Here" context menu option in 2D editor making 2 undo actions.

## Additional information

The nodes returned by `paste_nodes()` were never really used. Only 2D editor made use of them, but you can see in the code that the list is immediately overwritten by the fallthrough. It only worked, because pasting nodes also selects them.

At first I wanted to just remove the returned list, but then I realized that pasting nodes in 2D editor was making 2 undo actions. Returning the list was actually needed to fix that.

I noticed some more problems in these context menu options. They involve Scene dock for no reason. I plan to make follow-up PRs to improve this old code.