### PR TITLE
Fix precision issues with 3D editor freelook/panning when far away from the origin

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -219,8 +219,12 @@ void ViewportNavigationControl::_update_navigation() {
 
 			const Vector3 direction = forward + right;
 			const Vector3 motion = direction * speed;
-			viewport->view_3d_controller->cursor.pos += motion;
-			viewport->view_3d_controller->cursor.eye_pos += motion;
+			viewport->view_3d_controller->cursor.pos_x += motion.x;
+			viewport->view_3d_controller->cursor.pos_y += motion.y;
+			viewport->view_3d_controller->cursor.pos_z += motion.z;
+			viewport->view_3d_controller->cursor.eye_pos_x += motion.x;
+			viewport->view_3d_controller->cursor.eye_pos_y += motion.y;
+			viewport->view_3d_controller->cursor.eye_pos_z += motion.z;
 		} break;
 
 		case View3DController::NAV_MODE_LOOK: {
@@ -1187,7 +1191,7 @@ Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
 	Vector2 screen_he = cm.get_viewport_half_extents();
 
 	Transform3D camera_transform;
-	camera_transform.translate_local(view_3d_controller->cursor.pos);
+	camera_transform.translate_local(Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z));
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -view_3d_controller->cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -view_3d_controller->cursor.y_rot);
 	camera_transform.translate_local(0, 0, view_3d_controller->cursor.distance);
@@ -4373,7 +4377,9 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 
 		} break;
 		case VIEW_CENTER_TO_ORIGIN: {
-			view_3d_controller->cursor.pos = Vector3(0, 0, 0);
+			view_3d_controller->cursor.pos_x = 0;
+			view_3d_controller->cursor.pos_y = 0;
+			view_3d_controller->cursor.pos_z = 0;
 			_disable_follow_mode();
 
 		} break;
@@ -4405,7 +4411,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 				Transform3D xform = camera_transform;
 				if (view_3d_controller->is_orthogonal()) {
 					Vector3 offset = camera_transform.basis.xform(Vector3(0, 0, view_3d_controller->cursor.distance));
-					xform.origin = view_3d_controller->cursor.pos + offset;
+					xform.origin = Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z) + offset;
 				} else {
 					xform.scale_basis(sp->get_scale());
 				}
@@ -4724,7 +4730,9 @@ void Node3DEditorViewport::_preview_camera_property_changed() {
 void Node3DEditorViewport::_sync_cursor_from_transform(const Transform3D &p_transform) {
 	const Basis basis = p_transform.basis;
 
-	view_3d_controller->cursor.eye_pos = p_transform.origin;
+	view_3d_controller->cursor.eye_pos_x = p_transform.origin.x;
+	view_3d_controller->cursor.eye_pos_y = p_transform.origin.y;
+	view_3d_controller->cursor.eye_pos_z = p_transform.origin.z;
 	view_3d_controller->cursor.x_rot = -basis.get_euler().x;
 	view_3d_controller->cursor.y_rot = -basis.get_euler().y;
 	view_3d_controller->cursor.unsnapped_x_rot = view_3d_controller->cursor.x_rot;
@@ -4734,7 +4742,9 @@ void Node3DEditorViewport::_sync_cursor_from_transform(const Transform3D &p_tran
 	if (view_3d_controller->is_orthogonal()) {
 		distance = (get_zfar() - get_znear()) / 2.0;
 	}
-	view_3d_controller->cursor.pos = p_transform.origin - basis.get_column(2) * distance;
+	view_3d_controller->cursor.pos_x = p_transform.origin.x - basis.get_column(2).x * distance;
+	view_3d_controller->cursor.pos_y = p_transform.origin.y - basis.get_column(2).y * distance;
+	view_3d_controller->cursor.pos_z = p_transform.origin.z - basis.get_column(2).z * distance;
 }
 
 void Node3DEditorViewport::_update_centered_labels() {
@@ -5120,7 +5130,10 @@ void Node3DEditorViewport::update_transform_gizmo_highlight() {
 
 void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 	if (p_state.has("position")) {
-		view_3d_controller->cursor.pos = p_state["position"];
+		Vector3 pos = p_state["position"];
+		view_3d_controller->cursor.pos_x = pos.x;
+		view_3d_controller->cursor.pos_y = pos.y;
+		view_3d_controller->cursor.pos_z = pos.z;
 	}
 	if (p_state.has("x_rotation")) {
 		view_3d_controller->cursor.x_rot = p_state["x_rotation"];
@@ -5276,7 +5289,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 
 Dictionary Node3DEditorViewport::get_state() const {
 	Dictionary d;
-	d["position"] = view_3d_controller->cursor.pos;
+	d["position"] = Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z);
 	d["x_rotation"] = view_3d_controller->cursor.x_rot;
 	d["y_rotation"] = view_3d_controller->cursor.y_rot;
 	d["distance"] = view_3d_controller->cursor.distance;
@@ -5376,7 +5389,9 @@ void Node3DEditorViewport::focus_selection() {
 		center /= count;
 	}
 
-	view_3d_controller->cursor.pos = center;
+	view_3d_controller->cursor.pos_x = center.x;
+	view_3d_controller->cursor.pos_y = center.y;
+	view_3d_controller->cursor.pos_z = center.z;
 }
 
 void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, AABB *p_preview_bounds, AcceptDialog *p_accept) {
@@ -5469,7 +5484,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 
 	// Plane facing the camera using fallback distance.
 	if (is_orthogonal) {
-		plane = Plane(world_ray, view_3d_controller->cursor.pos - world_ray * (view_3d_controller->cursor.distance - FALLBACK_DISTANCE));
+		plane = Plane(world_ray, Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z) - world_ray * (view_3d_controller->cursor.distance - FALLBACK_DISTANCE));
 	} else {
 		plane = Plane(world_ray, world_pos + world_ray * FALLBACK_DISTANCE);
 	}

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -1540,7 +1540,9 @@ void RuntimeNodeSelect::_reset_camera_3d() {
 	if (game_camera) {
 		Transform3D transform = game_camera->get_camera_transform();
 		transform.translate_local(0, 0, -cursor.distance);
-		cursor.pos = transform.origin;
+		cursor.pos_x = transform.origin.x;
+		cursor.pos_y = transform.origin.y;
+		cursor.pos_z = transform.origin.z;
 
 		cursor.x_rot = -game_camera->get_global_rotation().x;
 		cursor.y_rot = -game_camera->get_global_rotation().y;

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -42,7 +42,7 @@ using namespace View3DControllerConsts;
 
 Transform3D View3DController::_to_camera_transform(const Cursor &p_cursor) const {
 	Transform3D camera_transform;
-	camera_transform.translate_local(p_cursor.pos);
+	camera_transform.translate_local(Vector3(p_cursor.pos_x, p_cursor.pos_y, p_cursor.pos_z));
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -p_cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -p_cursor.y_rot);
 
@@ -334,7 +334,7 @@ void View3DController::cursor_pan(const Ref<InputEventWithModifiers> &p_event, c
 
 	Transform3D camera_transform;
 
-	camera_transform.translate_local(cursor.pos);
+	camera_transform.translate_local(Vector3(cursor.pos_x, cursor.pos_y, cursor.pos_z));
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -cursor.y_rot);
 	Vector3 translation(
@@ -343,7 +343,9 @@ void View3DController::cursor_pan(const Ref<InputEventWithModifiers> &p_event, c
 			0);
 	translation *= cursor.distance / DISTANCE_DEFAULT;
 	camera_transform.translate_local(translation);
-	cursor.pos = camera_transform.origin;
+	cursor.pos_x = camera_transform.origin.x;
+	cursor.pos_y = camera_transform.origin.y;
+	cursor.pos_z = camera_transform.origin.z;
 
 	emit_signal(SNAME("cursor_panned"));
 }
@@ -439,7 +441,9 @@ void View3DController::cursor_look(const Ref<InputEventWithModifiers> &p_event, 
 	Vector3 pos = camera_transform.xform(Vector3(0, 0, 0));
 	Vector3 prev_pos = prev_camera_transform.xform(Vector3(0, 0, 0));
 	Vector3 diff = prev_pos - pos;
-	cursor.pos += diff;
+	cursor.pos_x += diff.x;
+	cursor.pos_y += diff.y;
+	cursor.pos_z += diff.z;
 
 	set_view_type(VIEW_TYPE_USER);
 }
@@ -476,10 +480,12 @@ void View3DController::update_camera(const real_t p_delta) {
 		if (freelook) {
 			// Higher inertia should increase "lag" (lerp with factor between 0 and 1).
 			// Inertia of zero should produce instant movement (lerp with factor of 1) in this case it returns a really high value and gets clamped to 1.
-			float factor = (1.0 / freelook_inertia) * p_delta;
+			double factor = (1.0 / freelook_inertia) * p_delta;
 
 			// We interpolate a different point here, because in freelook mode the focus point (cursor.pos) orbits around eye_pos
-			cursor_interp.eye_pos = old_camera_cursor.eye_pos.lerp(cursor.eye_pos, CLAMP(factor, 0, 1));
+			cursor_interp.eye_pos_x = Math::lerp(old_camera_cursor.eye_pos_x, cursor.eye_pos_x, CLAMP(factor, 0, 1));
+			cursor_interp.eye_pos_y = Math::lerp(old_camera_cursor.eye_pos_y, cursor.eye_pos_y, CLAMP(factor, 0, 1));
+			cursor_interp.eye_pos_z = Math::lerp(old_camera_cursor.eye_pos_z, cursor.eye_pos_z, CLAMP(factor, 0, 1));
 		}
 
 		cursor_interp.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_delta * (1 / orbit_inertia)));
@@ -494,18 +500,24 @@ void View3DController::update_camera(const real_t p_delta) {
 
 		if (freelook) {
 			Vector3 forward = _to_camera_transform(cursor_interp).basis.xform(Vector3(0, 0, -1));
-			cursor_interp.pos = cursor_interp.eye_pos + forward * cursor_interp.distance;
+			cursor_interp.pos_x = cursor_interp.eye_pos_x + forward.x * cursor_interp.distance;
+			cursor_interp.pos_y = cursor_interp.eye_pos_y + forward.y * cursor_interp.distance;
+			cursor_interp.pos_z = cursor_interp.eye_pos_z + forward.z * cursor_interp.distance;
 		} else {
-			cursor_interp.pos = old_camera_cursor.pos.lerp(cursor.pos, MIN(1.f, p_delta * (1 / translation_inertia)));
+			cursor_interp.pos_x = Math::lerp(old_camera_cursor.pos_x, cursor.pos_x, MIN(1.0, p_delta * (1 / translation_inertia)));
+			cursor_interp.pos_y = Math::lerp(old_camera_cursor.pos_y, cursor.pos_y, MIN(1.0, p_delta * (1 / translation_inertia)));
+			cursor_interp.pos_z = Math::lerp(old_camera_cursor.pos_z, cursor.pos_z, MIN(1.0, p_delta * (1 / translation_inertia)));
 			cursor_interp.distance = Math::lerp(old_camera_cursor.distance, cursor.distance, MIN((float)1.0, p_delta * (1 / zoom_inertia)));
 		}
 
 		// Apply camera transform.
 
 		const real_t tolerance = 0.001;
+		// Use a smaller tolerance for position, as it's always stored in doubles.
+		const double pos_tolerance = 0.000001;
 		if (!Math::is_equal_approx(old_camera_cursor.x_rot, cursor_interp.x_rot, tolerance) || !Math::is_equal_approx(old_camera_cursor.y_rot, cursor_interp.y_rot, tolerance)) {
 			equal = false;
-		} else if (!old_camera_cursor.pos.is_equal_approx(cursor_interp.pos)) {
+		} else if (!Math::is_equal_approx(old_camera_cursor.pos_x, cursor_interp.pos_x, pos_tolerance) || !Math::is_equal_approx(old_camera_cursor.pos_y, cursor_interp.pos_y, pos_tolerance) || !Math::is_equal_approx(old_camera_cursor.pos_z, cursor_interp.pos_z, pos_tolerance)) {
 			equal = false;
 		} else if (!Math::is_equal_approx(old_camera_cursor.distance, cursor_interp.distance, tolerance)) {
 			equal = false;
@@ -576,8 +588,12 @@ void View3DController::update_freelook(const float p_delta) {
 	}
 
 	const Vector3 motion = direction * speed * p_delta;
-	cursor.pos += motion;
-	cursor.eye_pos += motion;
+	cursor.pos_x += motion.x;
+	cursor.pos_y += motion.y;
+	cursor.pos_z += motion.z;
+	cursor.eye_pos_x += motion.x;
+	cursor.eye_pos_y += motion.y;
+	cursor.eye_pos_z += motion.z;
 }
 
 void View3DController::scale_freelook_speed(const float p_scale) {
@@ -717,9 +733,13 @@ void View3DController::set_freelook_enabled(const bool p_enabled) {
 	if (freelook) {
 		// Make sure eye_pos is synced, because freelook referential is eye pos rather than orbit pos.
 		Vector3 forward = to_camera_transform().basis.xform(Vector3(0, 0, -1));
-		cursor.eye_pos = cursor.pos - cursor.distance * forward;
+		cursor.eye_pos_x = cursor.pos_x - cursor.distance * forward.x;
+		cursor.eye_pos_y = cursor.pos_y - cursor.distance * forward.y;
+		cursor.eye_pos_z = cursor.pos_z - cursor.distance * forward.z;
 		// Also sync the interpolated cursor's eye_pos, otherwise switching to freelook will be trippy if inertia is active.
-		cursor_interp.eye_pos = cursor.eye_pos;
+		cursor_interp.eye_pos_x = cursor.eye_pos_x;
+		cursor_interp.eye_pos_y = cursor.eye_pos_y;
+		cursor_interp.eye_pos_z = cursor.eye_pos_z;
 
 		if (freelook_speed_zoom_link) {
 			// Re-adjust freelook speed from the current zoom level.

--- a/scene/debugger/view_3d_controller.h
+++ b/scene/debugger/view_3d_controller.h
@@ -140,14 +140,25 @@ public:
 	};
 
 	struct Cursor {
-		Vector3 pos;
+		// Store the X/Y/Z position individually as doubles, as Vector3 is 32-bit in single-precision builds.
+		// We want to always use doubles, so that freelook and panning behavior stays correct
+		// when far away from the origin.
+		double pos_x;
+		double pos_y;
+		double pos_z;
+
 		real_t x_rot;
 		real_t y_rot;
 		real_t distance;
 		real_t fov_scale;
 		real_t unsnapped_x_rot;
 		real_t unsnapped_y_rot;
-		Vector3 eye_pos; // Used for freelook.
+
+		// Used for freelook.
+		double eye_pos_x;
+		double eye_pos_y;
+		double eye_pos_z;
+
 		// TODO: These variables are not related to cursor manipulation, and specific
 		// to Node3DEditorPlugin. So remove them in the future.
 		bool region_select;


### PR DESCRIPTION
- *Related to https://github.com/godotengine/godot/pull/99986
and https://github.com/godotengine/godot/pull/100896.*

This works by converting the position and eye position members to double precision. This requires some more code as they need to be stored as `doubles` individually for X/Y/Z, since Vector3 is 32-bit in single-precision builds.

This fix works in both single-precision and double-precision builds, and both in the editor and Game tab camera override.

**Testing project:** [test_freelook_far.zip](https://github.com/user-attachments/files/30104419/test_freelook_far.zip)

## Preview

*All videos recorded in a single-precision build, so there is some shaking unrelated to freelook code that can't be fixed by this PR. The camera is at `(70000, 0, 20000)`.*

### Before

*The camera is only being moved forward or backward, yet it doesn't go straight ahead.*

https://github.com/user-attachments/assets/8489e49d-9da6-43dd-b999-a17135f5352b

### After

https://github.com/user-attachments/assets/dd20e7fc-8df0-4016-ae35-9d7e3a48e202

Even with freelook inertia set to 0.5, it works well:

https://github.com/user-attachments/assets/cc4500d6-1f3c-43cd-827a-8117eb5ba411

