### PR TITLE
Re-enable freelook inertia by default in the 3D editor

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -997,7 +997,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// 3D: Freelook
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_navigation_scheme", 0, "Default,Partially Axis-Locked (id Tech),Fully Axis-Locked (Minecraft)")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_sensitivity", 0.25, "0.01,2,0.001")
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_inertia", 0.0, "0,1,0.001")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_inertia", 0.05, "0,1,0.001")
 	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_base_speed", 5.0, "0,10,0.01,or_greater")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_activation_modifier", 0, "None,Shift,Alt,Meta,Ctrl")
 	_initial_set("editors/3d/freelook/freelook_invert_y_axis", false);


### PR DESCRIPTION
- *Follow-up to https://github.com/godotengine/godot/pull/121477
(can be merged independently).*

Freelook inertia was disabled by default in https://github.com/godotengine/godot/pull/35103, so this re-enables it.

The new default value (`0.05`) is more subtle than the default used in Godot 3 (`0.1`). This allows the camera to still be snappy and easy to control while feeling more natural.

Only translational (position) changes are affected by freelook inertia, not rotational changes (mouse input). This means pointing at things is still as fast as it can be.

The bug mentioned in https://github.com/godotengine/godot/issues/52378 doesn't occur as long as we keep orbit inertia to `0.0`, even without https://github.com/godotengine/godot/pull/121477.

cc @passivestar, as this was requested on the [Godot Contributors Chat](https://chat.godotengine.org/channel/usability?msg=MMNkePjGhDyREsFy4).

## Preview

### Before

https://github.com/user-attachments/assets/080f55fe-97f6-4947-a764-9ccd21e50dac

### After

https://github.com/user-attachments/assets/d5ad9976-4320-43e4-918c-5f02e66186e9

### `0.1` inertia (Godot 3 default) for comparsion

https://github.com/user-attachments/assets/b60816bf-ed09-411d-8bc2-ae9ea92408af