### PR TITLE
Make height/width stretch set minimum size on `AspectRatioContainer`

### DIFF
--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -43,6 +43,12 @@ Size2 AspectRatioContainer::get_minimum_size() const {
 		Size2 minsize = c->get_bound_minimum_size();
 		ms = ms.max(minsize);
 	}
+
+	if (stretch_mode == STRETCH_WIDTH_CONTROLS_HEIGHT) {
+		ms.y = MAX(ms.y, get_size().x / ratio);
+	} else if (stretch_mode == STRETCH_HEIGHT_CONTROLS_WIDTH) {
+		ms.x = MAX(ms.x, get_size().y * ratio);
+	}
 	return ms;
 }
 
@@ -51,6 +57,9 @@ void AspectRatioContainer::set_ratio(float p_ratio) {
 		return;
 	}
 	ratio = p_ratio;
+	if (stretch_mode == STRETCH_WIDTH_CONTROLS_HEIGHT || stretch_mode == STRETCH_HEIGHT_CONTROLS_WIDTH) {
+		update_minimum_size();
+	}
 	queue_sort();
 }
 
@@ -98,6 +107,11 @@ Vector<int> AspectRatioContainer::get_allowed_size_flags_vertical() const {
 
 void AspectRatioContainer::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_RESIZED: {
+			if (stretch_mode == STRETCH_WIDTH_CONTROLS_HEIGHT || stretch_mode == STRETCH_HEIGHT_CONTROLS_WIDTH) {
+				update_minimum_size();
+			}
+		} break;
 		case NOTIFICATION_SORT_CHILDREN: {
 			bool rtl = is_layout_rtl();
 			Size2 size = get_size();


### PR DESCRIPTION
The aspect ratio container currently does not set it's own size when it's stretch mode is set to "Height Controls Width" or "Width Controls Height" and only sets it's childrens size. This can cause problems when aspect ratio containers are used in H and VBoxContainers.

- Closes https://github.com/godotengine/godot/issues/75169

And here are some pictures to show what this looks like in practice both taken with the same settings:

Currently version:

<img width="523" height="211" alt="Kuvakaappaus_20260717_015512" src="https://github.com/user-attachments/assets/828fd613-4601-4905-868e-2a9affea72da" />

This PR:

<img width="732" height="211" alt="Kuvakaappaus_20260717_015432" src="https://github.com/user-attachments/assets/8e711dd9-f048-4310-9e63-6ee536a5f6e7" />

