### PR TITLE
Add theme items to define scroll margins in `ItemList`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -572,8 +572,20 @@
 			The size of the item text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.
 		</theme_item>
-		<theme_item name="scroll_bar_h_separation" data_type="constant" type="int" default="4">
+		<theme_item name="scrollbar_h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of items and the vertical scrollbar.
+		</theme_item>
+		<theme_item name="scrollbar_margin_bottom" data_type="constant" type="int" default="-1">
+			The bottom margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s bottom margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_left" data_type="constant" type="int" default="-1">
+			The left margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s left margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_right" data_type="constant" type="int" default="-1">
+			The right margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s right margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_top" data_type="constant" type="int" default="-1">
+			The top margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s top margin.
 		</theme_item>
 		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical spacing between items.

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -776,7 +776,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
 			p_theme->set_constant("v_separation", "ItemList", EDSCALE_RND(p_config.forced_even_separation));
 			p_theme->set_constant("h_separation", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
-			p_theme->set_constant("scroll_bar_h_separation", "ItemList", p_config.separation_margin);
+			p_theme->set_constant("scrollbar_h_separation", "ItemList", p_config.separation_margin);
 			p_theme->set_constant("icon_margin", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
 			p_theme->set_constant("outline_size", "ItemList", 0);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -780,7 +780,11 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("scroll_hint_color", "ItemList", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));
 			p_theme->set_constant("v_separation", "ItemList", EDSCALE_RND(p_config.base_margin * 1.5));
 			p_theme->set_constant("h_separation", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
-			p_theme->set_constant("scroll_bar_h_separation", "ItemList", style_itemlist_bg->get_margin(SIDE_RIGHT));
+			p_theme->set_constant("scrollbar_margin_left", "ItemList", 0);
+			p_theme->set_constant("scrollbar_margin_top", "ItemList", 0);
+			p_theme->set_constant("scrollbar_margin_right", "ItemList", 0);
+			p_theme->set_constant("scrollbar_margin_bottom", "ItemList", 0);
+			p_theme->set_constant("scrollbar_h_separation", "ItemList", EDSCALE_RND(1));
 			p_theme->set_constant("icon_margin", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
 			p_theme->set_constant("outline_size", "ItemList", 0);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -343,13 +343,26 @@ Rect2 ItemList::get_item_rect(int p_idx, bool p_expand) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), Rect2());
 
 	Rect2 ret = items[p_idx].rect_cache;
+
 	if (p_expand && p_idx % current_columns == current_columns - 1) {
 		int width = get_size().width - theme_cache.panel_style->get_minimum_size().width;
 		if (scroll_bar_v->is_visible()) {
-			width -= scroll_bar_v->get_bound_minimum_size().width + theme_cache.scroll_bar_h_separation;
+			int scroll_width = scroll_bar_v->get_bound_minimum_size().width + theme_cache.scrollbar_h_separation;
+			if (theme_cache.scrollbar_margin_right < 0) {
+				width -= scroll_width;
+			} else {
+				int scroll_margin = theme_cache.scrollbar_margin_right + scroll_width;
+				if (scroll_margin > theme_cache.panel_style->get_margin(SIDE_RIGHT)) {
+					width -= scroll_margin - theme_cache.panel_style->get_margin(SIDE_RIGHT);
+				}
+			}
+		} else {
+			width -= MAX(theme_cache.panel_style->get_margin(SIDE_RIGHT), theme_cache.scrollbar_margin_right);
 		}
+
 		ret.size.width = width - ret.position.x;
 	}
+
 	ret.position += theme_cache.panel_style->get_offset();
 	return ret;
 }
@@ -1404,23 +1417,47 @@ void ItemList::_notification(int p_what) {
 			Size2 scroll_bar_h_min = scroll_bar_h->is_visible() ? scroll_bar_h->get_bound_minimum_size() : Size2();
 			Size2 scroll_bar_v_min = scroll_bar_v->is_visible() ? scroll_bar_v->get_bound_minimum_size() : Size2();
 
-			int left_margin = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_RIGHT) : theme_cache.panel_style->get_margin(SIDE_LEFT);
-			int right_margin = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_LEFT) : theme_cache.panel_style->get_margin(SIDE_RIGHT);
+			int left_margin = 0;
+			if (theme_cache.scrollbar_margin_left < 0) {
+				left_margin = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_RIGHT) : theme_cache.panel_style->get_margin(SIDE_LEFT);
+			} else {
+				left_margin = theme_cache.scrollbar_margin_left;
+			}
+			int right_margin = 0;
+			if (theme_cache.scrollbar_margin_right < 0) {
+				right_margin = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_LEFT) : theme_cache.panel_style->get_margin(SIDE_RIGHT);
+			} else {
+				right_margin = theme_cache.scrollbar_margin_right;
+			}
+
+			int top_margin = theme_cache.scrollbar_margin_top < 0 ? theme_cache.panel_style->get_margin(SIDE_TOP) : theme_cache.scrollbar_margin_top;
+			int bottom_margin = theme_cache.scrollbar_margin_bottom < 0 ? theme_cache.panel_style->get_margin(SIDE_BOTTOM) : theme_cache.scrollbar_margin_bottom;
 
 			scroll_bar_v->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -scroll_bar_v_min.width - right_margin);
 			scroll_bar_v->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -right_margin);
-			scroll_bar_v->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, theme_cache.panel_style->get_margin(SIDE_TOP));
-			scroll_bar_v->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -scroll_bar_h_min.height - theme_cache.panel_style->get_margin(SIDE_BOTTOM));
+			scroll_bar_v->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, top_margin);
+			scroll_bar_v->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -scroll_bar_h_min.height - bottom_margin);
 
 			scroll_bar_h->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, left_margin);
 			scroll_bar_h->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -right_margin - scroll_bar_v_min.width);
-			scroll_bar_h->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -scroll_bar_h_min.height - theme_cache.panel_style->get_margin(SIDE_BOTTOM));
-			scroll_bar_h->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -theme_cache.panel_style->get_margin(SIDE_BOTTOM));
+			scroll_bar_h->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -scroll_bar_h_min.height - bottom_margin);
+			scroll_bar_h->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -bottom_margin);
 
 			Size2 size = get_size();
-			int width = size.width - theme_cache.panel_style->get_minimum_size().width;
+
+			int width = get_size().width - theme_cache.panel_style->get_minimum_size().width;
 			if (scroll_bar_v->is_visible()) {
-				width -= scroll_bar_v_min.width + theme_cache.scroll_bar_h_separation;
+				int scroll_width = scroll_bar_v_min.width + theme_cache.scrollbar_h_separation;
+				if (theme_cache.scrollbar_margin_right < 0) {
+					width -= scroll_width;
+				} else {
+					int scroll_margin = theme_cache.scrollbar_margin_right + scroll_width;
+					if (scroll_margin > theme_cache.panel_style->get_margin(SIDE_RIGHT)) {
+						width -= scroll_margin - theme_cache.panel_style->get_margin(SIDE_RIGHT);
+					}
+				}
+			} else {
+				width -= MAX(theme_cache.panel_style->get_margin(SIDE_RIGHT), theme_cache.scrollbar_margin_right);
 			}
 
 			draw_style_box(theme_cache.panel_style, Rect2(Point2(), size));
@@ -2487,7 +2524,11 @@ void ItemList::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, v_separation);
-	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scroll_bar_h_separation);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scrollbar_margin_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scrollbar_margin_top);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scrollbar_margin_right);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scrollbar_margin_bottom);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ItemList, scrollbar_h_separation);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, panel_style, "panel");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ItemList, focus_style, "focus");

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -163,7 +163,11 @@ protected:
 	struct ThemeCache {
 		int h_separation = 0;
 		int v_separation = 0;
-		int scroll_bar_h_separation = 0;
+		int scrollbar_margin_left = -1;
+		int scrollbar_margin_top = -1;
+		int scrollbar_margin_right = -1;
+		int scrollbar_margin_bottom = -1;
+		int scrollbar_h_separation = 0;
 
 		Ref<StyleBox> panel_style;
 		Ref<StyleBox> focus_style;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -970,7 +970,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("v_separation", "ItemList", Math::round(4 * scale));
 	theme->set_constant("icon_margin", "ItemList", Math::round(4 * scale));
 	theme->set_constant(SceneStringName(line_separation), "ItemList", Math::round(2 * scale));
-	theme->set_constant("scroll_bar_h_separation", "ItemList", Math::round(4 * scale));
+	theme->set_constant("scrollbar_margin_left", "ItemList", -1);
+	theme->set_constant("scrollbar_margin_top", "ItemList", -1);
+	theme->set_constant("scrollbar_margin_right", "ItemList", -1);
+	theme->set_constant("scrollbar_margin_bottom", "ItemList", -1);
+	theme->set_constant("scrollbar_h_separation", "ItemList", Math::round(4 * scale));
 
 	theme->set_font(SceneStringName(font), "ItemList", Ref<Font>());
 	theme->set_font_size(SceneStringName(font_size), "ItemList", -1);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120691.

This PR adds theme item constants to offset the scrollbars in `ItemList`. This change allows to close the issue mentioned above, as it allows those scrolls to better align with the rest of the ones in the editor.

## Additional information

I renamed the recently added `scroll_bar_h_separation` to `scrollbar_h_separation`, as all theme items in the engine use "scrollbar" as one word.