### PR TITLE
Add support for gamepad gyro auto-calibration

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -46,6 +46,9 @@
 
 #define STANDARD_GRAVITY 9.80665f
 
+static const GamepadMotionHelpers::CalibrationMode CALIBRATION_MODE_AUTO = GamepadMotionHelpers::CalibrationMode::Stillness | GamepadMotionHelpers::CalibrationMode::SensorFusion;
+static const GamepadMotionHelpers::CalibrationMode CALIBRATION_MODE_MANUAL = GamepadMotionHelpers::CalibrationMode::Manual;
+
 static const char *_joy_buttons[(size_t)JoyButton::SDL_MAX] = {
 	"a",
 	"b",
@@ -179,6 +182,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_joy_motion_sensors_calibration", "device", "calibration_info"), &Input::set_joy_motion_sensors_calibration);
 	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_calibrated", "device"), &Input::is_joy_motion_sensors_calibrated);
 	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_calibrating", "device"), &Input::is_joy_motion_sensors_calibrating);
+	ClassDB::bind_method(D_METHOD("set_joy_motion_sensors_auto_calibration_enabled", "device", "enable"), &Input::set_joy_motion_sensors_auto_calibration_enabled);
+	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_auto_calibration_enabled", "device"), &Input::is_joy_motion_sensors_auto_calibration_enabled);
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_finger_position", "device", "finger", "touchpad"), &Input::get_joy_touchpad_finger_position, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_finger_pressure", "device", "finger", "touchpad"), &Input::get_joy_touchpad_finger_pressure, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_fingers", "device", "touchpad"), &Input::get_joy_touchpad_fingers, DEFVAL(0));
@@ -1294,7 +1299,7 @@ Dictionary Input::get_joy_motion_sensors_calibration(int p_device) const {
 		return Dictionary();
 	}
 
-	if (!motion->calibrated) {
+	if (!motion->calibrated && !motion->auto_calibration_enabled) {
 		return Dictionary();
 	}
 
@@ -1338,7 +1343,27 @@ bool Input::is_joy_motion_sensors_calibrated(int p_device) const {
 	if (motion == nullptr) {
 		return false;
 	}
-	return motion->calibrated;
+	if (motion->calibrated) {
+		return true;
+	}
+	return motion->auto_calibration_enabled && motion->gamepad_motion->GetAutoCalibrationConfidence() > 0.0f;
+}
+
+void Input::set_joy_motion_sensors_auto_calibration_enabled(int p_device, bool p_enable) {
+	_THREAD_SAFE_METHOD_
+	MotionInfo *motion = joy_motion.getptr(p_device);
+	if (motion == nullptr) {
+		return;
+	}
+
+	motion->auto_calibration_enabled = p_enable;
+	motion->gamepad_motion->SetCalibrationMode(p_enable ? CALIBRATION_MODE_AUTO : CALIBRATION_MODE_MANUAL);
+}
+
+bool Input::is_joy_motion_sensors_auto_calibration_enabled(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	const MotionInfo *motion = joy_motion.getptr(p_device);
+	return motion != nullptr && motion->auto_calibration_enabled;
 }
 
 void Input::set_joy_motion_sensors_rate(int p_device, float p_rate) {
@@ -1966,6 +1991,7 @@ void Input::_update_joypad_features(int p_device) {
 		} else {
 			motion.gamepad_motion->Reset();
 		}
+		motion.gamepad_motion->SetCalibrationMode(motion.auto_calibration_enabled ? CALIBRATION_MODE_AUTO : CALIBRATION_MODE_MANUAL);
 		motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
 	}
 	if (joypad->features->get_joy_num_touchpads() > 0) {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -46,6 +46,9 @@
 
 #define STANDARD_GRAVITY 9.80665f
 
+static const GamepadMotionHelpers::CalibrationMode CALIBRATION_MODE_AUTO = GamepadMotionHelpers::CalibrationMode::Stillness | GamepadMotionHelpers::CalibrationMode::SensorFusion;
+static const GamepadMotionHelpers::CalibrationMode CALIBRATION_MODE_MANUAL = GamepadMotionHelpers::CalibrationMode::Manual;
+
 static const char *_joy_buttons[(size_t)JoyButton::SDL_MAX] = {
 	"a",
 	"b",
@@ -179,6 +182,8 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_joy_motion_sensors_calibration", "device", "calibration_info"), &Input::set_joy_motion_sensors_calibration);
 	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_calibrated", "device"), &Input::is_joy_motion_sensors_calibrated);
 	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_calibrating", "device"), &Input::is_joy_motion_sensors_calibrating);
+	ClassDB::bind_method(D_METHOD("set_joy_motion_sensors_auto_calibration_enabled", "device", "enable"), &Input::set_joy_motion_sensors_auto_calibration_enabled);
+	ClassDB::bind_method(D_METHOD("is_joy_motion_sensors_auto_calibration_enabled", "device"), &Input::is_joy_motion_sensors_auto_calibration_enabled);
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_finger_position", "device", "finger", "touchpad"), &Input::get_joy_touchpad_finger_position, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_finger_pressure", "device", "finger", "touchpad"), &Input::get_joy_touchpad_finger_pressure, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_joy_touchpad_fingers", "device", "touchpad"), &Input::get_joy_touchpad_fingers, DEFVAL(0));
@@ -1341,6 +1346,23 @@ bool Input::is_joy_motion_sensors_calibrated(int p_device) const {
 	return motion->calibrated;
 }
 
+void Input::set_joy_motion_sensors_auto_calibration_enabled(int p_device, bool p_enable) {
+	_THREAD_SAFE_METHOD_
+	MotionInfo *motion = joy_motion.getptr(p_device);
+	if (motion == nullptr) {
+		return;
+	}
+
+	motion->auto_calibration_enabled = p_enable;
+	motion->gamepad_motion->SetCalibrationMode(p_enable ? CALIBRATION_MODE_AUTO : CALIBRATION_MODE_MANUAL);
+}
+
+bool Input::is_joy_motion_sensors_auto_calibration_enabled(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	const MotionInfo *motion = joy_motion.getptr(p_device);
+	return motion != nullptr && motion->auto_calibration_enabled;
+}
+
 void Input::set_joy_motion_sensors_rate(int p_device, float p_rate) {
 	_THREAD_SAFE_METHOD_
 	MotionInfo *motion = joy_motion.getptr(p_device);
@@ -1886,6 +1908,10 @@ void Input::joy_motion_sensors(int p_device, const Vector3 &p_accelerometer, con
 	float delta_time = (new_timestamp - motion->last_timestamp) / 1000.0f;
 	motion->last_timestamp = new_timestamp;
 	motion->gamepad_motion->ProcessMotion(gyro_degrees.x, gyro_degrees.y, gyro_degrees.z, accel_g.x, accel_g.y, accel_g.z, delta_time);
+
+	if (motion->auto_calibration_enabled && motion->gamepad_motion->GetAutoCalibrationConfidence() > 0.0f) {
+		motion->calibrated = true;
+	}
 }
 
 void Input::joy_touchpad(int p_device, int p_touchpad, int p_finger, const Vector2 &p_position, float p_pressure, bool p_pressed) {
@@ -1966,6 +1992,7 @@ void Input::_update_joypad_features(int p_device) {
 		} else {
 			motion.gamepad_motion->Reset();
 		}
+		motion.gamepad_motion->SetCalibrationMode(motion.auto_calibration_enabled ? CALIBRATION_MODE_AUTO : CALIBRATION_MODE_MANUAL);
 		motion.last_timestamp = OS::get_singleton()->get_ticks_msec();
 	}
 	if (joypad->features->get_joy_num_touchpads() > 0) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -181,6 +181,7 @@ private:
 		bool sensors_enabled : 1;
 		bool calibrating : 1;
 		bool calibrated : 1;
+		bool auto_calibration_enabled : 1;
 		float sensor_data_rate = 0.0f;
 		uint64_t last_timestamp = 0;
 		GamepadMotion *gamepad_motion = nullptr;
@@ -189,6 +190,7 @@ private:
 			sensors_enabled = false;
 			calibrating = false;
 			calibrated = false;
+			auto_calibration_enabled = true;
 		}
 	};
 
@@ -441,6 +443,9 @@ public:
 
 	bool is_joy_motion_sensors_calibrating(int p_device) const;
 	bool is_joy_motion_sensors_calibrated(int p_device) const;
+
+	void set_joy_motion_sensors_auto_calibration_enabled(int p_device, bool p_enable);
+	bool is_joy_motion_sensors_auto_calibration_enabled(int p_device) const;
 
 	void set_joy_motion_sensors_rate(int p_device, float p_rate);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -443,6 +443,14 @@
 				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices. Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
 			</description>
 		</method>
+		<method name="is_joy_motion_sensors_auto_calibration_enabled" qualifiers="const" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns [code]true[/code] if automatic calibration is enabled on the joypad's motion sensors. Automatic calibration is enabled by default. See [method set_joy_motion_sensors_auto_calibration_enabled].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
+			</description>
+		</method>
 		<method name="is_joy_motion_sensors_calibrated" qualifiers="const" experimental="">
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
@@ -456,7 +464,7 @@
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Returns [code]true[/code] if the joypad's motion sensors are currently being calibrated.
+				Returns [code]true[/code] if the joypad's motion sensors are currently being manually calibrated.
 				See [method start_joy_motion_sensors_calibration] for an example on how to use joypad motion sensors and calibration in your games.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
@@ -665,6 +673,17 @@
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
 		</method>
+		<method name="set_joy_motion_sensors_auto_calibration_enabled" experimental="">
+			<return type="void" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Enables or disables automatic calibration of the joypad's gyroscope. Automatic calibration is enabled by default, so most games don't need to call this or perform any calibration.
+				While enabled, the gyroscope calibration is continuously refined whenever the joypad is detected to be held still, easing corrections in gradually. This removes the need for a dedicated calibration step in most games and keeps up with calibration drift, e.g. from the controller warming up during play.
+				When automatic calibration is disabled, the last calibrated values remain in effect.
+				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
+			</description>
+		</method>
 		<method name="set_joy_motion_sensors_calibration" experimental="">
 			<return type="void" />
 			<param index="0" name="device" type="int" />
@@ -681,6 +700,7 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Enables or disables the motion sensors (gyroscope and/or accelerometer), if available, on the specified joypad.
+				While the motion sensors are enabled, the gyroscope is calibrated automatically by default; see [method set_joy_motion_sensors_auto_calibration_enabled].
 				See [method start_joy_motion_sensors_calibration] for an example on how to use joypad motion sensors and calibration in your games.
 				It's recommended to disable the motion sensors when they're no longer being used, because otherwise it might drain the controller battery faster.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
@@ -707,8 +727,9 @@
 			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Starts the process of calibrating the specified joypad's gyroscope, if it has one.
+				Starts the process of manually calibrating the specified joypad's gyroscope, if it has one.
 				Once a joypad's gyroscope has been calibrated correctly (e.g. laying still on a table without being rotated), [method get_joy_gyroscope] will return values close or equal to [constant Vector3.ZERO] when the joypad is not being rotated.
+				Since the gyroscope is calibrated automatically by default (see [method set_joy_motion_sensors_auto_calibration_enabled]), most games don't need to calibrate manually. If automatic calibration is enabled, it's paused while the manual calibration is in progress, and resumes when [method stop_joy_motion_sensors_calibration] is called.
 				Here's an example of how to use joypad gyroscope and gyroscope calibration in your games:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -443,6 +443,14 @@
 				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices. Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
 			</description>
 		</method>
+		<method name="is_joy_motion_sensors_auto_calibration_enabled" qualifiers="const" experimental="">
+			<return type="bool" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns [code]true[/code] if automatic calibration is enabled on the joypad's motion sensors. Automatic calibration is enabled by default. See also [method set_joy_motion_sensors_auto_calibration_enabled].
+				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
+			</description>
+		</method>
 		<method name="is_joy_motion_sensors_calibrated" qualifiers="const" experimental="">
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
@@ -456,7 +464,7 @@
 			<return type="bool" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Returns [code]true[/code] if the joypad's motion sensors are currently being calibrated.
+				Returns [code]true[/code] if the joypad's motion sensors are currently being manually calibrated.
 				See [method start_joy_motion_sensors_calibration] for an example on how to use joypad motion sensors and calibration in your games.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
@@ -665,6 +673,17 @@
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>
 		</method>
+		<method name="set_joy_motion_sensors_auto_calibration_enabled" experimental="">
+			<return type="void" />
+			<param index="0" name="device" type="int" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Enables or disables automatic calibration of the joypad's gyroscope. Automatic calibration is enabled by default, so most games don't need to call this or perform any calibration.
+				While enabled, the gyroscope calibration is continuously refined whenever the joypad is detected to be held still, easing corrections in gradually. This removes the need for a dedicated calibration step in most games and keeps up with calibration drift, e.g. from the controller warming up during play.
+				When automatic calibration is disabled, the last calibrated values remain in effect.
+				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
+			</description>
+		</method>
 		<method name="set_joy_motion_sensors_calibration" experimental="">
 			<return type="void" />
 			<param index="0" name="device" type="int" />
@@ -681,6 +700,7 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Enables or disables the motion sensors (gyroscope and/or accelerometer), if available, on the specified joypad.
+				While the motion sensors are enabled, the gyroscope is calibrated automatically by default; see [method set_joy_motion_sensors_auto_calibration_enabled].
 				See [method start_joy_motion_sensors_calibration] for an example on how to use joypad motion sensors and calibration in your games.
 				It's recommended to disable the motion sensors when they're no longer being used, because otherwise it might drain the controller battery faster.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
@@ -707,8 +727,9 @@
 			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Starts the process of calibrating the specified joypad's gyroscope, if it has one.
+				Starts the process of manually calibrating the specified joypad's gyroscope, if it has one.
 				Once a joypad's gyroscope has been calibrated correctly (e.g. laying still on a table without being rotated), [method get_joy_gyroscope] will return values close or equal to [constant Vector3.ZERO] when the joypad is not being rotated.
+				Since the gyroscope is calibrated automatically by default (see [method set_joy_motion_sensors_auto_calibration_enabled]), most games don't need to calibrate manually. If automatic calibration is enabled, it's paused while the manual calibration is in progress, and resumes when [method stop_joy_motion_sensors_calibration] is called.
 				Here's an example of how to use joypad gyroscope and gyroscope calibration in your games:
 				[codeblocks]
 				[gdscript]
@@ -832,7 +853,7 @@
 			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Stops the calibration process of the specified joypad's motion sensors.
+				Stops the manual calibration process of the specified joypad's motion sensors.
 				See [method start_joy_motion_sensors_calibration] for an example on how to use joypad motion sensors and calibration in your games.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, macOS, and iOS.
 			</description>


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/15175

Integrates GamepadMotionHelpers auto-calibration, making it the default. A setter and getter are included in case auto-calibration is not desired. Note that manual calibration simply pauses auto-calibration while both are enabled.

Tested with a DualShock 4 on Windows 11.