### PR TITLE
OpenXR: Check buffer ID with plane tracking

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3624,17 +3624,17 @@
 			[b]Note:[/b] This requires that the OpenXR spatial entities extension is supported by the XR runtime. If not supported this setting will be ignored.
 		</member>
 		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/april_tag_dict" type="int" setter="" getter="" default="&quot;3&quot;">
-			The April Tag marker types the built-in marker tracking is set to recognize (if April Tag marker tracking is available and enabled).
+			The April Tag marker type the built-in marker tracking is set to recognize (if April Tag marker tracking is available and enabled).
 		</member>
 		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/aruco_dict" type="int" setter="" getter="" default="&quot;15&quot;">
-			The ArUco marker types the built-in marker tracking is set to recognize (if ArUco marker tracking is available and enabled).
+			The ArUco marker type the built-in marker tracking is set to recognize (if ArUco marker tracking is available and enabled).
 		</member>
 		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/enable" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], support for the marker tracking extension is requested. If supported, you will be able to query information about markers detected by the XR runtime, e.g., QR codes, ArUco markers, and April tags.
 			[b]Note:[/b] This requires that the OpenXR spatial entities and marker tracking extensions are supported by the XR runtime. If not supported this setting will be ignored. [member xr/openxr/extensions/spatial_entity/enabled] must be enabled for this setting to be used.
 		</member>
 		<member name="xr/openxr/extensions/spatial_entity/marker_tracking/enable_builtin_for_types" type="int" setter="" getter="" default="0">
-			We enable the built-in logic for handling marker tracking for each selected marker type. Godot will query markers and manage [OpenXRMarkerTracker] instances for you. If disabled you'll need to create your own spatial context and perform your own discovery queries.
+			Enables the built-in logic for handling marker tracking for each selected marker type. Godot will query markers and manage [OpenXRMarkerTracker] instances for you. If disabled you'll need to create your own spatial context and perform your own discovery queries.
 			[b]Note:[/b] This functionality requires that marker tracking is supported and enabled.
 		</member>
 		<member name="xr/openxr/extensions/user_presence" type="bool" setter="" getter="" default="false">

--- a/modules/openxr/doc_classes/OpenXRPlaneTracker.xml
+++ b/modules/openxr/doc_classes/OpenXRPlaneTracker.xml
@@ -15,10 +15,16 @@
 				Clears the mesh data for this tracker. You should only call this if you are handling your own discovery logic.
 			</description>
 		</method>
+		<method name="get_indices" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<description>
+				Gets the index data for the mesh.
+			</description>
+		</method>
 		<method name="get_mesh">
 			<return type="Mesh" />
 			<description>
-				Gets a mesh created from either the mesh data or from our bounding size for this plane.
+				Gets a mesh created from either the mesh data or from our bounding size for this plane. This mesh is cached and will return the same resource when called while vertex and index data remains unchanged.
 			</description>
 		</method>
 		<method name="get_mesh_offset" qualifiers="const">
@@ -32,6 +38,12 @@
 			<param index="0" name="thickness" type="float" default="0.01" />
 			<description>
 				Gets a collision shape built either from the mesh data or from our bounding size for this plane.
+			</description>
+		</method>
+		<method name="get_vertices" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Gets the vertex data for the mesh.
 			</description>
 		</method>
 		<method name="set_mesh_data">

--- a/modules/openxr/doc_classes/OpenXRSpatialPlaneTrackingCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialPlaneTrackingCapability.xml
@@ -9,10 +9,22 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_built_in_tracking_state">
+			<return type="int" enum="OpenXRSpatialEntityExtension.TrackingState" />
+			<description>
+				Returns the state of the built-in tracking system.
+			</description>
+		</method>
 		<method name="is_supported">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if plane tracking is supported by the current device.
+			</description>
+		</method>
+		<method name="start_built_in_tracking">
+			<return type="bool" />
+			<description>
+				Starts the built-in plane tracking logic. This will fail if built-in tracking is already enabled.
 			</description>
 		</method>
 		<method name="start_entity_discovery">
@@ -29,6 +41,13 @@
 				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
 				[param user_callback], when non-null, is called with two parameters usually twice. The first parameter is the [RID] of the discovery snapshot and the second parameter is a boolean where [code]false[/code] indicates the discovery snapshot is about to be processed, and [code]true[/code] indicates the discovery snapshot has been processed and [param component_data] has valid data. The second call is skipped if an error was encountered.
 				The returned [OpenXRFutureResult] is identical to the return from [method OpenXRSpatialEntityExtension.discover_spatial_entities].
+			</description>
+		</method>
+		<method name="stop_built_in_tracking">
+			<return type="void" />
+			<param index="0" name="clear_trackers" type="bool" default="true" />
+			<description>
+				Stops the built-in plane tracking logic.
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
@@ -419,6 +419,12 @@ Transform3D OpenXRSpatialComponentMesh2DList::get_transform(int64_t p_index) con
 	return openxr_api->transform_from_pose(mesh2d_data[p_index].origin);
 }
 
+XrSpatialBufferIdEXT OpenXRSpatialComponentMesh2DList::get_vertex_buffer_id(int64_t p_index) const {
+	ERR_FAIL_INDEX_V(p_index, mesh2d_data.size(), XR_NULL_SPATIAL_BUFFER_ID_EXT);
+
+	return mesh2d_data[p_index].vertexBuffer.bufferId;
+}
+
 PackedVector2Array OpenXRSpatialComponentMesh2DList::get_vertices(RID p_snapshot, int64_t p_index) const {
 	ERR_FAIL_INDEX_V(p_index, mesh2d_data.size(), PackedVector2Array());
 
@@ -434,6 +440,12 @@ PackedVector2Array OpenXRSpatialComponentMesh2DList::get_vertices(RID p_snapshot
 	ERR_FAIL_NULL_V(se_extension, PackedVector2Array());
 
 	return se_extension->get_vector2_buffer(p_snapshot, buffer.bufferId);
+}
+
+XrSpatialBufferIdEXT OpenXRSpatialComponentMesh2DList::get_index_buffer_id(int64_t p_index) const {
+	ERR_FAIL_INDEX_V(p_index, mesh2d_data.size(), XR_NULL_SPATIAL_BUFFER_ID_EXT);
+
+	return mesh2d_data[p_index].indexBuffer.bufferId;
 }
 
 PackedInt32Array OpenXRSpatialComponentMesh2DList::get_indices(RID p_snapshot, int64_t p_index) const {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
@@ -187,7 +187,9 @@ public:
 	virtual void *get_structure_data(void *p_next) override;
 
 	Transform3D get_transform(int64_t p_index) const;
+	XrSpatialBufferIdEXT get_vertex_buffer_id(int64_t p_index) const;
 	PackedVector2Array get_vertices(RID p_snapshot, int64_t p_index) const;
+	XrSpatialBufferIdEXT get_index_buffer_id(int64_t p_index) const;
 	PackedInt32Array get_indices(RID p_snapshot, int64_t p_index) const;
 
 private:

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -211,6 +211,12 @@ Transform3D OpenXRSpatialComponentPolygon2DList::get_transform(int64_t p_index) 
 	return openxr_api->transform_from_pose(polygon2d_data[p_index].origin);
 }
 
+XrSpatialBufferIdEXT OpenXRSpatialComponentPolygon2DList::get_vertex_buffer_id(int64_t p_index) const {
+	ERR_FAIL_INDEX_V(p_index, polygon2d_data.size(), XR_NULL_SPATIAL_BUFFER_ID_EXT);
+
+	return polygon2d_data[p_index].vertexBuffer.bufferId;
+}
+
 PackedVector2Array OpenXRSpatialComponentPolygon2DList::get_vertices(RID p_snapshot, int64_t p_index) const {
 	ERR_FAIL_INDEX_V(p_index, polygon2d_data.size(), PackedVector2Array());
 
@@ -287,6 +293,8 @@ void OpenXRPlaneTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_mesh_data"), &OpenXRPlaneTracker::clear_mesh_data);
 
 	ClassDB::bind_method(D_METHOD("get_mesh_offset"), &OpenXRPlaneTracker::get_mesh_offset);
+	ClassDB::bind_method(D_METHOD("get_vertices"), &OpenXRPlaneTracker::get_vertices);
+	ClassDB::bind_method(D_METHOD("get_indices"), &OpenXRPlaneTracker::get_indices);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &OpenXRPlaneTracker::get_mesh);
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_shape", "thickness"), &OpenXRPlaneTracker::get_shape, DEFVAL(0.01));
@@ -335,6 +343,10 @@ String OpenXRPlaneTracker::get_plane_label() const {
 }
 
 void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const PackedVector2Array &p_vertices, const PackedInt32Array &p_indices) {
+	set_mesh_data_with_buffer_ids(p_origin, p_vertices, p_indices, XR_NULL_SPATIAL_BUFFER_ID_EXT, XR_NULL_SPATIAL_BUFFER_ID_EXT);
+}
+
+void OpenXRPlaneTracker::set_mesh_data_with_buffer_ids(const Transform3D &p_origin, const PackedVector2Array &p_vertices, const PackedInt32Array &p_indices, XrSpatialBufferIdEXT p_vertex_buffer_id, XrSpatialBufferIdEXT p_index_buffer_id) {
 	if (p_vertices.size() < 3) {
 		if (mesh.has_mesh_data) {
 			clear_mesh_data();
@@ -348,15 +360,18 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 
 		if (mesh.vertices.size() != p_vertices.size()) {
 			has_changed = true;
+		} else if (p_vertex_buffer_id != XR_NULL_SPATIAL_BUFFER_ID_EXT) {
+			has_changed = true;
 		} else {
 			// Compare the vertices with a bit of margin, we ignore small jittering on vertices.
 			for (uint32_t i = 0; i < p_vertices.size() && !has_changed; i++) {
 				const Vector2 &a = p_vertices[i];
 				const Vector2 &b = mesh.vertices[i];
-				has_changed = (Math::abs(a.x - b.x) > 0.001) || (Math::abs(a.y - b.y) > 0.001);
+				has_changed = !a.is_equal_approx(b);
 			}
 		}
 		if (has_changed) {
+			vertex_buffer_id = p_vertex_buffer_id;
 			mesh.vertices = p_vertices;
 		}
 
@@ -370,6 +385,7 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 			// assume we don't need to rerun this.
 			if (has_changed || mesh.indices.size() != count) {
 				has_changed = true;
+				index_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
 
 				int offset = 1;
 				mesh.indices.resize(count);
@@ -383,12 +399,15 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 		} else {
 			if (mesh.indices.size() != p_indices.size()) {
 				has_changed = true;
+			} else if (p_index_buffer_id != XR_NULL_SPATIAL_BUFFER_ID_EXT) {
+				has_changed = true;
 			} else {
 				for (uint32_t i = 0; i < p_indices.size() && !has_changed; i++) {
 					has_changed = mesh.indices[i] != p_indices[i];
 				}
 			}
 			if (has_changed) {
+				index_buffer_id = p_index_buffer_id;
 				mesh.indices = p_indices;
 			}
 		}
@@ -409,6 +428,9 @@ void OpenXRPlaneTracker::clear_mesh_data() {
 #ifndef PHYSICS_3D_DISABLED
 	mesh.shape3d.unref();
 #endif
+
+	vertex_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
+	index_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
 
 	if (mesh.has_mesh_data) {
 		mesh.has_mesh_data = false;
@@ -599,6 +621,10 @@ OpenXRSpatialPlaneTrackingCapability::~OpenXRSpatialPlaneTrackingCapability() {
 void OpenXRSpatialPlaneTrackingCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_supported"), &OpenXRSpatialPlaneTrackingCapability::is_supported);
 	ClassDB::bind_method(D_METHOD("start_entity_discovery", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query", "user_callback"), &OpenXRSpatialPlaneTrackingCapability::start_entity_discovery, DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(Callable()));
+
+	ClassDB::bind_method(D_METHOD("get_built_in_tracking_state"), &OpenXRSpatialPlaneTrackingCapability::get_built_in_tracking_state);
+	ClassDB::bind_method(D_METHOD("start_built_in_tracking"), &OpenXRSpatialPlaneTrackingCapability::start_built_in_tracking);
+	ClassDB::bind_method(D_METHOD("stop_built_in_tracking", "clear_trackers"), &OpenXRSpatialPlaneTrackingCapability::stop_built_in_tracking, DEFVAL(true));
 }
 
 HashMap<String, bool *> OpenXRSpatialPlaneTrackingCapability::get_requested_extensions(XrVersion p_version) {
@@ -628,8 +654,8 @@ void OpenXRSpatialPlaneTrackingCapability::on_session_created(const XrSession p_
 	se_extension->connect(SNAME("spatial_discovery_recommended"), callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_on_spatial_discovery_recommended));
 
 	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_builtin_plane_detection")) {
-		// Start by creating our spatial context
-		_create_spatial_context();
+		// Start our built in tracking.
+		start_built_in_tracking();
 	}
 }
 
@@ -641,22 +667,9 @@ void OpenXRSpatialPlaneTrackingCapability::on_session_destroyed() {
 
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL(se_extension);
-	XRServer *xr_server = XRServer::get_singleton();
-	ERR_FAIL_NULL(xr_server);
 
-	// Free and unregister our anchors
-	for (const KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>>> &planes : plane_trackers) {
-		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane_tracker : planes.value) {
-			xr_server->remove_tracker(plane_tracker.value);
-		}
-	}
-	plane_trackers.clear();
-
-	// Free our spatial context
-	if (spatial_context.is_valid()) {
-		se_extension->free_spatial_context(spatial_context);
-		spatial_context = RID();
-	}
+	// Stop our built in tracking (if applicable), this will also clean up any planes previously detected.
+	stop_built_in_tracking();
 
 	se_extension->disconnect(SNAME("spatial_discovery_recommended"), callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_on_spatial_discovery_recommended));
 }
@@ -741,6 +754,65 @@ bool OpenXRSpatialPlaneTrackingCapability::is_supported() {
 	return spatial_plane_tracking_supported;
 }
 
+bool OpenXRSpatialPlaneTrackingCapability::start_built_in_tracking() {
+	ERR_FAIL_COND_V(builtin_tracking_state > 0, false);
+
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETTING_UP;
+
+	// Start by creating our spatial context
+	built_in_future = _create_spatial_context();
+	if (built_in_future.is_null()) {
+		builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETUP_FAILED;
+		return false;
+	}
+
+	return true;
+}
+
+void OpenXRSpatialPlaneTrackingCapability::stop_built_in_tracking(bool p_clear_trackers) {
+	// Reset our tracking state
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NOT_ACTIVE;
+
+	// Cancel any discovery query
+	if (discovery_query_result.is_valid()) {
+		if (discovery_query_result->get_status() == OpenXRFutureResult::RESULT_RUNNING) {
+			discovery_query_result->cancel_future();
+		}
+
+		discovery_query_result.unref();
+	}
+
+	// If we have our future object, clean it up.
+	if (built_in_future.is_valid()) {
+		if (built_in_future->get_status() == OpenXRFutureResult::RESULT_RUNNING) {
+			built_in_future->cancel_future();
+		}
+
+		built_in_future.unref();
+	}
+
+	// Free our spatial context
+	if (spatial_context.is_valid()) {
+		OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+		ERR_FAIL_NULL(se_extension);
+
+		if (p_clear_trackers && plane_trackers.has(spatial_context)) {
+			XRServer *xr_server = XRServer::get_singleton();
+			ERR_FAIL_NULL(xr_server);
+
+			// Free and unregister our anchors
+			HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &planes = plane_trackers[spatial_context];
+			for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane_tracker : planes) {
+				xr_server->remove_tracker(plane_tracker.value);
+			}
+			plane_trackers.erase(spatial_context);
+		}
+
+		se_extension->free_spatial_context(spatial_context);
+		spatial_context = RID();
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Discovery logic
 Ref<OpenXRFutureResult> OpenXRSpatialPlaneTrackingCapability::_create_spatial_context() {
@@ -753,12 +825,36 @@ Ref<OpenXRFutureResult> OpenXRSpatialPlaneTrackingCapability::_create_spatial_co
 	plane_configuration.instantiate();
 	capability_configurations.push_back(plane_configuration);
 
-	return se_extension->create_spatial_context(capability_configurations, nullptr, callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_on_spatial_context_created));
+	return se_extension->create_spatial_context(capability_configurations, nullptr, callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_on_spatial_context_created), callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_on_spatial_context_creation_failed));
 }
 
 void OpenXRSpatialPlaneTrackingCapability::_on_spatial_context_created(RID p_spatial_context) {
+	builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_ENABLED;
 	spatial_context = p_spatial_context;
 	need_discovery = true;
+
+	// We don't need our future anymore.
+	built_in_future.unref();
+}
+
+void OpenXRSpatialPlaneTrackingCapability::_on_spatial_context_creation_failed(int p_xr_result, bool p_is_completion_failure) {
+	XrResult result = XrResult(p_xr_result);
+
+	switch (result) {
+		case XR_ERROR_PERMISSION_INSUFFICIENT:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NO_PERMISSION;
+			break;
+		case XR_ERROR_SPATIAL_CAPABILITY_UNSUPPORTED_EXT:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_UNSUPPORTED_CAPABILITY;
+			break;
+		// We may wish to support additional error codes that are likely here.
+		default:
+			builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_SETUP_FAILED;
+			break;
+	}
+
+	// We don't need our future anymore.
+	built_in_future.unref();
 }
 
 void OpenXRSpatialPlaneTrackingCapability::_on_spatial_discovery_recommended(RID p_spatial_context) {
@@ -878,9 +974,16 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot, RID
 					}
 
 					if (mesh2d_list.is_valid()) {
-						plane_tracker->set_mesh_data(mesh2d_list->get_transform(i), mesh2d_list->get_vertices(p_snapshot, i), mesh2d_list->get_indices(p_snapshot, i));
+						XrSpatialBufferIdEXT vertex_buffer_id = mesh2d_list->get_vertex_buffer_id(i);
+						XrSpatialBufferIdEXT index_buffer_id = mesh2d_list->get_index_buffer_id(i);
+						if (plane_tracker->get_vertex_buffer_id() != vertex_buffer_id || plane_tracker->get_index_buffer_id() != index_buffer_id) {
+							plane_tracker->set_mesh_data_with_buffer_ids(mesh2d_list->get_transform(i), mesh2d_list->get_vertices(p_snapshot, i), mesh2d_list->get_indices(p_snapshot, i), vertex_buffer_id, index_buffer_id);
+						}
 					} else if (poly2d_list.is_valid()) {
-						plane_tracker->set_mesh_data(poly2d_list->get_transform(i), poly2d_list->get_vertices(p_snapshot, i));
+						XrSpatialBufferIdEXT vertex_buffer_id = poly2d_list->get_vertex_buffer_id(i);
+						if (plane_tracker->get_vertex_buffer_id() != vertex_buffer_id || plane_tracker->get_index_buffer_id() != XR_NULL_SPATIAL_BUFFER_ID_EXT) {
+							plane_tracker->set_mesh_data_with_buffer_ids(poly2d_list->get_transform(i), poly2d_list->get_vertices(p_snapshot, i), PackedInt32Array(), vertex_buffer_id, XR_NULL_SPATIAL_BUFFER_ID_EXT);
+						}
 					} else {
 						// Just in case we set this before.
 						plane_tracker->clear_mesh_data();

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
@@ -33,6 +33,7 @@
 #include "../openxr_extension_wrapper.h"
 #include "../openxr_future_extension.h"
 #include "openxr_spatial_entities.h"
+#include "openxr_spatial_entity_extension.h"
 
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/resources/3d/shape_3d.h"
@@ -109,6 +110,7 @@ public:
 	virtual void *get_structure_data(void *p_next) override;
 
 	Transform3D get_transform(int64_t p_index) const;
+	XrSpatialBufferIdEXT get_vertex_buffer_id(int64_t p_index) const;
 	PackedVector2Array get_vertices(RID p_snapshot, int64_t p_index) const;
 
 private:
@@ -164,13 +166,19 @@ public:
 	String get_plane_label() const;
 
 	void set_mesh_data(const Transform3D &p_origin, const PackedVector2Array &p_vertices, const PackedInt32Array &p_indices = PackedInt32Array());
+	void set_mesh_data_with_buffer_ids(const Transform3D &p_origin, const PackedVector2Array &p_vertices, const PackedInt32Array &p_indices = PackedInt32Array(), XrSpatialBufferIdEXT p_vertex_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT, XrSpatialBufferIdEXT p_index_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT);
 	void clear_mesh_data();
 
 	Transform3D get_mesh_offset() const;
+	PackedVector2Array get_vertices() const { return mesh.vertices; }
+	PackedInt32Array get_indices() const { return mesh.indices; }
 	Ref<Mesh> get_mesh();
 #ifndef PHYSICS_3D_DISABLED
 	Ref<Shape3D> get_shape(real_t p_thickness = 0.01);
 #endif
+
+	XrSpatialBufferIdEXT get_vertex_buffer_id() const { return vertex_buffer_id; }
+	XrSpatialBufferIdEXT get_index_buffer_id() const { return index_buffer_id; }
 
 protected:
 	static void _bind_methods();
@@ -212,6 +220,10 @@ private:
 			}
 		}
 	};
+
+	// Cache buffer ids so we can check for new data
+	XrSpatialBufferIdEXT vertex_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
+	XrSpatialBufferIdEXT index_buffer_id = XR_NULL_SPATIAL_BUFFER_ID_EXT;
 };
 
 // Plane tracking logic
@@ -238,12 +250,19 @@ public:
 
 	bool is_supported();
 
+	OpenXRSpatialEntityExtension::TrackingState get_built_in_tracking_state() { return builtin_tracking_state; }
+	bool start_built_in_tracking();
+	void stop_built_in_tracking(bool p_clear_trackers = true);
+
 private:
 	static OpenXRSpatialPlaneTrackingCapability *singleton;
 	bool spatial_plane_tracking_ext = false;
 	bool spatial_plane_tracking_supported = false;
 
+	OpenXRSpatialEntityExtension::TrackingState builtin_tracking_state = OpenXRSpatialEntityExtension::TrackingState::TRACKING_NOT_ACTIVE;
+	Ref<OpenXRFutureResult> built_in_future;
 	RID spatial_context;
+
 	bool need_discovery = false;
 	int discovery_cooldown = 0;
 	Ref<OpenXRFutureResult> discovery_query_result;
@@ -254,6 +273,7 @@ private:
 	// Discovery logic
 	Ref<OpenXRFutureResult> _create_spatial_context();
 	void _on_spatial_context_created(RID p_spatial_context);
+	void _on_spatial_context_creation_failed(int p_xr_result, bool p_is_completion_failure);
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR is a continuation on the plane tracking logic introduced not long ago. It properly checks whether the supplied buffer id's change. If they remain the same from discovery to discovery this means the mesh data remains unchanged and allows us to skip retrieving the mesh data and comparing it to the previous data.

This should result in a decent performance upgrade.

It also adds start/stop functions for the built-in plane tracking feature. This allows us to react properly when permissions have not been provided from the start. Making full use of this will require additional logic in the vendor plugin as each XR platform has different permission requirements.

## Additional information

This logic can be tested with the following demo project:

https://github.com/godotengine/godot-demo-projects/pull/1338

This PR is dependent on #121123
