### PR TITLE
Draw NavigationObstacle3D using a gizmo plugin instead of the navigation server debug draw

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -622,6 +622,9 @@ void EditorNode::_update_from_settings() {
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_avoidance_obstacles_radius_color(GLOBAL_GET("debug/shapes/avoidance/3d/obstacles_radius_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(GLOBAL_GET("debug/shapes/avoidance/3d/obstacles_static_edge_pushin_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(GLOBAL_GET("debug/shapes/avoidance/3d/obstacles_static_edge_pushout_color"));
 #endif // DEBUG_ENABLED
 }
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/main/scene_tree.h"
+#include "scene/resources/3d/primitive_meshes.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -64,6 +65,25 @@ void NavigationObstacle3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	if (!obstacle) {
 		return;
+	}
+
+	float radius = obstacle->get_radius();
+	if (radius >= CMP_EPSILON) {
+		Array sphere_array;
+		sphere_array.resize(RSE::ARRAY_MAX);
+		SphereMesh::create_mesh_array(sphere_array, radius, radius * 2, 32);
+
+		Ref<ArrayMesh> sphere_mesh = memnew(ArrayMesh);
+		sphere_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, sphere_array);
+
+		Ref<StandardMaterial3D> radius_material = get_material("radius_material", p_gizmo);
+		Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_color();
+		if (!p_gizmo->is_selected()) {
+			mat_color.a *= 0.3;
+		}
+		radius_material->set_albedo(mat_color);
+		p_gizmo->add_mesh(sphere_mesh, radius_material);
+		p_gizmo->add_collision_triangles(sphere_mesh->generate_triangle_mesh());
 	}
 
 	const Vector<Vector3> &vertices = obstacle->get_vertices();
@@ -107,11 +127,22 @@ void NavigationObstacle3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
-
 	if (obstacle->are_vertices_valid()) {
-		p_gizmo->add_lines(lines_mesh_vertices, ns3d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_material());
+		Ref<StandardMaterial3D> cage_material = get_material("cage_material_out", p_gizmo);
+		Color mat_color = ns3d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color();
+		if (!p_gizmo->is_selected()) {
+			mat_color.a *= 0.3;
+		}
+		cage_material->set_albedo(mat_color);
+		p_gizmo->add_lines(lines_mesh_vertices, cage_material);
 	} else {
-		p_gizmo->add_lines(lines_mesh_vertices, ns3d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_material());
+		Ref<StandardMaterial3D> cage_material = get_material("cage_material_in", p_gizmo);
+		Color mat_color = ns3d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color();
+		if (!p_gizmo->is_selected()) {
+			mat_color.a *= 0.3;
+		}
+		cage_material->set_albedo(mat_color);
+		p_gizmo->add_lines(lines_mesh_vertices, cage_material);
 	}
 	p_gizmo->add_collision_segments(lines_mesh_vertices);
 
@@ -240,6 +271,12 @@ void NavigationObstacle3DGizmoPlugin::commit_subgizmos(const EditorNode3DGizmo *
 
 NavigationObstacle3DGizmoPlugin::NavigationObstacle3DGizmoPlugin() {
 	current_state = VISIBLE;
+
+	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
+
+	create_material("cage_material_in", ns3d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color());
+	create_material("cage_material_out", ns3d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color());
+	create_material("radius_material", ns3d->get_debug_navigation_avoidance_obstacles_radius_color(), false, false, true);
 }
 
 void NavigationObstacle3DEditorPlugin::_notification(int p_what) {

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -555,7 +555,7 @@ void NavigationObstacle3D::_update_fake_agent_radius_debug() {
 
 	bool is_debug_enabled = false;
 	if (Engine::get_singleton()->is_editor_hint()) {
-		is_debug_enabled = true;
+		is_debug_enabled = false;
 	} else if (ns3d->get_debug_enabled() &&
 			ns3d->get_debug_avoidance_enabled() &&
 			ns3d->get_debug_navigation_avoidance_enable_obstacles_radius()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes: https://github.com/godotengine/godot/issues/120309
- Fixes (partially): https://github.com/godotengine/godot/issues/121445

## Additional information

`NavigationObstacle3D` vertices now respect gizmo visibility settings and no longer render on top of geometry unless X-Ray mode is enabled
| Normal | X-Ray |
|--------|--------|
|<img width="400" height="400" alt="nav-obstacle-vertices-normal" src="https://github.com/user-attachments/assets/04f4b83b-174c-4f22-b0cc-055215fff6c2" />|<img width="400" height="400" alt="nav-obstacle-vertices-xray" src="https://github.com/user-attachments/assets/801acc3a-0a88-42be-88d4-fb8f163c68fe" />|

`NavigationObstacle3D` avoidance radius now respects the **View Gizmos** option and the gizmo visibility toggle
| Normal | X-Ray |
|--------|--------|
|<img width="400" height="400" alt="nav-obstacle-radius-normal" src="https://github.com/user-attachments/assets/adbe23f4-19f6-4cbd-bd68-3a968a77883e" />|<img width="400" height="400" alt="nav-obstacle-radius-xray" src="https://github.com/user-attachments/assets/61bd2d23-d793-4459-8057-3918caf15cd4" />|

