### PR TITLE
Clear `EditorHelp` docs upon exiting the Project Manager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -2009,6 +2009,8 @@ ProjectManager::~ProjectManager() {
 	singleton = nullptr;
 	EditorInspector::cleanup_plugins();
 
+	EditorHelp::cleanup_doc();
+
 #if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 	EditorHelpHighlighter::free_singleton();
 #endif


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Regression from https://github.com/godotengine/godot/pull/121278
- This warning when closing the Project Manager:
```
WARNING: A Thread object is being destroyed without its completion having been realized.
Please call wait_to_finish() on it to ensure correct cleanup.
   at: Thread::~Thread (core\os\thread.cpp:118)
``` 

## Additional information

When the Quick Settings are opened, docs are generated, but proper cleanup never happens, but it should, as in the main editor.

The function is safe to call even if the docs weren't generated.
