### PR TITLE
Editor: Focus 3D viewport when changing layout

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -7185,6 +7185,26 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 			first_split->set_touch_dragger_enabled(touch_optimizations);
 			second_split->set_touch_dragger_enabled(touch_optimizations);
 		} break;
+		case NOTIFICATION_PROCESS: {
+			set_process(false);
+
+			Node3DEditorViewport *viewports[4];
+			for (int i = 0; i < 4; i++) {
+				viewports[i] = Node3DEditor::get_singleton()->get_editor_viewport(i);
+				ERR_FAIL_NULL(viewports[i]);
+			}
+
+			if (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field()) {
+				Vector2 mouse_pos = get_global_mouse_position();
+				for (int i = 0; i < 4; i++) {
+					if (viewports[i]->is_visible() && viewports[i]->get_global_rect().has_point(mouse_pos)) {
+						viewports[i]->get_surface()->grab_focus();
+						return;
+					}
+				}
+				viewports[0]->get_surface()->grab_focus();
+			}
+		} break;
 	}
 }
 
@@ -7254,6 +7274,8 @@ void Node3DEditorViewportContainer::set_view(View p_view) {
 			_update_split_drag_margin();
 		} break;
 	}
+
+	set_process(true);
 }
 
 Node3DEditorViewportContainer::View Node3DEditorViewportContainer::get_view() {

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -7186,6 +7186,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 			second_split->set_touch_dragger_enabled(touch_optimizations);
 		} break;
 		case NOTIFICATION_PROCESS: {
+			// Only call the code below for a single frame after processing has been enabled.
 			set_process(false);
 
 			Node3DEditorViewport *viewports[4];
@@ -7275,6 +7276,9 @@ void Node3DEditorViewportContainer::set_view(View p_view) {
 		} break;
 	}
 
+	// Force the code in `_notification()` to be called for a single frame on the next frame.
+	// We use this instead of `call_deferred()`, because `call_deferred()`
+	// only works for viewports that didn't change their visibility in the `set_view()` call.
 	set_process(true);
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121486

## Summary of changes
When `set_view` is called (by keyboard shortcut or menu option), the code waits for `NOTIFICATION_PROCESS` and focuses the viewport the mouse is hovering on.

## Additional information
I used `NOTIFICATION_PROCESS`, because `call_deferred` only worked for viewports that didn't change their visibility in the `set_view` call. Not sure why.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
