### PR TITLE
[3.x] Minor BVH correctness fixes

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -177,17 +177,20 @@ public:
 	}
 
 	uint32_t get_tree_id(uint32_t p_handle) const {
+		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
 		return item_get_tree_id(h);
 	}
 	int get_subindex(uint32_t p_handle) const {
+		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
 		return item_get_subindex(h);
 	}
 
 	T *get(uint32_t p_handle) const {
+		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
 		return item_get_userdata(h);
@@ -478,6 +481,7 @@ private:
 
 public:
 	void item_get_AABB(BVHHandle p_handle, BOUNDS &r_aabb) {
+		BVH_LOCKED_FUNCTION
 		BVHABB_CLASS abb;
 		tree.item_get_ABB(p_handle, abb);
 		abb.to(r_aabb);
@@ -575,12 +579,16 @@ private:
 		BVHABB_CLASS abb_from = expanded_abb_from;
 
 		// remove from pairing list for every partner
-		for (unsigned int n = 0; n < p_from.extended_pairs.size(); n++) {
+		for (uint32_t n = 0; n < p_from.extended_pairs.size(); n++) {
 			BVHHandle h_to = p_from.extended_pairs[n].handle;
 			if (_find_leavers_process_pair(p_from, abb_from, p_handle, h_to, p_full_check)) {
 				// we need to keep the counter n up to date if we deleted a pair
 				// as the number of items in p_from.extended_pairs will have decreased by 1
 				// and we don't want to miss an item
+
+				// Note this can overflow to UINT32_MAX if we process the 0th element,
+				// but it's fine as it will increment back to zero next loop,
+				// it is not UB with uint32_t.
 				n--;
 			}
 		}
@@ -795,7 +803,7 @@ private:
 		Mutex *_mutex;
 	};
 
-	Mutex _mutex;
+	mutable Mutex _mutex;
 
 	// local toggle for turning on and off thread safety in project settings
 	bool _thread_safe;

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -31,6 +31,8 @@
 #ifndef BVH_ABB_H
 #define BVH_ABB_H
 
+#include <float.h>
+
 // special optimized version of axis aligned bounding box
 template <class BOUNDS = AABB, class POINT = Vector3>
 struct BVH_ABB {
@@ -256,7 +258,7 @@ struct BVH_ABB {
 	}
 
 	// Actually surface area metric.
-	float get_area() const {
+	real_t get_area() const {
 		POINT d = calculate_size();
 		return 2 * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -235,7 +235,8 @@ private:
 
 		// no need to keep back references for children at the moment
 
-		uint32_t sibling_id; // always a node id, as tnode is never a leaf
+		// Always a node id, as tnode is never a leaf.
+		uint32_t sibling_id = BVHCommon::INVALID;
 		bool sibling_present = false;
 
 		// if there are more children, or this is the root node, don't try and delete


### PR DESCRIPTION
Very minor fixes to BVH.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

* Adds lockguards to remaining bvh functions. As I mentioned in #73628 , the multithread mode was originally intended for testing (and defaults to off in 3.x), and some functions were known not to be covered, so I thought I'd finally get around to protecting these functions. 
* set `sibling_id` instead of uninitialized. This never got read unless `sibling_present` was set, in which case `sibling_id` was also, but this could prevent a compiler warning.
* added `<float.h>` include for `FLT_MAX`. Used in preference to `<cfloat>` as the former is used more in 3.x.
* added comment to explain that unsigned overflow was expected and not an active bug
* return area as `real_t`. Not super important in 3.x as we don't build `real_t` as 64 bit, but worth doing.

## Additional information
Will also port these in 4.x, the `real_t` change in particular is worth doing there.
I'll check whether the lock guards are covering everything in 4.x, as it's more relevant there, as multithread is set by default if I remember right.

Turns out most of these are already fixed in 4.x, barring the lock guards so I'll do a PR for that.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
