### PR TITLE
[LibGodot]: Extend LibGodot Core to the web platform

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -26,9 +26,13 @@ web_files = [
     "display_server_web.cpp",
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",
-    "web_main.cpp",
     "os_web.cpp",
 ]
+
+if env["library_type"] == "executable":
+    web_files += ["web_main.cpp"]
+else:
+    web_files += ["web_libgodot.cpp"]
 
 if env["target"] == "editor":
     env.add_source_files(web_files, "editor/*.cpp")
@@ -74,9 +78,25 @@ if len(env["EXPORTED_FUNCTIONS"]):
 if len(env["EXPORTED_RUNTIME_METHODS"]):
     sys_env.Append(LINKFLAGS=["-sEXPORTED_RUNTIME_METHODS=" + repr(sorted(list(set(env["EXPORTED_RUNTIME_METHODS"]))))])
 
-build = []
+main_js = None
+main_wasm = None
+side_wasm = None
 build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
-if env["dlink_enabled"]:
+side_target = "#bin/godot.side${PROGSUFFIX}.wasm"
+
+if env["library_type"] == "static_library":
+    # Create dummy js file.
+    main_js = env.NoCache(env.Textfile(build_targets[0], ""))[0]
+    # Godot static library, currently only includes web_files.
+    web_lib = sys_env.add_library("#bin/godot", web_files)
+elif env["library_type"] == "shared_library":
+    # Create dummy js file.
+    main_js = env.NoCache(env.Textfile(build_targets[0], ""))[0]
+    # Export LibGodot related functions from the side library.
+    env.Append(LINKFLAGS=["-sEXPORTED_FUNCTIONS=_libgodot_create_godot_instance,_libgodot_destroy_godot_instance"])
+    # The side library, containing all Godot code.
+    side_wasm = env.add_program(side_target, web_files)
+elif env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
@@ -92,20 +112,19 @@ if env["dlink_enabled"]:
     sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
 
     # The main emscripten runtime, with exported standard libraries.
-    sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
+    main_js, main_wasm = sys_env.add_program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
-    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
-    build = sys + [wasm[0]]
+    side_wasm = env.add_program(side_target, web_files)
 else:
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
-    build = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
+    main_js, main_wasm = sys_env.add_program(build_targets, web_files + ["web_runtime.cpp"])
 
-sys_env.Depends(build[0], sys_env["JS_LIBS"])
-sys_env.Depends(build[0], sys_env["JS_PRE"])
-sys_env.Depends(build[0], sys_env["JS_POST"])
-sys_env.Depends(build[0], sys_env["JS_EXTERNS"])
+sys_env.Depends(main_js, sys_env["JS_LIBS"])
+sys_env.Depends(main_js, sys_env["JS_PRE"])
+sys_env.Depends(main_js, sys_env["JS_POST"])
+sys_env.Depends(main_js, sys_env["JS_EXTERNS"])
 
 engine = [
     "js/engine/features.js",
@@ -118,7 +137,7 @@ js_engine = env.CreateEngineFile("#bin/godot${PROGSUFFIX}.engine.js", engine, ex
 env.Depends(js_engine, externs)
 
 wrap_list = [
-    build[0],
+    main_js,
     js_engine,
 ]
 js_wrapped = env.NoCache(
@@ -126,6 +145,6 @@ js_wrapped = env.NoCache(
 )
 
 # 0 - unwrapped js file (use wrapped one instead)
-# 1 - wasm file
-# 2 - wasm side (when dlink is enabled).
-env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)
+# 1 - wasm file (when libgodot is disabled).
+# 2 - wasm side (when dlink is enabled or shared libgodot is used).
+env.CreateTemplateZip(js_wrapped, main_wasm, side_wasm)

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -79,6 +79,7 @@ def get_flags():
     return {
         "arch": "wasm32",
         "target": "template_debug",
+        "supported": ["library"],
         "builtin_pcre2_with_jit": False,
         "vulkan": False,
         # Embree is heavy and requires too much memory (GH-70621).
@@ -293,11 +294,13 @@ def configure(env: "SConsEnvironment"):
             env["proxy_to_pthread"] = False
 
         env.Append(CPPDEFINES=["WEB_DLINK_ENABLED"])
+        env.extra_suffix = ".dlink" + env.extra_suffix
+
+    if env["dlink_enabled"] or env["library_type"] == "shared_library":
         env.Append(CCFLAGS=["-sSIDE_MODULE=2"])
         env.Append(LINKFLAGS=["-sSIDE_MODULE=2"])
         env.Append(CCFLAGS=["-fvisibility=hidden"])
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
-        env.extra_suffix = ".dlink" + env.extra_suffix
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])
     env.Append(CCFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -79,6 +79,7 @@ def get_flags():
     return {
         "arch": "wasm32",
         "target": "template_debug",
+        "supported": ["library"],
         "builtin_pcre2_with_jit": False,
         "rendering_device": False,
         # Embree is heavy and requires too much memory (GH-70621).
@@ -280,11 +281,13 @@ def configure(env: "SConsEnvironment"):
             env["proxy_to_pthread"] = False
 
         env.Append(CPPDEFINES=["WEB_DLINK_ENABLED"])
+        env.extra_suffix = ".dlink" + env.extra_suffix
+
+    if env["dlink_enabled"] or env["library_type"] == "shared_library":
         env.Append(CCFLAGS=["-sSIDE_MODULE=2"])
         env.Append(LINKFLAGS=["-sSIDE_MODULE=2"])
         env.Append(CCFLAGS=["-fvisibility=hidden"])
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
-        env.extra_suffix = ".dlink" + env.extra_suffix
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])
 

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -35,18 +35,20 @@ def create_template_zip(env, js, wasm, side):
     zip_dir = env.Dir(env.GetTemplateZipPath())
     in_files = [
         js,
-        wasm,
         "#platform/web/js/libs/audio.worklet.js",
         "#platform/web/js/libs/audio.position.worklet.js",
     ]
     out_files = [
         zip_dir.File(binary_name + ".js"),
-        zip_dir.File(binary_name + ".wasm"),
         zip_dir.File(binary_name + ".audio.worklet.js"),
         zip_dir.File(binary_name + ".audio.position.worklet.js"),
     ]
-    # Dynamic linking (extensions) specific.
-    if env["dlink_enabled"]:
+
+    if wasm is not None:
+        in_files.append(wasm)  # Wasm (contains the actual Godot code or pure runtime).
+        out_files.append(zip_dir.File(binary_name + ".wasm"))
+    # Dynamic linking specific.
+    if side is not None:
         in_files.append(side)  # Side wasm (contains the actual Godot code).
         out_files.append(zip_dir.File(binary_name + ".side.wasm"))
 

--- a/platform/web/web_libgodot.cpp
+++ b/platform/web/web_libgodot.cpp
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  web_libgodot.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "godot_js.h"
+#include "os_web.h"
+
+#include "core/extension/godot_instance.h"
+#include "core/extension/libgodot.h"
+#include "core/io/resource_loader.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
+#include "core/variant/variant.h"
+#include "main/main.h"
+
+#include <cstdlib>
+
+[[maybe_unused]] static OS_Web *os = nullptr;
+
+static GodotInstance *instance = nullptr;
+
+void print_web_header() {
+	// Emscripten.
+	char *emscripten_version_char = godot_js_emscripten_get_version();
+	String emscripten_version = vformat("Emscripten %s", emscripten_version_char);
+	// `free()` is used here because it's not memory that was allocated by Godot.
+	free(emscripten_version_char);
+
+	// Build features.
+	String thread_support = OS::get_singleton()->has_feature("threads")
+			? "multi-threaded"
+			: "single-threaded";
+	String extensions_support = OS::get_singleton()->has_feature("web_extensions")
+			? "GDExtension support"
+			: "no GDExtension support";
+
+	Vector<String> build_configuration = { emscripten_version, thread_support, extensions_support };
+	print_line(vformat("Build configuration: %s.", String(", ").join(build_configuration)));
+}
+
+GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+
+	os = new OS_Web();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	instance = memnew(GodotInstance);
+	if (!instance->initialize(p_init_func)) {
+		memdelete(instance);
+		// Note: When Godot Engine supports reinitialization, clear the instance pointer here.
+		//instance = nullptr;
+		return nullptr;
+	}
+
+	print_web_header();
+
+	// Ease up compatibility.
+	ResourceLoader::set_abort_on_missing_resources(false);
+
+	return (GDExtensionObjectPtr)instance;
+}
+
+void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		godot_instance->stop();
+		memdelete(godot_instance);
+		instance = nullptr;
+		Main::cleanup();
+	}
+}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Extends https://github.com/godotengine/godot/pull/110863 to include the web platform.
Related to https://github.com/godotengine/godot-proposals/issues/6267 .

## Additional information

Demo: https://github.com/NoctemCat/GodotPRDemos/tree/libgodot_web_core

LibGodot Core part is split from https://github.com/godotengine/godot/pull/118976 . The split part only implements it as far as already merged LibGodot Core, so it doesn't do too much additional work. Because of that it is affected by several problems, which include already existing ones:
- You need to manually copy all used `CCFLAGS`, `LINKFLAGS`, etc. yourself (example https://github.com/NoctemCat/LibGodotCoreWebExample/blob/master/SConstruct), which is really verbose for the web platform.
- Doesn't combine static libraries https://redirect.github.com/godotengine/godot/issues/111876 so for now only shared LibGodot is working. They can be combined, but every other platform is still affected, so it is left as it is.
- Web iteration is unique and this PR doesn't replicate it properly, so it is similar to https://redirect.github.com/godotengine/godot/issues/112044 , related discussion https://redirect.github.com/godotengine/godot-proposals/discussions/14838 .

I also checked the original Migeran PR to see if it already implemented the web platform, it didn't.

### Workflows overview

Simple editor workflow:
- Build editor as a shared library.
- Build LibGodot `godot-cpp` code using the `Program` scons builder and link the editor library to it.
- Launch the editor and create the project as usual.

Simple web export workflow:
- Build web godot export template as a shared library, for now the template zip is incomplete (missing `godot.wasm` and emscripten js glue code in `godot.js`).
- Build LibGodot `godot-cpp` code using the `Program` scons builder and with `-sSIDE_MODULE=1` removed.
- Add the resulted wasm file to the template zip as `godot.wasm`, extract `godot.js` and prepend the resulted js file to it, then add it back to the zip.
- Use the finished template zip as a custom template when exporting.

No AI used.
