### PR TITLE
Use OS taskbar progress when `ProgressDialog` is shown

### DIFF
--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -132,6 +132,17 @@ ProgressDialog *ProgressDialog::singleton = nullptr;
 
 void ProgressDialog::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			Window *base_window = get_window();
+			if (base_window) {
+				base_window->set_taskbar_progress_value(0.0);
+				if (is_visible()) {
+					base_window->set_taskbar_progress_state(DisplayServerEnums::PROGRESS_STATE_NORMAL);
+				} else {
+					base_window->set_taskbar_progress_state(DisplayServerEnums::PROGRESS_STATE_NOPROGRESS);
+				}
+			}
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			Ref<StyleBox> style = main->get_theme_stylebox(SceneStringName(panel), SNAME("PopupMenu"));
 			main_border_size = style->get_minimum_size();
@@ -241,6 +252,11 @@ bool ProgressDialog::task_step(const String &p_task, const String &p_state, int 
 		t.progress->set_value(t.progress->get_value() + 1);
 	} else {
 		t.progress->set_value(p_step);
+	}
+
+	Window *base_window = get_window();
+	if (base_window) {
+		base_window->set_taskbar_progress_value(t.progress->get_as_ratio());
 	}
 
 	t.state->set_text(p_state);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15166

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR makes the Godot editor use the OS taskbar progress API when `ProgressDialog` is shown.

Demo: (Shown when the Godot editor launches a project)

https://github.com/user-attachments/assets/52fb3170-1c9e-422b-8fb4-ec046981c013