### PR TITLE
Fix FOV override not applied in next pass material when stencil mode is enabled

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2482,6 +2482,13 @@ void BaseMaterial3D::set_flag(Flags p_flag, bool p_enabled) {
 		update_configuration_warning();
 	}
 
+	if (stencil_mode == STENCIL_MODE_OUTLINE || stencil_mode == STENCIL_MODE_XRAY) {
+		Ref<BaseMaterial3D> stencil_next_pass = _get_stencil_next_pass();
+		if (stencil_next_pass.is_valid()) {
+			stencil_next_pass->set_flag(p_flag, p_enabled);
+		}
+	}
+
 	_queue_shader_change();
 }
 
@@ -2983,6 +2990,13 @@ float BaseMaterial3D::get_z_clip_scale() const {
 void BaseMaterial3D::set_fov_override(float p_fov_override) {
 	fov_override = p_fov_override;
 	_material_set_param(shader_names->fov_override, p_fov_override);
+
+	if (stencil_mode == STENCIL_MODE_OUTLINE || stencil_mode == STENCIL_MODE_XRAY) {
+		Ref<BaseMaterial3D> stencil_next_pass = _get_stencil_next_pass();
+		if (stencil_next_pass.is_valid()) {
+			stencil_next_pass->set_fov_override(p_fov_override);
+		}
+	}
 }
 
 float BaseMaterial3D::get_fov_override() const {
@@ -3161,6 +3175,8 @@ void BaseMaterial3D::_prepare_stencil_effect() {
 			stencil_next_pass->set_grow_enabled(true);
 			stencil_next_pass->set_grow(stencil_effect_outline_thickness);
 			stencil_next_pass->set_albedo(stencil_effect_color);
+			stencil_next_pass->set_flag(FLAG_USE_FOV_OVERRIDE, flags[FLAG_USE_FOV_OVERRIDE]);
+			stencil_next_pass->set_fov_override(fov_override);
 			stencil_next_pass->set_stencil_mode(STENCIL_MODE_CUSTOM);
 			stencil_next_pass->set_stencil_flags(STENCIL_FLAG_READ);
 			stencil_next_pass->set_stencil_compare(STENCIL_COMPARE_NOT_EQUAL);
@@ -3176,6 +3192,8 @@ void BaseMaterial3D::_prepare_stencil_effect() {
 			stencil_next_pass->set_grow_enabled(false);
 			stencil_next_pass->set_grow(0);
 			stencil_next_pass->set_albedo(stencil_effect_color);
+			stencil_next_pass->set_flag(FLAG_USE_FOV_OVERRIDE, flags[FLAG_USE_FOV_OVERRIDE]);
+			stencil_next_pass->set_fov_override(fov_override);
 			stencil_next_pass->set_stencil_mode(STENCIL_MODE_CUSTOM);
 			stencil_next_pass->set_stencil_flags(STENCIL_FLAG_READ);
 			stencil_next_pass->set_stencil_compare(STENCIL_COMPARE_NOT_EQUAL);


### PR DESCRIPTION
Fixes #111482

As clay already pointed out in the comments of the issue, the FOV setting was not carried over to the next pass material when using stencil mode outline or xray. I added this carry over.
Furthermore, I added that the next pass material updates when the FOV override value is changed and when the FOV flag (or any flag) is set.

Regarding the flag change, I am not sure whether it is wanted behaviour that the next pass material adapts to every flag that is changed in the first pass material. Doing so helps when changing specific flags, like for example "fixed size". However, most of those flags also are not carried over when the stencil mode is set and I am unsure how to deal with it. I could add them as well or restrict the flag change only to the FOV override flag using another if statement.