### PR TITLE
Fix Decal gizmo arrow being too tall at certain sizes in the 3D editor

### DIFF
--- a/editor/scene/3d/gizmos/decal_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/decal_gizmo_plugin.cpp
@@ -121,7 +121,7 @@ void DecalGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		// Draw a directional arrow at the decal's origin.
 		constexpr int arrow_points = 7;
-		const float arrow_length = size.y * 0.5;
+		constexpr float arrow_length = 0.5;
 
 		const Vector3 arrow[arrow_points] = {
 			Vector3(0, 0, -1),


### PR DESCRIPTION
The arrow's height was being scaled twice: once by the arrow array initialization, and once by the transform operation below.

This fixes the issue reported in https://github.com/godotengine/godot/pull/119605#issuecomment-4536136511. cc @passivestar

## Preview

Before | After
-|-
<img width="735" height="649" alt="image" src="https://github.com/user-attachments/assets/8c620ce1-542b-49e6-a061-17f09177f5c9" /> | <img width="735" height="649" alt="image" src="https://github.com/user-attachments/assets/eafd2127-b762-406a-9971-cb5f06c71eba" />
