### PR TITLE
Detect locale from file name when adding localization remaps.

### DIFF
--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -196,7 +196,21 @@ void LocalizationEditor::_translation_res_option_add(const PackedStringArray &p_
 	ERR_FAIL_COND(!remaps.has(key));
 	PackedStringArray r = remaps[key];
 	for (int i = 0; i < p_paths.size(); i++) {
-		r.push_back(p_paths[i] + ":" + "en");
+		String locale;
+		PackedStringArray path_split = p_paths[i].get_file().get_basename().rsplit("_", true, 2);
+		path_split.reverse();
+		if (TranslationServer::get_singleton()->get_all_countries().has(path_split[0])) {
+			if (path_split.size() > 1 && TranslationServer::get_singleton()->get_all_languages().has(path_split[1])) {
+				locale = path_split[1] + "_" + path_split[0];
+			} else {
+				locale = "en";
+			}
+		} else if (TranslationServer::get_singleton()->get_all_languages().has(path_split[0])) {
+			locale = path_split[0];
+		} else {
+			locale = "en"; // Fallback to English if the locale is not available.
+		}
+		r.push_back(p_paths[i] + ":" + locale);
 	}
 	remaps[key] = r;
 


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15189

## Additional information

This handles detect both language and country from file name to add them automatically as locale. 

I remember there being a third parameter (script I think) but it was not there in the UI so I did not look into it further.
