### PR TITLE
Fix incorrect freed autoload check

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -522,7 +522,7 @@ void EditorAutoloadSettings::update_autoload() {
 			if (old_info.path == info.path) {
 				// Still the same resource, check status
 				info.node = old_info.node;
-				if (info.node && info.node->is_instance()) {
+				if (info.node && info.node->is_inside_tree()) {
 					Ref<Script> scr = info.node->get_script();
 					info.in_editor = scr.is_valid() && scr->is_tool();
 					if (info.is_singleton == old_info.is_singleton && info.in_editor == old_info.in_editor) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

To check if an autoload was freed, it currently checks for `scene_file_path` by using [`Node::is_instance()`](https://github.com/godotengine/godot/blob/c12e51972a41665743be79c7d3e3fd5c871d97f3/scene/main/node.h#L874), and not if it was actually freed or not. I fixed it by check if the node is inside the tree, as a freed node cannot be inside the tree anyways, this is also the way it's done in [other places](https://github.com/godotengine/godot/blob/c12e51972a41665743be79c7d3e3fd5c871d97f3/editor/scene/2d/scene_paint_2d_editor_plugin.cpp#L242).

Somehow (I still don't know how) this can cause a crash, with a seemingly corrupted RID, like in PhantomCamera. PhantomCamera seems to do weird stuff regarding their singleton registration, which can cause the crash. The actual error can be seen in [this issue](https://github.com/ramokz/phantom-camera/issues/665). How the crash actually happens is a mistery to me, I just know that this fixes it.

## Additional information

- No AI used.