### PR TITLE
[CrashHandler] Save and restore signal handlers.

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -39,10 +39,6 @@
 #include "core/version.h"
 #include "main/main.h"
 
-#ifndef DEBUG_ENABLED
-#undef CRASH_HANDLER_ENABLED
-#endif
-
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>
@@ -262,9 +258,9 @@ void CrashHandler::disable() {
 	}
 
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, SIG_DFL);
-	signal(SIGFPE, SIG_DFL);
-	signal(SIGILL, SIG_DFL);
+	signal(SIGSEGV, old_sig_segf);
+	signal(SIGFPE, old_sig_fpe);
+	signal(SIGILL, old_sig_ill);
 #endif
 
 	disabled = true;
@@ -272,8 +268,8 @@ void CrashHandler::disable() {
 
 void CrashHandler::initialize() {
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, handle_crash);
-	signal(SIGFPE, handle_crash);
-	signal(SIGILL, handle_crash);
+	old_sig_segf = signal(SIGSEGV, handle_crash);
+	old_sig_fpe = signal(SIGFPE, handle_crash);
+	old_sig_ill = signal(SIGILL, handle_crash);
 #endif
 }

--- a/platform/linuxbsd/crash_handler_linuxbsd.h
+++ b/platform/linuxbsd/crash_handler_linuxbsd.h
@@ -30,8 +30,24 @@
 
 #pragma once
 
+#ifndef DEBUG_ENABLED
+#undef CRASH_HANDLER_ENABLED
+#endif
+
+#include <csignal>
+
+#ifndef _GNU_SOURCE
+typedef typeof(void(int)) *sighandler_t;
+#endif
+
 class CrashHandler {
 	bool disabled;
+
+#ifdef CRASH_HANDLER_ENABLED
+	sighandler_t old_sig_segf = nullptr;
+	sighandler_t old_sig_fpe = nullptr;
+	sighandler_t old_sig_ill = nullptr;
+#endif
 
 public:
 	void initialize();

--- a/platform/macos/crash_handler_macos.h
+++ b/platform/macos/crash_handler_macos.h
@@ -30,8 +30,21 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED)
+#define CRASH_HANDLER_ENABLED 1
+#endif
+
+typedef typeof(void(int)) *sighandler_t;
+
 class CrashHandler {
 	bool disabled;
+
+#ifdef CRASH_HANDLER_ENABLED
+	sighandler_t old_sig_segf = nullptr;
+	sighandler_t old_sig_fpe = nullptr;
+	sighandler_t old_sig_ill = nullptr;
+	sighandler_t old_sig_trap = nullptr;
+#endif
 
 public:
 	void initialize();

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -42,10 +42,6 @@
 
 #include <cstdio>
 
-#if defined(DEBUG_ENABLED)
-#define CRASH_HANDLER_ENABLED 1
-#endif
-
 #ifdef CRASH_HANDLER_ENABLED
 #include "stack_trace_macos.h"
 
@@ -212,10 +208,10 @@ void CrashHandler::disable() {
 	}
 
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, SIG_DFL);
-	signal(SIGFPE, SIG_DFL);
-	signal(SIGILL, SIG_DFL);
-	signal(SIGTRAP, SIG_DFL);
+	signal(SIGSEGV, old_sig_segf);
+	signal(SIGFPE, old_sig_fpe);
+	signal(SIGILL, old_sig_ill);
+	signal(SIGTRAP, old_sig_trap);
 #endif
 
 	disabled = true;
@@ -223,9 +219,9 @@ void CrashHandler::disable() {
 
 void CrashHandler::initialize() {
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, handle_crash);
-	signal(SIGFPE, handle_crash);
-	signal(SIGILL, handle_crash);
-	signal(SIGTRAP, handle_crash);
+	old_sig_segf = signal(SIGSEGV, handle_crash);
+	old_sig_fpe = signal(SIGFPE, handle_crash);
+	old_sig_ill = signal(SIGILL, handle_crash);
+	old_sig_trap = signal(SIGTRAP, handle_crash);
 #endif
 }

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -38,6 +38,12 @@
 
 #ifdef _MSC_VER
 extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);
+#else
+
+#include <csignal>
+#ifndef _GNU_SOURCE
+typedef typeof(void(int)) *sighandler_t;
+#endif
 #endif
 
 #endif
@@ -45,6 +51,11 @@ extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);
 class CrashHandler {
 	bool disabled;
 
+#if !defined(_MSC_VER) && defined(CRASH_HANDLER_EXCEPTION)
+	sighandler_t old_sig_segf = nullptr;
+	sighandler_t old_sig_fpe = nullptr;
+	sighandler_t old_sig_ill = nullptr;
+#endif
 public:
 	void initialize();
 

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -115,6 +115,10 @@ public:
 };
 
 DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
+	if (OS::get_singleton() == nullptr || OS::get_singleton()->is_disable_crash_handler() || IsDebuggerPresent()) {
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
 	HANDLE process = GetCurrentProcess();
 	HANDLE hThread = GetCurrentThread();
 	DWORD offset_from_symbol = 0;
@@ -122,10 +126,6 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	std::vector<module_data> modules;
 	DWORD cbNeeded;
 	std::vector<HMODULE> module_handles(1);
-
-	if (OS::get_singleton() == nullptr || OS::get_singleton()->is_disable_crash_handler() || IsDebuggerPresent()) {
-		return EXCEPTION_CONTINUE_SEARCH;
-	}
 
 	if (OS::get_singleton()->is_crash_handler_silent()) {
 		std::_Exit(0);

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -46,7 +46,6 @@
 #include <psapi.h>
 
 #include <algorithm>
-#include <csignal>
 #include <cstdlib>
 #include <iterator>
 #include <vector>
@@ -209,7 +208,7 @@ int64_t get_image_base(const String &p_path) {
 	}
 }
 
-extern void CrashHandlerException(int signal) {
+static void handle_crash(int signal) {
 	CrashHandlerData data;
 
 	if (OS::get_singleton() == nullptr || OS::get_singleton()->is_disable_crash_handler() || IsDebuggerPresent()) {
@@ -310,9 +309,9 @@ void CrashHandler::disable() {
 	}
 
 #if defined(CRASH_HANDLER_EXCEPTION)
-	signal(SIGSEGV, nullptr);
-	signal(SIGFPE, nullptr);
-	signal(SIGILL, nullptr);
+	signal(SIGSEGV, old_sig_segf);
+	signal(SIGFPE, old_sig_fpe);
+	signal(SIGILL, old_sig_ill);
 #endif
 
 	disabled = true;
@@ -320,8 +319,8 @@ void CrashHandler::disable() {
 
 void CrashHandler::initialize() {
 #if defined(CRASH_HANDLER_EXCEPTION)
-	signal(SIGSEGV, CrashHandlerException);
-	signal(SIGFPE, CrashHandlerException);
-	signal(SIGILL, CrashHandlerException);
+	old_sig_segf = signal(SIGSEGV, handle_crash);
+	old_sig_fpe = signal(SIGFPE, handle_crash);
+	old_sig_ill = signal(SIGILL, handle_crash);
 #endif
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121494
- Closes https://github.com/godotengine/godot/issues/119079

## Additional information

Instead of resetting signal handlers, saves existing handlers when initializing `CrashHandler` and restores them when it is disabled.