### PR TITLE
Use const references in core/ and scene/

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -411,7 +411,7 @@ Quaternion Basis::get_rotation_quaternion() const {
 	return m.get_quaternion();
 }
 
-void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) {
+void Basis::rotate_to_align(const Vector3 &p_start_direction, const Vector3 &p_end_direction) {
 	// Takes two vectors and rotates the basis from the first vector to the second vector.
 	// Adopted from: https://gist.github.com/kevinmoran/b45980723e53edeb8a5a43c49f134724
 	const Vector3 axis = p_start_direction.cross(p_end_direction).normalized();

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -76,7 +76,7 @@ struct [[nodiscard]] Basis {
 	void get_rotation_axis_angle_local(Vector3 &p_axis, real_t &p_angle) const;
 	Quaternion get_rotation_quaternion() const;
 
-	void rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction);
+	void rotate_to_align(const Vector3 &p_start_direction, const Vector3 &p_end_direction);
 
 	Vector3 rotref_posscale_decomposition(Basis &r_rotref) const;
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -615,7 +615,7 @@ Vector<Vector3> compute_convex_mesh_points(const Plane *p_planes, int p_plane_co
 		max = x2; \
 	}
 
-_FORCE_INLINE_ bool planeBoxOverlap(Vector3 p_normal, real_t p_d, Vector3 p_maxbox) {
+_FORCE_INLINE_ bool planeBoxOverlap(const Vector3 &p_normal, real_t p_d, const Vector3 &p_maxbox) {
 	int q;
 	Vector3 vmin, vmax;
 	for (q = 0; q <= 2; q++) {

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -150,7 +150,7 @@ Projection Projection::create_frustum(real_t p_left, real_t p_right, real_t p_bo
 	return proj;
 }
 
-Projection Projection::create_frustum_aspect(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {
+Projection Projection::create_frustum_aspect(real_t p_size, real_t p_aspect, const Vector2 &p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {
 	Projection proj;
 	proj.set_frustum(p_size, p_aspect, p_offset, p_near, p_far, p_flip_fov);
 	return proj;
@@ -393,7 +393,7 @@ void Projection::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, rea
 	te[15] = 0;
 }
 
-void Projection::set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {
+void Projection::set_frustum(real_t p_size, real_t p_aspect, const Vector2 &p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {
 	if (!p_flip_fov) {
 		p_size *= p_aspect;
 	}

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -82,7 +82,7 @@ struct [[nodiscard]] Projection {
 	void set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
 	void set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
-	void set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
+	void set_frustum(real_t p_size, real_t p_aspect, const Vector2 &p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
 	void adjust_perspective_znear(real_t p_new_znear);
 
 	static Projection create_depth_correction(bool p_flip_y);
@@ -93,7 +93,7 @@ struct [[nodiscard]] Projection {
 	static Projection create_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
 	static Projection create_orthogonal_aspect(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
 	static Projection create_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
-	static Projection create_frustum_aspect(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
+	static Projection create_frustum_aspect(real_t p_size, real_t p_aspect, const Vector2 &p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
 	static Projection create_fit_aabb(const AABB &p_aabb);
 	Projection perspective_znear_adjusted(real_t p_new_znear) const;
 	Plane get_projection_plane(Planes p_plane) const;

--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -153,7 +153,7 @@ Quaternion TransformInterpolator::_quat_slerp_unchecked(const Quaternion &p_from
 			scale0 * p_from.w + scale1 * to1.w);
 }
 
-Basis TransformInterpolator::_basis_slerp_unchecked(Basis p_from, Basis p_to, real_t p_fraction) {
+Basis TransformInterpolator::_basis_slerp_unchecked(const Basis &p_from, const Basis &p_to, real_t p_fraction) {
 	Quaternion from = _basis_to_quat_unchecked(p_from);
 	Quaternion to = _basis_to_quat_unchecked(p_to);
 

--- a/core/math/transform_interpolator.h
+++ b/core/math/transform_interpolator.h
@@ -65,7 +65,7 @@ private:
 	}
 	static Vector3 _basis_orthonormalize(Basis &r_basis);
 	static Method _test_basis(Basis p_basis, bool r_needed_normalize, Quaternion &r_quat);
-	static Basis _basis_slerp_unchecked(Basis p_from, Basis p_to, real_t p_fraction);
+	static Basis _basis_slerp_unchecked(const Basis &p_from, const Basis &p_to, real_t p_fraction);
 	static Quaternion _quat_slerp_unchecked(const Quaternion &p_from, const Quaternion &p_to, real_t p_fraction);
 	static Quaternion _basis_to_quat_unchecked(const Basis &p_basis);
 	static bool _basis_is_orthogonal(const Basis &p_basis, real_t p_epsilon = 0.01f);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -338,7 +338,7 @@ void CPUParticles2D::restart(bool p_keep_seed) {
 	_set_emitting();
 }
 
-void CPUParticles2D::set_direction(Vector2 p_direction) {
+void CPUParticles2D::set_direction(const Vector2 &p_direction) {
 	direction = p_direction;
 }
 
@@ -505,7 +505,7 @@ void CPUParticles2D::set_emission_sphere_radius(real_t p_radius) {
 #endif
 }
 
-void CPUParticles2D::set_emission_rect_extents(Vector2 p_extents) {
+void CPUParticles2D::set_emission_rect_extents(const Vector2 &p_extents) {
 	if (p_extents == emission_rect_extents) {
 		return;
 	}

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -271,7 +271,7 @@ public:
 
 	///////////////////
 
-	void set_direction(Vector2 p_direction);
+	void set_direction(const Vector2 &p_direction);
 	Vector2 get_direction() const;
 
 	void set_spread(real_t p_spread);
@@ -300,7 +300,7 @@ public:
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(real_t p_radius);
-	void set_emission_rect_extents(Vector2 p_extents);
+	void set_emission_rect_extents(const Vector2 &p_extents);
 	void set_emission_points(const Vector<Vector2> &p_points);
 	void set_emission_normals(const Vector<Vector2> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -126,7 +126,7 @@ Vector<Vector2> Line2D::get_points() const {
 	return _points;
 }
 
-void Line2D::set_point_position(int i, Vector2 p_pos) {
+void Line2D::set_point_position(int i, const Vector2 &p_pos) {
 	ERR_FAIL_INDEX(i, _points.size());
 	_points.set(i, p_pos);
 	queue_redraw();
@@ -149,7 +149,7 @@ void Line2D::clear_points() {
 	}
 }
 
-void Line2D::add_point(Vector2 p_pos, int p_atpos) {
+void Line2D::add_point(const Vector2 &p_pos, int p_atpos) {
 	if (p_atpos < 0 || _points.size() < p_atpos) {
 		_points.push_back(p_pos);
 	} else {
@@ -163,7 +163,7 @@ void Line2D::remove_point(int i) {
 	queue_redraw();
 }
 
-void Line2D::set_default_color(Color p_color) {
+void Line2D::set_default_color(const Color &p_color) {
 	_default_color = p_color;
 	queue_redraw();
 }

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -67,14 +67,14 @@ public:
 	void set_points(const Vector<Vector2> &p_points);
 	Vector<Vector2> get_points() const;
 
-	void set_point_position(int i, Vector2 pos);
+	void set_point_position(int i, const Vector2 &pos);
 	Vector2 get_point_position(int i) const;
 
 	int get_point_count() const;
 
 	void clear_points();
 
-	void add_point(Vector2 pos, int atpos = -1);
+	void add_point(const Vector2 &pos, int atpos = -1);
 	void remove_point(int i);
 
 	void set_closed(bool p_closed);
@@ -86,7 +86,7 @@ public:
 	void set_curve(const Ref<Curve> &curve);
 	Ref<Curve> get_curve() const;
 
-	void set_default_color(Color color);
+	void set_default_color(const Color &color);
 	Color get_default_color() const;
 
 	void set_gradient(const Ref<Gradient> &gradient);

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -431,7 +431,7 @@ void LineBuilder::build() {
 	}
 }
 
-void LineBuilder::strip_begin(Vector2 up, Vector2 down, Color color, float uvx) {
+void LineBuilder::strip_begin(const Vector2 &up, const Vector2 &down, const Color &color, float uvx) {
 	int vi = vertices.size();
 
 	vertices.push_back(up);
@@ -451,7 +451,7 @@ void LineBuilder::strip_begin(Vector2 up, Vector2 down, Color color, float uvx) 
 	_last_index[DOWN] = vi + 1;
 }
 
-void LineBuilder::strip_add_quad(Vector2 up, Vector2 down, Color color, float uvx) {
+void LineBuilder::strip_add_quad(const Vector2 &up, const Vector2 &down, const Color &color, float uvx) {
 	int vi = vertices.size();
 
 	vertices.push_back(up);
@@ -478,7 +478,7 @@ void LineBuilder::strip_add_quad(Vector2 up, Vector2 down, Color color, float uv
 	_last_index[DOWN] = vi + 1;
 }
 
-void LineBuilder::strip_add_tri(Vector2 up, Orientation orientation) {
+void LineBuilder::strip_add_tri(const Vector2 &up, Orientation orientation) {
 	int vi = vertices.size();
 
 	vertices.push_back(up);
@@ -502,7 +502,7 @@ void LineBuilder::strip_add_tri(Vector2 up, Orientation orientation) {
 	_last_index[opposite_orientation] = vi;
 }
 
-void LineBuilder::strip_add_arc(Vector2 center, float angle_delta, Orientation orientation) {
+void LineBuilder::strip_add_arc(const Vector2 &center, float angle_delta, Orientation orientation) {
 	// Take the two last vertices and extrude an arc made of triangles
 	// that all share one of the initial vertices
 
@@ -531,7 +531,7 @@ void LineBuilder::strip_add_arc(Vector2 center, float angle_delta, Orientation o
 	strip_add_tri(rpos, orientation);
 }
 
-void LineBuilder::new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Color color, Rect2 uv_rect) {
+void LineBuilder::new_arc(const Vector2 &center, const Vector2 &vbegin, float angle_delta, const Color &color, const Rect2 &uv_rect) {
 	// Make a standalone arc that doesn't use existing vertices,
 	// with undistorted UVs from within a square section
 

--- a/scene/2d/line_builder.h
+++ b/scene/2d/line_builder.h
@@ -69,13 +69,13 @@ private:
 	};
 
 	// Triangle-strip methods
-	void strip_begin(Vector2 up, Vector2 down, Color color, float uvx);
-	void strip_new_quad(Vector2 up, Vector2 down, Color color, float uvx);
-	void strip_add_quad(Vector2 up, Vector2 down, Color color, float uvx);
-	void strip_add_tri(Vector2 up, Orientation orientation);
-	void strip_add_arc(Vector2 center, float angle_delta, Orientation orientation);
+	void strip_begin(const Vector2 &up, const Vector2 &down, const Color &color, float uvx);
+	void strip_new_quad(const Vector2 &up, const Vector2 &down, const Color &color, float uvx);
+	void strip_add_quad(const Vector2 &up, const Vector2 &down, const Color &color, float uvx);
+	void strip_add_tri(const Vector2 &up, Orientation orientation);
+	void strip_add_arc(const Vector2 &center, float angle_delta, Orientation orientation);
 
-	void new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Color color, Rect2 uv_rect);
+	void new_arc(const Vector2 &center, const Vector2 &vbegin, float angle_delta, const Color &color, const Rect2 &uv_rect);
 
 private:
 	bool _interpolate_color = false;

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -642,7 +642,7 @@ real_t NavigationAgent2D::get_path_max_distance() {
 	return path_max_distance;
 }
 
-void NavigationAgent2D::set_target_position(Vector2 p_position) {
+void NavigationAgent2D::set_target_position(const Vector2 &p_position) {
 	// Intentionally not checking for equality of the parameter, as we want to update the path even if the target position is the same in case the world changed.
 	// Revisit later when the navigation server can update the path without requesting a new path.
 
@@ -704,7 +704,7 @@ Vector2 NavigationAgent2D::_get_final_position() const {
 	return navigation_path[navigation_path.size() - 1];
 }
 
-void NavigationAgent2D::set_velocity_forced(Vector2 p_velocity) {
+void NavigationAgent2D::set_velocity_forced(const Vector2 &p_velocity) {
 	// Intentionally not checking for equality of the parameter.
 	// We need to always submit the velocity to the navigation server, even when it is the same, in order to run avoidance every frame.
 	// Revisit later when the navigation server can update avoidance without users resubmitting the velocity.
@@ -713,12 +713,12 @@ void NavigationAgent2D::set_velocity_forced(Vector2 p_velocity) {
 	velocity_forced_submitted = true;
 }
 
-void NavigationAgent2D::set_velocity(const Vector2 p_velocity) {
+void NavigationAgent2D::set_velocity(const Vector2 &p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
 }
 
-void NavigationAgent2D::_avoidance_done(Vector2 p_new_velocity) {
+void NavigationAgent2D::_avoidance_done(const Vector2 &p_new_velocity) {
 	safe_velocity = p_new_velocity;
 	emit_signal(SNAME("velocity_computed"), safe_velocity);
 }
@@ -1030,7 +1030,7 @@ bool NavigationAgent2D::get_debug_use_custom() const {
 	return debug_use_custom;
 }
 
-void NavigationAgent2D::set_debug_path_custom_color(Color p_color) {
+void NavigationAgent2D::set_debug_path_custom_color(const Color &p_color) {
 #ifdef DEBUG_ENABLED
 	if (debug_path_custom_color == p_color) {
 		return;

--- a/scene/2d/navigation/navigation_agent_2d.h
+++ b/scene/2d/navigation/navigation_agent_2d.h
@@ -180,7 +180,7 @@ public:
 	void set_path_max_distance(real_t p_pmd);
 	real_t get_path_max_distance();
 
-	void set_target_position(Vector2 p_position);
+	void set_target_position(const Vector2 &p_position);
 	Vector2 get_target_position() const;
 
 	void set_simplify_path(bool p_enabled);
@@ -217,12 +217,12 @@ public:
 	bool is_navigation_finished();
 	Vector2 get_final_position();
 
-	void set_velocity(const Vector2 p_velocity);
+	void set_velocity(const Vector2 &p_velocity);
 	Vector2 get_velocity() { return velocity; }
 
-	void set_velocity_forced(const Vector2 p_velocity);
+	void set_velocity_forced(const Vector2 &p_velocity);
 
-	void _avoidance_done(Vector2 p_new_velocity);
+	void _avoidance_done(const Vector2 &p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
 
@@ -247,7 +247,7 @@ public:
 	void set_debug_use_custom(bool p_enabled);
 	bool get_debug_use_custom() const;
 
-	void set_debug_path_custom_color(Color p_color);
+	void set_debug_path_custom_color(const Color &p_color);
 	Color get_debug_path_custom_color() const;
 
 	void set_debug_path_custom_point_size(float p_point_size);

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -231,7 +231,7 @@ bool NavigationLink2D::get_navigation_layer_value(int p_layer_number) const {
 	return get_navigation_layers() & (1 << (p_layer_number - 1));
 }
 
-void NavigationLink2D::set_start_position(Vector2 p_position) {
+void NavigationLink2D::set_start_position(const Vector2 &p_position) {
 	if (start_position.is_equal_approx(p_position)) {
 		return;
 	}
@@ -251,7 +251,7 @@ void NavigationLink2D::set_start_position(Vector2 p_position) {
 #endif // DEBUG_ENABLED
 }
 
-void NavigationLink2D::set_end_position(Vector2 p_position) {
+void NavigationLink2D::set_end_position(const Vector2 &p_position) {
 	if (end_position.is_equal_approx(p_position)) {
 		return;
 	}
@@ -271,7 +271,7 @@ void NavigationLink2D::set_end_position(Vector2 p_position) {
 #endif // DEBUG_ENABLED
 }
 
-void NavigationLink2D::set_global_start_position(Vector2 p_position) {
+void NavigationLink2D::set_global_start_position(const Vector2 &p_position) {
 	if (is_inside_tree()) {
 		set_start_position(to_local(p_position));
 	} else {
@@ -287,7 +287,7 @@ Vector2 NavigationLink2D::get_global_start_position() const {
 	}
 }
 
-void NavigationLink2D::set_global_end_position(Vector2 p_position) {
+void NavigationLink2D::set_global_end_position(const Vector2 &p_position) {
 	if (is_inside_tree()) {
 		set_end_position(to_local(p_position));
 	} else {

--- a/scene/2d/navigation/navigation_link_2d.h
+++ b/scene/2d/navigation/navigation_link_2d.h
@@ -80,16 +80,16 @@ public:
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
 
-	void set_start_position(Vector2 p_position);
+	void set_start_position(const Vector2 &p_position);
 	Vector2 get_start_position() const { return start_position; }
 
-	void set_end_position(Vector2 p_position);
+	void set_end_position(const Vector2 &p_position);
 	Vector2 get_end_position() const { return end_position; }
 
-	void set_global_start_position(Vector2 p_position);
+	void set_global_start_position(const Vector2 &p_position);
 	Vector2 get_global_start_position() const;
 
-	void set_global_end_position(Vector2 p_position);
+	void set_global_end_position(const Vector2 &p_position);
 	Vector2 get_global_end_position() const;
 
 	void set_enter_cost(real_t p_enter_cost);

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -309,7 +309,7 @@ bool NavigationObstacle2D::get_avoidance_enabled() const {
 	return avoidance_enabled;
 }
 
-void NavigationObstacle2D::set_velocity(const Vector2 p_velocity) {
+void NavigationObstacle2D::set_velocity(const Vector2 &p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
 }
@@ -423,7 +423,7 @@ void NavigationObstacle2D::_update_map(RID p_map) {
 	NavigationServer2D::get_singleton()->obstacle_set_map(obstacle, p_map);
 }
 
-void NavigationObstacle2D::_update_position(const Vector2 p_position) {
+void NavigationObstacle2D::_update_position(const Vector2 &p_position) {
 	NavigationServer2D::get_singleton()->obstacle_set_position(obstacle, p_position);
 #ifdef DEBUG_ENABLED
 	queue_redraw();

--- a/scene/2d/navigation/navigation_obstacle_2d.h
+++ b/scene/2d/navigation/navigation_obstacle_2d.h
@@ -104,10 +104,10 @@ public:
 	void set_avoidance_layer_value(int p_layer_number, bool p_value);
 	bool get_avoidance_layer_value(int p_layer_number) const;
 
-	void set_velocity(const Vector2 p_velocity);
+	void set_velocity(const Vector2 &p_velocity);
 	Vector2 get_velocity() const { return velocity; }
 
-	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+	void _avoidance_done(const Vector3 &p_new_velocity); // Dummy
 
 	void set_affect_navigation_mesh(bool p_enabled);
 	bool get_affect_navigation_mesh() const;
@@ -127,6 +127,6 @@ public:
 
 private:
 	void _update_map(RID p_map);
-	void _update_position(const Vector2 p_position);
+	void _update_position(const Vector2 &p_position);
 	void _update_transform();
 };

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -737,7 +737,7 @@ RID Skeleton2D::get_skeleton() const {
 	return skeleton;
 }
 
-void Skeleton2D::set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, real_t p_amount, bool p_persistent) {
+void Skeleton2D::set_bone_local_pose_override(int p_bone_idx, const Transform2D &p_override, real_t p_amount, bool p_persistent) {
 	ERR_FAIL_INDEX_MSG(p_bone_idx, (int)bones.size(), "Bone index is out of range!");
 	bones[p_bone_idx].local_pose_override = p_override;
 	bones[p_bone_idx].local_pose_override_amount = p_amount;

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -163,7 +163,7 @@ public:
 
 	RID get_skeleton() const;
 
-	void set_bone_local_pose_override(int p_bone_idx, Transform2D p_override, real_t p_amount, bool p_persistent = true);
+	void set_bone_local_pose_override(int p_bone_idx, const Transform2D &p_override, real_t p_amount, bool p_persistent = true);
 	Transform2D get_bone_local_pose_override(int p_bone_idx);
 
 	Ref<SkeletonModificationStack2D> get_modification_stack() const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -339,7 +339,7 @@ bool TileMap::is_layer_enabled(int p_layer) const {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, false, is_enabled);
 }
 
-void TileMap::set_layer_modulate(int p_layer, Color p_modulate) {
+void TileMap::set_layer_modulate(int p_layer, const Color &p_modulate) {
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_modulate, p_modulate);
 }
 
@@ -448,7 +448,7 @@ void TileMap::set_y_sort_enabled(bool p_enable) {
 	update_configuration_warnings();
 }
 
-void TileMap::set_cell(int p_layer, const Vector2i &p_coords, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile) {
+void TileMap::set_cell(int p_layer, const Vector2i &p_coords, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) {
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_cell, p_coords, p_source_id, p_atlas_coords, p_alternative_tile);
 }
 
@@ -764,7 +764,7 @@ TypedArray<Vector2i> TileMap::get_used_cells(int p_layer) const {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, TypedArray<Vector2i>(), get_used_cells);
 }
 
-TypedArray<Vector2i> TileMap::get_used_cells_by_id(int p_layer, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile) const {
+TypedArray<Vector2i> TileMap::get_used_cells_by_id(int p_layer, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) const {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, TypedArray<Vector2i>(), get_used_cells_by_id, p_source_id, p_atlas_coords, p_alternative_tile);
 }
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -139,7 +139,7 @@ public:
 	String get_layer_name(int p_layer) const;
 	void set_layer_enabled(int p_layer, bool p_visible);
 	bool is_layer_enabled(int p_layer) const;
-	void set_layer_modulate(int p_layer, Color p_modulate);
+	void set_layer_modulate(int p_layer, const Color &p_modulate);
 	Color get_layer_modulate(int p_layer) const;
 	void set_layer_y_sort_enabled(int p_layer, bool p_enabled);
 	bool is_layer_y_sort_enabled(int p_layer) const;
@@ -167,7 +167,7 @@ public:
 #endif // NAVIGATION_2D_DISABLED
 
 	// Cells accessors.
-	void set_cell(int p_layer, const Vector2i &p_coords, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);
+	void set_cell(int p_layer, const Vector2i &p_coords, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i &p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);
 	void erase_cell(int p_layer, const Vector2i &p_coords);
 	int get_cell_source_id(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	Vector2i get_cell_atlas_coords(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
@@ -206,7 +206,7 @@ public:
 	Vector2i get_neighbor_cell(const Vector2i &p_coords, TileSet::CellNeighbor p_cell_neighbor) const;
 
 	TypedArray<Vector2i> get_used_cells(int p_layer) const;
-	TypedArray<Vector2i> get_used_cells_by_id(int p_layer, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE) const;
+	TypedArray<Vector2i> get_used_cells_by_id(int p_layer, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i &p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE) const;
 	Rect2i get_used_rect() const;
 
 	// Override some methods of the CanvasItem class to pass the changes to the quadrants CanvasItems.

--- a/scene/3d/aim_modifier_3d.cpp
+++ b/scene/3d/aim_modifier_3d.cpp
@@ -211,7 +211,7 @@ void AimModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skele
 	_process_aim(p_index, p_skeleton, p_apply_bone, skel_tr.basis.get_rotation_quaternion().xform_inv(reference_origin), p_amount);
 }
 
-void AimModifier3D::_process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, Vector3 p_target, float p_amount) {
+void AimModifier3D::_process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const Vector3 &p_target, float p_amount) {
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 
 	// Prepare forward_vector and rest.

--- a/scene/3d/aim_modifier_3d.h
+++ b/scene/3d/aim_modifier_3d.h
@@ -54,7 +54,7 @@ protected:
 
 	virtual void _process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
 	virtual void _process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) override;
-	virtual void _process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, Vector3 p_target, float p_amount);
+	virtual void _process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const Vector3 &p_target, float p_amount);
 	virtual void _validate_setting(int p_index) override;
 
 public:

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -162,7 +162,7 @@ AudioFrame AudioStreamPlayer3D::_calc_output_vol_stereo(const Vector3 &source_di
 }
 
 #ifndef PHYSICS_3D_DISABLED
-void AudioStreamPlayer3D::_calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, const FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &direct_path_vol, FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &reverb_vol) {
+void AudioStreamPlayer3D::_calc_reverb_vol(Area3D *area, const Vector3 &listener_area_pos, const FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &direct_path_vol, FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &reverb_vol) {
 	reverb_vol.resize_uninitialized(VOLUME_VECTOR_SIZE);
 	for (AudioFrame &frame : reverb_vol) {
 		frame = AudioFrame(0, 0);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -87,7 +87,7 @@ private:
 	static AudioFrame _calc_output_vol_stereo(const Vector3 &source_dir, real_t panning_strength);
 
 #ifndef PHYSICS_3D_DISABLED
-	void _calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, const FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &direct_path_vol, FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &reverb_vol);
+	void _calc_reverb_vol(Area3D *area, const Vector3 &listener_area_pos, const FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &direct_path_vol, FixedVector<AudioFrame, VOLUME_VECTOR_SIZE> &reverb_vol);
 #endif // PHYSICS_3D_DISABLED
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->force_update_panning = true; }

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -337,7 +337,7 @@ void Camera3D::set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far) {
 	update_gizmos();
 }
 
-void Camera3D::set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far) {
+void Camera3D::set_frustum(real_t p_size, const Vector2 &p_offset, real_t p_z_near, real_t p_z_far) {
 	if (!force_change && size == p_size && frustum_offset == p_offset && p_z_near == _near && p_z_far == _far && mode == PROJECTION_FRUSTUM) {
 		return;
 	}
@@ -755,7 +755,7 @@ void Camera3D::set_near(real_t p_near) {
 	_update_camera_mode();
 }
 
-void Camera3D::set_frustum_offset(Vector2 p_offset) {
+void Camera3D::set_frustum_offset(const Vector2 &p_offset) {
 	frustum_offset = p_offset;
 	_update_camera_mode();
 }

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -138,7 +138,7 @@ public:
 
 	void set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
 	void set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
-	void set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far);
+	void set_frustum(real_t p_size, const Vector2 &p_offset, real_t p_z_near, real_t p_z_far);
 	void set_projection(Camera3D::ProjectionType p_mode);
 
 	void make_current();
@@ -160,7 +160,7 @@ public:
 	void set_size(real_t p_size);
 	void set_far(real_t p_far);
 	void set_near(real_t p_near);
-	void set_frustum_offset(Vector2 p_offset);
+	void set_frustum_offset(const Vector2 &p_offset);
 
 	virtual Transform3D get_camera_transform() const;
 	virtual Projection get_camera_projection() const;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -267,7 +267,7 @@ void CPUParticles3D::restart(bool p_keep_seed) {
 	_set_emitting();
 }
 
-void CPUParticles3D::set_direction(Vector3 p_direction) {
+void CPUParticles3D::set_direction(const Vector3 &p_direction) {
 	direction = p_direction;
 }
 
@@ -435,7 +435,7 @@ void CPUParticles3D::set_emission_sphere_radius(real_t p_radius) {
 	update_gizmos();
 }
 
-void CPUParticles3D::set_emission_box_extents(Vector3 p_extents) {
+void CPUParticles3D::set_emission_box_extents(const Vector3 &p_extents) {
 	emission_box_extents = p_extents;
 	update_gizmos();
 }
@@ -452,7 +452,7 @@ void CPUParticles3D::set_emission_colors(const Vector<Color> &p_colors) {
 	emission_colors = p_colors;
 }
 
-void CPUParticles3D::set_emission_ring_axis(Vector3 p_axis) {
+void CPUParticles3D::set_emission_ring_axis(const Vector3 &p_axis) {
 	emission_ring_axis = p_axis;
 	update_gizmos();
 }

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -267,7 +267,7 @@ public:
 
 	///////////////////
 
-	void set_direction(Vector3 p_direction);
+	void set_direction(const Vector3 &p_direction);
 	Vector3 get_direction() const;
 
 	void set_spread(real_t p_spread);
@@ -299,11 +299,11 @@ public:
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(real_t p_radius);
-	void set_emission_box_extents(Vector3 p_extents);
+	void set_emission_box_extents(const Vector3 &p_extents);
 	void set_emission_points(const Vector<Vector3> &p_points);
 	void set_emission_normals(const Vector<Vector3> &p_normals);
 	void set_emission_colors(const Vector<Color> &p_colors);
-	void set_emission_ring_axis(Vector3 p_axis);
+	void set_emission_ring_axis(const Vector3 &p_axis);
 	void set_emission_ring_height(real_t p_height);
 	void set_emission_ring_radius(real_t p_radius);
 	void set_emission_ring_inner_radius(real_t p_radius);

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -116,7 +116,7 @@ real_t Decal::get_normal_fade() const {
 	return normal_fade;
 }
 
-void Decal::set_modulate(Color p_modulate) {
+void Decal::set_modulate(const Color &p_modulate) {
 	modulate = p_modulate;
 	RS::get_singleton()->decal_set_modulate(decal, p_modulate);
 }

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -82,7 +82,7 @@ public:
 	void set_albedo_mix(real_t p_mix);
 	real_t get_albedo_mix() const;
 
-	void set_modulate(Color p_modulate);
+	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;
 
 	void set_upper_fade(real_t p_energy);

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -707,7 +707,7 @@ real_t NavigationAgent3D::get_path_max_distance() {
 	return path_max_distance;
 }
 
-void NavigationAgent3D::set_target_position(Vector3 p_position) {
+void NavigationAgent3D::set_target_position(const Vector3 &p_position) {
 	// Intentionally not checking for equality of the parameter, as we want to update the path even if the target position is the same in case the world changed.
 	// Revisit later when the navigation server can update the path without requesting a new path.
 
@@ -769,7 +769,7 @@ Vector3 NavigationAgent3D::_get_final_position() const {
 	return navigation_path[navigation_path.size() - 1] - Vector3(0, path_height_offset, 0);
 }
 
-void NavigationAgent3D::set_velocity_forced(Vector3 p_velocity) {
+void NavigationAgent3D::set_velocity_forced(const Vector3 &p_velocity) {
 	// Intentionally not checking for equality of the parameter.
 	// We need to always submit the velocity to the navigation server, even when it is the same, in order to run avoidance every frame.
 	// Revisit later when the navigation server can update avoidance without users resubmitting the velocity.
@@ -778,12 +778,12 @@ void NavigationAgent3D::set_velocity_forced(Vector3 p_velocity) {
 	velocity_forced_submitted = true;
 }
 
-void NavigationAgent3D::set_velocity(const Vector3 p_velocity) {
+void NavigationAgent3D::set_velocity(const Vector3 &p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
 }
 
-void NavigationAgent3D::_avoidance_done(Vector3 p_new_velocity) {
+void NavigationAgent3D::_avoidance_done(const Vector3 &p_new_velocity) {
 	safe_velocity = p_new_velocity;
 	if (!use_3d_avoidance) {
 		safe_velocity.y = stored_y_velocity;
@@ -1102,7 +1102,7 @@ bool NavigationAgent3D::get_debug_use_custom() const {
 	return debug_use_custom;
 }
 
-void NavigationAgent3D::set_debug_path_custom_color(Color p_color) {
+void NavigationAgent3D::set_debug_path_custom_color(const Color &p_color) {
 #ifdef DEBUG_ENABLED
 	if (debug_path_custom_color == p_color) {
 		return;

--- a/scene/3d/navigation/navigation_agent_3d.h
+++ b/scene/3d/navigation/navigation_agent_3d.h
@@ -203,7 +203,7 @@ public:
 	void set_path_max_distance(real_t p_pmd);
 	real_t get_path_max_distance();
 
-	void set_target_position(Vector3 p_position);
+	void set_target_position(const Vector3 &p_position);
 	Vector3 get_target_position() const;
 
 	void set_simplify_path(bool p_enabled);
@@ -240,12 +240,12 @@ public:
 	bool is_navigation_finished();
 	Vector3 get_final_position();
 
-	void set_velocity(const Vector3 p_velocity);
+	void set_velocity(const Vector3 &p_velocity);
 	Vector3 get_velocity() { return velocity; }
 
-	void set_velocity_forced(const Vector3 p_velocity);
+	void set_velocity_forced(const Vector3 &p_velocity);
 
-	void _avoidance_done(Vector3 p_new_velocity);
+	void _avoidance_done(const Vector3 &p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
 
@@ -270,7 +270,7 @@ public:
 	void set_debug_use_custom(bool p_enabled);
 	bool get_debug_use_custom() const;
 
-	void set_debug_path_custom_color(Color p_color);
+	void set_debug_path_custom_color(const Color &p_color);
 	Color get_debug_path_custom_color() const;
 
 	void set_debug_path_custom_point_size(float p_point_size);

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -394,7 +394,7 @@ bool NavigationLink3D::get_navigation_layer_value(int p_layer_number) const {
 	return get_navigation_layers() & (1 << (p_layer_number - 1));
 }
 
-void NavigationLink3D::set_start_position(Vector3 p_position) {
+void NavigationLink3D::set_start_position(const Vector3 &p_position) {
 	if (start_position.is_equal_approx(p_position)) {
 		return;
 	}
@@ -415,7 +415,7 @@ void NavigationLink3D::set_start_position(Vector3 p_position) {
 	update_configuration_warnings();
 }
 
-void NavigationLink3D::set_end_position(Vector3 p_position) {
+void NavigationLink3D::set_end_position(const Vector3 &p_position) {
 	if (end_position.is_equal_approx(p_position)) {
 		return;
 	}
@@ -436,7 +436,7 @@ void NavigationLink3D::set_end_position(Vector3 p_position) {
 	update_configuration_warnings();
 }
 
-void NavigationLink3D::set_global_start_position(Vector3 p_position) {
+void NavigationLink3D::set_global_start_position(const Vector3 &p_position) {
 	if (is_inside_tree()) {
 		set_start_position(to_local(p_position));
 	} else {
@@ -452,7 +452,7 @@ Vector3 NavigationLink3D::get_global_start_position() const {
 	}
 }
 
-void NavigationLink3D::set_global_end_position(Vector3 p_position) {
+void NavigationLink3D::set_global_end_position(const Vector3 &p_position) {
 	if (is_inside_tree()) {
 		set_end_position(to_local(p_position));
 	} else {

--- a/scene/3d/navigation/navigation_link_3d.h
+++ b/scene/3d/navigation/navigation_link_3d.h
@@ -84,16 +84,16 @@ public:
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
 
-	void set_start_position(Vector3 p_position);
+	void set_start_position(const Vector3 &p_position);
 	Vector3 get_start_position() const { return start_position; }
 
-	void set_end_position(Vector3 p_position);
+	void set_end_position(const Vector3 &p_position);
 	Vector3 get_end_position() const { return end_position; }
 
-	void set_global_start_position(Vector3 p_position);
+	void set_global_start_position(const Vector3 &p_position);
 	Vector3 get_global_start_position() const;
 
-	void set_global_end_position(Vector3 p_position);
+	void set_global_end_position(const Vector3 &p_position);
 	Vector3 get_global_end_position() const;
 
 	void set_enter_cost(real_t p_enter_cost);

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -389,7 +389,7 @@ void NavigationObstacle3D::set_use_3d_avoidance(bool p_use_3d_avoidance) {
 	notify_property_list_changed();
 }
 
-void NavigationObstacle3D::set_velocity(const Vector3 p_velocity) {
+void NavigationObstacle3D::set_velocity(const Vector3 &p_velocity) {
 	velocity = p_velocity;
 	velocity_submitted = true;
 }
@@ -506,7 +506,7 @@ void NavigationObstacle3D::_update_map(RID p_map) {
 	map_current = p_map;
 }
 
-void NavigationObstacle3D::_update_position(const Vector3 p_position) {
+void NavigationObstacle3D::_update_position(const Vector3 &p_position) {
 	NavigationServer3D::get_singleton()->obstacle_set_position(obstacle, p_position);
 }
 

--- a/scene/3d/navigation/navigation_obstacle_3d.h
+++ b/scene/3d/navigation/navigation_obstacle_3d.h
@@ -113,10 +113,10 @@ public:
 	void set_use_3d_avoidance(bool p_use_3d_avoidance);
 	bool get_use_3d_avoidance() const { return use_3d_avoidance; }
 
-	void set_velocity(const Vector3 p_velocity);
+	void set_velocity(const Vector3 &p_velocity);
 	Vector3 get_velocity() const { return velocity; }
 
-	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+	void _avoidance_done(const Vector3 &p_new_velocity); // Dummy
 
 	void set_affect_navigation_mesh(bool p_enabled);
 	bool get_affect_navigation_mesh() const;
@@ -136,7 +136,7 @@ public:
 
 private:
 	void _update_map(RID p_map);
-	void _update_position(const Vector3 p_position);
+	void _update_position(const Vector3 &p_position);
 	void _update_transform();
 	void _update_use_3d_avoidance(bool p_use_3d_avoidance);
 };

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -876,7 +876,7 @@ void Node3D::update_gizmos() {
 #endif
 }
 
-void Node3D::set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform) {
+void Node3D::set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, const Transform3D &p_transform) {
 	ERR_THREAD_GUARD;
 #ifdef TOOLS_ENABLED
 	if (!is_inside_world()) {
@@ -1259,12 +1259,12 @@ void Node3D::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target
 	set_scale(original_scale);
 }
 
-Vector3 Node3D::to_local(Vector3 p_global) const {
+Vector3 Node3D::to_local(const Vector3 &p_global) const {
 	ERR_READ_THREAD_GUARD_V(Vector3());
 	return get_global_transform().affine_inverse().xform(p_global);
 }
 
-Vector3 Node3D::to_global(Vector3 p_local) const {
+Vector3 Node3D::to_global(const Vector3 &p_local) const {
 	ERR_READ_THREAD_GUARD_V(Vector3());
 	return get_global_transform().xform(p_local);
 }

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -293,7 +293,7 @@ public:
 
 	void set_disable_gizmos(bool p_enabled);
 	void update_gizmos();
-	void set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform = Transform3D());
+	void set_subgizmo_selection(Ref<Node3DGizmo> p_gizmo, int p_id, const Transform3D &p_transform = Transform3D());
 	void clear_subgizmo_selection();
 	Vector<Ref<Node3DGizmo>> get_gizmos() const;
 	TypedArray<Node3DGizmo> get_gizmos_bind() const;
@@ -330,8 +330,8 @@ public:
 	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
-	Vector3 to_local(Vector3 p_global) const;
-	Vector3 to_global(Vector3 p_local) const;
+	Vector3 to_local(const Vector3 &p_global) const;
+	Vector3 to_global(const Vector3 &p_local) const;
 
 	void set_notify_transform(bool p_enabled);
 	bool is_transform_notification_enabled() const;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -373,7 +373,7 @@ PackedStringArray PathFollow3D::get_configuration_warnings() const {
 	return warnings;
 }
 
-Transform3D PathFollow3D::correct_posture(Transform3D p_transform, PathFollow3D::RotationMode p_rotation_mode) {
+Transform3D PathFollow3D::correct_posture(const Transform3D &p_transform, PathFollow3D::RotationMode p_rotation_mode) {
 	Transform3D t = p_transform;
 
 	// Modify frame according to rotation mode.

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -134,7 +134,7 @@ public:
 
 	void update_transform();
 
-	static Transform3D correct_posture(Transform3D p_transform, PathFollow3D::RotationMode p_rotation_mode);
+	static Transform3D correct_posture(const Transform3D &p_transform, PathFollow3D::RotationMode p_rotation_mode);
 };
 
 VARIANT_ENUM_CAST(PathFollow3D::RotationMode);

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -63,7 +63,7 @@ ReflectionProbe::AmbientMode ReflectionProbe::get_ambient_mode() const {
 	return ambient_mode;
 }
 
-void ReflectionProbe::set_ambient_color(Color p_ambient) {
+void ReflectionProbe::set_ambient_color(const Color &p_ambient) {
 	ambient_color = p_ambient;
 	RS::get_singleton()->reflection_probe_set_ambient_color(probe, p_ambient);
 }

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -84,7 +84,7 @@ public:
 	void set_ambient_mode(AmbientMode p_mode);
 	AmbientMode get_ambient_mode() const;
 
-	void set_ambient_color(Color p_ambient);
+	void set_ambient_color(const Color &p_ambient);
 	Color get_ambient_color() const;
 
 	void set_ambient_color_energy(float p_energy);

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -126,7 +126,7 @@ bool FabrikInverseKinematic::build_chain(Task *p_task, bool p_force_simple_chain
 	return true;
 }
 
-void FabrikInverseKinematic::solve_simple(Task *p_task, bool p_solve_magnet, Vector3 p_origin_pos) {
+void FabrikInverseKinematic::solve_simple(Task *p_task, bool p_solve_magnet, const Vector3 &p_origin_pos) {
 	real_t distance_to_goal(1e4);
 	real_t previous_distance_to_goal(0);
 	int can_solve(p_task->max_iterations);
@@ -173,7 +173,7 @@ void FabrikInverseKinematic::solve_simple_backwards(const Chain &r_chain, bool p
 	}
 }
 
-void FabrikInverseKinematic::solve_simple_forwards(Chain &r_chain, bool p_solve_magnet, Vector3 p_origin_pos) {
+void FabrikInverseKinematic::solve_simple_forwards(Chain &r_chain, bool p_solve_magnet, const Vector3 &p_origin_pos) {
 	if (p_solve_magnet && !r_chain.middle_chain_item) {
 		return;
 	}

--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -96,10 +96,10 @@ private:
 	/// Init a chain that starts from the root to tip
 	static bool build_chain(Task *p_task, bool p_force_simple_chain = true);
 
-	static void solve_simple(Task *p_task, bool p_solve_magnet, Vector3 p_origin_pos);
+	static void solve_simple(Task *p_task, bool p_solve_magnet, const Vector3 &p_origin_pos);
 	/// Special solvers that solve only chains with one end effector
 	static void solve_simple_backwards(const Chain &r_chain, bool p_solve_magnet);
-	static void solve_simple_forwards(Chain &r_chain, bool p_solve_magnet, Vector3 p_origin_pos);
+	static void solve_simple_forwards(Chain &r_chain, bool p_solve_magnet, const Vector3 &p_origin_pos);
 
 public:
 	static Task *create_simple_task(Skeleton3D *p_sk, BoneId root_bone, BoneId tip_bone, const Transform3D &goal_transform);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -96,7 +96,7 @@ void SpriteBase3D::_notification(int p_what) {
 	}
 }
 
-void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect) {
+void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, const Rect2 &p_dst_rect, const Rect2 &p_src_rect) {
 	ERR_FAIL_COND(p_texture.is_null());
 
 	Rect2 final_rect;

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -104,7 +104,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _draw() = 0;
-	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
+	void draw_texture_rect(Ref<Texture2D> p_texture, const Rect2 &p_dst_rect, const Rect2 &p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
 	_FORCE_INLINE_ RID &get_material() { return material; }

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -420,7 +420,7 @@ Variant GeometryInstance3D::get_instance_shader_parameter(const StringName &p_na
 	return RS::get_singleton()->instance_geometry_get_shader_parameter(get_instance(), p_name);
 }
 
-void GeometryInstance3D::set_custom_aabb(AABB p_aabb) {
+void GeometryInstance3D::set_custom_aabb(const AABB &p_aabb) {
 	if (p_aabb == custom_aabb) {
 		return;
 	}

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -202,7 +202,7 @@ public:
 	void set_instance_shader_parameter(const StringName &p_name, const Variant &p_value);
 	Variant get_instance_shader_parameter(const StringName &p_name) const;
 
-	void set_custom_aabb(AABB p_aabb);
+	void set_custom_aabb(const AABB &p_aabb);
 	AABB get_custom_aabb() const;
 
 	void set_ignore_occlusion_culling(bool p_enabled);

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -578,7 +578,7 @@ void XRController3D::_input_float_changed(const String &p_name, float p_value) {
 	emit_signal(SNAME("input_float_changed"), p_name, p_value);
 }
 
-void XRController3D::_input_vector2_changed(const String &p_name, Vector2 p_value) {
+void XRController3D::_input_vector2_changed(const String &p_name, const Vector2 &p_value) {
 	emit_signal(SNAME("input_vector2_changed"), p_name, p_value);
 }
 

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -143,7 +143,7 @@ protected:
 	void _button_pressed(const String &p_name);
 	void _button_released(const String &p_name);
 	void _input_float_changed(const String &p_name, float p_value);
-	void _input_vector2_changed(const String &p_name, Vector2 p_value);
+	void _input_vector2_changed(const String &p_name, const Vector2 &p_value);
 	void _profile_changed(const String &p_role);
 
 public:

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -1151,7 +1151,7 @@ void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_
 	}
 }
 
-void RuntimeNodeSelect::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
+void RuntimeNodeSelect::_pan_callback(const Vector2 &p_scroll_vec, Ref<InputEvent> p_event) {
 	Vector2 scroll = SceneTree::get_singleton()->get_root()->get_screen_transform().affine_inverse().xform(p_scroll_vec);
 	view_2d_offset.x -= scroll.x / view_2d_zoom;
 	view_2d_offset.y -= scroll.y / view_2d_zoom;
@@ -1160,7 +1160,7 @@ void RuntimeNodeSelect::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_ev
 }
 
 // A very shallow copy of the same function inside CanvasItemEditor.
-void RuntimeNodeSelect::_zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event) {
+void RuntimeNodeSelect::_zoom_callback(float p_zoom_factor, const Vector2 &p_origin, Ref<InputEvent> p_event) {
 	real_t prev_zoom = view_2d_zoom;
 	view_2d_zoom = CLAMP(view_2d_zoom * p_zoom_factor, VIEW_2D_MIN_ZOOM, VIEW_2D_MAX_ZOOM);
 

--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -181,8 +181,8 @@ private:
 
 	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	void _find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
-	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
-	void _zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event);
+	void _pan_callback(const Vector2 &p_scroll_vec, Ref<InputEvent> p_event);
+	void _zoom_callback(float p_zoom_factor, const Vector2 &p_origin, Ref<InputEvent> p_event);
 	void _reset_camera_2d();
 	void _update_view_2d();
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2672,7 +2672,7 @@ void ColorPresetButton::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPresetButton, overbright_indicator);
 }
 
-ColorPresetButton::ColorPresetButton(Color p_color, int p_size, bool p_recent) {
+ColorPresetButton::ColorPresetButton(const Color &p_color, int p_size, bool p_recent) {
 	preset_color = p_color;
 	recent = p_recent;
 	set_toggle_mode(true);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -75,7 +75,7 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	ColorPresetButton(Color p_color, int p_size, bool p_recent);
+	ColorPresetButton(const Color &p_color, int p_size, bool p_recent);
 	~ColorPresetButton();
 };
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -948,7 +948,7 @@ Control::GrowDirection Control::get_v_grow_direction() const {
 	return data.v_grow;
 }
 
-void Control::_compute_layout_rect(Rect2 p_rect, bool p_keep_offsets) {
+void Control::_compute_layout_rect(const Rect2 &p_rect, bool p_keep_offsets) {
 	Size2 parent_rect_size = get_parent_anchorable_rect().size;
 
 	if (p_keep_offsets) {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -365,7 +365,7 @@ private:
 	void _set_global_position(const Point2 &p_point);
 	void _set_size(const Size2 &p_size);
 
-	void _compute_layout_rect(Rect2 p_rect, bool p_keep_offsets = false);
+	void _compute_layout_rect(const Rect2 &p_rect, bool p_keep_offsets = false);
 
 	void _set_layout_mode(LayoutMode p_mode);
 	void _update_layout_mode();

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2328,7 +2328,7 @@ void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 	}
 }
 
-void GraphEdit::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
+void GraphEdit::_pan_callback(const Vector2 &p_scroll_vec, Ref<InputEvent> p_event) {
 	ERR_FAIL_NULL_MSG(connections_layer, "connections_layer is missing.");
 
 	scroll_offset = (scroll_offset - p_scroll_vec).clamp(min_scroll_offset, max_scroll_offset - get_size());
@@ -2343,7 +2343,7 @@ void GraphEdit::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
 	connections_layer->queue_redraw();
 }
 
-void GraphEdit::_zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event) {
+void GraphEdit::_zoom_callback(float p_zoom_factor, const Vector2 &p_origin, Ref<InputEvent> p_event) {
 	// We need to invalidate all connections since we don't know whether
 	// the user is zooming/panning at the same time.
 	_invalidate_connection_line_cache();
@@ -2772,7 +2772,7 @@ void GraphEdit::_show_grid_toggled() {
 	queue_redraw();
 }
 
-void GraphEdit::set_minimap_size(Vector2 p_size) {
+void GraphEdit::set_minimap_size(const Vector2 &p_size) {
 	minimap->set_size(p_size);
 	Vector2 minimap_size = minimap->get_size(); // The size might've been adjusted by the minimum size.
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -312,8 +312,8 @@ private:
 
 	Dictionary type_names;
 
-	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
-	void _zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event);
+	void _pan_callback(const Vector2 &p_scroll_vec, Ref<InputEvent> p_event);
+	void _zoom_callback(float p_zoom_factor, const Vector2 &p_origin, Ref<InputEvent> p_event);
 
 	void _zoom_minus();
 	void _zoom_reset();
@@ -464,7 +464,7 @@ public:
 	void set_zoom_step(float p_zoom_step);
 	float get_zoom_step() const;
 
-	void set_minimap_size(Vector2 p_size);
+	void set_minimap_size(const Vector2 &p_size);
 	Vector2 get_minimap_size() const;
 	void set_minimap_opacity(float p_opacity);
 	float get_minimap_opacity() const;

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -76,7 +76,7 @@ public:
 	void set_offset(Point2 p_offset) { offset = p_offset; }
 
 	Color get_color() { return color; }
-	void set_color(Color p_color) { color = p_color; }
+	void set_color(const Color &p_color) { color = p_color; }
 
 	uint32_t get_glyph_index() const { return glyph_index; }
 	void set_glyph_index(uint32_t p_glyph_index) { glyph_index = p_glyph_index; }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2140,7 +2140,7 @@ void TextEdit::_notification(int p_what) {
 	}
 }
 
-void TextEdit::_draw_selection_handle(Vector2 p_pos) const {
+void TextEdit::_draw_selection_handle(const Vector2 &p_pos) const {
 	Color handle_color = theme_cache.caret_color;
 	int line_height = get_line_height();
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -534,7 +534,7 @@ private:
 	bool selection_handle_enabled = true;
 	Vector<Point2i> _get_selection_handles_pos(int p_cursor) const;
 	bool _is_first_column(int p_line, int p_column) const;
-	void _draw_selection_handle(Vector2 p_pos) const;
+	void _draw_selection_handle(const Vector2 &p_pos) const;
 
 	void _cancel_inertial_scroll();
 

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -35,7 +35,7 @@
 #include "core/os/keyboard.h"
 #include "scene/main/viewport.h"
 
-bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) {
+bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, const Rect2 &p_canvas_rect) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
 		Vector2 scroll_vec = Vector2((mb->get_button_index() == MouseButton::WHEEL_RIGHT) - (mb->get_button_index() == MouseButton::WHEEL_LEFT), (mb->get_button_index() == MouseButton::WHEEL_DOWN) - (mb->get_button_index() == MouseButton::WHEEL_UP));

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -105,7 +105,7 @@ public:
 	bool is_panning() const;
 	void set_force_drag(bool p_force);
 
-	bool gui_input(const Ref<InputEvent> &p_ev, Rect2 p_canvas_rect = Rect2());
+	bool gui_input(const Ref<InputEvent> &p_ev, const Rect2 &p_canvas_rect = Rect2());
 	void release_pan_key();
 
 	ViewPanner();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3285,7 +3285,7 @@ void Viewport::_update_mouse_over(const Ref<InputEventMouse> &p_mm) {
 	}
 }
 
-void Viewport::_update_mouse_over(Vector2 p_pos) {
+void Viewport::_update_mouse_over(const Vector2 &p_pos) {
 	gui.last_mouse_pos = p_pos; // Necessary, because mouse cursor can be over Viewports that are not reached by the InputEvent.
 	// Look for embedded windows at mouse position.
 	if (is_embedding_subwindows()) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -504,7 +504,7 @@ private:
 	SubWindowResize _sub_window_get_resize_margin(Window *p_subwindow, const Point2 &p_point);
 
 	void _update_mouse_over(const Ref<InputEventMouse> &p_mm);
-	virtual void _update_mouse_over(Vector2 p_pos);
+	virtual void _update_mouse_over(const Vector2 &p_pos);
 	virtual void _mouse_leave_viewport();
 
 	virtual bool _can_consume_input_events() const { return true; }

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3309,7 +3309,7 @@ bool Window::is_attached_in_viewport() const {
 	return get_embedder();
 }
 
-void Window::_update_mouse_over(Vector2 p_pos) {
+void Window::_update_mouse_over(const Vector2 &p_pos) {
 	if (!mouse_in_window) {
 		if (is_embedded()) {
 			mouse_in_window = true;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -259,7 +259,7 @@ private:
 	virtual bool _can_consume_input_events() const override;
 
 	bool mouse_in_window = false;
-	void _update_mouse_over(Vector2 p_pos) override;
+	void _update_mouse_over(const Vector2 &p_pos) override;
 	void _mouse_leave_viewport() override;
 
 	void _update_displayed_title();

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
@@ -408,7 +408,7 @@ int SkeletonModification2DFABRIK::get_fabrik_joint_bone_index(int p_joint_idx) c
 	return fabrik_data_chain[p_joint_idx].bone_idx;
 }
 
-void SkeletonModification2DFABRIK::set_fabrik_joint_magnet_position(int p_joint_idx, Vector2 p_magnet_position) {
+void SkeletonModification2DFABRIK::set_fabrik_joint_magnet_position(int p_joint_idx, const Vector2 &p_magnet_position) {
 	ERR_FAIL_INDEX_MSG(p_joint_idx, fabrik_data_chain.size(), "FABRIK joint out of range!");
 	fabrik_data_chain.write[p_joint_idx].magnet_position = p_magnet_position;
 }

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.h
@@ -95,7 +95,7 @@ public:
 	void set_fabrik_joint_bone_index(int p_joint_idx, int p_bone_idx);
 	int get_fabrik_joint_bone_index(int p_joint_idx) const;
 
-	void set_fabrik_joint_magnet_position(int p_joint_idx, Vector2 p_magnet_position);
+	void set_fabrik_joint_magnet_position(int p_joint_idx, const Vector2 &p_magnet_position);
 	Vector2 get_fabrik_joint_magnet_position(int p_joint_idx) const;
 	void set_fabrik_joint_use_target_rotation(int p_joint_idx, bool p_use_target_rotation);
 	bool get_fabrik_joint_use_target_rotation(int p_joint_idx) const;

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
@@ -365,7 +365,7 @@ bool SkeletonModification2DJiggle::get_use_gravity() const {
 	return use_gravity;
 }
 
-void SkeletonModification2DJiggle::set_gravity(Vector2 p_gravity) {
+void SkeletonModification2DJiggle::set_gravity(const Vector2 &p_gravity) {
 	gravity = p_gravity;
 	_update_jiggle_joint_data();
 }
@@ -497,7 +497,7 @@ bool SkeletonModification2DJiggle::get_jiggle_joint_use_gravity(int p_joint_idx)
 	return jiggle_data_chain[p_joint_idx].use_gravity;
 }
 
-void SkeletonModification2DJiggle::set_jiggle_joint_gravity(int p_joint_idx, Vector2 p_gravity) {
+void SkeletonModification2DJiggle::set_jiggle_joint_gravity(int p_joint_idx, const Vector2 &p_gravity) {
 	ERR_FAIL_INDEX(p_joint_idx, jiggle_data_chain.size());
 	jiggle_data_chain.write[p_joint_idx].gravity = p_gravity;
 }

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.h
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.h
@@ -103,7 +103,7 @@ public:
 	float get_damping() const;
 	void set_use_gravity(bool p_use_gravity);
 	bool get_use_gravity() const;
-	void set_gravity(Vector2 p_gravity);
+	void set_gravity(const Vector2 &p_gravity);
 	Vector2 get_gravity() const;
 
 	void set_use_colliders(bool p_use_colliders);
@@ -129,7 +129,7 @@ public:
 	float get_jiggle_joint_damping(int p_joint_idx) const;
 	void set_jiggle_joint_use_gravity(int p_joint_idx, bool p_use_gravity);
 	bool get_jiggle_joint_use_gravity(int p_joint_idx) const;
-	void set_jiggle_joint_gravity(int p_joint_idx, Vector2 p_gravity);
+	void set_jiggle_joint_gravity(int p_joint_idx, const Vector2 &p_gravity);
 	Vector2 get_jiggle_joint_gravity(int p_joint_idx) const;
 
 	SkeletonModification2DJiggle();

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -95,7 +95,7 @@ Vector<int> TileMapPattern::_get_tile_data() const {
 	return data;
 }
 
-void TileMapPattern::set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile) {
+void TileMapPattern::set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) {
 	ERR_FAIL_COND_MSG(p_coords.x < 0 || p_coords.y < 0, vformat("Cannot set cell with negative coords in a TileMapPattern. Wrong coords: %s", p_coords));
 
 	size = size.max(p_coords + Vector2i(1, 1));
@@ -1187,7 +1187,7 @@ void TileSet::remove_source_level_tile_proxy(int p_source_from) {
 	emit_changed();
 }
 
-void TileSet::set_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_source_to, Vector2i p_coords_to) {
+void TileSet::set_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_source_to, const Vector2i &p_coords_to) {
 	ERR_FAIL_COND(p_source_from == TileSet::INVALID_SOURCE || p_source_to == TileSet::INVALID_SOURCE);
 	ERR_FAIL_COND(p_coords_from == TileSetSource::INVALID_ATLAS_COORDS || p_coords_to == TileSetSource::INVALID_ATLAS_COORDS);
 
@@ -1198,18 +1198,18 @@ void TileSet::set_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_f
 	emit_changed();
 }
 
-Array TileSet::get_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
+Array TileSet::get_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from) {
 	Array from = { p_source_from, p_coords_from };
 	ERR_FAIL_COND_V(!coords_level_proxies.has(from), Array());
 	return coords_level_proxies[from];
 }
 
-bool TileSet::has_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
+bool TileSet::has_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from) {
 	Array from = { p_source_from, p_coords_from };
 	return coords_level_proxies.has(from);
 }
 
-void TileSet::remove_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from) {
+void TileSet::remove_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from) {
 	Array from = { p_source_from, p_coords_from };
 	ERR_FAIL_COND(!coords_level_proxies.has(from));
 
@@ -1218,7 +1218,7 @@ void TileSet::remove_coords_level_tile_proxy(int p_source_from, Vector2i p_coord
 	emit_changed();
 }
 
-void TileSet::set_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from, int p_source_to, Vector2i p_coords_to, int p_alternative_to) {
+void TileSet::set_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from, int p_source_to, const Vector2i &p_coords_to, int p_alternative_to) {
 	ERR_FAIL_COND(p_source_from == TileSet::INVALID_SOURCE || p_source_to == TileSet::INVALID_SOURCE);
 	ERR_FAIL_COND(p_coords_from == TileSetSource::INVALID_ATLAS_COORDS || p_coords_to == TileSetSource::INVALID_ATLAS_COORDS);
 
@@ -1229,19 +1229,19 @@ void TileSet::set_alternative_level_tile_proxy(int p_source_from, Vector2i p_coo
 	emit_changed();
 }
 
-Array TileSet::get_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
+Array TileSet::get_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from) {
 	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	ERR_FAIL_COND_V(!alternative_level_proxies.has(from), Array());
 
 	return alternative_level_proxies[from];
 }
 
-bool TileSet::has_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
+bool TileSet::has_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from) {
 	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	return alternative_level_proxies.has(from);
 }
 
-void TileSet::remove_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) {
+void TileSet::remove_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from) {
 	Array from = { p_source_from, p_coords_from, p_alternative_from };
 	ERR_FAIL_COND(!alternative_level_proxies.has(from));
 
@@ -1283,7 +1283,7 @@ Array TileSet::get_alternative_level_tile_proxies() const {
 	return output;
 }
 
-Array TileSet::map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) const {
+Array TileSet::map_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from) const {
 	Array from = { p_source_from, p_coords_from, p_alternative_from };
 
 	// Check if the tile is valid, and if so, don't map the tile and return the input.
@@ -1500,7 +1500,7 @@ Vector<Vector2> TileSet::get_tile_shape_polygon() const {
 	return points;
 }
 
-void TileSet::draw_tile_shape(CanvasItem *p_canvas_item, Transform2D p_transform, Color p_color, bool p_filled, Ref<Texture2D> p_texture) const {
+void TileSet::draw_tile_shape(CanvasItem *p_canvas_item, const Transform2D &p_transform, const Color &p_color, bool p_filled, Ref<Texture2D> p_texture) const {
 	if (tile_meshes_dirty) {
 		Vector<Vector2> shape = get_tile_shape_polygon();
 		Vector<Vector2> uvs;
@@ -2203,7 +2203,7 @@ Vector2i TileSet::map_pattern(const Vector2i &p_position_in_tilemap, const Vecto
 	return output;
 }
 
-void TileSet::draw_cells_outline(CanvasItem *p_canvas_item, const RBSet<Vector2i> &p_cells, Color p_color, Transform2D p_transform) const {
+void TileSet::draw_cells_outline(CanvasItem *p_canvas_item, const RBSet<Vector2i> &p_cells, const Color &p_color, const Transform2D &p_transform) const {
 	Vector<Vector2> polygon = get_tile_shape_polygon();
 	for (const Vector2i &E : p_cells) {
 		Vector2 center = map_to_local(E);
@@ -2312,7 +2312,7 @@ Vector<Point2> TileSet::get_terrain_peering_bit_polygon(int p_terrain_set, TileS
 
 #define TERRAIN_ALPHA 0.6
 
-void TileSet::draw_terrains(CanvasItem *p_canvas_item, Transform2D p_transform, const TileData *p_tile_data) {
+void TileSet::draw_terrains(CanvasItem *p_canvas_item, const Transform2D &p_transform, const TileData *p_tile_data) {
 	ERR_FAIL_NULL(p_tile_data);
 
 	if (terrain_bits_meshes_dirty) {
@@ -2554,7 +2554,7 @@ void TileSet::_source_changed() {
 	emit_changed();
 }
 
-Vector<Point2> TileSet::_get_square_terrain_polygon(Vector2i p_size) {
+Vector<Point2> TileSet::_get_square_terrain_polygon(const Vector2i &p_size) {
 	Rect2 rect(-Vector2(p_size) / 6.0, Vector2(p_size) / 3.0);
 	return {
 		rect.position,
@@ -2564,7 +2564,7 @@ Vector<Point2> TileSet::_get_square_terrain_polygon(Vector2i p_size) {
 	};
 }
 
-Vector<Point2> TileSet::_get_square_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_square_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Rect2 bit_rect;
 	bit_rect.size = Vector2(p_size) / 3;
 	switch (p_bit) {
@@ -2607,7 +2607,7 @@ Vector<Point2> TileSet::_get_square_corner_or_side_terrain_peering_bit_polygon(V
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_square_corner_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_square_corner_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	Vector<Vector2> polygon;
 	switch (p_bit) {
@@ -2649,7 +2649,7 @@ Vector<Point2> TileSet::_get_square_corner_terrain_peering_bit_polygon(Vector2i 
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_square_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_square_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	Vector<Vector2> polygon;
 	switch (p_bit) {
@@ -2683,7 +2683,7 @@ Vector<Point2> TileSet::_get_square_side_terrain_peering_bit_polygon(Vector2i p_
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_isometric_terrain_polygon(Vector2i p_size) {
+Vector<Point2> TileSet::_get_isometric_terrain_polygon(const Vector2i &p_size) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	return {
 		Vector2(1, 0) * unit,
@@ -2693,7 +2693,7 @@ Vector<Point2> TileSet::_get_isometric_terrain_polygon(Vector2i p_size) {
 	};
 }
 
-Vector<Point2> TileSet::_get_isometric_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_isometric_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	Vector<Vector2> polygon;
 	switch (p_bit) {
@@ -2751,7 +2751,7 @@ Vector<Point2> TileSet::_get_isometric_corner_or_side_terrain_peering_bit_polygo
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_isometric_corner_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_isometric_corner_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	Vector<Vector2> polygon;
 	switch (p_bit) {
@@ -2793,7 +2793,7 @@ Vector<Point2> TileSet::_get_isometric_corner_terrain_peering_bit_polygon(Vector
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_isometric_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_isometric_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	Vector<Vector2> polygon;
 	switch (p_bit) {
@@ -2827,7 +2827,7 @@ Vector<Point2> TileSet::_get_isometric_side_terrain_peering_bit_polygon(Vector2i
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_half_offset_terrain_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis) {
+Vector<Point2> TileSet::_get_half_offset_terrain_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis) {
 	Vector2 unit = Vector2(p_size) / 6.0;
 	if (p_offset_axis == TileSet::TILE_OFFSET_AXIS_HORIZONTAL) {
 		return {
@@ -2850,7 +2850,7 @@ Vector<Point2> TileSet::_get_half_offset_terrain_polygon(Vector2i p_size, float 
 	}
 }
 
-Vector<Point2> TileSet::_get_half_offset_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_half_offset_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
 	Vector<Vector2> point_list = {
 		Vector2(3, (3.0 * (1.0 - p_overlap * 2.0)) / 2.0),
 		Vector2(3, 3.0 * (1.0 - p_overlap * 2.0)),
@@ -3008,7 +3008,7 @@ Vector<Point2> TileSet::_get_half_offset_corner_or_side_terrain_peering_bit_poly
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_half_offset_corner_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_half_offset_corner_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
 	Vector<Vector2> point_list = {
 		Vector2(3, 0),
 		Vector2(3, 3.0 * (1.0 - p_overlap * 2.0)),
@@ -3112,7 +3112,7 @@ Vector<Point2> TileSet::_get_half_offset_corner_terrain_peering_bit_polygon(Vect
 	return polygon;
 }
 
-Vector<Point2> TileSet::_get_half_offset_side_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
+Vector<Point2> TileSet::_get_half_offset_side_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit) {
 	Vector<Vector2> point_list = {
 		Vector2(3, 3.0 * (1.0 - p_overlap * 2.0)),
 		Vector2(0, 3),
@@ -3638,7 +3638,7 @@ void TileSet::_compatibility_conversion() {
 	compatibility_data = HashMap<int, CompatibilityTileData *>();
 }
 
-Array TileSet::compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose) {
+Array TileSet::compatibility_tilemap_map(int p_tile_id, const Vector2i &p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose) {
 	Array cannot_convert_array = {
 		TileSet::INVALID_SOURCE,
 		TileSetAtlasSource::INVALID_ATLAS_COORDS,
@@ -4678,7 +4678,7 @@ Ref<Texture2D> TileSetAtlasSource::get_texture() const {
 	return texture;
 }
 
-void TileSetAtlasSource::set_margins(Vector2i p_margins) {
+void TileSetAtlasSource::set_margins(const Vector2i &p_margins) {
 	if (p_margins.x < 0 || p_margins.y < 0) {
 		WARN_PRINT("Atlas source margins should be positive.");
 		margins = p_margins.maxi(0);
@@ -4694,7 +4694,7 @@ Vector2i TileSetAtlasSource::get_margins() const {
 	return margins;
 }
 
-void TileSetAtlasSource::set_separation(Vector2i p_separation) {
+void TileSetAtlasSource::set_separation(const Vector2i &p_separation) {
 	if (p_separation.x < 0 || p_separation.y < 0) {
 		WARN_PRINT("Atlas source separation should be positive.");
 		separation = p_separation.maxi(0);
@@ -4710,7 +4710,7 @@ Vector2i TileSetAtlasSource::get_separation() const {
 	return separation;
 }
 
-void TileSetAtlasSource::set_texture_region_size(Vector2i p_tile_size) {
+void TileSetAtlasSource::set_texture_region_size(const Vector2i &p_tile_size) {
 	if (p_tile_size.x <= 0 || p_tile_size.y <= 0) {
 		WARN_PRINT("Atlas source tile_size should be strictly positive.");
 		texture_region_size = p_tile_size.maxi(1);
@@ -4989,7 +4989,7 @@ void TileSetAtlasSource::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-void TileSetAtlasSource::create_tile(const Vector2i p_atlas_coords, const Vector2i p_size) {
+void TileSetAtlasSource::create_tile(const Vector2i &p_atlas_coords, const Vector2i &p_size) {
 	// Create a tile if it does not exists.
 	ERR_FAIL_COND(p_atlas_coords.x < 0 || p_atlas_coords.y < 0);
 	ERR_FAIL_COND(p_size.x <= 0 || p_size.y <= 0);
@@ -5019,7 +5019,7 @@ void TileSetAtlasSource::create_tile(const Vector2i p_atlas_coords, const Vector
 	_try_emit_changed();
 }
 
-void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
+void TileSetAtlasSource::remove_tile(const Vector2i &p_atlas_coords) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 
 	// Remove all covered positions from the mapping cache
@@ -5040,11 +5040,11 @@ void TileSetAtlasSource::remove_tile(Vector2i p_atlas_coords) {
 	_try_emit_changed();
 }
 
-bool TileSetAtlasSource::has_tile(Vector2i p_atlas_coords) const {
+bool TileSetAtlasSource::has_tile(const Vector2i &p_atlas_coords) const {
 	return tiles.has(p_atlas_coords);
 }
 
-Vector2i TileSetAtlasSource::get_tile_at_coords(Vector2i p_atlas_coords) const {
+Vector2i TileSetAtlasSource::get_tile_at_coords(const Vector2i &p_atlas_coords) const {
 	if (!_coords_mapping_cache.has(p_atlas_coords)) {
 		return INVALID_ATLAS_COORDS;
 	}
@@ -5052,7 +5052,7 @@ Vector2i TileSetAtlasSource::get_tile_at_coords(Vector2i p_atlas_coords) const {
 	return _coords_mapping_cache[p_atlas_coords];
 }
 
-void TileSetAtlasSource::set_tile_animation_columns(const Vector2i p_atlas_coords, int p_frame_columns) {
+void TileSetAtlasSource::set_tile_animation_columns(const Vector2i &p_atlas_coords, int p_frame_columns) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_COND(p_frame_columns < 0);
 
@@ -5070,12 +5070,12 @@ void TileSetAtlasSource::set_tile_animation_columns(const Vector2i p_atlas_coord
 	_try_emit_changed();
 }
 
-int TileSetAtlasSource::get_tile_animation_columns(const Vector2i p_atlas_coords) const {
+int TileSetAtlasSource::get_tile_animation_columns(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	return tiles[p_atlas_coords].animation_columns;
 }
 
-void TileSetAtlasSource::set_tile_animation_separation(const Vector2i p_atlas_coords, const Vector2i p_separation) {
+void TileSetAtlasSource::set_tile_animation_separation(const Vector2i &p_atlas_coords, const Vector2i &p_separation) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_COND(p_separation.x < 0 || p_separation.y < 0);
 
@@ -5093,12 +5093,12 @@ void TileSetAtlasSource::set_tile_animation_separation(const Vector2i p_atlas_co
 	_try_emit_changed();
 }
 
-Vector2i TileSetAtlasSource::get_tile_animation_separation(const Vector2i p_atlas_coords) const {
+Vector2i TileSetAtlasSource::get_tile_animation_separation(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Vector2i(), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	return tiles[p_atlas_coords].animation_separation;
 }
 
-void TileSetAtlasSource::set_tile_animation_speed(const Vector2i p_atlas_coords, real_t p_speed) {
+void TileSetAtlasSource::set_tile_animation_speed(const Vector2i &p_atlas_coords, real_t p_speed) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_COND(p_speed <= 0);
 
@@ -5107,12 +5107,12 @@ void TileSetAtlasSource::set_tile_animation_speed(const Vector2i p_atlas_coords,
 	_try_emit_changed();
 }
 
-real_t TileSetAtlasSource::get_tile_animation_speed(const Vector2i p_atlas_coords) const {
+real_t TileSetAtlasSource::get_tile_animation_speed(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1.0, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	return tiles[p_atlas_coords].animation_speed;
 }
 
-void TileSetAtlasSource::set_tile_animation_mode(const Vector2i p_atlas_coords, TileSetAtlasSource::TileAnimationMode p_mode) {
+void TileSetAtlasSource::set_tile_animation_mode(const Vector2i &p_atlas_coords, TileSetAtlasSource::TileAnimationMode p_mode) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 
 	tiles[p_atlas_coords].animation_mode = p_mode;
@@ -5120,13 +5120,13 @@ void TileSetAtlasSource::set_tile_animation_mode(const Vector2i p_atlas_coords, 
 	_try_emit_changed();
 }
 
-TileSetAtlasSource::TileAnimationMode TileSetAtlasSource::get_tile_animation_mode(const Vector2i p_atlas_coords) const {
+TileSetAtlasSource::TileAnimationMode TileSetAtlasSource::get_tile_animation_mode(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), TILE_ANIMATION_MODE_DEFAULT, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 
 	return tiles[p_atlas_coords].animation_mode;
 }
 
-void TileSetAtlasSource::set_tile_animation_frames_count(const Vector2i p_atlas_coords, int p_frames_count) {
+void TileSetAtlasSource::set_tile_animation_frames_count(const Vector2i &p_atlas_coords, int p_frames_count) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_COND(p_frames_count < 1);
 
@@ -5154,12 +5154,12 @@ void TileSetAtlasSource::set_tile_animation_frames_count(const Vector2i p_atlas_
 	_try_emit_changed();
 }
 
-int TileSetAtlasSource::get_tile_animation_frames_count(const Vector2i p_atlas_coords) const {
+int TileSetAtlasSource::get_tile_animation_frames_count(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	return tiles[p_atlas_coords].animation_frames_durations.size();
 }
 
-void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index, real_t p_duration) {
+void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i &p_atlas_coords, int p_frame_index, real_t p_duration) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_INDEX(p_frame_index, (int)tiles[p_atlas_coords].animation_frames_durations.size());
 	ERR_FAIL_COND(p_duration <= 0.0);
@@ -5169,13 +5169,13 @@ void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i p_atla
 	_try_emit_changed();
 }
 
-real_t TileSetAtlasSource::get_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index) const {
+real_t TileSetAtlasSource::get_tile_animation_frame_duration(const Vector2i &p_atlas_coords, int p_frame_index) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	ERR_FAIL_INDEX_V(p_frame_index, (int)tiles[p_atlas_coords].animation_frames_durations.size(), 0.0);
 	return tiles[p_atlas_coords].animation_frames_durations[p_frame_index];
 }
 
-real_t TileSetAtlasSource::get_tile_animation_total_duration(const Vector2i p_atlas_coords) const {
+real_t TileSetAtlasSource::get_tile_animation_total_duration(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 
 	real_t sum = 0.0;
@@ -5185,7 +5185,7 @@ real_t TileSetAtlasSource::get_tile_animation_total_duration(const Vector2i p_at
 	return sum;
 }
 
-Vector2i TileSetAtlasSource::get_tile_size_in_atlas(Vector2i p_atlas_coords) const {
+Vector2i TileSetAtlasSource::get_tile_size_in_atlas(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Vector2i(-1, -1), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 
 	return tiles[p_atlas_coords].size_in_atlas;
@@ -5200,7 +5200,7 @@ Vector2i TileSetAtlasSource::get_tile_id(int p_index) const {
 	return tiles_ids[p_index];
 }
 
-bool TileSetAtlasSource::has_room_for_tile(Vector2i p_atlas_coords, Vector2i p_size, int p_animation_columns, Vector2i p_animation_separation, int p_frames_count, Vector2i p_ignored_tile) const {
+bool TileSetAtlasSource::has_room_for_tile(const Vector2i &p_atlas_coords, const Vector2i &p_size, int p_animation_columns, const Vector2i &p_animation_separation, int p_frames_count, const Vector2i &p_ignored_tile) const {
 	if (p_atlas_coords.x < 0 || p_atlas_coords.y < 0) {
 		return false;
 	}
@@ -5262,7 +5262,7 @@ void TileSetAtlasSource::clear_tiles_outside_texture() {
 	}
 }
 
-PackedVector2Array TileSetAtlasSource::get_tiles_to_be_removed_on_change(Ref<Texture2D> p_texture, Vector2i p_margins, Vector2i p_separation, Vector2i p_texture_region_size) {
+PackedVector2Array TileSetAtlasSource::get_tiles_to_be_removed_on_change(Ref<Texture2D> p_texture, const Vector2i &p_margins, const Vector2i &p_separation, const Vector2i &p_texture_region_size) {
 	ERR_FAIL_COND_V(p_margins.x < 0 || p_margins.y < 0, PackedVector2Array());
 	ERR_FAIL_COND_V(p_separation.x < 0 || p_separation.y < 0, PackedVector2Array());
 	ERR_FAIL_COND_V(p_texture_region_size.x <= 0 || p_texture_region_size.y <= 0, PackedVector2Array());
@@ -5293,7 +5293,7 @@ PackedVector2Array TileSetAtlasSource::get_tiles_to_be_removed_on_change(Ref<Tex
 	return output;
 }
 
-Rect2i TileSetAtlasSource::get_tile_texture_region(Vector2i p_atlas_coords, int p_frame) const {
+Rect2i TileSetAtlasSource::get_tile_texture_region(const Vector2i &p_atlas_coords, int p_frame) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Rect2i(), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_INDEX_V(p_frame, (int)tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
 
@@ -5308,7 +5308,7 @@ Rect2i TileSetAtlasSource::get_tile_texture_region(Vector2i p_atlas_coords, int 
 	return Rect2(origin, region_size);
 }
 
-bool TileSetAtlasSource::is_position_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Vector2 p_position) const {
+bool TileSetAtlasSource::is_position_in_tile_texture_region(const Vector2i &p_atlas_coords, int p_alternative_tile, const Vector2 &p_position) const {
 	Size2 size = get_tile_texture_region(p_atlas_coords).size;
 	TileData *tile_data = get_tile_data(p_atlas_coords, p_alternative_tile);
 	if (tile_data->get_transpose()) {
@@ -5319,7 +5319,7 @@ bool TileSetAtlasSource::is_position_in_tile_texture_region(const Vector2i p_atl
 	return rect.has_point(p_position);
 }
 
-bool TileSetAtlasSource::is_rect_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Rect2 p_rect) const {
+bool TileSetAtlasSource::is_rect_in_tile_texture_region(const Vector2i &p_atlas_coords, int p_alternative_tile, const Rect2 &p_rect) const {
 	Size2 size = get_tile_texture_region(p_atlas_coords).size;
 	TileData *tile_data = get_tile_data(p_atlas_coords, p_alternative_tile);
 	if (tile_data->get_transpose()) {
@@ -5343,7 +5343,7 @@ Ref<Texture2D> TileSetAtlasSource::get_runtime_texture() const {
 	}
 }
 
-Rect2i TileSetAtlasSource::get_runtime_tile_texture_region(Vector2i p_atlas_coords, int p_frame) const {
+Rect2i TileSetAtlasSource::get_runtime_tile_texture_region(const Vector2i &p_atlas_coords, int p_frame) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Rect2i(), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_INDEX_V(p_frame, (int)tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
 
@@ -5359,7 +5359,7 @@ Rect2i TileSetAtlasSource::get_runtime_tile_texture_region(Vector2i p_atlas_coor
 	}
 }
 
-void TileSetAtlasSource::move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_new_atlas_coords, Vector2i p_new_size) {
+void TileSetAtlasSource::move_tile_in_atlas(const Vector2i &p_atlas_coords, const Vector2i &p_new_atlas_coords, const Vector2i &p_new_size) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 
 	TileAlternativesData &tad = tiles[p_atlas_coords];
@@ -5394,7 +5394,7 @@ void TileSetAtlasSource::move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_
 	_try_emit_changed();
 }
 
-int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_id_override) {
+int TileSetAtlasSource::create_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_id_override) {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), TileSetSource::INVALID_TILE_ALTERNATIVE, vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_COND_V_MSG(p_alternative_id_override >= 0 && tiles[p_atlas_coords].alternatives.has(p_alternative_id_override), TileSetSource::INVALID_TILE_ALTERNATIVE, vformat("Cannot create alternative tile. Another alternative exists with id %d.", p_alternative_id_override));
 
@@ -5414,7 +5414,7 @@ int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, i
 	return new_alternative_id;
 }
 
-void TileSetAtlasSource::remove_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) {
+void TileSetAtlasSource::remove_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_COND_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
 	p_alternative_tile = alternative_no_transform(p_alternative_tile);
@@ -5428,7 +5428,7 @@ void TileSetAtlasSource::remove_alternative_tile(const Vector2i p_atlas_coords, 
 	_try_emit_changed();
 }
 
-void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, int p_alternative_tile, int p_new_id) {
+void TileSetAtlasSource::set_alternative_tile_id(const Vector2i &p_atlas_coords, int p_alternative_tile, int p_new_id) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_COND_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
 	p_alternative_tile = alternative_no_transform(p_alternative_tile);
@@ -5446,22 +5446,22 @@ void TileSetAtlasSource::set_alternative_tile_id(const Vector2i p_atlas_coords, 
 	_try_emit_changed();
 }
 
-bool TileSetAtlasSource::has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const {
+bool TileSetAtlasSource::has_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), false, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
 	return tiles[p_atlas_coords].alternatives.has(alternative_no_transform(p_alternative_tile));
 }
 
-int TileSetAtlasSource::get_next_alternative_tile_id(const Vector2i p_atlas_coords) const {
+int TileSetAtlasSource::get_next_alternative_tile_id(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), TileSetSource::INVALID_TILE_ALTERNATIVE, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
 	return tiles[p_atlas_coords].next_alternative_id;
 }
 
-int TileSetAtlasSource::get_alternative_tiles_count(const Vector2i p_atlas_coords) const {
+int TileSetAtlasSource::get_alternative_tiles_count(const Vector2i &p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), -1, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
 	return tiles[p_atlas_coords].alternatives_ids.size();
 }
 
-int TileSetAtlasSource::get_alternative_tile_id(const Vector2i p_atlas_coords, int p_index) const {
+int TileSetAtlasSource::get_alternative_tile_id(const Vector2i &p_atlas_coords, int p_index) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), TileSetSource::INVALID_TILE_ALTERNATIVE, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
 	p_index = alternative_no_transform(p_index);
 	ERR_FAIL_INDEX_V(p_index, tiles[p_atlas_coords].alternatives_ids.size(), TileSetSource::INVALID_TILE_ALTERNATIVE);
@@ -5469,7 +5469,7 @@ int TileSetAtlasSource::get_alternative_tile_id(const Vector2i p_atlas_coords, i
 	return tiles[p_atlas_coords].alternatives_ids[p_index];
 }
 
-TileData *TileSetAtlasSource::get_tile_data(const Vector2i p_atlas_coords, int p_alternative_tile) const {
+TileData *TileSetAtlasSource::get_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), nullptr, vformat("The TileSetAtlasSource atlas has no tile at %s.", String(p_atlas_coords)));
 	p_alternative_tile = alternative_no_transform(p_alternative_tile);
 	ERR_FAIL_COND_V_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), nullptr, vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
@@ -5562,7 +5562,7 @@ TileSetAtlasSource::~TileSetAtlasSource() {
 	}
 }
 
-TileData *TileSetAtlasSource::_get_atlas_tile_data(Vector2i p_atlas_coords, int p_alternative_tile) {
+TileData *TileSetAtlasSource::_get_atlas_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile) {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), nullptr, vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	p_alternative_tile = alternative_no_transform(p_alternative_tile);
 	ERR_FAIL_COND_V_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), nullptr, vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
@@ -5570,14 +5570,14 @@ TileData *TileSetAtlasSource::_get_atlas_tile_data(Vector2i p_atlas_coords, int 
 	return tiles[p_atlas_coords].alternatives[p_alternative_tile];
 }
 
-const TileData *TileSetAtlasSource::_get_atlas_tile_data(Vector2i p_atlas_coords, int p_alternative_tile) const {
+const TileData *TileSetAtlasSource::_get_atlas_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), nullptr, vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 	ERR_FAIL_COND_V_MSG(!tiles[p_atlas_coords].alternatives.has(p_alternative_tile), nullptr, vformat("TileSetAtlasSource has no alternative with id %d for tile coords %s.", p_alternative_tile, String(p_atlas_coords)));
 
 	return tiles[p_atlas_coords].alternatives[p_alternative_tile];
 }
 
-void TileSetAtlasSource::_compute_next_alternative_id(const Vector2i p_atlas_coords) {
+void TileSetAtlasSource::_compute_next_alternative_id(const Vector2i &p_atlas_coords) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
 
 	while (tiles[p_atlas_coords].alternatives.has(tiles[p_atlas_coords].next_alternative_id)) {
@@ -5585,7 +5585,7 @@ void TileSetAtlasSource::_compute_next_alternative_id(const Vector2i p_atlas_coo
 	};
 }
 
-void TileSetAtlasSource::_clear_coords_mapping_cache(Vector2i p_atlas_coords) {
+void TileSetAtlasSource::_clear_coords_mapping_cache(const Vector2i &p_atlas_coords) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	TileAlternativesData &tad = tiles[p_atlas_coords];
 	for (int frame = 0; frame < (int)tad.animation_frames_durations.size(); frame++) {
@@ -5606,7 +5606,7 @@ void TileSetAtlasSource::_clear_coords_mapping_cache(Vector2i p_atlas_coords) {
 	}
 }
 
-void TileSetAtlasSource::_create_coords_mapping_cache(Vector2i p_atlas_coords) {
+void TileSetAtlasSource::_create_coords_mapping_cache(const Vector2i &p_atlas_coords) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 
 	TileAlternativesData &tad = tiles[p_atlas_coords];
@@ -5770,22 +5770,22 @@ Vector2i TileSetScenesCollectionSource::get_tile_id(int p_tile_index) const {
 	return Vector2i();
 }
 
-bool TileSetScenesCollectionSource::has_tile(Vector2i p_atlas_coords) const {
+bool TileSetScenesCollectionSource::has_tile(const Vector2i &p_atlas_coords) const {
 	return p_atlas_coords == Vector2i();
 }
 
-int TileSetScenesCollectionSource::get_alternative_tiles_count(const Vector2i p_atlas_coords) const {
+int TileSetScenesCollectionSource::get_alternative_tiles_count(const Vector2i &p_atlas_coords) const {
 	return scenes_ids.size();
 }
 
-int TileSetScenesCollectionSource::get_alternative_tile_id(const Vector2i p_atlas_coords, int p_index) const {
+int TileSetScenesCollectionSource::get_alternative_tile_id(const Vector2i &p_atlas_coords, int p_index) const {
 	ERR_FAIL_COND_V(p_atlas_coords != Vector2i(), TileSetSource::INVALID_TILE_ALTERNATIVE);
 	ERR_FAIL_INDEX_V(p_index, scenes_ids.size(), TileSetSource::INVALID_TILE_ALTERNATIVE);
 
 	return scenes_ids[p_index];
 }
 
-bool TileSetScenesCollectionSource::has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const {
+bool TileSetScenesCollectionSource::has_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) const {
 	ERR_FAIL_COND_V(p_atlas_coords != Vector2i(), false);
 	return scenes.has(TileSetAtlasSource::alternative_no_transform(p_alternative_tile));
 }
@@ -6229,7 +6229,7 @@ bool TileData::get_transpose() const {
 	return transpose;
 }
 
-void TileData::set_texture_origin(Vector2i p_texture_origin) {
+void TileData::set_texture_origin(const Vector2i &p_texture_origin) {
 	texture_origin = p_texture_origin;
 	emit_signal(CoreStringName(changed));
 }
@@ -6246,7 +6246,7 @@ Ref<Material> TileData::get_material() const {
 	return material;
 }
 
-void TileData::set_modulate(Color p_modulate) {
+void TileData::set_modulate(const Color &p_modulate) {
 	modulate = p_modulate;
 	emit_signal(CoreStringName(changed));
 }

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -73,7 +73,7 @@ union TileMapCell {
 		return hash_one_uint64(p_hash._u64t);
 	}
 
-	TileMapCell(int p_source_id = -1, Vector2i p_atlas_coords = Vector2i(-1, -1), int p_alternative_tile = -1) { // default are INVALID_SOURCE, INVALID_ATLAS_COORDS, INVALID_TILE_ALTERNATIVE
+	TileMapCell(int p_source_id = -1, const Vector2i &p_atlas_coords = Vector2i(-1, -1), int p_alternative_tile = -1) { // default are INVALID_SOURCE, INVALID_ATLAS_COORDS, INVALID_TILE_ALTERNATIVE
 		source_id = p_source_id;
 		set_atlas_coords(p_atlas_coords);
 		alternative_tile = p_alternative_tile;
@@ -129,7 +129,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i p_atlas_coords, int p_alternative_tile = 0);
+	void set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile = 0);
 	bool has_cell(const Vector2i &p_coords) const;
 	void remove_cell(const Vector2i &p_coords, bool p_update_size = true);
 	int get_cell_source_id(const Vector2i &p_coords) const;
@@ -209,7 +209,7 @@ private:
 
 public:
 	// Format of output array [source_id, atlas_coords, alternative]
-	Array compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose);
+	Array compatibility_tilemap_map(int p_tile_id, const Vector2i &p_coords, bool p_flip_h, bool p_flip_v, bool p_transpose);
 #endif // DISABLE_DEPRECATED
 
 public:
@@ -391,20 +391,20 @@ private:
 	RBMap<Array, Array> alternative_level_proxies;
 
 	// Helpers
-	Vector<Point2> _get_square_terrain_polygon(Vector2i p_size);
-	Vector<Point2> _get_square_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_square_corner_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_square_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_square_terrain_polygon(const Vector2i &p_size);
+	Vector<Point2> _get_square_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_square_corner_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_square_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
 
-	Vector<Point2> _get_isometric_terrain_polygon(Vector2i p_size);
-	Vector<Point2> _get_isometric_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_isometric_corner_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_isometric_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_isometric_terrain_polygon(const Vector2i &p_size);
+	Vector<Point2> _get_isometric_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_isometric_corner_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_isometric_side_terrain_peering_bit_polygon(const Vector2i &p_size, TileSet::CellNeighbor p_bit);
 
-	Vector<Point2> _get_half_offset_terrain_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis);
-	Vector<Point2> _get_half_offset_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_half_offset_corner_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
-	Vector<Point2> _get_half_offset_side_terrain_peering_bit_polygon(Vector2i p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_half_offset_terrain_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis);
+	Vector<Point2> _get_half_offset_corner_or_side_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_half_offset_corner_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
+	Vector<Point2> _get_half_offset_side_terrain_peering_bit_polygon(const Vector2i &p_size, float p_overlap, TileSet::TileOffsetAxis p_offset_axis, TileSet::CellNeighbor p_bit);
 
 protected:
 	static void _bind_methods();
@@ -513,21 +513,21 @@ public:
 	bool has_source_level_tile_proxy(int p_source_from);
 	void remove_source_level_tile_proxy(int p_source_from);
 
-	void set_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_source_to, Vector2i p_coords_to);
-	Array get_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
-	bool has_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
-	void remove_coords_level_tile_proxy(int p_source_from, Vector2i p_coords_from);
+	void set_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_source_to, const Vector2i &p_coords_to);
+	Array get_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from);
+	bool has_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from);
+	void remove_coords_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from);
 
-	void set_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from, int p_source_to, Vector2i p_coords_to, int p_alternative_to);
-	Array get_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
-	bool has_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
-	void remove_alternative_level_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from);
+	void set_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from, int p_source_to, const Vector2i &p_coords_to, int p_alternative_to);
+	Array get_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from);
+	bool has_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from);
+	void remove_alternative_level_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from);
 
 	Array get_source_level_tile_proxies() const;
 	Array get_coords_level_tile_proxies() const;
 	Array get_alternative_level_tile_proxies() const;
 
-	Array map_tile_proxy(int p_source_from, Vector2i p_coords_from, int p_alternative_from) const;
+	Array map_tile_proxy(int p_source_from, const Vector2i &p_coords_from, int p_alternative_from) const;
 
 	void cleanup_invalid_tile_proxies();
 	void clear_tile_proxies();
@@ -545,7 +545,7 @@ public:
 
 	// Helpers
 	Vector<Vector2> get_tile_shape_polygon() const;
-	void draw_tile_shape(CanvasItem *p_canvas_item, Transform2D p_transform, Color p_color, bool p_filled = false, Ref<Texture2D> p_texture = Ref<Texture2D>()) const;
+	void draw_tile_shape(CanvasItem *p_canvas_item, const Transform2D &p_transform, const Color &p_color, bool p_filled = false, Ref<Texture2D> p_texture = Ref<Texture2D>()) const;
 
 	// Used by TileMap/TileMapLayer
 	Vector2 map_to_local(const Vector2i &p_pos) const;
@@ -554,11 +554,11 @@ public:
 	Vector2i get_neighbor_cell(const Vector2i &p_coords, TileSet::CellNeighbor p_cell_neighbor) const;
 	TypedArray<Vector2i> get_surrounding_cells(const Vector2i &p_coords) const;
 	Vector2i map_pattern(const Vector2i &p_position_in_tilemap, const Vector2i &p_coords_in_pattern, Ref<TileMapPattern> p_pattern) const;
-	void draw_cells_outline(CanvasItem *p_canvas_item, const RBSet<Vector2i> &p_cells, Color p_color, Transform2D p_transform = Transform2D()) const;
+	void draw_cells_outline(CanvasItem *p_canvas_item, const RBSet<Vector2i> &p_cells, const Color &p_color, const Transform2D &p_transform = Transform2D()) const;
 
 	Vector<Point2> get_terrain_polygon(int p_terrain_set);
 	Vector<Point2> get_terrain_peering_bit_polygon(int p_terrain_set, TileSet::CellNeighbor p_bit);
-	void draw_terrains(CanvasItem *p_canvas_item, Transform2D p_transform, const TileData *p_tile_data);
+	void draw_terrains(CanvasItem *p_canvas_item, const Transform2D &p_transform, const TileData *p_tile_data);
 	Vector<Vector<Ref<Texture2D>>> generate_terrains_icons(Size2i p_size);
 
 	// Resource management
@@ -610,12 +610,12 @@ public:
 	// Tiles.
 	virtual int get_tiles_count() const = 0;
 	virtual Vector2i get_tile_id(int tile_index) const = 0;
-	virtual bool has_tile(Vector2i p_atlas_coords) const = 0;
+	virtual bool has_tile(const Vector2i &p_atlas_coords) const = 0;
 
 	// Alternative tiles.
-	virtual int get_alternative_tiles_count(const Vector2i p_atlas_coords) const = 0;
-	virtual int get_alternative_tile_id(const Vector2i p_atlas_coords, int p_index) const = 0;
-	virtual bool has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const = 0;
+	virtual int get_alternative_tiles_count(const Vector2i &p_atlas_coords) const = 0;
+	virtual int get_alternative_tile_id(const Vector2i &p_atlas_coords, int p_index) const = 0;
+	virtual bool has_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) const = 0;
 };
 
 class TileSetAtlasSource : public TileSetSource {
@@ -665,13 +665,13 @@ private:
 	Vector<Vector2i> tiles_ids;
 	HashMap<Vector2i, Vector2i> _coords_mapping_cache; // Maps any coordinate to the including tile
 
-	TileData *_get_atlas_tile_data(Vector2i p_atlas_coords, int p_alternative_tile);
-	const TileData *_get_atlas_tile_data(Vector2i p_atlas_coords, int p_alternative_tile) const;
+	TileData *_get_atlas_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile);
+	const TileData *_get_atlas_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile) const;
 
-	void _compute_next_alternative_id(const Vector2i p_atlas_coords);
+	void _compute_next_alternative_id(const Vector2i &p_atlas_coords);
 
-	void _clear_coords_mapping_cache(Vector2i p_atlas_coords);
-	void _create_coords_mapping_cache(Vector2i p_atlas_coords);
+	void _clear_coords_mapping_cache(const Vector2i &p_atlas_coords);
+	void _create_coords_mapping_cache(const Vector2i &p_atlas_coords);
 
 	bool use_texture_padding = true;
 	Ref<CanvasTexture> padded_texture;
@@ -721,11 +721,11 @@ public:
 	// Base properties.
 	void set_texture(Ref<Texture2D> p_texture);
 	Ref<Texture2D> get_texture() const;
-	void set_margins(Vector2i p_margins);
+	void set_margins(const Vector2i &p_margins);
 	Vector2i get_margins() const;
-	void set_separation(Vector2i p_separation);
+	void set_separation(const Vector2i &p_separation);
 	Vector2i get_separation() const;
-	void set_texture_region_size(Vector2i p_tile_size);
+	void set_texture_region_size(const Vector2i &p_tile_size);
 	Vector2i get_texture_region_size() const;
 
 	// Padding.
@@ -733,62 +733,62 @@ public:
 	bool get_use_texture_padding() const;
 
 	// Base tiles.
-	void create_tile(const Vector2i p_atlas_coords, const Vector2i p_size = Vector2i(1, 1));
-	void remove_tile(Vector2i p_atlas_coords);
-	virtual bool has_tile(Vector2i p_atlas_coords) const override;
-	void move_tile_in_atlas(Vector2i p_atlas_coords, Vector2i p_new_atlas_coords = INVALID_ATLAS_COORDS, Vector2i p_new_size = Vector2i(-1, -1));
-	Vector2i get_tile_size_in_atlas(Vector2i p_atlas_coords) const;
+	void create_tile(const Vector2i &p_atlas_coords, const Vector2i &p_size = Vector2i(1, 1));
+	void remove_tile(const Vector2i &p_atlas_coords);
+	virtual bool has_tile(const Vector2i &p_atlas_coords) const override;
+	void move_tile_in_atlas(const Vector2i &p_atlas_coords, const Vector2i &p_new_atlas_coords = INVALID_ATLAS_COORDS, const Vector2i &p_new_size = Vector2i(-1, -1));
+	Vector2i get_tile_size_in_atlas(const Vector2i &p_atlas_coords) const;
 
 	virtual int get_tiles_count() const override;
 	virtual Vector2i get_tile_id(int p_index) const override;
 
-	bool has_room_for_tile(Vector2i p_atlas_coords, Vector2i p_size, int p_animation_columns, Vector2i p_animation_separation, int p_frames_count, Vector2i p_ignored_tile = INVALID_ATLAS_COORDS) const;
-	PackedVector2Array get_tiles_to_be_removed_on_change(Ref<Texture2D> p_texture, Vector2i p_margins, Vector2i p_separation, Vector2i p_texture_region_size);
-	Vector2i get_tile_at_coords(Vector2i p_atlas_coords) const;
+	bool has_room_for_tile(const Vector2i &p_atlas_coords, const Vector2i &p_size, int p_animation_columns, const Vector2i &p_animation_separation, int p_frames_count, const Vector2i &p_ignored_tile = INVALID_ATLAS_COORDS) const;
+	PackedVector2Array get_tiles_to_be_removed_on_change(Ref<Texture2D> p_texture, const Vector2i &p_margins, const Vector2i &p_separation, const Vector2i &p_texture_region_size);
+	Vector2i get_tile_at_coords(const Vector2i &p_atlas_coords) const;
 
 	bool has_tiles_outside_texture() const;
 	Vector<Vector2i> get_tiles_outside_texture() const;
 	void clear_tiles_outside_texture();
 
 	// Animation.
-	void set_tile_animation_columns(const Vector2i p_atlas_coords, int p_frame_columns);
-	int get_tile_animation_columns(const Vector2i p_atlas_coords) const;
-	void set_tile_animation_separation(const Vector2i p_atlas_coords, const Vector2i p_separation);
-	Vector2i get_tile_animation_separation(const Vector2i p_atlas_coords) const;
-	void set_tile_animation_speed(const Vector2i p_atlas_coords, real_t p_speed);
-	real_t get_tile_animation_speed(const Vector2i p_atlas_coords) const;
-	void set_tile_animation_mode(const Vector2i p_atlas_coords, const TileSetAtlasSource::TileAnimationMode p_mode);
-	TileSetAtlasSource::TileAnimationMode get_tile_animation_mode(const Vector2i p_atlas_coords) const;
-	void set_tile_animation_frames_count(const Vector2i p_atlas_coords, int p_frames_count);
-	int get_tile_animation_frames_count(const Vector2i p_atlas_coords) const;
-	void set_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index, real_t p_duration);
-	real_t get_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index) const;
-	real_t get_tile_animation_total_duration(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_columns(const Vector2i &p_atlas_coords, int p_frame_columns);
+	int get_tile_animation_columns(const Vector2i &p_atlas_coords) const;
+	void set_tile_animation_separation(const Vector2i &p_atlas_coords, const Vector2i &p_separation);
+	Vector2i get_tile_animation_separation(const Vector2i &p_atlas_coords) const;
+	void set_tile_animation_speed(const Vector2i &p_atlas_coords, real_t p_speed);
+	real_t get_tile_animation_speed(const Vector2i &p_atlas_coords) const;
+	void set_tile_animation_mode(const Vector2i &p_atlas_coords, const TileSetAtlasSource::TileAnimationMode p_mode);
+	TileSetAtlasSource::TileAnimationMode get_tile_animation_mode(const Vector2i &p_atlas_coords) const;
+	void set_tile_animation_frames_count(const Vector2i &p_atlas_coords, int p_frames_count);
+	int get_tile_animation_frames_count(const Vector2i &p_atlas_coords) const;
+	void set_tile_animation_frame_duration(const Vector2i &p_atlas_coords, int p_frame_index, real_t p_duration);
+	real_t get_tile_animation_frame_duration(const Vector2i &p_atlas_coords, int p_frame_index) const;
+	real_t get_tile_animation_total_duration(const Vector2i &p_atlas_coords) const;
 
 	// Alternative tiles.
-	int create_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_id_override = -1);
-	void remove_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile);
-	void set_alternative_tile_id(const Vector2i p_atlas_coords, int p_alternative_tile, int p_new_id);
-	virtual bool has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const override;
-	int get_next_alternative_tile_id(const Vector2i p_atlas_coords) const;
+	int create_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_id_override = -1);
+	void remove_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile);
+	void set_alternative_tile_id(const Vector2i &p_atlas_coords, int p_alternative_tile, int p_new_id);
+	virtual bool has_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) const override;
+	int get_next_alternative_tile_id(const Vector2i &p_atlas_coords) const;
 
-	virtual int get_alternative_tiles_count(const Vector2i p_atlas_coords) const override;
-	virtual int get_alternative_tile_id(const Vector2i p_atlas_coords, int p_index) const override;
+	virtual int get_alternative_tiles_count(const Vector2i &p_atlas_coords) const override;
+	virtual int get_alternative_tile_id(const Vector2i &p_atlas_coords, int p_index) const override;
 
 	// Get data associated to a tile.
-	TileData *get_tile_data(const Vector2i p_atlas_coords, int p_alternative_tile) const;
+	TileData *get_tile_data(const Vector2i &p_atlas_coords, int p_alternative_tile) const;
 
 	// Helpers.
 	Vector2i get_atlas_grid_size() const;
-	Rect2i get_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
-	bool is_position_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Vector2 p_position) const;
-	bool is_rect_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Rect2 p_rect) const;
+	Rect2i get_tile_texture_region(const Vector2i &p_atlas_coords, int p_frame = 0) const;
+	bool is_position_in_tile_texture_region(const Vector2i &p_atlas_coords, int p_alternative_tile, const Vector2 &p_position) const;
+	bool is_rect_in_tile_texture_region(const Vector2i &p_atlas_coords, int p_alternative_tile, const Rect2 &p_rect) const;
 
 	static int alternative_no_transform(int p_alternative_id);
 
 	// Getters for texture and tile region (padded or not)
 	Ref<Texture2D> get_runtime_texture() const;
-	Rect2i get_runtime_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
+	Rect2i get_runtime_tile_texture_region(const Vector2i &p_atlas_coords, int p_frame = 0) const;
 
 	~TileSetAtlasSource();
 };
@@ -822,12 +822,12 @@ public:
 	// Tiles.
 	int get_tiles_count() const override;
 	Vector2i get_tile_id(int p_tile_index) const override;
-	bool has_tile(Vector2i p_atlas_coords) const override;
+	bool has_tile(const Vector2i &p_atlas_coords) const override;
 
 	// Alternative tiles.
-	int get_alternative_tiles_count(const Vector2i p_atlas_coords) const override;
-	int get_alternative_tile_id(const Vector2i p_atlas_coords, int p_index) const override;
-	bool has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const override;
+	int get_alternative_tiles_count(const Vector2i &p_atlas_coords) const override;
+	int get_alternative_tile_id(const Vector2i &p_atlas_coords, int p_index) const override;
+	bool has_alternative_tile(const Vector2i &p_atlas_coords, int p_alternative_tile) const override;
 
 	// Scenes accessors. Lot are similar to "Alternative tiles".
 	int get_scene_tiles_count() { return get_alternative_tiles_count(Vector2i()); }
@@ -960,11 +960,11 @@ public:
 	void set_transpose(bool p_transpose);
 	bool get_transpose() const;
 
-	void set_texture_origin(Vector2i p_texture_origin);
+	void set_texture_origin(const Vector2i &p_texture_origin);
 	Vector2i get_texture_origin() const;
 	void set_material(Ref<Material> p_material);
 	Ref<Material> get_material() const;
-	void set_modulate(Color p_modulate);
+	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;
 	void set_z_index(int p_z_index);
 	int get_z_index() const;

--- a/scene/resources/3d/fog_material.cpp
+++ b/scene/resources/3d/fog_material.cpp
@@ -46,7 +46,7 @@ float FogMaterial::get_density() const {
 	return density;
 }
 
-void FogMaterial::set_albedo(Color p_albedo) {
+void FogMaterial::set_albedo(const Color &p_albedo) {
 	albedo = p_albedo;
 	RS::get_singleton()->material_set_param(_get_material(), "albedo", albedo);
 }
@@ -55,7 +55,7 @@ Color FogMaterial::get_albedo() const {
 	return albedo;
 }
 
-void FogMaterial::set_emission(Color p_emission) {
+void FogMaterial::set_emission(const Color &p_emission) {
 	emission = p_emission;
 	RS::get_singleton()->material_set_param(_get_material(), "emission", emission);
 }

--- a/scene/resources/3d/fog_material.h
+++ b/scene/resources/3d/fog_material.h
@@ -59,10 +59,10 @@ public:
 	void set_density(float p_density);
 	float get_density() const;
 
-	void set_albedo(Color p_color);
+	void set_albedo(const Color &p_color);
 	Color get_albedo() const;
 
-	void set_emission(Color p_color);
+	void set_emission(const Color &p_color);
 	Color get_emission() const;
 
 	void set_height_falloff(float p_falloff);

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -331,7 +331,7 @@ void PrimitiveMesh::set_uv2_padding(float p_padding) {
 	request_update();
 }
 
-Vector2 PrimitiveMesh::get_uv2_scale(Vector2 p_margin_scale) const {
+Vector2 PrimitiveMesh::get_uv2_scale(const Vector2 &p_margin_scale) const {
 	Vector2 uv2_scale;
 	Vector2 lightmap_size = get_lightmap_size_hint();
 
@@ -726,7 +726,7 @@ void BoxMesh::_create_mesh_array(Array &p_arr) const {
 	BoxMesh::create_mesh_array(p_arr, size, subdivide_w, subdivide_h, subdivide_d, _add_uv2, _uv2_padding);
 }
 
-void BoxMesh::create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w, int subdivide_h, int subdivide_d, bool p_add_uv2, const float p_uv2_padding) {
+void BoxMesh::create_mesh_array(Array &p_arr, const Vector3 &size, int subdivide_w, int subdivide_h, int subdivide_d, bool p_add_uv2, const float p_uv2_padding) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z;
 	float onethird = 1.0 / 3.0;
@@ -1565,7 +1565,7 @@ int PlaneMesh::get_subdivide_depth() const {
 	return subdivide_d;
 }
 
-void PlaneMesh::set_center_offset(const Vector3 p_offset) {
+void PlaneMesh::set_center_offset(const Vector3 &p_offset) {
 	if (p_offset.is_equal_approx(center_offset)) {
 		return;
 	}

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -75,7 +75,7 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const {}
 	GDVIRTUAL0RC(Array, _create_mesh_array)
 
-	Vector2 get_uv2_scale(Vector2 p_margin_scale = Vector2(1.0, 1.0)) const;
+	Vector2 get_uv2_scale(const Vector2 &p_margin_scale = Vector2(1.0, 1.0)) const;
 	float get_lightmap_texel_size() const;
 	virtual void _update_lightmap_size() {}
 
@@ -174,7 +174,7 @@ protected:
 	virtual void _update_lightmap_size() override;
 
 public:
-	static void create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w = 0, int subdivide_h = 0, int subdivide_d = 0, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
+	static void create_mesh_array(Array &p_arr, const Vector3 &size, int subdivide_w = 0, int subdivide_h = 0, int subdivide_d = 0, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
 
 	void set_size(const Vector3 &p_size);
 	Vector3 get_size() const;
@@ -272,7 +272,7 @@ public:
 	void set_subdivide_depth(const int p_divisions);
 	int get_subdivide_depth() const;
 
-	void set_center_offset(const Vector3 p_offset);
+	void set_center_offset(const Vector3 &p_offset);
 	Vector3 get_center_offset() const;
 
 	void set_orientation(const Orientation p_orientation);

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -530,7 +530,7 @@ float PhysicalSkyMaterial::get_rayleigh_coefficient() const {
 	return rayleigh;
 }
 
-void PhysicalSkyMaterial::set_rayleigh_color(Color p_rayleigh_color) {
+void PhysicalSkyMaterial::set_rayleigh_color(const Color &p_rayleigh_color) {
 	rayleigh_color = p_rayleigh_color;
 	RS::get_singleton()->material_set_param(_get_material(), "rayleigh_color", rayleigh_color);
 }
@@ -557,7 +557,7 @@ float PhysicalSkyMaterial::get_mie_eccentricity() const {
 	return mie_eccentricity;
 }
 
-void PhysicalSkyMaterial::set_mie_color(Color p_mie_color) {
+void PhysicalSkyMaterial::set_mie_color(const Color &p_mie_color) {
 	mie_color = p_mie_color;
 	RS::get_singleton()->material_set_param(_get_material(), "mie_color", mie_color);
 }
@@ -584,7 +584,7 @@ float PhysicalSkyMaterial::get_sun_disk_scale() const {
 	return sun_disk_scale;
 }
 
-void PhysicalSkyMaterial::set_ground_color(Color p_ground_color) {
+void PhysicalSkyMaterial::set_ground_color(const Color &p_ground_color) {
 	ground_color = p_ground_color;
 	RS::get_singleton()->material_set_param(_get_material(), "ground_color", ground_color);
 }

--- a/scene/resources/3d/sky_material.h
+++ b/scene/resources/3d/sky_material.h
@@ -192,7 +192,7 @@ public:
 	void set_rayleigh_coefficient(float p_rayleigh);
 	float get_rayleigh_coefficient() const;
 
-	void set_rayleigh_color(Color p_rayleigh_color);
+	void set_rayleigh_color(const Color &p_rayleigh_color);
 	Color get_rayleigh_color() const;
 
 	void set_turbidity(float p_turbidity);
@@ -204,13 +204,13 @@ public:
 	void set_mie_eccentricity(float p_eccentricity);
 	float get_mie_eccentricity() const;
 
-	void set_mie_color(Color p_mie_color);
+	void set_mie_color(const Color &p_mie_color);
 	Color get_mie_color() const;
 
 	void set_sun_disk_scale(float p_sun_disk_scale);
 	float get_sun_disk_scale() const;
 
-	void set_ground_color(Color p_ground_color);
+	void set_ground_color(const Color &p_ground_color);
 	Color get_ground_color() const;
 
 	void set_energy_multiplier(float p_multiplier);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -112,7 +112,7 @@ int Curve::_add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_
 	return ret;
 }
 
-int Curve::add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
+int Curve::add_point(const Vector2 &p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
 	int ret = _add_point(p_position, p_left_tangent, p_right_tangent, p_left_mode, p_right_mode);
 	notify_property_list_changed();
 
@@ -120,7 +120,7 @@ int Curve::add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_t
 }
 
 // TODO: Needed to make the curve editor function properly until https://github.com/godotengine/godot/issues/76985 is fixed.
-int Curve::add_point_no_update(Vector2 p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
+int Curve::add_point_no_update(const Vector2 &p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
 	int ret = _add_point(p_position, p_left_tangent, p_right_tangent, p_left_mode, p_right_mode);
 
 	return ret;

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -79,12 +79,12 @@ public:
 
 	void set_point_count(int p_count);
 
-	int add_point(Vector2 p_position,
+	int add_point(const Vector2 &p_position,
 			real_t p_left_tangent = 0,
 			real_t p_right_tangent = 0,
 			TangentMode p_left_mode = TANGENT_FREE,
 			TangentMode p_right_mode = TANGENT_FREE);
-	int add_point_no_update(Vector2 p_position,
+	int add_point_no_update(const Vector2 &p_position,
 			real_t p_left_tangent = 0,
 			real_t p_right_tangent = 0,
 			TangentMode p_left_mode = TANGENT_FREE,

--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -150,7 +150,7 @@ void DrawableTexture2D::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect,
 }
 
 // Perform a blit operation from the given source to the given rect on self.
-void DrawableTexture2D::blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
+void DrawableTexture2D::blit_rect(const Rect2i &p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
 	// Use user Shader if exists.
 	RID material = default_material;
 	if (p_material.is_valid()) {
@@ -180,7 +180,7 @@ void DrawableTexture2D::blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_s
 }
 
 // Perform a blit operation from the given sources to the given rect on self and extra targets
-void DrawableTexture2D::blit_rect_multi(const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
+void DrawableTexture2D::blit_rect_multi(const Rect2i &p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
 	RID material = default_material;
 	if (p_material.is_valid()) {
 		material = p_material->get_rid();

--- a/scene/resources/drawable_texture_2d.h
+++ b/scene/resources/drawable_texture_2d.h
@@ -80,8 +80,8 @@ public:
 
 	void setup(int p_width, int p_height, DrawableFormat p_format, const Color &p_modulate = Color(1, 1, 1, 1), bool p_use_mipmaps = false);
 
-	void blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
-	void blit_rect_multi(const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
+	void blit_rect(const Rect2i &p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
+	void blit_rect_multi(const Rect2i &p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
 
 	virtual Ref<Image> get_image() const override;
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -948,14 +948,14 @@ void Environment::set_volumetric_fog_density(float p_density) {
 float Environment::get_volumetric_fog_density() const {
 	return volumetric_fog_density;
 }
-void Environment::set_volumetric_fog_albedo(Color p_color) {
+void Environment::set_volumetric_fog_albedo(const Color &p_color) {
 	volumetric_fog_albedo = p_color;
 	_update_volumetric_fog();
 }
 Color Environment::get_volumetric_fog_albedo() const {
 	return volumetric_fog_albedo;
 }
-void Environment::set_volumetric_fog_emission(Color p_color) {
+void Environment::set_volumetric_fog_emission(const Color &p_color) {
 	volumetric_fog_emission = p_color;
 	_update_volumetric_fog();
 }

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -414,9 +414,9 @@ public:
 	bool is_volumetric_fog_enabled() const;
 	void set_volumetric_fog_density(float p_density);
 	float get_volumetric_fog_density() const;
-	void set_volumetric_fog_albedo(Color p_color);
+	void set_volumetric_fog_albedo(const Color &p_color);
 	Color get_volumetric_fog_albedo() const;
-	void set_volumetric_fog_emission(Color p_color);
+	void set_volumetric_fog_emission(const Color &p_color);
 	Color get_volumetric_fog_emission() const;
 	void set_volumetric_fog_emission_energy(float p_begin);
 	float get_volumetric_fog_emission_energy() const;

--- a/scene/resources/font.compat.inc
+++ b/scene/resources/font.compat.inc
@@ -58,15 +58,15 @@ real_t Font::_draw_char_outline_bind_compat_104872(RID p_canvas_item, const Poin
 	return draw_char_outline(p_canvas_item, p_pos, p_char, p_font_size, p_size, p_modulate, 0.0);
 }
 
-RID Font::_find_variation_bind_compat_80954(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform) const {
+RID Font::_find_variation_bind_compat_80954(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform) const {
 	return find_variation(p_variation_coordinates, p_face_index, p_strength, p_transform, 0, 0, 0, 0, 0.0, 0, Vector<Color>());
 }
 
-RID Font::_find_variation_bind_compat_87668(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph) const {
+RID Font::_find_variation_bind_compat_87668(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph) const {
 	return find_variation(p_variation_coordinates, p_face_index, p_strength, p_transform, p_spacing_top, p_spacing_bottom, p_spacing_space, p_spacing_glyph, 0.0, 0, Vector<Color>());
 }
 
-RID Font::_find_variation_bind_compat_117149(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset) const {
+RID Font::_find_variation_bind_compat_117149(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset) const {
 	return find_variation(p_variation_coordinates, p_face_index, p_strength, p_transform, p_spacing_top, p_spacing_bottom, p_spacing_space, p_spacing_glyph, p_baseline_offset, 0, Vector<Color>());
 }
 

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2383,7 +2383,7 @@ real_t FontFile::get_oversampling() const {
 	return oversampling_override;
 }
 
-RID FontFile::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
+RID FontFile::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
 	// Find existing variation cache.
 	const Dictionary &supported_coords = get_supported_variation_list();
 	int make_linked_from = -1;
@@ -2531,7 +2531,7 @@ float FontFile::get_embolden(int p_cache_index) const {
 	return TS->font_get_embolden(cache[p_cache_index]);
 }
 
-void FontFile::set_transform(int p_cache_index, Transform2D p_transform) {
+void FontFile::set_transform(int p_cache_index, const Transform2D &p_transform) {
 	ERR_FAIL_COND(p_cache_index < 0);
 	ERR_FAIL_COND(!_ensure_rid(p_cache_index));
 	TS->font_set_transform(cache[p_cache_index], p_transform);
@@ -3134,7 +3134,7 @@ float FontVariation::get_variation_embolden() const {
 	return variation.embolden;
 }
 
-void FontVariation::set_variation_transform(Transform2D p_transform) {
+void FontVariation::set_variation_transform(const Transform2D &p_transform) {
 	if (variation.transform != p_transform) {
 		variation.transform = p_transform;
 		_invalidate_rids();
@@ -3213,7 +3213,7 @@ Vector<Color> FontVariation::get_palette_custom_colors() const {
 	return custom_colors;
 }
 
-RID FontVariation::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
+RID FontVariation::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
 	Ref<Font> f = _get_base_font_or_default();
 	if (f.is_valid()) {
 		return f->find_variation(p_variation_coordinates, p_face_index, p_strength, p_transform, p_spacing_top, p_spacing_bottom, p_spacing_space, p_spacing_glyph, p_baseline_offset, p_palette_index, p_custom_colors);
@@ -3744,7 +3744,7 @@ int SystemFont::get_spacing(TextServer::SpacingType p_spacing) const {
 	}
 }
 
-RID SystemFont::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, Transform2D p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
+RID SystemFont::find_variation(const Dictionary &p_variation_coordinates, int p_face_index, float p_strength, const Transform2D &p_transform, int p_spacing_top, int p_spacing_bottom, int p_spacing_space, int p_spacing_glyph, float p_baseline_offset, int64_t p_palette_index, const Vector<Color> &p_custom_colors) const {
 	Ref<Font> f = _get_base_font_or_default();
 	if (f.is_valid()) {
 		Dictionary var = p_variation_coordinates;

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -106,9 +106,9 @@ protected:
 	void _draw_multiline_string_outline_bind_compat_104872(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_max_lines = -1, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL) const;
 	real_t _draw_char_bind_compat_104872(RID p_canvas_item, const Point2 &p_pos, char32_t p_char, int p_font_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0)) const;
 	real_t _draw_char_outline_bind_compat_104872(RID p_canvas_item, const Point2 &p_pos, char32_t p_char, int p_font_size = DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0)) const;
-	RID _find_variation_bind_compat_80954(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D()) const;
-	RID _find_variation_bind_compat_87668(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0) const;
-	RID _find_variation_bind_compat_117149(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0) const;
+	RID _find_variation_bind_compat_80954(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D()) const;
+	RID _find_variation_bind_compat_87668(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0) const;
+	RID _find_variation_bind_compat_117149(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0) const;
 	static void _bind_compatibility_methods();
 #endif
 
@@ -124,7 +124,7 @@ public:
 	virtual TypedArray<Font> get_fallbacks() const;
 
 	// Output.
-	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const { return RID(); }
+	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const { return RID(); }
 	virtual RID _get_rid() const { return RID(); }
 	virtual TypedArray<RID> get_rids() const;
 
@@ -305,7 +305,7 @@ public:
 	virtual real_t get_oversampling() const;
 
 	// Cache.
-	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
+	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
 	virtual RID _get_rid() const override;
 
 	virtual int get_cache_count() const;
@@ -322,7 +322,7 @@ public:
 	virtual void set_embolden(int p_cache_index, float p_strength);
 	virtual float get_embolden(int p_cache_index) const;
 
-	virtual void set_transform(int p_cache_index, Transform2D p_transform);
+	virtual void set_transform(int p_cache_index, const Transform2D &p_transform);
 	virtual Transform2D get_transform(int p_cache_index) const;
 
 	virtual void set_extra_spacing(int p_cache_index, TextServer::SpacingType p_spacing, int64_t p_value);
@@ -454,7 +454,7 @@ public:
 	virtual void set_variation_embolden(float p_strength);
 	virtual float get_variation_embolden() const;
 
-	virtual void set_variation_transform(Transform2D p_transform);
+	virtual void set_variation_transform(const Transform2D &p_transform);
 	virtual Transform2D get_variation_transform() const;
 
 	virtual void set_variation_face_index(int p_face_index);
@@ -476,7 +476,7 @@ public:
 	virtual void set_palette_custom_colors(const Vector<Color> &p_colors);
 
 	// Output.
-	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
+	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
 	virtual RID _get_rid() const override;
 
 	FontVariation();
@@ -582,7 +582,7 @@ public:
 
 	virtual int get_spacing(TextServer::SpacingType p_spacing) const override;
 
-	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, Transform2D p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
+	virtual RID find_variation(const Dictionary &p_variation_coordinates, int p_face_index = 0, float p_strength = 0.0, const Transform2D &p_transform = Transform2D(), int p_spacing_top = 0, int p_spacing_bottom = 0, int p_spacing_space = 0, int p_spacing_glyph = 0, float p_baseline_offset = 0.0, int64_t p_palette_index = 0, const Vector<Color> &p_custom_colors = Vector<Color>()) const override;
 	virtual RID _get_rid() const override;
 
 	int64_t get_face_count() const override;

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -72,7 +72,7 @@ private:
 		}
 	}
 
-	_FORCE_INLINE_ Color transform_color_space(const Color p_color) const {
+	_FORCE_INLINE_ Color transform_color_space(const Color &p_color) const {
 		switch (interpolation_color_space) {
 			case GRADIENT_COLOR_SPACE_SRGB:
 			default:
@@ -96,7 +96,7 @@ private:
 		}
 	}
 
-	_FORCE_INLINE_ Color inv_transform_color_space(const Color p_color) const {
+	_FORCE_INLINE_ Color inv_transform_color_space(const Color &p_color) const {
 		switch (interpolation_color_space) {
 			case GRADIENT_COLOR_SPACE_SRGB:
 			default:

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -360,7 +360,7 @@ bool GradientTexture2D::is_using_hdr() const {
 	return use_hdr;
 }
 
-void GradientTexture2D::set_fill_from(Vector2 p_fill_from) {
+void GradientTexture2D::set_fill_from(const Vector2 &p_fill_from) {
 	fill_from = p_fill_from;
 	_queue_update();
 	emit_changed();
@@ -370,7 +370,7 @@ Vector2 GradientTexture2D::get_fill_from() const {
 	return fill_from;
 }
 
-void GradientTexture2D::set_fill_to(Vector2 p_fill_to) {
+void GradientTexture2D::set_fill_to(const Vector2 &p_fill_to) {
 	fill_to = p_fill_to;
 	_queue_update();
 	emit_changed();

--- a/scene/resources/gradient_texture.h
+++ b/scene/resources/gradient_texture.h
@@ -124,9 +124,9 @@ public:
 
 	void set_fill(Fill p_fill);
 	Fill get_fill() const;
-	void set_fill_from(Vector2 p_fill_from);
+	void set_fill_from(const Vector2 &p_fill_from);
 	Vector2 get_fill_from() const;
-	void set_fill_to(Vector2 p_fill_to);
+	void set_fill_to(const Vector2 &p_fill_to);
 	Vector2 get_fill_to() const;
 
 	void set_repeat(Repeat p_repeat);

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1780,7 +1780,7 @@ void ArrayMesh::_recompute_aabb() {
 }
 
 // TODO: Need to add binding to add_surface using future MeshSurfaceData object.
-void ArrayMesh::add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data, const Vector<AABB> &p_bone_aabbs, const Vector<RenderingServerTypes::SurfaceData::LOD> &p_lods, const Vector4 p_uv_scale) {
+void ArrayMesh::add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data, const Vector<AABB> &p_bone_aabbs, const Vector<RenderingServerTypes::SurfaceData::LOD> &p_lods, const Vector4 &p_uv_scale) {
 	ERR_FAIL_COND(surfaces.size() == RSE::MAX_MESH_SURFACES);
 	_create_if_empty();
 

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -346,7 +346,7 @@ protected:
 public:
 	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = TypedArray<Array>(), const Dictionary &p_lods = Dictionary(), BitField<ArrayFormat> p_flags = 0);
 
-	void add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RenderingServerTypes::SurfaceData::LOD> &p_lods = Vector<RenderingServerTypes::SurfaceData::LOD>(), const Vector4 p_uv_scale = Vector4());
+	void add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RenderingServerTypes::SurfaceData::LOD> &p_lods = Vector<RenderingServerTypes::SurfaceData::LOD>(), const Vector4 &p_uv_scale = Vector4());
 
 	Array surface_get_arrays(int p_surface) const override;
 	TypedArray<Array> surface_get_blend_shape_arrays(int p_surface) const override;

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1400,7 +1400,7 @@ bool ParticleProcessMaterial::has_min_max_property(const String &p_name) {
 	return min_max_properties.has(p_name);
 }
 
-void ParticleProcessMaterial::set_direction(Vector3 p_direction) {
+void ParticleProcessMaterial::set_direction(const Vector3 &p_direction) {
 	direction = p_direction;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->direction, direction);
 }
@@ -1797,7 +1797,7 @@ void ParticleProcessMaterial::set_emission_sphere_radius(real_t p_radius) {
 #endif
 }
 
-void ParticleProcessMaterial::set_emission_box_extents(Vector3 p_extents) {
+void ParticleProcessMaterial::set_emission_box_extents(const Vector3 &p_extents) {
 	emission_box_extents = p_extents;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_box_extents, p_extents);
 #ifdef TOOLS_ENABLED
@@ -1829,7 +1829,7 @@ void ParticleProcessMaterial::set_emission_point_count(int p_count) {
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_texture_point_count, p_count);
 }
 
-void ParticleProcessMaterial::set_emission_ring_axis(Vector3 p_axis) {
+void ParticleProcessMaterial::set_emission_ring_axis(const Vector3 &p_axis) {
 	emission_ring_axis = p_axis;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_ring_axis, p_axis);
 #ifdef TOOLS_ENABLED

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -398,7 +398,7 @@ protected:
 public:
 	static bool has_min_max_property(const String &p_name);
 
-	void set_direction(Vector3 p_direction);
+	void set_direction(const Vector3 &p_direction);
 	Vector3 get_direction() const;
 
 	void set_spread(float p_spread);
@@ -462,11 +462,11 @@ public:
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(real_t p_radius);
-	void set_emission_box_extents(Vector3 p_extents);
+	void set_emission_box_extents(const Vector3 &p_extents);
 	void set_emission_point_texture(const Ref<Texture2D> &p_points);
 	void set_emission_normal_texture(const Ref<Texture2D> &p_normals);
 	void set_emission_color_texture(const Ref<Texture2D> &p_colors);
-	void set_emission_ring_axis(Vector3 p_axis);
+	void set_emission_ring_axis(const Vector3 &p_axis);
 	void set_emission_ring_height(real_t p_height);
 	void set_emission_ring_radius(real_t p_radius);
 	void set_emission_ring_inner_radius(real_t p_radius);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -173,7 +173,7 @@ bool StyleBoxFlat::is_draw_center_enabled() const {
 	return draw_center;
 }
 
-void StyleBoxFlat::set_skew(Vector2 p_skew) {
+void StyleBoxFlat::set_skew(const Vector2 &p_skew) {
 	skew = p_skew;
 	emit_changed();
 }

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -90,7 +90,7 @@ public:
 	void set_draw_center(bool p_enabled);
 	bool is_draw_center_enabled() const;
 
-	void set_skew(Vector2 p_skew);
+	void set_skew(const Vector2 &p_skew);
 	Vector2 get_skew() const;
 
 	void set_shadow_color(const Color &p_color);

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -290,7 +290,7 @@ void SurfaceTool::add_vertex(const Vector3 &p_vertex) {
 	format |= Mesh::ARRAY_FORMAT_VERTEX;
 }
 
-void SurfaceTool::set_color(Color p_color) {
+void SurfaceTool::set_color(const Color &p_color) {
 	ERR_FAIL_COND(!begun);
 
 	ERR_FAIL_COND(!first && !(format & Mesh::ARRAY_FORMAT_COLOR));

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -196,7 +196,7 @@ public:
 
 	void begin(Mesh::PrimitiveType p_primitive);
 
-	void set_color(Color p_color);
+	void set_color(const Color &p_color);
 	void set_normal(const Vector3 &p_normal);
 	void set_tangent(const Plane &p_tangent);
 	void set_uv(const Vector2 &p_uv);

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -617,7 +617,7 @@ void CodeHighlighter::set_uint_suffix_enabled(bool p_enabled) {
 	uint_suffix_enabled = p_enabled;
 }
 
-void CodeHighlighter::set_number_color(Color p_color) {
+void CodeHighlighter::set_number_color(const Color &p_color) {
 	number_color = p_color;
 	clear_highlighting_cache();
 }
@@ -626,7 +626,7 @@ Color CodeHighlighter::get_number_color() const {
 	return number_color;
 }
 
-void CodeHighlighter::set_symbol_color(Color p_color) {
+void CodeHighlighter::set_symbol_color(const Color &p_color) {
 	symbol_color = p_color;
 	clear_highlighting_cache();
 }
@@ -635,7 +635,7 @@ Color CodeHighlighter::get_symbol_color() const {
 	return symbol_color;
 }
 
-void CodeHighlighter::set_function_color(Color p_color) {
+void CodeHighlighter::set_function_color(const Color &p_color) {
 	function_color = p_color;
 	clear_highlighting_cache();
 }
@@ -644,7 +644,7 @@ Color CodeHighlighter::get_function_color() const {
 	return function_color;
 }
 
-void CodeHighlighter::set_member_variable_color(Color p_color) {
+void CodeHighlighter::set_member_variable_color(const Color &p_color) {
 	member_color = p_color;
 	clear_highlighting_cache();
 }

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -129,16 +129,16 @@ public:
 	void clear_color_regions();
 	Dictionary get_color_regions() const;
 
-	void set_number_color(Color p_color);
+	void set_number_color(const Color &p_color);
 	Color get_number_color() const;
 
-	void set_symbol_color(Color p_color);
+	void set_symbol_color(const Color &p_color);
 	Color get_symbol_color() const;
 
-	void set_function_color(Color p_color);
+	void set_function_color(const Color &p_color);
 	Color get_function_color() const;
 
-	void set_member_variable_color(Color p_color);
+	void set_member_variable_color(const Color &p_color);
 	Color get_member_variable_color() const;
 
 	void set_uint_suffix_enabled(bool p_enabled);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Minor performance issues caused by passing the following data types by value instead of const references where possible:

* AABB
* Basis
* Color
* Point2
* Rect2
* Rect2i
* Transform2D
* Transform3D
* Vector2
* Vector2i
* Vector3
* Vector4

## Additional information

Let me know if we should break this PR into multiple PRs, I'm aware this PR is touching many areas at once despite being a simple change.

AI was used implementing this simple patch across the code base since a simple regex search and replace won't do the trick in areas where the function parameters are modified.