### PR TITLE
Support multiple samplerates in Android with OpenSL audio driver

### DIFF
--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -79,8 +79,19 @@ void AudioDriverOpenSL::_buffer_callbacks(
 
 	ad->_buffer_callback(queueItf);
 }
+static int _sanitize_mix_rate(int p_mix_rate) {
+	static const int opensl_rates[] = { SL_SAMPLINGRATE_8, SL_SAMPLINGRATE_11_025, SL_SAMPLINGRATE_12, SL_SAMPLINGRATE_16, SL_SAMPLINGRATE_22_05, SL_SAMPLINGRATE_24, SL_SAMPLINGRATE_32, SL_SAMPLINGRATE_44_1, SL_SAMPLINGRATE_48, SL_SAMPLINGRATE_64, SL_SAMPLINGRATE_88_2, SL_SAMPLINGRATE_96, SL_SAMPLINGRATE_192 };
+	for (const int samplerate : opensl_rates) {
+		if (p_mix_rate == samplerate / 1000) {
+			return p_mix_rate;
+		}
+	}
+	return AudioDriverOpenSL::DEFAULT_MIX_RATE;
+}
 
 Error AudioDriverOpenSL::init() {
+	mix_rate = _sanitize_mix_rate(_get_configured_mix_rate());
+
 	SLresult res;
 	SLEngineOption EngineOption[] = {
 		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
@@ -130,7 +141,7 @@ void AudioDriverOpenSL::start() {
 	/* Setup the format of the content in the buffer queue */
 	pcm.formatType = SL_DATAFORMAT_PCM;
 	pcm.numChannels = 2;
-	pcm.samplesPerSec = SL_SAMPLINGRATE_44_1;
+	pcm.samplesPerSec = SLuint32(mix_rate) * 1000;
 	pcm.bitsPerSample = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.containerSize = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.channelMask = SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
@@ -213,7 +224,7 @@ Error AudioDriverOpenSL::init_input_device() {
 	SLDataFormat_PCM format_pcm = {
 		SL_DATAFORMAT_PCM,
 		1,
-		SL_SAMPLINGRATE_44_1,
+		SLuint32(mix_rate) * 1000,
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_SPEAKER_FRONT_CENTER,
@@ -300,7 +311,7 @@ Error AudioDriverOpenSL::input_stop() {
 }
 
 int AudioDriverOpenSL::get_mix_rate() const {
-	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
+	return mix_rate;
 }
 
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -30,6 +30,9 @@
 
 #include "audio_driver_opensl.h"
 
+#include "java_godot_io_wrapper.h"
+#include "os_android.h"
+
 #include "core/os/os.h"
 
 #define MAX_NUMBER_INTERFACES 3
@@ -79,8 +82,28 @@ void AudioDriverOpenSL::_buffer_callbacks(
 
 	ad->_buffer_callback(queueItf);
 }
+static int _sanitize_mix_rate(int p_mix_rate) {
+	static const int opensl_rates[] = { SL_SAMPLINGRATE_8, SL_SAMPLINGRATE_11_025, SL_SAMPLINGRATE_12, SL_SAMPLINGRATE_16, SL_SAMPLINGRATE_22_05, SL_SAMPLINGRATE_24, SL_SAMPLINGRATE_32, SL_SAMPLINGRATE_44_1, SL_SAMPLINGRATE_48, SL_SAMPLINGRATE_64, SL_SAMPLINGRATE_88_2, SL_SAMPLINGRATE_96, SL_SAMPLINGRATE_192 };
+	for (const int samplerate : opensl_rates) {
+		if (p_mix_rate == samplerate / 1000) {
+			return p_mix_rate;
+		}
+	}
+	WARN_PRINT("Mix rate not supported by OpenSL, using default mix rate.");
+	return AudioDriverOpenSL::DEFAULT_MIX_RATE;
+}
 
 Error AudioDriverOpenSL::init() {
+	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
+	ERR_FAIL_NULL_V_MSG(godot_io_java, ERR_INVALID_PARAMETER, "Godot IO Java Wrapper not available.");
+	mix_rate = _sanitize_mix_rate(godot_io_java->get_audio_output_sample_rate());
+
+	buffer_size = godot_io_java->get_audio_output_buffer_size();
+	if (buffer_size < MIN_BUFFER_SIZE) {
+		WARN_PRINT("Audio output buffer size not valid, using default.");
+		buffer_size = DEFAULT_BUFFER_SIZE;
+	}
+
 	SLresult res;
 	SLEngineOption EngineOption[] = {
 		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
@@ -98,9 +121,6 @@ void AudioDriverOpenSL::start() {
 	active = false;
 
 	SLresult res;
-
-	buffer_size = 1024;
-
 	for (int i = 0; i < BUFFER_COUNT; i++) {
 		buffers[i] = memnew_arr(int16_t, buffer_size * 2);
 		memset(buffers[i], 0, buffer_size * 4);
@@ -130,7 +150,7 @@ void AudioDriverOpenSL::start() {
 	/* Setup the format of the content in the buffer queue */
 	pcm.formatType = SL_DATAFORMAT_PCM;
 	pcm.numChannels = 2;
-	pcm.samplesPerSec = SL_SAMPLINGRATE_44_1;
+	pcm.samplesPerSec = SLuint32(mix_rate) * 1000;
 	pcm.bitsPerSample = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.containerSize = SL_PCMSAMPLEFORMAT_FIXED_16;
 	pcm.channelMask = SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT;
@@ -213,7 +233,7 @@ Error AudioDriverOpenSL::init_input_device() {
 	SLDataFormat_PCM format_pcm = {
 		SL_DATAFORMAT_PCM,
 		1,
-		SL_SAMPLINGRATE_44_1,
+		SLuint32(mix_rate) * 1000,
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_PCMSAMPLEFORMAT_FIXED_16,
 		SL_SPEAKER_FRONT_CENTER,
@@ -300,7 +320,7 @@ Error AudioDriverOpenSL::input_stop() {
 }
 
 int AudioDriverOpenSL::get_mix_rate() const {
-	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
+	return mix_rate;
 }
 
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
@@ -343,6 +363,18 @@ void AudioDriverOpenSL::finish() {
 	if (sl) {
 		(*sl)->Destroy(sl);
 		sl = nullptr;
+	}
+	if (buffers[0]) {
+		for (int i = 0; i < BUFFER_COUNT; i++) {
+			if (buffers[i]) {
+				memdelete_arr(buffers[i]);
+				buffers[i] = nullptr;
+			}
+		}
+	}
+	if (mixdown_buffer) {
+		memdelete_arr(mixdown_buffer);
+		mixdown_buffer = nullptr;
 	}
 }
 

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -50,6 +50,7 @@ class AudioDriverOpenSL : public AudioDriver {
 	int16_t *buffers[BUFFER_COUNT] = {};
 	int32_t *mixdown_buffer = nullptr;
 	int last_free = 0;
+	int mix_rate = DEFAULT_MIX_RATE;
 
 	Vector<int16_t> rec_buffer;
 
@@ -86,6 +87,8 @@ class AudioDriverOpenSL : public AudioDriver {
 	Error init_input_device();
 
 public:
+	static const int DEFAULT_MIX_RATE = SL_SAMPLINGRATE_44_1 / 1000;
+
 	virtual const char *get_name() const override {
 		return "Android";
 	}

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -41,15 +41,18 @@ class AudioDriverOpenSL : public AudioDriver {
 	Mutex mutex;
 
 	enum {
-		BUFFER_COUNT = 2
+		BUFFER_COUNT = 2,
+		DEFAULT_BUFFER_SIZE = 1024,
+		MIN_BUFFER_SIZE = 32,
 	};
 
 	bool pause = false;
 
-	uint32_t buffer_size = 0;
+	uint32_t buffer_size = DEFAULT_BUFFER_SIZE;
 	int16_t *buffers[BUFFER_COUNT] = {};
 	int32_t *mixdown_buffer = nullptr;
 	int last_free = 0;
+	int mix_rate = DEFAULT_MIX_RATE;
 
 	Vector<int16_t> rec_buffer;
 
@@ -86,6 +89,8 @@ class AudioDriverOpenSL : public AudioDriver {
 	Error init_input_device();
 
 public:
+	static const int DEFAULT_MIX_RATE = SL_SAMPLINGRATE_44_1 / 1000;
+
 	virtual const char *get_name() const override {
 		return "Android";
 	}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotIO.java
@@ -38,6 +38,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
+import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -100,6 +101,54 @@ public class GodotIO {
 	/////////////////////////
 	// MISCELLANEOUS OS IO
 	/////////////////////////
+
+	public int getAudioOutputSampleRate() {
+		AudioManager audioManager = (AudioManager)getContext().getSystemService(Context.AUDIO_SERVICE);
+		if (audioManager != null) {
+			String sampleRateStr = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE);
+			if (sampleRateStr != null) {
+				try {
+					int sampleRate = Integer.parseInt(sampleRateStr);
+					if (sampleRate > 0) {
+						return sampleRate;
+					} else {
+						Log.w(TAG, "Invalid sample rate from AudioManager");
+					}
+				} catch (NumberFormatException e) {
+					Log.w(TAG, "Failed to parse sample rate from AudioManager", e);
+				}
+			} else {
+				Log.w(TAG, "Sample rate not available from AudioManager");
+			}
+		} else {
+			Log.w(TAG, "AudioManager not available");
+		}
+		return 0;
+	}
+
+	public int getAudioOutputBufferSize() {
+		AudioManager audioManager = (AudioManager)getContext().getSystemService(Context.AUDIO_SERVICE);
+		if (audioManager != null) {
+			String bufferSizeStr = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER);
+			if (bufferSizeStr != null) {
+				try {
+					int bufferSize = Integer.parseInt(bufferSizeStr);
+					if (bufferSize > 0) {
+						return bufferSize;
+					} else {
+						Log.w(TAG, "Invalid buffer size from AudioManager");
+					}
+				} catch (NumberFormatException e) {
+					Log.w(TAG, "Failed to parse buffer size from AudioManager", e);
+				}
+			} else {
+				Log.w(TAG, "Buffer size not available from AudioManager");
+			}
+		} else {
+			Log.w(TAG, "AudioManager not available");
+		}
+		return 0;
+	}
 
 	public int openURI(String uriString) {
 		try {

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -56,6 +56,8 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_cache_dir = p_env->GetMethodID(cls, "getCacheDir", "()Ljava/lang/String;");
 		_get_temp_dir = p_env->GetMethodID(cls, "getTempDir", "()Ljava/lang/String;");
 		_get_data_dir = p_env->GetMethodID(cls, "getDataDir", "()Ljava/lang/String;");
+		_get_audio_output_sample_rate = p_env->GetMethodID(cls, "getAudioOutputSampleRate", "()I");
+		_get_audio_output_buffer_size = p_env->GetMethodID(cls, "getAudioOutputBufferSize", "()I");
 		_get_display_cutouts = p_env->GetMethodID(cls, "getDisplayCutouts", "()[I"),
 		_get_display_safe_area = p_env->GetMethodID(cls, "getDisplaySafeArea", "()[I"),
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
@@ -129,6 +131,26 @@ String GodotIOJavaWrapper::get_user_data_dir(const String &p_user_dir) {
 		return jstring_to_string(s, env);
 	} else {
 		return String();
+	}
+}
+
+int GodotIOJavaWrapper::get_audio_output_sample_rate() {
+	if (_get_audio_output_sample_rate) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, 0);
+		return env->CallIntMethod(godot_io_instance, _get_audio_output_sample_rate);
+	} else {
+		return 0;
+	}
+}
+
+int GodotIOJavaWrapper::get_audio_output_buffer_size() {
+	if (_get_audio_output_buffer_size) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, 0);
+		return env->CallIntMethod(godot_io_instance, _get_audio_output_buffer_size);
+	} else {
+		return 0;
 	}
 }
 

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -46,6 +46,8 @@ private:
 	jmethodID _get_cache_dir = nullptr;
 	jmethodID _get_data_dir = nullptr;
 	jmethodID _get_temp_dir = nullptr;
+	jmethodID _get_audio_output_sample_rate = nullptr;
+	jmethodID _get_audio_output_buffer_size = nullptr;
 	jmethodID _get_display_cutouts = nullptr;
 	jmethodID _get_display_rotation = nullptr;
 	jmethodID _get_display_safe_area = nullptr;
@@ -75,6 +77,8 @@ public:
 	String get_locale();
 	String get_model();
 	int get_screen_dpi();
+	int get_audio_output_sample_rate();
+	int get_audio_output_buffer_size();
 	float get_scaled_density();
 	float get_screen_refresh_rate(float fallback);
 	TypedArray<Rect2> get_display_cutouts();


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Fixes the samplerate being converted to[ the hardcoded 44100](https://github.com/godotengine/godot/blob/c12e51972a41665743be79c7d3e3fd5c871d97f3/platform/android/audio_driver_opensl.cpp#L303) on android devices that run at different sameplrates...which is most androids these days running at 48000Hz. Converting all audio drains battery and often results in glitchy audio.  

## Additional information
- Summary of changes: Allows the mix_rate to be set by the android device rather than it be hardcoded to 44100.

- Motivation: I was getting glitchy audio and battery drain in a voice chat app I'm developing and found it was due to both the mic and playback having their samplerate converted in realtime from 44100 to 48000 to interface with the hardware.

- Related: Fixes  #39631, #39612 

- Technical overview:  Sets mix rate at initialization by _get_configured_mix_rate() after being sanitized against the samplerates that OpenSL supports...its basically what the other audio drivers do but with the extra sanitization step to overcome OpenSL limitations (which is presumably why it was left hardocded before).  If nothing matches it falls back to the previously hardcoded value of 44100 for backward compatibility.

- Testing: Ran through clang-tidy and clang-format.  Tested on multiple android devices with realtime mic and speaker playback operating at 48000Hz and it cleared up the glitchy symptoms I was experiencing earlier.