### PR TITLE
Editor: Add Multiple Project Directories

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -823,6 +823,11 @@
 		<member name="filesystem/directories/default_project_path" type="String" setter="" getter="">
 			The folder where new projects should be created by default when clicking the project manager's [b]New Project[/b] button. This can be set to the same value as [member filesystem/directories/autoscan_project_path] for convenience.
 		</member>
+		<member name="filesystem/directories/enable_multiple_project_directories" type="bool" setter="" getter="">
+			If [code]true[/code], allows adding separate directories for projects. Only the projects within the selected directory will be shown.
+			[b]Note:[/b] While [code]true[/code], scanning will only scan the currently selected directory.
+			[b]Note:[/b] While [code]true[/code], importing a project will add it to the currently selected directory, but its folder will not be moved or copied. If installing a project from a zip file or creating a new project, if the chosen path is not in the directory list, it will be added.
+		</member>
 		<member name="filesystem/external_programs/3d_model_editor" type="String" setter="" getter="">
 			The program that opens 3D model scene files when clicking "Open in External Program" option in Filesystem Dock. If not specified, the file will be opened in the system's default program.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -820,6 +820,11 @@
 		<member name="filesystem/directories/default_project_path" type="String" setter="" getter="">
 			The folder where new projects should be created by default when clicking the project manager's [b]New Project[/b] button. This can be set to the same value as [member filesystem/directories/autoscan_project_path] for convenience.
 		</member>
+		<member name="filesystem/directories/enable_multiple_project_directories" type="bool" setter="" getter="">
+			If [code]true[/code], allows adding separate directories for projects. Only the projects within the selected directory will be shown.
+			[b]Note:[/b] While [code]true[/code], scanning will only scan the currently selected directory.
+			[b]Note:[/b] While [code]true[/code], importing a project will add it to the currently selected directory, but its folder will not be moved or copied. If installing a project from a zip file or creating a new project, if the chosen path is not in the directory list, it will be added.
+		</member>
 		<member name="filesystem/external_programs/3d_model_editor" type="String" setter="" getter="">
 			The program that opens 3D model scene files when clicking "Open in External Program" option in Filesystem Dock. If not specified, the file will be opened in the system's default program.
 		</member>

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/project_manager/project_manager.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_icons.h"
 #include "editor/themes/editor_scale.h"
@@ -406,7 +407,7 @@ void ProjectDialog::_install_path_changed() {
 void ProjectDialog::_browse_project_path() {
 	String path = project_path->get_text();
 	if (path.is_relative_path()) {
-		path = EDITOR_GET("filesystem/directories/default_project_path");
+		path = current_dir;
 	}
 	if (mode == MODE_IMPORT && install_path->is_visible_in_tree()) {
 		// Select last ZIP file.
@@ -437,7 +438,7 @@ void ProjectDialog::_browse_install_path() {
 
 	String path = install_path->get_text();
 	if (path.is_relative_path() || !DirAccess::dir_exists_absolute(path)) {
-		path = EDITOR_GET("filesystem/directories/default_project_path");
+		path = current_dir;
 	}
 	if (create_dir->is_pressed()) {
 		// Select parent directory of install path.
@@ -810,7 +811,11 @@ void ProjectDialog::ok_pressed() {
 			}
 		}
 #endif
-		emit_signal(SNAME("project_created"), path, mode == MODE_NEW || edit_check_box->is_pressed());
+		if (multi_dir && mode == MODE_IMPORT) {
+			emit_signal(SNAME("project_imported"), path, edit_check_box->is_pressed());
+		} else {
+			emit_signal(SNAME("project_created"), path, mode == MODE_NEW || edit_check_box->is_pressed());
+		}
 	} else if (mode == MODE_DUPLICATE) {
 		emit_signal(SNAME("project_duplicated"), original_project_path, path, edit_check_box->is_visible() && edit_check_box->is_pressed());
 	} else if (mode == MODE_RENAME) {
@@ -844,6 +849,10 @@ void ProjectDialog::set_project_name(const String &p_name) {
 
 void ProjectDialog::set_project_path(const String &p_path) {
 	project_path->set_text(p_path);
+}
+
+void ProjectDialog::set_current_directory(const String &p_dir) {
+	current_dir = p_dir;
 }
 
 void ProjectDialog::ask_for_path_and_show() {
@@ -888,7 +897,7 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 			install_path->set_text(original_dir);
 			fdialog_project->set_current_dir(original_dir);
 		} else {
-			String fav_dir = EDITOR_GET("filesystem/directories/default_project_path");
+			String fav_dir = current_dir;
 			fav_dir = fav_dir.simplify_path();
 			if (!fav_dir.is_empty()) {
 				project_path->set_text(fav_dir);
@@ -1015,6 +1024,7 @@ void ProjectDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("project_created"));
 	ADD_SIGNAL(MethodInfo("project_duplicated"));
 	ADD_SIGNAL(MethodInfo("projects_updated"));
+	ADD_SIGNAL(MethodInfo("project_imported"));
 }
 
 ProjectDialog::ProjectDialog() {
@@ -1245,4 +1255,7 @@ ProjectDialog::ProjectDialog() {
 
 	dialog_error = memnew(AcceptDialog);
 	add_child(dialog_error);
+
+	multi_dir = EDITOR_GET("filesystem/directories/enable_multiple_project_directories");
+	current_dir = EDITOR_GET("filesystem/directories/default_project_path");
 }

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -116,6 +116,11 @@ private:
 	void _update_ok_button();
 	void _validate_path();
 
+	// Project Directory
+
+	bool multi_dir = false;
+	String current_dir;
+
 	// Project path for MODE_NEW and MODE_INSTALL. Install path for MODE_IMPORT.
 	// Install path is only visible when importing a ZIP.
 	String _get_target_path();
@@ -159,6 +164,7 @@ public:
 	void set_zip_title(const String &p_title);
 	void set_original_project_path(const String &p_path);
 	void set_duplicate_can_edit(bool p_duplicate_can_edit);
+	void set_current_directory(const String &p_dir);
 
 	void ask_for_path_and_show();
 	void show_dialog(bool p_reset_name = true, bool p_is_confirmed = true);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -786,6 +786,11 @@ void ProjectList::save_config() {
 	_config.save(_config_path);
 }
 
+void ProjectList::reload_config() {
+	_config.clear();
+	_config.load(_config_path);
+}
+
 // Load project data from p_property_key and return it in a ProjectList::Item.
 // p_favorite is passed directly into the Item.
 ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_favorite) {
@@ -969,6 +974,28 @@ void ProjectList::update_project_list() {
 	queue_accessibility_update();
 }
 
+void ProjectList::update_directory_projects(const String &p_dir) {
+	_current_dir = p_dir;
+	for (int i = 0; i < _projects.size(); i++) {
+		_remove_project(i, false);
+		i--;
+	}
+
+	load_project_list();
+
+	for (int i = 0; i < _projects.size(); i++) {
+		_create_project_item_control(i);
+	}
+
+	sort_projects();
+	_update_icons_async();
+	update_dock_menu();
+
+	set_v_scroll(0);
+	emit_signal(SNAME(SIGNAL_LIST_CHANGED));
+	queue_accessibility_update();
+}
+
 void ProjectList::sort_projects() {
 	SortArray<Item, ProjectListComparator> sorter;
 	sorter.compare.order_option = _order_option;
@@ -1080,12 +1107,32 @@ void ProjectList::find_projects_multiple(const PackedStringArray &p_paths) {
 }
 
 void ProjectList::load_project_list() {
-	_config.load(_config_path);
-	Vector<String> sections = _config.get_sections();
+	if (multi_dir) {
+		_config.load(_config_path);
 
-	for (const String &path : sections) {
-		bool favorite = _config.get_value(path, "favorite", false);
-		_projects.push_back(load_project_data(path, favorite));
+		if (!_config.has_section(_current_dir)) {
+			return;
+		}
+
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
+
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			const String path = p[0];
+			const bool favorite = p[1];
+			_projects.push_back(load_project_data(path, favorite));
+		}
+	} else {
+		_config.load(_config_path);
+		Vector<String> sections = _config.get_sections();
+
+		for (const String &path : sections) {
+			bool favorite = _config.get_value(path, "favorite", false);
+			_projects.push_back(load_project_data(path, favorite));
+		}
 	}
 }
 
@@ -1115,13 +1162,72 @@ void ProjectList::_scan_folder_recursive(const String &p_path, List<String> *r_p
 	da->list_dir_end();
 }
 
+void ProjectList::_update_dir_list(const String &p_dir) {
+	ProjectManager::get_singleton()->update_dir_list(p_dir);
+}
+
 // Project list items.
 
 void ProjectList::add_project(const String &dir_path, bool favorite) {
-	if (!_config.has_section(dir_path)) {
-		_config.set_value(dir_path, "favorite", favorite);
+	if (multi_dir) {
+		const String base_dir = dir_path.get_base_dir();
+		if (_config.has_section(base_dir)) {
+			bool contains_project = false;
+			const PackedStringArray keys = _config.get_section_keys(base_dir);
+			int idx = 0;
+			for (const String &key : keys) {
+				if (key == active) {
+					continue;
+				}
+				idx += 1;
+				Vector<Variant> project = _config.get_value(base_dir, key, Variant());
+				if (project[0] == dir_path) {
+					contains_project = true;
+					break;
+				}
+			}
+			if (!contains_project) {
+				Vector<Variant> project = { dir_path, favorite };
+				_config.set_value(dir_path.get_base_dir(), vformat("project_%d", idx), project);
+			}
+		} else {
+			Vector<Variant> project = { dir_path, favorite };
+			_config.set_value(base_dir, active, false);
+			_config.set_value(base_dir, vformat("project_%d", 0), project);
+
+			_update_dir_list(base_dir);
+		}
+	} else {
+		if (!_config.has_section(dir_path)) {
+			_config.set_value(dir_path, "favorite", favorite);
+		}
 	}
+
 	queue_accessibility_update();
+}
+
+void ProjectList::import_project(const String &p_dir_path) {
+	PackedStringArray keys = _config.get_section_keys(_current_dir);
+	for (const String &key : keys) {
+		if (key == active) {
+			continue;
+		}
+		Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+		if (p[0] == p_dir_path) {
+			return;
+		}
+	}
+	Vector<Variant> p = { p_dir_path, false };
+	_config.set_value(_current_dir, vformat("project_%d", keys.size()), p);
+}
+
+void ProjectList::create_project_item(const String &p_dir_path, bool p_select) {
+	_projects.push_back(load_project_data(p_dir_path, false));
+
+	if (p_select) {
+		_selected_project_paths.clear();
+		_selected_project_paths.insert(p_dir_path);
+	}
 }
 
 void ProjectList::set_project_version(const String &p_project_path, int p_version) {
@@ -1139,9 +1245,27 @@ int ProjectList::refresh_project(const String &dir_path) {
 	// If it isn't in the list anymore, it is removed.
 	// If it is in the list but doesn't exist anymore, it is marked as missing.
 
-	bool should_be_in_list = _config.has_section(dir_path);
-	bool is_favorite = _config.get_value(dir_path, "favorite", false);
+	bool should_be_in_list = false;
+	bool is_favorite = false;
+	int index = -1;
+	if (multi_dir) {
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
 
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			if (p[0] == dir_path) {
+				should_be_in_list = true;
+				is_favorite = p[1];
+				break;
+			}
+		}
+	} else {
+		should_be_in_list = _config.has_section(dir_path);
+		is_favorite = _config.get_value(dir_path, "favorite", false);
+	}
 	bool was_selected = _selected_project_paths.has(dir_path);
 
 	int temp_title_index = -1;
@@ -1157,7 +1281,6 @@ int ProjectList::refresh_project(const String &dir_path) {
 		}
 	}
 
-	int index = -1;
 	if (should_be_in_list) {
 		// Recreate it with updated info
 
@@ -1268,7 +1391,26 @@ void ProjectList::_remove_project(int p_index, bool p_update_config) {
 	_projects.remove_at(p_index);
 
 	if (p_update_config) {
-		_config.erase_section(item.path);
+		if (multi_dir) {
+			Vector<Vector<Variant>> ps;
+			PackedStringArray keys = _config.get_section_keys(_current_dir);
+			for (const String &key : keys) {
+				if (key == active) {
+					continue;
+				}
+
+				Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+				if (p[0] != item.path) {
+					ps.append(p);
+				}
+				_config.erase_section_key(_current_dir, key);
+			}
+			for (int i = 0; i < ps.size(); i++) {
+				_config.set_value(_current_dir, vformat("project_%d", i), ps[i]);
+			}
+		} else {
+			_config.erase_section(item.path);
+		}
 		// Not actually saving the file, in case you are doing more changes to settings
 	}
 
@@ -1341,10 +1483,26 @@ void ProjectList::_on_favorite_pressed(Node *p_hb) {
 
 	int index = control->get_index();
 	Item item = _projects.write[index]; // Take copy
-
+	const String base_dir = item.path.get_base_dir();
 	item.favorite = !item.favorite;
 
-	_config.set_value(item.path, "favorite", item.favorite);
+	if (multi_dir) {
+		PackedStringArray keys = _config.get_section_keys(base_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
+
+			Vector<Variant> p = _config.get_value(base_dir, key, Variant());
+			if (p[0] == item.path) {
+				p.write[1] = item.favorite;
+				_config.set_value(base_dir, key, p);
+				break;
+			}
+		}
+	} else {
+		_config.set_value(item.path, "favorite", item.favorite);
+	}
 	save_config();
 
 	_projects.write[index] = item;
@@ -1560,20 +1718,48 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 		return;
 	}
 
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
-			_config.erase_section(item.path);
+	if (multi_dir) {
+		Vector<Vector<Variant>> ps;
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (int i = 0; i < _projects.size(); i++) {
+			Item &item = _projects.write[i];
+			if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
+				memdelete(item.control);
+				_projects.remove_at(i);
+				--i;
+			}
+		}
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
 
-			// Comment out for now until we have a better warning system to
-			// ensure users delete their project only.
-			//if (p_delete_project_contents) {
-			//	OS::get_singleton()->move_to_trash(item.path);
-			//}
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			if (!_selected_project_paths.has(p[0])) {
+				ps.append(p);
+			}
+			_config.erase_section_key(_current_dir, key);
+		}
+		for (int i = 0; i < ps.size(); i++) {
+			_config.set_value(_current_dir, vformat("project_%d", i), ps[i]);
+		}
 
-			memdelete(item.control);
-			_projects.remove_at(i);
-			--i;
+	} else {
+		for (int i = 0; i < _projects.size(); ++i) {
+			Item &item = _projects.write[i];
+			if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
+				_config.erase_section(item.path);
+
+				// Comment out for now until we have a better warning system to
+				// ensure users delete their project only.
+				//if (p_delete_project_contents) {
+				//	OS::get_singleton()->move_to_trash(item.path);
+				//}
+
+				memdelete(item.control);
+				_projects.remove_at(i);
+				--i;
+			}
 		}
 	}
 
@@ -1725,6 +1911,12 @@ ProjectList::ProjectList() {
 	project_list_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_child(project_list_vbox);
 
-	_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
+	multi_dir = EDITOR_GET("filesystem/directories/enable_multiple_project_directories");
+
+	if (multi_dir) {
+		_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("multi_dir.cfg");
+	} else {
+		_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
+	}
 	_migrate_config();
 }

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -788,6 +788,11 @@ void ProjectList::save_config() {
 	_config.save(_config_path);
 }
 
+void ProjectList::reload_config() {
+	_config.clear();
+	_config.load(_config_path);
+}
+
 // Load project data from p_property_key and return it in a ProjectList::Item.
 // p_favorite is passed directly into the Item.
 ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_favorite) {
@@ -971,6 +976,28 @@ void ProjectList::update_project_list() {
 	queue_accessibility_update();
 }
 
+void ProjectList::update_directory_projects(const String &p_dir) {
+	_current_dir = p_dir;
+	for (int i = 0; i < _projects.size(); i++) {
+		_remove_project(i, false);
+		i--;
+	}
+
+	load_project_list();
+
+	for (int i = 0; i < _projects.size(); i++) {
+		_create_project_item_control(i);
+	}
+
+	sort_projects();
+	_update_icons_async();
+	update_dock_menu();
+
+	set_v_scroll(0);
+	emit_signal(SNAME(SIGNAL_LIST_CHANGED));
+	queue_accessibility_update();
+}
+
 void ProjectList::sort_projects() {
 	SortArray<Item, ProjectListComparator> sorter;
 	sorter.compare.order_option = _order_option;
@@ -1082,12 +1109,32 @@ void ProjectList::find_projects_multiple(const PackedStringArray &p_paths) {
 }
 
 void ProjectList::load_project_list() {
-	_config.load(_config_path);
-	Vector<String> sections = _config.get_sections();
+	if (multi_dir) {
+		_config.load(_config_path);
 
-	for (const String &path : sections) {
-		bool favorite = _config.get_value(path, "favorite", false);
-		_projects.push_back(load_project_data(path, favorite));
+		if (!_config.has_section(_current_dir)) {
+			return;
+		}
+
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
+
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			const String path = p[0];
+			const bool favorite = p[1];
+			_projects.push_back(load_project_data(path, favorite));
+		}
+	} else {
+		_config.load(_config_path);
+		Vector<String> sections = _config.get_sections();
+
+		for (const String &path : sections) {
+			bool favorite = _config.get_value(path, "favorite", false);
+			_projects.push_back(load_project_data(path, favorite));
+		}
 	}
 }
 
@@ -1117,13 +1164,72 @@ void ProjectList::_scan_folder_recursive(const String &p_path, List<String> *r_p
 	da->list_dir_end();
 }
 
+void ProjectList::_update_dir_list(const String &p_dir) {
+	ProjectManager::get_singleton()->update_dir_list(p_dir);
+}
+
 // Project list items.
 
 void ProjectList::add_project(const String &dir_path, bool favorite) {
-	if (!_config.has_section(dir_path)) {
-		_config.set_value(dir_path, "favorite", favorite);
+	if (multi_dir) {
+		const String base_dir = dir_path.get_base_dir();
+		if (_config.has_section(base_dir)) {
+			bool contains_project = false;
+			const PackedStringArray keys = _config.get_section_keys(base_dir);
+			int idx = 0;
+			for (const String &key : keys) {
+				if (key == active) {
+					continue;
+				}
+				idx += 1;
+				Vector<Variant> project = _config.get_value(base_dir, key, Variant());
+				if (project[0] == dir_path) {
+					contains_project = true;
+					break;
+				}
+			}
+			if (!contains_project) {
+				Vector<Variant> project = { dir_path, favorite };
+				_config.set_value(dir_path.get_base_dir(), vformat("project_%d", idx), project);
+			}
+		} else {
+			Vector<Variant> project = { dir_path, favorite };
+			_config.set_value(base_dir, active, false);
+			_config.set_value(base_dir, vformat("project_%d", 0), project);
+
+			_update_dir_list(base_dir);
+		}
+	} else {
+		if (!_config.has_section(dir_path)) {
+			_config.set_value(dir_path, "favorite", favorite);
+		}
 	}
+
 	queue_accessibility_update();
+}
+
+void ProjectList::import_project(const String &p_dir_path) {
+	PackedStringArray keys = _config.get_section_keys(_current_dir);
+	for (const String &key : keys) {
+		if (key == active) {
+			continue;
+		}
+		Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+		if (p[0] == p_dir_path) {
+			return;
+		}
+	}
+	Vector<Variant> p = { p_dir_path, false };
+	_config.set_value(_current_dir, vformat("project_%d", keys.size()), p);
+}
+
+void ProjectList::create_project_item(const String &p_dir_path, bool p_select) {
+	_projects.push_back(load_project_data(p_dir_path, false));
+
+	if (p_select) {
+		_selected_project_paths.clear();
+		_selected_project_paths.insert(p_dir_path);
+	}
 }
 
 void ProjectList::set_project_version(const String &p_project_path, int p_version) {
@@ -1141,9 +1247,27 @@ int ProjectList::refresh_project(const String &dir_path) {
 	// If it isn't in the list anymore, it is removed.
 	// If it is in the list but doesn't exist anymore, it is marked as missing.
 
-	bool should_be_in_list = _config.has_section(dir_path);
-	bool is_favorite = _config.get_value(dir_path, "favorite", false);
+	bool should_be_in_list = false;
+	bool is_favorite = false;
+	int index = -1;
+	if (multi_dir) {
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
 
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			if (p[0] == dir_path) {
+				should_be_in_list = true;
+				is_favorite = p[1];
+				break;
+			}
+		}
+	} else {
+		should_be_in_list = _config.has_section(dir_path);
+		is_favorite = _config.get_value(dir_path, "favorite", false);
+	}
 	bool was_selected = _selected_project_paths.has(dir_path);
 
 	int temp_title_index = -1;
@@ -1159,7 +1283,6 @@ int ProjectList::refresh_project(const String &dir_path) {
 		}
 	}
 
-	int index = -1;
 	if (should_be_in_list) {
 		// Recreate it with updated info
 
@@ -1278,7 +1401,26 @@ void ProjectList::_remove_project(int p_index, bool p_update_config) {
 	_projects.remove_at(p_index);
 
 	if (p_update_config) {
-		_config.erase_section(item.path);
+		if (multi_dir) {
+			Vector<Vector<Variant>> ps;
+			PackedStringArray keys = _config.get_section_keys(_current_dir);
+			for (const String &key : keys) {
+				if (key == active) {
+					continue;
+				}
+
+				Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+				if (p[0] != item.path) {
+					ps.append(p);
+				}
+				_config.erase_section_key(_current_dir, key);
+			}
+			for (int i = 0; i < ps.size(); i++) {
+				_config.set_value(_current_dir, vformat("project_%d", i), ps[i]);
+			}
+		} else {
+			_config.erase_section(item.path);
+		}
 		// Not actually saving the file, in case you are doing more changes to settings
 	}
 
@@ -1351,10 +1493,26 @@ void ProjectList::_on_favorite_pressed(Node *p_hb) {
 
 	int index = control->get_index();
 	Item item = _projects.write[index]; // Take copy
-
+	const String base_dir = item.path.get_base_dir();
 	item.favorite = !item.favorite;
 
-	_config.set_value(item.path, "favorite", item.favorite);
+	if (multi_dir) {
+		PackedStringArray keys = _config.get_section_keys(base_dir);
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
+
+			Vector<Variant> p = _config.get_value(base_dir, key, Variant());
+			if (p[0] == item.path) {
+				p.write[1] = item.favorite;
+				_config.set_value(base_dir, key, p);
+				break;
+			}
+		}
+	} else {
+		_config.set_value(item.path, "favorite", item.favorite);
+	}
 	save_config();
 
 	_projects.write[index] = item;
@@ -1570,20 +1728,48 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 		return;
 	}
 
-	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
-			_config.erase_section(item.path);
+	if (multi_dir) {
+		Vector<Vector<Variant>> ps;
+		PackedStringArray keys = _config.get_section_keys(_current_dir);
+		for (int i = 0; i < _projects.size(); i++) {
+			Item &item = _projects.write[i];
+			if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
+				memdelete(item.control);
+				_projects.remove_at(i);
+				--i;
+			}
+		}
+		for (const String &key : keys) {
+			if (key == active) {
+				continue;
+			}
 
-			// Comment out for now until we have a better warning system to
-			// ensure users delete their project only.
-			//if (p_delete_project_contents) {
-			//	OS::get_singleton()->move_to_trash(item.path);
-			//}
+			Vector<Variant> p = _config.get_value(_current_dir, key, Variant());
+			if (!_selected_project_paths.has(p[0])) {
+				ps.append(p);
+			}
+			_config.erase_section_key(_current_dir, key);
+		}
+		for (int i = 0; i < ps.size(); i++) {
+			_config.set_value(_current_dir, vformat("project_%d", i), ps[i]);
+		}
 
-			memdelete(item.control);
-			_projects.remove_at(i);
-			--i;
+	} else {
+		for (int i = 0; i < _projects.size(); ++i) {
+			Item &item = _projects.write[i];
+			if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
+				_config.erase_section(item.path);
+
+				// Comment out for now until we have a better warning system to
+				// ensure users delete their project only.
+				//if (p_delete_project_contents) {
+				//	OS::get_singleton()->move_to_trash(item.path);
+				//}
+
+				memdelete(item.control);
+				_projects.remove_at(i);
+				--i;
+			}
 		}
 	}
 
@@ -1735,6 +1921,12 @@ ProjectList::ProjectList() {
 	project_list_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_child(project_list_vbox);
 
-	_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
+	multi_dir = EDITOR_GET("filesystem/directories/enable_multiple_project_directories");
+
+	if (multi_dir) {
+		_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("multi_dir.cfg");
+	} else {
+		_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
+	}
 	_migrate_config();
 }

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -242,6 +242,14 @@ private:
 	VBoxContainer *project_list_vbox = nullptr;
 	PopupMenu *project_context_menu = nullptr;
 
+	// Project Directory
+
+	bool multi_dir = false;
+	String _current_dir;
+	const String active = "active";
+
+	void _update_dir_list(const String &p_dir);
+
 	// Projects scan.
 
 	struct ScanData {
@@ -310,11 +318,13 @@ public:
 	// Initialization & loading.
 
 	void save_config();
+	void reload_config();
 
 	// Project list updates.
 
 	void load_project_list();
 	void update_project_list();
+	void update_directory_projects(const String &p_dir);
 	void sort_projects();
 	int get_project_count() const;
 
@@ -324,6 +334,8 @@ public:
 	// Project list items.
 
 	void add_project(const String &dir_path, bool favorite);
+	void import_project(const String &p_dir_path);
+	void create_project_item(const String &p_dir_path, bool p_select = false);
 	void set_project_version(const String &p_project_path, int version);
 	int refresh_project(const String &dir_path);
 	void ensure_project_visible(int p_index);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -242,6 +242,14 @@ private:
 	VBoxContainer *project_list_vbox = nullptr;
 	PopupMenu *project_context_menu = nullptr;
 
+	// Project Directory
+
+	bool multi_dir = false;
+	String _current_dir;
+	const String active = "active";
+
+	void _update_dir_list(const String &p_dir);
+
 	// Projects scan.
 
 	struct ScanData {
@@ -309,11 +317,13 @@ public:
 	// Initialization & loading.
 
 	void save_config();
+	void reload_config();
 
 	// Project list updates.
 
 	void load_project_list();
 	void update_project_list();
+	void update_directory_projects(const String &p_dir);
 	void sort_projects();
 	int get_project_count() const;
 
@@ -323,6 +333,8 @@ public:
 	// Project list items.
 
 	void add_project(const String &dir_path, bool favorite);
+	void import_project(const String &p_dir_path);
+	void create_project_item(const String &p_dir_path, bool p_select = false);
 	void set_project_version(const String &p_project_path, int version);
 	int refresh_project(const String &dir_path);
 	void ensure_project_visible(int p_index);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -43,6 +43,7 @@
 #include "editor/asset_library/asset_library_editor_plugin.h"
 #include "editor/doc/editor_help.h"
 #include "editor/editor_string_names.h"
+#include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_about.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_title_bar.h"
@@ -131,6 +132,7 @@ void ProjectManager::_notification(int p_what) {
 
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_dim_window();
+			update_active_dir();
 		} break;
 
 		case NOTIFICATION_WM_ABOUT: {
@@ -250,6 +252,14 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 
 		_set_main_view_icon(MAIN_VIEW_PROJECTS, get_editor_theme_icon("ProjectList"));
 		_set_main_view_icon(MAIN_VIEW_ASSETLIB, get_editor_theme_icon("AssetStore"));
+
+		// Directory
+		{
+			if (multi_dir) {
+				manage_dir_btn->set_button_icon(get_editor_theme_icon("Folder"));
+				add_dir_btn->set_button_icon(get_editor_theme_icon("Add"));
+			}
+		}
 
 		// Project list.
 		{
@@ -453,8 +463,9 @@ void ProjectManager::_project_list_menu_option(int p_option) {
 	}
 }
 
-void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size) {
+void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size, bool p_autowrap) {
 	error_dialog->set_text(p_message);
+	error_dialog->set_autowrap(p_autowrap);
 	error_dialog->popup_centered(p_min_size);
 }
 
@@ -481,6 +492,7 @@ void ProjectManager::_restart_confirmed() {
 	ERR_FAIL_COND(err);
 
 	_dim_window();
+	update_active_dir();
 	get_tree()->quit();
 }
 
@@ -507,7 +519,15 @@ void ProjectManager::_update_list_placeholder() {
 }
 
 void ProjectManager::_scan_projects() {
-	scan_dir->popup_file_dialog();
+	if (multi_dir) {
+		if (dir_option_btn->get_item_text(0) == "Empty") {
+			scan_dir->popup_file_dialog();
+		} else {
+			project_list->find_projects(current_dir);
+		}
+	} else {
+		scan_dir->popup_file_dialog();
+	}
 }
 
 void ProjectManager::_run_project() {
@@ -611,6 +631,7 @@ void ProjectManager::_open_selected_projects() {
 	project_list->project_opening_initiated = true;
 
 	_dim_window();
+	update_active_dir();
 	get_tree()->quit();
 }
 
@@ -953,7 +974,27 @@ void ProjectManager::_on_project_created(const String &dir, bool edit) {
 	project_list->save_config();
 	search_box->clear();
 
-	int i = project_list->refresh_project(dir);
+	if (dir.get_base_dir() != current_dir && edit) {
+		project_list->create_project_item(dir, true);
+	} else if (dir.get_base_dir() == current_dir) {
+		int i = project_list->refresh_project(dir);
+		project_list->ensure_project_visible(i);
+		_update_list_placeholder();
+	}
+
+	if (edit) {
+		_open_selected_projects_check_warnings();
+	}
+
+	project_list->update_dock_menu();
+}
+
+void ProjectManager::_on_project_imported(const String &p_dir, bool edit) {
+	project_list->import_project(p_dir);
+	project_list->save_config();
+	search_box->clear();
+
+	int i = project_list->refresh_project(p_dir);
 	project_list->ensure_project_visible(i);
 	_update_list_placeholder();
 
@@ -1010,6 +1051,308 @@ void ProjectManager::_on_search_term_submitted(const String &p_text) {
 
 LineEdit *ProjectManager::get_search_box() {
 	return search_box;
+}
+
+// Project directory management.
+
+void ProjectManager::_manage_project_dirs() {
+	for (int i = 0; i < project_directories->get_child_count() - 1; i++) {
+		project_directories->get_child(i)->queue_free();
+	}
+
+	for (KeyValue<String, bool> &dir : dir_set) {
+		const String folder = dir.key.get_slicec('/', dir.key.get_slice_count("/") - 1);
+
+		Button *p_dir = memnew(Button);
+		project_directories->add_child(p_dir);
+		project_directories->move_child(p_dir, -2);
+
+		p_dir->set_text(folder.capitalize());
+		p_dir->set_tooltip_text(dir.key);
+		p_dir->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+		p_dir->set_button_icon(get_editor_theme_icon("Remove"));
+		p_dir->set_meta("active", dir.value);
+		p_dir->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_remove_project_dir).bind(p_dir));
+
+		if (dir.value) {
+			p_dir->set_theme_type_variation(SNAME("ProjectDirectoryActiveButton"));
+		}
+	}
+	temp_dir_set = dir_set;
+	dir_manage_dialog->popup_centered(Vector2(300, 200) * EDSCALE);
+}
+
+void ProjectManager::_load_project_dirs() {
+	ConfigFile config;
+	config.load(dir_config_path);
+
+	Error err = config.load(dir_config_path);
+	if (err == ERR_FILE_NOT_FOUND) {
+		config.save(dir_config_path);
+
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+	} else if (err != OK) {
+		_show_error(vformat(TTR("Couldn't load multi_dir.cfg at %s.\nError: %d"), dir_config_path.get_base_dir(), err));
+
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+	} else if (err == OK) {
+		PackedStringArray dirs = config.get_sections();
+		if (dirs.is_empty()) {
+			current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+			dir_option_btn->add_item("Empty", 0);
+
+			dir_fdialog->set_current_path(current_dir.get_base_dir());
+			return;
+		}
+
+		for (const String &dir : dirs) {
+			bool active = config.get_value(dir, "active", bool());
+			dir_set[dir] = active;
+		}
+
+		_update_dir_list();
+	}
+}
+
+void ProjectManager::update_dir_list(const String &p_dir) {
+	dir_set[p_dir] = false;
+	_update_dir_list();
+}
+
+void ProjectManager::_update_dir_list() {
+	dir_option_btn->clear();
+
+	if (dir_set.is_empty()) {
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+		return;
+	}
+
+	int idx = -1;
+	bool no_dir_active = true;
+	for (KeyValue<String, bool> &dir : dir_set) {
+		idx += 1;
+		PackedStringArray item = dir.key.split("/");
+		dir_option_btn->add_item(item[item.size() - 1].capitalize(), idx);
+		dir_option_btn->set_item_metadata(idx, dir.key);
+		bool active = dir.value;
+
+		if (active) {
+			no_dir_active = false;
+			current_dir = dir.key;
+			dir_option_btn->select(idx);
+		}
+	}
+	if (no_dir_active) {
+		dir_option_btn->select(0);
+		const String dir = dir_option_btn->get_item_metadata(0);
+		current_dir = dir;
+		dir_set[dir] = true;
+
+		_update_new_active_dir_projects(current_dir);
+	}
+}
+
+void ProjectManager::_remove_project_dir(Button *p_dir) {
+	if (p_dir->get_meta("active")) {
+		confirm_dialog->set_text(vformat(TTR("Directory \"%s\" is the selected directory,\nare you sure you want to remove it from the list?"), p_dir->get_text()));
+		confirm_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ProjectManager::_remove_active_dir).bind(p_dir), CONNECT_ONE_SHOT);
+		confirm_dialog->popup_centered(Size2(400 * EDSCALE, 0));
+		return;
+	}
+	const String dir = p_dir->get_tooltip_text();
+	temp_dir_set.erase(dir);
+
+	if (dir_to_make_active == p_dir->get_tooltip_text()) {
+		for (KeyValue<String, bool> &t : temp_dir_set) {
+			dir_to_make_active = t.key;
+			break;
+		}
+	}
+	p_dir->queue_free();
+}
+
+void ProjectManager::_remove_active_dir(Button *p_dir) {
+	const String d_dir = p_dir->get_tooltip_text();
+	temp_dir_set.erase(d_dir);
+	for (KeyValue<String, bool> &t : temp_dir_set) {
+		dir_to_make_active = t.key;
+		break;
+	}
+	temp_dir_set.erase(d_dir);
+	p_dir->queue_free();
+}
+
+void ProjectManager::_add_project_dir(const String &p_dir) {
+	const String folder = p_dir.get_slicec('/', p_dir.get_slice_count("/") - 1);
+
+	Button *dir_btn = memnew(Button);
+	project_directories->add_child(dir_btn);
+	project_directories->move_child(dir_btn, -2);
+
+	dir_btn->set_text(folder.capitalize());
+	dir_btn->set_tooltip_text(p_dir);
+	dir_btn->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	dir_btn->set_button_icon(get_editor_theme_icon("Remove"));
+	dir_btn->set_meta("active", false);
+	dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_remove_project_dir).bind(dir_btn));
+
+	temp_dir_set[p_dir] = false;
+}
+
+void ProjectManager::_apply_project_dirs() {
+	ConfigFile config;
+	config.load(dir_config_path);
+
+	PackedStringArray new_dirs;
+	PackedStringArray create_dirs;
+	if (temp_dir_set.is_empty()) {
+		config.clear();
+		dir_set.clear();
+		current_dir.clear();
+		project_list->update_directory_projects(current_dir);
+		_update_list_placeholder();
+	} else {
+		for (KeyValue<String, bool> &p : dir_set) {
+			if (!temp_dir_set.has(p.key)) {
+				config.erase_section(p.key);
+			}
+		}
+
+		HashMap<String, bool> dir_cache;
+		dir_cache = dir_set;
+		dir_set.clear();
+		for (KeyValue<String, bool> &p : temp_dir_set) {
+			const String dir = p.key;
+			bool active = p.value;
+			Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			if (dir_cache.has(dir)) {
+				dir_set[dir] = active;
+				continue;
+			}
+			if (d->exists(dir)) {
+				new_dirs.append(dir);
+				config.set_value(dir, "active", active);
+				dir_set[dir] = active;
+			} else {
+				create_dirs.append(dir);
+				config.set_value(dir, "active", active);
+			}
+		}
+
+		bool new_active_dir = false;
+		if (!dir_to_make_active.is_empty()) {
+			PackedStringArray sections = config.get_sections();
+			for (const String &sect : sections) {
+				if (sect == dir_to_make_active) {
+					config.set_value(sect, "active", true);
+					dir_set[sect] = true;
+					new_active_dir = true;
+
+					break;
+				}
+			}
+		}
+		if (new_active_dir) {
+			_update_new_active_dir_projects(dir_to_make_active);
+			dir_to_make_active.clear();
+		}
+
+		if (!new_dirs.is_empty()) {
+			project_list->find_projects_multiple(new_dirs);
+		}
+		if (!create_dirs.is_empty()) {
+			_create_project_dirs(create_dirs);
+		}
+	}
+	config.save(dir_config_path);
+
+	_update_dir_list();
+	project_list->reload_config();
+}
+
+void ProjectManager::_create_project_dirs(const PackedStringArray &p_dirs) {
+	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	PackedStringArray err_string;
+	PackedStringArray s_dirs;
+	for (const String &dir : p_dirs) {
+		if (!d->dir_exists(dir) && d->make_dir(dir) != OK) {
+			err_string.append(dir);
+			continue;
+		}
+		s_dirs.append(dir);
+	}
+
+	ConfigFile config;
+	config.load(dir_config_path);
+	for (const String &s_dir : s_dirs) {
+		config.set_value(s_dir, "active", false);
+		dir_set[s_dir] = false;
+	}
+	_update_dir_list();
+
+	if (err_string.size() > 0) {
+		String error_msg = TTR("Couldn't create directory at:");
+		for (const String &err : err_string) {
+			error_msg += vformat("\n%s", err);
+		}
+		error_msg += vformat("\nCheck permissions");
+		if (err_string.size() > 1) {
+			_show_error(TTRC(error_msg), Vector2(600 * EDSCALE, 0), true);
+		} else {
+			_show_error(TTRC(error_msg), Vector2(400 * EDSCALE, 0), true);
+		}
+		error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &ProjectManager::_manage_project_dirs), CONNECT_ONE_SHOT);
+	}
+}
+
+void ProjectManager::_dir_option_selected(const int p_id) {
+	current_dir = dir_option_btn->get_item_metadata(p_id);
+	for (KeyValue<String, bool> &dir : dir_set) {
+		dir.value = false;
+	}
+	dir_set[current_dir] = true;
+
+	project_dialog->set_current_directory(current_dir);
+	project_list->update_directory_projects(current_dir);
+}
+
+void ProjectManager::_dir_path_selected(const String &p_dir) {
+	dir_manage_dialog->popup_centered(Size2(300, 200) * EDSCALE);
+	_add_project_dir(p_dir);
+}
+
+void ProjectManager::_show_dir_file_dialog() {
+	dir_fdialog->set_current_dir(current_dir.get_base_dir());
+	dir_fdialog->popup_file_dialog();
+}
+
+void ProjectManager::_update_new_active_dir_projects(const String &p_dir) const {
+	project_list->update_directory_projects(p_dir);
+}
+
+void ProjectManager::update_active_dir() {
+	ConfigFile config;
+	config.load(dir_config_path);
+	PackedStringArray sects = config.get_sections();
+	for (const String &sect : sects) {
+		config.set_value(sect, "active", false);
+	}
+	for (KeyValue<String, bool> &dir : dir_set) {
+		if (dir.value) {
+			config.set_value(dir.key, "active", true);
+			break;
+		}
+	}
+	config.save(dir_config_path);
 }
 
 // Project tag management.
@@ -1236,6 +1579,7 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 #ifndef MACOS_ENABLED
 		if (k->get_keycode_with_modifiers() == (KeyModifierMask::META | Key::Q)) {
 			_dim_window();
+			update_active_dir();
 			get_tree()->quit();
 		}
 #endif
@@ -1392,6 +1736,11 @@ ProjectManager::ProjectManager() {
 
 		FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 		FileDialog::set_default_display_mode((FileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
+
+		multi_dir = EDITOR_GET("filesystem/directories/enable_multiple_project_directories");
+		if (multi_dir) {
+			dir_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("multi_dir.cfg");
+		}
 
 		int swap_cancel_ok = EDITOR_GET("interface/editor/appearance/accept_dialog_cancel_ok_buttons");
 		if (swap_cancel_ok != 0) { // 0 is auto, set in register_scene based on DisplayServer.
@@ -1594,6 +1943,56 @@ ProjectManager::ProjectManager() {
 			filter_option->add_item(TTRC("Tags"));
 		}
 
+		/* Project Directory */
+		{
+			if (multi_dir) {
+				HBoxContainer *project_dir_hb = memnew(HBoxContainer);
+				local_projects_vb->add_child(project_dir_hb);
+
+				Label *label = memnew(Label(TTR("Current Directory:")));
+				project_dir_hb->add_child(label);
+
+				dir_option_btn = memnew(OptionButton);
+				project_dir_hb->add_child(dir_option_btn);
+				dir_option_btn->set_fit_to_longest_item(false);
+				dir_option_btn->connect(SceneStringName(item_selected), callable_mp(this, &ProjectManager::_dir_option_selected));
+
+				// Directory Manage Dialog
+
+				dir_manage_dialog = memnew(ConfirmationDialog);
+				add_child(dir_manage_dialog);
+				dir_manage_dialog->set_title("Manage Project Directories");
+				dir_manage_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_apply_project_dirs));
+
+				project_directories = memnew(HFlowContainer);
+				dir_manage_dialog->add_child(project_directories);
+
+				add_dir_btn = memnew(Button);
+				project_directories->add_child(add_dir_btn);
+				add_dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_dir_file_dialog));
+
+				// Confirm Dialog
+
+				confirm_dialog = memnew(ConfirmationDialog);
+				dir_manage_dialog->add_child(confirm_dialog);
+				confirm_dialog->set_title(TTRC("Remove Directory"));
+				confirm_dialog->set_ok_button_text("Yes");
+				confirm_dialog->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+
+				// File Dialog
+
+				dir_fdialog = memnew(EditorFileDialog);
+				dir_fdialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+				dir_fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+				dir_fdialog->set_title(TTRC("Select a Folder to Add"));
+				add_child(dir_fdialog);
+				dir_fdialog->connect("dir_selected", callable_mp(this, &ProjectManager::_dir_path_selected));
+				dir_fdialog->connect("about_to_popup", callable_mp((Window *)dir_manage_dialog, &Window::hide));
+
+				_load_project_dirs();
+			}
+		}
+
 		// Project list and its sidebar.
 		{
 			HBoxContainer *project_list_hbox = memnew(HBoxContainer);
@@ -1669,16 +2068,16 @@ ProjectManager::ProjectManager() {
 
 			project_list_sidebar->add_child(memnew(HSeparator));
 
-			ScrollContainer *sidebar_scroll_containter = memnew(ScrollContainer);
-			sidebar_scroll_containter->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-			sidebar_scroll_containter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-			project_list_sidebar->add_child(sidebar_scroll_containter);
-			VBoxContainer *sidebar_buttons_containter = memnew(VBoxContainer);
-			sidebar_scroll_containter->add_child(sidebar_buttons_containter);
+			ScrollContainer *sidebar_scroll_container = memnew(ScrollContainer);
+			sidebar_scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+			sidebar_scroll_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			project_list_sidebar->add_child(sidebar_scroll_container);
+			VBoxContainer *sidebar_buttons_container = memnew(VBoxContainer);
+			sidebar_scroll_container->add_child(sidebar_buttons_container);
 
 			open_btn_container = memnew(HBoxContainer);
 			open_btn_container->set_anchors_preset(Control::PRESET_FULL_RECT);
-			sidebar_buttons_containter->add_child(open_btn_container);
+			sidebar_buttons_container->add_child(open_btn_container);
 
 			open_btn = memnew(Button);
 			open_btn->set_text(TTRC("Edit"));
@@ -1707,35 +2106,45 @@ ProjectManager::ProjectManager() {
 			run_btn->set_text(TTRC("Run"));
 			run_btn->set_shortcut(ED_SHORTCUT("project_manager/run_project", TTRC("Run Project"), KeyModifierMask::CMD_OR_CTRL | Key::R));
 			run_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_run_project));
-			sidebar_buttons_containter->add_child(run_btn);
+			sidebar_buttons_container->add_child(run_btn);
 
 			rename_btn = memnew(Button);
 			rename_btn->set_text(TTRC("Rename"));
 			// The F2 shortcut isn't overridden with Enter on macOS as Enter is already used to edit a project.
 			rename_btn->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTRC("Rename Project"), Key::F2));
 			rename_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_rename_project));
-			sidebar_buttons_containter->add_child(rename_btn);
+			sidebar_buttons_container->add_child(rename_btn);
 
 			duplicate_btn = memnew(Button);
 			duplicate_btn->set_text(TTRC("Duplicate"));
 			duplicate_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_duplicate_project));
-			sidebar_buttons_containter->add_child(duplicate_btn);
+			sidebar_buttons_container->add_child(duplicate_btn);
 
 			manage_tags_btn = memnew(Button);
 			manage_tags_btn->set_text(TTRC("Manage Tags"));
 			manage_tags_btn->set_shortcut(ED_SHORTCUT("project_manager/project_tags", TTRC("Manage Tags"), KeyModifierMask::CMD_OR_CTRL | Key::T));
-			sidebar_buttons_containter->add_child(manage_tags_btn);
+			sidebar_buttons_container->add_child(manage_tags_btn);
 
 			erase_btn = memnew(Button);
 			erase_btn->set_text(TTRC("Remove"));
 			erase_btn->set_shortcut(ED_SHORTCUT("project_manager/remove_project", TTRC("Remove Project"), Key::KEY_DELETE));
 			erase_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_erase_project));
-			sidebar_buttons_containter->add_child(erase_btn);
+			sidebar_buttons_container->add_child(erase_btn);
 
 			erase_missing_btn = memnew(Button);
 			erase_missing_btn->set_text(TTRC("Remove Missing"));
 			erase_missing_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_erase_missing_projects));
-			sidebar_buttons_containter->add_child(erase_missing_btn);
+			sidebar_buttons_container->add_child(erase_missing_btn);
+
+			if (multi_dir) {
+				sidebar_buttons_container->add_child(memnew(HSeparator));
+
+				manage_dir_btn = memnew(Button);
+				sidebar_buttons_container->add_child(manage_dir_btn);
+				manage_dir_btn->set_text("Manage Directories");
+				manage_dir_btn->set_shortcut(ED_SHORTCUT("project_manager/project_directory", TTRC("Manage Directory"), KeyModifierMask::CMD_OR_CTRL | Key::D));
+				manage_dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_manage_project_dirs));
+			}
 
 			donate_btn = memnew(Button);
 			donate_btn->set_text(TTRC("Donate"));
@@ -1873,11 +2282,16 @@ ProjectManager::ProjectManager() {
 		project_dialog = memnew(ProjectDialog);
 		project_dialog->connect("projects_updated", callable_mp(this, &ProjectManager::_on_projects_updated));
 		project_dialog->connect("project_created", callable_mp(this, &ProjectManager::_on_project_created));
+		if (multi_dir) {
+			project_dialog->connect("project_imported", callable_mp(this, &ProjectManager::_on_project_imported));
+		}
 		project_dialog->connect("project_duplicated", callable_mp(this, &ProjectManager::_on_project_duplicated));
+		project_dialog->set_current_directory(current_dir);
 		add_child(project_dialog);
 
 		error_dialog = memnew(AcceptDialog);
 		error_dialog->set_title(TTRC("Error"));
+		error_dialog->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		add_child(error_dialog);
 
 		about_dialog = memnew(EditorAbout);
@@ -1961,7 +2375,11 @@ ProjectManager::ProjectManager() {
 
 	// Initialize project list.
 	{
-		project_list->load_project_list();
+		if (multi_dir) {
+			project_list->update_directory_projects(current_dir);
+		} else {
+			project_list->load_project_list();
+		}
 
 		Ref<DirAccess> dir_access = DirAccess::create(DirAccess::AccessType::ACCESS_FILESYSTEM);
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -43,6 +43,7 @@
 #include "editor/asset_library/asset_library_editor_plugin.h"
 #include "editor/doc/editor_help.h"
 #include "editor/editor_string_names.h"
+#include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_about.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_title_bar.h"
@@ -134,6 +135,7 @@ void ProjectManager::_notification(int p_what) {
 
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_dim_window();
+			update_active_dir();
 		} break;
 
 		case NOTIFICATION_WM_ABOUT: {
@@ -268,6 +270,14 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 
 		_set_main_view_icon(MAIN_VIEW_PROJECTS, get_editor_theme_icon("ProjectList"));
 		_set_main_view_icon(MAIN_VIEW_ASSETLIB, get_editor_theme_icon("AssetStore"));
+
+		// Directory
+		{
+			if (multi_dir) {
+				manage_dir_btn->set_button_icon(get_editor_theme_icon("Folder"));
+				add_dir_btn->set_button_icon(get_editor_theme_icon("Add"));
+			}
+		}
 
 		// Project list.
 		{
@@ -476,8 +486,9 @@ void ProjectManager::_project_list_menu_option(int p_option) {
 	}
 }
 
-void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size) {
+void ProjectManager::_show_error(const String &p_message, const Size2 &p_min_size, bool p_autowrap) {
 	error_dialog->set_text(p_message);
+	error_dialog->set_autowrap(p_autowrap);
 	error_dialog->popup_centered(p_min_size);
 }
 
@@ -510,6 +521,7 @@ void ProjectManager::_restart_confirmed() {
 	ERR_FAIL_COND(err);
 
 	_dim_window();
+	update_active_dir();
 	get_tree()->quit();
 }
 
@@ -536,7 +548,15 @@ void ProjectManager::_update_list_placeholder() {
 }
 
 void ProjectManager::_scan_projects() {
-	scan_dir->popup_file_dialog();
+	if (multi_dir) {
+		if (dir_option_btn->get_item_text(0) == "Empty") {
+			scan_dir->popup_file_dialog();
+		} else {
+			project_list->find_projects(current_dir);
+		}
+	} else {
+		scan_dir->popup_file_dialog();
+	}
 }
 
 void ProjectManager::_run_project() {
@@ -640,6 +660,7 @@ void ProjectManager::_open_selected_projects() {
 	project_list->project_opening_initiated = true;
 
 	_dim_window();
+	update_active_dir();
 	get_tree()->quit();
 }
 
@@ -982,7 +1003,27 @@ void ProjectManager::_on_project_created(const String &dir, bool edit) {
 	project_list->save_config();
 	search_box->clear();
 
-	int i = project_list->refresh_project(dir);
+	if (dir.get_base_dir() != current_dir && edit) {
+		project_list->create_project_item(dir, true);
+	} else if (dir.get_base_dir() == current_dir) {
+		int i = project_list->refresh_project(dir);
+		project_list->ensure_project_visible(i);
+		_update_list_placeholder();
+	}
+
+	if (edit) {
+		_open_selected_projects_check_warnings();
+	}
+
+	project_list->update_dock_menu();
+}
+
+void ProjectManager::_on_project_imported(const String &p_dir, bool edit) {
+	project_list->import_project(p_dir);
+	project_list->save_config();
+	search_box->clear();
+
+	int i = project_list->refresh_project(p_dir);
 	project_list->ensure_project_visible(i);
 	_update_list_placeholder();
 
@@ -1039,6 +1080,308 @@ void ProjectManager::_on_search_term_submitted(const String &p_text) {
 
 LineEdit *ProjectManager::get_search_box() {
 	return search_box;
+}
+
+// Project directory management.
+
+void ProjectManager::_manage_project_dirs() {
+	for (int i = 0; i < project_directories->get_child_count() - 1; i++) {
+		project_directories->get_child(i)->queue_free();
+	}
+
+	for (KeyValue<String, bool> &dir : dir_set) {
+		const String folder = dir.key.get_slicec('/', dir.key.get_slice_count("/") - 1);
+
+		Button *p_dir = memnew(Button);
+		project_directories->add_child(p_dir);
+		project_directories->move_child(p_dir, -2);
+
+		p_dir->set_text(folder.capitalize());
+		p_dir->set_tooltip_text(dir.key);
+		p_dir->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+		p_dir->set_button_icon(get_editor_theme_icon("Remove"));
+		p_dir->set_meta("active", dir.value);
+		p_dir->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_remove_project_dir).bind(p_dir));
+
+		if (dir.value) {
+			p_dir->set_theme_type_variation(SNAME("ProjectDirectoryActiveButton"));
+		}
+	}
+	temp_dir_set = dir_set;
+	dir_manage_dialog->popup_centered(Vector2(300, 200) * EDSCALE);
+}
+
+void ProjectManager::_load_project_dirs() {
+	ConfigFile config;
+	config.load(dir_config_path);
+
+	Error err = config.load(dir_config_path);
+	if (err == ERR_FILE_NOT_FOUND) {
+		config.save(dir_config_path);
+
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+	} else if (err != OK) {
+		_show_error(vformat(TTR("Couldn't load multi_dir.cfg at %s.\nError: %d"), dir_config_path.get_base_dir(), err));
+
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+	} else if (err == OK) {
+		PackedStringArray dirs = config.get_sections();
+		if (dirs.is_empty()) {
+			current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+			dir_option_btn->add_item("Empty", 0);
+
+			dir_fdialog->set_current_path(current_dir.get_base_dir());
+			return;
+		}
+
+		for (const String &dir : dirs) {
+			bool active = config.get_value(dir, "active", bool());
+			dir_set[dir] = active;
+		}
+
+		_update_dir_list();
+	}
+}
+
+void ProjectManager::update_dir_list(const String &p_dir) {
+	dir_set[p_dir] = false;
+	_update_dir_list();
+}
+
+void ProjectManager::_update_dir_list() {
+	dir_option_btn->clear();
+
+	if (dir_set.is_empty()) {
+		current_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		dir_option_btn->add_item("Empty", 0);
+
+		dir_fdialog->set_current_path(current_dir.get_base_dir());
+		return;
+	}
+
+	int idx = -1;
+	bool no_dir_active = true;
+	for (KeyValue<String, bool> &dir : dir_set) {
+		idx += 1;
+		PackedStringArray item = dir.key.split("/");
+		dir_option_btn->add_item(item[item.size() - 1].capitalize(), idx);
+		dir_option_btn->set_item_metadata(idx, dir.key);
+		bool active = dir.value;
+
+		if (active) {
+			no_dir_active = false;
+			current_dir = dir.key;
+			dir_option_btn->select(idx);
+		}
+	}
+	if (no_dir_active) {
+		dir_option_btn->select(0);
+		const String dir = dir_option_btn->get_item_metadata(0);
+		current_dir = dir;
+		dir_set[dir] = true;
+
+		_update_new_active_dir_projects(current_dir);
+	}
+}
+
+void ProjectManager::_remove_project_dir(Button *p_dir) {
+	if (p_dir->get_meta("active")) {
+		confirm_dialog->set_text(vformat(TTR("Directory \"%s\" is the selected directory,\nare you sure you want to remove it from the list?"), p_dir->get_text()));
+		confirm_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ProjectManager::_remove_active_dir).bind(p_dir), CONNECT_ONE_SHOT);
+		confirm_dialog->popup_centered(Size2(400 * EDSCALE, 0));
+		return;
+	}
+	const String dir = p_dir->get_tooltip_text();
+	temp_dir_set.erase(dir);
+
+	if (dir_to_make_active == p_dir->get_tooltip_text()) {
+		for (KeyValue<String, bool> &t : temp_dir_set) {
+			dir_to_make_active = t.key;
+			break;
+		}
+	}
+	p_dir->queue_free();
+}
+
+void ProjectManager::_remove_active_dir(Button *p_dir) {
+	const String d_dir = p_dir->get_tooltip_text();
+	temp_dir_set.erase(d_dir);
+	for (KeyValue<String, bool> &t : temp_dir_set) {
+		dir_to_make_active = t.key;
+		break;
+	}
+	temp_dir_set.erase(d_dir);
+	p_dir->queue_free();
+}
+
+void ProjectManager::_add_project_dir(const String &p_dir) {
+	const String folder = p_dir.get_slicec('/', p_dir.get_slice_count("/") - 1);
+
+	Button *dir_btn = memnew(Button);
+	project_directories->add_child(dir_btn);
+	project_directories->move_child(dir_btn, -2);
+
+	dir_btn->set_text(folder.capitalize());
+	dir_btn->set_tooltip_text(p_dir);
+	dir_btn->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	dir_btn->set_button_icon(get_editor_theme_icon("Remove"));
+	dir_btn->set_meta("active", false);
+	dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_remove_project_dir).bind(dir_btn));
+
+	temp_dir_set[p_dir] = false;
+}
+
+void ProjectManager::_apply_project_dirs() {
+	ConfigFile config;
+	config.load(dir_config_path);
+
+	PackedStringArray new_dirs;
+	PackedStringArray create_dirs;
+	if (temp_dir_set.is_empty()) {
+		config.clear();
+		dir_set.clear();
+		current_dir.clear();
+		project_list->update_directory_projects(current_dir);
+		_update_list_placeholder();
+	} else {
+		for (KeyValue<String, bool> &p : dir_set) {
+			if (!temp_dir_set.has(p.key)) {
+				config.erase_section(p.key);
+			}
+		}
+
+		HashMap<String, bool> dir_cache;
+		dir_cache = dir_set;
+		dir_set.clear();
+		for (KeyValue<String, bool> &p : temp_dir_set) {
+			const String dir = p.key;
+			bool active = p.value;
+			Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			if (dir_cache.has(dir)) {
+				dir_set[dir] = active;
+				continue;
+			}
+			if (d->exists(dir)) {
+				new_dirs.append(dir);
+				config.set_value(dir, "active", active);
+				dir_set[dir] = active;
+			} else {
+				create_dirs.append(dir);
+				config.set_value(dir, "active", active);
+			}
+		}
+
+		bool new_active_dir = false;
+		if (!dir_to_make_active.is_empty()) {
+			PackedStringArray sections = config.get_sections();
+			for (const String &sect : sections) {
+				if (sect == dir_to_make_active) {
+					config.set_value(sect, "active", true);
+					dir_set[sect] = true;
+					new_active_dir = true;
+
+					break;
+				}
+			}
+		}
+		if (new_active_dir) {
+			_update_new_active_dir_projects(dir_to_make_active);
+			dir_to_make_active.clear();
+		}
+
+		if (!new_dirs.is_empty()) {
+			project_list->find_projects_multiple(new_dirs);
+		}
+		if (!create_dirs.is_empty()) {
+			_create_project_dirs(create_dirs);
+		}
+	}
+	config.save(dir_config_path);
+
+	_update_dir_list();
+	project_list->reload_config();
+}
+
+void ProjectManager::_create_project_dirs(const PackedStringArray &p_dirs) {
+	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	PackedStringArray err_string;
+	PackedStringArray s_dirs;
+	for (const String &dir : p_dirs) {
+		if (!d->dir_exists(dir) && d->make_dir(dir) != OK) {
+			err_string.append(dir);
+			continue;
+		}
+		s_dirs.append(dir);
+	}
+
+	ConfigFile config;
+	config.load(dir_config_path);
+	for (const String &s_dir : s_dirs) {
+		config.set_value(s_dir, "active", false);
+		dir_set[s_dir] = false;
+	}
+	_update_dir_list();
+
+	if (err_string.size() > 0) {
+		String error_msg = TTR("Couldn't create directory at:");
+		for (const String &err : err_string) {
+			error_msg += vformat("\n%s", err);
+		}
+		error_msg += vformat("\nCheck permissions");
+		if (err_string.size() > 1) {
+			_show_error(TTRC(error_msg), Vector2(600 * EDSCALE, 0), true);
+		} else {
+			_show_error(TTRC(error_msg), Vector2(400 * EDSCALE, 0), true);
+		}
+		error_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &ProjectManager::_manage_project_dirs), CONNECT_ONE_SHOT);
+	}
+}
+
+void ProjectManager::_dir_option_selected(const int p_id) {
+	current_dir = dir_option_btn->get_item_metadata(p_id);
+	for (KeyValue<String, bool> &dir : dir_set) {
+		dir.value = false;
+	}
+	dir_set[current_dir] = true;
+
+	project_dialog->set_current_directory(current_dir);
+	project_list->update_directory_projects(current_dir);
+}
+
+void ProjectManager::_dir_path_selected(const String &p_dir) {
+	dir_manage_dialog->popup_centered(Size2(300, 200) * EDSCALE);
+	_add_project_dir(p_dir);
+}
+
+void ProjectManager::_show_dir_file_dialog() {
+	dir_fdialog->set_current_dir(current_dir.get_base_dir());
+	dir_fdialog->popup_file_dialog();
+}
+
+void ProjectManager::_update_new_active_dir_projects(const String &p_dir) const {
+	project_list->update_directory_projects(p_dir);
+}
+
+void ProjectManager::update_active_dir() {
+	ConfigFile config;
+	config.load(dir_config_path);
+	PackedStringArray sects = config.get_sections();
+	for (const String &sect : sects) {
+		config.set_value(sect, "active", false);
+	}
+	for (KeyValue<String, bool> &dir : dir_set) {
+		if (dir.value) {
+			config.set_value(dir.key, "active", true);
+			break;
+		}
+	}
+	config.save(dir_config_path);
 }
 
 // Project tag management.
@@ -1265,6 +1608,7 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 #ifndef MACOS_ENABLED
 		if (k->get_keycode_with_modifiers() == (KeyModifierMask::META | Key::Q)) {
 			_dim_window();
+			update_active_dir();
 			get_tree()->quit();
 		}
 #endif
@@ -1421,6 +1765,11 @@ ProjectManager::ProjectManager() {
 
 		FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 		FileDialog::set_default_display_mode((FileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
+
+		multi_dir = EDITOR_GET("filesystem/directories/enable_multiple_project_directories");
+		if (multi_dir) {
+			dir_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("multi_dir.cfg");
+		}
 
 		int swap_cancel_ok = EDITOR_GET("interface/editor/appearance/accept_dialog_cancel_ok_buttons");
 		if (swap_cancel_ok != 0) { // 0 is auto, set in register_scene based on DisplayServer.
@@ -1623,6 +1972,56 @@ ProjectManager::ProjectManager() {
 			filter_option->add_item(TTRC("Tags"));
 		}
 
+		/* Project Directory */
+		{
+			if (multi_dir) {
+				HBoxContainer *project_dir_hb = memnew(HBoxContainer);
+				local_projects_vb->add_child(project_dir_hb);
+
+				Label *label = memnew(Label(TTR("Current Directory:")));
+				project_dir_hb->add_child(label);
+
+				dir_option_btn = memnew(OptionButton);
+				project_dir_hb->add_child(dir_option_btn);
+				dir_option_btn->set_fit_to_longest_item(false);
+				dir_option_btn->connect(SceneStringName(item_selected), callable_mp(this, &ProjectManager::_dir_option_selected));
+
+				// Directory Manage Dialog
+
+				dir_manage_dialog = memnew(ConfirmationDialog);
+				add_child(dir_manage_dialog);
+				dir_manage_dialog->set_title("Manage Project Directories");
+				dir_manage_dialog->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_apply_project_dirs));
+
+				project_directories = memnew(HFlowContainer);
+				dir_manage_dialog->add_child(project_directories);
+
+				add_dir_btn = memnew(Button);
+				project_directories->add_child(add_dir_btn);
+				add_dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_dir_file_dialog));
+
+				// Confirm Dialog
+
+				confirm_dialog = memnew(ConfirmationDialog);
+				dir_manage_dialog->add_child(confirm_dialog);
+				confirm_dialog->set_title(TTRC("Remove Directory"));
+				confirm_dialog->set_ok_button_text("Yes");
+				confirm_dialog->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+
+				// File Dialog
+
+				dir_fdialog = memnew(EditorFileDialog);
+				dir_fdialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+				dir_fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+				dir_fdialog->set_title(TTRC("Select a Folder to Add"));
+				add_child(dir_fdialog);
+				dir_fdialog->connect("dir_selected", callable_mp(this, &ProjectManager::_dir_path_selected));
+				dir_fdialog->connect("about_to_popup", callable_mp((Window *)dir_manage_dialog, &Window::hide));
+
+				_load_project_dirs();
+			}
+		}
+
 		// Project list and its sidebar.
 		{
 			HBoxContainer *project_list_hbox = memnew(HBoxContainer);
@@ -1699,16 +2098,16 @@ ProjectManager::ProjectManager() {
 
 			project_list_sidebar->add_child(memnew(HSeparator));
 
-			ScrollContainer *sidebar_scroll_containter = memnew(ScrollContainer);
-			sidebar_scroll_containter->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-			sidebar_scroll_containter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-			project_list_sidebar->add_child(sidebar_scroll_containter);
-			VBoxContainer *sidebar_buttons_containter = memnew(VBoxContainer);
-			sidebar_scroll_containter->add_child(sidebar_buttons_containter);
+			ScrollContainer *sidebar_scroll_container = memnew(ScrollContainer);
+			sidebar_scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+			sidebar_scroll_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+			project_list_sidebar->add_child(sidebar_scroll_container);
+			VBoxContainer *sidebar_buttons_container = memnew(VBoxContainer);
+			sidebar_scroll_container->add_child(sidebar_buttons_container);
 
 			open_btn_container = memnew(HBoxContainer);
 			open_btn_container->set_anchors_preset(Control::PRESET_FULL_RECT);
-			sidebar_buttons_containter->add_child(open_btn_container);
+			sidebar_buttons_container->add_child(open_btn_container);
 
 			open_btn = memnew(Button);
 			open_btn->set_text(TTRC("Edit"));
@@ -1737,35 +2136,45 @@ ProjectManager::ProjectManager() {
 			run_btn->set_text(TTRC("Run"));
 			run_btn->set_shortcut(ED_SHORTCUT("project_manager/run_project", TTRC("Run Project"), KeyModifierMask::CMD_OR_CTRL | Key::R));
 			run_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_run_project));
-			sidebar_buttons_containter->add_child(run_btn);
+			sidebar_buttons_container->add_child(run_btn);
 
 			rename_btn = memnew(Button);
 			rename_btn->set_text(TTRC("Rename"));
 			// The F2 shortcut isn't overridden with Enter on macOS as Enter is already used to edit a project.
 			rename_btn->set_shortcut(ED_SHORTCUT("project_manager/rename_project", TTRC("Rename Project"), Key::F2));
 			rename_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_rename_project));
-			sidebar_buttons_containter->add_child(rename_btn);
+			sidebar_buttons_container->add_child(rename_btn);
 
 			duplicate_btn = memnew(Button);
 			duplicate_btn->set_text(TTRC("Duplicate"));
 			duplicate_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_duplicate_project));
-			sidebar_buttons_containter->add_child(duplicate_btn);
+			sidebar_buttons_container->add_child(duplicate_btn);
 
 			manage_tags_btn = memnew(Button);
 			manage_tags_btn->set_text(TTRC("Manage Tags"));
 			manage_tags_btn->set_shortcut(ED_SHORTCUT("project_manager/project_tags", TTRC("Manage Tags"), KeyModifierMask::CMD_OR_CTRL | Key::T));
-			sidebar_buttons_containter->add_child(manage_tags_btn);
+			sidebar_buttons_container->add_child(manage_tags_btn);
 
 			erase_btn = memnew(Button);
 			erase_btn->set_text(TTRC("Remove"));
 			erase_btn->set_shortcut(ED_SHORTCUT("project_manager/remove_project", TTRC("Remove Project"), Key::KEY_DELETE));
 			erase_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_erase_project));
-			sidebar_buttons_containter->add_child(erase_btn);
+			sidebar_buttons_container->add_child(erase_btn);
 
 			erase_missing_btn = memnew(Button);
 			erase_missing_btn->set_text(TTRC("Remove Missing"));
 			erase_missing_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_erase_missing_projects));
-			sidebar_buttons_containter->add_child(erase_missing_btn);
+			sidebar_buttons_container->add_child(erase_missing_btn);
+
+			if (multi_dir) {
+				sidebar_buttons_container->add_child(memnew(HSeparator));
+
+				manage_dir_btn = memnew(Button);
+				sidebar_buttons_container->add_child(manage_dir_btn);
+				manage_dir_btn->set_text("Manage Directories");
+				manage_dir_btn->set_shortcut(ED_SHORTCUT("project_manager/project_directory", TTRC("Manage Directory"), KeyModifierMask::CMD_OR_CTRL | Key::D));
+				manage_dir_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_manage_project_dirs));
+			}
 
 			donate_btn = memnew(Button);
 			donate_btn->set_text(TTRC("Donate"));
@@ -1903,11 +2312,16 @@ ProjectManager::ProjectManager() {
 		project_dialog = memnew(ProjectDialog);
 		project_dialog->connect("projects_updated", callable_mp(this, &ProjectManager::_on_projects_updated));
 		project_dialog->connect("project_created", callable_mp(this, &ProjectManager::_on_project_created));
+		if (multi_dir) {
+			project_dialog->connect("project_imported", callable_mp(this, &ProjectManager::_on_project_imported));
+		}
 		project_dialog->connect("project_duplicated", callable_mp(this, &ProjectManager::_on_project_duplicated));
+		project_dialog->set_current_directory(current_dir);
 		add_child(project_dialog);
 
 		error_dialog = memnew(AcceptDialog);
 		error_dialog->set_title(TTRC("Error"));
+		error_dialog->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		add_child(error_dialog);
 
 		about_dialog = memnew(EditorAbout);
@@ -1991,7 +2405,11 @@ ProjectManager::ProjectManager() {
 
 	// Initialize project list.
 	{
-		project_list->load_project_list();
+		if (multi_dir) {
+			project_list->update_directory_projects(current_dir);
+		} else {
+			project_list->load_project_list();
+		}
 
 		Ref<DirAccess> dir_access = DirAccess::create(DirAccess::AccessType::ACCESS_FILESYSTEM);
 

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -122,7 +122,7 @@ class ProjectManager : public Control {
 
 	AcceptDialog *error_dialog = nullptr;
 
-	void _show_error(const String &p_message, const Size2 &p_min_size = Size2());
+	void _show_error(const String &p_message, const Size2 &p_min_size = Size2(), bool p_autowrap = false);
 	void _dim_window();
 
 	// Quick settings.
@@ -207,6 +207,7 @@ class ProjectManager : public Control {
 	void _open_donate_page();
 
 	void _on_project_created(const String &dir, bool edit);
+	void _on_project_imported(const String &p_dir, bool p_edit);
 	void _on_project_duplicated(const String &p_original_path, const String &p_duplicate_path, bool p_edit);
 	void _on_projects_updated();
 	void _on_open_options_selected(int p_option);
@@ -216,6 +217,44 @@ class ProjectManager : public Control {
 	void _on_order_option_changed(int p_idx);
 	void _on_search_term_changed(const String &p_term);
 	void _on_search_term_submitted(const String &p_text);
+
+	// Project directory management.
+
+	String dir_config_path;
+
+	bool multi_dir = false;
+	HashMap<String, bool> dir_set;
+	HashMap<String, bool> temp_dir_set;
+	String current_dir;
+	String dir_to_make_active;
+
+	Button *manage_dir_btn = nullptr;
+	HFlowContainer *project_directories = nullptr;
+	Button *add_dir_btn = nullptr;
+
+	ConfirmationDialog *dir_manage_dialog = nullptr;
+	ConfirmationDialog *confirm_dialog = nullptr;
+	EditorFileDialog *dir_fdialog = nullptr;
+
+	OptionButton *dir_option_btn = nullptr;
+
+	void _manage_project_dirs();
+	void _load_project_dirs();
+	void _update_dir_list();
+
+	void _remove_project_dir(Button *p_dir);
+	void _remove_active_dir(Button *p_dir);
+	void _add_project_dir(const String &p_dir);
+	void _apply_project_dirs();
+	void _create_project_dirs(const PackedStringArray &p_dirs);
+
+	void _dir_option_selected(const int p_id);
+	void _dir_path_selected(const String &p_dir);
+
+	void _show_dir_file_dialog();
+
+	void _update_new_active_dir_projects(const String &p_dir) const;
+	void update_active_dir();
 
 	// Project tag management.
 
@@ -237,7 +276,7 @@ class ProjectManager : public Control {
 	void _add_project_tag(const String &p_tag);
 	void _delete_project_tag(const String &p_tag);
 	void _apply_project_tags();
-	void _set_new_tag_name(const String p_name);
+	void _set_new_tag_name(const String p_dir);
 	void _create_new_tag();
 
 	// Project converter/migration tool.
@@ -281,6 +320,10 @@ public:
 
 	bool is_initialized() const { return initialized; }
 	LineEdit *get_search_box();
+
+	// Project directory management.
+
+	void update_dir_list(const String &p_dir);
 
 	// Project tag management.
 

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -126,7 +126,7 @@ class ProjectManager : public Control {
 
 	AcceptDialog *error_dialog = nullptr;
 
-	void _show_error(const String &p_message, const Size2 &p_min_size = Size2());
+	void _show_error(const String &p_message, const Size2 &p_min_size = Size2(), bool p_autowrap = false);
 	void _dim_window();
 
 	// Quick settings.
@@ -211,6 +211,7 @@ class ProjectManager : public Control {
 	void _open_donate_page();
 
 	void _on_project_created(const String &dir, bool edit);
+	void _on_project_imported(const String &p_dir, bool p_edit);
 	void _on_project_duplicated(const String &p_original_path, const String &p_duplicate_path, bool p_edit);
 	void _on_projects_updated();
 	void _on_open_options_selected(int p_option);
@@ -220,6 +221,44 @@ class ProjectManager : public Control {
 	void _on_order_option_changed(int p_idx);
 	void _on_search_term_changed(const String &p_term);
 	void _on_search_term_submitted(const String &p_text);
+
+	// Project directory management.
+
+	String dir_config_path;
+
+	bool multi_dir = false;
+	HashMap<String, bool> dir_set;
+	HashMap<String, bool> temp_dir_set;
+	String current_dir;
+	String dir_to_make_active;
+
+	Button *manage_dir_btn = nullptr;
+	HFlowContainer *project_directories = nullptr;
+	Button *add_dir_btn = nullptr;
+
+	ConfirmationDialog *dir_manage_dialog = nullptr;
+	ConfirmationDialog *confirm_dialog = nullptr;
+	EditorFileDialog *dir_fdialog = nullptr;
+
+	OptionButton *dir_option_btn = nullptr;
+
+	void _manage_project_dirs();
+	void _load_project_dirs();
+	void _update_dir_list();
+
+	void _remove_project_dir(Button *p_dir);
+	void _remove_active_dir(Button *p_dir);
+	void _add_project_dir(const String &p_dir);
+	void _apply_project_dirs();
+	void _create_project_dirs(const PackedStringArray &p_dirs);
+
+	void _dir_option_selected(const int p_id);
+	void _dir_path_selected(const String &p_dir);
+
+	void _show_dir_file_dialog();
+
+	void _update_new_active_dir_projects(const String &p_dir) const;
+	void update_active_dir();
 
 	// Project tag management.
 
@@ -241,7 +280,7 @@ class ProjectManager : public Control {
 	void _add_project_tag(const String &p_tag);
 	void _delete_project_tag(const String &p_tag);
 	void _apply_project_tags();
-	void _set_new_tag_name(const String p_name);
+	void _set_new_tag_name(const String p_dir);
 	void _create_new_tag();
 
 	// Project converter/migration tool.
@@ -285,6 +324,10 @@ public:
 
 	bool is_initialized() const { return initialized; }
 	LineEdit *get_search_box();
+
+	// Project directory management.
+
+	void update_dir_list(const String &p_dir);
 
 	// Project tag management.
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -681,6 +681,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
 	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "filesystem/directories/enable_multiple_project_directories", true, "")
+	set_restart_if_changed("filesystem/directories/enable_multiple_project_directories", true);
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -680,6 +680,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
 	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "filesystem/directories/enable_multiple_project_directories", true, "")
+	set_restart_if_changed("filesystem/directories/enable_multiple_project_directories", true);
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1611,6 +1611,22 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
 		}
+
+		// Project Directory
+		{
+			p_theme->set_type_variation("ProjectDirectoryActiveButton", "Button");
+			Ref<StyleBoxFlat> dir = p_config.button_style->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_hover->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_pressed->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectDirectoryActiveButton", dir);
+		}
 	}
 
 	// Editor and main screen.

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1614,6 +1614,22 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
 		}
+
+		// Project Directory
+		{
+			p_theme->set_type_variation("ProjectDirectoryActiveButton", "Button");
+			Ref<StyleBoxFlat> dir = p_config.button_style->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_hover->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_pressed->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectDirectoryActiveButton", dir);
+		}
 	}
 
 	// Editor and main screen.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1651,6 +1651,22 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
 		}
+
+		// Project Directory
+		{
+			p_theme->set_type_variation("ProjectDirectoryActiveButton", "Button");
+			Ref<StyleBoxFlat> dir = p_config.button_style->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_hover->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_pressed->duplicate();
+			dir->set_bg_color(Color("#68768A"));
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectDirectoryActiveButton", dir);
+		}
 	}
 
 	// Editor and main screen.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1654,6 +1654,22 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
 			p_theme->set_stylebox(SceneStringName(pressed), "ProjectTagButton", tag);
 		}
+
+		// Project Directory
+		{
+			p_theme->set_type_variation("ProjectDirectoryActiveButton", "Button");
+			Ref<StyleBoxFlat> dir = p_config.button_style->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(CoreStringName(normal), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_hover->duplicate();
+			dir->set_bg_color(Color("#68768A").darkened(0.2));
+			p_theme->set_stylebox(SceneStringName(hover), "ProjectDirectoryActiveButton", dir);
+
+			dir = p_config.button_style_pressed->duplicate();
+			dir->set_bg_color(Color("#68768A"));
+			p_theme->set_stylebox(SceneStringName(pressed), "ProjectDirectoryActiveButton", dir);
+		}
 	}
 
 	// Editor and main screen.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds the option to add and select from multiple project directories, allowing for better organisation of projects without flooding a single list.

https://github.com/user-attachments/assets/577a9ef4-c1bd-4f94-8b7f-c0bc9137a7c9

Only the projects in the selected directory is shown.

Closes [#3560](https://github.com/godotengine/godot-proposals/issues/3560)

## Additional information

- Scan: Only scans the folder of the currently selected directory. If no directories have been added, opens the dialog and will add the selected folder.
- Import: Only imports the project to the currently selected directory.
- Install and Create: Can choose any directory. If the chosen path is not in the list, it is added (along with any projects in the path)

Some other details:

- Editor Setting: Will be off by default, on in this PR for easier testing.
- ConfigFile: Uses a separate configfile from `projects.cfg` as the organisation of the directories and their contents require a different format.