### PR TITLE
Fix `Polygon2D` editor draw line being placed incorrect on first click

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -696,6 +696,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 
 							polygon_create.clear();
 						} else if (!polygon_create.has(closest)) {
+							create_to = mtx.affine_inverse().xform(mb->get_position());
 							//add temporarily if not exists
 							polygon_create.push_back(closest);
 						}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Using the "Polygons" tab in the `Polygon2D` editor, when you first click a point while creating a custom polygon, the drawing line will look like this:

<img width="350" height="262" alt="image" src="https://github.com/user-attachments/assets/293756ca-9589-472c-acf0-b8fa9afb1f11" />
<br><br>

This PR fixes that.