### PR TITLE
[3.x] Fix crash in `CowData` `Span` constructor with empty span

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -378,6 +378,9 @@ void CowData<T>::_ref(const CowData &p_from) {
 
 template <typename T>
 CowData<T>::CowData(Span<T> p_span) {
+	if (p_span.is_empty()) {
+		return;
+	}
 	CRASH_COND(resize(p_span.size()));
 	for (size_t i = 0; i < p_span.size(); i++) {
 		_ptr[i] = p_span[i];


### PR DESCRIPTION
## What problem(s) does this PR solve?

If you try and construct `CowData` from an empty `Span`:
* it calls `resize()` - which does nothing as the size is 0, so `_ptr` doesn't get set and is NULL
* the for loop doesn't execute (zero size)
* `*_get_size()` dereferences a NULL pointer -> CRASH

## Additional information
May also exist in 4.x, I'll do a PR there too if it looks like it needs fixing.
...
Actually it looks like `CowData` has diverged quite a bit in 4.x, so I'll leave it to @Ivorforce to decide whether this needs fixing there.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
