### PR TITLE
[3.x] `Vector` and `CowData` move semantics

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -145,6 +145,12 @@ public:
 		_ptr[p_index] = p_elem;
 	}
 
+	_FORCE_INLINE_ void set(int p_index, const T &&p_elem) {
+		CRASH_BAD_INDEX(p_index, size());
+		_copy_on_write();
+		_ptr[p_index] = std::move(p_elem);
+	}
+
 	_FORCE_INLINE_ T &get_m(int p_index) {
 		CRASH_BAD_INDEX(p_index, size());
 		_copy_on_write();
@@ -191,6 +197,20 @@ public:
 	_FORCE_INLINE_ ~CowData();
 	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
 	_FORCE_INLINE_ explicit CowData(Span<T> p_span);
+
+	_FORCE_INLINE_ CowData(CowData<T> &&p_from) {
+		_ptr = p_from._ptr;
+		p_from._ptr = nullptr;
+	}
+
+	_FORCE_INLINE_ CowData &operator=(CowData<T> &&p_from) {
+		if (this != &p_from) {
+			_unref(_ptr);
+			_ptr = p_from._ptr;
+			p_from._ptr = nullptr;
+		}
+		return *this;
+	}
 };
 
 template <class T>

--- a/core/vector.h
+++ b/core/vector.h
@@ -83,6 +83,7 @@ public:
 	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ void set(int p_index, T &&p_elem) { _cowdata.set(p_index, std::move(p_elem)); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 
 	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return _cowdata.span(); }
@@ -127,6 +128,16 @@ public:
 			_cowdata(p_from) {}
 	inline Vector &operator=(const Vector &p_from) {
 		_cowdata._ref(p_from._cowdata);
+		return *this;
+	}
+
+	_FORCE_INLINE_ Vector(Vector<T> &&p_from) :
+			_cowdata(std::move(p_from._cowdata)) {}
+
+	_FORCE_INLINE_ Vector<T> &operator=(Vector<T> &&p_from) {
+		if (this != &p_from) {
+			_cowdata = std::move(p_from._cowdata);
+		}
 		return *this;
 	}
 
@@ -193,7 +204,7 @@ template <class T>
 bool Vector<T>::push_back(T p_elem) {
 	Error err = resize(size() + 1);
 	ERR_FAIL_COND_V(err, true);
-	set(size() - 1, p_elem);
+	set(size() - 1, std::move(p_elem));
 
 	return false;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?
Move semantics should allow returning a `Vector` or passing it without triggering COW (which requires atomic operations), so it should be cheaper.

Additonally `set()` and `push_back()` can make use of `T` that has move semantics.

## Additional information
* I'm not an expert on move semantics (a lot of copy paste here :grin: ) so could do with checking.
* As far as I can see this shouldn't reopen the use after free bug when `push_back` parameter was a const ref (if the const ref was within the `Vector`, and the push caused it to resize, thus invalidating the parameter. 

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
