### PR TITLE
[3.x] `Vector` reduce writes in `invert` & `append`

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -181,9 +181,13 @@ public:
 
 template <class T>
 void Vector<T>::invert() {
-	for (int i = 0; i < size() / 2; i++) {
-		T *p = ptrw();
-		SWAP(p[i], p[size() - i - 1]);
+	int len = size();
+	if (len <= 1) {
+		return;
+	}
+	T *p = ptrw();
+	for (int i = 0; i < len / 2; i++) {
+		SWAP(p[i], p[len - i - 1]);
 	}
 }
 
@@ -195,8 +199,11 @@ void Vector<T>::append_array(Vector<T> p_other) {
 	}
 	const int bs = size();
 	resize(bs + ds);
+
+	T *w = ptrw();
+	const T *r = p_other.ptr();
 	for (int i = 0; i < ds; ++i) {
-		ptrw()[bs + i] = p_other[i];
+		w[bs + i] = r[i];
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
Creating writes / reads in a hot loop is expensive because of the use of COW machinery etc.
Moves the creation to one-offs outside the loops, should be an easy win.

* I think this could be done for some of the reads in 4.x too, but not absolutely sure. Leave this to @Ivorforce .

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
