### PR TITLE
[3.x] `Vector` & `LocalVector` ordered_insert uses binary search

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -254,13 +254,8 @@ public:
 	}
 
 	void ordered_insert(T p_val) {
-		U i;
-		for (i = 0; i < count; i++) {
-			if (p_val < data[i]) {
-				break;
-			}
-		}
-		insert(i, p_val);
+		U idx = span().bisect(p_val, false);
+		insert(idx, std::move(p_val));
 	}
 
 	explicit operator PoolVector<T>() const {

--- a/core/vector.h
+++ b/core/vector.h
@@ -113,13 +113,8 @@ public:
 	}
 
 	void ordered_insert(const T &p_val) {
-		int i;
-		for (i = 0; i < _cowdata.size(); i++) {
-			if (p_val < operator[](i)) {
-				break;
-			};
-		};
-		insert(i, p_val);
+		int idx = span().bisect(p_val, false);
+		insert(idx, p_val);
 	}
 
 	_FORCE_INLINE_ Vector() {}


### PR DESCRIPTION
Standard binary search is much faster for large vector sizes than linear search.
See e.g.
https://medium.com/@amit25173/binary-search-vs-linear-search-69f8510fdfd5
https://stackoverflow.com/questions/75859008/binary-search-algorithm-using-size-t-instead-of-using-int

## What problem(s) does this PR solve?
Faster `ordered_insert`

## Additional information
On average, binary search will complete faster than linear search, with the gains rising exponentially with vector size:

| vector size | linear steps | binary search steps |
| ---- | ----- | -----|
| 10 | 5 | 4 |
| 1000 | 500 | 10 |

With `ordered_insert`, you actually have to shift the data afterwards which is O(n) :grin: , but the search stage is much faster. 

* I'll make a version for 4.x too.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
