### PR TITLE
`Vector` & `LocalVector` ordered_insert uses binary search

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -314,13 +314,8 @@ public:
 	}
 
 	void ordered_insert(T p_val) {
-		U i;
-		for (i = 0; i < count; i++) {
-			if (p_val < data[i]) {
-				break;
-			}
-		}
-		insert(i, p_val);
+		U idx = span().bisect(p_val, false);
+		insert(idx, std::move(p_val));
 	}
 
 	Vector<uint8_t> to_byte_array() const { //useful to pass stuff to gpu or variant

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -200,13 +200,8 @@ public:
 	}
 
 	void ordered_insert(const T &p_val) {
-		Size i;
-		for (i = 0; i < _cowdata.size(); i++) {
-			if (p_val < operator[](i)) {
-				break;
-			}
-		}
-		insert(i, p_val);
+		int idx = span().bisect(p_val, false);
+		insert(idx, p_val);
 	}
 
 	void operator=(const Vector &p_from) { _cowdata = p_from._cowdata; }


### PR DESCRIPTION
Standard binary search is much faster for large vector sizes than linear search.

Forward port of #121527

See e.g.
https://medium.com/@amit25173/binary-search-vs-linear-search-69f8510fdfd5
https://stackoverflow.com/questions/75859008/binary-search-algorithm-using-size-t-instead-of-using-int

## What problem(s) does this PR solve?
Faster `ordered_insert`

## Additional information
On average, binary search will complete faster than linear search, with the gains rising exponentially with vector size:

| vector size | linear steps | binary search steps |
| ---- | ----- | -----|
| 10 | 5 | 4 |
| 1000 | 500 | 10 |

With `ordered_insert`, you actually have to shift the data afterwards which is O(n) :grin: , but the search stage is much faster. 

* thanks to @Ivorforce for pointing out `Span` already contained bisect code, so I've just called that instead of duplicating in `LocalVector` and `Vector`.