### PR TITLE
Fix non-float `ARRAY_CUSTOM*` discarding green and blue channels in compatability renderer

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -993,9 +993,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				uint32_t fmtsize[RSE::ARRAY_CUSTOM_MAX] = { 4, 4, 4, 8, 4, 8, 12, 16 };
 				GLenum gl_type[RSE::ARRAY_CUSTOM_MAX] = { GL_UNSIGNED_BYTE, GL_BYTE, GL_HALF_FLOAT, GL_HALF_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT };
 				GLboolean norm[RSE::ARRAY_CUSTOM_MAX] = { GL_TRUE, GL_TRUE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
+				size_t gl_size[RSE::ARRAY_CUSTOM_MAX] = { sizeof(GLubyte), sizeof(GLbyte), sizeof(GLhalf), sizeof(GLhalf), sizeof(GLfloat), sizeof(GLfloat), sizeof(GLfloat), sizeof(GLfloat) };
 				attribs[i].type = gl_type[fmt];
 				attributes_stride += fmtsize[fmt];
-				attribs[i].size = fmtsize[fmt] / sizeof(float);
+				attribs[i].size = fmtsize[fmt] / gl_size[fmt];
 				attribs[i].normalized = norm[fmt];
 			} break;
 			case RSE::ARRAY_BONES: {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Attempting to use `ARRAY_CUSTOM_RGBA8_UNORM` on the compatability renderer currently discards the green and blue channels:

<img width="1413" height="573" alt="Screenshot from 2026-07-18 13-17-35" src="https://github.com/user-attachments/assets/c496a5cf-7211-474e-aae7-e9036f48facb" />

After applying this patch:

<img width="1413" height="573" alt="Screenshot from 2026-07-18 13-14-05" src="https://github.com/user-attachments/assets/d6f903ee-e287-46fb-b6a3-ce96da36c03c" />

## Additional information

This is due to the attribute binding logic expecting all attributes to be the same size as a float.  I've replicated the above structure for `gl_type`.  

Regression tested with `ARRAY_CUSTOM_RGBA_FLOAT` which seems to function as before.