### PR TITLE
Fix error when creating new scene

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -3473,6 +3473,7 @@ bool SceneTreeDock::_check_node_recursive(Variant &r_variant, Node *p_node, Node
 
 void SceneTreeDock::set_edited_scene(Node *p_scene) {
 	edited_scene = p_scene;
+	scene_tree->set_selected(nullptr, false);
 	_update_create_root_dialog_visibility();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

1. Select a node in the Scene dock
2. Create a new scene via FileSystem dock
3.
```
ERROR: Cannot get path of node as it is not in a scene tree.
```


Setting edited scene updates visibility of Scene's SceneTreeEditor, which automatically tries to select current node when made visible. However the previously selected node is no longer there at this point.

EDIT:
Fixes #121931

## Additional information

Probably "regression" from #116905
Some call that is no longer deferred causes the tree to try selecting too early.