### PR TITLE
Hide status bar when no errors in `AnimationTree`

### DIFF
--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -130,6 +130,7 @@ void AnimationTreeEditor::_update_error_message() {
 		last_error_key = String();
 		error_button->hide();
 		error_scroll->hide();
+		status_bar->hide(); // Since status bar is currently only used for errors.
 		current_scope_error_label->clear();
 		return;
 	}
@@ -272,6 +273,7 @@ void AnimationTreeEditor::_update_error_message() {
 
 	error_button->set_text(itos(count));
 	error_button->show();
+	status_bar->show();
 }
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
@@ -547,8 +549,9 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	editor_base->set_v_size_flags(SIZE_EXPAND_FILL);
 	editor_vbox->add_child(editor_base);
 
-	HBoxContainer *status_bar = memnew(HBoxContainer);
+	status_bar = memnew(HBoxContainer);
 	editor_vbox->add_child(status_bar);
+	status_bar->hide();
 
 	current_scope_error_label = memnew(RichTextLabel);
 	current_scope_error_label->set_fit_content(true);

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -57,6 +57,7 @@ class AnimationTreeEditor : public EditorDock {
 
 	ScrollContainer *path_edit = nullptr;
 	HBoxContainer *path_hb = nullptr;
+	HBoxContainer *status_bar = nullptr;
 	RichTextLabel *current_scope_error_label = nullptr;
 	Button *error_button = nullptr;
 	ScrollContainer *error_scroll = nullptr;


### PR DESCRIPTION
In the `AnimationTree` dock, there's a bit of unnecessary vertical space taken up by the status bar that houses the error icon and label, noticeable when no errors are present and the status bar is blank. 

Since this status bar is currently only being used for errors, this PR hides it then too.

### Master
<img width="596" height="131" alt="image" src="https://github.com/user-attachments/assets/5f7993ab-a8f6-46d4-8fbe-a4098a89ba48" />

### This PR
<img width="603" height="124" alt="image" src="https://github.com/user-attachments/assets/ce697e91-a497-45c6-9fb1-78b5a9f425b1" />

cc @TokageItLab