### PR TITLE
Fix antialiasing artifacts in StyleBoxFlat

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -479,9 +479,24 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	Color border_color_blend = (draw_center ? bg_color : border_color_alpha);
 	Color border_color_inner = blend_on ? border_color_blend : border_color;
 
+	real_t aa_size_scaled = 1.0f;
+	if (aa_on) {
+		real_t scale_factor = TextServer::get_current_drawn_item_oversampling();
+		if (scale_factor == 0.0) {
+			scale_factor = 1.0;
+		}
+
+		// Adjust AA feather size to account for the 2D scale factor, so that
+		// antialiasing doesn't become blurry at viewport resolutions higher
+		// than the default when using the `canvas_items` stretch mode
+		// (or when using `oversampling` values different than `1.0`).
+		aa_size_scaled = aa_size / scale_factor;
+	}
+
 	// Adapt borders (prevent weird overlapping/glitchy drawings).
-	real_t width = MAX(style_rect.size.width, 0);
-	real_t height = MAX(style_rect.size.height, 0);
+	real_t aa_shrink = aa_on ? aa_size_scaled * 2 : 0;
+	real_t width = MAX(style_rect.size.width - aa_shrink, 0);
+	real_t height = MAX(style_rect.size.height - aa_shrink, 0);
 	real_t adapted_border[4] = { 1000000.0, 1000000.0, 1000000.0, 1000000.0 };
 	adapt_values(SIDE_TOP, SIDE_BOTTOM, adapted_border, border_width, height, height, height);
 	adapt_values(SIDE_LEFT, SIDE_RIGHT, adapted_border, border_width, width, width, width);
@@ -496,20 +511,6 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	Rect2 infill_rect = style_rect.grow_individual(-adapted_border[SIDE_LEFT], -adapted_border[SIDE_TOP], -adapted_border[SIDE_RIGHT], -adapted_border[SIDE_BOTTOM]);
 
 	Rect2 border_style_rect = style_rect;
-
-	real_t aa_size_scaled = 1.0f;
-	if (aa_on) {
-		real_t scale_factor = TextServer::get_current_drawn_item_oversampling();
-		if (scale_factor == 0.0) {
-			scale_factor = 1.0;
-		}
-
-		// Adjust AA feather size to account for the 2D scale factor, so that
-		// antialiasing doesn't become blurry at viewport resolutions higher
-		// than the default when using the `canvas_items` stretch mode
-		// (or when using `oversampling` values different than `1.0`).
-		aa_size_scaled = aa_size / scale_factor;
-	}
 
 	if (aa_on) {
 		for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #68306 and #68514, partially closes #118931

## Additional information

StyleboxFlat automatically adapts it's corner and border size to fit the dimensions of the sbf when it gets resized. Currently this adapting doesn't take the small ring of antialiasing into account that's added on the outside of the sbf. This means you get visible overlaps if the border- or background colors are semi-transparent, and you can also get small "dots" where two large rounded corners meet. This PR makes it so that the aa is taken into account when adapting.

Before:
<img width="700" height="368" alt="image" src="https://github.com/user-attachments/assets/e7c2e8d5-d009-422a-b6c8-a224de19861b" />

After:
<img width="669" height="362" alt="image" src="https://github.com/user-attachments/assets/fbf5752a-ac8e-44b4-b732-4a33277b9bcc" />
