### PR TITLE
Clarify docs regarding how `modulate` is applied to a `CanvasItem`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -666,14 +666,14 @@
 			The material applied to this [CanvasItem].
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)" keywords="color, colour">
-			The color applied to this [CanvasItem]. This property does affect child [CanvasItem]s, unlike [member self_modulate] which only affects the node itself.
+			The color by which each pixel in this [CanvasItem] is multiplied. This property does affect child [CanvasItem]s, unlike [member self_modulate] which only affects the node itself.
 		</member>
 		<member name="oversampling_with_scale" type="int" setter="set_oversampling_with_scale" getter="get_oversampling_with_scale" enum="CanvasItem.OversamplingWithScale" default="0">
 			If enabled, oversampling for this [CanvasItem] is automatically adjusted with scale. This makes fonts and [DPITexture] images automatically re-render to match the actual scale they are drawn at, for crisper visuals. This has a performance impact on the CPU every time the node's scale changes, so it is disabled by default.
 			[b]Note:[/b] For [Control] nodes with [member Control.offset_transform_enabled] set to [code]true[/code], scale-based oversampling is only effective if [member Control.offset_transform_visual_only] is [code]false[/code]. This ensures there is no performance overhead when using visual-only offset transforms (as often used in animations).
 		</member>
 		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" default="Color(1, 1, 1, 1)">
-			The color applied to this [CanvasItem]. This property does [b]not[/b] affect child [CanvasItem]s, unlike [member modulate] which affects both the node itself and its children.
+			The color by which each pixel in this [CanvasItem] is multiplied. This property does [b]not[/b] affect child [CanvasItem]s, unlike [member modulate] which affects both the node itself and its children.
 			[b]Note:[/b] Internal children are also not affected by this property (see the [code]include_internal[/code] parameter in [method Node.add_child]). For built-in nodes this includes sliders in [ColorPicker], and the tab bar in [TabContainer].
 		</member>
 		<member name="show_behind_parent" type="bool" setter="set_draw_behind_parent" getter="is_draw_behind_parent_enabled" default="false">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #117992

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

I tried to keep the update super simple. Just reworded the first sentence so that it could clarify that `modulate` was applied via multiplication. I added "each pixel" because it felt weird to say that a `CanvasItem` is multiplied by a color, but it makes sense to say that a pixel is multiplied by a color.

Let me know if it would be better to include information about what color space the multiplication is done in (see https://github.com/godotengine/godot/issues/117992#issuecomment-4188885168). If so, I can look into the code and then update the PR with that info.