### PR TITLE
Reverse the logic of `EditorProperty::_get_v_separation()`

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -191,7 +191,7 @@ private:
 
 	void _update_popup();
 	void _focusable_focused(int p_index);
-	int _get_v_separation() const { return bottom_editor ? 0 : theme_cache.vertical_separation; }
+	int _get_v_separation() const { return bottom_editor ? theme_cache.vertical_separation : 0; }
 
 	bool selectable = true;
 	bool selected = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121524 

## Overview

<img width="655" height="84" alt="image" src="https://github.com/user-attachments/assets/01490c0b-8f6a-4ac5-a194-702bc18fe49c" />

`_get_v_seperation()` would always return 0, because in all use cases of this function there is a check for bottom_editor. It should return the actual seperation,

<img width="908" height="190" alt="image" src="https://github.com/user-attachments/assets/b7fa2da1-845f-4c58-b2a4-ad984dce083e" />


## Additional information

Fixes the issue:

<img width="926" height="120" alt="image" src="https://github.com/user-attachments/assets/9b0d6e85-72fe-4510-8fe2-308be380e524" />