### PR TITLE
Add PrimitiveGeometry3D nodes: Box3D, Sphere3D, Cylinder3D, and Capsule3D.

### DIFF
--- a/doc/classes/Box3D.xml
+++ b/doc/classes/Box3D.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Box3D" inherits="PrimitiveGeometry3D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A primitive box shape.
+	</brief_description>
+	<description>
+		A quick box shape with optional collision.
+		[b]Performance:[/b] Primitive Geometry nodes are intended both for fast level prototyping as well as finished games, as they have a cheap CPU cost due to using primitive meshes and collision.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
+			The box's width, height and depth.
+		</member>
+	</members>
+</class>

--- a/doc/classes/Capsule3D.xml
+++ b/doc/classes/Capsule3D.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Capsule3D" inherits="PrimitiveGeometry3D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A primitive capsule shape.
+	</brief_description>
+	<description>
+		A quick capsule shape with optional collision.
+		[b]Performance:[/b] Primitive Geometry nodes are intended both for fast level prototyping as well as finished games, as they have a cheap CPU cost due to using primitive meshes and collision.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+			The height of the capsule.
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
+			The radius of the capsule.
+		</member>
+	</members>
+</class>

--- a/doc/classes/Cylinder3D.xml
+++ b/doc/classes/Cylinder3D.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Cylinder3D" inherits="PrimitiveGeometry3D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A primitive cylinder shape.
+	</brief_description>
+	<description>
+		A quick cylinder shape with optional collision.
+		[b]Performance:[/b] Primitive Geometry nodes are intended both for fast level prototyping as well as finished games, as they have a cheap CPU cost due to using primitive meshes and collision.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+			The height of the cylinder.
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
+			The radius of the cylinder.
+		</member>
+	</members>
+</class>

--- a/doc/classes/PrimitiveGeometry3D.xml
+++ b/doc/classes/PrimitiveGeometry3D.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PrimitiveGeometry3D" inherits="GeometryInstance3D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		The base class for Primitive Geometry shapes.
+	</brief_description>
+	<description>
+		This is the base class for primitive geometry shapes.
+		Each shape has paramaters such as size, radius, or height, which can be adjusted to change the proportions of the shape. They can also be translated and rotated.
+		[b]Performance:[/b] Primitive Geometry nodes are intended both for fast level prototyping as well as finished games, as they have a cheap CPU cost due to using primitive meshes and collision.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_collision_layer_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="get_collision_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_collision_layer_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member collision_layer], given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_collision_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
+			The physics layers this PrimitiveGeometry3D [b]is in[/b]. Collision objects can exist in one or more of 32 different layers. See also [member collision_mask].
+			[b]Note:[/b] Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]C
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
+			The physics layers this PrimitiveGeometry3D [b]scans[/b]. Collision objects can scan one or more of 32 different layers. See also [member collision_layer].
+			[b]Note:[/b] Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+		</member>
+		<member name="collision_priority" type="float" setter="set_collision_priority" getter="get_collision_priority" default="1.0">
+			The priority used to solve colliding when occurring penetration. The higher the priority is, the lower the penetration into the object will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
+		</member>
+		<member name="material" type="Material" setter="set_material" getter="get_material">
+			The material used to render the shape.
+		</member>
+		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">
+			Adds a collision shape to the physics engine for this node. This will always act like a static body. Note that the collision shape is still active even if the node itself is hidden. See also [member collision_mask] and [member collision_priority].
+		</member>
+	</members>
+</class>

--- a/doc/classes/Sphere3D.xml
+++ b/doc/classes/Sphere3D.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Sphere3D" inherits="PrimitiveGeometry3D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A primitive sphere shape.
+	</brief_description>
+	<description>
+		A quick sphere shape with optional collision.
+		[b]Performance:[/b] Primitive Geometry nodes are intended both for fast level prototyping as well as finished games, as they have a cheap CPU cost due to using primitive meshes and collision.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+			The radius of the sphere.
+		</member>
+	</members>
+</class>

--- a/editor/icons/Box3D.svg
+++ b/editor/icons/Box3D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fc7f7f" stroke-width="2" d="m8 2 6 3v6l-6 3-6-3V5zm0 12V8l6-3M8 8 2 5"/></svg>

--- a/editor/icons/Capsule3D.svg
+++ b/editor/icons/Capsule3D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fc7f7f" stroke-width="2" d="M4 6a4 4 0 0 1 8 0v4a4 4 0 0 1-8 0zm0 1.25a2.5 1 0 0 0 8 0m-4-5v12"/></svg>

--- a/editor/icons/Cylinder3D.svg
+++ b/editor/icons/Cylinder3D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fc7f7f" stroke-width="2" d="M2 4v8a6 2 0 0 0 12 0V4A6 2 0 0 0 2 4a6 2 0 0 0 12 0"/></svg>

--- a/editor/icons/Sphere3D.svg
+++ b/editor/icons/Sphere3D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fc7f7f" stroke-width="2" d="M8 2a6 6 0 0 0 0 12A6 6 0 0 0 8 2v12M2.05 7.4a6 2 0 0 0 11.9 0"/></svg>

--- a/editor/scene/3d/gizmos/primitive_geometry_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/primitive_geometry_3d_gizmo_plugin.cpp
@@ -1,0 +1,241 @@
+/**************************************************************************/
+/*  primitive_geometry_3d_gizmo_plugin.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "primitive_geometry_3d_gizmo_plugin.h"
+
+#include "core/math/geometry_3d.h"
+#include "core/math/triangle_mesh.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/scene/3d/gizmos/gizmo_3d_helper.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/3d/primitive_geometry_3d.h"
+
+PrimitiveGeometry3DGizmoPlugin::PrimitiveGeometry3DGizmoPlugin() {
+	helper.instantiate();
+	create_handle_material("handles");
+}
+
+bool PrimitiveGeometry3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
+	return Object::cast_to<PrimitiveGeometry3D>(p_spatial) != nullptr;
+}
+
+String PrimitiveGeometry3DGizmoPlugin::get_gizmo_name() const {
+	return "PrimitiveGeometry3D";
+}
+
+int PrimitiveGeometry3DGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+String PrimitiveGeometry3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
+	const PrimitiveGeometry3D *cs = Object::cast_to<PrimitiveGeometry3D>(p_gizmo->get_node_3d());
+
+
+	if (Object::cast_to<Sphere3D>(cs)) {
+		return "Radius";
+	}
+
+	if (Object::cast_to<Box3D>(cs)) {
+		return helper->box_get_handle_name(p_id);
+	}
+
+	if (Object::cast_to<Capsule3D>(cs)) {
+		return helper->capsule_get_handle_name(p_id);
+	}
+
+	if (Object::cast_to<Cylinder3D>(cs)) {
+		return helper->cylinder_get_handle_name(p_id);
+	}
+
+	return "";
+}
+
+Variant PrimitiveGeometry3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
+	PrimitiveGeometry3D *cs = Object::cast_to<PrimitiveGeometry3D>(p_gizmo->get_node_3d());
+
+	if (Object::cast_to<Sphere3D>(cs)) {
+		Sphere3D* ss = (Sphere3D*)cs;
+		return ss->get_radius();
+	}
+
+	if (Object::cast_to<Box3D>(cs)) {
+		Box3D* ss = (Box3D*)cs;
+		return ss->get_size();
+	}
+
+	if (Object::cast_to<Capsule3D>(cs)) {
+		Capsule3D* ss = (Capsule3D*)cs;
+		return Vector2(ss->get_radius(), ss->get_height());
+	}
+
+	if (Object::cast_to<Cylinder3D>(cs)) {
+		Cylinder3D* ss = (Cylinder3D*)cs;
+		return Vector2(ss->get_radius(), ss->get_height());
+	}
+
+	return Variant();
+}
+
+void PrimitiveGeometry3DGizmoPlugin::begin_handle_action(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) {
+	helper->initialize_handle_action(get_handle_value(p_gizmo, p_id, p_secondary), p_gizmo->get_node_3d()->get_global_transform());
+}
+
+void PrimitiveGeometry3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) {
+	PrimitiveGeometry3D *cs = Object::cast_to<PrimitiveGeometry3D>(p_gizmo->get_node_3d());
+
+	Vector3 sg[2];
+	helper->get_segment(p_camera, p_point, sg);
+
+	if (Object::cast_to<Sphere3D>(cs)) {
+		Sphere3D* ss = (Sphere3D*)cs;
+		Vector3 ra, rb;
+		Geometry3D::get_closest_points_between_segments(Vector3(), Vector3(4096, 0, 0), sg[0], sg[1], ra, rb);
+		float d = ra.x;
+		if (Node3DEditor::get_singleton()->is_snap_enabled()) {
+			d = Math::snapped(d, Node3DEditor::get_singleton()->get_translate_snap());
+		}
+
+		if (d < 0.001) {
+			d = 0.001;
+		}
+
+		ss->set_radius(d);
+	}
+
+	if (Object::cast_to<Box3D>(cs)) {
+		Box3D* bs = (Box3D*)cs;
+		Vector3 size = bs->get_size();
+		Vector3 position;
+		helper->box_set_handle(sg, p_id, size, position);
+		bs->set_size(size);
+		cs->set_global_position(position);
+	}
+
+	if (Object::cast_to<Capsule3D>(cs)) {
+		Capsule3D* cs2 = (Capsule3D*)cs;
+
+		real_t height = cs2->get_height();
+		real_t radius = cs2->get_radius();
+		Vector3 position;
+		helper->capsule_set_handle(sg, p_id, height, radius, position);
+		cs2->set_height(height);
+		cs2->set_radius(radius);
+		cs->set_global_position(position);
+	}
+
+	if (Object::cast_to<Cylinder3D>(cs)) {
+		Cylinder3D* cs2 = (Cylinder3D*)cs;
+
+		real_t height = cs2->get_height();
+		real_t radius = cs2->get_radius();
+		Vector3 position;
+		helper->cylinder_set_handle(sg, p_id, height, radius, position);
+		cs2->set_height(height);
+		cs2->set_radius(radius);
+		cs->set_global_position(position);
+	}
+}
+
+void PrimitiveGeometry3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) {
+	PrimitiveGeometry3D *cs = Object::cast_to<PrimitiveGeometry3D>(p_gizmo->get_node_3d());
+
+	// there's no helper->commit_sphere_handle so manual implementation
+	if (Object::cast_to<Sphere3D>(cs)) {
+		Sphere3D* ss = (Sphere3D*)cs;
+		if (p_cancel) {
+			ss->set_radius(p_restore);
+			return;
+		}
+
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("Change Sphere Radius"));
+		ur->add_do_method(ss, "set_radius", ss->get_radius());
+		ur->add_undo_method(ss, "set_radius", p_restore);
+		ur->commit_action();
+	}
+
+	if (Object::cast_to<Box3D>(cs)) {
+		helper->box_commit_handle(TTR("Change Box Size"), p_cancel, cs, cs);
+	}
+
+	if (Object::cast_to<Capsule3D>(cs)) {
+		helper->cylinder_commit_handle(p_id, TTR("Change Capsule Radius"), TTR("Change Capsule Height"), p_cancel, cs, cs, cs);
+	}
+
+	if (Object::cast_to<Cylinder3D>(cs)) {
+		helper->cylinder_commit_handle(p_id, TTR("Change Cylinder Radius"), TTR("Change Cylinder Height"), p_cancel, cs, cs, cs);
+	}
+}
+
+void PrimitiveGeometry3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
+	PrimitiveGeometry3D *cs = Object::cast_to<PrimitiveGeometry3D>(p_gizmo->get_node_3d());
+
+	p_gizmo->clear();
+
+	const Ref<Material> handles_material = get_material("handles");
+
+	if (Object::cast_to<Sphere3D>(cs)) {
+		Sphere3D* sp = (Sphere3D*)cs;
+
+		Vector<Vector3> handles;
+		handles.push_back(Vector3(sp->get_radius(), 0.f, 0.f));
+		p_gizmo->add_handles(handles, handles_material);
+	}
+
+	if (Object::cast_to<Box3D>(cs)) {
+		Box3D* bs = (Box3D*)cs;
+
+		const Vector<Vector3> handles = helper->box_get_handles(bs->get_size());
+		p_gizmo->add_handles(handles, handles_material);
+	}
+
+	if (Object::cast_to<Capsule3D>(cs)) {
+		Capsule3D* cs2 = (Capsule3D*)cs;
+
+		Vector<Vector3> handles = helper->capsule_get_handles(cs2->get_height(), cs2->get_radius());
+		p_gizmo->add_handles(handles, handles_material);
+	}
+
+	if (Object::cast_to<Cylinder3D>(cs)) {
+		Cylinder3D* cs2 = (Cylinder3D*)cs;
+
+		Vector<Vector3> handles = helper->cylinder_get_handles(cs2->get_height(), cs2->get_radius());
+		p_gizmo->add_handles(handles, handles_material);
+	}
+
+	Ref<TriangleMesh> triangle_mesh = cs->generate_triangle_mesh();
+	if (triangle_mesh.is_valid()) {
+		p_gizmo->add_collision_triangles(triangle_mesh);
+	}
+}
+
+void PrimitiveGeometry3DGizmoPlugin::set_show_only_when_selected(bool p_enabled) {
+	show_only_when_selected = p_enabled;
+}

--- a/editor/scene/3d/gizmos/primitive_geometry_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/primitive_geometry_3d_gizmo_plugin.h
@@ -1,0 +1,60 @@
+/**************************************************************************/
+/*  primitive_geometry_3d_gizmo_plugin.h                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
+
+class Gizmo3DHelper;
+
+class PrimitiveGeometry3DGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(PrimitiveGeometry3DGizmoPlugin, EditorNode3DGizmoPlugin);
+
+	void create_collision_material(const String &p_name, float p_alpha);
+
+	Ref<Gizmo3DHelper> helper;
+
+	inline static bool show_only_when_selected = false;
+
+public:
+	bool has_gizmo(Node3D *p_spatial) override;
+	String get_gizmo_name() const override;
+	int get_priority() const override;
+	void redraw(EditorNode3DGizmo *p_gizmo) override;
+	static void set_show_only_when_selected(bool p_enabled);
+
+	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	void begin_handle_action(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) override;
+	void set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
+	void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
+
+	PrimitiveGeometry3DGizmoPlugin();
+};

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -76,6 +76,7 @@
 #include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/primitive_geometry_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/sprite_base_3d_gizmo_plugin.h"
@@ -2842,6 +2843,7 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<AudioStreamPlayer3DGizmoPlugin>(memnew(AudioStreamPlayer3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<AudioListener3DGizmoPlugin>(memnew(AudioListener3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<MeshInstance3DGizmoPlugin>(memnew(MeshInstance3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<PrimitiveGeometry3DGizmoPlugin>(memnew(PrimitiveGeometry3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<OccluderInstance3DGizmoPlugin>(memnew(OccluderInstance3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SpriteBase3DGizmoPlugin>(memnew(SpriteBase3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Label3DGizmoPlugin>(memnew(Label3DGizmoPlugin)));

--- a/scene/3d/primitive_geometry_3d.cpp
+++ b/scene/3d/primitive_geometry_3d.cpp
@@ -1,0 +1,467 @@
+/**************************************************************************/
+/*  primitive_geometry_3d.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "primitive_geometry_3d.h"
+#include "core/math/aabb.h"
+#include "core/math/triangle_mesh.h"
+#include "core/object/class_db.h"
+#include "core/object/property_info.h"
+#include "core/os/memory.h"
+#include "scene/main/node.h"
+#include "scene/resources/3d/box_shape_3d.h"
+#include "scene/resources/3d/capsule_shape_3d.h"
+#include "scene/resources/3d/cylinder_shape_3d.h"
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/3d/sphere_shape_3d.h"
+#include "servers/physics_3d/physics_server_3d.h"
+
+void PrimitiveGeometry3D::set_material(const Ref<Material> &p_material) {
+	material = p_material;
+	if (mesh.is_valid()) {
+		mesh->set_material(material);
+	}
+};
+Ref<Material> PrimitiveGeometry3D::get_material() const {
+	return material;
+};
+
+Ref<TriangleMesh> PrimitiveGeometry3D::generate_triangle_mesh() const {
+	return mesh->generate_triangle_mesh();
+}
+
+#ifndef PHYSICS_3D_DISABLED
+void PrimitiveGeometry3D::initiate_collision() {
+	PhysicsServer3D *singleton = PhysicsServer3D::get_singleton();
+	instantiate_collision_shape();
+	collision_body = singleton->body_create();
+	singleton->body_set_mode(collision_body, PS3DE::BODY_MODE_STATIC);
+	singleton->body_set_state(collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
+	singleton->body_add_shape(collision_body, shape->get_rid());
+	singleton->body_set_space(collision_body, get_world_3d()->get_space());
+	singleton->body_attach_object_instance_id(collision_body, get_instance_id());
+	set_collision_layer(collision_layer);
+	set_collision_mask(collision_mask);
+	set_collision_priority(collision_priority);
+}
+
+void PrimitiveGeometry3D::destroy_collision() {
+	PhysicsServer3D::get_singleton()->free_rid(collision_body);
+	collision_body = RID();
+	shape = nullptr;
+}
+
+
+void PrimitiveGeometry3D::set_use_collision(bool p_enable) {
+	if (use_collision == p_enable) {
+		return;
+	}
+
+	use_collision = p_enable;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	if (use_collision) {
+		initiate_collision();
+	} else {
+		destroy_collision();
+	}
+
+	notify_property_list_changed();
+	update_gizmos();
+}
+
+bool PrimitiveGeometry3D::is_using_collision() const {
+	return use_collision;
+}
+
+void PrimitiveGeometry3D::set_collision_layer(uint32_t p_layer) {
+	collision_layer = p_layer;
+	if (collision_body.is_valid()) {
+		PhysicsServer3D::get_singleton()->body_set_collision_layer(collision_body, p_layer);
+	}
+}
+
+uint32_t PrimitiveGeometry3D::get_collision_layer() const {
+	return collision_layer;
+}
+
+void PrimitiveGeometry3D::set_collision_mask(uint32_t p_mask) {
+	collision_mask = p_mask;
+	if (collision_body.is_valid()) {
+		PhysicsServer3D::get_singleton()->body_set_collision_mask(collision_body, p_mask);
+	}
+}
+
+uint32_t PrimitiveGeometry3D::get_collision_mask() const {
+	return collision_mask;
+}
+
+void PrimitiveGeometry3D::set_collision_layer_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
+	uint32_t layer = get_collision_layer();
+	if (p_value) {
+		layer |= 1 << (p_layer_number - 1);
+	} else {
+		layer &= ~(1 << (p_layer_number - 1));
+	}
+	set_collision_layer(layer);
+}
+
+bool PrimitiveGeometry3D::get_collision_layer_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
+	return get_collision_layer() & (1 << (p_layer_number - 1));
+}
+
+void PrimitiveGeometry3D::set_collision_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_collision_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_collision_mask(mask);
+}
+
+bool PrimitiveGeometry3D::get_collision_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
+	return get_collision_mask() & (1 << (p_layer_number - 1));
+}
+
+void PrimitiveGeometry3D::set_collision_priority(real_t p_priority) {
+	collision_priority = p_priority;
+	if (collision_body.is_valid()) {
+		PhysicsServer3D::get_singleton()->body_set_collision_priority(collision_body, p_priority);
+	}
+}
+
+real_t PrimitiveGeometry3D::get_collision_priority() const {
+	return collision_priority;
+}
+#endif // PHYSICS_3D_DISABLED
+
+AABB PrimitiveGeometry3D::get_aabb() const {
+	return mesh->get_aabb();
+}
+
+void PrimitiveGeometry3D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+#ifndef PHYSICS_3D_DISABLED
+			if (use_collision) {
+				initiate_collision();
+			}
+#endif
+			instantiate_mesh();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+#ifndef PHYSICS_3D_DISABLED
+			if (collision_body.is_valid()) {
+				destroy_collision();
+			}
+#endif
+			mesh = nullptr;
+		} break;
+
+#ifndef PHYSICS_3D_DISABLED
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (collision_body.is_valid()) {
+				PhysicsServer3D::get_singleton()->body_set_state(collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
+			}
+		} break;
+#endif
+	}
+};
+
+void PrimitiveGeometry3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_material", "material"), &Box3D::set_material);
+	ClassDB::bind_method(D_METHOD("get_material"), &Box3D::get_material);
+
+#ifndef PHYSICS_3D_DISABLED
+	ClassDB::bind_method(D_METHOD("set_use_collision", "operation"), &PrimitiveGeometry3D::set_use_collision);
+	ClassDB::bind_method(D_METHOD("is_using_collision"), &PrimitiveGeometry3D::is_using_collision);
+
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &PrimitiveGeometry3D::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &PrimitiveGeometry3D::get_collision_layer);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &PrimitiveGeometry3D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &PrimitiveGeometry3D::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask_value", "layer_number", "value"), &PrimitiveGeometry3D::set_collision_mask_value);
+	ClassDB::bind_method(D_METHOD("get_collision_mask_value", "layer_number"), &PrimitiveGeometry3D::get_collision_mask_value);
+
+	ClassDB::bind_method(D_METHOD("set_collision_layer_value", "layer_number", "value"), &PrimitiveGeometry3D::set_collision_layer_value);
+	ClassDB::bind_method(D_METHOD("get_collision_layer_value", "layer_number"), &PrimitiveGeometry3D::get_collision_layer_value);
+
+	ClassDB::bind_method(D_METHOD("set_collision_priority", "priority"), &PrimitiveGeometry3D::set_collision_priority);
+	ClassDB::bind_method(D_METHOD("get_collision_priority"), &PrimitiveGeometry3D::get_collision_priority);
+#endif // PHYSICS_3D_DISABLED
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
+
+#ifndef PHYSICS_3D_DISABLED
+	ADD_GROUP("Collision", "collision_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_collision"), "set_use_collision", "is_using_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority"), "set_collision_priority", "get_collision_priority");
+#endif // PHYSICS_3D_DISABLED
+}
+
+void PrimitiveGeometry3D::_validate_property(PropertyInfo &p_property) const {
+	if (!use_collision && p_property.name.begins_with("collision_")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
+// Primitive classes
+
+void Box3D::set_size(const Vector3 &p_size) {
+	ERR_FAIL_COND_MSG(p_size.x < 0.f || p_size.y < 0.f || p_size.z < 0.f, "Box3D size cannot be negative.");
+	size = p_size;
+	if (mesh.is_valid()) {
+		((Ref<BoxMesh>)mesh)->set_size(size);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<BoxShape3D>)shape)->set_size(size);
+	}
+#endif
+	update_gizmos();
+}
+
+Vector3 Box3D::get_size() const {
+	return size;
+}
+
+void Box3D::instantiate_mesh() {
+	Ref<BoxMesh> box_mesh = memnew(BoxMesh);
+	box_mesh->set_size(size);
+	box_mesh->set_material(material);
+	set_base(box_mesh->get_rid());
+	mesh = box_mesh;
+}
+
+#ifndef PHYSICS_3D_DISABLED
+void Box3D::instantiate_collision_shape() {
+	Ref<BoxShape3D> box_shape = memnew(BoxShape3D);
+	box_shape->set_size(size);
+	shape = box_shape;
+};
+#endif
+
+void Box3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &Box3D::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &Box3D::get_size);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
+}
+
+
+void Sphere3D::set_radius(const float p_radius) {
+	ERR_FAIL_COND_MSG(p_radius < 0.f, "Sphere3D radius cannot be negative.");
+	radius = p_radius;
+	if (mesh.is_valid()) {
+		((Ref<SphereMesh>)mesh)->set_radius(p_radius);
+		((Ref<SphereMesh>)mesh)->set_height(p_radius*2.f);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<SphereShape3D>)shape)->set_radius(radius);
+	}
+#endif
+	update_gizmos();
+}
+
+float Sphere3D::get_radius() const {
+	return radius;
+}
+
+void Sphere3D::instantiate_mesh() {
+	Ref<SphereMesh> sphere_mesh = memnew(SphereMesh);
+	sphere_mesh->set_radius(radius);
+	sphere_mesh->set_height(radius*2.f);
+	sphere_mesh->set_material(material);
+	set_base(sphere_mesh->get_rid());
+	mesh = sphere_mesh;
+}
+
+#ifndef PHYSICS_3D_DISABLED
+void Sphere3D::instantiate_collision_shape() {
+	Ref<SphereShape3D> sphere_shape = memnew(SphereShape3D);
+	sphere_shape->set_radius(radius);
+	shape = sphere_shape;
+};
+#endif
+
+void Sphere3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Sphere3D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &Sphere3D::get_radius);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_NONE, "suffix:m"), "set_radius", "get_radius");
+}
+
+
+void Cylinder3D::set_radius(const float p_radius) {
+	ERR_FAIL_COND_MSG(p_radius < 0.f, "Cylinder3D radius cannot be negative.");
+	radius = p_radius;
+	if (mesh.is_valid()) {
+		((Ref<CylinderMesh>)mesh)->set_bottom_radius(p_radius);
+		((Ref<CylinderMesh>)mesh)->set_top_radius(p_radius);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<CylinderShape3D>)shape)->set_radius(radius);
+	}
+#endif
+	update_gizmos();
+}
+
+float Cylinder3D::get_radius() const {
+	return radius;
+}
+
+void Cylinder3D::set_height(const float p_height) {
+	ERR_FAIL_COND_MSG(p_height < 0.f, "Cylinder3D height cannot be negative.");
+	height = p_height;
+	if (mesh.is_valid()) {
+		((Ref<CylinderMesh>)mesh)->set_height(p_height);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<CylinderShape3D>)shape)->set_height(radius);
+	}
+#endif
+	update_gizmos();
+}
+
+float Cylinder3D::get_height() const {
+	return height;
+}
+
+void Cylinder3D::instantiate_mesh() {
+	Ref<CylinderMesh> cylinder_mesh = memnew(CylinderMesh);
+	cylinder_mesh->set_bottom_radius(radius);
+	cylinder_mesh->set_top_radius(radius);
+	cylinder_mesh->set_height(height);
+	cylinder_mesh->set_material(material);
+	set_base(cylinder_mesh->get_rid());
+	mesh = cylinder_mesh;
+}
+
+#ifndef PHYSICS_3D_DISABLED
+void Cylinder3D::instantiate_collision_shape() {
+	Ref<CylinderShape3D> cylinder_shape = memnew(CylinderShape3D);
+	cylinder_shape->set_radius(radius);
+	cylinder_shape->set_height(height);
+	shape = cylinder_shape;
+};
+#endif
+
+void Cylinder3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Cylinder3D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &Cylinder3D::get_radius);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &Cylinder3D::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &Cylinder3D::get_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_NONE, "suffix:m"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_NONE, "suffix:m"), "set_height", "get_height");
+}
+
+
+void Capsule3D::set_radius(const float p_radius) {
+	ERR_FAIL_COND_MSG(p_radius < 0.f, "Capsule3D radius cannot be negative.");
+	radius = p_radius;
+	if (mesh.is_valid()) {
+		((Ref<CapsuleMesh>)mesh)->set_radius(p_radius);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<CapsuleShape3D>)shape)->set_radius(radius);
+	}
+#endif
+	update_gizmos();
+}
+
+float Capsule3D::get_radius() const {
+	return radius;
+}
+
+void Capsule3D::set_height(const float p_height) {
+	ERR_FAIL_COND_MSG(p_height < 0.f, "Capsule3D height cannot be negative.");
+	height = p_height;
+	if (mesh.is_valid()) {
+		((Ref<CapsuleMesh>)mesh)->set_height(p_height);
+	}
+#ifndef PHYSICS_3D_DISABLED
+	if (shape.is_valid()) {
+		((Ref<CapsuleShape3D>)shape)->set_height(radius);
+	}
+#endif
+	update_gizmos();
+}
+
+float Capsule3D::get_height() const {
+	return height;
+}
+
+void Capsule3D::instantiate_mesh() {
+	Ref<CapsuleMesh> capsule_mesh = memnew(CapsuleMesh);
+	capsule_mesh->set_radius(radius);
+	capsule_mesh->set_height(height);
+	capsule_mesh->set_material(material);
+	set_base(capsule_mesh->get_rid());
+	mesh = capsule_mesh;
+}
+
+#ifndef PHYSICS_3D_DISABLED
+void Capsule3D::instantiate_collision_shape() {
+	Ref<CapsuleShape3D> capsule_shape = memnew(CapsuleShape3D);
+	capsule_shape->set_radius(radius);
+	capsule_shape->set_height(height);
+	shape = capsule_shape;
+};
+#endif
+
+void Capsule3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Capsule3D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &Capsule3D::get_radius);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &Capsule3D::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &Capsule3D::get_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_NONE, "suffix:m"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_NONE, "suffix:m"), "set_height", "get_height");
+}

--- a/scene/3d/primitive_geometry_3d.h
+++ b/scene/3d/primitive_geometry_3d.h
@@ -1,0 +1,197 @@
+/**************************************************************************/
+/*  primitive_geometry_3d.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/aabb.h"
+#include "core/math/math_defs.h"
+#include "core/math/triangle_mesh.h"
+#include "core/math/vector3.h"
+#include "core/object/object.h"
+#include "core/templates/rid.h"
+#include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/3d/shape_3d.h"
+#include "scene/resources/material.h"
+#include "scene/resources/mesh.h"
+
+// Core primitive geometry class, handles collision and materials
+class PrimitiveGeometry3D : public GeometryInstance3D {
+	GDCLASS(PrimitiveGeometry3D, GeometryInstance3D);
+
+protected:
+	Ref<Material> material;
+	Ref<PrimitiveMesh> mesh;
+
+#ifndef PHYSICS_3D_DISABLED
+	Ref<Shape3D> shape;
+
+private:
+	bool use_collision = true;
+	uint32_t collision_layer = 1;
+	uint32_t collision_mask = 1;
+	real_t collision_priority = 1.0;
+	RID collision_body;
+#endif // PHYSICS_3D_DISABLED
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+
+public:
+	void set_material(const Ref<Material> &p_material);
+	Ref<Material> get_material() const;
+
+#ifndef PHYSICS_3D_DISABLED
+	void initiate_collision();
+	void destroy_collision();
+
+	void set_use_collision(bool p_enable);
+	bool is_using_collision() const;
+
+	void set_collision_layer(uint32_t p_layer);
+	uint32_t get_collision_layer() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_collision_layer_value(int p_layer_number, bool p_value);
+	bool get_collision_layer_value(int p_layer_number) const;
+
+	void set_collision_mask_value(int p_layer_number, bool p_value);
+	bool get_collision_mask_value(int p_layer_number) const;
+
+	void set_collision_priority(real_t p_priority);
+	real_t get_collision_priority() const;
+#endif
+
+	AABB get_aabb() const override;
+	Ref<TriangleMesh> generate_triangle_mesh() const override;
+
+private:
+	virtual void instantiate_mesh() = 0;
+#ifndef PHYSICS_3D_DISABLED
+	virtual void instantiate_collision_shape() = 0;
+#endif
+
+};
+
+// All the primitive geometries
+
+class Box3D : public PrimitiveGeometry3D {
+	GDCLASS(Box3D, PrimitiveGeometry3D);
+
+	Vector3 size = Vector3(1.f, 1.f, 1.f);
+
+protected:
+	static void _bind_methods();
+
+private:
+	void instantiate_mesh() override;
+#ifndef PHYSICS_3D_DISABLED
+	void instantiate_collision_shape() override;
+#endif
+
+public:
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
+
+	Box3D() {};
+};
+
+class Sphere3D : public PrimitiveGeometry3D {
+	GDCLASS(Sphere3D, PrimitiveGeometry3D);
+
+	float radius = 1.f;
+
+protected:
+	static void _bind_methods();
+
+private:
+	void instantiate_mesh() override;
+#ifndef PHYSICS_3D_DISABLED
+	void instantiate_collision_shape() override;
+#endif
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+
+	Sphere3D() {};
+};
+
+class Cylinder3D : public PrimitiveGeometry3D {
+	GDCLASS(Cylinder3D, PrimitiveGeometry3D);
+
+	float radius = 0.5f;
+	float height = 2.0f;
+
+protected:
+	static void _bind_methods();
+
+private:
+	void instantiate_mesh() override;
+#ifndef PHYSICS_3D_DISABLED
+	void instantiate_collision_shape() override;
+#endif
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+	void set_height(const float p_height);
+	float get_height() const;
+
+	Cylinder3D() {};
+};
+
+class Capsule3D : public PrimitiveGeometry3D {
+	GDCLASS(Capsule3D, PrimitiveGeometry3D);
+
+	float radius = 0.5f;
+	float height = 2.0f;
+
+protected:
+	static void _bind_methods();
+
+private:
+	void instantiate_mesh() override;
+#ifndef PHYSICS_3D_DISABLED
+	void instantiate_collision_shape() override;
+#endif
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+	void set_height(const float p_height);
+	float get_height() const;
+
+	Capsule3D() {};
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -252,6 +252,7 @@
 #include "scene/3d/look_at_modifier_3d.h"
 #include "scene/3d/marker_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/primitive_geometry_3d.h"
 #include "scene/3d/modifier_bone_target_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
 #include "scene/3d/node_3d.h"
@@ -634,6 +635,11 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Camera3D);
 	GDREGISTER_CLASS(AudioListener3D);
 	GDREGISTER_CLASS(MeshInstance3D);
+	GDREGISTER_ABSTRACT_CLASS(PrimitiveGeometry3D);
+	GDREGISTER_CLASS(Box3D);
+	GDREGISTER_CLASS(Sphere3D);
+	GDREGISTER_CLASS(Cylinder3D);
+	GDREGISTER_CLASS(Capsule3D);
 #ifndef DISABLE_DEPRECATED
 	MeshInstance3D::use_parent_skeleton_compat = GLOBAL_GET("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d");
 #endif


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

# This pull request is designed to simplify the process of adding 3D primitive shapes like boxes and spheres to Godot.

## What problem(s) does this PR solve?

- Level prototyping in Godot has always been difficult, you either had to use a StaticBody3D, add a MeshInstance3D as a child, create a BoxMesh with the right size, add a CollisionShape3D as a child, create a BoxShape3D with the right size, and every time you change the size you have to change both of them, and creating a new box requires you to make the BoxMesh and BoxShape3D unique,  or you had to use CSG nodes which are overkill for creating simple boxes without any CSG, and they have to be replaced with StaticBody3Ds for performance if you ever plan on releasing your game.
- Well worry no more because this Pull Request solves all of that problem! Instead, just add a Box3D node, resize it by dragging the circles, move it with the arrows and be finished with a performant and CPU-friendly box! Also includes Sphere3D, Cylinder3D, and Capsule3D.

## Additional information

- These nodes aren't only for level prototyping, they work well for finished games too.
- All the PrimitiveGeometry3D nodes have built-in collision and materials.
- PrimitiveGeometry3D nodes cannot be used inside other nodes like Area3D, RigidBody3D, or CharacterBody3D because they already act as StaticBody3Ds.
- There is no 2D versions of these nodes, but they probably could be implemented with a similar method to the one I used here.
- I'm not sure if PrimitiveGeometry3D is a good name for these nodes but that's just what I chose.
- No AI was used, but I did copy a lot of code from other files such as csg_shape.cpp and collision_shape_3d_gizmo_plugin.cpp
- I would enjoy if this got merged before 4.8, since in my opinion this would revolutionize Godot for 3D.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

## Example
<img width="2560" height="1440" alt="Screenshot (56)" src="https://github.com/user-attachments/assets/40d43037-2518-4f74-9156-2809f6a4eb39" />

