### PR TITLE
[Docs] Document `InstancePlaceholder.create_instance` parameters

### DIFF
--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -16,6 +16,8 @@
 			<param index="1" name="custom_scene" type="PackedScene" default="null" />
 			<description>
 				Call this method to actually load in the node. The created node will be placed as a sibling [i]above[/i] the [InstancePlaceholder] in the scene tree. The [Node]'s reference is also returned for convenience.
+				If [param replace] is [code]true[/code], the [InstancePlaceholder] is freed afterwards.
+				If [param custom_scene] is not [code]null[/code], this method instantiates [param custom_scene] instead of the original [PackedScene], and tries to set the same stored properties on the new instance. Properties that cannot be set print warnings, but do not cause an error.
 				[b]Note:[/b] [method create_instance] is not thread-safe. Use [method Object.call_deferred] if calling from a thread.
 			</description>
 		</method>


### PR DESCRIPTION
## What problem(s) does this PR solve?

~~In the [InstancePlaceholder docs](https://docs.godotengine.org/en/stable/classes/class_instanceplaceholder.html), it is unclear that `create_instance` can be called multiple times. This is a seemingly valid use case, and one that I would like to use. Seems to be used in practice (found it from a YouTube short), and the code seems to encourage it by allowing the placeholder to stay in the scene after `create_instance` is called. I added to the description that this is a valid use case.~~

In addition, the parameters for `create_instance` had no description, when their exact behaviors are not obvious from their names. Read the source code and added descriptions. 