### PR TITLE
Fix incorrect kerning offset in fallback text server

### DIFF
--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2701,6 +2701,8 @@ Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 			int32_t glyph_a = FT_Get_Char_Index(fd->face, p_glyph_pair.x);
 			int32_t glyph_b = FT_Get_Char_Index(fd->face, p_glyph_pair.y);
 			FT_Get_Kerning(fd->face, glyph_a, glyph_b, FT_KERNING_DEFAULT, &delta);
+			delta.x /= 64;
+			delta.y /= 64;
 			if (fd->msdf) {
 				return Vector2(delta.x, delta.y) * (double)p_size / (double)fd->msdf_source_size;
 			} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size * 64) {


### PR DESCRIPTION
Changed `TextServerFallback::_font_get_kerning` to correctly convert from 26.6 fractional pixels returned by `FT_Get_Kerning` to normal pixels. Previously, this has caused incorrect kerning calculations for some fonts (e.g. DejaVu Sans) when using fallback text server.

## What problem(s) does this PR solve?

- Closes #121449

## Additional information

<img width="658" height="221" alt="image" src="https://github.com/user-attachments/assets/f051d04c-321c-4916-a4a1-90324c05f839" />

Tested master and this PR with DejaVu Sans rasterized font and MSDF variant in RichTextBox, Label, and as editor font. Fonts with fixed size were not tested. [MVP-bug-121449.zip](https://github.com/user-attachments/files/30163624/MVP-bug-121449.zip)