### PR TITLE
Fix `DirAccessWindows::list_dir_begin()` for listing contents of root dirs of virtual drives

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -93,7 +93,14 @@ Error DirAccessWindows::list_dir_begin() {
 	_cishidden = false;
 
 	list_dir_end();
-	p->h = FindFirstFileExW((LPCWSTR)(String(current_dir + "\\*").utf16().get_data()), FindExInfoStandard, &p->fu, FindExSearchNameMatch, nullptr, 0);
+
+	String dir_glob = current_dir;
+	if (dir_glob.ends_with("\\")) {
+		dir_glob += "*";
+	} else {
+		dir_glob += "\\*";
+	}
+	p->h = FindFirstFileExW((LPCWSTR)(dir_glob.utf16().get_data()), FindExInfoStandard, &p->fu, FindExSearchNameMatch, nullptr, 0);
 
 	if (p->h == INVALID_HANDLE_VALUE) {
 		return ERR_CANT_OPEN;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The FileDialog on Windows doesn't show any files for the root directory of drives that are mapped to a directory using `subst`.

To reproduce, map a directory (not a drive) to a new drive letter, like this:
`subst X: C:\Windows`
Start Godot, and in the Project Manager click "Import" and select the X: drive - it will show up empty.

What's the bug in the current code?
`DirAccessWindows::list_dir_begin` appends a `\*` to the `current_dir`. If, and only if, `current_dir` is the root of a drive, it ends with a backslash, like this: `\\?\X:\`. Appending `\*` to that creates a double backslash, and the path that is passed to `FindFirstFileExW` will be `\\?\X:\\*`.
Now, the `\\?\` prefix is a well-known Win32 hack to allow long filenames, but as a side-effect, it disables path normalization. This means that the double backslash between the colon and the asterisk is not removed: https://projectzero.google/2016/02/the-definitive-guide-on-win32-to-nt.html

Why does the double backslash break listing the contents of subst-ed drives, but not physical drives? The device driver internally handles a double backslash that directly follows the drive letter plus colon. `subst`, on the other hand, just replaces the drive letter with the path the drive is mapped to, and ends up with that path followed by a double backslash, which is invalid if not normalized. The result is `FindFirstFileExW` will return  `INVALID_HANDLE_VALUE`.


## Additional information

This is my first contribution, let me know of any details I may have missed! Thank you
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
