### PR TITLE
EditorProperty: Fix Bottom Editor vertical separation logic

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -191,7 +191,7 @@ private:
 
 	void _update_popup();
 	void _focusable_focused(int p_index);
-	int _get_v_separation() const { return bottom_editor ? 0 : theme_cache.vertical_separation; }
+	int _get_v_separation() const { return bottom_editor && bottom_editor_seperation ? theme_cache.vertical_separation : 0; }
 
 	bool selectable = true;
 	bool selected = false;
@@ -218,6 +218,7 @@ private:
 protected:
 	bool has_borders = false;
 	bool can_override = false;
+	bool bottom_editor_seperation = false;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1123,6 +1123,8 @@ EditorSettingsDialog::~EditorSettingsDialog() {
 }
 
 void EditorSettingsPropertyWrapper::_setup_override_info() {
+	bottom_editor_seperation = true;
+
 	override_container = memnew(HBoxContainer);
 
 	override_icon = memnew(TextureRect);


### PR DESCRIPTION
Second shot at solving this issue, see #121538

## What problem(s) does this PR solve?

- Closes #121524 
<img width="884" height="96" alt="image" src="https://github.com/user-attachments/assets/5eede823-f7c6-44e7-a25a-565c620093b4" />


## Additional information

`_get_v_separation()` is only used if `bottom_editor` is defined, so the previous implementation would always return `0`.
This adds a new variable, which controls if the seperation is used or not.