### PR TITLE
Make BlendSpace toolbar need less width

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -420,10 +420,12 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 	min_value->set_value(blend_space->get_min_space());
 
 	sync->select(blend_space->get_sync_mode());
+	sync->set_fit_to_longest_item(false);
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
 	cyclic_length_value->set_visible(blend_space->get_sync_mode() == AnimationNodeBlendSpace1D::SYNC_MODE_CYCLIC_CONSTANT);
 
 	interpolation->select(blend_space->get_blend_mode());
+	interpolation->set_fit_to_longest_item(false);
 
 	label_value->set_text(blend_space->get_value_label());
 
@@ -1009,6 +1011,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	snap_value->set_step(0.01);
 	snap_value->set_max(1000);
 	snap_value->set_accessibility_name(TTRC("Grid Step"));
+	snap_value->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_value->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 	top_hb->add_child(memnew(Label(TTR("Sync"))));
@@ -1045,7 +1049,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
-	open_editor->set_text(TTR("Open Editor"));
+	open_editor->set_text(TTR("Edit"));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
 	edit_hb->add_child(open_editor_sep);
@@ -1058,6 +1062,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	index_edit->set_allow_greater(false);
 	index_edit->set_allow_lesser(false);
 	index_edit->set_accessibility_name(TTRC("Blend Point Index"));
+	index_edit->get_line_edit()->add_theme_constant_override("minimum_character_width", 1);
+	index_edit->get_line_edit()->set_expand_to_text_length_enabled(true);
 	index_edit->set_tooltip_text(TTR("Index of the blend point.\nValues outside of the valid range will be clamped to the nearest index."));
 	index_edit->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_index));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_edit_focus_entered));
@@ -1071,7 +1077,9 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->set_min(-ABS_MAX);
 	edit_value->set_max(ABS_MAX);
 	edit_value->set_step(STEP_UNIT);
-	edit_value->set_accessibility_name(TTRC("Blend Value"));
+	edit_value->set_accessibility_name(TTRC("Blend Point Position"));
+	edit_value->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_value->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
 
 	edit_hb->hide();

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -420,10 +420,12 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 	min_value->set_value(blend_space->get_min_space());
 
 	sync->select(blend_space->get_sync_mode());
+	sync->set_fit_to_longest_item(false);
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
 	cyclic_length_value->set_visible(blend_space->get_sync_mode() == AnimationNodeBlendSpace1D::SYNC_MODE_CYCLIC_CONSTANT);
 
 	interpolation->select(blend_space->get_blend_mode());
+	interpolation->set_fit_to_longest_item(false);
 
 	label_value->set_text(blend_space->get_value_label());
 
@@ -1009,6 +1011,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	snap_value->set_step(0.01);
 	snap_value->set_max(1000);
 	snap_value->set_accessibility_name(TTRC("Grid Step"));
+	snap_value->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_value->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 	top_hb->add_child(memnew(Label(TTR("Sync"))));
@@ -1045,7 +1049,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
-	open_editor->set_text(TTR("Open Editor"));
+	open_editor->set_text(TTR("Open"));
+	open_editor->set_tooltip_text(TTR("Open in editor."));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
 	edit_hb->add_child(open_editor_sep);
@@ -1058,6 +1063,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	index_edit->set_allow_greater(false);
 	index_edit->set_allow_lesser(false);
 	index_edit->set_accessibility_name(TTRC("Blend Point Index"));
+	index_edit->get_line_edit()->add_theme_constant_override("minimum_character_width", 1);
+	index_edit->get_line_edit()->set_expand_to_text_length_enabled(true);
 	index_edit->set_tooltip_text(TTR("Index of the blend point.\nValues outside of the valid range will be clamped to the nearest index."));
 	index_edit->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_index));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_edit_focus_entered));
@@ -1071,7 +1078,9 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->set_min(-ABS_MAX);
 	edit_value->set_max(ABS_MAX);
 	edit_value->set_step(STEP_UNIT);
-	edit_value->set_accessibility_name(TTRC("Blend Value"));
+	edit_value->set_accessibility_name(TTRC("Blend Point Position"));
+	edit_value->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_value->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
 
 	edit_hb->hide();

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -763,10 +763,12 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 	auto_triangles->set_pressed(blend_space->get_auto_triangles());
 
 	sync->select(blend_space->get_sync_mode());
+	sync->set_fit_to_longest_item(false);
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
 	cyclic_length_value->set_visible(blend_space->get_sync_mode() == AnimationNodeBlendSpace2D::SYNC_MODE_CYCLIC_CONSTANT);
 
 	interpolation->select(blend_space->get_blend_mode());
+	interpolation->set_fit_to_longest_item(false);
 
 	max_x_value->set_value(blend_space->get_max_space().x);
 	max_y_value->set_value(blend_space->get_max_space().y);
@@ -1266,6 +1268,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_x->set_step(0.01);
 	snap_x->set_max(1000);
 	snap_x->set_accessibility_name(TTRC("Grid X Step"));
+	snap_x->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_x->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	snap_y = memnew(SpinBox);
 	top_hb->add_child(snap_y);
@@ -1274,6 +1278,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);
 	snap_y->set_accessibility_name(TTRC("Grid Y Step"));
+	snap_y->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_y->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -1311,7 +1317,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
-	open_editor->set_text(TTR("Open Editor"));
+	open_editor->set_text(TTR("Edit"));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
 	edit_hb->add_child(open_editor_sep);
@@ -1324,6 +1330,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	index_edit->set_allow_greater(false);
 	index_edit->set_allow_lesser(false);
 	index_edit->set_accessibility_name(TTRC("Blend Point Index"));
+	index_edit->get_line_edit()->add_theme_constant_override("minimum_character_width", 1);
+	index_edit->get_line_edit()->set_expand_to_text_length_enabled(true);
 	index_edit->set_tooltip_text(TTR("Index of the blend point.\nValues outside of the valid range will be clamped to the nearest index."));
 	index_edit->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_index));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_edit_focus_entered));
@@ -1337,14 +1345,18 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_x->set_min(-ABS_MAX);
 	edit_x->set_max(ABS_MAX);
 	edit_x->set_step(STEP_UNIT);
-	edit_x->set_accessibility_name(TTRC("Blend X Value"));
+	edit_x->set_accessibility_name(TTRC("Blend Point X Position"));
+	edit_x->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_x->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_x->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	edit_y = memnew(SpinBox);
 	edit_hb->add_child(edit_y);
 	edit_y->set_min(-ABS_MAX);
 	edit_y->set_max(ABS_MAX);
 	edit_y->set_step(STEP_UNIT);
-	edit_y->set_accessibility_name(TTRC("Blend Y Value"));
+	edit_y->set_accessibility_name(TTRC("Blend Point Y Position"));
+	edit_y->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_y->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_y->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 
 	edit_hb->hide();

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -763,10 +763,12 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 	auto_triangles->set_pressed(blend_space->get_auto_triangles());
 
 	sync->select(blend_space->get_sync_mode());
+	sync->set_fit_to_longest_item(false);
 	cyclic_length_value->set_value(blend_space->get_cyclic_length());
 	cyclic_length_value->set_visible(blend_space->get_sync_mode() == AnimationNodeBlendSpace2D::SYNC_MODE_CYCLIC_CONSTANT);
 
 	interpolation->select(blend_space->get_blend_mode());
+	interpolation->set_fit_to_longest_item(false);
 
 	max_x_value->set_value(blend_space->get_max_space().x);
 	max_y_value->set_value(blend_space->get_max_space().y);
@@ -1266,6 +1268,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_x->set_step(0.01);
 	snap_x->set_max(1000);
 	snap_x->set_accessibility_name(TTRC("Grid X Step"));
+	snap_x->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_x->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	snap_y = memnew(SpinBox);
 	top_hb->add_child(snap_y);
@@ -1274,6 +1278,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);
 	snap_y->set_accessibility_name(TTRC("Grid Y Step"));
+	snap_y->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
+	snap_y->get_line_edit()->set_expand_to_text_length_enabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -1311,7 +1317,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
-	open_editor->set_text(TTR("Open Editor"));
+	open_editor->set_text(TTR("Open"));
+	open_editor->set_tooltip_text(TTR("Open in editor."));
 	open_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_open_editor), CONNECT_DEFERRED);
 	open_editor_sep = memnew(VSeparator);
 	edit_hb->add_child(open_editor_sep);
@@ -1324,6 +1331,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	index_edit->set_allow_greater(false);
 	index_edit->set_allow_lesser(false);
 	index_edit->set_accessibility_name(TTRC("Blend Point Index"));
+	index_edit->get_line_edit()->add_theme_constant_override("minimum_character_width", 1);
+	index_edit->get_line_edit()->set_expand_to_text_length_enabled(true);
 	index_edit->set_tooltip_text(TTR("Index of the blend point.\nValues outside of the valid range will be clamped to the nearest index."));
 	index_edit->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_index));
 	index_edit->get_line_edit()->connect(SceneStringName(focus_entered), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_edit_focus_entered));
@@ -1337,14 +1346,18 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_x->set_min(-ABS_MAX);
 	edit_x->set_max(ABS_MAX);
 	edit_x->set_step(STEP_UNIT);
-	edit_x->set_accessibility_name(TTRC("Blend X Value"));
+	edit_x->set_accessibility_name(TTRC("Blend Point X Position"));
+	edit_x->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_x->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_x->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	edit_y = memnew(SpinBox);
 	edit_hb->add_child(edit_y);
 	edit_y->set_min(-ABS_MAX);
 	edit_y->set_max(ABS_MAX);
 	edit_y->set_step(STEP_UNIT);
-	edit_y->set_accessibility_name(TTRC("Blend Y Value"));
+	edit_y->set_accessibility_name(TTRC("Blend Point Y Position"));
+	edit_y->get_line_edit()->add_theme_constant_override("minimum_character_width", 3);
+	edit_y->get_line_edit()->set_expand_to_text_length_enabled(true);
 	edit_y->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 
 	edit_hb->hide();

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -255,7 +255,8 @@ void AnimationNodeBlendTreeEditor::update_graph_immediately() {
 		if (AnimationTreeEditor::get_singleton()->can_edit(agnode)) {
 			node->add_child(memnew(HSeparator));
 			Button *open_in_editor = memnew(Button);
-			open_in_editor->set_text(TTR("Open Editor"));
+			open_in_editor->set_text(TTR("Open"));
+			open_in_editor->set_tooltip_text(TTR("Open in editor."));
 			open_in_editor->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			node->add_child(open_in_editor);
 			open_in_editor->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendTreeEditor::_open_in_editor).bind(E), CONNECT_DEFERRED);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -801,9 +801,9 @@ String AnimationNodeStateMachineEditor::get_tooltip(const Point2 &p_pos) const {
 
 	String tooltip_text;
 	if (hovered_node_area == HOVER_NODE_PLAY) {
-		tooltip_text = vformat(TTR("Play/Travel to %s"), hovered_node_name);
+		tooltip_text = vformat(TTR("Play/Travel to %s."), hovered_node_name);
 	} else if (hovered_node_area == HOVER_NODE_EDIT) {
-		tooltip_text = vformat(TTR("Edit %s"), hovered_node_name);
+		tooltip_text = vformat(TTR("Open %s in editor."), hovered_node_name);
 	} else {
 		tooltip_text = hovered_node_name;
 	}


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/119136.
This PR is deliberately small in scope for cherry-picking to 4.7, to make the experience less problematic for small screens.
A more comprehensive solution is being worked on, for 4.8, pending merge of https://github.com/godotengine/godot/pull/118970.

Shrinks width of the BlendSpace toolbar, from left-to-right, by:
- Reducing the minimum width of the Grid Step box to 2 characters, expands as needed.
- Disabling `fit_to_longest_item` for the Sync Mode dropdown, as it already claims variable space with "Cyclic Constant" adding a SpinBox.
- Disabling `fit_to_longest_item` for the Blend Mode dropdown, since everything to its right is after a spacer.
- Changing the `"Open Editor"` button to say just `"Edit"` instead, to match StateMachine tooltip `"Edit state"`. It also doesn't need to be used as much [since double-clicking was implemented](https://github.com/godotengine/godot/pull/109839).
- Reducing the minimum width of the Index box to 1 character, expands when needed.
- Reducing the minimum width of the Position boxes to 3 characters, wide enough for the minus symbol + 3 digits + decimal point, expands as needed.

Additionally changes the blend point position tooltips to not say "Value" and just say "Position" instead. It's clearer.

### Before
> <img width="1483" height="446" alt="image" src="https://github.com/user-attachments/assets/322ce0e4-4fc0-41ee-b6b3-f6a91e663df8" />

### After
> <img width="1185" height="366" alt="image" src="https://github.com/user-attachments/assets/a5421548-7ead-491a-a688-b4564a851b83" />

cc @TokageItLab 