### PR TITLE
Import Dock: Fix incorrect behavior when editing multiple files

### DIFF
--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -64,7 +64,6 @@ public:
 			values[p_name] = p_value;
 			if (checking) {
 				checked.insert(p_name);
-				notify_property_list_changed();
 			}
 			return true;
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121556 

## Overview

<img width="448" height="203" alt="image" src="https://github.com/user-attachments/assets/68b76811-4739-4d19-bd0a-465195afd85f" />

If `checking` is `false` (when one `Resource`, is selected) we don't emit `property_list_changed`, but if it's `true`, we do, which causes the various problems in the linked issue. I have removed the `notify_property_list_changed`, to be consistent with the other path, and to fix the issue.

## Video of the new behaviour

https://github.com/user-attachments/assets/abb915cf-3fe6-47b1-a5dd-2d07f35d606e

## Additional info

Tested. 
No AI was used.