### PR TITLE
Always set error.start_line in `GDScriptTokenizerText::string()`

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -880,6 +880,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 	String result;
 	char32_t prev = 0;
 	int prev_pos = 0;
+	int prev_line = 0;
 
 	for (;;) {
 		// Consume actual string.
@@ -896,6 +897,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 			} else {
 				error = make_error("Invisible text direction control character present in the string, escape it (\"\\u" + String::num_int64(ch, 16) + "\") to avoid confusion.");
 			}
+			error.start_line = line;
 			error.start_column = column;
 			error.end_column = column + 1;
 			push_error(error);
@@ -990,6 +992,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 							} else {
 								// Make error, but keep parsing the string.
 								Token error = make_error("Invalid hexadecimal digit in unicode escape sequence.");
+								error.start_line = line;
 								error.start_column = column;
 								error.end_column = column + 1;
 								push_error(error);
@@ -1019,6 +1022,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 						break;
 					default:
 						Token error = make_error("Invalid escape in string.");
+						error.start_line = line;
 						error.start_column = column - 2;
 						push_error(error);
 						valid_escape = false;
@@ -1030,9 +1034,11 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 						if (prev == 0) {
 							prev = escaped;
 							prev_pos = column - 2;
+							prev_line = line;
 							continue;
 						} else {
 							Token error = make_error("Invalid UTF-16 sequence in string, unpaired lead surrogate.");
+							error.start_line = line;
 							error.start_column = column - 2;
 							push_error(error);
 							valid_escape = false;
@@ -1041,6 +1047,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 					} else if ((escaped & 0xfffffc00) == 0xdc00) {
 						if (prev == 0) {
 							Token error = make_error("Invalid UTF-16 sequence in string, unpaired trail surrogate.");
+							error.start_line = line;
 							error.start_column = column - 2;
 							push_error(error);
 							valid_escape = false;
@@ -1051,7 +1058,10 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 					}
 					if (prev != 0) {
 						Token error = make_error("Invalid UTF-16 sequence in string, unpaired lead surrogate.");
+						error.start_line = prev_line;
 						error.start_column = prev_pos;
+						error.end_line = prev_line;
+						error.end_column = prev_pos + 2;
 						push_error(error);
 						prev = 0;
 					}
@@ -1064,7 +1074,10 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 		} else if (ch == quote_char) {
 			if (prev != 0) {
 				Token error = make_error("Invalid UTF-16 sequence in string, unpaired lead surrogate");
+				error.start_line = prev_line;
 				error.start_column = prev_pos;
+				error.end_line = prev_line;
+				error.end_column = prev_pos + 2;
 				push_error(error);
 				prev = 0;
 			}
@@ -1086,7 +1099,10 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 		} else {
 			if (prev != 0) {
 				Token error = make_error("Invalid UTF-16 sequence in string, unpaired lead surrogate");
+				error.start_line = prev_line;
 				error.start_column = prev_pos;
+				error.end_line = prev_line;
+				error.end_column = prev_pos + 2;
 				push_error(error);
 				prev = 0;
 			}
@@ -1099,7 +1115,10 @@ GDScriptTokenizer::Token GDScriptTokenizerText::string() {
 	}
 	if (prev != 0) {
 		Token error = make_error("Invalid UTF-16 sequence in string, unpaired lead surrogate");
+		error.start_line = prev_line;
 		error.start_column = prev_pos;
+		error.end_line = prev_line;
+		error.end_column = prev_pos + 2;
 		push_error(error);
 		prev = 0;
 	}

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "../gdscript_cache.h"
+#include "../gdscript_parser.h"
 #include "gdscript_test_runner.h"
 
 #include "core/io/file_access.h"
@@ -140,6 +141,40 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 			}
 		}
 	}
+}
+
+static void check_single_multiline_string_error(const String &p_string, int p_start_line, int p_start_column, int p_end_line, int p_end_column, const String &p_message) {
+	const String source = String("var s = \"\"\"\n") + p_string + "\n\"\"\"\n";
+
+	GDScriptParser parser;
+	parser.parse(source, "", false);
+	const List<GDScriptParser::ParserError> &errors = parser.get_errors();
+
+	REQUIRE_MESSAGE(errors.size() == 1, vformat("Expected exactly one error, got %d.", errors.size()));
+
+	const GDScriptParser::ParserError &error = errors.front()->get();
+
+	CHECK(error.start_line == p_start_line);
+	CHECK(error.start_column == p_start_column);
+	CHECK(error.end_line == p_end_line);
+	CHECK(error.end_column == p_end_column);
+	CHECK(error.message == p_message);
+}
+
+// These can't be part of the regular parser tests because they cannot test the position information of errors.
+TEST_CASE("[Modules][GDScript] Validate multi-line string error positions") {
+	check_single_multiline_string_error(String::chr(0x200E), 2, 1, 2, 2, "Invisible text direction control character present in the string, escape it (\"\\u200e\") to avoid confusion.");
+	check_single_multiline_string_error("\\Uzzzzzz", 2, 3, 2, 4, "Invalid hexadecimal digit in unicode escape sequence.");
+	check_single_multiline_string_error("\\p", 2, 1, 2, 3, "Invalid escape in string.");
+	check_single_multiline_string_error("abc\ndef\nghi\\p", 4, 4, 4, 6, "Invalid escape in string.");
+	check_single_multiline_string_error("\\uD800\\uD800", 2, 11, 2, 13, "Invalid UTF-16 sequence in string, unpaired lead surrogate.");
+	check_single_multiline_string_error("\\uDC00", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired trail surrogate.");
+	check_single_multiline_string_error("\\uD800\\u0041", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate.");
+	check_single_multiline_string_error("\\uD800\"abc", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate");
+	check_single_multiline_string_error("\\uD800x", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate");
+	check_single_multiline_string_error("\\uD800\\\n\\u0041", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate.");
+	check_single_multiline_string_error("\\uD800\\", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate");
+	check_single_multiline_string_error("\\uD800\\\nx", 2, 5, 2, 7, "Invalid UTF-16 sequence in string, unpaired lead surrogate");
 }
 
 } // namespace GDScriptTests


### PR DESCRIPTION
## What problem(s) does this PR solve?

`GDScriptTokenizerText::string()` returns errors with line and column data but does not properly handle multi-line string tokens. It sets `start_column` to the column of the physical line but leaves `start_line` set to the start of the token (which may be a few lines up!) This leads to a line/column combination that reads beyond the bounds of the line, crashing the process.

Set `start_line` to the current physical line whenever we set `start_column`.

- Closes #121294 

## Additional information

No AI was used. Fix was simply finding every place `start_column` was assigned within the function and assigning `start_line` in kind.

This is my first time adding unit tests and went through a few iterations regarding layout and naming. I settled on `SUBCASE` with a lambda and descriptive names but am open to different layout suggestions.