### PR TITLE
Bug fix in Tile Set Atlas Source Editor

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4070,6 +4070,41 @@ String EditorInspector::get_selected_path() const {
 	return property_selected;
 }
 
+bool EditorInspector::has_section(const String &p_section) const {
+	for (EditorInspectorSection *section : sections) {
+		if (section->get_section() == p_section) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void EditorInspector::set_section_fold(const String &p_section, bool p_fold) {
+	ERR_FAIL_COND(!has_section(p_section));
+
+	for (EditorInspectorSection *section : sections) {
+		if (section->get_section() == p_section) {
+			if (p_fold) {
+				section->fold();
+			} else {
+				section->unfold();
+			}
+			return;
+		}
+	}
+}
+
+HashMap<String, bool> EditorInspector::get_sections_fold() const {
+	HashMap<String, bool> fold_state;
+	for (EditorInspectorSection *section : sections) {
+		if (!section->object) {
+			continue;
+		}
+		fold_state.insert(section->get_section(), !section->object->editor_is_section_unfolded(section->get_section()));
+	}
+	return fold_state;
+}
+
 void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> p_plugin) {
 	for (const EditorInspectorPlugin::AddedEditor &F : p_plugin->added_editors) {
 		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
@@ -4733,6 +4768,7 @@ void EditorInspector::update_tree() {
 			if (editor_inspector_array) {
 				_add_section_in_tree(editor_inspector_array, current_vbox);
 				editor_inspector_array_per_prefix[array_element_prefix] = editor_inspector_array;
+				sections.push_back(editor_inspector_array);
 			}
 
 			continue;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -911,6 +911,10 @@ public:
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
 
+	bool has_section(const String &p_section) const;
+	void set_section_fold(const String &p_section, bool p_fold);
+	HashMap<String, bool> get_sections_fold() const;
+
 	void update_tree();
 	void update_property(const String &p_prop);
 	void edit(Object *p_object);

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -605,6 +605,8 @@ void TileSetAtlasSourceEditor::_update_atlas_source_inspector() {
 }
 
 void TileSetAtlasSourceEditor::_update_tile_inspector() {
+	HashMap<String, bool> sections_fold = tile_inspector->get_sections_fold();
+	int scroll_offset = tile_inspector->get_scroll_offset();
 	// Update visibility.
 	tile_inspector->edit(nullptr);
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
@@ -613,6 +615,12 @@ void TileSetAtlasSourceEditor::_update_tile_inspector() {
 			tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_proxy_object_changed));
 			tile_proxy_object->edit(tile_set_atlas_source, selection);
 			tile_inspector->edit(tile_proxy_object.ptr());
+			for (const KeyValue<String, bool> &E : sections_fold) {
+				if (tile_inspector->has_section(E.key)) {
+					tile_inspector->set_section_fold(E.key, E.value);
+				}
+			}
+			callable_mp(tile_inspector, &EditorInspector::set_scroll_offset).call_deferred(scroll_offset);
 		}
 		tile_inspector->set_visible(!selection.is_empty());
 		tile_inspector_no_tile_selected_label->set_visible(selection.is_empty());


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a regression in the **TileSet** dock when editing a `TileSet` from a `TileMapLayer`.

The issue was that the fold state of the properties in the **Select** tab was lost whenever a property changed. This was especially noticeable when adding animation frames to a tile: every change caused the inspector to collapse, forcing the user to reopen the **Animations** section, then the **Frames** section, before they could continue editing. This resulted in at least two extra clicks per frame addition, and often required scrolling back to the previous position.

This regression was introduced by merge commit `e1bd317` (PR #117574). It was not present before **4.7.dev4** and is still present in the latest `master` branch.


---

## Solution

The `EditorInspector`, which displays and edits the properties, is rebuilt every time the `TileSetAtlasSource` changes. As a result, its fold state is lost, this PR preserves the inspector state before it is destroyed and restores that state when the new inspector is created.

---

## Demonstration

The video below shows:

1. **4.7.dev3**, where the issue is **not** present.
2. **4.7.dev4**, where the regression first appears.
3. The latest **master** branch, where the issue is still present.
4. This PR applied, showing the issue resolved.

https://github.com/user-attachments/assets/51d644d4-387a-4c9d-9eb3-36106919bed4

---
## Related discussion

### Issues

* Closes https://github.com/godotengine/godot/issues/120489
* Closes https://github.com/godotengine/godot/issues/119192

## Pull Request

* #120517
* #119193

