### PR TITLE
Add links from core to the docs, to guide contributors better.

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -30,6 +30,13 @@
 
 #pragma once
 
+/*
+ * This file contains macros for error handling.
+ *
+ * For an overview, see:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/common_engine_methods_and_macros.html#error-macros
+ */
+
 #include "core/typedefs.h"
 
 class String;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -346,6 +346,12 @@ private:
 class ClassDB;
 class ScriptInstance;
 
+/**
+ * Base class for all OBJECT Variant types.
+ *
+ * For documentation, see:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/object_class.html
+ */
 class Object {
 public:
 	typedef Object self_type;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -37,6 +37,15 @@
 
 class Main;
 
+/**
+ * String (UTF-32 Unicode array) with interning semantics.
+ *
+ * Two different StringNames with the same String contents use the same buffer (by interning).
+ * By this, lookup of (existing) StringName, as well as equality checks, are fast.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 class [[nodiscard]] _WARN_UNUSED_ StringName {
 	struct Table;
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -167,6 +167,16 @@ public:
 /*  CharStringT                                                          */
 /*************************************************************************/
 
+/**
+ * Generalized string with copy-on-write semantics.
+ *
+ * Most users should use one of the aliases below (e.g. CharString).
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ *
+ * @tparam T Specifies the contained character type, which usually also denotes the encoding.
+ */
 template <typename T>
 class [[nodiscard]] CharStringT {
 	CowData<T> _cowdata;
@@ -261,6 +271,12 @@ using Char16String = CharStringT<char16_t>;
 /*  String                                                               */
 /*************************************************************************/
 
+/**
+ * String (UTF-32 Unicode array) with copy-on-write semantics.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 class [[nodiscard]] _WARN_UNUSED_ String {
 	CowData<char32_t> _cowdata;
 	static constexpr char32_t _null = 0;

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -43,39 +43,13 @@ class StringName;
 class Variant;
 
 /**
- * An array-based implementation of a hash map. It is very efficient in terms of performance and
- * memory usage. Works like a dynamic array, adding elements to the end of the array, and
- * allows you to access array elements by their index by using `get_by_index` method.
- * Example:
- * ```
- *  AHashMap<int, Object *> map;
+ * Key-value container (aka hash table or dictionary) using robin-hood hashing.
  *
- *  int get_object_id_by_number(int p_number) {
- *		int id = map.get_index(p_number);
- *		return id;
- *  }
+ * Key-values are not pointer-stable.
+ * Indices are stable as long as no elements are removed; otherwise arbitrary.
  *
- *  Object *get_object_by_id(int p_id) {
- *		map.get_by_index(p_id).value;
- *  }
- * ```
- * Still, don`t erase the elements because ID can break.
- *
- * When an element erase, its place is taken by the element from the end.
- *
- *        <-------------
- *      |               |
- *  6 8 X 9 32 -1 5 -10 7 X X X
- *  6 8 7 9 32 -1 5 -10 X X X X
- *
- *
- * Use RBMap if you need to iterate over sorted elements.
- *
- * Use HashMap if:
- *   - You need to keep an iterator or const pointer to Key and you intend to add/remove elements in the meantime.
- *   - You need to preserve the insertion order when using erase.
- *
- * It is recommended to use `HashMap` if `KeyValue` size is very large.
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -36,12 +36,12 @@
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
 
 /**
- * A high performance Vector of fixed capacity.
- * Especially useful if you need to create an array on the stack, to
- *  prevent dynamic allocations (especially in bottleneck code).
+ * Array-like storage that's local (no allocations).
  *
- * Choose CAPACITY such that it is enough for all elements that could be added through all branches.
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  *
+ * @tparam CAPACITY Must be enough for all elements that could be added through all code branches.
  */
 template <class T, uint32_t CAPACITY>
 class _WARN_UNUSED_ FixedVector {

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -38,20 +38,6 @@
 
 #include <initializer_list>
 
-/**
- * A HashMap implementation that uses open addressing with Robin Hood hashing.
- * Robin Hood hashing swaps out entries that have a smaller probing distance
- * than the to-be-inserted entry, that evens out the average probing distance
- * and enables faster lookups. Backward shift deletion is employed to further
- * improve the performance and to avoid infinite loops in rare cases.
- *
- * Keys and values are stored in a double linked list by insertion order. This
- * has a slight performance overhead on lookup, which can be mostly compensated
- * using a paged allocator if required.
- *
- * The assignment operator copy the pairs from one map to the other.
- */
-
 template <typename TKey, typename TValue>
 struct HashMapElement {
 	HashMapElement *next = nullptr;
@@ -62,6 +48,15 @@ struct HashMapElement {
 			data(p_key, p_value) {}
 };
 
+/**
+ * Key-value container (aka hash table or dictionary) using robin-hood hashing.
+ *
+ * Key-values are pointer-stable across HashMap mutations.
+ * Remembers insertion order and iterates by it.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>,

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -35,14 +35,14 @@
 #include "core/templates/hashfuncs.h"
 
 /**
- * Implementation of Set using a bidi indexed hash map.
- * Use RBSet instead of this only if the following conditions are met:
+ * Set container using robin hood hashing.
  *
- * - You need to keep an iterator or const pointer to Key and you intend to add/remove elements in the meantime.
- * - Iteration order does matter (via operator<)
+ * Elements are not pointer stable.
+ * The element order is arbitrary.
  *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */
-
 template <typename TKey,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>>

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -37,13 +37,13 @@
 #include <initializer_list>
 
 /**
- * Generic Templatized Linked List Implementation.
- * The implementation differs from the STL one because
- * a compatible preallocated linked list can be written
- * using the same API, or features such as erasing an element
- * from the iterator.
+ * Ordered storage implemented as a doubly linked list.
+ *
+ * Elements are pointer stable.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */
-
 template <typename T, typename A = DefaultAllocator>
 class _WARN_UNUSED_ List {
 	struct _Data;

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -39,8 +39,14 @@
 #include <initializer_list>
 #include <type_traits>
 
-// If tight, it grows strictly as much as needed.
-// Otherwise, it grows exponentially (the default and what you want in most cases).
+/**
+ * Array-like container with unique ownership.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ *
+ * @tparam tight Disable exponential growth (reallocate element-by-element instead).
+ */
 template <typename T, typename U = uint32_t, bool force_trivial = false, bool tight = false>
 class _WARN_UNUSED_ LocalVector {
 	static_assert(!force_trivial, "force_trivial is no longer supported. Use resize_uninitialized instead.");

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -36,9 +36,18 @@
 
 #include <initializer_list>
 
-// based on the very nice implementation of rb-trees by:
-// https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
-
+/**
+ * Key-value container (aka dictionary) using a red-black tree for lookup.
+ *
+ * Elements are ordered by key (using the < comparison operator).
+ * Key-Values are pointer-stable until removed.
+ *
+ * Implementation based on:
+ * https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename K, typename V, typename C = Comparator<K>, typename A = DefaultAllocator>
 class _WARN_UNUSED_ RBMap {
 	enum Color {

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -35,9 +35,18 @@
 
 #include <initializer_list>
 
-// based on the very nice implementation of rb-trees by:
-// https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
-
+/**
+ * Set container using a red-black tree for lookup.
+ *
+ * Elements are ordered (using the < comparison operator).
+ * Key-Values are pointer-stable until removed.
+ *
+ * Implementation based on:
+ * https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename T, typename C = Comparator<T>, typename A = DefaultAllocator>
 class _WARN_UNUSED_ RBSet {
 	enum Color {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -30,14 +30,6 @@
 
 #pragma once
 
-/**
- * @class Vector
- * Vector container. Simple copy-on-write container.
- *
- * LocalVector is an alternative available for internal use when COW is not
- * required.
- */
-
 #include "core/error/error_macros.h"
 #include "core/templates/cowdata.h"
 #include "core/templates/sort_array.h"
@@ -58,6 +50,12 @@ public:
 	}
 };
 
+/**
+ * Array-like container with copy-on-write semantics.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename T>
 class _WARN_UNUSED_ Vector {
 	friend class VectorWriteProxy<T>;

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -33,6 +33,12 @@
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
 
+/**
+ * Ordered set container with copy-on-write semantics.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename T>
 class _WARN_UNUSED_ VSet {
 	Vector<T> _data;

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -44,6 +44,12 @@ class Variant;
 struct ArrayPrivate;
 struct ContainerType;
 
+/**
+ * Array-like Variant container with ref semantics on top of copy-on-write semantics.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 class _WARN_UNUSED_ Array {
 	mutable ArrayPrivate *_p;
 	void _ref(const Array &p_from) const;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -43,6 +43,14 @@ struct ContainerTypeValidate;
 struct DictionaryPrivate;
 struct StringLikeVariantComparator;
 
+/**
+ * Key-value Variant container (aka hash table or dictionary) using robin-hood hashing.
+ *
+ * Uses `HashMap` internally, thus remembers insertion order and is pointer-stable.
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 class _WARN_UNUSED_ Dictionary {
 	mutable DictionaryPrivate *_p;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

It is often reported that Godot's C++ documentation is lacking.

However, there is more to it than many contributors may realize; it's just "hidden" in the docs.
This PR adds a short class description to some of the more major/common cases, with backlinks to the C++ docs.

## Additional information

I also reduced or reworded some documentation that is superfluous.

The general guideline going forward:
- Documentation contains guidance and free text.
- Class doc describes the identity, contracts, and links to guidance.
- Implementation details are documented in the code itself.

It's not a perfect system, but it's a start.