### PR TITLE
Fix clang specific build errors in C# module, related to `_WARN_UNUSED_`

### DIFF
--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1118,10 +1118,8 @@ void godotsharp_array_make_read_only(Array *p_self) {
 }
 
 void godotsharp_array_set_typed(Array *p_self, uint32_t p_elem_type, const StringName *p_elem_class_name, const Ref<CSharpScript> *p_elem_script) {
-	Variant elem_script_variant;
 	StringName elem_class_name = *p_elem_class_name;
 	if (p_elem_script && p_elem_script->is_valid()) {
-		elem_script_variant = Variant(p_elem_script->ptr());
 		elem_class_name = p_elem_script->ptr()->get_instance_base_type();
 	}
 	p_self->set_typed(p_elem_type, elem_class_name, p_elem_script->ptr());
@@ -1282,16 +1280,12 @@ void godotsharp_dictionary_make_read_only(Dictionary *p_self) {
 }
 
 void godotsharp_dictionary_set_typed(Dictionary *p_self, uint32_t p_key_type, const StringName *p_key_class_name, const Ref<CSharpScript> *p_key_script, uint32_t p_value_type, const StringName *p_value_class_name, const Ref<CSharpScript> *p_value_script) {
-	Variant key_script_variant;
 	StringName key_class_name = *p_key_class_name;
 	if (p_key_script && p_key_script->is_valid()) {
-		key_script_variant = Variant(p_key_script->ptr());
 		key_class_name = p_key_script->ptr()->get_instance_base_type();
 	}
-	Variant value_script_variant;
 	StringName value_class_name = *p_value_class_name;
 	if (p_value_script && p_value_script->is_valid()) {
-		value_script_variant = Variant(p_value_script->ptr());
 		value_class_name = p_value_script->ptr()->get_instance_base_type();
 	}
 	p_self->set_typed(p_key_type, key_class_name, p_key_script->ptr(), p_value_type, value_class_name, p_value_script->ptr());


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Followup to https://github.com/godotengine/godot/pull/121425

"Assigned but unread" warnings are produced by clang but not by gcc. It seems like CI does not cover compiling the C# module with clang, so I missed those in the PR linked above.

