### PR TITLE
Avoid generating the `__pycache__` in-tree

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
+
+import os
+import sys
+
+# Avoid generating __pycache__ in-tree.
+sys.pycache_prefix = os.path.abspath("bin/__scons_pycache__")
+
 from misc.utility.scons_hints import *
 
 EnsureSConsVersion(4, 4)
 EnsurePythonVersion(3, 9)
 
-# System
 import glob
-import os
 import pickle
-import sys
 from collections import OrderedDict
 from importlib.util import module_from_spec, spec_from_file_location
 from types import ModuleType


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related to https://github.com/godotengine/godot/pull/101641

Generates py cache to `bin` instead of tree-local `__pycache__` folders. 
Most IDEs hide these anyway, but it's still nice to have them out of the way.

## Additional information

The pycache file structure is a little awkward, with the full path recreated inside the folder, like `/Users/lukas/dev/godot/bin/__scons_pycache__/Users/lukas/dev/godot/core/`.

However, that's not our problem to fix I think. It works fine and it's not intended for user eyes anyway.