### PR TITLE
Remove `p_soft_reload` from `ScriptLanguage` reload callbacks

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -712,7 +712,7 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 				scripts_to_reload.push_back(script);
 			}
 			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-				ScriptServer::get_language(i)->reload_scripts(scripts_to_reload, true);
+				ScriptServer::get_language(i)->reload_scripts(scripts_to_reload);
 			}
 		}
 		script_paths_to_reload.clear();

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -200,10 +200,10 @@ void Script::_bind_methods() {
 void Script::reload_from_file() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() && is_tool()) {
-		get_language()->reload_tool_script(this, true);
+		get_language()->reload_tool_script(this);
 	} else {
 		Array scripts = { this };
-		get_language()->reload_scripts(scripts, true);
+		get_language()->reload_scripts(scripts);
 	}
 #else
 	Resource::reload_from_file();

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -400,8 +400,8 @@ public:
 	virtual Vector<StackInfo> debug_get_current_stack_info() { return Vector<StackInfo>(); }
 
 	virtual void reload_all_scripts() = 0;
-	virtual void reload_scripts(const Array &p_scripts, bool p_soft_reload) = 0;
-	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) = 0;
+	virtual void reload_scripts(const Array &p_scripts) = 0;
+	virtual void reload_tool_script(const Ref<Script> &p_script) = 0;
 	/* LOADER FUNCTIONS */
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -656,8 +656,14 @@ public:
 	}
 
 	EXBIND0(reload_all_scripts)
-	EXBIND2(reload_scripts, const Array &, bool)
-	EXBIND2(reload_tool_script, const Ref<Script> &, bool)
+	GDVIRTUAL2_REQUIRED(_reload_scripts, const Array &, bool);
+	virtual void reload_scripts(const Array &p_scripts) override {
+		GDVIRTUAL_CALL(_reload_scripts, p_scripts, true);
+	}
+	GDVIRTUAL2_REQUIRED(_reload_tool_script, const Ref<Script> &, bool);
+	virtual void reload_tool_script(const Ref<Script> &p_script) override {
+		GDVIRTUAL_CALL(_reload_tool_script, p_script, true);
+	}
 	/* LOADER FUNCTIONS */
 
 	GDVIRTUAL0RC_REQUIRED(PackedStringArray, _get_recognized_extensions)

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -320,6 +320,7 @@
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
 				Reloads all [param scripts] from disk and the specifics of how that happens is [ScriptLanguageExtension] specific.
+				[param soft_reload] is always [code]true[/code].
 			</description>
 		</method>
 		<method name="_reload_tool_script" qualifiers="virtual required">
@@ -328,6 +329,7 @@
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
 				Reloads the given [param script] from disk and the specifics of how that happens is [ScriptLanguageExtension] specific.
+				[param soft_reload] is always [code]true[/code].
 			</description>
 		</method>
 		<method name="_remove_named_global_constant" qualifiers="virtual required">

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2502,11 +2502,11 @@ void GDScriptLanguage::reload_all_scripts() {
 #endif // TOOLS_ENABLED
 	}
 
-	reload_scripts(scripts, true);
+	reload_scripts(scripts);
 #endif // DEBUG_ENABLED
 }
 
-void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) {
+void GDScriptLanguage::reload_scripts(const Array &p_scripts) {
 #ifdef DEBUG_ENABLED
 
 	List<Ref<GDScript>> scripts;
@@ -2539,44 +2539,6 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 		}
 
 		to_reload.insert(scr, HashMap<ObjectID, List<Pair<StringName, Variant>>>());
-
-		if (!p_soft_reload) {
-			//save state and remove script from instances
-			HashMap<ObjectID, List<Pair<StringName, Variant>>> &map = to_reload[scr];
-
-			while (scr->instances.first()) {
-				GDScriptInstance *instance = scr->instances.first()->self();
-				//save instance info
-				List<Pair<StringName, Variant>> state;
-				instance->get_property_state(state);
-				map[instance->get_owner()->get_instance_id()] = state;
-				instance->get_owner()->set_script(Variant());
-			}
-
-			//same thing for placeholders
-#ifdef TOOLS_ENABLED
-
-			while (scr->placeholders.size()) {
-				Object *obj = (*scr->placeholders.begin())->get_owner();
-
-				//save instance info
-				if (obj->get_script_instance()) {
-					map.insert(obj->get_instance_id(), List<Pair<StringName, Variant>>());
-					List<Pair<StringName, Variant>> &state = map[obj->get_instance_id()];
-					obj->get_script_instance()->get_property_state(state);
-					obj->set_script(Variant());
-				} else {
-					// no instance found. Let's remove it so we don't loop forever
-					scr->placeholders.erase(*scr->placeholders.begin());
-				}
-			}
-
-#endif // TOOLS_ENABLED
-
-			for (const KeyValue<ObjectID, List<Pair<StringName, Variant>>> &F : scr->pending_reload_state) {
-				map[F.key] = F.value; //pending to reload, use this one instead
-			}
-		}
 	}
 
 	for (KeyValue<Ref<GDScript>, HashMap<ObjectID, List<Pair<StringName, Variant>>>> &E : to_reload) {
@@ -2595,7 +2557,7 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 		} else {
 			scr->load_source_code(scr->get_path());
 		}
-		scr->reload(p_soft_reload);
+		scr->reload(true);
 
 		//restore state if saved
 		for (KeyValue<ObjectID, List<Pair<StringName, Variant>>> &F : E.value) {
@@ -2606,10 +2568,6 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 				continue;
 			}
 
-			if (!p_soft_reload) {
-				//clear it just in case (may be a pending reload state)
-				obj->set_script(Variant());
-			}
 			obj->set_script(scr);
 
 			ScriptInstance *script_inst = obj->get_script_instance();
@@ -2642,9 +2600,9 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload
 #endif // DEBUG_ENABLED
 }
 
-void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
+void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script) {
 	Array scripts = { p_script };
-	reload_scripts(scripts, p_soft_reload);
+	reload_scripts(scripts);
 }
 
 void GDScriptLanguage::frame() {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -621,8 +621,8 @@ public:
 	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) override;
 
 	virtual void reload_all_scripts() override;
-	virtual void reload_scripts(const Array &p_scripts, bool p_soft_reload) override;
-	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
+	virtual void reload_scripts(const Array &p_scripts) override;
+	virtual void reload_tool_script(const Ref<Script> &p_script) override;
 
 	virtual void frame() override;
 

--- a/modules/gdscript/gdscript_resource_format.cpp
+++ b/modules/gdscript/gdscript_resource_format.cpp
@@ -171,7 +171,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 	}
 
 	if (ScriptServer::is_reload_scripts_on_save_enabled()) {
-		GDScriptLanguage::get_singleton()->reload_tool_script(p_resource, true);
+		GDScriptLanguage::get_singleton()->reload_tool_script(p_resource);
 	}
 
 	return OK;

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -98,7 +98,7 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 	Ref<GDScript> scr = ResourceLoader::load(path);
 	if (scr.is_valid() && (scr->load_source_code(path) == OK)) {
 		if (scr->is_tool()) {
-			scr->get_language()->reload_tool_script(scr, true);
+			scr->get_language()->reload_tool_script(scr);
 		} else {
 			scr->reload(true);
 		}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -563,20 +563,20 @@ struct CSharpScriptDepSort {
 void CSharpLanguage::reload_all_scripts() {
 #ifdef GD_MONO_HOT_RELOAD
 	if (is_assembly_reloading_needed()) {
-		reload_assemblies(false);
+		reload_assemblies();
 	}
 #endif
 }
 
-void CSharpLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) {
+void CSharpLanguage::reload_scripts(const Array &p_scripts) {
 #ifdef GD_MONO_HOT_RELOAD
 	if (is_assembly_reloading_needed()) {
-		reload_assemblies(p_soft_reload);
+		reload_assemblies();
 	}
 #endif
 }
 
-void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {
+void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script) {
 	CRASH_COND(!Engine::get_singleton()->is_editor_hint());
 
 #ifdef TOOLS_ENABLED
@@ -585,7 +585,7 @@ void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft
 
 #ifdef GD_MONO_HOT_RELOAD
 	if (is_assembly_reloading_needed()) {
-		reload_assemblies(p_soft_reload);
+		reload_assemblies();
 	}
 #endif
 }
@@ -622,7 +622,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 	return true;
 }
 
-void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
+void CSharpLanguage::reload_assemblies() {
 	ERR_FAIL_NULL(gdmono);
 	if (!gdmono->is_runtime_initialized()) {
 		return;
@@ -865,7 +865,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 #endif
 
 		if (!scr->get_path().is_empty() && !scr->get_path().begins_with("csharp://")) {
-			scr->reload(p_soft_reload);
+			scr->reload();
 
 			if (!scr->valid) {
 				scr->pending_reload_instances.clear();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -481,7 +481,7 @@ public:
 
 #ifdef GD_MONO_HOT_RELOAD
 	bool is_assembly_reloading_needed();
-	void reload_assemblies(bool p_soft_reload);
+	void reload_assemblies();
 #endif
 
 	_FORCE_INLINE_ ManagedCallableMiddleman *get_managed_callable_middleman() const {
@@ -560,8 +560,8 @@ public:
 	/* TODO? */ void get_public_annotations(List<MethodInfo> *p_annotations) const override {}
 
 	void reload_all_scripts() override;
-	void reload_scripts(const Array &p_scripts, bool p_soft_reload) override;
-	void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
+	void reload_scripts(const Array &p_scripts) override;
+	void reload_tool_script(const Ref<Script> &p_script) override;
 
 	/* LOADER FUNCTIONS */
 	void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/modules/mono/csharp_script_resource_format.cpp
+++ b/modules/mono/csharp_script_resource_format.cpp
@@ -142,7 +142,7 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 
 #ifdef TOOLS_ENABLED
 	if (ScriptServer::is_reload_scripts_on_save_enabled()) {
-		CSharpLanguage::get_singleton()->reload_tool_script(p_resource, false);
+		CSharpLanguage::get_singleton()->reload_tool_script(p_resource);
 	}
 #endif
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -88,7 +88,7 @@ namespace GodotTools.Build
             if (Internal.IsAssembliesReloadingNeeded())
             {
                 BuildManager.UpdateLastValidBuildDateTime();
-                Internal.ReloadAssemblies(softReload: false);
+                Internal.ReloadAssemblies();
             }
         }
 
@@ -109,7 +109,7 @@ namespace GodotTools.Build
             if (Internal.IsAssembliesReloadingNeeded())
             {
                 BuildManager.UpdateLastValidBuildDateTime();
-                Internal.ReloadAssemblies(softReload: false);
+                Internal.ReloadAssemblies();
             }
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -20,7 +20,7 @@ namespace GodotTools
                 if (Internal.IsAssembliesReloadingNeeded())
                 {
                     BuildManager.UpdateLastValidBuildDateTime();
-                    Internal.ReloadAssemblies(softReload: false);
+                    Internal.ReloadAssemblies();
                 }
             }
         }
@@ -30,7 +30,7 @@ namespace GodotTools
             if (Internal.IsAssembliesReloadingNeeded())
             {
                 BuildManager.UpdateLastValidBuildDateTime();
-                Internal.ReloadAssemblies(softReload: false);
+                Internal.ReloadAssemblies();
             }
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -50,7 +50,7 @@ namespace GodotTools.Internals
 
         public static bool IsAssembliesReloadingNeeded() => godot_icall_Internal_IsAssembliesReloadingNeeded();
 
-        public static void ReloadAssemblies(bool softReload) => godot_icall_Internal_ReloadAssemblies(softReload);
+        public static void ReloadAssemblies() => godot_icall_Internal_ReloadAssemblies();
 
         public static void EditorDebuggerNodeReloadScripts() => godot_icall_Internal_EditorDebuggerNodeReloadScripts();
 
@@ -138,7 +138,7 @@ namespace GodotTools.Internals
 
         private static partial bool godot_icall_Internal_IsAssembliesReloadingNeeded();
 
-        private static partial void godot_icall_Internal_ReloadAssemblies(bool softReload);
+        private static partial void godot_icall_Internal_ReloadAssemblies();
 
         private static partial void godot_icall_Internal_EditorDebuggerNodeReloadScripts();
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -152,9 +152,9 @@ bool godot_icall_Internal_IsAssembliesReloadingNeeded() {
 #endif
 }
 
-void godot_icall_Internal_ReloadAssemblies(bool p_soft_reload) {
+void godot_icall_Internal_ReloadAssemblies() {
 #ifdef GD_MONO_HOT_RELOAD
-	callable_mp(MonoBind::GodotSharp::get_singleton(), &MonoBind::GodotSharp::reload_assemblies).call_deferred(p_soft_reload);
+	callable_mp(MonoBind::GodotSharp::get_singleton(), &MonoBind::GodotSharp::reload_assemblies).call_deferred();
 #endif
 }
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1118,10 +1118,8 @@ void godotsharp_array_make_read_only(Array *p_self) {
 }
 
 void godotsharp_array_set_typed(Array *p_self, uint32_t p_elem_type, const StringName *p_elem_class_name, const Ref<CSharpScript> *p_elem_script) {
-	Variant elem_script_variant;
 	StringName elem_class_name = *p_elem_class_name;
 	if (p_elem_script && p_elem_script->is_valid()) {
-		elem_script_variant = Variant(p_elem_script->ptr());
 		elem_class_name = p_elem_script->ptr()->get_instance_base_type();
 	}
 	p_self->set_typed(p_elem_type, elem_class_name, p_elem_script->ptr());
@@ -1282,16 +1280,12 @@ void godotsharp_dictionary_make_read_only(Dictionary *p_self) {
 }
 
 void godotsharp_dictionary_set_typed(Dictionary *p_self, uint32_t p_key_type, const StringName *p_key_class_name, const Ref<CSharpScript> *p_key_script, uint32_t p_value_type, const StringName *p_value_class_name, const Ref<CSharpScript> *p_value_script) {
-	Variant key_script_variant;
 	StringName key_class_name = *p_key_class_name;
 	if (p_key_script && p_key_script->is_valid()) {
-		key_script_variant = Variant(p_key_script->ptr());
 		key_class_name = p_key_script->ptr()->get_instance_base_type();
 	}
-	Variant value_script_variant;
 	StringName value_class_name = *p_value_class_name;
 	if (p_value_script && p_value_script->is_valid()) {
-		value_script_variant = Variant(p_value_script->ptr());
 		value_class_name = p_value_script->ptr()->get_instance_base_type();
 	}
 	p_self->set_typed(p_key_type, key_class_name, p_key_script->ptr(), p_value_type, value_class_name, p_value_script->ptr());

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -856,13 +856,13 @@ namespace MonoBind {
 
 GodotSharp *GodotSharp::singleton = nullptr;
 
-void GodotSharp::reload_assemblies(bool p_soft_reload) {
+void GodotSharp::reload_assemblies() {
 #ifdef GD_MONO_HOT_RELOAD
 	CRASH_COND(CSharpLanguage::get_singleton() == nullptr);
 	// This method may be called more than once with `call_deferred`, so we need to check
 	// again if reloading is needed to avoid reloading multiple times unnecessarily.
 	if (CSharpLanguage::get_singleton()->is_assembly_reloading_needed()) {
-		CSharpLanguage::get_singleton()->reload_assemblies(p_soft_reload);
+		CSharpLanguage::get_singleton()->reload_assemblies();
 	}
 #endif
 }

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -163,7 +163,7 @@ protected:
 public:
 	static GodotSharp *get_singleton() { return singleton; }
 
-	void reload_assemblies(bool p_soft_reload);
+	void reload_assemblies();
 
 	GodotSharp();
 	~GodotSharp();


### PR DESCRIPTION
Requires https://github.com/godotengine/godot/pull/121565

## What problem(s) does this PR solve?

`ScriptLanguage::reload_scripts` and `ScriptLanguage::reload_tool_script` are only ever called with `p_soft_reload = true`. That makes sense, because those methods are used to react to reloads triggered by the debugger (hot reloads), or reloads in the editor (e.g for tool scripts). In both of those cases languages should maintain existing instances to the best of their abilities.

So there really is no point to this parameter. Removing it allows us to get rid of some dead GDScript code and makes implementing those functions correctly, more straight forward.

## Additional information

There is in theory one call to `reload_scripts` which passes `false` but that's in the csharp module, and specific to their implementation of `ScriptLanguage`. Since that implementation doesn't actually do something with the parameter other than propagating it down to `CSharpScript::reload` which does nothing with it, it's still save to remove.