### PR TITLE
Wayland: Fix IME popup position under fractional scaling on KDE Plasma

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -5794,7 +5794,10 @@ void WaylandThread::window_set_ime_position(const Point2i &p_pos, DisplayServerE
 	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
 
 	if (ss && ss->wp_text_input && ss->ime_enabled) {
-		ss->ime_rect = Rect2i(p_pos, Size2i(1, 10));
+		WindowState *ws = window_get_state(p_window_id);
+		double scale = ws ? window_state_get_scale_factor(ws) : 1.0;
+		Point2i logical_pos = scale_vector2i(p_pos, 1.0 / scale);
+		ss->ime_rect = Rect2i(logical_pos, Size2i(1, 10));
 		zwp_text_input_v3_set_cursor_rectangle(ss->wp_text_input, ss->ime_rect.position.x, ss->ime_rect.position.y, ss->ime_rect.size.x, ss->ime_rect.size.y);
 		zwp_text_input_v3_commit(ss->wp_text_input);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- This PR fixes incorrect IME popup positioning under fractional scaling on KDE Wayland.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Godot internally uses physical coordinates, while Wayland protocols use logical coordinates.
On KDE Plasma, physical and logical coordinates reported by the compositor do not match under fractional scaling. Therefore, the position must be converted to logical coordinates before being passed to the compositor.
This issue does not occur on GNOME because its physical and logical coordinates match in this case.

Tested on ArchLinux KDE Plasma 6.7.3 3840x2400 scale 250%

Before this PR:
<img width="640" alt="スクリーンショット_20260718_194054" src="https://github.com/user-attachments/assets/15db01ec-73a6-47fd-8b73-2eadf2b9f792" />

After this PR:
<img width="640" alt="スクリーンショット_20260718_194125" src="https://github.com/user-attachments/assets/67f8120a-3e78-4c76-95e6-a0368a96e656" />

Split from #119479