### PR TITLE
Engine Update Label: Show `enum` constant Name instead of Value when `HTTPRequest` fails

### DIFF
--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/json.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_string_names.h"
@@ -52,7 +53,7 @@ void EngineUpdateLabel::_check_update() {
 void EngineUpdateLabel::_http_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body) {
 	if (p_result != OK) {
 		_set_status(UpdateStatus::ERROR);
-		_set_message(TTRC("Failed to check for updates. Error: %d."), theme_cache.error_color, p_result);
+		_set_message(TTRC("Failed to check for updates. Error: %s."), theme_cache.error_color, _http_result_enum_string(p_result));
 		return;
 	}
 
@@ -256,6 +257,26 @@ EngineUpdateLabel::VersionType EngineUpdateLabel::_get_version_type(const String
 String EngineUpdateLabel::_extract_sub_string(const String &p_line) const {
 	int j = p_line.find_char('"') + 1;
 	return p_line.substr(j, p_line.find_char('"', j) - j);
+}
+
+String EngineUpdateLabel::_http_result_enum_string(int p_constant) const {
+	String result = String::num_int64(p_constant);
+
+	List<StringName> constants;
+	ClassDB::get_enum_constants(SNAME("HTTPRequest"), SNAME("Result"), &constants);
+	for (const StringName &E : constants) {
+		bool success = false;
+		int int_constant = ClassDB::get_integer_constant(SNAME("HTTPRequest"), E, &success);
+		if (!success) {
+			continue;
+		}
+		if (int_constant == p_constant) {
+			result = E.string().trim_prefix("RESULT_");
+			break;
+		}
+	}
+
+	return result;
 }
 
 void EngineUpdateLabel::_notification(int p_what) {

--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -52,7 +52,7 @@ void EngineUpdateLabel::_check_update() {
 void EngineUpdateLabel::_http_request_completed(int p_result, int p_response_code, const PackedStringArray &p_headers, const PackedByteArray &p_body) {
 	if (p_result != OK) {
 		_set_status(UpdateStatus::ERROR);
-		_set_message(TTRC("Failed to check for updates. Error: %d."), theme_cache.error_color, p_result);
+		_set_message(TTRC("Failed to check for updates. Error: %s."), theme_cache.error_color, _http_result_enum_string(p_result));
 		return;
 	}
 
@@ -256,6 +256,23 @@ EngineUpdateLabel::VersionType EngineUpdateLabel::_get_version_type(const String
 String EngineUpdateLabel::_extract_sub_string(const String &p_line) const {
 	int j = p_line.find_char('"') + 1;
 	return p_line.substr(j, p_line.find_char('"', j) - j);
+}
+
+String EngineUpdateLabel::_http_result_enum_string(int p_constant) const {
+	String fallback = itos(p_constant);
+
+	const GDType::Member *member = HTTPRequest::get_gdtype_static().members(true).getptr(SNAME("Result"));
+
+	ERR_FAIL_NULL_V(member, fallback);
+	ERR_FAIL_COND_V(member->type != GDType::Member::Type::ENUM, fallback);
+
+	for (const KeyValue<StringName, int64_t> &E : member->payload.enum_info->values) {
+		if (E.value == p_constant) {
+			return E.key.string().trim_prefix("RESULT_");
+		}
+	}
+
+	return fallback;
 }
 
 void EngineUpdateLabel::_notification(int p_what) {

--- a/editor/project_manager/engine_update_label.h
+++ b/editor/project_manager/engine_update_label.h
@@ -93,6 +93,7 @@ private:
 
 	VersionType _get_version_type(const String &p_string, int *r_index = nullptr) const;
 	String _extract_sub_string(const String &p_line) const;
+	String _http_result_enum_string(int p_constant) const;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Doesn't close any proposal, it's just a small QOL feature. Replaces the integer error code with a human readable error code.
Now the user doesn't have to check online or open the in-engine docs to figure out roughly what happened.

## Before

<img width="299" height="81" alt="image" src="https://github.com/user-attachments/assets/6fd75901-6940-4a2b-b19a-6c11b2ca98f8" />

## After

<img width="445" height="114" alt="image" src="https://github.com/user-attachments/assets/66156341-d211-4160-b030-bbcd1c6f22c8" />

## Additional information

No AI was used.