### PR TITLE
GDExt: Allow specifying inclusion/exclusion tags

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -806,6 +806,9 @@ Error GDExtension::open_library(const String &p_path, const Ref<GDExtensionLoade
 	loader = p_loader;
 
 	Error err = loader->open_library(p_path);
+	if (err == ERR_SKIP) {
+		return err;
+	}
 
 	ERR_FAIL_COND_V_MSG(err == ERR_FILE_NOT_FOUND, err, vformat("GDExtension dynamic library not found: '%s'.", p_path));
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Can't open GDExtension dynamic library: '%s'.", p_path));

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -71,6 +71,15 @@ Vector<SharedObject> GDExtensionLibraryLoader::find_extension_dependencies(const
 	return dependencies_shared_objects;
 }
 
+bool GDExtensionLibraryLoader::match_all_tags(PackedStringArray p_tags, std::function<bool(String)> p_has_feature) {
+	for (const String &tag : p_tags) {
+		if (!p_has_feature(tag)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 String GDExtensionLibraryLoader::find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags) {
 	// First, check the explicit libraries.
 	if (p_config->has_section("libraries")) {
@@ -283,6 +292,31 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 		return err;
 	}
 
+	PackedStringArray include_tags = config->get_value("configuration", "include_tags", PackedStringArray());
+	PackedStringArray exclude_tags = config->get_value("configuration", "exclude_tags", PackedStringArray());
+	std::function<bool(String)> has_tag = [](const String &p_feature) {
+		return OS::get_singleton()->has_feature(p_feature);
+	};
+	if (include_tags.size()) {
+		bool matches = false;
+		for (const String &tag : include_tags) {
+			matches = match_all_tags(tag.split(".", false), has_tag);
+			if (matches) {
+				break;
+			}
+		}
+		if (!matches) {
+			return ERR_SKIP;
+		}
+	}
+	if (exclude_tags.size()) {
+		for (const String &tag : exclude_tags) {
+			if (match_all_tags(tag.split(".", false), has_tag)) {
+				return ERR_SKIP;
+			}
+		}
+	}
+
 	if (!config->has_section_key("configuration", "entry_symbol")) {
 		ERR_PRINT(vformat("GDExtension configuration file must contain a \"configuration/entry_symbol\" key: '%s'.", p_path));
 		return ERR_INVALID_DATA;
@@ -362,7 +396,7 @@ Error GDExtensionLibraryLoader::parse_gdextension_file(const String &p_path) {
 		}
 	}
 
-	library_path = find_extension_library(p_path, config, [](const String &p_feature) { return OS::get_singleton()->has_feature(p_feature); });
+	library_path = find_extension_library(p_path, config, has_tag);
 
 	if (library_path.is_empty()) {
 		const String os_arch = OS::get_singleton()->get_name().to_lower() + "." + Engine::get_singleton()->get_architecture_name();

--- a/core/extension/gdextension_library_loader.h
+++ b/core/extension/gdextension_library_loader.h
@@ -68,6 +68,7 @@ private:
 #endif
 
 public:
+	static bool match_all_tags(PackedStringArray p_tags, std::function<bool(String)> p_has_feature);
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 	static Vector<SharedObject> find_extension_dependencies(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature);
 

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -140,6 +140,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::load_extension_with_loader(co
 	extension.instantiate();
 	Error err = extension->open_library(p_path, p_loader);
 	if (err != OK) {
+		if (err == ERR_SKIP) {
+			return LOAD_STATUS_OK;
+		}
 		return LOAD_STATUS_FAILED;
 	}
 
@@ -192,6 +195,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::reload_extension(const String
 
 	Error err = extension->open_library(p_path, extension->loader);
 	if (err != OK) {
+		if (err == ERR_SKIP) {
+			return LOAD_STATUS_OK;
+		}
 		return LOAD_STATUS_FAILED;
 	}
 

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -140,6 +140,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::load_extension_with_loader(co
 	extension.instantiate();
 	Error err = extension->open_library(p_path, p_loader);
 	if (err != OK) {
+		if (err == ERR_SKIP) {
+			return LOAD_STATUS_NOT_LOADED;
+		}
 		return LOAD_STATUS_FAILED;
 	}
 
@@ -192,6 +195,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::reload_extension(const String
 
 	Error err = extension->open_library(p_path, extension->loader);
 	if (err != OK) {
+		if (err == ERR_SKIP) {
+			return LOAD_STATUS_NOT_LOADED;
+		}
 		return LOAD_STATUS_FAILED;
 	}
 

--- a/editor/export/gdextension_export_plugin.h
+++ b/editor/export/gdextension_export_plugin.h
@@ -61,6 +61,32 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 		return;
 	}
 
+	PackedStringArray include_tags = config->get_value("configuration", "include_tags", PackedStringArray());
+	PackedStringArray exclude_tags = config->get_value("configuration", "exclude_tags", PackedStringArray());
+	std::function<bool(String)> has_tag = [p_features](const String &p_feature) {
+		return p_features.has(p_feature);
+	};
+	if (include_tags.size()) {
+		bool matches = false;
+		for (const String &tag : include_tags) {
+			if (!GDExtensionLibraryLoader::match_all_tags(tag.split(".", false), has_tag)) {
+				continue;
+			}
+			matches = true;
+			break;
+		}
+		if (!matches) {
+			return;
+		}
+	}
+	if (exclude_tags.size()) {
+		for (const String &tag : exclude_tags) {
+			if (GDExtensionLibraryLoader::match_all_tags(tag.split(".", false), has_tag)) {
+				return;
+			}
+		}
+	}
+
 	ERR_FAIL_COND_MSG(!config->has_section_key("configuration", "entry_symbol"), "Failed to export GDExtension file, missing entry symbol: " + p_path);
 
 	String entry_symbol = config->get_value("configuration", "entry_symbol");

--- a/editor/export/gdextension_export_plugin.h
+++ b/editor/export/gdextension_export_plugin.h
@@ -61,6 +61,32 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 		return;
 	}
 
+	PackedStringArray include_tags = config->get_value("configuration", "include_tags", PackedStringArray());
+	PackedStringArray exclude_tags = config->get_value("configuration", "exclude_tags", PackedStringArray());
+	std::function<bool(String)> has_tag = [p_features](const String &p_feature) {
+		return p_features.has(p_feature);
+	};
+	if (include_tags.size()) {
+		bool matches = false;
+		for (const String &tag : include_tags) {
+			if (!GDExtensionLibraryLoader::match_all_tags(tag.split(".", false), has_tag)) {
+				continue;
+			}
+			matches = true;
+			break;
+		}
+		if (!matches) {
+			return; // We can't skip() since the .gdextension file is referenced in the project settings.
+		}
+	}
+	if (exclude_tags.size()) {
+		for (const String &tag : exclude_tags) {
+			if (GDExtensionLibraryLoader::match_all_tags(tag.split(".", false), has_tag)) {
+				return; // We can't skip() since the .gdextension file is referenced in the project settings.
+			}
+		}
+	}
+
 	ERR_FAIL_COND_MSG(!config->has_section_key("configuration", "entry_symbol"), "Failed to export GDExtension file, missing entry symbol: " + p_path);
 
 	String entry_symbol = config->get_value("configuration", "entry_symbol");


### PR DESCRIPTION
## What problem(s) does this PR solve?

- See https://github.com/godotengine/webrtc-native/issues/182 .

## Additional information

This is useful for extensions that can be skipped on specific platforms like the WebRTC extension (which on Web is part of core), so users don't have to manually add the exclusion for specific export presets..

See also: https://github.com/godotengine/webrtc-native/pull/194