### PR TITLE
GDScript: Add a few more tests related to name conflicts

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -11,6 +11,7 @@ sources:
   - "**/{SConstruct,SCsub,*.py}"
   - "**/*.{h,hpp,hh,hxx,c,cpp,cc,cxx,m,mm,inc,glsl}"
   - misc/extension_api_validation/**
+  - modules/*/tests/**
   - modules/mono/**/*.{cs,csproj,sln,props,targets}
   - platform/android/java/{gradle*,**/*.{jar,java,kt,gradle}}
   - platform/web/{package{,-lock}.json,js/**/*.js}

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.gd
@@ -1,6 +1,0 @@
-extends Node
-
-var script: int
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
@@ -1,2 +1,0 @@
-GDTEST_ANALYZER_ERROR
->> ERROR at line 3: Member "script" redefined (original in native class 'Node')

--- a/modules/gdscript/tests/scripts/analyzer/errors/shadowing.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/shadowing.gd
@@ -8,6 +8,14 @@ class Vector2: pass
 enum Vector2i { A, B }
 const Vector3 = 0
 var Vector3i
+var Node = ""
+var script: int
+
+class C extends Resource:
+	const changed: int = 0
+	var resource_name: String
+	var NOTIFICATION_POSTINITIALIZE = 1
+
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/shadowing.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/shadowing.out
@@ -4,3 +4,8 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 8: The member "Vector2i" cannot have the same name as a builtin type.
 >> ERROR at line 9: The member "Vector3" cannot have the same name as a builtin type.
 >> ERROR at line 10: The member "Vector3i" cannot have the same name as a builtin type.
+>> ERROR at line 11: The member "Node" shadows a native class.
+>> ERROR at line 12: Member "script" redefined (original in native class 'RefCounted')
+>> ERROR at line 15: Member "changed" redefined (original in native class 'Resource')
+>> ERROR at line 16: Member "resource_name" redefined (original in native class 'Resource')
+>> ERROR at line 17: Member "NOTIFICATION_POSTINITIALIZE" redefined (original in native class 'Resource')


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds some more checks where there are name conflicts to the GDScript test suite, for some branches in the analyzer that were previously not covered.

Also merged `overload_script_variable.gd` into `shadowing.gd` in the spirit of https://github.com/godotengine/godot/pull/99899
