### PR TITLE
Fix crash when saving a scene rapidly from an EngineDebugger call

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2253,6 +2253,11 @@ void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
 }
 
 void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
+	if (save_scene_progress) {
+		// A save call is currently in progress
+		queued_save_scene_files.push_back(p_file);
+		return;
+	}
 	save_scene_progress = memnew(EditorProgress("save", TTR("Saving Scene"), 4));
 
 	if (editor_data.get_edited_scene_root() != nullptr) {
@@ -2340,6 +2345,11 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 void EditorNode::_close_save_scene_progress() {
 	memdelete_notnull(save_scene_progress);
 	save_scene_progress = nullptr;
+	if (!queued_save_scene_files.is_empty()) {
+		String filename = queued_save_scene_files.front()->get();
+		queued_save_scene_files.pop_front();
+		_save_scene_with_preview(filename);
+	}
 }
 
 bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_node) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -469,6 +469,7 @@ private:
 
 	String saving_scene;
 	EditorProgress *save_scene_progress = nullptr;
+	List<String> queued_save_scene_files;
 
 	DynamicFontImportSettingsDialog *fontdata_import_settings = nullptr;
 	SceneImportSettingsDialog *scene_import_settings = nullptr;


### PR DESCRIPTION
For some reason, sending a message to an EngineDebuggerPlugin that results in it saving a scene multiple times in quick succession causes a crash.

Fix this by making the `_save_scene_with_preview` method check to see if a save call is currently in-progress and queue a call in a list rather than proceeding with the save.

## What problem(s) does this PR solve?

- Fixes a crash when calling `EditorInterface.save_scene()` rapidly from an EngineDebuggerPlugin's `_capture` method.
  - I've uploaded a reference project that recreates this issue that you can [download here.](https://www.mew151.net/creative/godot-save-spam-crash.zip) Load the project in Godot 4.7 and hit the "Play" button to load the main scene and the editor should quickly crash.
    - To recreate it yourself (I get it, I wouldn't just blindly execute some random person's code on my machine) you can:
       1. Create an `EditorDebuggerPlugin` object that responds to some message by calling `EditorInterface.save_scene()`
       2. Create an object that sends that message to the debugger multiple times rapidly (I set up a timer to send 10 messages over the span of 1 second).
       3. Run that scene so that the crash conditions can be met

## Additional information
- No AI tools were used in the creation of the pull request.
- I definitely have some suspicion that the real culprit is some kind of threading issue with the engine debugger since this is not reproducible if you take away the `EngineDebuggerPlugin` from the equation. This fix only addresses saving the scene but there may be other accessible editor properties/methods that may not be safe either and the root problem is not actually addressed here.