### PR TITLE
[TextServer] Clamp outline size, when font size is clamped.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1513,7 +1513,13 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 				ERR_FAIL_V_MSG(false, "FreeType: Failed to load glyph stroker.");
 			}
 
-			FT_Stroker_Set(stroker, (int)(fd->size.y * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
+			double sz = double(fd->size.x) / 64.0;
+			double out_sz = double(fd->size.y);
+			if (sz > 2048.0) {
+				out_sz /= fd->scale;
+			}
+
+			FT_Stroker_Set(stroker, (int)(out_sz * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1513,7 +1513,14 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 				ERR_FAIL_V_MSG(false, "FreeType: Failed to load glyph stroker.");
 			}
 
-			FT_Stroker_Set(stroker, (int)(fd->size.y * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
+			double sz = double(fd->size.x) / 64.0;
+			double out_sz = double(fd->size.y);
+			if (sz > 2048.0) {
+				// Clamp outline size when the font size is clamped.
+				out_sz /= fd->scale;
+			}
+
+			FT_Stroker_Set(stroker, (int)(out_sz * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -780,7 +780,13 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 				ERR_FAIL_V_MSG(false, "FreeType: Failed to load glyph stroker.");
 			}
 
-			FT_Stroker_Set(stroker, (int)(fd->size.y * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
+			double sz = double(fd->size.x) / 64.0;
+			double out_sz = double(fd->size.y);
+			if (sz > 2048.0) {
+				out_sz /= fd->scale;
+			}
+
+			FT_Stroker_Set(stroker, (int)(out_sz * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -780,7 +780,14 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 				ERR_FAIL_V_MSG(false, "FreeType: Failed to load glyph stroker.");
 			}
 
-			FT_Stroker_Set(stroker, (int)(fd->size.y * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
+			double sz = double(fd->size.x) / 64.0;
+			double out_sz = double(fd->size.y);
+			if (sz > 2048.0) {
+				// Clamp outline size when the font size is clamped.
+				out_sz /= fd->scale;
+			}
+
+			FT_Stroker_Set(stroker, (int)(out_sz * 16.0), FT_STROKER_LINECAP_BUTT, FT_STROKER_LINEJOIN_ROUND, 0);
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120689
