### PR TITLE
Add `callv_err()` helper method to Callable

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -394,16 +394,12 @@ int Array::find_custom(const Callable &p_callable, int p_from) const {
 		return ret;
 	}
 
-	const Variant *argptrs[1];
-
 	for (int i = p_from; i < size(); i++) {
-		const Variant &val = _p->array[i];
-		argptrs[0] = &val;
-		Variant res;
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, res, ce);
+		const Variant res = p_callable.callv_err(args, ce);
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_FAIL_V_MSG(ret, vformat("Error calling method from 'find_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(ret, vformat("Error calling method from 'find_custom': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 
 		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, ret, "Error calling method from 'find_custom': Return type of callable must be boolean.");
@@ -454,16 +450,12 @@ int Array::rfind_custom(const Callable &p_callable, int p_from) const {
 		p_from = _p->array.size() - 1;
 	}
 
-	const Variant *argptrs[1];
-
 	for (int i = p_from; i >= 0; i--) {
-		const Variant &val = _p->array[i];
-		argptrs[0] = &val;
-		Variant res;
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, res, ce);
+		const Variant res = p_callable.callv_err(args, ce);
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_FAIL_V_MSG(-1, vformat("Error calling method from 'rfind_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(-1, vformat("Error calling method from 'rfind_custom': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 
 		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, -1, "Error calling method from 'rfind_custom': Return type of callable must be boolean.");
@@ -605,16 +597,13 @@ Array Array::filter(const Callable &p_callable) const {
 	new_arr._p->typed = _p->typed;
 	int accepted_count = 0;
 
-	const Variant *argptrs[1];
 	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
-		Variant result;
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
+		const Variant result = p_callable.callv_err(args, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'filter': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'filter': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 
 		if (result.operator bool()) {
@@ -632,15 +621,13 @@ Array Array::map(const Callable &p_callable) const {
 	Array new_arr;
 	new_arr.resize(size());
 
-	const Variant *argptrs[1];
 	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, write[i], ce);
+		write[i] = p_callable.callv_err(args, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'map': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'map': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 	}
 
@@ -655,16 +642,12 @@ Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const 
 		start = 1;
 	}
 
-	const Variant *argptrs[2];
 	for (int i = start; i < size(); i++) {
-		argptrs[0] = &ret;
-		argptrs[1] = &get(i);
-
-		Variant result;
+		const Vector<Variant> args = { ret, _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 2, result, ce);
+		const Variant result = p_callable.callv_err(args, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Variant(), vformat("Error calling method from 'reduce': %s.", Variant::get_callable_error_text(p_callable, argptrs, 2, ce)));
+			ERR_FAIL_V_MSG(Variant(), vformat("Error calling method from 'reduce': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 		ret = result;
 	}
@@ -673,15 +656,12 @@ Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const 
 }
 
 bool Array::any(const Callable &p_callable) const {
-	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
-		Variant result;
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
+		const Variant result = p_callable.callv_err(args, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'any': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'any': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 
 		if (result.operator bool()) {
@@ -695,15 +675,12 @@ bool Array::any(const Callable &p_callable) const {
 }
 
 bool Array::all(const Callable &p_callable) const {
-	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
-		Variant result;
+		const Vector<Variant> args = { _p->array[i] };
 		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
+		const Variant result = p_callable.callv_err(args, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'all': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'all': %s.", Variant::get_callable_error_text(p_callable, args, ce)));
 		}
 
 		if (!(result.operator bool())) {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -86,6 +86,22 @@ Variant Callable::callv(const Array &p_arguments) const {
 	return ret;
 }
 
+Variant Callable::callv_err(const Vector<Variant> &p_arguments, CallError &r_call_error) const {
+	const Variant **argptrs = nullptr;
+	int argcount = p_arguments.size();
+	if (argcount > 0) {
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		int i = 0;
+		for (const Variant &v : p_arguments) {
+			argptrs[i] = &v;
+			i++;
+		}
+	}
+	Variant ret;
+	callp(argptrs, argcount, ret, r_call_error);
+	return ret;
+}
+
 Error Callable::rpcp(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const {
 	if (is_null()) {
 		r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -73,6 +73,7 @@ public:
 	void callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const;
 	void call_deferredp(const Variant **p_arguments, int p_argcount) const;
 	Variant callv(const Array &p_arguments) const;
+	Variant callv_err(const Vector<Variant> &p_arguments, CallError &r_call_error) const;
 
 	template <typename... VarArgs>
 	void call_deferred(VarArgs... p_args) const {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3592,6 +3592,20 @@ String Variant::get_callable_error_text(const Callable &p_callable, const Varian
 	}
 }
 
+String Variant::get_callable_error_text(const Callable &p_callable, const Vector<Variant> &p_arguments, const Callable::CallError &p_ce) {
+	const Variant **argptrs = nullptr;
+	int argcount = p_arguments.size();
+	if (argcount > 0) {
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		int i = 0;
+		for (const Variant &v : p_arguments) {
+			argptrs[i] = &v;
+			i++;
+		}
+	}
+	return get_callable_error_text(p_callable, argptrs, argcount, p_ce);
+}
+
 void Variant::register_types() {
 	_register_variant_gdtypes();
 	_register_variant_operators();

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -671,6 +671,7 @@ public:
 	static String get_call_error_text(const StringName &p_method, const Variant **p_argptrs, int p_argcount, const Callable::CallError &p_ce);
 	static String get_call_error_text(Object *p_base, const StringName &p_method, const Variant **p_argptrs, int p_argcount, const Callable::CallError &p_ce);
 	static String get_callable_error_text(const Callable &p_callable, const Variant **p_argptrs, int p_argcount, const Callable::CallError &p_ce);
+	static String get_callable_error_text(const Callable &p_callable, const Vector<Variant> &p_arguments, const Callable::CallError &p_ce);
 
 	//dynamic (includes Object)
 	void get_method_list(List<MethodInfo> *p_list) const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The only way to call a Callable and get back a potential error is to use `callp()`. All other methods just fail silently. The problem with `callp()` is that it takes `const Variant **` as parameter, which is annoying to set up.

This PR adds a helper method `callv_err()`, which is similar to `callv()`, but also takes CallError as parameter, so you can make validated calls with the convenience of `Vector<Variant>`.

## Additional information

I applied the method in Array. Unfortunately some basic benchmark revealed that the new method is consistently slower :/
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
