### PR TITLE
Don't use hidden tabs for dock slot minimum size

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -363,7 +363,6 @@ SideDockTabContainer::SideDockTabContainer(int p_slot, const Rect2i &p_slot_rect
 	grid_rect = p_slot_rect;
 	set_custom_minimum_size(Size2(170 * EDSCALE, 0));
 	set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	set_use_hidden_tabs_for_min_size(true);
 }
 
 Rect2 BottomSideDockTabContainer::get_floating_dock_rect(EditorDock *p_dock) {
@@ -381,5 +380,4 @@ BottomSideDockTabContainer::BottomSideDockTabContainer(int p_slot, const Rect2i 
 
 	set_custom_minimum_size(Size2(0, 170 * EDSCALE));
 	set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	set_use_hidden_tabs_for_min_size(true);
 }


### PR DESCRIPTION
A plugin dock sitting in a dock slot as a **hidden tab** could force the whole editor to be taller than the window, pushing the bottom panel and the FileSystem dock off-screen. This PR stops hidden dock tabs from constraining the slot's minimum size.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121574

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

The dock slots enable `use_hidden_tabs_for_min_size`, so even a never-selected plugin dock contributes its minimum size to the slot. The editor columns all share one horizontal split, which stretches every column to the same height:

```text
DockHSplitMain  ← its min height = the tallest column, and it stretches ALL columns to it
├── left column    ← hidden plugin dock reports min height 5000 px
├── center column  ← stretched to 5000 px as well
│   ├── main workspace
│   └── bottom panel        ← now sits at y ≈ 4900 — the window is only ~1600 px tall
└── right column (Inspector)
```

So one oversized hidden tab silently resizes the entire editor beyond the window; everything anchored to the bottom of the layout (bottom panel, lower dock slots) ends up below the window edge. The user sees them "disappear" with no way to get them back.

Worse, the oversized minimum doesn't need to be intentional. Hidden tabs are never laid out (`TabContainer` only anchors the current tab), so an autowrapped `Label` in a hidden dock still has its initial ~1-character-wide rect and wraps a ~120-character help text into hundreds of lines: measured **25×13868 px** minimum size for a perfectly innocent plugin dock. Any plugin using an autowrapped label in a dock can break the whole editor this way.

Exactly one thing: a dock slot's minimum size now follows its **current** tab instead of the maximum over all tabs (hidden ones included). Nothing else — no layout code, no core `TabContainer` behavior, and the Project Settings / Export dialogs keep the flag.

`use_hidden_tabs_for_min_size` was applied to the dock slots in #25353 (3.2 era, before plugins could place arbitrary controls into dock slots) and assumes hidden tabs report a meaningful, bounded minimum size. Hidden plugin docks are unlaid-out and unbounded, so that premise no longer holds. With this PR a dock's minimum size is only enforced **while it is actually shown** — a state the user can always leave by switching tabs, unlike the current permanent breakage.

### Side effects — verified scenario by scenario

| Scenario | Before this PR | After this PR (measured) |
| --- | --- | --- |
| Hidden dock with oversized minimum (this bug) | Editor permanently taller than the window, bottom panel unreachable | No effect while hidden |
| Switching between built-in docks (Scene/Import, FileSystem/History, Inspector/Signals/Groups — all tabs cycled) | No split movement | No split movement — every split offset identical across all switches |
| Switching to a dock whose minimum fits the window (1400 px) | (min was permanently reserved) | Slot grows to exactly the minimum while shown, neighbor dock shrinks, bottom panel untouched; switching back restores the exact previous layout |
| Switching to a dock whose minimum exceeds the window (5000 px) | Editor broken at all times, even with the dock hidden | Layout exceeds the window only while that tab is shown (unavoidable for a truly visible oversized control); switching back restores the exact previous layout |
| Autowrapped label dock, first time shown | (hidden minimum already broke the editor) | Laid out at the real slot width on first show, minimum collapses 13868 px → 918 px, no split movement |
| Project Settings / Export dialogs (#21404) | Flag enabled | Unchanged — flag kept |

