### PR TITLE
Style: Overhaul and enforce clang-format rules for glsl files 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -93,3 +93,6 @@ a3088fecf1837aa22fcf2bccae413598a2e91766
 
 # Style: Apply left qualifier alignment rule
 eb1b8e8edacc3c7449ea8ac894812720e7ee48bf
+
+# Style: Apply updated `clang-format` glsl rules
+b4f964db067307f4a0d0fe1fa0380d29233dd74a

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -93,3 +93,6 @@ a3088fecf1837aa22fcf2bccae413598a2e91766
 
 # Style: Apply left qualifier alignment rule
 eb1b8e8edacc3c7449ea8ac894812720e7ee48bf
+
+# Style: Apply updated `clang-format` glsl rules
+e7a584d905b036cbcbd2c3f0fcba2961ce49bdaf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: clang-format
         name: clang-format-glsl
         files: \.glsl$
+        exclude: drivers/gles3/shaders/scene.glsl # See https://github.com/llvm/llvm-project/issues/142426.
         types_or: [text]
         args: [-style=file:misc/utility/clang_format_glsl.yml]
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -16,6 +16,7 @@ USE_INSTANCING = false
 
 #ifdef USE_ATTRIBUTES
 layout(location = 0) in vec2 vertex_attrib;
+/* clang-format on */
 layout(location = 3) in vec4 color_attrib;
 layout(location = 4) in vec2 uv_attrib;
 
@@ -102,18 +103,14 @@ flat out vec4 varying_E;
 flat out uvec2 varying_F;
 flat out uvec4 varying_G;
 
-// This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
-layout(std140) uniform MaterialUniforms{ //ubo:4
-
+layout(std140) uniform MaterialUniforms { //ubo:4
 #MATERIAL_UNIFORMS
-
 };
 #endif
 
 uniform mediump uint batch_flags;
 
-/* clang-format on */
 #include "canvas_uniforms_inc.glsl"
 
 out vec2 uv_interp;
@@ -345,16 +342,11 @@ uniform highp uint specular_shininess_in;
 
 layout(location = 0) out vec4 frag_color;
 
-/* clang-format off */
-// This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
-layout(std140) uniform MaterialUniforms{ //ubo:4
-
+layout(std140) uniform MaterialUniforms { //ubo:4
 #MATERIAL_UNIFORMS
-
 };
 #endif
-/* clang-format on */
 
 #GLOBALS
 
@@ -451,6 +443,7 @@ vec3 light_normal_compute(vec3 light_vec, vec3 normal, vec3 base_color, vec3 lig
 #endif
 
 /* clang-format off */
+// Must be formatted like this to work around a driver bug on some mobile devices.
 #define SHADOW_TEST(m_uv) { highp float sd = SHADOW_DEPTH(m_uv); shadow += step(sd, shadow_uv.z / shadow_uv.w); }
 /* clang-format on */
 

--- a/drivers/gles3/shaders/canvas_occlusion.glsl
+++ b/drivers/gles3/shaders/canvas_occlusion.glsl
@@ -11,6 +11,8 @@ mode_shadow_RGBA = #define MODE_SHADOW \n#define USE_RGBA_SHADOWS
 
 layout(location = 0) in vec3 vertex;
 
+/* clang-format on */
+
 uniform highp mat4 projection;
 uniform highp vec4 modelview1;
 uniform highp vec4 modelview2;
@@ -32,7 +34,6 @@ void main() {
 
 #[fragment]
 
-
 uniform highp mat4 projection;
 uniform highp vec4 modelview1;
 uniform highp vec4 modelview2;
@@ -50,7 +51,7 @@ layout(location = 0) out highp float out_buf;
 #endif
 
 void main() {
-    float out_depth = 1.0;
+	float out_depth = 1.0;
 
 #ifdef MODE_SHADOW
 	out_depth = depth / z_far;

--- a/drivers/gles3/shaders/canvas_sdf.glsl
+++ b/drivers/gles3/shaders/canvas_sdf.glsl
@@ -24,21 +24,20 @@ void main() {
 	gl_Position = vec4(vertex_attrib, 1.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
 
 #define SDF_MAX_LENGTH 16384.0
 
 #if defined(MODE_LOAD) || defined(MODE_LOAD_SHRINK)
-uniform lowp sampler2D src_pixels;//texunit:0
+uniform lowp sampler2D src_pixels; //texunit:0
 #else
-uniform highp isampler2D src_process;//texunit:0
+uniform highp isampler2D src_process; //texunit:0
 #endif
 
-uniform	ivec2 size;
-uniform	int stride;
-uniform	int shift;
-uniform	ivec2 base_size;
+uniform ivec2 size;
+uniform int stride;
+uniform int shift;
+uniform ivec2 base_size;
 
 #if defined(MODE_LOAD) || defined(MODE_LOAD_SHRINK) || defined(MODE_PROCESS)
 layout(location = 0) out ivec4 distance_field;
@@ -47,7 +46,7 @@ layout(location = 0) out vec4 distance_field;
 #endif
 
 vec4 float_to_vec4(float p_float) {
-    highp vec4 comp = fract(p_float * vec4(255.0 * 255.0 * 255.0, 255.0 * 255.0, 255.0, 1.0));
+	highp vec4 comp = fract(p_float * vec4(255.0 * 255.0 * 255.0, 255.0 * 255.0, 255.0, 1.0));
 	comp -= comp.xxyz * vec4(0.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
 	return comp;
 }
@@ -175,7 +174,7 @@ void main() {
 
 	d /= SDF_MAX_LENGTH;
 	d = clamp(d, -1.0, 1.0);
-	distance_field = float_to_vec4(d*0.5+0.5);
+	distance_field = float_to_vec4(d * 0.5 + 0.5);
 
 #endif
 
@@ -199,7 +198,7 @@ void main() {
 	}
 	d /= SDF_MAX_LENGTH;
 	d = clamp(d, -1.0, 1.0);
-	distance_field = float_to_vec4(d*0.5+0.5);
+	distance_field = float_to_vec4(d * 0.5 + 0.5);
 
 #endif
 }

--- a/drivers/gles3/shaders/effects/copy.glsl
+++ b/drivers/gles3/shaders/effects/copy.glsl
@@ -23,8 +23,9 @@ CONVERT_LINEAR_TO_SRGB = false
 
 layout(location = 0) in vec2 vertex_attrib;
 
-out vec2 uv_interp;
 /* clang-format on */
+
+out vec2 uv_interp;
 
 #if defined(USE_COPY_SECTION) || defined(MODE_GAUSSIAN_BLUR)
 // Defined in 0-1 coords.
@@ -46,11 +47,9 @@ void main() {
 #endif
 }
 
-/* clang-format off */
 #[fragment]
 
 in vec2 uv_interp;
-/* clang-format on */
 #if defined(USE_TEXTURE_3D) || defined(USE_TEXTURE_2D_ARRAY)
 uniform float layer;
 uniform float lod;

--- a/drivers/gles3/shaders/effects/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/effects/cubemap_filter.glsl
@@ -18,15 +18,11 @@ void main() {
 	gl_Position = vec4(uv_interp, 0.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
-
 
 #define M_PI 3.14159265359
 
 uniform samplerCube source_cube; //texunit:0
-
-/* clang-format on */
 
 uniform int face_id;
 

--- a/drivers/gles3/shaders/effects/glow.glsl
+++ b/drivers/gles3/shaders/effects/glow.glsl
@@ -23,9 +23,7 @@ void main() {
 	gl_Position = vec4(vertex_attrib, 1.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
-/* clang-format on */
 
 #ifdef MODE_FILTER
 #ifdef USE_MULTIVIEW

--- a/drivers/gles3/shaders/effects/post.glsl
+++ b/drivers/gles3/shaders/effects/post.glsl
@@ -28,9 +28,7 @@ void main() {
 	gl_Position = vec4(vertex_attrib, 1.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
-/* clang-format on */
 
 // If we reach this code, we always tonemap.
 #define APPLY_TONEMAPPING

--- a/drivers/gles3/shaders/feed.glsl
+++ b/drivers/gles3/shaders/feed.glsl
@@ -11,15 +11,15 @@ USE_EXTERNAL_SAMPLER = false
 
 layout(location = 0) in vec2 vertex_attrib;
 
-out vec2 uv_interp;
+/* clang-format on */
 
+out vec2 uv_interp;
 
 void main() {
 	uv_interp = vertex_attrib * 0.5 + 0.5;
 	gl_Position = vec4(vertex_attrib, 1.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
 
 layout(location = 0) out vec4 frag_color;

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -18,19 +18,15 @@ USERDATA6_USED = false
 #define SDF_MAX_LENGTH 16384.0
 
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
+	/* clang-format on */
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
-// This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
-layout(std140) uniform MaterialUniforms{ //ubo:2
-
+layout(std140) uniform MaterialUniforms { //ubo:2
 #MATERIAL_UNIFORMS
-
 };
 #endif
-
-/* clang-format on */
 
 #define MAX_ATTRACTORS 32
 
@@ -504,9 +500,7 @@ void main() {
 	out_velocity_flags.w = uintBitsToFloat(flags);
 }
 
-/* clang-format off */
 #[fragment]
 
 void main() {
 }
-/* clang-format on */

--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -13,6 +13,7 @@ MODE_3D = false
 
 // ParticleData
 layout(location = 0) in highp vec4 color;
+/* clang-format on */
 layout(location = 1) in highp vec4 velocity_flags;
 layout(location = 2) in highp vec4 custom;
 layout(location = 3) in highp vec4 xform_1;
@@ -21,7 +22,6 @@ layout(location = 4) in highp vec4 xform_2;
 layout(location = 5) in highp vec4 xform_3;
 #endif
 
-/* clang-format on */
 out highp vec4 out_xform_1; //tfb:
 out highp vec4 out_xform_2; //tfb:
 #ifdef MODE_3D
@@ -184,9 +184,7 @@ void main() {
 #endif
 }
 
-/* clang-format off */
 #[fragment]
 
 void main() {
 }
-/* clang-format on */

--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -13,6 +13,7 @@ MODE_3D = false
 
 // ParticleData
 layout(location = 0) in highp vec4 color;
+/* clang-format on */
 layout(location = 1) in highp vec4 velocity_flags;
 layout(location = 2) in highp vec4 custom;
 layout(location = 3) in highp vec4 xform_1;
@@ -21,7 +22,6 @@ layout(location = 4) in highp vec4 xform_2;
 layout(location = 5) in highp vec4 xform_3;
 #endif
 
-/* clang-format on */
 out highp vec4 out_xform_1; //tfb:
 out highp vec4 out_xform_2; //tfb:
 #ifdef MODE_3D
@@ -183,9 +183,7 @@ void main() {
 #endif
 }
 
-/* clang-format off */
 #[fragment]
 
 void main() {
 }
-/* clang-format on */

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -234,14 +234,12 @@ struct SceneData {
 // The containing data block is for historic reasons.
 layout(std140) uniform SceneDataBlock { // ubo:2
 	SceneData data;
-}
-scene_data_block;
+} scene_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
 layout(std140) uniform PrevSceneDataBlock { // ubo:13
 	SceneData data;
-}
-prev_scene_data_block;
+} prev_scene_data_block;
 #endif
 
 #ifndef RENDER_MOTION_VECTORS
@@ -484,14 +482,12 @@ struct MultiviewData {
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
-}
-multiview_data_block;
+} multiview_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
 layout(std140) uniform PrevMultiviewDataBlock { // ubo:14
 	MultiviewData data;
-}
-prev_multiview_data_block;
+} prev_multiview_data_block;
 #endif // RENDER_MOTION_VECTORS
 
 #endif // USE_MULTIVIEW
@@ -554,17 +550,11 @@ out highp vec4 shadow_coord4;
 
 #ifdef MATERIAL_UNIFORMS_USED
 
-/* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
-/* clang-format on */
 
 #endif
-
-/* clang-format off */
 
 #if defined(RENDER_MOTION_VECTORS)
 out highp vec4 clip_position;
@@ -573,7 +563,6 @@ out highp vec4 prev_clip_position;
 
 #GLOBALS
 
-/* clang-format on */
 invariant gl_Position;
 
 void vertex_shader(vec4 vertex_angle_attrib_input,
@@ -998,7 +987,6 @@ void main() {
 	gl_Position = clip_position;
 }
 
-/* clang-format off */
 #[fragment]
 
 // Default to SPECULAR_SCHLICK_GGX.
@@ -1006,7 +994,7 @@ void main() {
 #define SPECULAR_SCHLICK_GGX
 #endif
 
-#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) ||defined(LIGHT_CLEARCOAT_USED)
+#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) || defined(LIGHT_CLEARCOAT_USED)
 #ifndef NORMAL_USED
 #define NORMAL_USED
 #endif
@@ -1156,13 +1144,9 @@ layout(std140) uniform GlobalShaderUniformData { //ubo:1
 /* Material Uniforms */
 #ifdef MATERIAL_UNIFORMS_USED
 
-/* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
-/* clang-format on */
 
 #endif
 
@@ -1218,8 +1202,7 @@ struct SceneData {
 
 layout(std140) uniform SceneDataBlock { // ubo:2
 	SceneData data;
-}
-scene_data_block;
+} scene_data_block;
 
 #ifdef USE_MULTIVIEW
 struct MultiviewData {
@@ -1230,8 +1213,7 @@ struct MultiviewData {
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
-}
-multiview_data_block;
+} multiview_data_block;
 #endif
 
 uniform highp mat4 world_transform;
@@ -1502,11 +1484,7 @@ layout(location = 0) out vec4 motion_vectors;
 
 #endif // !RENDER_MATERIAL
 
-/* clang-format off */
-
 #GLOBALS
-
-/* clang-format on */
 
 #ifndef RENDER_MOTION_VECTORS
 vec3 F0(float metallic, float specular, vec3 albedo) {
@@ -1588,11 +1566,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	vec3 area_diffuse_tex_color = vec3(1.0);
 	vec3 area_specular_tex_color = vec3(1.0);
 
-	/* clang-format off */
-
 #CODE : LIGHT
-
-	/* clang-format on */
 
 #else
 	float NdotL = min(A + dot(N, L), 1.0);
@@ -1694,7 +1668,6 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float D = D_GGX(cNdotH, alpha_ggx);
 		float G = V_GGX(cNdotL, cNdotV, alpha_ggx);
 #endif // LIGHT_ANISOTROPY_USED
-	   // F
 #if !defined(LIGHT_CLEARCOAT_USED)
 		float cLdotH5 = SchlickFresnel(cLdotH);
 #endif
@@ -1854,11 +1827,7 @@ void light_process_area(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 	vec3 area_specular = ltc_specular * fresnel_color;
 	float attenuation = light_attenuation_ltc;
 
-	/* clang-format off */
-
 #CODE : LIGHT
-
-	/* clang-format on */
 
 #else
 	float area = a_len * b_len;
@@ -2980,7 +2949,6 @@ void main() {
 				specular_light);
 	} else {
 #endif // !USE_VERTEX_LIGHTING
-	   // Just apply shadows to vertex lighting.
 		diffuse_light *= directional_shadow;
 		specular_light *= directional_shadow;
 #ifndef USE_VERTEX_LIGHTING

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -237,14 +237,12 @@ struct SceneData {
 // The containing data block is for historic reasons.
 layout(std140) uniform SceneDataBlock { // ubo:2
 	SceneData data;
-}
-scene_data_block;
+} scene_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
 layout(std140) uniform PrevSceneDataBlock { // ubo:13
 	SceneData data;
-}
-prev_scene_data_block;
+} prev_scene_data_block;
 #endif
 
 #ifndef RENDER_MOTION_VECTORS
@@ -487,14 +485,12 @@ struct MultiviewData {
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
-}
-multiview_data_block;
+} multiview_data_block;
 
 #ifdef RENDER_MOTION_VECTORS
 layout(std140) uniform PrevMultiviewDataBlock { // ubo:14
 	MultiviewData data;
-}
-prev_multiview_data_block;
+} prev_multiview_data_block;
 #endif // RENDER_MOTION_VECTORS
 
 #endif // USE_MULTIVIEW
@@ -557,17 +553,11 @@ out highp vec4 shadow_coord4;
 
 #ifdef MATERIAL_UNIFORMS_USED
 
-/* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
-/* clang-format on */
 
 #endif
-
-/* clang-format off */
 
 #if defined(RENDER_MOTION_VECTORS)
 out highp vec4 clip_position;
@@ -576,7 +566,6 @@ out highp vec4 prev_clip_position;
 
 #GLOBALS
 
-/* clang-format on */
 invariant gl_Position;
 
 void vertex_shader(vec4 vertex_angle_attrib_input,
@@ -1002,7 +991,6 @@ void main() {
 	gl_Position = clip_position;
 }
 
-/* clang-format off */
 #[fragment]
 
 // Default to SPECULAR_SCHLICK_GGX.
@@ -1010,7 +998,7 @@ void main() {
 #define SPECULAR_SCHLICK_GGX
 #endif
 
-#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) ||defined(LIGHT_CLEARCOAT_USED)
+#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) || defined(LIGHT_CLEARCOAT_USED)
 #ifndef NORMAL_USED
 #define NORMAL_USED
 #endif
@@ -1193,13 +1181,9 @@ layout(std140) uniform GlobalShaderUniformData { //ubo:1
 /* Material Uniforms */
 #ifdef MATERIAL_UNIFORMS_USED
 
-/* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
-/* clang-format on */
 
 #endif
 
@@ -1255,8 +1239,7 @@ struct SceneData {
 
 layout(std140) uniform SceneDataBlock { // ubo:2
 	SceneData data;
-}
-scene_data_block;
+} scene_data_block;
 
 #ifdef USE_MULTIVIEW
 struct MultiviewData {
@@ -1267,8 +1250,7 @@ struct MultiviewData {
 
 layout(std140) uniform MultiviewDataBlock { // ubo:9
 	MultiviewData data;
-}
-multiview_data_block;
+} multiview_data_block;
 #endif
 
 uniform highp mat4 world_transform;
@@ -1543,11 +1525,7 @@ layout(location = 0) out vec4 motion_vectors;
 
 #endif // !RENDER_MATERIAL
 
-/* clang-format off */
-
 #GLOBALS
-
-/* clang-format on */
 
 #ifndef RENDER_MOTION_VECTORS
 vec3 F0(float metallic, float specular, vec3 albedo) {
@@ -1629,11 +1607,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	vec3 area_diffuse_tex_color = vec3(1.0);
 	vec3 area_specular_tex_color = vec3(1.0);
 
-	/* clang-format off */
-
 #CODE : LIGHT
-
-	/* clang-format on */
 
 #else
 	float NdotL = min(A + dot(N, L), 1.0);
@@ -1735,7 +1709,6 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float D = D_GGX(cNdotH, alpha_ggx);
 		float G = V_GGX(cNdotL, cNdotV, alpha_ggx);
 #endif // LIGHT_ANISOTROPY_USED
-	   // F
 #if !defined(LIGHT_CLEARCOAT_USED)
 		float cLdotH5 = SchlickFresnel(cLdotH);
 #endif
@@ -1895,11 +1868,7 @@ void light_process_area(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 	vec3 area_specular = ltc_specular * fresnel_color;
 	float attenuation = light_attenuation_ltc;
 
-	/* clang-format off */
-
 #CODE : LIGHT
-
-	/* clang-format on */
 
 #else
 	float area = a_len * b_len;
@@ -3158,7 +3127,6 @@ void main() {
 				specular_light);
 	} else {
 #endif // !USE_VERTEX_LIGHTING
-	   // Just apply shadows to vertex lighting.
 		diffuse_light *= directional_shadow;
 		specular_light *= directional_shadow;
 #ifndef USE_VERTEX_LIGHTING

--- a/drivers/gles3/shaders/skeleton.glsl
+++ b/drivers/gles3/shaders/skeleton.glsl
@@ -32,6 +32,7 @@ USE_EIGHT_WEIGHTS = false
 
 // These come from the source mesh and the output from previous passes.
 layout(location = 0) in highp VFORMAT in_vertex;
+/* clang-format on */
 #ifdef MODE_BLEND_PASS
 #ifdef USE_NORMAL
 layout(location = 1) in highp uvec2 in_normal;
@@ -273,10 +274,7 @@ void main() {
 #endif // MODE_2D
 }
 
-/* clang-format off */
 #[fragment]
 
 void main() {
-
 }
-/* clang-format on */

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -15,9 +15,9 @@ USE_HALF_RES_PASS = false
 #[vertex]
 
 layout(location = 0) in vec2 vertex_attrib;
+/* clang-format on */
 
 out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 #ifdef USE_INVERTED_Y
@@ -29,7 +29,6 @@ void main() {
 	gl_Position = vec4(uv_interp, -1.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
 
 #define M_PI 3.14159265359
@@ -37,8 +36,6 @@ void main() {
 #include "tonemap_inc.glsl"
 
 in vec2 uv_interp;
-
-/* clang-format on */
 
 uniform samplerCube radiance; //texunit:-2
 #ifdef USE_CUBEMAP_PASS
@@ -67,8 +64,7 @@ struct DirectionalLightData {
 
 layout(std140) uniform DirectionalLights { //ubo:4
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #define DIRECTIONAL_LIGHT_ENABLED uint(1 << 0)
 
@@ -88,16 +84,11 @@ uniform float fog_density;
 uniform float fog_sky_affect;
 uniform uint directional_light_count;
 
-/* clang-format off */
-
 #ifdef MATERIAL_UNIFORMS_USED
-layout(std140) uniform MaterialUniforms{ //ubo:3
-
+layout(std140) uniform MaterialUniforms { //ubo:3
 #MATERIAL_UNIFORMS
-
 };
 #endif
-/* clang-format on */
 #GLOBALS
 
 #ifdef USE_CUBEMAP_PASS
@@ -123,8 +114,7 @@ layout(std140) uniform MultiviewData { // ubo:12
 	highp mat4 projection_matrix_view[MAX_VIEWS];
 	highp mat4 inv_projection_matrix_view[MAX_VIEWS];
 	highp vec4 eye_offset[MAX_VIEWS];
-}
-multiview_data;
+} multiview_data;
 #endif
 
 layout(location = 0) out vec4 frag_color;

--- a/drivers/gles3/shaders/tex_blit.glsl
+++ b/drivers/gles3/shaders/tex_blit.glsl
@@ -13,7 +13,7 @@ USE_OUTPUT3 = true
 #[vertex]
 
 layout(location = 0) in vec2 vertex_attrib;
-
+/* clang-format on */
 uniform vec2 offset;
 uniform vec2 size;
 
@@ -22,7 +22,7 @@ out vec2 uv;
 void main() {
 	uv = vertex_attrib * 0.5 + 0.5;
 	// This math scales the Vertex Attribute Quad to match the Rect the user passed in, based on Offset & Size
-	gl_Position = vec4( (offset * 2.0 - 1.0) + (size * (vertex_attrib + 1.0)), 1.0, 1.0);
+	gl_Position = vec4((offset * 2.0 - 1.0) + (size * (vertex_attrib + 1.0)), 1.0, 1.0);
 }
 
 #[fragment]
@@ -46,26 +46,23 @@ uniform float time;
 
 in vec2 uv;
 
-layout (location = 0) out vec4 out_color0;
+layout(location = 0) out vec4 out_color0;
 
 #ifdef USE_OUTPUT1
-layout (location = 1) out vec4 out_color1;
+layout(location = 1) out vec4 out_color1;
 #endif
 
 #ifdef USE_OUTPUT2
-layout (location = 2) out vec4 out_color2;
+layout(location = 2) out vec4 out_color2;
 #endif
 
 #ifdef USE_OUTPUT3
-layout (location = 3) out vec4 out_color3;
+layout(location = 3) out vec4 out_color3;
 #endif
 
-// This needs to be outside clang-format so the ubo comment is in the right place
 #ifdef MATERIAL_UNIFORMS_USED
-layout(std140) uniform MaterialUniforms{ //ubo:0
-
+layout(std140) uniform MaterialUniforms { //ubo:0
 #MATERIAL_UNIFORMS
-
 };
 #endif
 

--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -1,48 +1,15 @@
 # GLSL-specific rules.
-# The rules should be the same as .clang-format, except those explicitly mentioned.
-BasedOnStyle: LLVM
-AccessModifierOffset: -4
+BasedOnStyle: InheritParentConfig
+Macros:
+  # Treat struct-like objects as `struct` for the purposes of formatting.
+  - uniform=struct
+  - buffer=struct
+# Do not shift down `ubo:#` comments; they're position-critical.
+ReflowComments: false
+# NOTE: This is a duplicated value from the main config to work around a bug in clang-format when
+#  inheriting a parent config. This value changed to a boolean in v22, and automatically resolves
+#  "DontAlign" to "false". However, it does *not* perform this resolution in an inherited file,
+#  which causes the value to fallback to the LLVM value: "true". When comparing `--dump-config`
+#  outputs, this is the only instance of this happening, but future major version bumps should
+#  ratify this as well.
 AlignAfterOpenBracket: DontAlign
-AlignOperands: DontAlign
-AlignTrailingComments:
-  Kind: Never
-  OverEmptyLines: 0
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AttributeMacros:
-  - _ALWAYS_INLINE_
-  - _FORCE_INLINE_
-  - _NO_INLINE_
-BreakConstructorInitializers: AfterColon
-ColumnLimit: 0
-ConstructorInitializerIndentWidth: 8
-ContinuationIndentWidth: 8
-Cpp11BracedListStyle: false
-IncludeCategories:
-  - Regex: ^".*"$
-    Priority: 1
-  - Regex: ^<.*\.h>$
-    Priority: 2
-  - Regex: ^<.*>$
-    Priority: 3
-IndentCaseLabels: true
-IndentWidth: 4
-InsertBraces: true
-JavaImportGroups:
-  - org.godotengine
-  - android
-  - androidx
-  - com.android
-  - com.google
-  - java
-  - javax
-KeepEmptyLinesAtTheStartOfBlocks: false
-ObjCBlockIndentWidth: 4
-PackConstructorInitializers: NextLine
-RemoveSemicolon: false # Differs from base .clang-format
-SpacesInLineCommentPrefix:
-  Minimum: 0
-  Maximum: -1
-Standard: c++20
-TabWidth: 4
-UseTab: Always

--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -1,8 +1,12 @@
 # GLSL-specific rules.
 # The rules will be the same as .clang-format, except those explicitly mentioned.
 BasedOnStyle: InheritParentConfig
-# `uniform` and `buffer` not recognized as object-like containers.
-RemoveSemicolon: false
+Macros:
+  # Treat struct-like objects as `struct` for the purposes of formatting.
+  - uniform=struct
+  - buffer=struct
+# Do not shift down `ubo:#` comments; they're position-critical.
+ReflowComments: false
 # NOTE: This is a duplicated value from the main config to work around a bug in clang-format when
 #  inheriting a parent config. This value changed to a boolean in v22, and automatically resolves
 #  "DontAlign" to "false". However, it does *not* perform this resolution in an inherited file,

--- a/modules/betsy/bc1.glsl
+++ b/modules/betsy/bc1.glsl
@@ -21,8 +21,7 @@ layout(std430, binding = 2) readonly restrict buffer globalBuffer {
 layout(push_constant, std430) uniform Params {
 	uint p_numRefinements;
 	uint p_padding[3];
-}
-params;
+} params;
 
 layout(local_size_x = 8, //
 		local_size_y = 8, //

--- a/modules/betsy/bc4.glsl
+++ b/modules/betsy/bc4.glsl
@@ -17,8 +17,7 @@ layout(binding = 1, rg32ui) uniform restrict writeonly uimage2D dstTexture;
 layout(push_constant, std430) uniform Params {
 	uint p_channelIdx;
 	uint p_padding[3];
-}
-params;
+} params;
 
 layout(local_size_x = 4, //
 		local_size_y = 4, //

--- a/modules/betsy/bc6h.glsl
+++ b/modules/betsy/bc6h.glsl
@@ -35,8 +35,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 p_textureSizeRcp;
 	uint padding0;
 	uint padding1;
-}
-params;
+} params;
 
 const float HALF_MAX = 65504.0f;
 const uint PATTERN_NUM = 32u;

--- a/modules/betsy/rgb_to_rgba.glsl
+++ b/modules/betsy/rgb_to_rgba.glsl
@@ -18,8 +18,7 @@ layout(std430, binding = 0) buffer Source {
 #else
 	uint data[];
 #endif
-}
-source;
+} source;
 
 #if defined(VER_FLOAT)
 layout(binding = 1, rgba32f) uniform writeonly image2D dest;
@@ -35,8 +34,7 @@ layout(push_constant, std430) uniform Params {
 	uint p_width;
 	uint p_height;
 	uint p_padding[2];
-}
-params;
+} params;
 
 void main() {
 	// gl_GlobalInvocationID is equivalent to the current texel coordinates.

--- a/modules/lightmapper_rd/lm_blendseams.glsl
+++ b/modules/lightmapper_rd/lm_blendseams.glsl
@@ -18,8 +18,7 @@ layout(push_constant, std430) uniform Params {
 	bool debug;
 	float blend;
 	uint pad[2];
-}
-params;
+} params;
 
 layout(location = 0) out vec3 uv_interp;
 
@@ -85,8 +84,7 @@ layout(push_constant, std430) uniform Params {
 	bool debug;
 	float blend;
 	uint pad[2];
-}
-params;
+} params;
 
 layout(location = 0) in vec3 uv_interp;
 

--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -19,8 +19,7 @@ layout(set = 0, binding = 0) uniform BakeParameters {
 	int shadowmask_light_idx;
 	uint transparency_rays;
 	float supersampling_factor;
-}
-bake_params;
+} bake_params;
 
 struct Vertex {
 	vec3 position;
@@ -31,8 +30,7 @@ struct Vertex {
 
 layout(set = 0, binding = 1, std430) restrict readonly buffer Vertices {
 	Vertex data[];
-}
-vertices;
+} vertices;
 
 #define CULL_DISABLED 0
 #define CULL_FRONT 1
@@ -56,13 +54,11 @@ struct ClusterAABB {
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer Triangles {
 	Triangle data[];
-}
-triangles;
+} triangles;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer TriangleIndices {
 	uint data[];
-}
-triangle_indices;
+} triangle_indices;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
 #define LIGHT_TYPE_OMNI 1
@@ -96,8 +92,7 @@ struct Light {
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer Lights {
 	Light data[];
-}
-lights;
+} lights;
 
 struct Seam {
 	uvec2 a;
@@ -106,13 +101,11 @@ struct Seam {
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer Seams {
 	Seam data[];
-}
-seams;
+} seams;
 
 layout(set = 0, binding = 6, std430) restrict readonly buffer Probes {
 	vec4 data[];
-}
-probe_positions;
+} probe_positions;
 
 layout(set = 0, binding = 7) uniform utexture3D grid;
 
@@ -124,13 +117,11 @@ layout(set = 0, binding = 11) uniform sampler area_light_atlas_sampler;
 
 layout(set = 0, binding = 12, std430) restrict readonly buffer ClusterIndices {
 	uint data[];
-}
-cluster_indices;
+} cluster_indices;
 
 layout(set = 0, binding = 13, std430) restrict readonly buffer ClusterAABBs {
 	ClusterAABB data[];
-}
-cluster_aabbs;
+} cluster_aabbs;
 
 // Fragment action constants
 const uint FA_NONE = 0;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -39,8 +39,7 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 layout(set = 1, binding = 0, std430) restrict buffer LightProbeData {
 	vec4 data[];
-}
-light_probes;
+} light_probes;
 
 layout(set = 1, binding = 1) uniform texture2DArray source_light;
 layout(set = 1, binding = 2) uniform texture2D environment;
@@ -90,8 +89,7 @@ layout(set = 1, binding = 4) uniform DenoiseParams {
 	int half_search_window;
 	float filter_strength;
 	uint slice_count;
-}
-denoise_params;
+} denoise_params;
 #endif
 
 layout(push_constant, std430) uniform Params {
@@ -103,8 +101,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 region_ofs;
 	uint probe_count;
 	uint denoiser_range;
-}
-params;
+} params;
 
 //check it, but also return distance and barycentric coords (for uv lookup)
 bool ray_hits_triangle(vec3 from, vec3 dir, float max_dist, vec3 p0, vec3 p1, vec3 p2, out float r_distance, out vec3 r_barycentric) {

--- a/modules/lightmapper_rd/lm_raster.glsl
+++ b/modules/lightmapper_rd/lm_raster.glsl
@@ -23,8 +23,7 @@ layout(push_constant, std430) uniform Params {
 	float bias;
 	ivec3 grid_size;
 	uint pad2;
-}
-params;
+} params;
 
 void main() {
 	uint triangle_idx = params.base_triangle + gl_VertexIndex / 3;
@@ -78,8 +77,7 @@ layout(push_constant, std430) uniform Params {
 	float bias;
 	ivec3 grid_size;
 	uint pad2;
-}
-params;
+} params;
 
 layout(location = 0) in vec3 vertex_interp;
 layout(location = 1) in vec3 normal_interp;

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -26,8 +26,7 @@ layout(push_constant, std140) uniform Pos {
 	float output_max_value;
 	uint pad1;
 	uint pad2;
-}
-data;
+} data;
 
 layout(location = 0) out vec2 uv;
 
@@ -72,8 +71,7 @@ layout(push_constant, std140) uniform Pos {
 	float output_max_value;
 	uint pad1;
 	uint pad2;
-}
-data;
+} data;
 
 layout(location = 0) in vec2 uv;
 

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -105,11 +105,9 @@ layout(location = 15) in uvec4 attrib_H;
 #endif // USE_ATTRIBUTES
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS
@@ -356,11 +354,9 @@ layout(location = 8) in vec2 pixel_size_interp;
 layout(location = 0) out vec4 frag_color;
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 vec2 screen_uv_to_sdf(vec2 p_uv) {

--- a/servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl
@@ -17,13 +17,11 @@ layout(push_constant, std430) uniform Constants {
 	uint cull_mode;
 	float pad3;
 	float pad4;
-}
-constants;
+} constants;
 
 layout(set = 0, binding = 0, std430) restrict readonly buffer OccluderTransforms {
 	mat2x4 transforms[];
-}
-occluder_transforms;
+} occluder_transforms;
 
 #else
 
@@ -33,8 +31,7 @@ layout(push_constant, std430) uniform Constants {
 	vec2 direction;
 	float z_far;
 	uint cull_mode;
-}
-constants;
+} constants;
 
 #endif
 
@@ -88,8 +85,7 @@ layout(push_constant, std430) uniform Constants {
 	uint cull_mode;
 	float pad3;
 	float pad4;
-}
-constants;
+} constants;
 
 #else
 
@@ -99,8 +95,7 @@ layout(push_constant, std430) uniform Constants {
 	vec2 direction;
 	float z_far;
 	uint cull_mode;
-}
-constants;
+} constants;
 
 #endif
 

--- a/servers/rendering/renderer_rd/shaders/canvas_sdf.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_sdf.glsl
@@ -18,8 +18,7 @@ layout(push_constant, std430) uniform Params {
 	int shift;
 	ivec2 base_size;
 	uvec2 pad;
-}
-params;
+} params;
 
 #define SDF_MAX_LENGTH 16384.0
 

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -68,8 +68,7 @@ layout(push_constant, std430) uniform Params {
 	vec4 modulation;
 	uvec4 lights;
 #endif
-}
-params;
+} params;
 
 // Specialization constants.
 
@@ -132,8 +131,7 @@ layout(set = 0, binding = 1, std140) uniform CanvasData {
 	float tex_to_sdf;
 	float shadow_pixel_size;
 	uint flags;
-}
-canvas_data;
+} canvas_data;
 
 #define LIGHT_FLAGS_BLEND_MASK (3 << 16)
 #define LIGHT_FLAGS_BLEND_MODE_ADD (0 << 16)
@@ -166,8 +164,7 @@ struct Light {
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer LightData {
 	Light data[];
-}
-light_array;
+} light_array;
 
 layout(set = 0, binding = 3) uniform texture2D atlas_texture;
 layout(set = 0, binding = 4) uniform texture2D shadow_atlas_texture;
@@ -181,8 +178,7 @@ layout(set = 0, binding = 7) uniform texture2D sdf_texture;
 
 layout(set = 0, binding = 9, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 /* SET1: Is reserved for the material */
 
@@ -192,8 +188,7 @@ global_shader_uniforms;
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
-}
-transforms;
+} transforms;
 
 /* SET3: Texture */
 

--- a/servers/rendering/renderer_rd/shaders/cluster_debug.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_debug.glsl
@@ -53,8 +53,7 @@ layout(push_constant, std430) uniform Params {
 	uint max_cluster_element_count_div_32;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 layout(set = 0, binding = 1, std430) buffer restrict readonly ClusterData {
 	uint data[];

--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -14,8 +14,7 @@ layout(push_constant, std430) uniform Params {
 	uint pad0;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 layout(set = 0, binding = 1, std140) uniform State {
 	mat4 projection;
@@ -29,8 +28,7 @@ layout(set = 0, binding = 1, std140) uniform State {
 	uint pad0;
 	uint pad1;
 	uint pad2;
-}
-state;
+} state;
 
 struct RenderElement {
 	uint type; //0-4
@@ -86,8 +84,7 @@ layout(set = 0, binding = 1, std140) uniform State {
 	uint pad0;
 	uint pad1;
 	uint pad2;
-}
-state;
+} state;
 
 //cluster data is layout linearly, each cell contains the follow information:
 // - list of bits for every element to mark as used, so (max_elem_count/32)*4 uints

--- a/servers/rendering/renderer_rd/shaders/cluster_store.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_store.glsl
@@ -15,8 +15,7 @@ layout(push_constant, std430) uniform Params {
 	uint max_cluster_element_count_div_32; //divided by 32
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 layout(set = 0, binding = 1, std430) buffer restrict readonly ClusterRender {
 	uint data[];

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -1,4 +1,3 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -8,7 +7,6 @@
 #include "blur_raster_inc.glsl"
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
@@ -29,7 +27,6 @@ void main() {
 	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -39,7 +36,6 @@ void main() {
 #include "blur_raster_inc.glsl"
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster_inc.glsl
@@ -20,5 +20,4 @@ layout(push_constant, std430) uniform Blur {
 	float glow_white; // 04 - 56
 	float glow_luminance_cap; // 04 - 60
 	float luminance_multiplier; // 04 - 64
-}
-blur;
+} blur;

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
@@ -26,8 +26,7 @@ layout(push_constant, std430) uniform Params {
 	float blur_size_near;
 	float blur_size_far;
 	uint pad[2];
-}
-params;
+} params;
 
 //used to work around downsampling filter
 #define DEPTH_GAP 0.0

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
@@ -1,4 +1,3 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -8,7 +7,6 @@
 #include "bokeh_dof_inc.glsl"
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
@@ -29,7 +27,6 @@ void main() {
 	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -39,7 +36,6 @@ void main() {
 #include "bokeh_dof_inc.glsl"
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 #ifdef MODE_GEN_BLUR_SIZE
 layout(location = 0) out float weight;

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -41,8 +41,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 octmap_border_size;
 
 	vec4 set_color;
-}
-params;
+} params;
 
 #ifdef MODE_OCTMAP_ARRAY_TO_PANORAMA
 layout(set = 0, binding = 0) uniform sampler2DArray source_color;

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -32,8 +32,7 @@ layout(push_constant, std430) uniform Params {
 	uint flags;
 
 	vec4 color;
-}
-params;
+} params;
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
@@ -79,8 +78,7 @@ layout(push_constant, std430) uniform Params {
 	uint flags;
 
 	vec4 color;
-}
-params;
+} params;
 
 #ifndef MODE_SET_COLOR
 #ifdef USE_MULTIVIEW

--- a/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
@@ -8,8 +8,7 @@ layout(push_constant, std430) uniform Params {
 	float z_far;
 	float z_near;
 	vec2 texel_size;
-}
-params;
+} params;
 
 layout(location = 0) out vec2 uv_interp;
 
@@ -33,8 +32,7 @@ layout(push_constant, std430) uniform Params {
 	float z_far;
 	float z_near;
 	vec2 texel_size;
-}
-params;
+} params;
 
 void main() {
 	vec2 uv = uv_interp;

--- a/servers/rendering/renderer_rd/shaders/effects/cube_to_octmap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cube_to_octmap.glsl
@@ -30,8 +30,7 @@ layout(push_constant, std430) uniform Params {
 	uint pad1;
 	uint pad2;
 	uint pad3;
-}
-params;
+} params;
 
 void main() {
 	vec3 dir = oct_to_vec3_with_border(uv_interp * 0.5 + 0.5, params.border_size);

--- a/servers/rendering/renderer_rd/shaders/effects/fsr_upscale.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr_upscale.glsl
@@ -62,8 +62,7 @@ layout(push_constant, std430) uniform Params {
 	int pass;
 	int pad1;
 	int pad2;
-}
-params;
+} params;
 
 AU4 Const0, Const1, Const2, Const3;
 

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
@@ -34,8 +34,7 @@ layout(push_constant, std430) uniform Params {
 	float min_luminance;
 	float exposure_adjust;
 	float pad[3];
-}
-params;
+} params;
 
 void main() {
 	uint t = gl_LocalInvocationID.y * BLOCK_SIZE + gl_LocalInvocationID.x;

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster.glsl
@@ -1,4 +1,3 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -8,7 +7,6 @@
 #include "luminance_reduce_raster_inc.glsl"
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
@@ -16,7 +14,6 @@ void main() {
 	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -26,7 +23,6 @@ void main() {
 #include "luminance_reduce_raster_inc.glsl"
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_exposure;
 

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster_inc.glsl
@@ -6,5 +6,4 @@ layout(push_constant, std430) uniform PushConstant {
 	float min_luminance;
 	float max_luminance;
 	uint pad1;
-}
-settings;
+} settings;

--- a/servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl
@@ -32,8 +32,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 resolution;
 	uint force_derive_from_depth;
 	uint pad;
-}
-params;
+} params;
 
 // Based on distance to line segment from https://www.shadertoy.com/view/3tdSDj
 

--- a/servers/rendering/renderer_rd/shaders/effects/motion_vectors_store.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/motion_vectors_store.glsl
@@ -14,8 +14,7 @@ layout(push_constant, std430) uniform Params {
 	highp mat4 reprojection_matrix;
 	vec2 resolution;
 	uint pad[2];
-}
-params;
+} params;
 
 void main() {
 	// Out of bounds check.

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler.glsl
@@ -39,8 +39,7 @@ layout(push_constant, std430) uniform Params {
 	uint size;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 // Use an approximation of the Jacobian.
 float calcWeight(float u, float v) {

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_downsampler_raster.glsl
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -32,11 +31,9 @@ layout(push_constant, std430) uniform Params {
 	uint size;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
@@ -57,7 +54,6 @@ void main() {
 	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -71,14 +67,12 @@ layout(push_constant, std430) uniform Params {
 	uint size;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 layout(set = 0, binding = 0) uniform sampler2D source_octmap;
 
 layout(location = 0) in vec2 uv_interp;
 layout(location = 0) out vec4 frag_color;
-/* clang-format on */
 
 float calcWeight(float u, float v) {
 	float val = u * u + v * v + 1.0;

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
@@ -47,8 +47,7 @@ layout(OCTMAP_FORMAT, set = 2, binding = 5) uniform restrict writeonly image2D d
 layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	vec2 pad;
-}
-params;
+} params;
 
 #define BASE_RESOLUTION 320
 
@@ -225,8 +224,8 @@ void main() {
 	}
 
 #ifdef USE_TEXTURE_ARRAY
-#define IMAGE_STORE(x)                             \
-	imageStore(x, ivec2(id), color);               \
+#define IMAGE_STORE(x) \
+	imageStore(x, ivec2(id), color); \
 	imageStore(x, ivec2(id) + ivec2(1, 0), color); \
 	imageStore(x, ivec2(id) + ivec2(0, 1), color); \
 	imageStore(x, ivec2(id) + ivec2(1, 1), color)

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
@@ -47,8 +47,7 @@ layout(OCTMAP_FORMAT, set = 2, binding = 5) uniform restrict writeonly image2D d
 layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	vec2 pad;
-}
-params;
+} params;
 
 #define BASE_RESOLUTION 320
 

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_filter_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_filter_raster.glsl
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -29,11 +28,9 @@ layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	int mip_level;
 	int pad;
-}
-params;
+} params;
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -3.0), vec2(-1.0, 1.0), vec2(3.0, 1.0));
@@ -41,7 +38,6 @@ void main() {
 	gl_Position = vec4(uv_interp, 0.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -54,15 +50,12 @@ layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	int mip_level;
 	int pad;
-}
-params;
+} params;
 
 layout(set = 0, binding = 0) uniform sampler2D source_octmap;
 
 layout(location = 0) in vec2 uv_interp;
 layout(location = 0) out vec4 frag_color;
-
-/* clang-format on */
 
 #ifdef USE_HIGH_QUALITY
 #define NUM_TAPS 32

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_inc.glsl
@@ -9,8 +9,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	bool use_direct_write;
 	uint pad;
-}
-params;
+} params;
 
 vec3 ImportanceSampleGGX(vec2 xi, float roughness4) {
 	// Compute distribution direction

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
@@ -1,4 +1,3 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -8,7 +7,6 @@
 #include "octmap_roughness_inc.glsl"
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
@@ -29,7 +27,6 @@ void main() {
 	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -44,7 +41,6 @@ layout(location = 0) in vec2 uv_interp;
 layout(set = 0, binding = 0) uniform sampler2D source_oct;
 
 layout(location = 0) out vec4 frag_color;
-/* clang-format on */
 
 void main() {
 	if (params.use_direct_write) {

--- a/servers/rendering/renderer_rd/shaders/effects/resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/resolve.glsl
@@ -29,8 +29,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	int sample_count;
 	uint pad;
-}
-params;
+} params;
 
 void main() {
 	// Pixel being shaded

--- a/servers/rendering/renderer_rd/shaders/effects/resolve_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/resolve_raster.glsl
@@ -1,4 +1,3 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
@@ -6,7 +5,6 @@
 #VERSION_DEFINES
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
@@ -14,7 +12,6 @@ void main() {
 	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -26,16 +23,15 @@ layout(location = 0) in vec2 uv_interp;
 layout(set = 0, binding = 0) uniform sampler2DMS source_depth;
 
 layout(push_constant, std430) uniform Params {
-    ivec2 pad;
+	ivec2 pad;
 	int sample_count;
-    int pad2;
-}
-params;
+	int pad2;
+} params;
 
-layout (location = 0) out float out_depth;
+layout(location = 0) out float out_depth;
 
 void main() {
-    ivec2 pos = ivec2(gl_FragCoord.xy);
+	ivec2 pos = ivec2(gl_FragCoord.xy);
 
 	float depth_avg = 0.0;
 	for (int i = 0; i < params.sample_count; i++) {

--- a/servers/rendering/renderer_rd/shaders/effects/roughness_limiter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/roughness_limiter.glsl
@@ -13,8 +13,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	float curve;
 	uint pad;
-}
-params;
+} params;
 
 #define HALF_PI 1.5707963267948966
 

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -17,8 +17,7 @@ layout(set = 0, binding = 5, std140) uniform SceneData {
 	mat4 inv_projection[2];
 	mat4 reprojection[2];
 	vec4 eye_offset[2];
-}
-scene_data;
+} scene_data;
 
 layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
@@ -32,8 +31,7 @@ layout(push_constant, std430) uniform Params {
 	int pad1;
 	int pad2;
 	int pad3;
-}
-params;
+} params;
 
 vec2 compute_cell_count(int level) {
 	int cell_count_x = max(1, params.screen_size.x >> level);

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_downsample.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_downsample.glsl
@@ -14,8 +14,7 @@ layout(rgba8, set = 0, binding = 3) uniform restrict writeonly image2D dest_norm
 layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	ivec2 pad;
-}
-params;
+} params;
 
 void get_sample(ivec2 sample_pos, inout float depth, inout ivec2 winner_sample_pos) {
 	float sample_depth = texelFetch(source_depth, sample_pos, 0).x;

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_filter.glsl
@@ -13,8 +13,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	uint mip_level;
 	int pad;
-}
-params;
+} params;
 
 shared vec4 cache[16][16];
 

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_hiz.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_hiz.glsl
@@ -12,8 +12,7 @@ layout(r32f, set = 0, binding = 1) uniform restrict writeonly image2D dest;
 layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	ivec2 pad;
-}
-params;
+} params;
 
 void main() {
 	ivec2 pixel_pos = ivec2(gl_GlobalInvocationID.xy);

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_resolve.glsl
@@ -17,8 +17,7 @@ layout(rgba16f, set = 0, binding = 6) uniform restrict writeonly image2D output_
 layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
 	ivec2 pad;
-}
-params;
+} params;
 
 void get_sample(float depth, vec3 normal, float roughness, ivec2 pixel_pos, out vec4 color, out float weight) {
 	float sample_depth = texelFetch(source_depth_half, pixel_pos, 0).x;

--- a/servers/rendering/renderer_rd/shaders/effects/shadow_frustum.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/shadow_frustum.glsl
@@ -1,17 +1,13 @@
-/* clang-format off */
 #[vertex]
 
 #version 450
 
 #VERSION_DEFINES
 
-/* clang-format on */
-
 layout(push_constant, std430) uniform Info {
 	mat4 mvp;
 	vec4 color;
-}
-info;
+} info;
 
 layout(location = 0) in vec3 vertex_attrib;
 
@@ -21,7 +17,6 @@ void main() {
 	gl_Position = vec4(vertex.xy, 0.0, 1.0);
 }
 
-/* clang-format off */
 #[fragment]
 
 #version 450
@@ -31,8 +26,7 @@ void main() {
 layout(push_constant, std430) uniform Info {
 	mat4 mvp;
 	vec4 color;
-}
-info;
+} info;
 
 layout(location = 0) out vec4 frag_color;
 

--- a/servers/rendering/renderer_rd/shaders/effects/smaa_blending.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/smaa_blending.glsl
@@ -35,8 +35,7 @@ layout(location = 1) out vec4 offset;
 layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
 	vec2 pad;
-}
-params;
+} params;
 
 void main() {
 	vec2 vertex_base;
@@ -69,8 +68,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
 	uint use_debanding;
 	float pad;
-}
-params;
+} params;
 
 #define textureLinear(tex, uv) srgb_to_linear(textureLod(tex, uv, 0.0).rgb)
 

--- a/servers/rendering/renderer_rd/shaders/effects/smaa_edge_detection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/smaa_edge_detection.glsl
@@ -36,8 +36,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
 	float threshold;
 	float reserved;
-}
-params;
+} params;
 
 void main() {
 	vec2 vertex_base;
@@ -70,8 +69,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
 	float threshold;
 	float reserved;
-}
-params;
+} params;
 
 #define SMAA_LOCAL_CONTRAST_ADAPTATION_FACTOR 2.0
 

--- a/servers/rendering/renderer_rd/shaders/effects/smaa_weight_calculation.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/smaa_weight_calculation.glsl
@@ -38,8 +38,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 size;
 
 	vec4 subsample_indices;
-}
-params;
+} params;
 
 #define SMAA_MAX_SEARCH_STEPS 32
 
@@ -79,8 +78,7 @@ layout(push_constant, std430) uniform Params {
 	ivec2 size;
 
 	vec4 subsample_indices;
-}
-params;
+} params;
 
 #define SMAA_MAX_SEARCH_STEPS 32
 #define SMAA_MAX_SEARCH_STEPS_DIAG 16

--- a/servers/rendering/renderer_rd/shaders/effects/sort.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/sort.glsl
@@ -44,15 +44,13 @@ shared vec2 g_LDS[SORT_SIZE];
 
 layout(set = 1, binding = 0, std430) restrict buffer SortBuffer {
 	vec2 data[];
-}
-sort_buffer;
+} sort_buffer;
 
 layout(push_constant, std430) uniform Params {
 	uint total_elements;
 	uint pad[3];
 	ivec4 job_params;
-}
-params;
+} params;
 
 void main() {
 #ifdef MODE_SORT_BLOCK

--- a/servers/rendering/renderer_rd/shaders/effects/ss_effects_downsample.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ss_effects_downsample.glsl
@@ -32,8 +32,7 @@ layout(push_constant, std430) uniform Params {
 	bool orthogonal;
 	float radius_sq;
 	uvec2 pad;
-}
-params;
+} params;
 
 layout(set = 0, binding = 0) uniform sampler2D source_depth;
 

--- a/servers/rendering/renderer_rd/shaders/effects/ssao.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssao.glsl
@@ -73,16 +73,14 @@ layout(set = 0, binding = 0) uniform sampler2DArray source_depth_mipmaps;
 layout(rgba8, set = 0, binding = 1) uniform restrict readonly image2D source_normal;
 layout(set = 0, binding = 2) uniform Constants { //get into a lower set
 	vec4 rotation_matrices[20];
-}
-constants;
+} constants;
 
 #ifdef ADAPTIVE
 layout(rg8, set = 1, binding = 0) uniform restrict readonly image2DArray source_ssao;
 layout(set = 1, binding = 1) uniform sampler2D source_importance;
 layout(set = 1, binding = 2, std430) buffer Counter {
 	uint sum;
-}
-counter;
+} counter;
 #endif
 
 layout(rg8, set = 2, binding = 0) uniform restrict writeonly image2D dest_image;
@@ -120,8 +118,7 @@ layout(push_constant, std430) uniform Params {
 
 	ivec2 pass_coord_offset;
 	vec2 pass_uv_offset;
-}
-params;
+} params;
 
 // packing/unpacking for edges; 2 bits per edge mean 4 gradient values (0, 0.33, 0.66, 1) for smoother transitions!
 float pack_edges(vec4 p_edgesLRTB) {

--- a/servers/rendering/renderer_rd/shaders/effects/ssao_blur.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssao_blur.glsl
@@ -33,8 +33,7 @@ layout(push_constant, std430) uniform Params {
 	float edge_sharpness;
 	float pad;
 	vec2 half_screen_pixel_size;
-}
-params;
+} params;
 
 vec4 unpack_edges(float p_packed_val) {
 	uint packed_val = uint(p_packed_val * 255.5);

--- a/servers/rendering/renderer_rd/shaders/effects/ssao_importance_map.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssao_importance_map.glsl
@@ -35,16 +35,14 @@ layout(r8, set = 1, binding = 0) uniform restrict writeonly image2D dest_image;
 #ifdef PROCESS_MAPB
 layout(set = 2, binding = 0, std430) buffer Counter {
 	uint sum;
-}
-counter;
+} counter;
 #endif
 
 layout(push_constant, std430) uniform Params {
 	vec2 half_screen_pixel_size;
 	float intensity;
 	float power;
-}
-params;
+} params;
 
 void main() {
 	// Pixel being shaded

--- a/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssao_interleave.glsl
@@ -31,8 +31,7 @@ layout(push_constant, std430) uniform Params {
 	float inv_sharpness;
 	uint size_modifier;
 	vec2 pixel_size;
-}
-params;
+} params;
 
 vec4 unpack_edges(float p_packed_val) {
 	uint packed_val = uint(p_packed_val * 255.5);

--- a/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
@@ -67,16 +67,14 @@ layout(set = 0, binding = 0) uniform sampler2DArray source_depth_mipmaps;
 layout(rgba8, set = 0, binding = 1) uniform restrict readonly image2D source_normal;
 layout(set = 0, binding = 2) uniform Constants { //get into a lower set
 	vec4 rotation_matrices[20];
-}
-constants;
+} constants;
 
 #ifdef ADAPTIVE
 layout(rgba16f, set = 1, binding = 0) uniform restrict readonly image2DArray source_ssil;
 layout(set = 1, binding = 1) uniform sampler2D source_importance;
 layout(set = 1, binding = 2, std430) buffer Counter {
 	uint sum;
-}
-counter;
+} counter;
 #endif
 
 layout(rgba16f, set = 2, binding = 0) uniform restrict writeonly image2D dest_image;
@@ -85,8 +83,7 @@ layout(r8, set = 2, binding = 1) uniform image2D edges_weights_image;
 layout(set = 3, binding = 0) uniform sampler2D last_frame;
 layout(set = 3, binding = 1) uniform ProjectionConstants {
 	mat4 reprojection;
-}
-projection_constants;
+} projection_constants;
 
 layout(push_constant, std430) uniform Params {
 	ivec2 screen_size;
@@ -120,8 +117,7 @@ layout(push_constant, std430) uniform Params {
 
 	ivec2 pass_coord_offset;
 	vec2 pass_uv_offset;
-}
-params;
+} params;
 
 float pack_edges(vec4 p_edgesLRTB) {
 	p_edgesLRTB = round(clamp(p_edgesLRTB, 0.0, 1.0) * 3.05);

--- a/servers/rendering/renderer_rd/shaders/effects/ssil_blur.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil_blur.glsl
@@ -36,8 +36,7 @@ layout(push_constant, std430) uniform Params {
 	float edge_sharpness;
 	float pad;
 	vec2 half_screen_pixel_size;
-}
-params;
+} params;
 
 vec4 unpack_edges(float p_packed_val) {
 	uint packed_val = uint(p_packed_val * 255.5);

--- a/servers/rendering/renderer_rd/shaders/effects/ssil_importance_map.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil_importance_map.glsl
@@ -36,16 +36,14 @@ layout(r8, set = 1, binding = 0) uniform restrict writeonly image2D dest_image;
 #ifdef PROCESS_MAPB
 layout(set = 2, binding = 0, std430) buffer Counter {
 	uint sum;
-}
-counter;
+} counter;
 #endif
 
 layout(push_constant, std430) uniform Params {
 	vec2 half_screen_pixel_size;
 	float intensity;
 	float pad;
-}
-params;
+} params;
 
 void main() {
 	// Pixel being shaded

--- a/servers/rendering/renderer_rd/shaders/effects/ssil_interleave.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil_interleave.glsl
@@ -34,8 +34,7 @@ layout(push_constant, std430) uniform Params {
 	float inv_sharpness;
 	uint size_modifier;
 	vec2 pixel_size;
-}
-params;
+} params;
 
 vec4 unpack_edges(float p_packed_val) {
 	uint packed_val = uint(p_packed_val * 255.5);

--- a/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
@@ -99,8 +99,7 @@ layout(push_constant, std430) uniform Params {
 
 	float depth_scale;
 	uint pad[3];
-}
-params;
+} params;
 
 layout(set = 0, binding = 0) uniform sampler2D source_image;
 layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2D dest_image;

--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -54,8 +54,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 resolution;
 	float disocclusion_threshold; // 0.1 / max(params.resolution.x, params.resolution.y)
 	float variance_dynamic;
-}
-params;
+} params;
 
 const ivec2 kOffsets3x3[9] = {
 	ivec2(-1, -1),

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -84,8 +84,7 @@ layout(push_constant, std430) uniform Params {
 	float luminance_multiplier;
 
 	vec4 tonemapper_params;
-}
-params;
+} params;
 
 layout(location = 0) out vec4 frag_color;
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
@@ -95,8 +95,7 @@ layout(push_constant, std430) uniform Params {
 
 	float output_max_value;
 	float pad[3];
-}
-params;
+} params;
 
 layout(location = 0) out vec4 frag_color;
 

--- a/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/vrs.glsl
@@ -20,8 +20,7 @@ layout(push_constant, std430) uniform Params {
 	float res1;
 	float res2;
 	float res3;
-}
-params;
+} params;
 
 void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
@@ -57,8 +56,7 @@ layout(push_constant, std430) uniform Params {
 	float res1;
 	float res2;
 	float res3;
-}
-params;
+} params;
 
 void main() {
 #ifdef USE_MULTIVIEW

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -74,8 +74,7 @@ layout(set = 0, binding = 15, std140) uniform SDFGI {
 	uint pad5;
 
 	ProbeCascadeData cascades[SDFGI_MAX_CASCADES];
-}
-sdfgi;
+} sdfgi;
 
 #define MAX_VOXEL_GI_INSTANCES 8
 
@@ -96,8 +95,7 @@ struct VoxelGIData {
 
 layout(set = 0, binding = 16, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
-}
-voxel_gi_instances;
+} voxel_gi_instances;
 
 layout(set = 0, binding = 17) uniform texture3D voxel_gi_textures[MAX_VOXEL_GI_INSTANCES];
 
@@ -109,8 +107,7 @@ layout(set = 0, binding = 18, std140) uniform SceneData {
 	ivec2 screen_size;
 	float pad1;
 	float pad2;
-}
-scene_data;
+} scene_data;
 
 #ifdef USE_VRS
 layout(r8ui, set = 0, binding = 19) uniform restrict readonly uimage2D vrs_buffer;
@@ -128,8 +125,7 @@ layout(push_constant, std430) uniform Params {
 	float z_far;
 	float pad2;
 	float pad3;
-}
-params;
+} params;
 
 vec2 octahedron_wrap(vec2 v) {
 	vec2 signVal;

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug.glsl
@@ -26,8 +26,7 @@ struct CascadeData {
 
 layout(set = 0, binding = 9, std140) uniform Cascades {
 	CascadeData data[MAX_CASCADES];
-}
-cascades;
+} cascades;
 
 layout(rgba16f, set = 0, binding = 10) uniform restrict writeonly image2D screen_buffer;
 
@@ -46,8 +45,7 @@ layout(push_constant, std430) uniform Params {
 	// We pack these more tightly than mat3 and vec3, which will require some reconstruction trickery.
 	float cam_basis[3][3];
 	float cam_origin[3];
-}
-params;
+} params;
 
 vec3 linear_to_srgb(vec3 color) {
 	const vec3 a = vec3(0.055f);

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug_probes.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_debug_probes.glsl
@@ -27,8 +27,7 @@ layout(push_constant, std430) uniform Params {
 	float y_mult;
 	uint probe_debug_index;
 	int probe_axis_size;
-}
-params;
+} params;
 
 // https://in4k.untergrund.net/html_articles/hugi_27_-_coding_corner_polaris_sphere_tessellation_101.htm
 
@@ -69,16 +68,14 @@ struct CascadeData {
 
 layout(set = 0, binding = 1, std140) uniform Cascades {
 	CascadeData data[MAX_CASCADES];
-}
-cascades;
+} cascades;
 
 layout(set = 0, binding = 4) uniform texture3D occlusion_texture;
 layout(set = 0, binding = 3) uniform sampler linear_sampler;
 
 layout(set = 0, binding = 5, std140) uniform SceneData {
 	mat4 projection[MAX_VIEWS];
-}
-scene_data;
+} scene_data;
 
 void main() {
 #ifdef MODE_PROBES
@@ -187,8 +184,7 @@ layout(push_constant, std430) uniform Params {
 	float y_mult;
 	uint probe_debug_index;
 	int probe_axis_size;
-}
-params;
+} params;
 
 #ifdef MODE_PROBES
 

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
@@ -17,8 +17,7 @@ layout(set = 0, binding = 4, std430) restrict readonly buffer DispatchData {
 	uint y;
 	uint z;
 	uint total_count;
-}
-dispatch_data;
+} dispatch_data;
 
 struct ProcessVoxel {
 	uint position; // xyz 7 bit packed, extra 11 bits for neighbors.
@@ -34,8 +33,7 @@ layout(set = 0, binding = 5, std430) restrict buffer ProcessVoxels {
 layout(set = 0, binding = 5, std430) restrict buffer readonly ProcessVoxels {
 #endif
 	ProcessVoxel data[];
-}
-process_voxels;
+} process_voxels;
 
 layout(r32ui, set = 0, binding = 6) uniform restrict uimage3D dst_light;
 layout(rgba8, set = 0, binding = 7) uniform restrict image3D dst_aniso0;
@@ -51,8 +49,7 @@ struct CascadeData {
 
 layout(set = 0, binding = 9, std140) uniform Cascades {
 	CascadeData data[MAX_CASCADES];
-}
-cascades;
+} cascades;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
 #define LIGHT_TYPE_OMNI 1
@@ -104,8 +101,7 @@ layout(push_constant, std430) uniform Params {
 	float bounce_feedback;
 	float y_mult;
 	bool use_occlusion;
-}
-params;
+} params;
 
 vec2 octahedron_wrap(vec2 v) {
 	vec2 signVal;

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
@@ -27,8 +27,7 @@ struct CascadeData {
 
 layout(set = 0, binding = 7, std140) uniform Cascades {
 	CascadeData data[MAX_CASCADES];
-}
-cascades;
+} cascades;
 
 layout(r32ui, set = 0, binding = 8) uniform restrict uimage2DArray lightprobe_texture_data;
 layout(rgba16i, set = 0, binding = 9) uniform restrict iimage2DArray lightprobe_history_texture;
@@ -80,8 +79,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 sky_irradiance_border_size;
 	bool store_ambient_texture;
 	uint pad;
-}
-params;
+} params;
 
 const float PI = 3.14159265f;
 const float GOLDEN_ANGLE = PI * (3.0 - sqrt(5.0));
@@ -292,9 +290,9 @@ void main() {
 
 		vec3 ray_dir2 = ray_dir * ray_dir;
 
-#define SH_ACCUM(m_idx, m_value)                       \
-	{                                                  \
-		vec3 l = light.rgb * (m_value);                \
+#define SH_ACCUM(m_idx, m_value) \
+	{ \
+		vec3 l = light.rgb * (m_value); \
 		sh_accum[probe_index].c[m_idx * 3 + 0] += l.r; \
 		sh_accum[probe_index].c[m_idx * 3 + 1] += l.g; \
 		sh_accum[probe_index].c[m_idx * 3 + 2] += l.b; \

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
@@ -27,8 +27,7 @@ struct CascadeData {
 
 layout(set = 0, binding = 7, std140) uniform Cascades {
 	CascadeData data[MAX_CASCADES];
-}
-cascades;
+} cascades;
 
 layout(r32ui, set = 0, binding = 8) uniform restrict uimage2DArray lightprobe_texture_data;
 layout(rgba16i, set = 0, binding = 9) uniform restrict iimage2DArray lightprobe_history_texture;
@@ -80,8 +79,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 sky_irradiance_border_size;
 	bool store_ambient_texture;
 	uint pad;
-}
-params;
+} params;
 
 const float PI = 3.14159265f;
 const float GOLDEN_ANGLE = PI * (3.0 - sqrt(5.0));

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_preprocess.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_preprocess.glsl
@@ -97,8 +97,7 @@ layout(set = 0, binding = 10, std430) restrict buffer DispatchData {
 	uint y;
 	uint z;
 	uint total_count;
-}
-dispatch_data;
+} dispatch_data;
 
 struct ProcessVoxel {
 	uint position; // xyz 7 bit packed, extra 11 bits for neighbors.
@@ -110,8 +109,7 @@ struct ProcessVoxel {
 
 layout(set = 0, binding = 11, std430) restrict buffer writeonly ProcessVoxels {
 	ProcessVoxel data[];
-}
-dst_process_voxels;
+} dst_process_voxels;
 
 shared ProcessVoxel store_positions[4 * 4 * 4];
 shared uint store_position_count;
@@ -130,8 +128,7 @@ layout(set = 0, binding = 5, std430) restrict buffer readonly DispatchData {
 	uint y;
 	uint z;
 	uint total_count;
-}
-dispatch_data;
+} dispatch_data;
 
 struct ProcessVoxel {
 	uint position; // xyz 7 bit packed, extra 11 bits for neighbors.
@@ -143,8 +140,7 @@ struct ProcessVoxel {
 
 layout(set = 0, binding = 6, std430) restrict buffer readonly ProcessVoxels {
 	ProcessVoxel data[];
-}
-src_process_voxels;
+} src_process_voxels;
 
 #endif
 
@@ -167,8 +163,7 @@ layout(push_constant, std430) uniform Params {
 	uint occlusion_index;
 	int cascade;
 	uint pad;
-}
-params;
+} params;
 
 void main() {
 #ifdef MODE_SCROLL

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -14,8 +14,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 pad;
 	float luminance_multiplier;
 	float brightness_multiplier;
-}
-params;
+} params;
 
 void main() {
 	vec2 base_arr[3] = vec2[](vec2(-1.0, -3.0), vec2(-1.0, 1.0), vec2(3.0, 1.0));
@@ -48,15 +47,13 @@ layout(push_constant, std430) uniform Params {
 	vec2 border_size;
 	float luminance_multiplier;
 	float brightness_multiplier;
-}
-params;
+} params;
 
 #include "../samplers_inc.glsl"
 
 layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 layout(set = 0, binding = 2, std140) uniform SkySceneData {
 	mat4 combined_reprojection[2];
@@ -80,8 +77,7 @@ layout(set = 0, binding = 2, std140) uniform SkySceneData {
 	uint directional_light_count; // 4 - 56
 	bool fog_use_legacy_blending; // 4 - 60
 	uint pad1; // 4 - 64
-}
-sky_scene_data;
+} sky_scene_data;
 
 struct DirectionalLightData {
 	vec4 direction_energy;
@@ -91,15 +87,12 @@ struct DirectionalLightData {
 
 layout(set = 0, binding = 3, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 layout(set = 2, binding = 0) uniform texture2D radiance;

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -21,8 +21,7 @@ layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 layout(push_constant, std430) uniform Params {
 	vec3 position;
@@ -35,15 +34,14 @@ layout(push_constant, std430) uniform Params {
 	uint shape;
 
 	mat4 transform;
-}
-params;
+} params;
 
 #ifdef NO_IMAGE_ATOMICS
 layout(set = 1, binding = 1) volatile buffer emissive_only_map_buffer {
 	uint emissive_only_map[];
 };
 #else
-layout(r32ui, set = 1, binding = 1) uniform volatile uimage3D emissive_only_map;
+layout(r32ui, set = 1, binding = 1) volatile uniform uimage3D emissive_only_map;
 #endif
 
 layout(set = 1, binding = 2, std140) uniform SceneParams {
@@ -65,8 +63,7 @@ layout(set = 1, binding = 2, std140) uniform SceneParams {
 
 	mat4 to_prev_view;
 	mat4 transform;
-}
-scene_params;
+} scene_params;
 
 #ifdef NO_IMAGE_ATOMICS
 layout(set = 1, binding = 3) volatile buffer density_only_map_buffer {
@@ -76,16 +73,14 @@ layout(set = 1, binding = 4) volatile buffer light_only_map_buffer {
 	uint light_only_map[];
 };
 #else
-layout(r32ui, set = 1, binding = 3) uniform volatile uimage3D density_only_map;
-layout(r32ui, set = 1, binding = 4) uniform volatile uimage3D light_only_map;
+layout(r32ui, set = 1, binding = 3) volatile uniform uimage3D density_only_map;
+layout(r32ui, set = 1, binding = 4) volatile uniform uimage3D light_only_map;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 2, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -21,8 +21,7 @@ layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 layout(push_constant, std430) uniform Params {
 	vec3 position;
@@ -35,8 +34,7 @@ layout(push_constant, std430) uniform Params {
 	uint shape;
 
 	mat4 transform;
-}
-params;
+} params;
 
 #ifdef NO_IMAGE_ATOMICS
 layout(set = 1, binding = 1) volatile buffer emissive_only_map_buffer {
@@ -65,8 +63,7 @@ layout(set = 1, binding = 2, std140) uniform SceneParams {
 
 	mat4 to_prev_view;
 	mat4 transform;
-}
-scene_params;
+} scene_params;
 
 #ifdef NO_IMAGE_ATOMICS
 layout(set = 1, binding = 3) volatile buffer density_only_map_buffer {
@@ -81,11 +78,9 @@ layout(r32ui, set = 1, binding = 4) volatile uniform uimage3D light_only_map;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 2, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -14,11 +14,10 @@ layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 #endif
 
+#include "../area_lights_inc.glsl"
 #include "../cluster_data_inc.glsl"
 #include "../light_data_inc.glsl"
 #include "../oct_inc.glsl"
-
-#include "../area_lights_inc.glsl"
 
 #define M_TAU 6.28318530718
 #define M_PI 3.14159265359
@@ -30,23 +29,19 @@ layout(set = 0, binding = 2) uniform texture2D directional_shadow_atlas;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 layout(set = 0, binding = 7, std430) buffer restrict readonly ClusterBuffer {
 	uint data[];
@@ -95,8 +90,7 @@ struct VoxelGIData {
 
 layout(set = 0, binding = 12, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
-}
-voxel_gi_instances;
+} voxel_gi_instances;
 
 layout(set = 0, binding = 13) uniform texture3D voxel_gi_textures[MAX_VOXEL_GI_INSTANCES];
 
@@ -141,8 +135,7 @@ layout(set = 1, binding = 0, std140) uniform SDFGI {
 	uint pad5;
 
 	SDFVoxelGICascadeData cascades[SDFGI_MAX_CASCADES];
-}
-sdfgi;
+} sdfgi;
 
 layout(set = 1, binding = 1) uniform texture2DArray sdfgi_ambient_texture;
 
@@ -192,8 +185,7 @@ layout(set = 0, binding = 15, std140) uniform Params {
 	mat4 to_prev_view;
 
 	mat3 radiance_inverse_xform;
-}
-params;
+} params;
 #ifndef MODE_COPY
 layout(set = 0, binding = 16) uniform texture3D prev_density_texture;
 

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -29,23 +29,19 @@ layout(set = 0, binding = 2) uniform texture2D directional_shadow_atlas;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 layout(set = 0, binding = 7, std430) buffer restrict readonly ClusterBuffer {
 	uint data[];
@@ -94,8 +90,7 @@ struct VoxelGIData {
 
 layout(set = 0, binding = 12, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
-}
-voxel_gi_instances;
+} voxel_gi_instances;
 
 layout(set = 0, binding = 13) uniform texture3D voxel_gi_textures[MAX_VOXEL_GI_INSTANCES];
 
@@ -140,8 +135,7 @@ layout(set = 1, binding = 0, std140) uniform SDFGI {
 	uint pad5;
 
 	SDFVoxelGICascadeData cascades[SDFGI_MAX_CASCADES];
-}
-sdfgi;
+} sdfgi;
 
 layout(set = 1, binding = 1) uniform texture2DArray sdfgi_ambient_texture;
 
@@ -191,8 +185,7 @@ layout(set = 0, binding = 15, std140) uniform Params {
 	mat4 to_prev_view;
 
 	mat3 radiance_inverse_xform;
-}
-params;
+} params;
 #ifndef MODE_COPY
 layout(set = 0, binding = 16) uniform texture3D prev_density_texture;
 

--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
@@ -20,8 +20,7 @@ struct CellChildren {
 
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
-}
-cell_children;
+} cell_children;
 
 struct CellData {
 	uint position; // xyz 10 bits
@@ -32,8 +31,7 @@ struct CellData {
 
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
-}
-cell_data;
+} cell_data;
 
 #endif // MODE DYNAMIC
 
@@ -68,8 +66,7 @@ struct Light {
 
 layout(set = 0, binding = 3, std140) uniform Lights {
 	Light data[MAX_LIGHTS];
-}
-lights;
+} lights;
 
 layout(set = 1, binding = 0) uniform texture2D area_light_atlas;
 
@@ -96,13 +93,11 @@ layout(push_constant, std430) uniform Params {
 	uint cell_count;
 	float aniso_strength;
 	float cell_size;
-}
-params;
+} params;
 
 layout(set = 0, binding = 4, std430) buffer Outputs {
 	vec4 data[];
-}
-outputs;
+} outputs;
 
 #endif // MODE DYNAMIC
 
@@ -137,8 +132,7 @@ layout(push_constant, std430) uniform Params {
 	float propagation;
 	float cell_size;
 	float pad[2];
-}
-params;
+} params;
 
 #ifdef MODE_DYNAMIC_LIGHTING
 

--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi_debug.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi_debug.glsl
@@ -13,8 +13,7 @@ struct CellData {
 
 layout(set = 0, binding = 1, std140) buffer CellDataBuffer {
 	CellData data[];
-}
-cell_data;
+} cell_data;
 
 layout(set = 0, binding = 2) uniform texture3D color_tex;
 
@@ -28,8 +27,7 @@ layout(push_constant, std430) uniform Params {
 	uint level;
 	ivec3 bounds;
 	uint pad;
-}
-params;
+} params;
 
 layout(location = 0) out vec4 color_interp;
 

--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi_sdf.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi_sdf.glsl
@@ -16,8 +16,7 @@ struct CellChildren {
 
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
-}
-cell_children;
+} cell_children;
 
 struct CellData {
 	uint position; // xyz 10 bits
@@ -28,8 +27,7 @@ struct CellData {
 
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
-}
-cell_data;
+} cell_data;
 
 layout(r8ui, set = 0, binding = 3) uniform restrict writeonly uimage3D sdf_tex;
 
@@ -38,8 +36,7 @@ layout(push_constant, std430) uniform Params {
 	uint end;
 	uint pad0;
 	uint pad1;
-}
-params;
+} params;
 
 void main() {
 	vec3 pos = vec3(gl_GlobalInvocationID);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -6,7 +6,6 @@
 
 /* Include half precision types. */
 #include "../half_inc.glsl"
-
 #include "scene_forward_clustered_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -118,11 +117,9 @@ layout(location = 8) out vec4 prev_screen_position;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 float global_time;
@@ -877,7 +874,6 @@ void main() {
 
 /* Include half precision types. */
 #include "../half_inc.glsl"
-
 #include "scene_forward_clustered_inc.glsl"
 
 /* Varyings */
@@ -1025,11 +1021,9 @@ layout(location = 14) in vec2 point_coord_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS
@@ -1080,9 +1074,8 @@ layout(location = 2) out vec2 motion_vector;
 #define SPECULAR_SCHLICK_GGX
 #endif
 
-#include "../scene_forward_lights_inc.glsl"
-
 #include "../scene_forward_gi_inc.glsl"
+#include "../scene_forward_lights_inc.glsl"
 
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
@@ -2346,10 +2339,10 @@ void fragment_shader(in SceneData scene_data) {
 					vec3 light_dir = directional_lights.data[i].direction;
 					vec3 base_normal_bias = geo_normal * (1.0 - max(0.0, dot(light_dir, -geo_normal)));
 
-#define BIAS_FUNC(m_var, m_idx)                                                                 \
-	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
+#define BIAS_FUNC(m_var, m_idx) \
+	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx]; \
 	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
+	normal_bias -= light_dir * dot(light_dir, normal_bias); \
 	m_var.xyz += normal_bias;
 
 					//version with soft shadows, more expensive

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -117,11 +117,9 @@ layout(location = 8) out vec4 prev_screen_position;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 float global_time;
@@ -989,11 +987,9 @@ layout(location = 14) in vec2 point_coord_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -34,8 +34,7 @@ layout(push_constant, std430) uniform DrawCall {
 	uint sc_packed_2;
 	uint uc_packed_0;
 #endif
-}
-draw_call;
+} draw_call;
 
 /* Specialization Constants */
 
@@ -196,28 +195,23 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std430) restrict readonly buffer ReflectionProbeData {
 	ReflectionData data[];
-}
-reflections;
+} reflections;
 
 layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #define LIGHTMAP_FLAG_USE_DIRECTION 1
 #define LIGHTMAP_FLAG_USE_SPECULAR_DIRECTION 2
@@ -236,8 +230,7 @@ struct Lightmap {
 
 layout(set = 0, binding = 8, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
-}
-lightmaps;
+} lightmaps;
 
 struct LightmapCapture {
 	vec4 sh[9];
@@ -245,21 +238,18 @@ struct LightmapCapture {
 
 layout(set = 0, binding = 9, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
-}
-lightmap_captures;
+} lightmap_captures;
 
 layout(set = 0, binding = 10) uniform texture2D decal_atlas;
 layout(set = 0, binding = 11) uniform texture2D decal_atlas_srgb;
 
 layout(set = 0, binding = 12, std430) restrict readonly buffer Decals {
 	DecalData data[];
-}
-decals;
+} decals;
 
 layout(set = 0, binding = 13, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 struct SDFVoxelGICascadeData {
 	vec3 position;
@@ -295,8 +285,7 @@ layout(set = 0, binding = 14, std140) uniform SDFGI {
 	uint pad5;
 
 	SDFVoxelGICascadeData cascades[SDFGI_MAX_CASCADES];
-}
-sdfgi;
+} sdfgi;
 
 layout(set = 0, binding = 15) uniform sampler DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
 
@@ -314,8 +303,7 @@ layout(set = 0, binding = 20) uniform texture2D area_light_atlas;
 layout(set = 1, binding = 0, std140) uniform SceneDataBlock {
 	SceneData data;
 	SceneData prev_data;
-}
-scene_data_block;
+} scene_data_block;
 
 struct ImplementationData {
 	uint cluster_shift;
@@ -344,8 +332,7 @@ struct ImplementationData {
 
 layout(set = 1, binding = 1, std140) uniform ImplementationDataBlock {
 	ImplementationData data;
-}
-implementation_data_block;
+} implementation_data_block;
 
 #define implementation_data implementation_data_block.data
 
@@ -465,8 +452,7 @@ struct VoxelGIData {
 
 layout(set = 1, binding = 32, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
-}
-voxel_gi_instances;
+} voxel_gi_instances;
 
 layout(set = 1, binding = 33) uniform texture3D volumetric_fog_texture;
 
@@ -507,7 +493,6 @@ vec3 get_energy_compensation(vec3 f0, float env) {
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
-}
-transforms;
+} transforms;
 
 /* Set 3 User Material */

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -34,8 +34,7 @@ layout(push_constant, std430) uniform DrawCall {
 	uint sc_packed_2;
 	uint uc_packed_0;
 #endif
-}
-draw_call;
+} draw_call;
 
 /* Specialization Constants */
 
@@ -204,28 +203,23 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std430) restrict readonly buffer ReflectionProbeData {
 	ReflectionData data[];
-}
-reflections;
+} reflections;
 
 layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #define LIGHTMAP_FLAG_USE_DIRECTION 1
 #define LIGHTMAP_FLAG_USE_SPECULAR_DIRECTION 2
@@ -244,8 +238,7 @@ struct Lightmap {
 
 layout(set = 0, binding = 8, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
-}
-lightmaps;
+} lightmaps;
 
 struct LightmapCapture {
 	vec4 sh[9];
@@ -253,21 +246,18 @@ struct LightmapCapture {
 
 layout(set = 0, binding = 9, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
-}
-lightmap_captures;
+} lightmap_captures;
 
 layout(set = 0, binding = 10) uniform texture2D decal_atlas;
 layout(set = 0, binding = 11) uniform texture2D decal_atlas_srgb;
 
 layout(set = 0, binding = 12, std430) restrict readonly buffer Decals {
 	DecalData data[];
-}
-decals;
+} decals;
 
 layout(set = 0, binding = 13, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 struct SDFVoxelGICascadeData {
 	vec3 position;
@@ -303,8 +293,7 @@ layout(set = 0, binding = 14, std140) uniform SDFGI {
 	uint pad5;
 
 	SDFVoxelGICascadeData cascades[SDFGI_MAX_CASCADES];
-}
-sdfgi;
+} sdfgi;
 
 layout(set = 0, binding = 15) uniform sampler DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
 
@@ -322,8 +311,7 @@ layout(set = 0, binding = 20) uniform texture2D area_light_atlas;
 layout(set = 1, binding = 0, std140) uniform SceneDataBlock {
 	SceneData data;
 	SceneData prev_data;
-}
-scene_data_block;
+} scene_data_block;
 
 struct ImplementationData {
 	uint cluster_shift;
@@ -352,8 +340,7 @@ struct ImplementationData {
 
 layout(set = 1, binding = 1, std140) uniform ImplementationDataBlock {
 	ImplementationData data;
-}
-implementation_data_block;
+} implementation_data_block;
 
 #define implementation_data implementation_data_block.data
 
@@ -474,8 +461,7 @@ struct VoxelGIData {
 
 layout(set = 1, binding = 32, std140) uniform VoxelGIs {
 	VoxelGIData data[MAX_VOXEL_GI_INSTANCES];
-}
-voxel_gi_instances;
+} voxel_gi_instances;
 
 layout(set = 1, binding = 33) uniform texture3D volumetric_fog_texture;
 
@@ -524,7 +510,6 @@ material_feedback;
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
-}
-transforms;
+} transforms;
 
 /* Set 3 User Material */

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -125,11 +125,9 @@ layout(location = 8) out vec4 specular_light_interp;
 #include "../scene_forward_vertex_lights_inc.glsl"
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #ifdef MODE_DUAL_PARABOLOID
@@ -988,18 +986,14 @@ layout(location = 14) in vec2 point_coord_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS
 
 #define scene_data scene_data_block.data
-
-/* clang-format on */
 
 #ifdef MODE_RENDER_DEPTH
 
@@ -1981,10 +1975,10 @@ void main() {
 					hvec3 light_dir = hvec3(directional_lights.data[i].direction);
 					hvec3 base_normal_bias = geo_normal * (half(1.0) - max(half(0.0), dot(light_dir, -geo_normal)));
 
-#define BIAS_FUNC(m_var, m_idx)                                                                        \
+#define BIAS_FUNC(m_var, m_idx) \
 	hvec3 normal_bias = base_normal_bias * half(directional_lights.data[i].shadow_normal_bias[m_idx]); \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                            \
-	normal_bias += light_dir * half(directional_lights.data[i].shadow_bias[m_idx]);                    \
+	normal_bias -= light_dir * dot(light_dir, normal_bias); \
+	normal_bias += light_dir * half(directional_lights.data[i].shadow_bias[m_idx]); \
 	m_var.xyz += vec3(normal_bias);
 
 					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -125,11 +125,9 @@ layout(location = 8) out vec4 specular_light_interp;
 #include "../scene_forward_vertex_lights_inc.glsl"
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #ifdef MODE_DUAL_PARABOLOID
@@ -961,18 +959,14 @@ layout(location = 14) in vec2 point_coord_interp;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 #GLOBALS
 
 #define scene_data scene_data_block.data
-
-/* clang-format on */
 
 #ifdef MODE_RENDER_DEPTH
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -24,8 +24,7 @@ layout(push_constant, std430) uniform DrawCall {
 	float sc_packed_2;
 	uint uc_packed_0;
 #endif
-}
-draw_call;
+} draw_call;
 
 /* Specialization Constants */
 
@@ -260,28 +259,23 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std430) restrict readonly buffer ReflectionProbeData {
 	ReflectionData data[];
-}
-reflections;
+} reflections;
 
 layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #define LIGHTMAP_FLAG_USE_DIRECTION 1
 #define LIGHTMAP_FLAG_USE_SPECULAR_DIRECTION 2
@@ -300,8 +294,7 @@ struct Lightmap {
 
 layout(set = 0, binding = 8, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
-}
-lightmaps;
+} lightmaps;
 
 struct LightmapCapture {
 	vec4 sh[9];
@@ -309,21 +302,18 @@ struct LightmapCapture {
 
 layout(set = 0, binding = 9, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
-}
-lightmap_captures;
+} lightmap_captures;
 
 layout(set = 0, binding = 10) uniform texture2D decal_atlas;
 layout(set = 0, binding = 11) uniform texture2D decal_atlas_srgb;
 
 layout(set = 0, binding = 12, std430) restrict readonly buffer Decals {
 	DecalData data[];
-}
-decals;
+} decals;
 
 layout(set = 0, binding = 13, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 layout(set = 0, binding = 14) uniform sampler DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
 
@@ -338,8 +328,7 @@ layout(set = 0, binding = 17) uniform texture2D area_light_atlas;
 layout(set = 1, binding = 0, std140) uniform SceneDataBlock {
 	SceneData data;
 	SceneData prev_data;
-}
-scene_data_block;
+} scene_data_block;
 
 struct InstanceData {
 	highp mat3x4 transform;
@@ -420,7 +409,6 @@ layout(set = 1, binding = 13 + 11) uniform sampler SAMPLER_LINEAR_WITH_MIPMAPS_A
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
-}
-transforms;
+} transforms;
 
 /* Set 3 User Material */

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -24,8 +24,7 @@ layout(push_constant, std430) uniform DrawCall {
 	float sc_packed_2;
 	uint uc_packed_0;
 #endif
-}
-draw_call;
+} draw_call;
 
 /* Specialization Constants */
 
@@ -268,28 +267,23 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
 layout(set = 0, binding = 3, std430) restrict readonly buffer OmniLights {
 	LightData data[];
-}
-omni_lights;
+} omni_lights;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer SpotLights {
 	LightData data[];
-}
-spot_lights;
+} spot_lights;
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer AreaLights {
 	LightData data[];
-}
-area_lights;
+} area_lights;
 
 layout(set = 0, binding = 6, std430) restrict readonly buffer ReflectionProbeData {
 	ReflectionData data[];
-}
-reflections;
+} reflections;
 
 layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
-}
-directional_lights;
+} directional_lights;
 
 #define LIGHTMAP_FLAG_USE_DIRECTION 1
 #define LIGHTMAP_FLAG_USE_SPECULAR_DIRECTION 2
@@ -308,8 +302,7 @@ struct Lightmap {
 
 layout(set = 0, binding = 8, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
-}
-lightmaps;
+} lightmaps;
 
 struct LightmapCapture {
 	vec4 sh[9];
@@ -317,21 +310,18 @@ struct LightmapCapture {
 
 layout(set = 0, binding = 9, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
-}
-lightmap_captures;
+} lightmap_captures;
 
 layout(set = 0, binding = 10) uniform texture2D decal_atlas;
 layout(set = 0, binding = 11) uniform texture2D decal_atlas_srgb;
 
 layout(set = 0, binding = 12, std430) restrict readonly buffer Decals {
 	DecalData data[];
-}
-decals;
+} decals;
 
 layout(set = 0, binding = 13, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 layout(set = 0, binding = 14) uniform sampler DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP;
 
@@ -346,8 +336,7 @@ layout(set = 0, binding = 17) uniform texture2D area_light_atlas;
 layout(set = 1, binding = 0, std140) uniform SceneDataBlock {
 	SceneData data;
 	SceneData prev_data;
-}
-scene_data_block;
+} scene_data_block;
 
 struct InstanceData {
 	highp mat3x4 transform;
@@ -437,7 +426,6 @@ material_feedback;
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
-}
-transforms;
+} transforms;
 
 /* Set 3 User Material */

--- a/servers/rendering/renderer_rd/shaders/giprobe_write.glsl
+++ b/servers/rendering/renderer_rd/shaders/giprobe_write.glsl
@@ -14,8 +14,7 @@ struct CellChildren {
 
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
-}
-cell_children;
+} cell_children;
 
 struct CellData {
 	uint position; // xyz 10 bits
@@ -26,8 +25,7 @@ struct CellData {
 
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
-}
-cell_data;
+} cell_data;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
 #define LIGHT_TYPE_OMNI 1
@@ -53,8 +51,7 @@ struct Light {
 
 layout(set = 0, binding = 3, std140) uniform Lights {
 	Light data[MAX_LIGHTS];
-}
-lights;
+} lights;
 
 #endif
 
@@ -70,13 +67,11 @@ layout(push_constant, std430) uniform Params {
 	uint cell_offset;
 	uint cell_count;
 	uint pad[2];
-}
-params;
+} params;
 
 layout(set = 0, binding = 4, std140) uniform Outputs {
 	vec4 data[];
-}
-output;
+} output;
 
 #ifdef MODE_COMPUTE_LIGHT
 

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -14,8 +14,7 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
-}
-global_shader_uniforms;
+} global_shader_uniforms;
 
 /* Set 1: FRAME AND PARTICLE DATA */
 
@@ -86,8 +85,7 @@ struct FrameParams {
 
 layout(set = 1, binding = 0, std430) restrict buffer FrameHistory {
 	FrameParams data[];
-}
-frame_history;
+} frame_history;
 
 #define PARTICLE_FLAG_ACTIVE uint(1)
 #define PARTICLE_FLAG_STARTED uint(2)
@@ -123,8 +121,7 @@ struct ParticleData {
 
 layout(set = 1, binding = 1, std430) restrict buffer Particles {
 	ParticleData data[];
-}
-particles;
+} particles;
 
 #define EMISSION_FLAG_HAS_POSITION 1
 #define EMISSION_FLAG_HAS_ROTATION_SCALE 2
@@ -146,8 +143,7 @@ layout(set = 1, binding = 2, std430) restrict buffer SourceEmission {
 	uint pad1;
 	uint pad2;
 	ParticleEmission data[];
-}
-src_particles;
+} src_particles;
 
 layout(set = 1, binding = 3, std430) restrict buffer DestEmission {
 	int particle_count;
@@ -155,8 +151,7 @@ layout(set = 1, binding = 3, std430) restrict buffer DestEmission {
 	uint pad1;
 	uint pad2;
 	ParticleEmission data[];
-}
-dst_particles;
+} dst_particles;
 
 /* SET 2: COLLIDER/ATTRACTOR TEXTURES */
 
@@ -168,11 +163,9 @@ layout(set = 2, binding = 1) uniform texture2D height_field_texture;
 /* SET 3: MATERIAL */
 
 #ifdef MATERIAL_UNIFORMS_USED
-/* clang-format off */
 layout(set = 3, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
-/* clang-format on */
 #endif
 
 layout(push_constant, std430) uniform Params {
@@ -184,8 +177,7 @@ layout(push_constant, std430) uniform Params {
 	bool sub_emitter_mode;
 	bool can_emit;
 	bool trail_pass;
-}
-params;
+} params;
 
 uint hash(uint x) {
 	x = ((x >> uint(16)) ^ x) * uint(0x45d9f3b);

--- a/servers/rendering/renderer_rd/shaders/particles_copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles_copy.glsl
@@ -23,27 +23,23 @@ struct ParticleData {
 
 layout(set = 0, binding = 1, std430) restrict readonly buffer Particles {
 	ParticleData data[];
-}
-particles;
+} particles;
 
 layout(set = 0, binding = 2, std430) restrict writeonly buffer Transforms {
 	vec4 data[];
-}
-instances;
+} instances;
 
 #ifdef USE_SORT_BUFFER
 
 layout(set = 1, binding = 0, std430) restrict buffer SortBuffer {
 	vec2 data[];
-}
-sort_buffer;
+} sort_buffer;
 
 #endif // USE_SORT_BUFFER
 
 layout(set = 2, binding = 0, std430) restrict readonly buffer TrailBindPoses {
 	mat4 data[];
-}
-trail_bind_poses;
+} trail_bind_poses;
 
 #define PARAMS_FLAG_ORDER_BY_LIFETIME 1
 #define PARAMS_FLAG_COPY_MODE_2D 2
@@ -71,8 +67,7 @@ layout(push_constant, std430) uniform Params {
 	uint align_axis;
 	uint pad1;
 	uint pad2;
-}
-params;
+} params;
 
 #define ALIGN_DISABLED 0
 #define ALIGN_BILLBOARD 1

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -280,7 +280,6 @@ void light_compute(hvec3 N, hvec3 L, hvec3 V, half A, hvec3 light_color, bool is
 			half D = D_GGX(cNdotH, alpha_ggx, N, H);
 			half G = V_GGX(cNdotL, cNdotV, alpha_ggx);
 #endif // LIGHT_ANISOTROPY_USED
-	   // F
 #if !defined(LIGHT_CLEARCOAT_USED)
 			half cLdotH5 = SchlickFresnel(cLdotH);
 #endif

--- a/servers/rendering/renderer_rd/shaders/skeleton.glsl
+++ b/servers/rendering/renderer_rd/shaders/skeleton.glsl
@@ -60,8 +60,7 @@ layout(push_constant, std430) uniform Params {
 
 	vec2 inverse_transform_y;
 	vec2 inverse_transform_offset;
-}
-params;
+} params;
 
 vec2 uint_to_vec2(uint base) {
 	uvec2 decode = (uvec2(base) >> uvec2(0, 16)) & uvec2(0xFFFF, 0xFFFF);

--- a/servers/rendering/renderer_rd/shaders/tex_blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/tex_blit.glsl
@@ -1,5 +1,3 @@
-/* clang-format off */
-
 #[vertex]
 
 #version 450
@@ -21,7 +19,7 @@ void main() {
 	uv = base_arr[gl_VertexIndex];
 	// gl_Position = vec4(uv * 2.0 - 1.0, 0.0, 1.0);
 
-	gl_Position = vec4( (data.offset + (uv * data.size)) * 2.0 - 1.0, 1.0, 1.0);
+	gl_Position = vec4((data.offset + (uv * data.size)) * 2.0 - 1.0, 1.0, 1.0);
 }
 
 #[fragment]
@@ -56,18 +54,18 @@ layout(set = 0, binding = 3) uniform texture2D source3;
 
 layout(location = 0) in vec2 uv;
 
-layout (location = 0) out vec4 out_color0;
+layout(location = 0) out vec4 out_color0;
 
 #ifdef USE_OUTPUT1
-layout (location = 1) out vec4 out_color1;
+layout(location = 1) out vec4 out_color1;
 #endif
 
 #ifdef USE_OUTPUT2
-layout (location = 2) out vec4 out_color2;
+layout(location = 2) out vec4 out_color2;
 #endif
 
 #ifdef USE_OUTPUT3
-layout (location = 3) out vec4 out_color3;
+layout(location = 3) out vec4 out_color3;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED


### PR DESCRIPTION
## What problem(s) does this PR solve?

Removes inconsistent logic across our `clang-format` jobs, unifying all relevant logic and explaining any differences.

## Additional information

Removed the need for us to explicitly disable semicolon checks, as `uniform`/`buffer` are both properly recognized as object containers. Also disabled comment reflow changes, as the files expect `ubo:#` to be positioned consistently.

This also unfortunately makes the processing time for `scene.glsl` even longer, though that's an existing problem; see [this RC thread](https://chat.godotengine.org/channel/buildsystem?msg=9dsr72sfBLFSWh9bv) for more details.