### PR TITLE
Fix `RichTextLabel` nesting with `[font_size][p]`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3976,7 +3976,7 @@ Color RichTextLabel::_find_fgcolor(Item *p_item) {
 
 bool RichTextLabel::_find_layout_subitem(Item *from, Item *to) {
 	if (from && from != to) {
-		if (from->type != ITEM_FONT && from->type != ITEM_COLOR && from->type != ITEM_UNDERLINE && from->type != ITEM_STRIKETHROUGH && from->type != ITEM_INDENT) {
+		if (from->type != ITEM_FONT && from->type != ITEM_FONT_SIZE && from->type != ITEM_COLOR && from->type != ITEM_UNDERLINE && from->type != ITEM_STRIKETHROUGH && from->type != ITEM_INDENT) {
 			return true;
 		}
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3972,7 +3972,7 @@ Color RichTextLabel::_find_fgcolor(Item *p_item) {
 
 bool RichTextLabel::_find_layout_subitem(Item *from, Item *to) {
 	if (from && from != to) {
-		if (from->type != ITEM_FONT && from->type != ITEM_COLOR && from->type != ITEM_UNDERLINE && from->type != ITEM_STRIKETHROUGH && from->type != ITEM_INDENT) {
+		if (from->type != ITEM_FONT && from->type != ITEM_FONT_SIZE && from->type != ITEM_COLOR && from->type != ITEM_UNDERLINE && from->type != ITEM_STRIKETHROUGH && from->type != ITEM_INDENT) {
 			return true;
 		}
 

--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -137,6 +137,26 @@ TEST_CASE("[SceneTree][RichTextLabel] Sizing with fit content") {
 	memdelete(test_label);
 }
 
+TEST_CASE("[SceneTree][RichTextLabel] Font size wrapping paragraph does not add empty first line") {
+	RichTextLabel *test_label = memnew(RichTextLabel);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_label);
+
+	test_label->set_use_bbcode(true);
+
+	test_label->set_text("[p][font_size=22]aaa[/font_size][/p]");
+	SceneTree::get_singleton()->process(0);
+	CHECK(test_label->get_paragraph_count() == 1);
+	CHECK(test_label->get_character_line(0) == 0);
+
+	test_label->set_text("[font_size=22][p]aaa[/p][/font_size]");
+	SceneTree::get_singleton()->process(0);
+	CHECK(test_label->get_paragraph_count() == 1);
+	CHECK(test_label->get_character_line(0) == 0);
+
+	memdelete(test_label);
+}
+
 } // namespace TestRichTextLabel
 
 #endif // ADVANCED_GUI_DISABLED

--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -146,13 +146,13 @@ TEST_CASE("[SceneTree][RichTextLabel] Font size wrapping paragraph does not add 
 
 	test_label->set_text("[p][font_size=22]aaa[/font_size][/p]");
 	SceneTree::get_singleton()->process(0);
-	CHECK(test_label->get_line_count() == 1);
 	CHECK(test_label->get_paragraph_count() == 1);
+	CHECK(test_label->get_character_line(0) == 0);
 
 	test_label->set_text("[font_size=22][p]aaa[/p][/font_size]");
 	SceneTree::get_singleton()->process(0);
-	CHECK(test_label->get_line_count() == 1);
 	CHECK(test_label->get_paragraph_count() == 1);
+	CHECK(test_label->get_character_line(0) == 0);
 
 	memdelete(test_label);
 }

--- a/tests/scene/test_rich_text_label.cpp
+++ b/tests/scene/test_rich_text_label.cpp
@@ -137,6 +137,26 @@ TEST_CASE("[SceneTree][RichTextLabel] Sizing with fit content") {
 	memdelete(test_label);
 }
 
+TEST_CASE("[SceneTree][RichTextLabel] Font size wrapping paragraph does not add empty first line") {
+	RichTextLabel *test_label = memnew(RichTextLabel);
+	Window *root = SceneTree::get_singleton()->get_root();
+	root->add_child(test_label);
+
+	test_label->set_use_bbcode(true);
+
+	test_label->set_text("[p][font_size=22]aaa[/font_size][/p]");
+	SceneTree::get_singleton()->process(0);
+	CHECK(test_label->get_line_count() == 1);
+	CHECK(test_label->get_paragraph_count() == 1);
+
+	test_label->set_text("[font_size=22][p]aaa[/p][/font_size]");
+	SceneTree::get_singleton()->process(0);
+	CHECK(test_label->get_line_count() == 1);
+	CHECK(test_label->get_paragraph_count() == 1);
+
+	memdelete(test_label);
+}
+
 } // namespace TestRichTextLabel
 
 #endif // ADVANCED_GUI_DISABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes a RichTextLabel BBCode regression introduced after 4.6 where nesting `[p]` inside `[font_size]` adds an unwanted empty first line.

Repro:
- Correct: `[p][font_size=22]aaa[/font_size][/p]`
- Broken before this fix: `[font_size=22][p]aaa[/p][/font_size]`

Root cause:
- `ITEM_FONT_SIZE` was not treated as formatting-only in layout-subitem detection.
- When `[font_size]` appeared before `[p]`, paragraph insertion logic treated it as prior layout content and split to a new line.

Fix:
- Treat `ITEM_FONT_SIZE` as formatting-only in `_find_layout_subitem()` so paragraph insertion does not create a leading blank line in this nesting case.

Regression coverage:
- Added a unit test that checks both tag orders produce one line and one paragraph, with no empty first line.

- Closes #120933