### PR TITLE
Only log haptic engine vibration error when one actually occurred

### DIFF
--- a/drivers/apple_embedded/apple_embedded.mm
+++ b/drivers/apple_embedded/apple_embedded.mm
@@ -106,12 +106,14 @@ void AppleEmbedded::vibrate_haptic_engine(float p_duration_seconds, float p_ampl
 					};
 				}
 
-				NSError *error;
+				NSError *error = nil;
 				CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
 
 				[[cur_haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
 
-				NSLog(@"Could not vibrate using haptic engine: %@", error);
+				if (error) {
+					NSLog(@"Could not vibrate using haptic engine: %@", error);
+				}
 			}
 
 			return;


### PR DESCRIPTION
On iOS, `AppleEmbedded::vibrate_haptic_engine` calls `NSLog(@"Could not vibrate using haptic engine: %@", error);` unconditionally after starting the haptic pattern player. Since `error` is nil on success, every successful `Input.vibrate_handheld()` call spams the console with:

```
Could not vibrate using haptic engine: (null)
```

This PR guards the log with an `if (error)` check (and initializes `error` to nil), matching the error handling style of the other haptic engine methods in the same file (`get_haptic_engine_instance`, `start_haptic_engine`, `stop_haptic_engine`).

No behavior change other than removing the misleading log line on success.

Noticed while running a game in debugger in Xcode on iPhone 15 Pro.  
