### PR TITLE
[Editor] Do not disable path overrides in tools build.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4218,12 +4218,14 @@ int Main::start() {
 #endif // TOOLS_ENABLED
 
 #if defined(OVERRIDE_PATH_ENABLED)
+#ifndef TOOLS_ENABLED
 	bool disable_override = GLOBAL_GET("application/config/disable_project_settings_override");
 	if (disable_override) {
 		script = String();
 		game_path = String();
 		main_loop_type = String();
 	}
+#endif // TOOLS_ENABLED
 #else
 	script = String();
 	game_path = String();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120943

## Additional information

Setting is intended for exported projects and interfere with editor functionality, `override.cfg` is still always disable if it's set.