### PR TITLE
Add raw_input property to `VirtualJoystick`

### DIFF
--- a/doc/classes/VirtualJoystick.xml
+++ b/doc/classes/VirtualJoystick.xml
@@ -43,6 +43,9 @@
 		<member name="joystick_size" type="float" setter="set_joystick_size" getter="get_joystick_size" default="100.0">
 			The size of the joystick in pixels.
 		</member>
+		<member name="raw_input" type="Vector2" setter="set_raw_input" getter="get_raw_input" default="Vector2(0, 0)">
+			The raw input of the joystick as [Vector2] with a maximum length of [code]1.0[/code]. Changing this property manually can be used to move the joystick tip by code.
+		</member>
 		<member name="tip_size" type="float" setter="set_tip_size" getter="get_tip_size" default="50.0">
 			The size of the joystick tip in pixels.
 		</member>

--- a/scene/gui/virtual_joystick.cpp
+++ b/scene/gui/virtual_joystick.cpp
@@ -212,6 +212,9 @@ void VirtualJoystick::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_initial_offset_ratio", "ratio"), &VirtualJoystick::set_initial_offset_ratio);
 	ClassDB::bind_method(D_METHOD("get_initial_offset_ratio"), &VirtualJoystick::get_initial_offset_ratio);
 
+	ClassDB::bind_method(D_METHOD("set_raw_input", "input"), &VirtualJoystick::set_raw_input);
+	ClassDB::bind_method(D_METHOD("get_raw_input"), &VirtualJoystick::get_raw_input);
+
 	ClassDB::bind_method(D_METHOD("set_action_left", "action"), &VirtualJoystick::set_action_left);
 	ClassDB::bind_method(D_METHOD("get_action_left"), &VirtualJoystick::get_action_left);
 
@@ -234,6 +237,8 @@ void VirtualJoystick::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "deadzone_ratio", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_deadzone_ratio", "get_deadzone_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "clampzone_ratio", PROPERTY_HINT_RANGE, "0,2,0.01"), "set_clampzone_ratio", "get_clampzone_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "initial_offset_ratio", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_initial_offset_ratio", "get_initial_offset_ratio");
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "raw_input", PROPERTY_HINT_NONE), "set_raw_input", "get_raw_input");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action_left", PROPERTY_HINT_INPUT_NAME, "show_builtin,loose_mode"), "set_action_left", "get_action_left");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action_right", PROPERTY_HINT_INPUT_NAME, "show_builtin,loose_mode"), "set_action_right", "get_action_right");
@@ -316,6 +321,14 @@ void VirtualJoystick::set_initial_offset_ratio(const Vector2 &p_ratio) {
 	}
 	initial_offset_ratio = p_ratio;
 	_reset();
+}
+
+void VirtualJoystick::set_raw_input(const Vector2 &p_input) {
+	_update_joystick(joystick_pos + p_input * joystick_size * 0.5f * clampzone_ratio);
+}
+
+Vector2 VirtualJoystick::get_raw_input() const {
+	return raw_input_vector;
 }
 
 Vector2 VirtualJoystick::get_initial_offset_ratio() const {

--- a/scene/gui/virtual_joystick.h
+++ b/scene/gui/virtual_joystick.h
@@ -108,6 +108,9 @@ public:
 	void set_initial_offset_ratio(const Vector2 &p_ratio);
 	Vector2 get_initial_offset_ratio() const;
 
+	void set_raw_input(const Vector2 &p_input);
+	Vector2 get_raw_input() const;
+
 	void set_action_left(const StringName &p_action);
 	StringName get_action_left() const;
 	void set_action_right(const StringName &p_action);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This PR adds `raw_input` property to directly access input of the joystick, without using input actions. It also can be used to move joystick tip by code.

- Closes (?) https://github.com/godotengine/godot-proposals/discussions/14216 (`raw_input` can be used to mirror external joystick)
- Closes https://github.com/godotengine/godot-proposals/issues/15028

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
No AI used. Better naming for new variable is welcome, I named it after variable in code.
