### PR TITLE
Replace empty render pass msaa resolve for the dedicated render command

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -4726,8 +4726,8 @@ void TextureStorage::render_target_do_msaa_resolve(RID p_render_target) {
 	if (!rt->msaa_needs_resolve) {
 		return;
 	}
-	RD::get_singleton()->draw_list_begin(rt->get_framebuffer());
-	RD::get_singleton()->draw_list_end();
+
+	RD::get_singleton()->texture_resolve_multisample(rt->color_multisample, rt->color);
 	rt->msaa_needs_resolve = false;
 }
 
@@ -5355,9 +5355,17 @@ RD::DataFormat TextureStorage::render_target_get_color_format(bool p_use_hdr, bo
 
 uint32_t TextureStorage::render_target_get_color_usage_bits(bool p_msaa) {
 	if (p_msaa) {
-		return RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+		// NOTE: `RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT` to support texture_resolve_multisample.
+		return RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+
 	} else {
 		// FIXME: Storage bit should only be requested when FSR is required.
-		return RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+		// NOTE: `RD::TEXTURE_USAGE_CAN_COPY_TO_BIT` to support texture_resolve_multisample.
+		return RD::TEXTURE_USAGE_SAMPLING_BIT |
+				RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+				RD::TEXTURE_USAGE_STORAGE_BIT;
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120637.

## Additional information
The #120637 issue is caused by faulty nvidia driver that cant comprehend empty draw list with msaa color attachment LOAD_OP_DONT_CARE and result in Error_DMA_PageFault. Replacing empty render pass for the dedicated resolve command solves the issue since the driver now may understand the intention. I dont get why there was an empty render pass in the first place when GPU api's have dedicated resolve command that may result in better driver optimizations.

#84957 that introduced the empty render pass msaa resolve points out that some mobile GPU's may have similar driver issues.

Im only concerned about potential performance cost of additional image usage flags on mobile gpus, maybe there will be no overhead at all, who knows. Mobile architecture is complete mystery for me. If there is a problem I may come up with different solution. :expressionless:

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
