### PR TITLE
Add checkbox for AI usage to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ https://contributing.godotengine.org/en/latest/engine/introduction.html#checklis
 <!-- Use of AI must be disclosed and should include a description of how it was used. -->
 
 - [ ] AI was not used
-- [ ] AI was used the following way:
+- [ ] AI was used in the following way:
 
 <!--
 Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,6 @@ Please target the `master` branch. We will take care of backporting relevant fix
 
 Before submitting, please read our checklist for contributors:
 https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-
-Use of AI must be disclosed and should include a description of how it was used.
 -->
 
 ## What problem(s) does this PR solve?
@@ -12,6 +10,11 @@ Use of AI must be disclosed and should include a description of how it was used.
 - Closes #
 
 ## Additional information
+
+<!-- Use of AI must be disclosed and should include a description of how it was used. -->
+
+- [ ] AI was not used
+- [ ] AI was used the following way:
 
 <!--
 Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

While the current PR template already contains info about AI disclosure, I have noticed that a lot of PRs still ignore this and reviewers have to ask about AI usage explicitly.

Adding checkboxes into the PR description would make it harder to miss/ignore than just having it in the comment, as shown below:


## Additional information

- [x] AI was not used
- [ ] AI was used the following way:

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
