### PR TITLE
Project Manager: Fix button sidebar size on different editor scales

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1670,7 +1670,7 @@ ProjectManager::ProjectManager() {
 
 			// The side bar with the edit, run, rename, etc. buttons.
 			VBoxContainer *project_list_sidebar = memnew(VBoxContainer);
-			project_list_sidebar->set_custom_minimum_size(Size2(120, 120));
+			project_list_sidebar->set_custom_minimum_size(Size2(120, 120) * EDSCALE);
 			project_list_hbox->add_child(project_list_sidebar);
 
 			project_list_sidebar->add_child(memnew(HSeparator));


### PR DESCRIPTION
## What problem(s) does this PR solve?
 
- The `VBoxContainer` containing the buttons not being scaled by the editor scale
 <img width="173" height="134" alt="image" src="https://github.com/user-attachments/assets/62d496bf-7e6a-460b-bd4c-3451eadf2453" />

(look how wide that is, on 100% it's much thinner)


## Images (scaled to the same size)

<img width="1000" height="719" alt="image" src="https://github.com/user-attachments/assets/67f235d0-0265-41ae-ab55-6371141f8a80" />

<img width="1000" height="729" alt="image" src="https://github.com/user-attachments/assets/ee792a36-0f18-4502-b05a-124fc71373be" />

<img width="1000" height="731" alt="image" src="https://github.com/user-attachments/assets/f6e854cc-6b5b-4dde-a296-2ff15e7b08b8" />


## Additional information

No AI was used.
