### PR TITLE
Fix Unrecognized UID error after deleting selected audio bus.

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1462,8 +1462,15 @@ void EditorAudioBuses::_file_moved(const String &p_old_path, const String &p_new
 	}
 }
 
-void EditorAudioBuses::_resource_removed(Ref<Resource> p_res) {
-	if (p_res->get_path() == ResourceUID::uid_to_path(edited_path)) {
+void EditorAudioBuses::_file_removed(const String &p_file) {
+	if (p_file == ResourceUID::uid_to_path(edited_path)) {
+		edited_path = "";
+		file->set_text("");
+	}
+}
+
+void EditorAudioBuses::_folder_removed(const String &p_folder) {
+	if (ResourceUID::uid_to_path(edited_path).begins_with(p_folder)) {
 		edited_path = "";
 		file->set_text("");
 	}
@@ -1637,7 +1644,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_rebuild_buses));
 	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &EditorAudioBuses::_rebuild_buses).unbind(3));
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &EditorAudioBuses::_file_moved));
-	FileSystemDock::get_singleton()->connect("resource_removed", callable_mp(this, &EditorAudioBuses::_resource_removed));
+	FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &EditorAudioBuses::_file_removed));
+	FileSystemDock::get_singleton()->connect("folder_removed", callable_mp(this, &EditorAudioBuses::_folder_removed));
 
 	set_process(true);
 }

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1463,7 +1463,7 @@ void EditorAudioBuses::_file_moved(const String &p_old_path, const String &p_new
 }
 
 void EditorAudioBuses::_file_removed(const String &p_file_path) {
-	if (p_file_path == "res://" + file->get_text()) {
+	if (p_file_path == ResourceUID::uid_to_path(edited_path)) {
 		edited_path = "";
 		file->set_text("");
 	}

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1462,6 +1462,13 @@ void EditorAudioBuses::_file_moved(const String &p_old_path, const String &p_new
 	}
 }
 
+void EditorAudioBuses::_file_removed(const String &p_file_path) {
+	if (p_file_path == "res://" + file->get_text()) {
+		edited_path = "";
+		file->set_text("");
+	}
+}
+
 void EditorAudioBuses::_select_layout() {
 	FileSystemDock::get_singleton()->navigate_to_path(ResourceUID::ensure_path(edited_path));
 }
@@ -1630,6 +1637,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_rebuild_buses));
 	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &EditorAudioBuses::_rebuild_buses).unbind(3));
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &EditorAudioBuses::_file_moved));
+	FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &EditorAudioBuses::_file_removed));
 
 	set_process(true);
 }

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1462,8 +1462,8 @@ void EditorAudioBuses::_file_moved(const String &p_old_path, const String &p_new
 	}
 }
 
-void EditorAudioBuses::_file_removed(const String &p_file_path) {
-	if (p_file_path == ResourceUID::uid_to_path(edited_path)) {
+void EditorAudioBuses::_resource_removed(Ref<Resource> p_res) {
+	if (p_res->get_path() == ResourceUID::uid_to_path(edited_path)) {
 		edited_path = "";
 		file->set_text("");
 	}
@@ -1637,7 +1637,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_rebuild_buses));
 	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &EditorAudioBuses::_rebuild_buses).unbind(3));
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &EditorAudioBuses::_file_moved));
-	FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &EditorAudioBuses::_file_removed));
+	FileSystemDock::get_singleton()->connect("resource_removed", callable_mp(this, &EditorAudioBuses::_resource_removed));
 
 	set_process(true);
 }

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -221,6 +221,7 @@ class EditorAudioBuses : public EditorDock {
 
 	void _server_save();
 	void _file_moved(const String &p_old_path, const String &p_new_path);
+	void _file_removed(const String &p_file_path);
 
 	void _select_layout();
 	void _load_layout();

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -221,7 +221,8 @@ class EditorAudioBuses : public EditorDock {
 
 	void _server_save();
 	void _file_moved(const String &p_old_path, const String &p_new_path);
-	void _resource_removed(Ref<Resource> p_res);
+	void _file_removed(const String &p_file);
+	void _folder_removed(const String &p_folder);
 
 	void _select_layout();
 	void _load_layout();

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -221,7 +221,7 @@ class EditorAudioBuses : public EditorDock {
 
 	void _server_save();
 	void _file_moved(const String &p_old_path, const String &p_new_path);
-	void _file_removed(const String &p_file_path);
+	void _resource_removed(Ref<Resource> p_res);
 
 	void _select_layout();
 	void _load_layout();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120819

## Changes

- Added a `_file_removed` callback for the `FileSystemDock` in the `EditorAudioBuses` class. It checks if removed file name matches selected audio bus file name and clears it.
