### PR TITLE
Revert "Implement `internationalization/locale/allow_fallback`"

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -357,9 +357,8 @@ StringName TranslationDomain::translate(const StringName &p_message, const Strin
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_context);
 
-	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && allow_fallback && fallback.length() >= 2) {
+	if (!res && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_context);
 	}
 
@@ -377,9 +376,8 @@ StringName TranslationDomain::translate_plural(const StringName &p_message, cons
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
 
-	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && allow_fallback && fallback.length() >= 2) {
+	if (!res && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_message_plural, p_n, p_context);
 	}
 

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -498,14 +498,6 @@ String TranslationServer::get_locale() const {
 	return locale;
 }
 
-void TranslationServer::set_fallback_allowed(const bool &p_allow) {
-	allow_fallback = p_allow;
-}
-
-bool TranslationServer::is_fallback_allowed() const {
-	return allow_fallback;
-}
-
 void TranslationServer::set_fallback_locale(const String &p_locale) {
 	fallback = p_locale;
 }
@@ -609,7 +601,6 @@ void TranslationServer::setup() {
 	}
 
 	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
-	allow_fallback = GLOBAL_DEF("internationalization/locale/allow_fallback", true);
 	main_domain->set_pseudolocalization_enabled(GLOBAL_DEF("internationalization/pseudolocalization/use_pseudolocalization", false));
 	main_domain->set_pseudolocalization_accents_enabled(GLOBAL_DEF("internationalization/pseudolocalization/replace_with_accents", true));
 	main_domain->set_pseudolocalization_double_vowels_enabled(GLOBAL_DEF("internationalization/pseudolocalization/double_vowels", false));

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -37,7 +37,6 @@ class TranslationServer : public Object {
 	GDCLASS(TranslationServer, Object);
 
 	String locale = "en";
-	bool allow_fallback = true;
 	String fallback;
 
 	Ref<TranslationDomain> main_domain;
@@ -110,8 +109,6 @@ public:
 
 	void set_locale(const String &p_locale);
 	String get_locale() const;
-	void set_fallback_allowed(const bool &p_allow);
-	bool is_fallback_allowed() const;
 	void set_fallback_locale(const String &p_locale);
 	String get_fallback_locale() const;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1723,12 +1723,8 @@
 		<member name="input_devices/sensors/enable_magnetometer" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the magnetometer sensor is enabled and [method Input.get_magnetometer] returns valid data.
 		</member>
-		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the locale will fall back to [member internationalization/locale/fallback] when a translation isn't available in a given language.
-			[b]Note:[/b] Not to be confused with [TextServerFallback].
-		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">
-			The locale to fall back to if a translation isn't available in a given language if [member internationalization/locale/allow_fallback] is [code]true[/code]. If left empty, [code]en[/code] (English) will be used.
+			The locale to fall back to if a translation isn't available in a given language. If left empty, [code]en[/code] (English) will be used.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/include_text_server_data" type="bool" setter="" getter="" default="false">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -487,9 +487,8 @@ void EditorNode::_update_from_settings() {
 		Viewport::DefaultCanvasItemTextureRepeat tr = (Viewport::DefaultCanvasItemTextureRepeat)current_repeat;
 		scene_root->set_default_canvas_item_texture_repeat(tr);
 	}
-	bool allow_fallback = GLOBAL_GET("internationalization/locale/allow_fallback");
 	String current_fallback_locale = GLOBAL_GET("internationalization/locale/fallback");
-	if (allow_fallback && current_fallback_locale != TranslationServer::get_singleton()->get_fallback_locale()) {
+	if (current_fallback_locale != TranslationServer::get_singleton()->get_fallback_locale()) {
 		TranslationServer::get_singleton()->set_fallback_locale(current_fallback_locale);
 		Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_main_domain();
 		if (!domain->is_enabled()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

This reverts commit 1ed0eefd2d5ff53da4b9437cb76795b24c4c05d9 (#117822)

## Additional information

One of our internationalization members noted that this PR was not appropriate as-is after the fact[^1]. As such, this aims to roll back the PR in question, given it's now known to be a solution looking for a problem.

[^1]: https://github.com/godotengine/godot/pull/117822#issuecomment-4905556278