### PR TITLE
Metal: Fix Forward+ light clustering black squares

### DIFF
--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -117,32 +117,6 @@ void main() {
 
 	uint aux = 0;
 
-	uint cluster_thread_group_index;
-	if (!sc_use_helper_check || !gl_HelperInvocation) {
-		//https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf
-
-		uvec4 mask;
-
-		while (true) {
-			// find the cluster offset of the first active thread
-			// threads that did break; go inactive and no longer count
-			uint first = subgroupBroadcastFirst(cluster_offset);
-			// update the mask for thread that match this cluster
-			mask = subgroupBallot(first == cluster_offset);
-			if (first == cluster_offset) {
-				// This thread belongs to the group of threads that match this offset,
-				// so exit the loop.
-				break;
-			}
-		}
-
-		cluster_thread_group_index = subgroupBallotExclusiveBitCount(mask);
-
-		if (cluster_thread_group_index == 0) {
-			aux = atomicOr(cluster_render.data[usage_write_offset], usage_write_bit);
-		}
-	}
-
 	//find the current element in the depth usage list and mark the current depth as used
 	float unit_depth = depth_interp * state.inv_z_far;
 
@@ -151,11 +125,36 @@ void main() {
 	uint z_write_offset = cluster_offset + state.cluster_depth_offset + element_index;
 	uint z_write_bit = 1 << z_bit;
 
-	if (!sc_use_helper_check || !gl_HelperInvocation) {
-		z_write_bit = subgroupOr(z_write_bit); //merge all Zs
-		if (cluster_thread_group_index == 0) {
-			aux = atomicOr(cluster_render.data[z_write_offset], z_write_bit);
+	if (sc_use_helper_check) {
+		//https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf
+		if (!gl_HelperInvocation) {
+			uvec4 mask;
+
+			while (true) {
+				// find the cluster offset of the first active thread
+				// threads that did break; go inactive and no longer count
+				uint first = subgroupBroadcastFirst(cluster_offset);
+				// update the mask for thread that match this cluster
+				mask = subgroupBallot(first == cluster_offset);
+				if (first == cluster_offset) {
+					// This thread belongs to the group of threads that match this offset,
+					// so exit the loop.
+					break;
+				}
+			}
+
+			uint cluster_thread_group_index = subgroupBallotExclusiveBitCount(mask);
+
+			z_write_bit = subgroupOr(z_write_bit); //merge all Zs
+
+			if (cluster_thread_group_index == 0) {
+				aux = atomicOr(cluster_render.data[usage_write_offset], usage_write_bit);
+				aux = atomicOr(cluster_render.data[z_write_offset], z_write_bit);
+			}
 		}
+	} else {
+		aux = atomicOr(cluster_render.data[usage_write_offset], usage_write_bit);
+		aux = atomicOr(cluster_render.data[z_write_offset], z_write_bit);
 	}
 
 #ifdef USE_ATTACHMENT


### PR DESCRIPTION
Fixes #121201

`cluster_render.glsl` picks one thread per group to do the `atomicOr` instead of all of them writing the same thing. Helper threads normally get skipped via `gl_HelperInvocation`.

On Apple/Metal `gl_HelperInvocation` is unreliable, so that skip got turned off; but the "pick one thread" part stayed. The picked thread can be a helper thread, and Metal throws away helper thread writes, so the light bit never lands and the tile ends up black.

Fix: when we can't trust the helper check, don't pick one thread; let them all write. `atomicOr` writing the same bit twice is harmless, and Metal already drops the helper threads' writes.