### PR TITLE
Revalidate open scripts on warning settings changes

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1608,6 +1608,7 @@ void ScriptEditor::_notification(int p_what) {
 			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ScriptEditor::_close_builtin_scripts_from_scene));
 			EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
 			EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &ScriptEditor::_project_settings_changed));
 			// Connect to scene_root child entered instead of scene_changed for new scenes.
 			EditorNode::get_singleton()->get_scene_root()->connect("child_entered_tree", callable_mp(this, &ScriptEditor::_connect_to_scene).unbind(1));
 			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
@@ -2802,6 +2803,18 @@ void ScriptEditor::_apply_editor_settings() {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(tab_container->get_tab_control(i))) {
 			teb->update_settings();
+		}
+	}
+}
+
+void ScriptEditor::_project_settings_changed() {
+	if (!ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/gdscript/warnings")) {
+		return;
+	}
+
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
+			seb->validate_script();
 		}
 	}
 }

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -329,6 +329,7 @@ class ScriptEditor : public PanelContainer {
 	void _save_editor_state(ScriptEditorBase *p_editor);
 	void _save_layout();
 	void _apply_editor_settings();
+	void _project_settings_changed();
 	void _files_moved(const String &p_old_file, const String &p_new_file);
 	void _file_removed(const String &p_file);
 	void _autosave_scripts();


### PR DESCRIPTION
## What problem(s) does this PR solve?
When changing GDScript warning-related Project Settings under debug/gdscript/warnings, open script tabs didnt immediately refresh their diagnostics. This left leave stale warnings visible until a manual revalidation trigger (such as editing/reopening the script).

This PR makes ScriptEditor react to ProjectSettings updates and revalidate all open script editors when settings in the warning group change, so diagnostics update immediately after toggling warning options.

- Closes #56266

## Additional information

Implementation summary:
- Connected ScriptEditor to the ProjectSettings settings_changed signal during editor setup.
- Added a ScriptEditor handler that:
	- Checks whether the change affects debug/gdscript/warnings.
	- Iterates open script tabs.
	- Calls validate_script() on each ScriptEditorBase instance.