### PR TITLE
Named varargs docs

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -149,6 +149,10 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 			p_method.qualifiers += " ";
 		}
 		p_method.qualifiers += "vararg";
+
+		if (!p_methodinfo.rest_argument.name.is_empty()) {
+			argument_doc_from_arginfo(p_method.rest_argument, p_methodinfo.rest_argument);
+		}
 	}
 
 	if (p_methodinfo.flags & METHOD_FLAG_STATIC) {

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -106,7 +106,6 @@ public:
 		bool is_experimental = false;
 		String experimental_message;
 		Vector<ArgumentDoc> arguments;
-		// NOTE: Only for GDScript for now. The rest argument is not saved to the XML file.
 		ArgumentDoc rest_argument;
 		Vector<int> errors_returned;
 		String keywords;

--- a/core/object/method_info.cpp
+++ b/core/object/method_info.cpp
@@ -30,6 +30,9 @@
 
 #include "method_info.h"
 
+#include "core/object/property_info.h"
+#include "core/string/string_name.h"
+#include "core/templates/hashfuncs.h"
 #include "core/variant/array.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/typed_array.h" // IWYU pragma: keep. `convert_property_list` return type.
@@ -47,6 +50,11 @@ MethodInfo::operator Dictionary() const {
 	d["id"] = id;
 	Dictionary r = return_val;
 	d["return"] = r;
+
+	if (!rest_argument.name.is_empty()) {
+		d["rest_argument"] = (Dictionary)rest_argument;
+	}
+
 	return d;
 }
 
@@ -81,6 +89,10 @@ MethodInfo MethodInfo::from_dict(const Dictionary &p_dict) {
 		mi.flags = p_dict["flags"];
 	}
 
+	if (p_dict.has("rest_argument")) {
+		mi.rest_argument = PropertyInfo::from_dict(p_dict["rest_argument"]);
+	}
+
 	return mi;
 }
 
@@ -111,6 +123,10 @@ uint32_t MethodInfo::get_compatibility_hash() const {
 
 	hash = hash_murmur3_one_32(flags & METHOD_FLAG_CONST ? 1 : 0, hash);
 	hash = hash_murmur3_one_32(flags & METHOD_FLAG_VARARG ? 1 : 0, hash);
+
+	if (flags & METHOD_FLAG_VARARG && rest_argument.name != StringName()) {
+		hash = hash_murmur3_one_32(rest_argument.name.hash(), hash);
+	}
 
 	return hash_fmix32(hash);
 }

--- a/core/object/method_info.h
+++ b/core/object/method_info.h
@@ -54,6 +54,7 @@ struct MethodInfo {
 	Vector<Variant> default_arguments;
 	int return_val_metadata = 0;
 	Vector<int> arguments_metadata;
+	PropertyInfo rest_argument;
 
 	int get_argument_meta(int p_arg) const {
 		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);

--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -49,6 +49,17 @@
 												<xs:attribute type="xs:string" name="default" use="optional" />
 											</xs:complexType>
 										</xs:element>
+										<xs:element name="rest_param" maxOccurs="1" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:sequence />
+												</xs:sequence>
+												<xs:attribute type="xs:string" name="name" />
+												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
+											</xs:complexType>
+										</xs:element>
 										<xs:element type="xs:string" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
@@ -93,6 +104,17 @@
 												<xs:attribute type="xs:string" name="enum" use="optional" />
 												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 												<xs:attribute type="xs:string" name="default" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="rest_param" maxOccurs="1" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:sequence />
+												</xs:sequence>
+												<xs:attribute type="xs:string" name="name" />
+												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 											</xs:complexType>
 										</xs:element>
 										<xs:element type="xs:string" name="description" />
@@ -155,6 +177,17 @@
 												<xs:attribute type="xs:string" name="name" />
 												<xs:attribute type="xs:string" name="type" />
 												<xs:attribute type="xs:string" name="keywords" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="rest_param" maxOccurs="1" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:sequence />
+												</xs:sequence>
+												<xs:attribute type="xs:string" name="name" />
+												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 											</xs:complexType>
 										</xs:element>
 										<xs:element type="xs:string" name="description" />
@@ -223,6 +256,17 @@
 												<xs:attribute type="xs:string" name="enum" use="optional" />
 												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 												<xs:attribute type="xs:string" name="default" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="rest_param" maxOccurs="1" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:sequence />
+												</xs:sequence>
+												<xs:attribute type="xs:string" name="name" />
+												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 											</xs:complexType>
 										</xs:element>
 										<xs:element type="xs:string" name="description" />

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -237,13 +237,14 @@ class State:
                     return_type = TypeName("void")
 
                 params = self.parse_params(constructor, "constructor")
+                rest_param = self.parse_rest_param(constructor, "constructor")
 
                 desc_element = constructor.find("description")
                 method_desc = None
                 if desc_element is not None:
                     method_desc = desc_element.text
 
-                method_def = MethodDef(method_name, return_type, params, method_desc, qualifiers)
+                method_def = MethodDef(method_name, return_type, params, method_desc, qualifiers, rest_param)
                 method_def.definition_name = "constructor"
                 method_def.deprecated = constructor.get("deprecated")
                 method_def.experimental = constructor.get("experimental")
@@ -268,13 +269,14 @@ class State:
                     return_type = TypeName("void")
 
                 params = self.parse_params(method, "method")
+                rest_param = self.parse_rest_param(method, "method")
 
                 desc_element = method.find("description")
                 method_desc = None
                 if desc_element is not None:
                     method_desc = desc_element.text
 
-                method_def = MethodDef(method_name, return_type, params, method_desc, qualifiers)
+                method_def = MethodDef(method_name, return_type, params, method_desc, qualifiers, rest_param)
                 method_def.deprecated = method.get("deprecated")
                 method_def.experimental = method.get("experimental")
                 if method_name not in class_def.methods:
@@ -298,6 +300,7 @@ class State:
                     return_type = TypeName("void")
 
                 params = self.parse_params(operator, "operator")
+                rest_param = self.parse_rest_param(operator, "operator")
 
                 desc_element = operator.find("description")
                 method_desc = None
@@ -351,13 +354,14 @@ class State:
                 qualifiers = annotation.get("qualifiers")
 
                 params = self.parse_params(annotation, "annotation")
+                rest_param = self.parse_rest_param(annotation, "annotation")
 
                 desc_element = annotation.find("description")
                 annotation_desc = None
                 if desc_element is not None:
                     annotation_desc = desc_element.text
 
-                annotation_def = AnnotationDef(annotation_name, params, annotation_desc, qualifiers)
+                annotation_def = AnnotationDef(annotation_name, params, annotation_desc, qualifiers, rest_param)
                 if annotation_name not in class_def.annotations:
                     class_def.annotations[annotation_name] = []
 
@@ -375,13 +379,14 @@ class State:
                     continue
 
                 params = self.parse_params(signal, "signal")
+                rest_param = self.parse_rest_param(signal, "signal")
 
                 desc_element = signal.find("description")
                 signal_desc = None
                 if desc_element is not None:
                     signal_desc = desc_element.text
 
-                signal_def = SignalDef(signal_name, params, signal_desc)
+                signal_def = SignalDef(signal_name, params, signal_desc, rest_param)
                 signal_def.deprecated = signal.get("deprecated")
                 signal_def.experimental = signal.get("experimental")
                 class_def.signals[signal_name] = signal_def
@@ -445,6 +450,15 @@ class State:
         cast: list[ParameterDef] = params
 
         return cast
+
+    def parse_rest_param(self, root: ET.Element, context: str) -> ParameterDef | None:
+        rest_param_element = root.find("rest_param")
+        if rest_param_element is None:
+            return None
+
+        param_name = rest_param_element.get("name", "args")
+        type_name = TypeName.from_element(rest_param_element)
+        return ParameterDef(param_name, type_name, "[]")
 
     def sort_classes(self) -> None:
         self.classes = OrderedDict(sorted(self.classes.items(), key=lambda t: t[0].lower()))
@@ -520,11 +534,14 @@ class ParameterDef(DefinitionBase):
 
 
 class SignalDef(DefinitionBase):
-    def __init__(self, name: str, parameters: list[ParameterDef], description: str | None) -> None:
+    def __init__(
+        self, name: str, parameters: list[ParameterDef], description: str | None, rest_param: ParameterDef | None = None
+    ) -> None:
         super().__init__("signal", name)
 
         self.parameters = parameters
         self.description = description
+        self.rest_param = rest_param
 
 
 class AnnotationDef(DefinitionBase):
@@ -534,12 +551,14 @@ class AnnotationDef(DefinitionBase):
         parameters: list[ParameterDef],
         description: str | None,
         qualifiers: str | None,
+        rest_param: ParameterDef | None = None,
     ) -> None:
         super().__init__("annotation", name)
 
         self.parameters = parameters
         self.description = description
         self.qualifiers = qualifiers
+        self.rest_param = rest_param
 
 
 class MethodDef(DefinitionBase):
@@ -550,6 +569,7 @@ class MethodDef(DefinitionBase):
         parameters: list[ParameterDef],
         description: str | None,
         qualifiers: str | None,
+        rest_param: ParameterDef | None = None,
     ) -> None:
         super().__init__("method", name)
 
@@ -557,6 +577,7 @@ class MethodDef(DefinitionBase):
         self.parameters = parameters
         self.description = description
         self.qualifiers = qualifiers
+        self.rest_param = rest_param
 
 
 class ConstantDef(DefinitionBase):
@@ -1626,7 +1647,14 @@ def make_method_signature(
         if arg.default_value is not None:
             out += f" = {arg.default_value}"
 
-    if qualifiers is not None and "vararg" in qualifiers:
+    if hasattr(definition, "rest_param") and definition.rest_param is not None:
+        rest_param = definition.rest_param
+        if len(definition.parameters) > 0:
+            out += f", ...{rest_param.name}\\: {rest_param.type_name.to_rst(state)}"
+        else:
+            out += f"\\ ...{rest_param.name}\\: {rest_param.type_name.to_rst(state)}"
+    elif qualifiers is not None and "vararg" in qualifiers:
+        # Fallback to plain vararg display
         if len(definition.parameters) > 0:
             out += ", ..."
         else:

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1115,6 +1115,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 						md.qualifiers += " ";
 					}
 					md.qualifiers += "vararg";
+
+					if (!mi.rest_argument.name.is_empty()) {
+						DocData::argument_doc_from_arginfo(md.rest_argument, mi.rest_argument);
+					}
 				}
 
 				DocData::return_doc_from_retinfo(md, mi.return_val);
@@ -1160,6 +1164,10 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 						atd.qualifiers += " ";
 					}
 					atd.qualifiers += "vararg";
+
+					if (!ai.rest_argument.name.is_empty()) {
+						DocData::argument_doc_from_arginfo(atd.rest_argument, ai.rest_argument);
+					}
 				}
 
 				DocData::return_doc_from_retinfo(atd, ai.return_val);
@@ -1260,6 +1268,20 @@ static Error _parse_methods(Ref<XMLParser> &parser, Vector<DocData::MethodDoc> &
 							if (parser->get_node_type() == XMLParser::NODE_TEXT) {
 								method.description = parser->get_node_data();
 							}
+						} else if (name == "rest_param") {
+							DocData::ArgumentDoc argument;
+							ERR_FAIL_COND_V(!parser->has_attribute("name"), ERR_FILE_CORRUPT);
+							argument.name = parser->get_named_attribute_value("name");
+							ERR_FAIL_COND_V(!parser->has_attribute("type"), ERR_FILE_CORRUPT);
+							argument.type = parser->get_named_attribute_value("type");
+							if (parser->has_attribute("enum")) {
+								argument.enumeration = parser->get_named_attribute_value("enum");
+								if (parser->has_attribute("is_bitfield")) {
+									argument.is_bitfield = parser->get_named_attribute_value("is_bitfield").to_lower() == "true";
+								}
+							}
+
+							method.rest_argument = argument;
 						}
 
 					} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END && parser->get_node_name() == element) {
@@ -1671,6 +1693,23 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 				} else {
 					_write_string(f, 3, "<param index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape(true) + "\" type=\"" + a.type.xml_escape(true) + "\"" + enum_text + " />");
 				}
+			}
+
+			if (!m.rest_argument.name.is_empty()) {
+				String enum_text;
+				if (!m.rest_argument.enumeration.is_empty()) {
+					enum_text = " enum=\"" + m.rest_argument.enumeration.xml_escape(true) + "\"";
+					if (m.rest_argument.is_bitfield) {
+						enum_text += " is_bitfield=\"true\"";
+					}
+				}
+
+				String rest_type;
+				if (!m.rest_argument.type.is_empty()) {
+					rest_type = " type=\"" + m.rest_argument.type.xml_escape(true) + "\"";
+				}
+
+				_write_string(f, 3, "<rest_param name=\"" + m.rest_argument.name.xml_escape(true) + "\"" + rest_type + enum_text + " />");
 			}
 
 			_write_string(f, 3, "<description>");

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3973,6 +3973,10 @@ EditorHelpBit::HelpData EditorHelpBit::_get_annotation_help_data(const StringNam
 			}
 			current.qualifiers = annotation.qualifiers;
 
+			const DocData::ArgumentDoc &rest_argument = annotation.rest_argument;
+			const DocType rest_argument_doc_type = { rest_argument.type, rest_argument.enumeration, rest_argument.is_bitfield };
+			current.rest_argument = { rest_argument.name, rest_argument_doc_type, rest_argument.default_value };
+
 			if (annotation.name == p_annotation_name) {
 				result = current;
 

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -405,7 +405,8 @@
 		</annotation>
 		<annotation name="@export_enum" qualifiers="vararg">
 			<return type="void" />
-			<param index="0" name="names" type="String" />
+			<param index="0" name="first_name" type="String" />
+			<rest_param name="rest_names" type="Array" />
 			<description>
 				Export an [int], [String], [Array][lb][int][rb], [Array][lb][String][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
 				See also [constant PROPERTY_HINT_ENUM].

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -795,7 +795,14 @@ static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool
 		if (p_arg_idx >= p_info.arguments.size()) {
 			arghint += String::chr(0xFFFF);
 		}
-		arghint += "...args: Array"; // `MethodInfo` does not support the rest parameter name.
+
+		arghint += "...";
+		arghint += p_info.rest_argument.name.is_empty() ? "args" : p_info.rest_argument.name;
+
+		if (p_is_annotation) {
+			arghint += ": Array";
+		}
+
 		if (p_arg_idx >= p_info.arguments.size()) {
 			arghint += String::chr(0xFFFF);
 		}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -37,6 +37,8 @@
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "core/object/class_db.h"
+#include "core/object/method_info.h"
+#include "core/object/property_info.h"
 #include "scene/main/multiplayer_api.h"
 
 #ifdef DEBUG_ENABLED
@@ -151,7 +153,10 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
-		register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);
+
+		MethodInfo export_enum_info = MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "first_name"));
+		export_enum_info.rest_argument = PropertyInfo(Variant::ARRAY, "rest_names");
+		register_annotation(export_enum_info, AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);
 		register_annotation(MethodInfo("@export_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_FILE, Variant::STRING>, varray(""), true);
 		register_annotation(MethodInfo("@export_file_path", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_FILE_PATH, Variant::STRING>, varray(""), true);
 		register_annotation(MethodInfo("@export_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_DIR, Variant::STRING>);

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -46,6 +46,8 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
 
+#include "modules/gdscript/language_server/godot_lsp.h"
+
 void GDScriptWorkspace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_new_signal", "obj", "function", "args"), &GDScriptWorkspace::apply_new_signal);
 	ClassDB::bind_method(D_METHOD("get_file_path", "uri"), &GDScriptWorkspace::get_file_path);
@@ -346,7 +348,22 @@ Error GDScriptWorkspace::initialize() {
 				symbol.children.push_back(symbol_arg);
 			}
 			if (data.qualifiers.contains("vararg")) {
-				params += params.is_empty() ? "..." : ", ...";
+				if (!params.is_empty()) {
+					params += ", ";
+				}
+
+				if (!data.rest_argument.name.is_empty()) {
+					params += "..." + data.rest_argument.name;
+					if (!data.rest_argument.type.is_empty()) {
+						params += ": " + data.rest_argument.type;
+					}
+
+					LSP::DocumentSymbol rest_argument_symbol;
+					rest_argument_symbol.name = data.rest_argument.name;
+					rest_argument_symbol.kind = LSP::SymbolKind::Variable;
+					rest_argument_symbol.detail = data.rest_argument.type;
+					symbol.children.push_back(rest_argument_symbol);
+				}
 			}
 
 			String return_type = data.return_type;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/117927

## Additional information

Update existing `MethodInfo` object to support defining PropertyInfo for a vararg. This information can be seen from the following places:

- Editor Help (F1 doc search)
- Editor definition hover
- Editor inline hints
- External Editor hover command
- Generated `.rst` files (so web documentation too)
- Generated @GDScript.xml (which is the basis for all the above)

> I've included screenshots of the results when not apparent from the diff.

I choose to extend MethodInfo after reading [this Comment](https://github.com/godotengine/godot/pull/117966#issuecomment-4169961789) which suggested it in response to a previous attempt. 

## AI DISCLOSURE
Used Gemini models with OpenCode for exploration purposes, finding places where varags parsing was hardcoded