### PR TITLE
Add and apply `RETURN_IF_ERROR` to return an `Error` when it's not `OK`.

### DIFF
--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -72,10 +72,7 @@ Error AESContext::start(Mode p_mode, const PackedByteArray &p_key, const PackedB
 		WARN_PRINT("ECB mode does not require an initialization vector (IV). Pass an empty IV argument when using ECB.");
 		iv.clear();
 	}
-	Error err = ctx.setup(ctx_mode, ctx_cipher, p_key.ptr(), p_key.size(), iv.size() ? iv.ptr() : nullptr, iv.size());
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(ctx.setup(ctx_mode, ctx_cipher, p_key.ptr(), p_key.size(), iv.size() ? iv.ptr() : nullptr, iv.size()));
 	mode = p_mode;
 	return OK;
 }

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -126,6 +126,16 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * issues when expanded e.g. after an `if (cond) ERR_FAIL();` without braces.
  */
 
+/**
+ * Evaluate the expression. If it results in an Error != OK, silently return the error.
+ */
+#define RETURN_IF_ERROR(m_exp) \
+	if (Error _err_propagate_error = (m_exp); unlikely(_err_propagate_error != OK)) { \
+		static_assert(std::is_same_v<std::decay_t<decltype(m_exp)>, Error>, "RETURN_IF_ERROR expects an Error-returning expression"); \
+		return _err_propagate_error; \
+	} else \
+		((void)0)
+
 // Index out of bounds error macros.
 // These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
 

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -176,10 +176,7 @@ String GDExtensionLibraryLoader::find_extension_library(const String &p_path, Re
 }
 
 Error GDExtensionLibraryLoader::open_library(const String &p_path) {
-	Error err = parse_gdextension_file(p_path);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(parse_gdextension_file(p_path));
 
 	String abs_path = ProjectSettings::get_singleton()->globalize_path(library_path);
 
@@ -198,7 +195,7 @@ Error GDExtensionLibraryLoader::open_library(const String &p_path) {
 	};
 
 	// Apple has a complex lookup system which goes beyond looking up the filename, so we try that first.
-	err = OS::get_singleton()->open_dynamic_library(abs_path, library, &data);
+	Error err = OS::get_singleton()->open_dynamic_library(abs_path, library, &data);
 	if (err != OK) {
 #ifdef APPLE_EMBEDDED_ENABLED
 		err = OS::get_singleton()->open_dynamic_library(String(), library, &data);

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -117,10 +117,7 @@ static Error _erase_recursive(DirAccess *p_dir) {
 	}
 
 	for (const String &E : files) {
-		Error err = p_dir->remove(p_dir->get_current_dir().path_join(E));
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(p_dir->remove(p_dir->get_current_dir().path_join(E)));
 	}
 
 	return OK;

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -156,10 +156,7 @@ Error FileAccessPatched::get_error() const {
 	}
 
 	if (patched_file.is_valid()) {
-		Error inner_error = patched_file->get_error();
-		if (inner_error != OK) {
-			return inner_error;
-		}
+		RETURN_IF_ERROR(patched_file->get_error());
 	}
 
 	return last_error;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -156,10 +156,7 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(connection.is_null(), ERR_INVALID_DATA);
 
-	Error err = verify_headers(p_headers);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(verify_headers(p_headers));
 
 	String uri = p_url;
 	if (tls_options.is_null() && http_proxy_port != -1) {

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -427,17 +427,11 @@ Error JSON::_parse_value(Variant &r_value, Token &r_token, const char32_t *p_str
 
 	if (r_token.type == TK_CURLY_BRACKET_OPEN) {
 		Dictionary d;
-		Error err = _parse_object(d, p_str, r_index, p_len, r_line, p_depth + 1, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_object(d, p_str, r_index, p_len, r_line, p_depth + 1, r_err_str));
 		r_value = d;
 	} else if (r_token.type == TK_BRACKET_OPEN) {
 		Array a;
-		Error err = _parse_array(a, p_str, r_index, p_len, r_line, p_depth + 1, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_array(a, p_str, r_index, p_len, r_line, p_depth + 1, r_err_str));
 		r_value = a;
 	} else if (r_token.type == TK_IDENTIFIER) {
 		String id = r_token.value;
@@ -468,10 +462,7 @@ Error JSON::_parse_array(Array &r_array, const char32_t *p_str, int &r_index, in
 	bool need_comma = false;
 
 	while (r_index < p_len) {
-		Error err = _get_token(p_str, r_index, p_len, token, r_line, r_err_str);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_get_token(p_str, r_index, p_len, token, r_line, r_err_str));
 
 		if (token.type == TK_BRACKET_CLOSE) {
 			return OK;
@@ -488,10 +479,7 @@ Error JSON::_parse_array(Array &r_array, const char32_t *p_str, int &r_index, in
 		}
 
 		Variant v;
-		err = _parse_value(v, token, p_str, r_index, p_len, r_line, p_depth, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_value(v, token, p_str, r_index, p_len, r_line, p_depth, r_err_str));
 
 		r_array.push_back(v);
 		need_comma = true;
@@ -509,10 +497,7 @@ Error JSON::_parse_object(Dictionary &r_object, const char32_t *p_str, int &r_in
 
 	while (r_index < p_len) {
 		if (at_key) {
-			Error err = _get_token(p_str, r_index, p_len, token, r_line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_get_token(p_str, r_index, p_len, token, r_line, r_err_str));
 
 			if (token.type == TK_CURLY_BRACKET_CLOSE) {
 				return OK;
@@ -534,26 +519,17 @@ Error JSON::_parse_object(Dictionary &r_object, const char32_t *p_str, int &r_in
 			}
 
 			key = token.value;
-			err = _get_token(p_str, r_index, p_len, token, r_line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_get_token(p_str, r_index, p_len, token, r_line, r_err_str));
 			if (token.type != TK_COLON) {
 				r_err_str = "Expected ':'";
 				return ERR_PARSE_ERROR;
 			}
 			at_key = false;
 		} else {
-			Error err = _get_token(p_str, r_index, p_len, token, r_line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_get_token(p_str, r_index, p_len, token, r_line, r_err_str));
 
 			Variant v;
-			err = _parse_value(v, token, p_str, r_index, p_len, r_line, p_depth, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_value(v, token, p_str, r_index, p_len, r_line, p_depth, r_err_str));
 			r_object[key] = v;
 			need_comma = true;
 			at_key = true;
@@ -576,12 +552,9 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 	Token token;
 	r_err_line = 0;
 
-	Error err = _get_token(str, idx, len, token, r_err_line, r_err_str);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_get_token(str, idx, len, token, r_err_line, r_err_str));
 
-	err = _parse_value(r_ret, token, str, idx, len, r_err_line, 0, r_err_str);
+	Error err = _parse_value(r_ret, token, str, idx, len, r_err_line, 0, r_err_str);
 
 	// Check if EOF is reached
 	// or it's a type of the next token.

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -148,10 +148,7 @@ static Error _decode_container_type(const uint8_t *&p_buffer, int &r_left, int *
 		} break;
 		case CONTAINER_TYPE_KIND_CLASS_NAME: {
 			String str;
-			Error err = _decode_string(p_buffer, r_left, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_decode_string(p_buffer, r_left, r_len, str));
 
 			r_type.builtin_type = Variant::OBJECT;
 			if (p_allow_objects) {
@@ -163,10 +160,7 @@ static Error _decode_container_type(const uint8_t *&p_buffer, int &r_left, int *
 		} break;
 		case CONTAINER_TYPE_KIND_SCRIPT: {
 			String path;
-			Error err = _decode_string(p_buffer, r_left, r_len, path);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_decode_string(p_buffer, r_left, r_len, path));
 
 			r_type.builtin_type = Variant::OBJECT;
 			if (p_allow_objects) {
@@ -254,10 +248,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::STRING: {
 			String str;
-			Error err = _decode_string(buf, len, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 			r_variant = str;
 
 		} break;
@@ -630,10 +621,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::STRING_NAME: {
 			String str;
-			Error err = _decode_string(buf, len, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 			r_variant = StringName(str);
 
 		} break;
@@ -667,10 +655,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 				for (uint32_t i = 0; i < total; i++) {
 					String str;
-					Error err = _decode_string(buf, len, r_len, str);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 
 					if (i < namecount) {
 						names.push_back(str);
@@ -718,10 +703,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 				ERR_FAIL_COND_V(!p_allow_objects, ERR_UNAUTHORIZED);
 
 				String str;
-				Error err = _decode_string(buf, len, r_len, str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 
 				if (str.is_empty()) {
 					r_variant = (Object *)nullptr;
@@ -751,17 +733,11 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 					for (int i = 0; i < count; i++) {
 						str = String();
-						err = _decode_string(buf, len, r_len, str);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 
 						Variant value;
 						int used;
-						err = decode_variant(value, buf, len, &used, p_allow_objects, p_depth + 1);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERROR(decode_variant(value, buf, len, &used, p_allow_objects, p_depth + 1));
 
 						buf += used;
 						len -= used;
@@ -791,10 +767,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::SIGNAL: {
 			String name;
-			Error err = _decode_string(buf, len, r_len, name);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_decode_string(buf, len, r_len, name));
 
 			ERR_FAIL_COND_V(len < 8, ERR_INVALID_DATA);
 			ObjectID id = ObjectID(decode_uint64(buf));
@@ -809,20 +782,14 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			{
 				ContainerTypeKind key_type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_DICTIONARY_KEY);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, key_type_kind, key_type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_decode_container_type(buf, len, r_len, p_allow_objects, key_type_kind, key_type));
 			}
 
 			ContainerType value_type;
 
 			{
 				ContainerTypeKind value_type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_DICTIONARY_VALUE);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, value_type_kind, value_type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_decode_container_type(buf, len, r_len, p_allow_objects, value_type_kind, value_type));
 			}
 
 			ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
@@ -876,10 +843,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			{
 				ContainerTypeKind type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_ARRAY);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, type_kind, type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_decode_container_type(buf, len, r_len, p_allow_objects, type_kind, type));
 			}
 
 			ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
@@ -1056,10 +1020,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			for (int32_t i = 0; i < count; i++) {
 				String str;
-				Error err = _decode_string(buf, len, r_len, str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_decode_string(buf, len, r_len, str));
 
 				strings.push_back(str);
 			}
@@ -1833,17 +1794,11 @@ Error encode_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len, bo
 			const Dictionary dict = p_variant;
 
 			{
-				Error err = _encode_container_type(dict.get_key_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_encode_container_type(dict.get_key_type(), buf, r_len, p_full_objects));
 			}
 
 			{
-				Error err = _encode_container_type(dict.get_value_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_encode_container_type(dict.get_value_type(), buf, r_len, p_full_objects));
 			}
 
 			if (buf) {
@@ -1875,10 +1830,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len, bo
 			const Array array = p_variant;
 
 			{
-				Error err = _encode_container_type(array.get_element_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_encode_container_type(array.get_element_type(), buf, r_len, p_full_objects));
 			}
 
 			if (buf) {

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -50,10 +50,7 @@ int PacketPeer::get_encode_buffer_max_size() const {
 Error PacketPeer::get_packet_buffer(Vector<uint8_t> &r_buffer) {
 	const uint8_t *buffer;
 	int buffer_size;
-	Error err = get_packet(&buffer, buffer_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(get_packet(&buffer, buffer_size));
 
 	r_buffer.resize(buffer_size);
 	if (buffer_size == 0) {
@@ -81,10 +78,7 @@ Error PacketPeer::put_packet_buffer(const Vector<uint8_t> &p_buffer) {
 Error PacketPeer::get_var(Variant &r_variant, bool p_allow_objects) {
 	const uint8_t *buffer;
 	int buffer_size;
-	Error err = get_packet(&buffer, buffer_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(get_packet(&buffer, buffer_size));
 
 	return decode_variant(r_variant, buffer, buffer_size, nullptr, p_allow_objects);
 }
@@ -198,10 +192,7 @@ Error PacketPeerStream::_poll_buffer() const {
 
 	int read = 0;
 	ERR_FAIL_COND_V(input_buffer.size() < ring_buffer.space_left(), ERR_UNAVAILABLE);
-	Error err = peer->get_partial_data(input_buffer.ptrw(), ring_buffer.space_left(), read);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(peer->get_partial_data(input_buffer.ptrw(), ring_buffer.space_left(), read));
 	if (read == 0) {
 		return OK;
 	}

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -98,10 +98,7 @@ int PacketPeerUDP::get_available_packet_count() const {
 }
 
 Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	Error err = _poll();
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_poll());
 	if (queue_count == 0) {
 		return ERR_UNAVAILABLE;
 	}

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -99,10 +99,7 @@ Error RemoteFilesystemClient::_store_file(const String &p_path, const LocalVecto
 	Ref<FileAccess> f = FileAccess::open(full_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_FILE_CANT_OPEN, vformat("Unable to open file for writing to remote filesystem cache: '%s'.", p_path));
 	f->store_buffer(p_file.ptr(), p_file.size());
-	Error err = f->get_error();
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(f->get_error());
 	f.unref(); // Unref to ensure file is not locked and modified time can be obtained.
 
 	r_modified_time = FileAccess::get_modified_time(full_path);

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -602,10 +602,7 @@ void ResourceImporter::_bind_methods() {
 Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
-	Error err = cf->load(p_path + ".import");
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(cf->load(p_path + ".import"));
 	cf->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(p_uid));
 	cf->save(p_path + ".import");
 

--- a/core/io/stream_peer_gzip.cpp
+++ b/core/io/stream_peer_gzip.cpp
@@ -123,10 +123,7 @@ Error StreamPeerGZIP::_process(uint8_t *p_dst, int p_dst_size, const uint8_t *p_
 
 Error StreamPeerGZIP::put_data(const uint8_t *p_data, int p_bytes) {
 	int wrote = 0;
-	Error err = put_partial_data(p_data, p_bytes, wrote);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(put_partial_data(p_data, p_bytes, wrote));
 	ERR_FAIL_COND_V(p_bytes != wrote, ERR_OUT_OF_MEMORY);
 	return OK;
 }
@@ -145,10 +142,7 @@ Error StreamPeerGZIP::put_partial_data(const uint8_t *p_data, int p_bytes, int &
 		int sent = 0;
 		int to_write = 0;
 		// Compress or decompress
-		Error err = _process(buffer.ptrw(), MIN(buffer.size(), rb.space_left()), p_data + r_sent, p_bytes - r_sent, sent, to_write);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_process(buffer.ptrw(), MIN(buffer.size(), rb.space_left()), p_data + r_sent, p_bytes - r_sent, sent, to_write));
 		// When decompressing, we might need to do another round.
 		r_sent += sent;
 
@@ -167,10 +161,7 @@ Error StreamPeerGZIP::put_partial_data(const uint8_t *p_data, int p_bytes, int &
 
 Error StreamPeerGZIP::get_data(uint8_t *p_buffer, int p_bytes) {
 	int received = 0;
-	Error err = get_partial_data(p_buffer, p_bytes, received);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(get_partial_data(p_buffer, p_bytes, received));
 	ERR_FAIL_COND_V(p_bytes != received, ERR_UNAVAILABLE);
 	return OK;
 }

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -53,10 +53,7 @@ Error StreamPeerTCP::bind(int p_port, const IPAddress &p_host) {
 	if (p_host.is_wildcard()) {
 		ip_type = IP::TYPE_ANY;
 	}
-	Error err = _sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type));
 	_sock->set_blocking_enabled(false);
 	NetSocket::Address addr(p_host, p_port);
 	return _sock->bind(addr);
@@ -70,10 +67,7 @@ Error StreamPeerTCP::connect_to_host(const IPAddress &p_host, int p_port) {
 
 	if (!_sock->is_open()) {
 		IP::Type ip_type = p_host.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
-		Error err = _sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type));
 		_sock->set_blocking_enabled(false);
 	}
 

--- a/core/io/stream_peer_uds.cpp
+++ b/core/io/stream_peer_uds.cpp
@@ -53,10 +53,7 @@ Error StreamPeerUDS::bind(const String &p_path) {
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
 
 	IP::Type ip_type = IP::TYPE_NONE;
-	Error err = _sock->open(NetSocket::Family::UNIX, NetSocket::TYPE_NONE, ip_type);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_sock->open(NetSocket::Family::UNIX, NetSocket::TYPE_NONE, ip_type));
 	_sock->set_blocking_enabled(false);
 	NetSocket::Address addr(p_path);
 	return _sock->bind(addr);
@@ -69,10 +66,7 @@ Error StreamPeerUDS::connect_to_host(const String &p_path) {
 
 	if (!_sock->is_open()) {
 		IP::Type ip_type = IP::TYPE_NONE;
-		Error err = _sock->open(NetSocket::Family::UNIX, NetSocket::TYPE_NONE, ip_type);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_sock->open(NetSocket::Family::UNIX, NetSocket::TYPE_NONE, ip_type));
 		_sock->set_blocking_enabled(false);
 	}
 

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -286,10 +286,7 @@ Error CowData<T>::insert(Size p_pos, T &&p_val) {
 	const Size new_size = size() + 1;
 	ERR_FAIL_INDEX_V(p_pos, new_size, ERR_INVALID_PARAMETER);
 
-	Error error = _insert_uninitialized(p_pos, 1);
-	if (error) {
-		return error;
-	}
+	RETURN_IF_ERROR(_insert_uninitialized(p_pos, 1));
 
 	// Create the new element at the given index.
 	memnew_placement(_ptr + p_pos, T(std::move(p_val)));
@@ -300,10 +297,7 @@ Error CowData<T>::insert(Size p_pos, T &&p_val) {
 
 template <typename T>
 Error CowData<T>::push_back(T &&p_val) {
-	Error error = _insert_uninitialized(size(), 1);
-	if (error) {
-		return error;
-	}
+	RETURN_IF_ERROR(_insert_uninitialized(size(), 1));
 
 	memnew_placement(_ptr + size(), T(std::move(p_val)));
 	*_get_size() = size() + 1;
@@ -331,10 +325,7 @@ Error CowData<T>::append(Span<T> p_span) {
 	const bool span_in_self = _ptr && p_span.ptr() >= _ptr && p_span.ptr() < _ptr + size();
 	const Size idx_in_self = span_in_self ? (p_span.ptr() - _ptr) : -1;
 
-	const Error error = _insert_uninitialized(size(), p_span.size());
-	if (error) {
-		return error;
-	}
+	RETURN_IF_ERROR(_insert_uninitialized(size(), p_span.size()));
 	const T *span_ptr = span_in_self ? (_ptr + idx_in_self) : p_span.ptr();
 	copy_arr_placement(_ptr + size(), span_ptr, p_span.size());
 	*_get_size() = size() + p_span.size();
@@ -350,10 +341,7 @@ Error CowData<T>::_insert_uninitialized(USize p_index, USize p_count, USize p_ca
 	} else if (_get_refcount()->get() == 1) {
 		if (capacity() < p_capacity) {
 			// Need to grow.
-			const Error error = _realloc_exact(p_capacity);
-			if (error) {
-				return error;
-			}
+			RETURN_IF_ERROR(_realloc_exact(p_capacity));
 		}
 
 		// Relocate elements up.
@@ -365,10 +353,7 @@ Error CowData<T>::_insert_uninitialized(USize p_index, USize p_count, USize p_ca
 		// Initialize the data elsewhere first and only swap when it's ready.
 		CowData new_data;
 
-		const Error error = new_data._alloc_exact(p_capacity);
-		if (error) {
-			return error;
-		}
+		RETURN_IF_ERROR(new_data._alloc_exact(p_capacity));
 
 		// Copy over elements.
 		copy_arr_placement(new_data._ptr, _ptr, p_index);
@@ -417,10 +402,7 @@ Error CowData<T>::_remove(USize p_index, USize p_count) {
 		// Remove by forking.
 		CowData new_data;
 
-		const Error error = new_data._alloc_exact(smaller_capacity(capacity(), new_size));
-		if (error) {
-			return error;
-		}
+		RETURN_IF_ERROR(new_data._alloc_exact(smaller_capacity(capacity(), new_size)));
 
 		// Copy over elements.
 		copy_arr_placement(new_data._ptr, _ptr, p_index);
@@ -466,10 +448,7 @@ Error CowData<T>::resize(Size p_size) {
 	if (p_size > prev_size) {
 		// Caller wants to grow.
 
-		const Error error = _insert_uninitialized(prev_size, p_size - prev_size);
-		if (error) {
-			return error;
-		}
+		RETURN_IF_ERROR(_insert_uninitialized(prev_size, p_size - prev_size));
 
 		// Construct new elements.
 		if constexpr (p_initialize) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -677,18 +677,12 @@ Error VariantParser::_parse_byte_array(Stream *p_stream, Vector<uint8_t> &r_cons
 Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_stream, int &r_line, String &r_err_str, ResourceParser *p_res_parser) {
 	if (r_token.type == TK_CURLY_BRACKET_OPEN) {
 		Dictionary d;
-		Error err = _parse_dictionary(d, p_stream, r_line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_dictionary(d, p_stream, r_line, r_err_str, p_res_parser));
 		r_value = d;
 		return OK;
 	} else if (r_token.type == TK_BRACKET_OPEN) {
 		Array a;
-		Error err = _parse_array(a, p_stream, r_line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_array(a, p_stream, r_line, r_err_str, p_res_parser));
 		r_value = a;
 		return OK;
 	} else if (r_token.type == TK_IDENTIFIER) {
@@ -708,10 +702,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Math::NaN;
 		} else if (id == "Vector2") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 2) {
 				r_err_str = "Expected 2 arguments for constructor";
@@ -721,10 +712,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector2(args[0], args[1]);
 		} else if (id == "Vector2i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int32_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 2) {
 				r_err_str = "Expected 2 arguments for constructor";
@@ -734,10 +722,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector2i(args[0], args[1]);
 		} else if (id == "Rect2") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -747,10 +732,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Rect2(args[0], args[1], args[2], args[3]);
 		} else if (id == "Rect2i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int32_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -760,10 +742,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Rect2i(args[0], args[1], args[2], args[3]);
 		} else if (id == "Vector3") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 3) {
 				r_err_str = "Expected 3 arguments for constructor";
@@ -773,10 +752,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector3(args[0], args[1], args[2]);
 		} else if (id == "Vector3i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int32_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 3) {
 				r_err_str = "Expected 3 arguments for constructor";
@@ -786,10 +762,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector3i(args[0], args[1], args[2]);
 		} else if (id == "Vector4") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -799,10 +772,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector4(args[0], args[1], args[2], args[3]);
 		} else if (id == "Vector4i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int32_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -812,10 +782,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Vector4i(args[0], args[1], args[2], args[3]);
 		} else if (id == "Transform2D" || id == "Matrix32") { //compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 6) {
 				r_err_str = "Expected 6 arguments for constructor";
@@ -829,10 +796,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = m;
 		} else if (id == "Plane") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -842,10 +806,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Plane(args[0], args[1], args[2], args[3]);
 		} else if (id == "Quaternion" || id == "Quat") { // "Quat" kept for compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -855,10 +816,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Quaternion(args[0], args[1], args[2], args[3]);
 		} else if (id == "AABB" || id == "Rect3") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 6) {
 				r_err_str = "Expected 6 arguments for constructor";
@@ -868,10 +826,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = AABB(Vector3(args[0], args[1], args[2]), Vector3(args[3], args[4], args[5]));
 		} else if (id == "Basis" || id == "Matrix3") { //compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 9) {
 				r_err_str = "Expected 9 arguments for constructor";
@@ -881,10 +836,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Basis(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
 		} else if (id == "Transform3D" || id == "Transform") { // "Transform" kept for compatibility with Godot <4.
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 12) {
 				r_err_str = "Expected 12 arguments for constructor";
@@ -894,10 +846,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Transform3D(Basis(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]), Vector3(args[9], args[10], args[11]));
 		} else if (id == "Projection") { // "Transform" kept for compatibility with Godot <4.
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 16) {
 				r_err_str = "Expected 16 arguments for constructor";
@@ -907,10 +856,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = Projection(Vector4(args[0], args[1], args[2], args[3]), Vector4(args[4], args[5], args[6], args[7]), Vector4(args[8], args[9], args[10], args[11]), Vector4(args[12], args[13], args[14], args[15]));
 		} else if (id == "Color") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<float>(p_stream, args, r_line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -1034,10 +980,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				}
 
 				if (at_key) {
-					Error err = get_token(p_stream, r_token, r_line, r_err_str);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(get_token(p_stream, r_token, r_line, r_err_str));
 
 					if (r_token.type == TK_PARENTHESIS_CLOSE) {
 						r_value = ref.is_valid() ? Variant(ref) : Variant(obj);
@@ -1061,27 +1004,17 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 
 					key = r_token.value;
 
-					err = get_token(p_stream, r_token, r_line, r_err_str);
-
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(get_token(p_stream, r_token, r_line, r_err_str));
 					if (r_token.type != TK_COLON) {
 						r_err_str = "Expected ':'";
 						return ERR_PARSE_ERROR;
 					}
 					at_key = false;
 				} else {
-					Error err = get_token(p_stream, r_token, r_line, r_err_str);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(get_token(p_stream, r_token, r_line, r_err_str));
 
 					Variant v;
-					err = parse_value(r_token, v, p_stream, r_line, r_err_str, p_res_parser);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERROR(parse_value(r_token, v, p_stream, r_line, r_err_str, p_res_parser));
 					obj->set(key, v);
 					need_comma = true;
 					at_key = true;
@@ -1096,10 +1029,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 
 			if (p_res_parser && id == "Resource" && p_res_parser->func) {
 				Ref<Resource> res;
-				Error err = p_res_parser->func(p_res_parser->userdata, p_stream, res, r_line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(p_res_parser->func(p_res_parser->userdata, p_stream, res, r_line, r_err_str));
 
 				r_value = res;
 			} else if (p_res_parser && id == "ExtResource" && p_res_parser->ext_func) {
@@ -1115,10 +1045,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				r_value = res;
 			} else if (p_res_parser && id == "SubResource" && p_res_parser->sub_func) {
 				Ref<Resource> res;
-				Error err = p_res_parser->sub_func(p_res_parser->userdata, p_stream, res, r_line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(p_res_parser->sub_func(p_res_parser->userdata, p_stream, res, r_line, r_err_str));
 
 				r_value = res;
 			} else {
@@ -1410,10 +1337,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = array;
 		} else if (id == "PackedByteArray" || id == "PoolByteArray" || id == "ByteArray") {
 			Vector<uint8_t> args;
-			Error err = _parse_byte_array(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_byte_array(p_stream, args, r_line, r_err_str));
 
 			Vector<uint8_t> arr;
 			{
@@ -1428,10 +1352,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedInt32Array" || id == "PackedIntArray" || id == "PoolIntArray" || id == "IntArray") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int32_t>(p_stream, args, r_line, r_err_str));
 
 			Vector<int32_t> arr;
 			{
@@ -1446,10 +1367,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedInt64Array") {
 			Vector<int64_t> args;
-			Error err = _parse_construct<int64_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<int64_t>(p_stream, args, r_line, r_err_str));
 
 			Vector<int64_t> arr;
 			{
@@ -1464,10 +1382,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedFloat32Array" || id == "PackedRealArray" || id == "PoolRealArray" || id == "FloatArray") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<float>(p_stream, args, r_line, r_err_str));
 
 			Vector<float> arr;
 			{
@@ -1482,10 +1397,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedFloat64Array") {
 			Vector<double> args;
-			Error err = _parse_construct<double>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<double>(p_stream, args, r_line, r_err_str));
 
 			Vector<double> arr;
 			{
@@ -1546,10 +1458,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedVector2Array" || id == "PoolVector2Array" || id == "Vector2Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			Vector<Vector2> arr;
 			{
@@ -1564,10 +1473,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedVector3Array" || id == "PoolVector3Array" || id == "Vector3Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			Vector<Vector3> arr;
 			{
@@ -1582,10 +1488,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedVector4Array" || id == "PoolVector4Array" || id == "Vector4Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<real_t>(p_stream, args, r_line, r_err_str));
 
 			Vector<Vector4> arr;
 			{
@@ -1600,10 +1503,7 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = arr;
 		} else if (id == "PackedColorArray" || id == "PoolColorArray" || id == "ColorArray") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, r_line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_construct<float>(p_stream, args, r_line, r_err_str));
 
 			Vector<Color> arr;
 			{
@@ -1651,10 +1551,7 @@ Error VariantParser::_parse_array(Array &r_array, Stream *p_stream, int &r_line,
 			return ERR_FILE_CORRUPT;
 		}
 
-		Error err = get_token(p_stream, token, r_line, r_err_str);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(get_token(p_stream, token, r_line, r_err_str));
 
 		if (token.type == TK_BRACKET_CLOSE) {
 			return OK;
@@ -1671,10 +1568,7 @@ Error VariantParser::_parse_array(Array &r_array, Stream *p_stream, int &r_line,
 		}
 
 		Variant v;
-		err = parse_value(token, v, p_stream, r_line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(parse_value(token, v, p_stream, r_line, r_err_str, p_res_parser));
 
 		r_array.push_back(v);
 		need_comma = true;
@@ -1694,10 +1588,7 @@ Error VariantParser::_parse_dictionary(Dictionary &r_object, Stream *p_stream, i
 		}
 
 		if (at_key) {
-			Error err = get_token(p_stream, token, r_line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(get_token(p_stream, token, r_line, r_err_str));
 
 			if (token.type == TK_CURLY_BRACKET_CLOSE) {
 				return OK;
@@ -1713,30 +1604,19 @@ Error VariantParser::_parse_dictionary(Dictionary &r_object, Stream *p_stream, i
 				}
 			}
 
-			err = parse_value(token, key, p_stream, r_line, r_err_str, p_res_parser);
+			RETURN_IF_ERROR(parse_value(token, key, p_stream, r_line, r_err_str, p_res_parser));
 
-			if (err) {
-				return err;
-			}
-
-			err = get_token(p_stream, token, r_line, r_err_str);
-
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(get_token(p_stream, token, r_line, r_err_str));
 			if (token.type != TK_COLON) {
 				r_err_str = "Expected ':'";
 				return ERR_PARSE_ERROR;
 			}
 			at_key = false;
 		} else {
-			Error err = get_token(p_stream, token, r_line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(get_token(p_stream, token, r_line, r_err_str));
 
 			Variant v;
-			err = parse_value(token, v, p_stream, r_line, r_err_str, p_res_parser);
+			Error err = parse_value(token, v, p_stream, r_line, r_err_str, p_res_parser);
 			if (err && err != ERR_FILE_MISSING_DEPENDENCIES) {
 				return err;
 			}
@@ -1861,10 +1741,7 @@ Error VariantParser::_parse_tag(Token &r_token, Stream *p_stream, int &r_line, S
 
 		get_token(p_stream, r_token, r_line, r_err_str);
 		Variant value;
-		Error err = parse_value(r_token, value, p_stream, r_line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(parse_value(r_token, value, p_stream, r_line, r_err_str, p_res_parser));
 
 		r_tag.fields[id] = value;
 	}
@@ -1934,10 +1811,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &r_line, String 
 			if (c == '"') { //quoted
 				p_stream->saved = '"';
 				Token tk;
-				Error err = get_token(p_stream, tk, r_line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(get_token(p_stream, tk, r_line, r_err_str));
 				if (tk.type != TK_STRING) {
 					r_err_str = "Error reading quoted string";
 					return ERR_INVALID_DATA;
@@ -1962,10 +1836,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &r_line, String 
 
 Error VariantParser::parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser) {
 	Token token;
-	Error err = get_token(p_stream, token, r_err_line, r_err_str);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(get_token(p_stream, token, r_err_line, r_err_str));
 
 	if (token.type == TK_EOF) {
 		return ERR_FILE_EOF;

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -951,10 +951,7 @@ Error RenderingDeviceDriverMetal::swap_chain_resize(CommandQueueID p_cmd_queue, 
 
 	DataFormat new_data_format = DATA_FORMAT_MAX;
 	ColorSpace new_color_space = COLOR_SPACE_MAX;
-	Error err = surface->resize(p_desired_framebuffer_count, new_data_format, new_color_space);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(surface->resize(p_desired_framebuffer_count, new_data_format, new_color_space));
 
 	if (new_data_format != swap_chain->data_format) {
 		_swap_chain_release(swap_chain);

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -35,10 +35,7 @@
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	const uint64_t buffer_size = f->get_length();
 	Vector<uint8_t> file_buffer;
-	Error err = file_buffer.resize(buffer_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(file_buffer.resize(buffer_size));
 	{
 		uint8_t *writer = file_buffer.ptrw();
 		f->get_buffer(writer, buffer_size);

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -124,10 +124,7 @@ Error DAPeer::send_data() {
 		int data_sent = 0;
 		while (data_sent < formatted_data.size()) {
 			int curr_sent = 0;
-			Error err = connection->put_partial_data(formatted_data.ptr() + data_sent, formatted_data.size() - data_sent, curr_sent);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(connection->put_partial_data(formatted_data.ptr() + data_sent, formatted_data.size() - data_sent, curr_sent));
 			data_sent += curr_sent;
 		}
 		res_queue.pop_front();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -299,10 +299,7 @@ Error EditorDebuggerNode::start(const String &p_uri) {
 	current_uri = p_uri;
 
 	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));
-	const Error err = server->start(p_uri);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(server->start(p_uri));
 	set_process(true);
 	EditorNode::get_log()->add_message("--- Debugging process started ---", EditorLog::MSG_TYPE_EDITOR);
 	return OK;

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -1294,10 +1294,7 @@ Error DocTools::load_classes(const String &p_dir) {
 	while (!path.is_empty()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			Ref<XMLParser> parser = memnew(XMLParser);
-			Error err2 = parser->open(p_dir.path_join(path));
-			if (err2) {
-				return err2;
-			}
+			RETURN_IF_ERROR(parser->open(p_dir.path_join(path)));
 
 			_load(parser);
 		}
@@ -1877,10 +1874,7 @@ Error DocTools::load_compressed(const uint8_t *p_data, int64_t p_compressed_size
 	class_list.clear();
 
 	Ref<XMLParser> parser = memnew(XMLParser);
-	Error err = parser->open_buffer(data);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(parser->open_buffer(data));
 
 	_load(parser);
 
@@ -1889,10 +1883,7 @@ Error DocTools::load_compressed(const uint8_t *p_data, int64_t p_compressed_size
 
 Error DocTools::load_xml(const uint8_t *p_data, int64_t p_size) {
 	Ref<XMLParser> parser = memnew(XMLParser);
-	Error err = parser->_open_buffer(p_data, p_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(parser->_open_buffer(p_data, p_size));
 
 	_load(parser);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5056,10 +5056,7 @@ Error EditorNode::open_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		}
 	}
 
-	Error err = load_scene(p_scene, p_ignore_broken_deps, p_set_inherited, p_force_open_imported);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(load_scene(p_scene, p_ignore_broken_deps, p_set_inherited, p_force_open_imported));
 
 	int current_scene_idx = editor_data.get_edited_scene_count() - 1;
 	Node *new_scene = editor_data.get_edited_scene_root(current_scene_idx);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -447,10 +447,7 @@ Error EditorExportPlatform::_save_pack_file(const Ref<EditorExportPreset> &p_pre
 	sd.ofs = (pd->use_sparse_pck) ? 0 : pd->f->get_position();
 	sd.size = p_data.size();
 	sd.delta = p_delta;
-	Error err = _encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_encrypt_and_store_data(ftmp, simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, sd.encrypted));
 	if (!pd->use_sparse_pck) {
 		ERR_FAIL_COND_V(pd->f->get_position() - sd.ofs < (uint64_t)p_data.size(), ERR_FILE_CANT_WRITE);
 	}
@@ -520,10 +517,7 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 	Vector<uint8_t> patch_data = p_data;
 
 	if (delta) {
-		Error err = DeltaEncoding::encode_delta(old_data, p_data, patch_data, p_preset->get_patch_delta_zstd_level());
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(DeltaEncoding::encode_delta(old_data, p_data, patch_data, p_preset->get_patch_delta_zstd_level()));
 
 		int64_t reduction_bytes = MAX(0, p_data.size() - patch_data.size());
 		double reduction_ratio = reduction_bytes / (double)p_data.size();
@@ -2473,22 +2467,16 @@ Error EditorExportPlatform::export_zip(const Ref<EditorExportPreset> &p_preset, 
 
 Error EditorExportPlatform::export_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
-	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
-	err = save_pack_patch(p_preset, p_debug, p_path);
+	RETURN_IF_ERROR(_load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches));
+	Error err = save_pack_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }
 
 Error EditorExportPlatform::export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
-	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
-	err = save_zip_patch(p_preset, p_debug, p_path);
+	RETURN_IF_ERROR(_load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches));
+	Error err = save_zip_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }
@@ -2712,10 +2700,8 @@ Error EditorExportPlatform::ssh_push_to_remote(const String &p_host, const Strin
 		OS::get_singleton()->print("\n");
 	}
 
-	Error err = OS::get_singleton()->execute(scp_path, args, &out, &exit_code, true);
-	if (err != OK) {
-		return err;
-	} else if (exit_code != 0) {
+	RETURN_IF_ERROR(OS::get_singleton()->execute(scp_path, args, &out, &exit_code, true));
+	if (exit_code != 0) {
 		if (!out.is_empty()) {
 			print_line(out);
 		}

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -990,10 +990,7 @@ Error EditorExportPlatformAppleEmbedded::_convert_to_framework(const String &p_s
 	}
 
 	if (!filesystem_da->dir_exists(p_destination)) {
-		Error make_dir_err = filesystem_da->make_dir_recursive(p_destination);
-		if (make_dir_err) {
-			return make_dir_err;
-		}
+		RETURN_IF_ERROR(filesystem_da->make_dir_recursive(p_destination));
 	}
 
 	String asset = p_source.ends_with("/") ? p_source.left(-1) : p_source;
@@ -1256,10 +1253,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 		destination = destination_dir;
 
 		// Convert to framework and copy.
-		Error err = _convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier"));
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
 	} else if (p_is_framework && asset.ends_with(".xcframework")) {
 		// For Apple Embedded platforms we need to turn .dylib inside .xcframework
 		// into .framework to be able to send application to AppStore
@@ -1285,22 +1279,13 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		if (dylibs > 0) {
 			// Convert to framework and copy.
-			Error err = _convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier"));
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
 		} else {
 			// Copy as is.
 			if (!filesystem_da->dir_exists(destination_dir)) {
-				Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
-				if (make_dir_err) {
-					return make_dir_err;
-				}
+				RETURN_IF_ERROR(filesystem_da->make_dir_recursive(destination_dir));
 			}
-			Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 		}
 	} else if (p_is_framework && asset.ends_with(".framework")) {
 		// Framework.
@@ -1320,15 +1305,9 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		// Copy as is.
 		if (!filesystem_da->dir_exists(destination_dir)) {
-			Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
-			if (make_dir_err) {
-				return make_dir_err;
-			}
+			RETURN_IF_ERROR(filesystem_da->make_dir_recursive(destination_dir));
 		}
-		Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 	} else {
 		// Unknown resource.
 		asset_path = base_dir;
@@ -1347,15 +1326,9 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		// Copy as is.
 		if (!filesystem_da->dir_exists(destination_dir)) {
-			Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
-			if (make_dir_err) {
-				return make_dir_err;
-			}
+			RETURN_IF_ERROR(filesystem_da->make_dir_recursive(destination_dir));
 		}
-		Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 	}
 
 	if (asset_path.ends_with("/")) {

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -311,10 +311,7 @@ Error EditorExportPlatformExtension::export_zip(const Ref<EditorExportPreset> &p
 Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches));
 
 	Error ret = FAILED;
 	if (GDVIRTUAL_CALL(_export_pack_patch, p_preset, p_debug, p_path, p_patches, p_flags, ret)) {
@@ -322,7 +319,7 @@ Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPre
 		return ret;
 	}
 
-	err = save_pack_patch(p_preset, p_debug, p_path);
+	Error err = save_pack_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }
@@ -330,10 +327,7 @@ Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPre
 Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches));
 
 	Error ret = FAILED;
 	if (GDVIRTUAL_CALL(_export_zip_patch, p_preset, p_debug, p_path, p_patches, p_flags, ret)) {
@@ -341,7 +335,7 @@ Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPres
 		return ret;
 	}
 
-	err = save_zip_patch(p_preset, p_debug, p_path);
+	Error err = save_zip_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3114,10 +3114,7 @@ void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file
 Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (FileAccess::exists(p_from + ".import")) {
-		Error err = da->copy(p_from, p_to);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(da->copy(p_from, p_to));
 
 		// Save the new .import file
 		Ref<ConfigFile> cfg;
@@ -3126,26 +3123,19 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 		String importer_name = cfg->get_value("remap", "importer");
 
 		if (importer_name == "keep" || importer_name == "skip") {
-			err = da->copy(p_from + ".import", p_to + ".import");
-			return err;
+			return da->copy(p_from + ".import", p_to + ".import");
 		}
 
 		// Roll a new uid for this copied .import file to avoid conflict.
 		ResourceUID::ID res_uid = ResourceUID::get_singleton()->create_id_for_path(p_to);
 		cfg->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(res_uid));
-		err = cfg->save(p_to + ".import");
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(cfg->save(p_to + ".import"));
 
 		// Make sure it's immediately added to the map so we can remap dependencies if we want to after this.
 		ResourceUID::get_singleton()->add_id(res_uid, p_to);
 	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID) {
 		// Files which do not use an uid can just be copied.
-		Error err = da->copy(p_from, p_to);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(da->copy(p_from, p_to));
 	} else {
 		// Load the resource and save it again in the new location (this generates a new UID).
 		Error err = OK;
@@ -3586,10 +3576,7 @@ Error EditorFileSystem::make_dir_recursive(const String &p_path, const String &p
 }
 
 Error EditorFileSystem::copy_file(const String &p_from, const String &p_to) {
-	Error err = _copy_file(p_from, p_to);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_copy_file(p_from, p_to));
 
 	EditorFileSystemDirectory *parent = get_filesystem_path(p_to.get_base_dir());
 	ERR_FAIL_NULL_V(parent, ERR_FILE_NOT_FOUND);

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -137,10 +137,7 @@ Error ColladaImport::_populate_skeleton(Skeleton3D *p_skeleton, Collada::Node *p
 
 	int id = r_bone++;
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _populate_skeleton(p_skeleton, p_node->children[i], r_bone, id);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_populate_skeleton(p_skeleton, p_node->children[i], r_bone, id));
 	}
 
 	return OK;
@@ -178,10 +175,7 @@ Error ColladaImport::_create_scene_skeletons(Collada::Node *p_node) {
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_scene_skeletons(p_node->children[i]);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_create_scene_skeletons(p_node->children[i]));
 	}
 	return OK;
 }
@@ -321,10 +315,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_scene(p_node->children[i], node);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_create_scene(p_node->children[i], node));
 	}
 	return OK;
 }
@@ -1321,10 +1312,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_resources(p_node->children[i], p_use_compression);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_create_resources(p_node->children[i], p_use_compression));
 	}
 	return OK;
 }

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -77,10 +77,7 @@ Error ResourceImporterBitMap::import(ResourceUID::ID p_source_id, const String &
 	float threshold = p_options["threshold"];
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(ImageLoader::load_image(p_source_file, image));
 
 	int w = image->get_width();
 	int h = image->get_height();

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -346,10 +346,7 @@ Error ResourceImporterLayeredTexture::import(ResourceUID::ID p_source_id, const 
 
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(ImageLoader::load_image(p_source_file, image));
 
 	if (compress_mode == COMPRESS_VRAM_COMPRESSED) {
 		//if using video ram, optimize

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -791,10 +791,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	// Load the main image.
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale));
 	images_imported.push_back(image);
 
 	// Load the editor-only image.
@@ -809,7 +806,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		}
 
 		editor_image.instantiate();
-		err = ImageLoader::load_image(p_source_file, editor_image, nullptr, editor_loader_flags, editor_scale);
+		Error err = ImageLoader::load_image(p_source_file, editor_image, nullptr, editor_loader_flags, editor_scale);
 
 		if (err != OK) {
 			WARN_PRINT(vformat("Failed to import an image resource for editor use from '%s'.", p_source_file));

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -64,10 +64,7 @@ Error ENetMultiplayerPeer::create_server(int p_port, int p_max_clients, int p_ma
 	set_refuse_new_connections(false);
 	Ref<ENetConnection> host;
 	host.instantiate();
-	Error err = host->create_host_bound(bind_ip, p_port, p_max_clients, 0, p_max_channels > 0 ? p_max_channels + SYSCH_MAX : 0, p_out_bandwidth);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(host->create_host_bound(bind_ip, p_port, p_max_clients, 0, p_max_channels > 0 ? p_max_channels + SYSCH_MAX : 0, p_out_bandwidth));
 
 	active_mode = MODE_SERVER;
 	unique_id = 1;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -538,10 +538,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 				for (GDScriptParser::ClassNode *look_class : script_classes) {
 					if (look_class->identifier && look_class->identifier->name == name) {
 						if (!look_class->self_type.is_set()) {
-							Error err = resolve_class_inheritance(look_class, id);
-							if (err) {
-								return err;
-							}
+							RETURN_IF_ERROR(resolve_class_inheritance(look_class, id));
 						}
 						base = look_class->self_type;
 						found = true;
@@ -652,11 +649,9 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 }
 
 Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive) {
-	Error err = resolve_class_inheritance(p_class);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(resolve_class_inheritance(p_class));
 
+	Error err = OK;
 	if (p_recursive) {
 		for (int i = 0; i < p_class->members.size(); i++) {
 			if (p_class->members[i].type == GDScriptParser::ClassNode::Member::CLASS) {
@@ -6739,16 +6734,10 @@ Error GDScriptAnalyzer::resolve_dependencies() {
 Error GDScriptAnalyzer::analyze() {
 	parser->errors.clear();
 
-	Error err = resolve_inheritance();
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(resolve_inheritance());
 
 	resolve_interface();
-	err = resolve_body();
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(resolve_body());
 
 	return resolve_dependencies();
 }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2781,10 +2781,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 			}
 
 			if (main_script->has_class(base.ptr())) {
-				Error err = _prepare_compilation(base.ptr(), p_class->base_type.class_type, p_keep_state);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_prepare_compilation(base.ptr(), p_class->base_type.class_type, p_keep_state));
 			} else if (!base->is_script_valid()) {
 				String base_qualified_name = base->fully_qualified_name;
 				String base_path = base->path;
@@ -2991,10 +2988,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 		// Subclass might still be parsing, just skip it
 		if (!parsing_classes.has(subclass_ptr)) {
-			Error err = _prepare_compilation(subclass_ptr, inner_class, p_keep_state);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_prepare_compilation(subclass_ptr, inner_class, p_keep_state));
 		}
 
 		p_script->constants.insert(name, subclass); //once parsed, goes to the list of constants
@@ -3018,16 +3012,10 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 			const GDScriptParser::VariableNode *variable = member.variable;
 			if (variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
 				if (variable->setter != nullptr) {
-					Error err = _parse_setter_getter(p_script, p_class, variable, true);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERROR(_parse_setter_getter(p_script, p_class, variable, true));
 				}
 				if (variable->getter != nullptr) {
-					Error err = _parse_setter_getter(p_script, p_class, variable, false);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERROR(_parse_setter_getter(p_script, p_class, variable, false));
 				}
 			}
 		}
@@ -3081,10 +3069,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 		StringName name = inner_class->identifier->name;
 		GDScript *subclass = p_script->subclasses[name].ptr();
 
-		Error err = _compile_class(subclass, inner_class, p_keep_state);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_compile_class(subclass, inner_class, p_keep_state));
 
 		has_static_data = has_static_data || inner_class->has_static_data;
 	}
@@ -3292,16 +3277,9 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	make_scripts(p_script, root, p_keep_state);
 
 	main_script->_owner = nullptr;
-	Error err = _prepare_compilation(main_script, parser->get_tree(), p_keep_state);
+	RETURN_IF_ERROR(_prepare_compilation(main_script, parser->get_tree(), p_keep_state));
 
-	if (err) {
-		return err;
-	}
-
-	err = _compile_class(main_script, root, p_keep_state);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_compile_class(main_script, root, p_keep_state));
 
 	ScriptLambdaInfo new_lambda_info = _get_script_lambda_replacement_info(p_script);
 
@@ -3313,7 +3291,7 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 		GDScriptCache::add_static_script(p_script);
 	}
 
-	err = GDScriptCache::finish_compiling(main_script->path);
+	Error err = GDScriptCache::finish_compiling(main_script->path);
 	if (err) {
 		_set_error(R"(Failed to compile depended scripts.)", nullptr);
 	}

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -190,10 +190,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 	for (uint32_t i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = decode_variant(v, b, total_len, &len, false);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(decode_variant(v, b, total_len, &len, false));
 		b += len;
 		total_len -= len;
 		constants.write[i] = v;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -124,10 +124,7 @@ Error GDScriptLanguageProtocol::LSPeer::send_data() {
 	while (!res_queue.is_empty()) {
 		CharString c_res = res_queue[0];
 		if (res_sent < c_res.size()) {
-			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent));
 			res_sent += sent;
 		}
 		// Response sent

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -351,10 +351,7 @@ bool EditorImportBlendRunner::_extract_error_message_xml(const Vector<uint8_t> &
 Error EditorImportBlendRunner::do_import_direct(const Dictionary &p_options) {
 	// Export glTF directly.
 	String python = vformat(PYTHON_SCRIPT_DIRECT, dict_to_python(p_options));
-	Error err = start_blender(python, true);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(start_blender(python, true));
 
 	return OK;
 }

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7238,11 +7238,8 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	p_state->set_base_path(p_path.get_base_dir());
 	p_state->filename = p_path.get_file();
-	Error err = _serialize(p_state);
-	if (err != OK) {
-		return err;
-	}
-	err = _serialize_file(p_state, p_path);
+	RETURN_IF_ERROR(_serialize(p_state));
+	Error err = _serialize_file(p_state, p_path);
 	if (err != OK) {
 		return Error::FAILED;
 	}

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1769,10 +1769,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		StringBuilder constants_source;
 		_generate_global_constants(constants_source);
 		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_constants.cs");
-		Error save_err = _save_file(output_file, constants_source);
-		if (save_err != OK) {
-			return save_err;
-		}
+		RETURN_IF_ERROR(_save_file(output_file, constants_source));
 
 		compile_items.push_back(output_file);
 	}
@@ -1782,10 +1779,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		StringBuilder extensions_source;
 		_generate_array_extensions(extensions_source);
 		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_extensions.cs");
-		Error save_err = _save_file(output_file, extensions_source);
-		if (save_err != OK) {
-			return save_err;
-		}
+		RETURN_IF_ERROR(_save_file(output_file, extensions_source));
 
 		compile_items.push_back(output_file);
 	}
@@ -1865,11 +1859,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		cs_built_in_ctors_content.append(CLOSE_BLOCK);
 
 		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR ".cs");
-		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
-
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_save_file(constructors_file, cs_built_in_ctors_content));
 
 		compile_items.push_back(constructors_file);
 	}
@@ -1899,20 +1889,14 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		if (icall.editor_only) {
 			continue;
 		}
-		Error err = _generate_cs_native_calls(icall, cs_icalls_content);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_generate_cs_native_calls(icall, cs_icalls_content));
 	}
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
 	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS ".cs");
 
-	Error err = _save_file(internal_methods_file, cs_icalls_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_save_file(internal_methods_file, cs_icalls_content));
 
 	compile_items.push_back(internal_methods_file);
 
@@ -1932,10 +1916,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
-	err = _save_file(includes_props_file, includes_props_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_save_file(includes_props_file, includes_props_content));
 
 	return OK;
 }
@@ -2023,11 +2004,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		cs_built_in_ctors_content.append(CLOSE_BLOCK);
 
 		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR_EDITOR ".cs");
-		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
-
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_save_file(constructors_file, cs_built_in_ctors_content));
 
 		compile_items.push_back(constructors_file);
 	}
@@ -2059,20 +2036,14 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		if (!icall.editor_only) {
 			continue;
 		}
-		Error err = _generate_cs_native_calls(icall, cs_icalls_content);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERROR(_generate_cs_native_calls(icall, cs_icalls_content));
 	}
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
 	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS_EDITOR ".cs");
 
-	Error err = _save_file(internal_methods_file, cs_icalls_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_save_file(internal_methods_file, cs_icalls_content));
 
 	compile_items.push_back(internal_methods_file);
 
@@ -2092,10 +2063,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
-	err = _save_file(includes_props_file, includes_props_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_save_file(includes_props_file, includes_props_content));
 
 	return OK;
 }

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -160,20 +160,15 @@ Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileacces
 	p_fileaccess->get_buffer(buffer.ptrw(), buffer.size());
 
 	String svg;
-	Error err = svg.append_utf8((const char *)buffer.ptr(), buffer.size());
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(svg.append_utf8((const char *)buffer.ptr(), buffer.size()));
 
 	if (p_flags & FLAG_CONVERT_COLORS) {
-		err = create_image_from_string(p_image, svg, p_scale, false, forced_color_map);
+		RETURN_IF_ERROR(create_image_from_string(p_image, svg, p_scale, false, forced_color_map));
 	} else {
-		err = create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>());
+		RETURN_IF_ERROR(create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>()));
 	}
 
-	if (err != OK) {
-		return err;
-	} else if (p_image->is_empty()) {
+	if (p_image->is_empty()) {
 		return ERR_INVALID_DATA;
 	}
 

--- a/modules/visual_shader/visual_shader.cpp
+++ b/modules/visual_shader/visual_shader.cpp
@@ -2118,10 +2118,7 @@ Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringB
 				continue;
 			}
 
-			Error err = _write_node(type, p_global_code, p_global_code_per_node, p_global_code_per_func, r_code, r_def_tex_params, p_input_connections, from_node, r_processed, p_for_preview, r_classes);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_write_node(type, p_global_code, p_global_code_per_node, p_global_code_per_func, r_code, r_def_tex_params, p_input_connections, from_node, r_processed, p_for_preview, r_classes));
 		}
 	}
 

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -200,10 +200,7 @@ Error WebSocketMultiplayerPeer::create_client(const String &p_url, const Ref<TLS
 	ERR_FAIL_COND_V(p_options.is_valid() && p_options->is_server(), ERR_INVALID_PARAMETER);
 	_clear();
 	Ref<WebSocketPeer> peer = _create_peer();
-	Error err = peer->connect_to_url(p_url, p_options);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(peer->connect_to_url(p_url, p_options));
 	PendingPeer pending;
 	pending.time = OS::get_singleton()->get_ticks_msec();
 	pending_peers[1] = pending;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -837,10 +837,7 @@ Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd));
 
 	String dst_path;
 	if (ed->pd.salt.length() == 32) {

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -143,10 +143,7 @@ Error create_directory(const String &p_dir) {
 // Note: this will overwrite the file at p_path if it already exists.
 Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data) {
 	String dir = p_path.get_base_dir();
-	Error err = create_directory(dir);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(create_directory(dir));
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
 	fa->store_buffer(p_data.ptr(), p_data.size());
@@ -182,10 +179,7 @@ Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_p
 
 	Vector<uint8_t> enc_data;
 	EditorExportPlatform::SavedData sd;
-	Error err = _store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_store_temp_file(simplified_path, p_data, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, p_delta, enc_data, sd));
 
 	String dst_path;
 	if (export_data->pd.salt.length() == 32) {
@@ -194,7 +188,7 @@ Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_p
 		dst_path = export_data->assets_directory + String("/") + simplified_path.trim_prefix("res://");
 	}
 	print_verbose("Saving project files from " + simplified_path + " into " + dst_path);
-	err = store_file_at_path(dst_path, enc_data);
+	Error err = store_file_at_path(dst_path, enc_data);
 
 	export_data->pd.file_ofs.push_back(sd);
 	return err;

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -96,10 +96,7 @@ void NetSocketAndroid::close() {
 }
 
 Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
-	Error err = NetSocketUnix::set_broadcasting_enabled(p_enabled);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(NetSocketUnix::set_broadcasting_enabled(p_enabled));
 
 	if (p_enabled != wants_broadcast) {
 		if (p_enabled) {
@@ -115,10 +112,7 @@ Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 }
 
 Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketUnix::join_multicast_group(p_multi_address, p_if_name);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(NetSocketUnix::join_multicast_group(p_multi_address, p_if_name));
 
 	if (!multicast_groups) {
 		multicast_lock_acquire();
@@ -129,10 +123,7 @@ Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, c
 }
 
 Error NetSocketAndroid::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketUnix::leave_multicast_group(p_multi_address, p_if_name);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(NetSocketUnix::leave_multicast_group(p_multi_address, p_if_name));
 
 	ERR_FAIL_COND_V(multicast_groups == 0, ERR_BUG);
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -807,15 +807,9 @@ Error OS_Android::move_to_trash(const String &p_path) {
 
 	// Check if it's a directory
 	if (da_ref->dir_exists(p_path)) {
-		Error err = da_ref->change_dir(p_path);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(da_ref->change_dir(p_path));
 		// This is directory, let's erase its contents
-		err = da_ref->erase_contents_recursive();
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(da_ref->erase_contents_recursive());
 		// Remove the top directory
 		return da_ref->remove(p_path);
 	} else if (da_ref->file_exists(p_path)) {

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -732,10 +732,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_
 	fd.opt_in_cb = p_options_in_cb;
 
 	String token;
-	Error err = make_request_token(token);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(make_request_token(token));
 
 	// Generate FileChooser message.
 	const char *method = nullptr;

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -131,10 +131,7 @@ Error AudioDriverWeb::init() {
 	mix_rate = audio_context.mix_rate;
 	channel_count = audio_context.channel_count;
 	buffer_length = Math::closest_power_of_2(uint32_t(latency * mix_rate / 1000));
-	Error err = create(buffer_length, channel_count);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(create(buffer_length, channel_count));
 	if (output_rb) {
 		memdelete_arr(output_rb);
 	}

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -794,23 +794,14 @@ Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int 
 			switch (p_option) {
 				// Run in Browser.
 				case 0: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
-					err = _start_server(bind_host, bind_port, use_tls);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(_export_project(p_preset, p_debug_flags));
+					RETURN_IF_ERROR(_start_server(bind_host, bind_port, use_tls));
 					return _launch_browser(bind_host, bind_port, use_tls);
 				} break;
 
 				// Start HTTP Server.
 				case 1: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(_export_project(p_preset, p_debug_flags));
 					return _start_server(bind_host, bind_port, use_tls);
 				} break;
 
@@ -824,10 +815,7 @@ Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int 
 			switch (p_option) {
 				// Run in Browser.
 				case 0: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERROR(_export_project(p_preset, p_debug_flags));
 					return _launch_browser(bind_host, bind_port, use_tls);
 				} break;
 

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -93,10 +93,7 @@ Error HTTPClientWeb::request(Method p_method, const String &p_url, const Vector<
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
 
-	Error err = verify_headers(p_headers);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(verify_headers(p_headers));
 
 	String url = (use_tls ? "https://" : "http://") + host + ":" + itos(port) + p_url;
 	Vector<CharString> keeper;

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -352,10 +352,7 @@ PFNWGLDELETECONTEXT gd_wglDeleteContext;
 PFNWGLGETPROCADDRESS gd_wglGetProcAddress;
 
 Error GLManagerNative_Windows::_create_context(GLWindow &win, GLDisplay &gl_display) {
-	Error err = _configure_pixel_format(win.hDC);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERROR(_configure_pixel_format(win.hDC));
 
 	HMODULE module = LoadLibraryW(L"opengl32.dll");
 	if (!module) {
@@ -434,10 +431,7 @@ Error GLManagerNative_Windows::window_create(DisplayServerEnums::WindowID p_wind
 	}
 
 	// configure the HDC to use a compatible pixel format
-	Error result = _configure_pixel_format(hDC);
-	if (result != OK) {
-		return result;
-	}
+	RETURN_IF_ERROR(_configure_pixel_format(hDC));
 
 	GLWindow win;
 	win.hwnd = p_hwnd;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -132,10 +132,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 
 	method = p_method;
 
-	Error err = _parse_url(p_url);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_parse_url(p_url));
 
 	headers = p_custom_headers;
 
@@ -157,7 +154,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 		thread.start(_thread_func, this);
 	} else {
 		client->set_blocking_mode(false);
-		err = _request();
+		Error err = _request();
 		if (err != OK) {
 			_defer_done(RESULT_CANT_CONNECT, 0, PackedStringArray(), PackedByteArray());
 			return ERR_CANT_CONNECT;

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -124,10 +124,7 @@ Error MultiplayerAPI::encode_and_compress_variant(const Variant &p_variant, uint
 		} break;
 		default:
 			// Any other case is not yet compressed.
-			Error err = encode_variant(p_variant, r_buffer, r_len, p_allow_object_decoding);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(encode_variant(p_variant, r_buffer, r_len, p_allow_object_decoding));
 			if (r_buffer) {
 				// The first byte is not used by the marshaling, so store the type
 				// so we know how to decompress and decode this variant.
@@ -197,10 +194,7 @@ Error MultiplayerAPI::decode_and_decompress_variant(Variant &r_variant, const ui
 			}
 		} break;
 		default:
-			Error err = decode_variant(r_variant, p_buffer, p_len, r_len, p_allow_object_decoding);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(decode_variant(r_variant, p_buffer, p_len, r_len, p_allow_object_decoding));
 	}
 
 	return OK;

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -139,10 +139,7 @@ Error CompressedTexture2D::load(const String &p_path) {
 	bool request_roughness;
 	int mipmap_limit;
 
-	Error err = _load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_2d_create(image);
@@ -527,10 +524,7 @@ Error CompressedTexture3D::load(const String &p_path) {
 	Image::Format tfmt;
 	bool tmm;
 
-	Error err = _load_data(p_path, data, tfmt, tw, th, td, tmm);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_load_data(p_path, data, tfmt, tw, th, td, tmm));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_3d_create(tfmt, tw, th, td, tmm, data);
@@ -682,10 +676,7 @@ Error CompressedTextureLayered::load(const String &p_path) {
 
 	int mipmap_limit;
 
-	Error err = _load_data(p_path, images, mipmap_limit);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERROR(_load_data(p_path, images, mipmap_limit));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_2d_layered_create(images, RSE::TextureLayeredType(layered_type));

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1201,10 +1201,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *c = p_node->get_child(i);
-		Error err = _parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map, ids_saved);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map, ids_saved));
 	}
 
 	return OK;
@@ -1404,10 +1401,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 	// Recursively parse child connections.
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *child = p_node->get_child(i);
-		Error err = _parse_connections(p_owner, child, name_map, variant_map, node_map, nodepath_map);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_parse_connections(p_owner, child, name_map, variant_map, node_map, nodepath_map));
 	}
 
 	return OK;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -944,10 +944,7 @@ Error RenderingDevice::_staging_buffer_allocate(StagingBuffers &p_staging_buffer
 					// Guess we did.. ok, let's see if we can insert a new block.
 					if ((uint64_t)p_staging_buffers.blocks.size() * p_staging_buffers.block_size < p_staging_buffers.max_size) {
 						// We can, so we are safe.
-						Error err = _insert_staging_block(p_staging_buffers);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERROR(_insert_staging_block(p_staging_buffers));
 						// Claim for this frame.
 						p_staging_buffers.blocks.write[p_staging_buffers.current].frame_used = frames_drawn;
 					} else {
@@ -972,10 +969,7 @@ Error RenderingDevice::_staging_buffer_allocate(StagingBuffers &p_staging_buffer
 			// This block may still be in use, let's not touch it unless we have to, so.. can we create a new one?
 			if ((uint64_t)p_staging_buffers.blocks.size() * p_staging_buffers.block_size < p_staging_buffers.max_size) {
 				// We are still allowed to create a new block, so let's do that and insert it for current pos.
-				Error err = _insert_staging_block(p_staging_buffers);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_insert_staging_block(p_staging_buffers));
 				// Claim for this frame.
 				p_staging_buffers.blocks.write[p_staging_buffers.current].frame_used = frames_drawn;
 			} else {
@@ -1107,10 +1101,7 @@ Error RenderingDevice::_buffer_update(Buffer *p_buffer, RID p_buffer_id, uint32_
 		uint32_t block_write_amount;
 		StagingRequiredAction required_action;
 
-		Error err = _staging_buffer_allocate(upload_staging_buffers, MIN(to_submit, upload_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_staging_buffer_allocate(upload_staging_buffers, MIN(to_submit, upload_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action));
 
 		if (!command_buffer_copies_vector.is_empty() && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL) {
 			if (_buffer_make_mutable(p_buffer, p_buffer_id)) {
@@ -1356,10 +1347,7 @@ Error RenderingDevice::buffer_get_data_async(RID p_buffer, const Callable &p_cal
 	uint32_t to_submit = p_size;
 	uint32_t submit_from = 0;
 	while (to_submit > 0) {
-		Error err = _staging_buffer_allocate(download_staging_buffers, MIN(to_submit, download_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERROR(_staging_buffer_allocate(download_staging_buffers, MIN(to_submit, download_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action));
 
 		const bool flush_frames = (get_data_request.frame_local_count > 0) && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL;
 		if (flush_frames) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8262,10 +8262,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 					}
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(p_block, p_function_info, false, &decl.size_expression, &array_size, &unknown_size);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_array_size(p_block, p_function_info, false, &decl.size_expression, &array_size, &unknown_size));
 						decl.size = array_size;
 
 						fixed_array_size = true;
@@ -8322,10 +8319,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				tk = _get_token();
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(p_block, p_function_info, false, &decl.size_expression, &var.array_size, &unknown_size);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERROR(_parse_array_size(p_block, p_function_info, false, &decl.size_expression, &var.array_size, &unknown_size));
 
 					decl.size = var.array_size;
 					array_size = var.array_size;
@@ -8408,10 +8402,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 								tk = _get_token();
 								if (tk.type == TK_BRACKET_OPEN) {
 									bool is_unknown_size = false;
-									Error error = _parse_array_size(p_block, p_function_info, false, nullptr, &array_size2, &is_unknown_size);
-									if (error != OK) {
-										return error;
-									}
+									RETURN_IF_ERROR(_parse_array_size(p_block, p_function_info, false, nullptr, &array_size2, &is_unknown_size));
 									if (is_unknown_size) {
 										array_size2 = var.array_size;
 									}
@@ -8631,10 +8622,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(block, p_function_info, true, p_can_break, p_can_continue);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(block, p_function_info, true, p_can_break, p_can_continue));
 
 			pos = _get_tkpos();
 			tk = _get_token();
@@ -8642,10 +8630,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				block = alloc_node<BlockNode>();
 				block->parent_block = p_block;
 				cf->blocks.push_back(block);
-				err = _parse_block(block, p_function_info, true, p_can_break, p_can_continue);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_parse_block(block, p_function_info, true, p_can_break, p_can_continue));
 			} else {
 				_set_tkpos(pos); //rollback
 			}
@@ -8842,10 +8827,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(case_block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(case_block, p_function_info, false, true, false);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(case_block, p_function_info, false, true, false));
 
 			return OK;
 
@@ -8876,10 +8858,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(default_block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(default_block, p_function_info, false, true, false);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(default_block, p_function_info, false, true, false));
 
 			return OK;
 
@@ -8893,10 +8872,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				do_block = alloc_node<BlockNode>();
 				do_block->parent_block = p_block;
 
-				Error err = _parse_block(do_block, p_function_info, true, true, true);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_parse_block(do_block, p_function_info, true, true, true));
 
 				tk = _get_token();
 				if (tk.type != TK_CF_WHILE) {
@@ -8934,10 +8910,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				cf->blocks.push_back(block);
 				p_block->statements.push_back(cf);
 
-				Error err = _parse_block(block, p_function_info, true, true, true);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_parse_block(block, p_function_info, true, true, true));
 			} else {
 				cf->expressions.push_back(n);
 				cf->blocks.push_back(do_block);
@@ -8969,10 +8942,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_DATATYPE;
 #endif // DEBUG_ENABLED
-			Error err = _parse_block(init_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(init_block, p_function_info, true, false, false));
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_UNSPECIFIED;
 #endif // DEBUG_ENABLED
@@ -8983,10 +8953,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			condition_block->single_statement = true;
 			condition_block->use_comma_between_statements = true;
 			cf->blocks.push_back(condition_block);
-			err = _parse_block(condition_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(condition_block, p_function_info, true, false, false));
 
 			BlockNode *expression_block = alloc_node<BlockNode>();
 			expression_block->block_type = BlockNode::BLOCK_TYPE_FOR_EXPRESSION;
@@ -8994,10 +8961,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			expression_block->single_statement = true;
 			expression_block->use_comma_between_statements = true;
 			cf->blocks.push_back(expression_block);
-			err = _parse_block(expression_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERROR(_parse_block(expression_block, p_function_info, true, false, false));
 
 			BlockNode *block = alloc_node<BlockNode>();
 			block->parent_block = init_block;
@@ -9007,11 +8971,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_BLOCK;
 #endif // DEBUG_ENABLED
-			err = _parse_block(block, p_function_info, true, true, true);
-			if (err != OK) {
-				return err;
-			}
-
+			RETURN_IF_ERROR(_parse_block(block, p_function_info, true, true, true));
 		} else if (tk.type == TK_CF_RETURN) {
 			//check return type
 			BlockNode *b = p_block;
@@ -9403,10 +9363,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				keyword_completion_context = CF_UNSPECIFIED;
 #endif // DEBUG_ENABLED
 				while (true) {
-					Error error = _parse_shader_mode(false, p_render_modes, defined_render_modes);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERROR(_parse_shader_mode(false, p_render_modes, defined_render_modes));
 
 					tk = _get_token();
 
@@ -9453,10 +9410,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					} else {
 						_set_tkpos(pos);
 
-						Error error = _parse_shader_mode(true, p_stencil_modes, defined_stencil_modes);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_shader_mode(true, p_stencil_modes, defined_stencil_modes));
 					}
 
 					tk = _get_token();
@@ -9573,10 +9527,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 								}
 
 								if (tk.type == TK_BRACKET_OPEN) {
-									Error error = _parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr);
-									if (error != OK) {
-										return error;
-									}
+									RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr));
 									fixed_array_size = true;
 									tk = _get_token();
 								}
@@ -9602,10 +9553,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							tk = _get_token();
 
 							if (tk.type == TK_BRACKET_OPEN) {
-								Error error = _parse_array_size(nullptr, constants, true, nullptr, &member->array_size, nullptr);
-								if (error != OK) {
-									return error;
-								}
+								RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &member->array_size, nullptr));
 								tk = _get_token();
 							}
 
@@ -9833,10 +9781,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				}
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr));
 					tk = _get_token();
 				}
 
@@ -9882,10 +9827,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &uniform.array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &uniform.array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -10396,10 +10338,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					}
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &varying.array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &varying.array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -10523,10 +10462,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				bool fixed_array_size = false;
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(nullptr, constants, !is_constant, nullptr, &array_size, &unknown_size);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERROR(_parse_array_size(nullptr, constants, !is_constant, nullptr, &array_size, &unknown_size));
 					fixed_array_size = true;
 					prev_pos = _get_tkpos();
 				}
@@ -10569,10 +10505,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						is_const_decl = true;
 
 						if (tk.type == TK_BRACKET_OPEN) {
-							Error error = _parse_array_size(nullptr, constants, false, nullptr, &constant.array_size, &unknown_size);
-							if (error != OK) {
-								return error;
-							}
+							RETURN_IF_ERROR(_parse_array_size(nullptr, constants, false, nullptr, &constant.array_size, &unknown_size));
 							tk = _get_token();
 						}
 
@@ -10628,10 +10561,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 									if (tk.type == TK_BRACKET_OPEN) {
 										bool is_unknown_size = false;
-										Error error = _parse_array_size(nullptr, constants, false, nullptr, &array_size2, &is_unknown_size);
-										if (error != OK) {
-											return error;
-										}
+										RETURN_IF_ERROR(_parse_array_size(nullptr, constants, false, nullptr, &array_size2, &is_unknown_size));
 										if (is_unknown_size) {
 											array_size2 = constant.array_size;
 										}
@@ -11061,10 +10991,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					tk = _get_token();
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr));
 						tk = _get_token();
 					}
 					if (tk.type != TK_IDENTIFIER) {
@@ -11100,10 +11027,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERROR(_parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -11203,10 +11127,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_BLOCK;
 #endif // DEBUG_ENABLED
-				Error err = _parse_block(func_node->body, builtins);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERROR(_parse_block(func_node->body, builtins));
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_GLOBAL_SPACE;
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds syntactical sugar to a common error handling pattern: Silently returning an `Error` when it's not `OK`.
This happens at least 200x in the codebase; probably way more in practice.

By adding this syntactical sugar, we incentivise silent error handling, which helps when the caller is supposed to decide whether to fail loudly or silently. In addition, it makes it easy and painless to swap loud failures like `ERR_FAIL_COND_V(err, err)` to silent ones like `GUARD_OK(err)`, if this turns out to be more appropriate.

It also makes these places easier to identify in case we ever want to rework our error handling.

## Additional information

Uses found and auto-swapped using the following regex:

```
(?:const )?Error (\w+) = (.*);\n\s+if \(\1( != OK)?\) \{\n\s+return \1;\n\s+\}
GUARD_OK($2);
```

Only needed some minor fixes afterwards, where the declared `Error` was used by other code afterwards.
Because we disallow shadowing this should be safe.

An alternative implementation might be `Error` type agnostic, being called `RETURN_IF_TRUE` (or something) instead. However, I think this is overzealous — the only thing we currently handle with macros like this is `Error` (and lately required parameters) and I think staying low tech is preferable.