### PR TITLE
Fix cyclical references for chained awaits

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2597,6 +2597,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						if (obj) {
 							if (obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
 								result = Signal(obj, SNAME("completed"));
+								// Drop reference to the awaited GDScriptFunctionState, this prevents cyclical leaks.
+								*argobj = Variant();
 							}
 						}
 					}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121618

## Additional information

The cyclic reference between `GDScriptFunctionState` objects is asymmetric, the two references are:
- The "caller" function state holds a reference to the "callee" state on the stack.
- The "callee" state holds a reference to the "caller" state via the `"completed"` signal connection.

This fix nulls out the first of those references (the callee state on the stack).
