### PR TITLE
Make key EditorProperty pass mouse events without fully deactivating mouse input but without the hackiness.

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -852,6 +852,10 @@ void EditorProperty::set_internal(bool p_internal) {
 	internal = p_internal;
 }
 
+void EditorProperty::make_passthrough(bool p_passthrough) {
+	set_mouse_behavior_recursive(p_passthrough ? MOUSE_BEHAVIOR_DISABLED : MOUSE_BEHAVIOR_INHERITED);
+}
+
 void EditorProperty::update_property() {
 	GDVIRTUAL_CALL(_update_property);
 }

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -267,6 +267,7 @@ public:
 	void set_doc_path(const String &p_doc_path);
 	void set_internal(bool p_internal);
 
+	virtual void make_passthrough(bool p_passthrough);
 	virtual void update_property();
 	void update_editor_property_status();
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3666,6 +3666,10 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 	}
 }
 
+void EditorPropertyResource::make_passthrough(bool p_passthrough) {
+	resource_picker->make_passthrough(p_passthrough);
+}
+
 void EditorPropertyResource::update_property() {
 	Ref<Resource> res = get_edited_property_display_value();
 

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -772,6 +772,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
 	void setup(Object *p_object, const String &p_path, const String &p_base_type);
 	EditorResourcePicker *get_resource_picker() const { return resource_picker; }

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -383,6 +383,10 @@ void EditorPropertyArray::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyArray::make_passthrough(bool p_passthrough) {
+	edit->set_mouse_filter(p_passthrough ? MOUSE_FILTER_PASS : MOUSE_FILTER_STOP);
+}
+
 void EditorPropertyArray::update_property() {
 	Variant array = get_edited_property_value();
 
@@ -1252,6 +1256,10 @@ void EditorPropertyDictionary::set_preview_value(bool p_preview_value) {
 	preview_value = p_preview_value;
 }
 
+void EditorPropertyDictionary::make_passthrough(bool p_passthrough) {
+	edit->set_mouse_filter(p_passthrough ? Control::MOUSE_FILTER_PASS : Control::MOUSE_FILTER_STOP);
+}
+
 void EditorPropertyDictionary::update_property() {
 	Variant updated_val = get_edited_property_value();
 
@@ -1414,9 +1422,8 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_draw_background(false);
 					new_prop->set_use_folding(is_using_folding());
 					new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
+					new_prop->make_passthrough(true);
 					new_prop->set_draw_label(false);
-					new_prop->set_mouse_filter(MOUSE_FILTER_PASS);
-					new_prop->set_mouse_behavior_recursive(MOUSE_BEHAVIOR_DISABLED);
 					EditorPropertyArray *arr_prop = Object::cast_to<EditorPropertyArray>(new_prop);
 					if (arr_prop) {
 						arr_prop->set_preview_value(true);

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -173,6 +173,7 @@ protected:
 public:
 	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyArray();
@@ -271,6 +272,7 @@ protected:
 public:
 	void setup(PropertyHint p_hint, const String &p_hint_string = "");
 	void set_preview_value(bool p_preview_value);
+	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyDictionary();

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1170,6 +1170,15 @@ Vector<String> EditorResourcePicker::get_allowed_types() const {
 	return types;
 }
 
+void EditorResourcePicker::make_passthrough(bool p_passthrough) {
+	assign_button->set_mouse_filter(p_passthrough ? Control::MOUSE_FILTER_PASS : Control::MOUSE_FILTER_STOP);
+	if (p_passthrough) {
+		assign_button->disconnect(SceneStringName(gui_input), callable_mp(this, &EditorResourcePicker::_button_input));
+	} else {
+		assign_button->connect(SceneStringName(gui_input), callable_mp(this, &EditorResourcePicker::_button_input));
+	}
+}
+
 bool EditorResourcePicker::is_resource_allowed(const Ref<Resource> &p_resource) {
 	if (p_resource.is_null()) {
 		return true;

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -141,6 +141,8 @@ public:
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;
 
+	void make_passthrough(bool p_passthrough);
+
 	bool is_resource_allowed(const Ref<Resource> &p_resource);
 	void set_edited_resource(Ref<Resource> p_resource);
 	void set_edited_resource_no_check(Ref<Resource> p_resource);


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #120486 
- Alternative to #121586

## Additional information
Alternatives based on the recommendation of @YeldhamDev here : https://github.com/godotengine/godot/pull/121586#issuecomment-5037223417
