### PR TITLE
Fix `XMLParser::close()` double‑free risk and enforce null‑terminator contract in `_open_buffer`

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -477,7 +477,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 Error XMLParser::_open_buffer(const uint8_t *p_buffer, size_t p_size) {
 	ERR_FAIL_COND_V(p_size == 0, ERR_INVALID_DATA);
 	ERR_FAIL_NULL_V(p_buffer, ERR_INVALID_DATA);
-	DEV_ASSERT(p_buffer[p_size] == 0);
+	ERR_FAIL_COND_V(p_buffer[p_size] != 0, ERR_INVALID_DATA);
 
 	if (data_copy) {
 		memdelete_arr(data_copy);

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -477,6 +477,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 Error XMLParser::_open_buffer(const uint8_t *p_buffer, size_t p_size) {
 	ERR_FAIL_COND_V(p_size == 0, ERR_INVALID_DATA);
 	ERR_FAIL_NULL_V(p_buffer, ERR_INVALID_DATA);
+	DEV_ASSERT(p_buffer[p_size] == 0);
 
 	if (data_copy) {
 		memdelete_arr(data_copy);
@@ -535,8 +536,8 @@ void XMLParser::skip_section() {
 }
 
 void XMLParser::close() {
-	if (data_copy) {
-		memdelete_arr(data);
+	if (data == data_copy && data_copy) {
+		memdelete_arr(data_copy);
 		data_copy = nullptr;
 	}
 	data = nullptr;

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -118,6 +118,9 @@ public:
 
 	Error open(const String &p_path);
 	Error open_buffer(const Vector<uint8_t> &p_buffer);
+
+	// The buffer `p_buffer` must be null-terminated (i.e. `p_buffer[p_size] == 0`)
+	// and must remain valid in memory for the lifetime of this parser.
 	Error _open_buffer(const uint8_t *p_buffer, size_t p_size);
 
 	void close();

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -231,4 +231,19 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_name(), "a");
 }
 
+TEST_CASE("[XMLParser] GDExtension raw buffer parsing") {
+	const char *input = "<a>value</a>";
+	XMLParser parser;
+	REQUIRE_EQ(parser._open_buffer((const uint8_t *)input, 12), OK);
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser.get_node_name(), "a");
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
+	CHECK_EQ(parser.get_node_data(), "value");
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+	CHECK_EQ(parser.get_node_name(), "a");
+}
+
 } // namespace TestXMLParser

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -244,6 +244,11 @@ TEST_CASE("[XMLParser] GDExtension raw buffer parsing") {
 	REQUIRE_EQ(parser.read(), OK);
 	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
 	CHECK_EQ(parser.get_node_name(), "a");
+
+	// A non-null-terminated buffer should fail and return ERR_INVALID_DATA.
+	XMLParser parser_fail;
+	const char input_no_null[] = { '<', 'a', '>', 'v', 'a', 'l', 'u', 'e', '<', '/', 'a', '>', 'X' };
+	REQUIRE_EQ(parser_fail._open_buffer((const uint8_t *)input_no_null, 12), ERR_INVALID_DATA);
 }
 
 } // namespace TestXMLParser


### PR DESCRIPTION
While tracing how XMLParser handles raw buffers from GDExtension, I spotted a quiet double‑free risk. _open_buffer takes a caller‑owned pointer but the internal token scanner assumes a null terminator—no guard, no check. And when the parser is closed, close() blindly deletes data, even if we never owned it. This patch makes close() conditional on data == data_copy so we only free what’s ours, and adds a DEV_ASSERT in _open_buffer to catch the missing terminator at dev time. Zero‑copy contract stays untouched, no overhead in release.

