### PR TITLE
Add support for multiple FileSystem and Inspector docks

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -886,6 +886,10 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 	_update_import_dock();
 }
 
+void FileSystemDock::_new_file_system_dock() {
+	EditorNode::get_singleton()->create_file_system_dock();
+}
+
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename) {
 	if (p_preview.is_valid()) {
 		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && files->get_item_metadata(p_index) == p_path) {
@@ -4224,6 +4228,7 @@ void FileSystemDock::save_layout_to_config(Ref<ConfigFile> &p_layout, const Stri
 	p_layout->set_value(p_section, "display_mode", get_display_mode());
 	p_layout->set_value(p_section, "file_sort", (int)get_file_sort());
 	p_layout->set_value(p_section, "file_list_display_mode", get_file_list_display_mode());
+	p_layout->set_value(p_section, "current_path", current_path);
 	p_layout->set_value(p_section, "selected_paths", get_selected_paths());
 	p_layout->set_value(p_section, "uncollapsed_paths", searched_tokens.is_empty() ? get_uncollapsed_paths() : uncollapsed_paths_before_search);
 }
@@ -4252,6 +4257,10 @@ void FileSystemDock::load_layout_from_config(const Ref<ConfigFile> &p_layout, co
 	if (p_layout->has_section_key(p_section, "file_list_display_mode")) {
 		FileListDisplayMode dock_filesystem_file_list_display_mode = FileListDisplayMode(int(p_layout->get_value(p_section, "file_list_display_mode")));
 		set_file_list_display_mode(dock_filesystem_file_list_display_mode);
+	}
+
+	if (p_layout->has_section_key(p_section, "current_path")) {
+		_navigate_to_path(p_layout->get_value(p_section, "current_path"));
 	}
 
 	// Restore uncollapsed state.
@@ -4411,39 +4420,44 @@ void FileSystemDock::_bind_methods() {
 }
 
 FileSystemDock::FileSystemDock() {
-	singleton = this;
+	const bool is_primary_dock = singleton == nullptr;
+	if (is_primary_dock) {
+		singleton = this;
+	}
 	set_name(TTRC("FileSystem"));
 	set_icon_name("Folder");
-	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::F));
 	set_default_slot(EditorDock::DOCK_SLOT_LEFT_BR);
 	set_available_layouts(DOCK_LAYOUT_ALL);
 
-	ProjectSettings::get_singleton()->add_hidden_prefix("file_customization/");
+	if (is_primary_dock) {
+		set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::F));
+		ProjectSettings::get_singleton()->add_hidden_prefix("file_customization/");
 
-	// `KeyModifierMask::CMD_OR_CTRL | Key::C` conflicts with other editor shortcuts.
-	ED_SHORTCUT("filesystem_dock/copy_path", TTRC("Copy Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::C);
-	ED_SHORTCUT("filesystem_dock/copy_absolute_path", TTRC("Copy Absolute Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::C);
-	ED_SHORTCUT("filesystem_dock/copy_uid", TTRC("Copy UID"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::C);
-	ED_SHORTCUT("filesystem_dock/duplicate", TTRC("Duplicate..."), KeyModifierMask::CMD_OR_CTRL | Key::D);
-	ED_SHORTCUT("filesystem_dock/delete", TTRC("Delete"), Key::KEY_DELETE);
-	ED_SHORTCUT("filesystem_dock/new_folder", TTRC("New Folder..."), Key::NONE);
-	ED_SHORTCUT("filesystem_dock/new_scene", TTRC("New Scene..."), Key::NONE);
-	ED_SHORTCUT("filesystem_dock/new_script", TTRC("New Script..."), Key::NONE);
-	ED_SHORTCUT("filesystem_dock/new_resource", TTRC("New Resource..."), Key::NONE);
-	ED_SHORTCUT("filesystem_dock/new_textfile", TTRC("New TextFile..."), Key::NONE);
-	ED_SHORTCUT("filesystem_dock/rename", TTRC("Rename..."), Key::F2);
-	ED_SHORTCUT_OVERRIDE("filesystem_dock/rename", "macos", Key::ENTER);
+		// `KeyModifierMask::CMD_OR_CTRL | Key::C` conflicts with other editor shortcuts.
+		ED_SHORTCUT("filesystem_dock/copy_path", TTRC("Copy Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::C);
+		ED_SHORTCUT("filesystem_dock/copy_absolute_path", TTRC("Copy Absolute Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::C);
+		ED_SHORTCUT("filesystem_dock/copy_uid", TTRC("Copy UID"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::C);
+		ED_SHORTCUT("filesystem_dock/duplicate", TTRC("Duplicate..."), KeyModifierMask::CMD_OR_CTRL | Key::D);
+		ED_SHORTCUT("filesystem_dock/delete", TTRC("Delete"), Key::KEY_DELETE);
+		ED_SHORTCUT("filesystem_dock/new_folder", TTRC("New Folder..."), Key::NONE);
+		ED_SHORTCUT("filesystem_dock/new_scene", TTRC("New Scene..."), Key::NONE);
+		ED_SHORTCUT("filesystem_dock/new_script", TTRC("New Script..."), Key::NONE);
+		ED_SHORTCUT("filesystem_dock/new_resource", TTRC("New Resource..."), Key::NONE);
+		ED_SHORTCUT("filesystem_dock/new_textfile", TTRC("New TextFile..."), Key::NONE);
+		ED_SHORTCUT("filesystem_dock/rename", TTRC("Rename..."), Key::F2);
+		ED_SHORTCUT_OVERRIDE("filesystem_dock/rename", "macos", Key::ENTER);
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
-	// Opening the system file manager or opening in an external program is not supported on the Android and web editors.
-	ED_SHORTCUT("filesystem_dock/show_in_explorer", TTRC("Open in File Manager"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::R);
-	ED_SHORTCUT("filesystem_dock/open_in_external_program", TTRC("Open in External Program"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::E);
-	ED_SHORTCUT("filesystem_dock/open_in_terminal", TTRC("Open in Terminal"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::T);
+		// Opening the system file manager or opening in an external program is not supported on the Android and web editors.
+		ED_SHORTCUT("filesystem_dock/show_in_explorer", TTRC("Open in File Manager"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::R);
+		ED_SHORTCUT("filesystem_dock/open_in_external_program", TTRC("Open in External Program"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::E);
+		ED_SHORTCUT("filesystem_dock/open_in_terminal", TTRC("Open in Terminal"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::T);
 #endif
 
-	ED_SHORTCUT("filesystem_dock/focus_path", TTRC("Focus Path"), KeyModifierMask::CMD_OR_CTRL | Key::L);
-	// Allow both Cmd + L and Cmd + Shift + G to match Safari's and Finder's shortcuts respectively.
-	ED_SHORTCUT_OVERRIDE_ARRAY("filesystem_dock/focus_path", "macos",
-			{ int32_t(KeyModifierMask::META | Key::L), int32_t(KeyModifierMask::META | KeyModifierMask::SHIFT | Key::G) });
+		ED_SHORTCUT("filesystem_dock/focus_path", TTRC("Focus Path"), KeyModifierMask::CMD_OR_CTRL | Key::L);
+		// Allow both Cmd + L and Cmd + Shift + G to match Safari's and Finder's shortcuts respectively.
+		ED_SHORTCUT_OVERRIDE_ARRAY("filesystem_dock/focus_path", "macos",
+				{ int32_t(KeyModifierMask::META | Key::L), int32_t(KeyModifierMask::META | KeyModifierMask::SHIFT | Key::G) });
+	}
 
 	// Properly translating color names would require a separate HashMap, so for simplicity they are provided as comments.
 	folder_colors["red"] = Color(1.0, 0.271, 0.271); // TTR("Red")
@@ -4500,6 +4514,12 @@ FileSystemDock::FileSystemDock() {
 	button_toggle_display_mode->set_tooltip_text(TTRC("Change Split Mode"));
 	button_toggle_display_mode->set_theme_type_variation("FlatMenuButton");
 	toolbar_hbc->add_child(button_toggle_display_mode);
+
+	Button *new_file_browser_button = memnew(Button);
+	new_file_browser_button->set_text(TTRC("New File Browser"));
+	new_file_browser_button->set_tooltip_text(TTRC("Create another FileSystem dock with its own path and selection."));
+	new_file_browser_button->connect(SceneStringName(pressed), callable_mp(this, &FileSystemDock::_new_file_system_dock));
+	toolbar_hbc->add_child(new_file_browser_button);
 
 	toolbar2_hbc = memnew(HBoxContainer);
 	top_vbc->add_child(toolbar2_hbc);
@@ -4720,5 +4740,7 @@ FileSystemDock::FileSystemDock() {
 }
 
 FileSystemDock::~FileSystemDock() {
-	singleton = nullptr;
+	if (singleton == this) {
+		singleton = nullptr;
+	}
 }

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -389,8 +389,11 @@ private:
 	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
 	void _on_open_editor_settings_file_exts();
+	void _new_file_system_dock();
 
 private:
+	// The primary dock remains the target of EditorInterface and existing editor
+	// integrations. Additional FileSystemDock instances are independent views.
 	inline static FileSystemDock *singleton = nullptr;
 
 public:

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -516,6 +516,25 @@ void InspectorDock::edit_resource(const Ref<Resource> &p_resource) {
 	_resource_selected(p_resource, "");
 }
 
+void InspectorDock::_new_inspector_dock() {
+	EditorNode::get_singleton()->create_inspector_dock();
+}
+
+void InspectorDock::_lock_toggled(bool p_locked) {
+	locked = p_locked;
+	if (!locked && !is_primary_instance) {
+		follow_primary(InspectorDock::get_singleton()->get_current_object());
+	}
+}
+
+void InspectorDock::follow_primary(Object *p_object) {
+	if (is_primary_instance || locked) {
+		return;
+	}
+	inspector->edit(p_object);
+	update(p_object);
+}
+
 void InspectorDock::open_resource(const String &p_type) {
 	_load_resource(p_type);
 }
@@ -555,6 +574,13 @@ void InspectorDock::update(Object *p_object) {
 	object_selector->update_path();
 
 	current = p_object;
+	if (is_primary_instance) {
+		for (InspectorDock *dock : instances) {
+			if (dock != this) {
+				dock->follow_primary(p_object);
+			}
+		}
+	}
 
 	const bool is_object = p_object != nullptr;
 	const bool is_resource = is_object && p_object->is_class("Resource");
@@ -581,10 +607,19 @@ void InspectorDock::update(Object *p_object) {
 	PopupMenu *p = object_menu->get_popup();
 
 	p->clear();
-	p->add_icon_shortcut(get_editor_theme_icon(SNAME("GuiTreeArrowDown")), ED_SHORTCUT("property_editor/expand_all", TTRC("Expand All")), EXPAND_ALL);
-	p->add_icon_shortcut(get_editor_theme_icon(SNAME("GuiTreeArrowRight")), ED_SHORTCUT("property_editor/collapse_all", TTRC("Collapse All")), COLLAPSE_ALL);
+	if (is_primary_instance) {
+		p->add_icon_shortcut(get_editor_theme_icon(SNAME("GuiTreeArrowDown")), ED_SHORTCUT("property_editor/expand_all", TTRC("Expand All")), EXPAND_ALL);
+		p->add_icon_shortcut(get_editor_theme_icon(SNAME("GuiTreeArrowRight")), ED_SHORTCUT("property_editor/collapse_all", TTRC("Collapse All")), COLLAPSE_ALL);
+	} else {
+		p->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowDown")), TTRC("Expand All"), EXPAND_ALL);
+		p->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowRight")), TTRC("Collapse All"), COLLAPSE_ALL);
+	}
 	// Calling it 'revertable' internally, because that's what the implementation is based on, but labeling it as 'non-default' because that's more user friendly, even if not 100% accurate.
-	p->add_shortcut(ED_SHORTCUT("property_editor/expand_revertable", TTRC("Expand Non-Default")), EXPAND_REVERTABLE);
+	if (is_primary_instance) {
+		p->add_shortcut(ED_SHORTCUT("property_editor/expand_revertable", TTRC("Expand Non-Default")), EXPAND_REVERTABLE);
+	} else {
+		p->add_item(TTRC("Expand Non-Default"), EXPAND_REVERTABLE);
+	}
 
 	p->add_separator(TTRC("Property Name Style"));
 	p->add_radio_check_item(vformat(TTR("Raw (e.g. \"%s\")"), "z_index"), PROPERTY_NAME_STYLE_RAW);
@@ -599,12 +634,21 @@ void InspectorDock::update(Object *p_object) {
 	}
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTRC("Copy Properties")), OBJECT_COPY_PARAMS);
-	p->add_shortcut(ED_SHORTCUT("property_editor/paste_params", TTRC("Paste Properties")), OBJECT_PASTE_PARAMS);
+	if (is_primary_instance) {
+		p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTRC("Copy Properties")), OBJECT_COPY_PARAMS);
+		p->add_shortcut(ED_SHORTCUT("property_editor/paste_params", TTRC("Paste Properties")), OBJECT_PASTE_PARAMS);
+	} else {
+		p->add_item(TTRC("Copy Properties"), OBJECT_COPY_PARAMS);
+		p->add_item(TTRC("Paste Properties"), OBJECT_PASTE_PARAMS);
+	}
 
 	if (is_resource || is_node) {
 		p->add_separator();
-		p->add_shortcut(ED_SHORTCUT("property_editor/make_subresources_unique", TTRC("Make Sub-Resources Unique")), OBJECT_UNIQUE_RESOURCES);
+		if (is_primary_instance) {
+			p->add_shortcut(ED_SHORTCUT("property_editor/make_subresources_unique", TTRC("Make Sub-Resources Unique")), OBJECT_UNIQUE_RESOURCES);
+		} else {
+			p->add_item(TTRC("Make Sub-Resources Unique"), OBJECT_UNIQUE_RESOURCES);
+		}
 	}
 
 	List<MethodInfo> methods;
@@ -712,10 +756,16 @@ void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 }
 
 InspectorDock::InspectorDock(EditorData &p_editor_data) {
-	singleton = this;
+	is_primary_instance = singleton == nullptr;
+	if (is_primary_instance) {
+		singleton = this;
+	}
+	instances.push_back(this);
 	set_name(TTRC("Inspector"));
 	set_icon_name("AnimationTrackList");
-	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")));
+	if (is_primary_instance) {
+		set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")));
+	}
 	set_default_slot(EditorDock::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
@@ -727,6 +777,20 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	main_vb->add_child(general_options_hb);
+
+	Button *new_inspector_button = memnew(Button);
+	new_inspector_button->set_text(TTRC("New Inspector"));
+	new_inspector_button->set_tooltip_text(TTRC("Create another Inspector dock."));
+	new_inspector_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_new_inspector_dock));
+	general_options_hb->add_child(new_inspector_button);
+
+	lock_button = memnew(Button);
+	lock_button->set_text(TTRC("Lock"));
+	lock_button->set_toggle_mode(true);
+	lock_button->set_tooltip_text(TTRC("Keep this Inspector focused on its current object."));
+	lock_button->connect(SceneStringName(toggled), callable_mp(this, &InspectorDock::_lock_toggled));
+	lock_button->set_visible(!is_primary_instance);
+	general_options_hb->add_child(lock_button);
 
 	resource_new_button = memnew(Button);
 	resource_new_button->set_theme_type_variation("FlatMenuButton");
@@ -759,12 +823,22 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_extra_button->set_tooltip_text(TTRC("Extra resource options."));
 	general_options_hb->add_child(resource_extra_button);
 	resource_extra_button->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_resource_extra_popup));
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
+	if (is_primary_instance) {
+		resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
+		resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
+	} else {
+		resource_extra_button->get_popup()->add_item(TTRC("Edit Resource from Clipboard"), RESOURCE_EDIT_CLIPBOARD);
+		resource_extra_button->get_popup()->add_item(TTRC("Copy Resource"), RESOURCE_COPY);
+	}
 	resource_extra_button->get_popup()->set_item_disabled(1, true);
 	resource_extra_button->get_popup()->add_separator();
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
+	if (is_primary_instance) {
+		resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
+		resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
+	} else {
+		resource_extra_button->get_popup()->add_item(TTRC("Show in FileSystem"), RESOURCE_SHOW_IN_FILESYSTEM);
+		resource_extra_button->get_popup()->add_item(TTRC("Make Resource Built-In"), RESOURCE_MAKE_BUILT_IN);
+	}
 	resource_extra_button->get_popup()->set_item_disabled(3, true);
 	resource_extra_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
@@ -803,7 +877,9 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	open_docs_button->set_theme_type_variation("FlatMenuButton");
 	open_docs_button->set_disabled(true);
 	open_docs_button->set_tooltip_text(TTRC("Open documentation for this object."));
-	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTRC("Open Documentation")));
+	if (is_primary_instance) {
+		open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTRC("Open Documentation")));
+	}
 	subresource_hb->add_child(open_docs_button);
 	open_docs_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_menu_option).bind(OBJECT_REQUEST_HELP));
 
@@ -880,5 +956,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 }
 
 InspectorDock::~InspectorDock() {
-	singleton = nullptr;
+	instances.erase(this);
+	if (singleton == this) {
+		singleton = nullptr;
+	}
 }

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -76,6 +76,9 @@ class InspectorDock : public EditorDock {
 	EditorInspector *inspector = nullptr;
 
 	Object *current = nullptr;
+	bool is_primary_instance = false;
+	bool locked = false;
+	Button *lock_button = nullptr;
 
 	Button *backward_button = nullptr;
 	Button *forward_button = nullptr;
@@ -132,11 +135,14 @@ class InspectorDock : public EditorDock {
 	void _menu_expand_revertable();
 	void _select_history(int p_idx);
 	void _prepare_history();
+	void _new_inspector_dock();
+	void _lock_toggled(bool p_locked);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 private:
 	static inline InspectorDock *singleton = nullptr;
+	static inline LocalVector<InspectorDock *> instances;
 
 public:
 	static InspectorDock *get_singleton() { return singleton; }
@@ -153,6 +159,9 @@ public:
 	void clear();
 	void set_info(const String &p_button_text, const String &p_message, bool p_is_warning);
 	void update(Object *p_object);
+	void follow_primary(Object *p_object);
+	bool is_locked() const { return locked; }
+	Object *get_current_object() const { return current; }
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6325,6 +6325,16 @@ void EditorNode::_save_editor_layout() {
 	config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
 
 	editor_dock_manager->save_docks_to_config(config, "docks");
+	PackedStringArray filesystem_docks;
+	for (const String &layout_key : filesystem_dock_instance_keys) {
+		filesystem_docks.push_back(layout_key);
+	}
+	config->set_value("docks", "filesystem_dock_instances", filesystem_docks);
+	PackedStringArray inspector_docks;
+	for (const String &layout_key : inspector_dock_instance_keys) {
+		inspector_docks.push_back(layout_key);
+	}
+	config->set_value("docks", "inspector_dock_instances", inspector_docks);
 	_save_open_scenes_to_config(config);
 	_save_central_editor_layout_to_config(config);
 	_save_window_settings_to_config(config, "EditorWindow");
@@ -6379,6 +6389,22 @@ void EditorNode::_load_editor_layout() {
 		}
 	} else {
 		ep.step(TTR("Loading docks..."), 1, true);
+		if (config->has_section_key("docks", "filesystem_dock_instances")) {
+			const PackedStringArray filesystem_docks = config->get_value("docks", "filesystem_dock_instances");
+			for (const String &layout_key : filesystem_docks) {
+				if (layout_key.begins_with("FileSystem_")) {
+					create_file_system_dock(layout_key);
+				}
+			}
+		}
+		if (config->has_section_key("docks", "inspector_dock_instances")) {
+			const PackedStringArray inspector_docks = config->get_value("docks", "inspector_dock_instances");
+			for (const String &layout_key : inspector_docks) {
+				if (layout_key.begins_with("Inspector_")) {
+					create_inspector_dock(layout_key);
+				}
+			}
+		}
 		editor_dock_manager->load_docks_from_config(config, "docks", true);
 
 		ep.step(TTR("Reopening scenes..."), 2, true);
@@ -8393,6 +8419,70 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	return settings;
 }
 
+FileSystemDock *EditorNode::create_file_system_dock(const String &p_layout_key) {
+	const bool is_primary_dock = FileSystemDock::get_singleton() == nullptr;
+	FileSystemDock *filesystem_dock = memnew(FileSystemDock);
+
+	if (!is_primary_dock) {
+		String dock_id = p_layout_key;
+		if (dock_id.is_empty()) {
+			filesystem_dock_instance_count++;
+			dock_id = vformat("FileSystem_%d", filesystem_dock_instance_count);
+		} else {
+			filesystem_dock_instance_count = MAX(filesystem_dock_instance_count, dock_id.trim_prefix("FileSystem_").to_int());
+		}
+		filesystem_dock->set_name(dock_id);
+		filesystem_dock->set_title(vformat(TTRC("FileSystem %d"), dock_id.trim_prefix("FileSystem_").to_int()));
+		filesystem_dock->set_layout_key(dock_id);
+		filesystem_dock->set_dock_shortcut(Ref<Shortcut>());
+		filesystem_dock->set_closable(true);
+		filesystem_dock_instance_keys.push_back(dock_id);
+	}
+
+	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
+	filesystem_dock->connect("instantiate", callable_mp(this, &EditorNode::_instantiate_request));
+	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_editor_layout));
+	if (is_primary_dock) {
+		get_project_settings()->connect_filesystem_dock_signals(filesystem_dock);
+	}
+	editor_dock_manager->add_dock(filesystem_dock);
+
+	if (!is_primary_dock && p_layout_key.is_empty()) {
+		editor_dock_manager->focus_dock(filesystem_dock);
+	}
+
+	return filesystem_dock;
+}
+
+InspectorDock *EditorNode::create_inspector_dock(const String &p_layout_key) {
+	const bool is_primary_dock = InspectorDock::get_singleton() == nullptr;
+	InspectorDock *inspector_dock = memnew(InspectorDock(editor_data));
+
+	if (!is_primary_dock) {
+		String dock_id = p_layout_key;
+		if (dock_id.is_empty()) {
+			inspector_dock_instance_count++;
+			dock_id = vformat("Inspector_%d", inspector_dock_instance_count);
+		} else {
+			inspector_dock_instance_count = MAX(inspector_dock_instance_count, dock_id.trim_prefix("Inspector_").to_int());
+		}
+		inspector_dock->set_name(dock_id);
+		inspector_dock->set_title(vformat(TTRC("Inspector %d"), dock_id.trim_prefix("Inspector_").to_int()));
+		inspector_dock->set_layout_key(dock_id);
+		inspector_dock->set_dock_shortcut(Ref<Shortcut>());
+		inspector_dock->set_closable(true);
+		inspector_dock_instance_keys.push_back(dock_id);
+	}
+
+	editor_dock_manager->add_dock(inspector_dock);
+	if (!is_primary_dock && p_layout_key.is_empty()) {
+		inspector_dock->follow_primary(InspectorDock::get_singleton()->get_current_object());
+		editor_dock_manager->focus_dock(inspector_dock);
+	}
+
+	return inspector_dock;
+}
+
 EditorNode::EditorNode() {
 	DEV_ASSERT(!singleton);
 	singleton = this;
@@ -9231,15 +9321,9 @@ EditorNode::EditorNode() {
 	memnew(ImportDock);
 	editor_dock_manager->add_dock(ImportDock::get_singleton());
 
-	FileSystemDock *filesystem_dock = memnew(FileSystemDock);
-	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
-	filesystem_dock->connect("instantiate", callable_mp(this, &EditorNode::_instantiate_request));
-	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_editor_layout));
-	get_project_settings()->connect_filesystem_dock_signals(filesystem_dock);
-	editor_dock_manager->add_dock(filesystem_dock);
+	FileSystemDock *filesystem_dock = create_file_system_dock();
 
-	memnew(InspectorDock(editor_data));
-	editor_dock_manager->add_dock(InspectorDock::get_singleton());
+	create_inspector_dock();
 
 	memnew(SignalsDock);
 	editor_dock_manager->add_dock(SignalsDock::get_singleton());

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -81,6 +81,7 @@ class EditorFeatureProfileManager;
 class EditorFileDialog;
 class EditorIconManager;
 class EditorFolding;
+class InspectorDock;
 class EditorLayoutsDialog;
 class EditorLog;
 class EditorMainScreen;
@@ -275,6 +276,10 @@ private:
 	EditorSelection *editor_selection = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;
 	HistoryDock *history_dock = nullptr;
+	int filesystem_dock_instance_count = 1;
+	Vector<String> filesystem_dock_instance_keys;
+	int inspector_dock_instance_count = 1;
+	Vector<String> inspector_dock_instance_keys;
 
 	ProjectExportDialog *project_export = nullptr;
 	ProjectSettingsEditor *project_settings_editor = nullptr;
@@ -804,6 +809,8 @@ public:
 	EditorSelectionHistory *get_editor_selection_history() { return &editor_history; }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
+	FileSystemDock *create_file_system_dock(const String &p_layout_key = String());
+	InspectorDock *create_inspector_dock(const String &p_layout_key = String());
 
 	void trigger_menu_option(int p_option, bool p_confirmed);
 	bool has_previous_closed_scenes() const;


### PR DESCRIPTION
## Summary

Adds an initial implementation for multiple FileSystemDock and InspectorDock
instances.

## Changes

- Adds factory methods for creating additional FileSystem and Inspector docks.
- Gives secondary docks unique layout keys and restores them from editor layout.
- Preserves the primary dock as the compatibility target for existing singleton APIs.
- Avoids duplicate global shortcut and ProjectSettings-prefix registration.
- Adds independent FileSystem paths and Inspector follow/lock behavior.

## Testing

- Built the Windows editor with `dev_build=yes`.
- Created, docked, floated, and closed secondary FileSystem and Inspector docks.
- Verified independent FileSystem paths.
- Verified Inspector follow and lock behavior.
- Verified layout restoration after restarting the editor.

## AI usage

Codex was used for source exploration and implementation assistance.
All changes were reviewed, built, and manually tested.