### PR TITLE
Fix binary resource loading when the type hint is a script class

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1205,6 +1205,15 @@ void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String
 	List<String> extensions;
 	ClassDB::get_extensions_for_type(p_type, &extensions);
 
+	if (extensions.is_empty() && ScriptServer::is_global_class(p_type)) {
+		// Script global classes are not registered in ClassDB, so resolve the
+		// native class they ultimately extend to find the right extensions.
+		const StringName native_base = ScriptServer::get_global_class_native_base(p_type);
+		if (native_base != StringName()) {
+			ClassDB::get_extensions_for_type(native_base, &extensions);
+		}
+	}
+
 	extensions.sort();
 
 	for (const String &E : extensions) {

--- a/tests/core/io/test_resource.cpp
+++ b/tests/core/io/test_resource.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_resource)
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "scene/main/node.h"
 #include "tests/test_utils.h"
 
@@ -569,6 +570,31 @@ TEST_CASE("[Resource] Saving and loading") {
 	CHECK_MESSAGE(
 			loaded_child_resource_text->get_name() == "I'm a child resource",
 			"The loaded child resource name should be equal to the expected value.");
+}
+
+TEST_CASE("[Resource] Loading with a script class type hint") {
+	Ref<Resource> resource = memnew(Resource);
+	resource->set_name("Type hinted");
+
+	const String save_path_binary = TestUtils::get_temp_path("type_hint.res");
+	const String save_path_text = TestUtils::get_temp_path("type_hint.tres");
+	ResourceSaver::save(resource, save_path_binary);
+	ResourceSaver::save(resource, save_path_text);
+
+	const StringName script_class = "TestTypeHintResource";
+	ScriptServer::add_global_class(script_class, "Resource", "GDScript", "res://test_type_hint_resource.gd", false, false);
+
+	const Ref<Resource> loaded_text = ResourceLoader::load(save_path_text, script_class);
+	CHECK_MESSAGE(
+			loaded_text.is_valid(),
+			"A text resource should load when the type hint is a script global class.");
+
+	const Ref<Resource> loaded_binary = ResourceLoader::load(save_path_binary, script_class);
+	CHECK_MESSAGE(
+			loaded_binary.is_valid(),
+			"A binary resource should load when the type hint is a script global class.");
+
+	ScriptServer::remove_global_class(script_class);
 }
 
 TEST_CASE("[Resource] Breaking circular references on save") {


### PR DESCRIPTION
Fixes #90769.

### Root cause

`ResourceFormatLoaderBinary::get_recognized_extensions_for_type()` resolves extensions via `ClassDB::get_extensions_for_type()`. That only walks classes registered in `ClassDB`, but a script global class (`class_name` in GDScript) lives in `ScriptServer`'s global class list instead.

So when the requested type is a custom resource class, the lookup returns an empty list, `ResourceFormatLoader::recognize_path()` finds no matching extension and returns `false`, and the binary loader is skipped entirely. `ResourceLoader::_load()` then ends up with no loader at all and the load fails with:

```
ERROR: No loader found for resource: res://my_resource.res (expected type: MyResource)
```

`ResourceFormatLoaderText` is unaffected because it offers `tres` for any type that is not a `PackedScene` or `GDExtension`, without consulting `ClassDB`. That asymmetry is exactly why the type hint worked for `.tres` but not `.res`.

### Fix

When `ClassDB` yields no extensions and the type is a script global class, resolve the native class it ultimately extends via `ScriptServer::get_global_class_native_base()` and look up the extensions for that.

The new branch only runs in the case that was previously broken — when `ClassDB` already knows the type, the extension list is non-empty and behavior is unchanged.

### Testing

Added a regression test to `tests/core/io/test_resource.cpp`. It registers a script global class through `ScriptServer::add_global_class()`, saves the same resource as both `.tres` and `.res`, and asserts both load when the type hint names that class. It unregisters the class afterwards, and adds no fixture files to the repository.

Verified the test genuinely reproduces the bug. On `master` without the fix, the text assertion passes and the binary one fails:

```
tests\core\io\test_resource.cpp:593: ERROR: CHECK( loaded_binary.is_valid() ) is NOT correct!
  values: CHECK( false )
  logged: A binary resource should load when the type hint is a script global class.
[doctest] test cases: 1 | 0 passed | 1 failed
```

With the fix applied, the full suite passes:

```
[doctest] test cases:   1411 |   1411 passed | 0 failed | 3 skipped
[doctest] assertions: 421208 | 421208 passed | 0 failed |
```

Built with GCC 15.2 (MinGW/UCRT64) on Windows, `target=editor tests=yes`. Both changed files are clean under clang-format 22.1.5.
