### PR TITLE
Check unsigned index in `LocalVector::remove_unordered`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -99,7 +99,7 @@ public:
 	/// Removes the item copying the last value into the position of the one to
 	/// remove. It's generally faster than `remove_at`.
 	void remove_at_unordered(U p_index) {
-		ERR_FAIL_INDEX(p_index, count);
+		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
 		count--;
 		if (count > p_index) {
 			data[p_index] = std::move(data[count]);


### PR DESCRIPTION
The only relevant change to forward port from #120807 , I noticed this hadn't been done in master.

## What problem(s) does this PR solve?
Doing the correct check for the count type, and prevents possible warnings.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
