### PR TITLE
`LocalVector::push_back` by const ref for complex types where no resize

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -78,13 +78,31 @@ public:
 	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(data, count); }
 	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
-	// Must take a copy instead of a reference (see GH-31736).
-	_FORCE_INLINE_ void push_back(T p_elem) {
+	// Overload for lvalues (copies).
+	_FORCE_INLINE_ void push_back(const T &p_elem) {
 		if (unlikely(count == capacity)) {
+			// Must take a copy instead of a reference (see GH-31736).
+			T local_copy = p_elem;
 			reserve(count + 1);
+			memnew_placement(&data[count++], T(std::move(local_copy)));
+		} else {
+			memnew_placement(&data[count++], T(p_elem));
 		}
+	}
 
-		memnew_placement(&data[count++], T(std::move(p_elem)));
+	// Overload for rvalues (moves).
+	_FORCE_INLINE_ void push_back(T &&p_elem) {
+		if (unlikely(count == capacity)) {
+			// STL states that p_elem should never be a self-insertion:
+			// i.e. vec.push_back(std::move(vec[0]));
+			// However for safety, and compatibility we can choose to make a copy
+			// here too.
+			T local_copy = std::move(p_elem);
+			reserve(count + 1);
+			memnew_placement(&data[count++], T(std::move(local_copy)));
+		} else {
+			memnew_placement(&data[count++], T(std::move(p_elem)));
+		}
 	}
 
 	void remove_at(U p_index) {

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -84,13 +84,31 @@ public:
 	_FORCE_INLINE_ Span<T> span() const _LIFETIME_BOUND_ { return Span(data, count); }
 	_FORCE_INLINE_ operator Span<T>() const _LIFETIME_BOUND_ { return span(); }
 
-	// Must take a copy instead of a reference (see GH-31736).
-	_FORCE_INLINE_ void push_back(T p_elem) {
+	// Overload for lvalues (copies).
+	_FORCE_INLINE_ void push_back(const T &p_elem) {
 		if (unlikely(count == capacity)) {
+			// Must take a copy instead of a reference (see GH-31736).
+			T local_copy(p_elem);
 			reserve(count + 1);
+			memnew_placement(&data[count++], T(std::move(local_copy)));
+		} else {
+			memnew_placement(&data[count++], T(p_elem));
 		}
+	}
 
-		memnew_placement(&data[count++], T(std::move(p_elem)));
+	// Overload for rvalues (moves).
+	_FORCE_INLINE_ void push_back(T &&p_elem) {
+		if (unlikely(count == capacity)) {
+			// STL states that p_elem should never be a self-insertion:
+			// i.e. vec.push_back(std::move(vec[0]));
+			// However for safety, and compatibility we can choose to make a copy
+			// here too.
+			T local_copy(std::move(p_elem));
+			reserve(count + 1);
+			memnew_placement(&data[count++], T(std::move(local_copy)));
+		} else {
+			memnew_placement(&data[count++], T(std::move(p_elem)));
+		}
 	}
 
 	void remove_at(U p_index) {


### PR DESCRIPTION
This new version of `push_back` is 38% faster for complex types (in the benchmark).
Same speed as the old `push_back` for simple types.

### Explanation
`push_back` doesn't need to pass by value in all cases, it only needs to do it in one specific case - where a resize will occur. This is because the temporary is a guard against the element being within the backing store.

Here we modify `push_back` so it passes by `const ref` instead of value, and only creates this temporary in the specific case of resizing. In other cases, it uses the fast path with no temporary.

## What problem(s) does this PR solve?

Increases the performance of `push_back()` for complex types, while still solving #31736.

## Additional information
In a lot of situations the existing pass-by-value `push_back()` is fine, but there are some structures where `push_back_by_reference` (with special copy for self insertion) can be more efficient, particularly when a copy or move is expensive (large or complex structures).

I've gone here for the compromise that STL went with, which mirrors my earlier technique. The difference is they don't attempt to switch technique depending on `T` (small / large / trivial), they leave it up to the compiler optimizer to decide. The compiler can easily exchange a `const ref` for passing in a register here if the `push_back` is inlined (and we `FORCE_INLINE`).

So in practice small types should work identically.

### Checking by address ( suggestion by @Ivorforce )
In addition to only using a temporary when resizing, I also did a preliminary look at performing an address check, as a temporary is only required when both:
(1) resizing
(2) the parameter is within the backing store address range

_However_, the address check is not free, and benchmarking suggests the address check may be a de-optimization for simple types, and hasn't sped up the complex type so far. In theory it could be useful for very expensive to copy / move types, but I think on balance this should be left for a follow up.

## Benchmarking
Benchmarking is always difficult to get right (and reliable and artifact free), and this has been quite tricky to do (trying different versions of the PR, and dealing with optimizer aggressively removing parts of the benchmark).

Benchmarking this in Godot 4 has proved difficult because there is a lot of variation, so I've additionally been using a small testbed that creates a cut down `LocalVector` in a small c++ program with benchmark.

This benchmark warms the cache, commits the pages, and finds the minimum time over multiple runs in each case.

Where:
* `[Old]` = old `push_back` (always push by value, no specialization)
* `[New] push_back` = this PR (use a temporary to perform a copy when resizing)
* `[New] push_back_check` = this PR _plus_ the address check

### Things to note from benchmarks
The timings are very close for the new `push_back` and the old `by_value` for simple types, which suggests they probably generate similar / the same assembly. There is some variation due to OS etc.

With complex types, the new `push_back` in this PR is a clear win, with the difference more obvious with reserved `LocalVector` (so the allocation isn't included as part of the timing).

```
=== COMPARATIVE LOCALVECTOR BENCHMARK ===

=== SIMPLE TYPE (N = 10000000) ===

--- Reserved (No Reallocations) ---
  [Old] push_back_by_value(T)    (Copy): 6.94959 ms
  [Old] push_back_by_value(T)    (Move): 7.08505 ms
  [New] push_back(const T&) (Copy): 7.00117 ms
  [New] push_back(T&&)      (Move): 6.99793 ms

  // This PR + ivorius address check
  [New] push_back_check(const T&) (Copy): 7.00046 ms
  [New] push_back_check(T&&)      (Move): 7.05167 ms

=== COMPLEX TYPE (N = 10000) ===

--- Reserved (No Reallocations) ---

  [Old] push_back_by_value(T)    (Copy): 2.27559 ms <---- SLOW
  [Old] push_back_by_value(T)    (Move): 2.93455 ms <---- SLOW
  [New] push_back(const T&) (Copy): 1.64222 ms
  [New] push_back(T&&)      (Move): 2.27559 ms

  // This PR + ivorius address check
  [New] push_back_check(const T&) (Copy): 1.64384 ms
  [New] push_back_check(T&&)      (Move): 2.27668 ms
```

#### Benchmark source:
_As always with benchmarking, I recommend independent testing, as it is very easy to have artifacts interfere with timings._

<details>

Note that this source code produces more results than those quoted above (including unreserved tests), but I've condensed the results to the most relevant.

```
#if defined(_MSC_VER)
#include <intrin.h>
#else
#include <x86intrin.h> // For RDTSCP compiler intrinsic support on GCC/Linux
#endif

#include <cassert>
#include <chrono>
#include <cstdint>
#include <cstdlib>
#include <cstring>
#include <iostream>
#include <limits>
#include <new>
#include <random>
#include <string>
#include <type_traits>
#include <utility>
#include <vector>

#define LOG(a)

// --- PORTING MACROS ---

#if defined(_MSC_VER)
#define _FORCE_INLINE_ __forceinline
#elif defined(__GNUC__) || defined(__clang__)
#define _FORCE_INLINE_ __attribute__((always_inline)) inline
#else
#define _FORCE_INLINE_ inline
#endif

#define _WARN_UNUSED_
#define CRASH_COND_MSG(cond, msg)          \
	do                                     \
	{                                      \
		if (cond)                          \
		{                                  \
			std::cerr << msg << std::endl; \
			std::abort();                  \
		}                                  \
	} while (0)
#define unlikely(x) (x)
#define MAX(a, b) ((a) > (b) ? (a) : (b))

// Forces the compiler to materialize a value and assume it has been read/written
template <typename T>
_FORCE_INLINE_ void do_not_optimize(T const &value)
{
#if defined(__GNUC__) || defined(__clang__)
	asm volatile(""
				 :
				 : "g"(value)
				 : "memory");
#else
	volatile const T *p = &value;
	(void)p;
#endif
}

// Breaks compiler provenance optimizations for microbenchmarks
template <typename T>
_FORCE_INLINE_ const T *hide_pointer(const T *ptr)
{
#if defined(__GNUC__) || defined(__clang__)
	asm volatile(""
				 : "+g"(ptr));
#endif
	return ptr;
}

_FORCE_INLINE_ void compiler_barrier()
{
#if defined(__GNUC__) || defined(__clang__)
	asm volatile("" ::
						 : "memory");
#endif
}

class RandomGenerator
{
public:
	RandomGenerator() = delete;

	static uint32_t get_next()
	{
		thread_local std::mt19937 engine(std::random_device{}());
		return engine();
	}

	static uint32_t get_range(uint32_t min, uint32_t max)
	{
		thread_local std::mt19937 engine(std::random_device{}());
		std::uniform_int_distribution<uint32_t> dist(min, max);
		return dist(engine);
	}
};

// --- MINIMAL LOCAL VECTOR ---
template <typename T, typename U = uint32_t, bool force_trivial = false, bool tight = false>
class _WARN_UNUSED_ LocalVector
{
	static_assert(!force_trivial, "force_trivial is no longer supported.");

private:
	U count = 0;
	U capacity = 0;
	T *data = nullptr;

public:
	_FORCE_INLINE_ U size() const { return count; }
	_FORCE_INLINE_ U get_capacity() const { return capacity; }

	void reserve(U p_size)
	{
		if (p_size > capacity)
		{
			if (tight)
			{
				capacity = p_size;
			}
			else
			{
				capacity = MAX((U)2, capacity + ((1 + capacity) >> 1));
				if (p_size > capacity)
				{
					capacity = p_size;
				}
			}
			data = (T *)std::realloc(data, capacity * sizeof(T));
			CRASH_COND_MSG(!data, "Out of memory");
		}
	}

	_FORCE_INLINE_ void push_back_by_value(T p_elem)
	{
		LOG("push_back_by_value");
		if (unlikely(count == capacity))
		{
			reserve(count + 1);
		}
		new (&data[count++]) T(std::move(p_elem));
	}

	_FORCE_INLINE_ void push_back_by_reference(const T &p_elem)
	{
		LOG("push_back_by_reference");
		if (unlikely(count == capacity))
		{
			T local_copy = p_elem;
			reserve(count + 1);
			new (&data[count++]) T(std::move(local_copy));
		}
		else
		{
			new (&data[count++]) T(p_elem);
		}
	}

	_FORCE_INLINE_ void push_back(const T &p_elem)
	{
		if (unlikely(count == capacity))
		{
			T local_copy = p_elem;
			reserve(count + 1);
			new (&data[count++]) T(std::move(local_copy));
		}
		else
		{
			new (&data[count++]) T(p_elem);
		}
	}

	_FORCE_INLINE_ void push_back(T &&p_elem)
	{
		if (unlikely(count == capacity))
		{
			T local_copy = std::move(p_elem);
			reserve(count + 1);
			new (&data[count++]) T(std::move(local_copy));
		}
		else
		{
			new (&data[count++]) T(std::move(p_elem));
		}
	}

	_FORCE_INLINE_ void push_back_check(const T &p_elem)
	{
		if (unlikely(count == capacity))
		{
			const T *elem_ptr = hide_pointer(&p_elem);
			if (elem_ptr >= data && elem_ptr < data + count)
			{
				T local_copy = p_elem;
				reserve(count + 1);
				new (&data[count++]) T(std::move(local_copy));
			}
			else
			{
				reserve(count + 1);
				new (&data[count++]) T(p_elem);
			}
		}
		else
		{
			new (&data[count++]) T(p_elem);
		}
	}

	_FORCE_INLINE_ void push_back_check(T &&p_elem)
	{
		if (unlikely(count == capacity))
		{
			const T *elem_ptr = hide_pointer(&p_elem);
			if (elem_ptr >= data && elem_ptr < data + count)
			{
				T local_copy = std::move(p_elem);
				reserve(count + 1);
				new (&data[count++]) T(std::move(local_copy));
			}
			else
			{
				reserve(count + 1);
				new (&data[count++]) T(std::move(p_elem));
			}
		}
		else
		{
			new (&data[count++]) T(std::move(p_elem));
		}
	}

	_FORCE_INLINE_ const T *get_data() const { return data; }

	const T &get_random() const
	{
		return data[RandomGenerator::get_next() % count];
	}

	void clear(bool and_free)
	{
		if (data)
		{
			if constexpr (!std::is_trivially_destructible_v<T>)
			{
				for (U i = 0; i < count; i++)
				{
					data[i].~T();
				}
			}

			if (and_free)
			{
				std::free(data);
				data = nullptr;
			}
		}
		count = 0;

		if (and_free)
		{
			capacity = 0;
		}
	}

	_FORCE_INLINE_ LocalVector() {}

	_FORCE_INLINE_ ~LocalVector()
	{
		if (data)
		{
			if constexpr (!std::is_trivially_destructible_v<T>)
			{
				for (U i = 0; i < count; i++)
				{
					data[i].~T();
				}
			}
			std::free(data);
		}
	}
};

// --- BENCHMARK TYPES ---

struct Simple
{
	uint64_t a = 0;
	Simple() {}
	Simple(uint32_t val) { a = val; }
	void init() { a = RandomGenerator::get_next(); }
};
static_assert(std::is_trivially_copyable_v<Simple>);
static_assert(sizeof(Simple) <= 16);

struct Complex
{
	enum
	{
		COMPLEX_SIZE = 1024 * 10
	};
	uint32_t more_data[COMPLEX_SIZE];
	uint32_t tally() const { return more_data[0]; }
	Complex()
	{
		for (uint32_t n = 0; n < COMPLEX_SIZE; n++)
		{
			more_data[n] = RandomGenerator::get_next();
		}
	}
	~Complex() {}
};
static_assert(sizeof(Complex) > 16);

// --- BENCHMARK HARNESS ---

#define MY_BARRIER(VC)                                 \
	compiler_barrier();                                \
	if (VC.size() > 0)                                 \
	{                                                  \
		do_not_optimize(VC.get_data()[VC.size() - 1]); \
	}

#ifdef FULL_OUTPUT
#define TEST_RESULT_OUTPUT(PRE_AMBLE, VALUE, VALUE_CYCLES)                 \
	std::cout << PRE_AMBLE << VALUE << " ms (" << (VALUE_CYCLES / 1000)    \
			  << " kcycles), " << (uint32_t)((VALUE_CYCLES / VALUE) / 100) \
			  << " hcyles/ms\n"
#else
#define TEST_RESULT_OUTPUT(PRE_AMBLE, VALUE, VALUE_CYCLES) \
	std::cout << PRE_AMBLE << VALUE << " ms\n"
#endif

#define TEST_RESULTS                                                       \
	TEST_RESULT_OUTPUT("  [Ref] push_back_by_reference(Copy)    (Lval): ", \
			t_reference_lval, t_reference_lval_cycles);                    \
	TEST_RESULT_OUTPUT("  [Ref] push_back_by_reference(Move)    (Rval): ", \
			t_reference_rval, t_reference_rval_cycles);                    \
	TEST_RESULT_OUTPUT("  [Old] push_back_by_value(T)    (Copy): ",        \
			t_value_lval, t_value_lval_cycles);                            \
	TEST_RESULT_OUTPUT("  [Old] push_back_by_value(T)    (Move): ",        \
			t_value_rval, t_value_rval_cycles);                            \
	TEST_RESULT_OUTPUT("  [New] push_back(const T&) (Copy): ", t_new_lval, \
			t_new_lval_cycles);                                            \
	TEST_RESULT_OUTPUT("  [New] push_back(T&&)      (Move): ", t_new_rval, \
			t_new_rval_cycles);                                            \
	TEST_RESULT_OUTPUT("  [New] push_back_check(const T&) (Copy): ",       \
			t_check_lval, t_check_lval_cycles);                            \
	TEST_RESULT_OUTPUT("  [New] push_back_check(T&&)      (Move): ",       \
			t_check_rval, t_check_rval_cycles);                            \
	std::cout << "  Tally: " << tally << "\n\n"

// Self-contained Copy microbenchmark block
#define BENCHMARK_COPY(TIMER_NAME, VECTOR, FUNC_NAME, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR) \
	double TIMER_NAME = std::numeric_limits<double>::max();                                         \
	uint64_t TIMER_NAME##_cycles = std::numeric_limits<uint64_t>::max();                            \
	for (uint32_t run = 0; run < num_runs; run++)                                                   \
	{                                                                                               \
		VECTOR.clear(CLEAR_AND_FREE);                                                               \
		unsigned int aux_start, aux_end;                                                            \
		auto start = std::chrono::high_resolution_clock::now();                                     \
		uint64_t start_cycles = __rdtscp(&aux_start);                                               \
		for (size_t i = 0; i < ITERATIONS; ++i)                                                     \
		{                                                                                           \
			VECTOR.FUNC_NAME(ITEM);                                                                 \
		}                                                                                           \
		MY_BARRIER(VECTOR)                                                                          \
		tally += TALLY_EXPR;                                                                        \
		uint64_t end_cycles = __rdtscp(&aux_end);                                                   \
		auto end = std::chrono::high_resolution_clock::now();                                       \
		std::chrono::duration<double, std::milli> duration = end - start;                           \
		uint64_t elapsed_cycles = end_cycles - start_cycles;                                        \
		if (duration.count() < TIMER_NAME)                                                          \
		{                                                                                           \
			TIMER_NAME = duration.count();                                                          \
		}                                                                                           \
		if (elapsed_cycles < TIMER_NAME##_cycles)                                                   \
		{                                                                                           \
			TIMER_NAME##_cycles = elapsed_cycles;                                                   \
		}                                                                                           \
	}

// Self-contained Move microbenchmark block
#define BENCHMARK_MOVE(TIMER_NAME, VECTOR, FUNC_NAME, ITERATIONS, MOVE_CREATE_EXPR, CLEAR_AND_FREE, TALLY_EXPR) \
	double TIMER_NAME = std::numeric_limits<double>::max();                                                     \
	uint64_t TIMER_NAME##_cycles = std::numeric_limits<uint64_t>::max();                                        \
	for (uint32_t run = 0; run < num_runs; run++)                                                               \
	{                                                                                                           \
		VECTOR.clear(CLEAR_AND_FREE);                                                                           \
		unsigned int aux_start, aux_end;                                                                        \
		auto start = std::chrono::high_resolution_clock::now();                                                 \
		uint64_t start_cycles = __rdtscp(&aux_start);                                                           \
		for (size_t i = 0; i < ITERATIONS; ++i)                                                                 \
		{                                                                                                       \
			auto item_move = MOVE_CREATE_EXPR;                                                                  \
			do_not_optimize(&item_move);                                                                        \
			VECTOR.FUNC_NAME(std::move(item_move));                                                             \
		}                                                                                                       \
		MY_BARRIER(VECTOR)                                                                                      \
		tally += TALLY_EXPR;                                                                                    \
		uint64_t end_cycles = __rdtscp(&aux_end);                                                               \
		auto end = std::chrono::high_resolution_clock::now();                                                   \
		std::chrono::duration<double, std::milli> duration = end - start;                                       \
		uint64_t elapsed_cycles = end_cycles - start_cycles;                                                    \
		if (duration.count() < TIMER_NAME)                                                                      \
		{                                                                                                       \
			TIMER_NAME = duration.count();                                                                      \
		}                                                                                                       \
		if (elapsed_cycles < TIMER_NAME##_cycles)                                                               \
		{                                                                                                       \
			TIMER_NAME##_cycles = elapsed_cycles;                                                               \
		}                                                                                                       \
	}

// Consolidates the cache warmups, execution, and outputs
#define RUN_BENCHMARK_SUITE(VECTOR, ITERATIONS, ITEM, MOVE_EXPR, CLEAR_AND_FREE, TALLY_EXPR)                                 \
	do                                                                                                                       \
	{                                                                                                                        \
		BENCHMARK_COPY(t_dummy, VECTOR, push_back, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR);                            \
		BENCHMARK_COPY(t_reference_lval, VECTOR, push_back_by_reference, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR);      \
		BENCHMARK_MOVE(t_reference_rval, VECTOR, push_back_by_reference, ITERATIONS, MOVE_EXPR, CLEAR_AND_FREE, TALLY_EXPR); \
		BENCHMARK_COPY(t_value_lval, VECTOR, push_back_by_value, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR);              \
		BENCHMARK_MOVE(t_value_rval, VECTOR, push_back_by_value, ITERATIONS, MOVE_EXPR, CLEAR_AND_FREE, TALLY_EXPR);         \
		BENCHMARK_COPY(t_new_lval, VECTOR, push_back, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR);                         \
		BENCHMARK_MOVE(t_new_rval, VECTOR, push_back, ITERATIONS, MOVE_EXPR, CLEAR_AND_FREE, TALLY_EXPR);                    \
		BENCHMARK_COPY(t_check_lval, VECTOR, push_back_check, ITERATIONS, ITEM, CLEAR_AND_FREE, TALLY_EXPR);                 \
		BENCHMARK_MOVE(t_check_rval, VECTOR, push_back_check, ITERATIONS, MOVE_EXPR, CLEAR_AND_FREE, TALLY_EXPR);            \
		TEST_RESULTS;                                                                                                        \
	} while (0)

int main()
{
	const size_t num_simple_iterations = 10000000;
	const size_t num_complex_iterations = 1000;

	uint32_t tally = 0;
	uint32_t num_runs = 40;

	std::cout << "=== COMPARATIVE LOCALVECTOR BENCHMARK ===\n\n";

	// ==========================================
	// 1. SIMPLE TYPE (Trivially Copyable, <= 16B)
	// ==========================================
	std::cout << "=== SIMPLE TYPE (N = " << num_simple_iterations << ") ===\n";

	std::cout << "--- Unreserved (Dynamic Growth) ---\n";
	{
		LocalVector<Simple> vec;
		Simple item;
		item.init();
		RUN_BENCHMARK_SUITE(vec, num_simple_iterations, item, Simple(i), true, vec.get_data()[RandomGenerator::get_next() % num_simple_iterations].a);
	}

	std::cout << "--- Reserved (No Reallocations) ---\n";
	{
		LocalVector<Simple> vec;
		vec.reserve(num_simple_iterations);
		Simple item;
		item.init();
		RUN_BENCHMARK_SUITE(vec, num_simple_iterations, item, Simple(i), false, vec.get_data()[RandomGenerator::get_next() % num_simple_iterations].a);
	}

	// ==========================================
	// 2. COMPLEX TYPE (Non-trivially Copyable)
	// ==========================================
	std::cout << "=== COMPLEX TYPE (N = " << num_complex_iterations << ") ===\n";

	std::cout << "--- Unreserved (Dynamic Growth) ---\n";
	{
		LocalVector<Complex> vec_comp;
		Complex item;
		RUN_BENCHMARK_SUITE(vec_comp, num_complex_iterations, item, item, true, vec_comp.get_random().tally());
	}

	std::cout << "--- Reserved (No Reallocations) ---\n";
	{
		Complex item;
		LocalVector<Complex> vec_comp;
		vec_comp.reserve(num_complex_iterations);
		RUN_BENCHMARK_SUITE(vec_comp, num_complex_iterations, item, item, false, vec_comp.get_random().tally());
	}

	return 0;
}
```

</details>

### R-value copy
Note that with R-values, STL doesn't actually copy temporaries at all. It just defines self-insertion as illegal, and undefined behaviour. I've got with a safer version here so far and made the copy, just for backward compatibility, but we could consider removing this temporary at a later date.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
