### PR TITLE
GDScript: Fix `GDScriptFunction::return_type` is invalid for coroutines

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1850,7 +1850,9 @@ void GDScriptByteCodeGenerator::write_return(const Address &p_return_value, bool
 		return;
 	}
 
-	switch (function->return_type.kind) {
+	const GDScriptDataType &return_type = function->return_type;
+
+	switch (return_type.kind) {
 		case GDScriptDataType::VARIANT: {
 			ERR_PRINT("Compiler bug: Unresolved return.");
 
@@ -1859,16 +1861,18 @@ void GDScriptByteCodeGenerator::write_return(const Address &p_return_value, bool
 			append(p_return_value);
 		} break;
 		case GDScriptDataType::BUILTIN: {
-			if (function->return_type.builtin_type == Variant::ARRAY && function->return_type.has_container_element_type(0)) {
-				const GDScriptDataType &element_type = function->return_type.get_container_element_type(0);
+			if (return_type.builtin_type == Variant::ARRAY && return_type.has_container_element_type(0)) {
+				const GDScriptDataType &element_type = return_type.get_container_element_type(0);
+
 				append_opcode(GDScriptFunction::OPCODE_RETURN_TYPED_ARRAY);
 				append(p_return_value);
 				append(get_constant_pos(element_type.script_type) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS));
 				append(element_type.builtin_type);
 				append(element_type.native_type);
-			} else if (function->return_type.builtin_type == Variant::DICTIONARY && function->return_type.has_container_element_types()) {
-				const GDScriptDataType &key_type = function->return_type.get_container_element_type_or_variant(0);
-				const GDScriptDataType &value_type = function->return_type.get_container_element_type_or_variant(1);
+			} else if (return_type.builtin_type == Variant::DICTIONARY && return_type.has_container_element_types()) {
+				const GDScriptDataType &key_type = return_type.get_container_element_type_or_variant(0);
+				const GDScriptDataType &value_type = return_type.get_container_element_type_or_variant(1);
+
 				append_opcode(GDScriptFunction::OPCODE_RETURN_TYPED_DICTIONARY);
 				append(p_return_value);
 				append(get_constant_pos(key_type.script_type) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS));
@@ -1880,21 +1884,22 @@ void GDScriptByteCodeGenerator::write_return(const Address &p_return_value, bool
 			} else {
 				append_opcode(GDScriptFunction::OPCODE_RETURN_TYPED_BUILTIN);
 				append(p_return_value);
-				append(function->return_type.builtin_type);
+				append(return_type.builtin_type);
 			}
 		} break;
 		case GDScriptDataType::NATIVE: {
+			const int nc_idx = GDScriptLanguage::get_singleton()->get_global_map()[return_type.native_type];
+			const Variant nc = GDScriptLanguage::get_singleton()->get_global_array()[nc_idx];
+			const int class_idx = get_constant_pos(nc) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS);
+
 			append_opcode(GDScriptFunction::OPCODE_RETURN_TYPED_NATIVE);
 			append(p_return_value);
-			int class_idx = GDScriptLanguage::get_singleton()->get_global_map()[function->return_type.native_type];
-			Variant nc = GDScriptLanguage::get_singleton()->get_global_array()[class_idx];
-			class_idx = get_constant_pos(nc) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS);
 			append(class_idx);
 		} break;
 		case GDScriptDataType::SCRIPT:
 		case GDScriptDataType::GDSCRIPT: {
-			Variant script = function->return_type.script_type;
-			int script_idx = get_constant_pos(script) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS);
+			const Variant script = return_type.script_type;
+			const int script_idx = get_constant_pos(script) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS);
 
 			append_opcode(GDScriptFunction::OPCODE_RETURN_TYPED_SCRIPT);
 			append(p_return_value);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -88,6 +88,7 @@ void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::N
 }
 
 GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner, bool p_handle_metatype) {
+	// TODO: Remove the `p_datatype.is_coroutine` condition in the future?
 	if (!p_datatype.is_set() || !p_datatype.is_hard_type() || p_datatype.is_coroutine) {
 		return GDScriptDataType();
 	}
@@ -2299,7 +2300,9 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	StringName func_name;
 	bool is_abstract = false;
 	bool is_static = false;
+	MethodInfo method_info;
 	Variant rpc_config;
+
 	GDScriptDataType return_type;
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;
@@ -2313,7 +2316,14 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		is_abstract = p_func->is_abstract;
 		is_static = p_func->is_static;
 		rpc_config = p_func->rpc_config;
-		return_type = _gdtype_from_datatype(p_func->return_type_constraint, p_script);
+
+		// NOTE: `_gdtype_from_datatype()` always uses `Variant` for coroutines, so we compensate for that here.
+		// Perhaps the behavior of `_gdtype_from_datatype()` should be changed instead.
+		GDScriptParser::DataType type = p_func->return_type_constraint;
+		type.is_coroutine = false;
+		return_type = _gdtype_from_datatype(type, p_script);
+
+		method_info.return_val = p_func->return_type_constraint.to_property_info(String());
 	} else {
 		if (p_for_ready) {
 			func_name = "@implicit_ready";
@@ -2322,10 +2332,9 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 	}
 
-	MethodInfo method_info;
-
 	codegen.function_name = func_name;
 	method_info.name = func_name;
+
 	codegen.is_static = is_static;
 	if (is_abstract) {
 		method_info.flags |= METHOD_FLAG_VIRTUAL_REQUIRED;
@@ -2333,6 +2342,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (is_static) {
 		method_info.flags |= METHOD_FLAG_STATIC;
 	}
+
 	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
 
 	int optional_parameters = 0;
@@ -2512,13 +2522,8 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		p_script->implicit_ready = gd_function;
 	}
 
-	if (p_func) {
-		gd_function->return_type = _gdtype_from_datatype(p_func->return_type_constraint, p_script);
-		method_info.return_val = p_func->return_type_constraint.to_property_info(String());
-
-		if (p_func->is_vararg()) {
-			gd_function->_vararg_index = vararg_addr.address;
-		}
+	if (p_func && p_func->is_vararg()) {
+		gd_function->_vararg_index = vararg_addr.address;
 	}
 
 	gd_function->method_info = method_info;
@@ -2543,6 +2548,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 	StringName func_name = SNAME("@static_initializer");
 	bool is_static = true;
 	Variant rpc_config;
+
 	GDScriptDataType return_type;
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -88,6 +88,7 @@ void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::N
 }
 
 GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner, bool p_handle_metatype) {
+	// TODO: Remove the `p_datatype.is_coroutine` condition in the future?
 	if (!p_datatype.is_set() || !p_datatype.is_hard_type() || p_datatype.is_coroutine) {
 		return GDScriptDataType();
 	}
@@ -2296,7 +2297,9 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	StringName func_name;
 	bool is_abstract = false;
 	bool is_static = false;
+	MethodInfo method_info;
 	Variant rpc_config;
+
 	GDScriptDataType return_type;
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;
@@ -2310,7 +2313,26 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		is_abstract = p_func->is_abstract;
 		is_static = p_func->is_static;
 		rpc_config = p_func->rpc_config;
-		return_type = _gdtype_from_datatype(p_func->return_type_constraint, p_script);
+
+		// TODO: `_gdtype_from_datatype()` always uses `Variant` for coroutines, so we compensate for that here.
+		// Perhaps the behavior of `_gdtype_from_datatype()` should be changed instead?
+		GDScriptParser::DataType type = p_func->return_type_constraint;
+		type.is_coroutine = false;
+		return_type = _gdtype_from_datatype(type, p_script);
+
+		if (func_name == GDScriptLanguage::get_singleton()->strings._init) {
+			// TODO: The analyzer and editor use the current class instead of `void` as the return type for `_init()`.
+			// We should clear up the confusion between `new()` and `_init()` to remove the special handling here.
+
+			GDScriptParser::DataType void_type;
+			void_type.kind = GDScriptParser::DataType::BUILTIN;
+			void_type.builtin_type = Variant::NIL;
+			void_type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+
+			method_info.return_val = void_type.to_property_info(String());
+		} else {
+			method_info.return_val = p_func->return_type_constraint.to_property_info(String());
+		}
 	} else {
 		if (p_for_ready) {
 			func_name = "@implicit_ready";
@@ -2319,10 +2341,9 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 	}
 
-	MethodInfo method_info;
-
 	codegen.function_name = func_name;
 	method_info.name = func_name;
+
 	codegen.is_static = is_static;
 	if (is_abstract) {
 		method_info.flags |= METHOD_FLAG_VIRTUAL_REQUIRED;
@@ -2330,6 +2351,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (is_static) {
 		method_info.flags |= METHOD_FLAG_STATIC;
 	}
+
 	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
 
 	int optional_parameters = 0;
@@ -2508,25 +2530,8 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		p_script->implicit_ready = gd_function;
 	}
 
-	if (p_func) {
-		gd_function->return_type = _gdtype_from_datatype(p_func->return_type_constraint, p_script);
-		if (func_name == GDScriptLanguage::get_singleton()->strings._init) {
-			// TODO: The analyzer and editor use the current class instead of `void` as the return type for `_init()`.
-			// We should clear up the confusion between `new()` and `_init()` to remove the special handling here.
-
-			GDScriptParser::DataType void_type;
-			void_type.kind = GDScriptParser::DataType::BUILTIN;
-			void_type.builtin_type = Variant::NIL;
-			void_type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
-
-			method_info.return_val = void_type.to_property_info(String());
-		} else {
-			method_info.return_val = p_func->return_type_constraint.to_property_info(String());
-		}
-
-		if (p_func->is_vararg()) {
-			gd_function->_vararg_index = vararg_addr.address;
-		}
+	if (p_func && p_func->is_vararg()) {
+		gd_function->_vararg_index = vararg_addr.address;
 	}
 
 	gd_function->method_info = method_info;
@@ -2551,6 +2556,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 	StringName func_name = SNAME("@static_initializer");
 	bool is_static = true;
 	Variant rpc_config;
+
 	GDScriptDataType return_type;
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -243,6 +243,7 @@ GDScriptFunction::~GDScriptFunction() {
 	for (int i = 0; i < argument_types.size(); i++) {
 		argument_types.write[i].script_type_ref = Ref<Script>();
 	}
+
 	return_type.script_type_ref = Ref<Script>();
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -346,6 +346,8 @@ private:
 	StringName source;
 	bool _static = false;
 	Vector<GDScriptDataType> argument_types;
+	// NOTE: This is the expected return type, but coroutines can actually return a `GDScriptFunctionState` object.
+	// In VM it is currently only used to return a default value on error (as a fallback).
 	GDScriptDataType return_type;
 	MethodInfo method_info;
 	Variant rpc_config;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -347,6 +347,8 @@ private:
 	StringName source;
 	bool _static = false;
 	Vector<GDScriptDataType> argument_types;
+	// NOTE: This is the expected return type, but coroutines can actually return a `GDScriptFunctionState` object.
+	// In VM it is currently only used to return a default value on error (as a fallback).
 	GDScriptDataType return_type;
 	MethodInfo method_info;
 	Variant rpc_config;

--- a/modules/gdscript/tests/scripts/runtime/errors/untyped_override_return_incompatible_value_coroutine.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/untyped_override_return_incompatible_value_coroutine.gd
@@ -1,0 +1,33 @@
+# GH-121584
+
+class A:
+	signal some_signal()
+
+	func bool_coroutine() -> bool:
+		await some_signal
+		return true
+
+	func resource_coroutine() -> Resource:
+		await some_signal
+		return null
+
+class B extends A:
+	func untyped_func():
+		return "string"
+
+	func bool_coroutine():
+		@warning_ignore("redundant_await")
+		return await untyped_func()
+
+	func resource_coroutine():
+		@warning_ignore("redundant_await")
+		return await untyped_func()
+
+func test():
+	var b := B.new()
+
+	var result_bool: bool = await b.bool_coroutine()
+	print(var_to_str(result_bool))
+
+	var result_resource: Resource = await b.resource_coroutine()
+	print(var_to_str(result_resource))

--- a/modules/gdscript/tests/scripts/runtime/errors/untyped_override_return_incompatible_value_coroutine.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/untyped_override_return_incompatible_value_coroutine.out
@@ -1,0 +1,5 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR at runtime/errors/untyped_override_return_incompatible_value_coroutine.gd:20 on B.bool_coroutine(): Trying to return a value of type "String" from a function whose return type is "bool".
+false
+>> SCRIPT ERROR at runtime/errors/untyped_override_return_incompatible_value_coroutine.gd:24 on B.resource_coroutine(): Trying to return a value of type "String" from a function whose return type is "Resource".
+null

--- a/modules/gdscript/tests/scripts/runtime/features/untyped_override_return_compatible_value_coroutine.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/untyped_override_return_compatible_value_coroutine.gd
@@ -1,0 +1,36 @@
+# GH-121584
+
+class A:
+	signal some_signal()
+
+	func bool_coroutine() -> bool:
+		await some_signal
+		return true
+
+	func resource_coroutine() -> Resource:
+		await some_signal
+		return null
+
+class B extends A:
+	func untyped_func_bool():
+		return true
+
+	func untyped_func_resource():
+		return Resource.new()
+
+	func bool_coroutine():
+		@warning_ignore("redundant_await")
+		return await untyped_func_bool()
+
+	func resource_coroutine():
+		@warning_ignore("redundant_await")
+		return await untyped_func_resource()
+
+func test():
+	var b := B.new()
+
+	var result_bool: bool = await b.bool_coroutine()
+	print(var_to_str(result_bool))
+
+	var result_resource: Resource = await b.resource_coroutine()
+	print(result_resource.get_class())

--- a/modules/gdscript/tests/scripts/runtime/features/untyped_override_return_compatible_value_coroutine.out
+++ b/modules/gdscript/tests/scripts/runtime/features/untyped_override_return_compatible_value_coroutine.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+Resource


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121584.

## Additional information

_None._
