### PR TITLE
Fix placement of endif in csg_shape.h

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -154,13 +154,13 @@ public:
 
 	void set_collision_priority(real_t p_priority);
 	real_t get_collision_priority() const;
+#endif // PHYSICS_3D_DISABLED
 
 	void set_autosmooth(bool p_smooth);
 	bool is_autosmooth() const;
 
 	void set_smoothing_angle(const float p_angle);
 	float get_smoothing_angle() const;
-#endif // PHYSICS_3D_DISABLED
 
 #ifndef DISABLE_DEPRECATED
 	void set_snap(float p_snap);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes compile error when 3D physics is disabled.

## Additional information

Might be good to have a CI builder that turns off the optional stuff (XR, 2D/3D physics, 2D/3D navigation) to catch this before dev snapshots, but I'm not sure if anyone other than me is actually using that feature of the build script.