### PR TITLE
Fix  GDExtension interface type mismatch between source file and json file about script instance.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1580,7 +1580,7 @@ static void gdextension_placeholder_script_instance_update(GDExtensionScriptInst
 	placeholder->update(properties_list, values_map);
 }
 
-static GDExtensionScriptInstancePtr gdextension_object_get_script_instance(GDExtensionConstObjectPtr p_object, GDExtensionConstObjectPtr p_language) {
+static GDExtensionScriptInstanceDataPtr gdextension_object_get_script_instance(GDExtensionConstObjectPtr p_object, GDExtensionConstObjectPtr p_language) {
 	if (!p_object || !p_language) {
 		return nullptr;
 	}

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -8332,14 +8332,14 @@
                 },
                 {
                     "name": "p_script_instance",
-                    "type": "GDExtensionScriptInstanceDataPtr",
+                    "type": "GDExtensionScriptInstancePtr",
                     "description": [
-                        "A pointer to the script instance data to attach to this object."
+                        "A pointer to the script instance to attach to this object. Create a script instance through the latest version of \"script_instance_create()\"."
                     ]
                 }
             ],
             "description": [
-                "Set the script instance data attached to this object."
+                "Set the script instance attached to this object."
             ],
             "since": "4.5"
         },


### PR DESCRIPTION
Fix  GDExtension interface type mismatch between source file and json file about script instance. file and declaration json file about `object_get_script_instance` and `object_set_script_instance`.

In GDExtension interface, both `GDExtensionScriptInstanceDataPtr` and `GDExtensionScriptInstancePtr` are `void *`. But the first is a custom data which from GDExtension, the later one is `ScriptInstanceExtension *` which created by godot.

Before this pr:
1. The return type of `gdextension_object_get_script_instance()` is `GDExtensionScriptInstancePtr`, but actually return `GDExtensionScriptInstanceDataPtr`.
2. The argument type of `gdextension_object_set_script_instance()` is `GDExtensionScriptInstancePtr`, but it is described as `GDExtensionScriptInstanceDataPtr` in "gdextension_interface.json".

Now:
1. `gdextension_object_get_script_instance()` is return `GDExtensionScriptInstanceDataPtr`.
2. `object_set_script_instance()` is argument type in "gdextension_interface.json" is fixed to `GDExtensionScriptInstancePtr`.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Just fix type mismatch to avoid confusing.

To be honest, I had stubbed by this question for a long time until I decided to research the implementation about `object_set_script_instance()` in Godot.


## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

1. This pr is not change any implementation, is should not break any compatibility.
2. I found the old commit for old implementation about "gdextension_interface.h", is use the correct type (`GDExtensionScriptInstancePtr` for `object_set_script_instance()`).