### PR TITLE
SCons: Pass `-mcmodel=medium` on Linux GCC sanitizers

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -162,6 +162,10 @@ def configure(env: "SConsEnvironment"):
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"
 
+        if not env["use_llvm"] and "64" in env["arch"]:
+            env.Append(CCFLAGS=["-mcmodel=medium"])
+            env.Append(LINKFLAGS=["-mcmodel=medium"])
+
         if env["use_ubsan"]:
             env.Append(CPPDEFINES=["UBSAN_ENABLED"])
             env.Append(


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #109158

## Additional information

Could feasibly be applied to other platforms, but I'm not in a position to do a deep-dive on that at this time, so this is isolated to the one platform this situation is confirmed for.