### PR TITLE
Fix broken file links in GDScript module README

### DIFF
--- a/modules/gdscript/README.md
+++ b/modules/gdscript/README.md
@@ -83,7 +83,7 @@ A fundamental cyclic dependency problem occurs when the types of two different m
 
 ### Compiling (see [`GDScriptCompiler`](gdscript_compiler.h))
 
-Compiling is the final step in making a GDScript executable in the [virtual machine](gdscript_vm.h) (VM). The compiler takes a `GDScript` object and an AST, and uses another class, [`GDScriptByteCodeGenerator`](gdscript_byte_codegen.h), to generate bytecode corresponding to the class. In doing this, it creates the objects that the VM understands how to run, like [`GDScriptFunction`](gdscript_function.h), and completes a few extra tasks needed for compilation, such as populating runtime class member information.
+Compiling is the final step in making a GDScript executable in the [virtual machine](gdscript_vm.cpp) (VM). The compiler takes a `GDScript` object and an AST, and uses another class, [`GDScriptByteCodeGenerator`](gdscript_byte_codegen.h), to generate bytecode corresponding to the class. In doing this, it creates the objects that the VM understands how to run, like [`GDScriptFunction`](gdscript_function.h), and completes a few extra tasks needed for compilation, such as populating runtime class member information.
 
 Importantly, the compilation process of a class, specifically the `GDScriptCompiler::_compile_class()` method, _cannot_ depend on information obtained by calling `GDScriptCompiler::_compile_class()` on another class, for the same cyclic dependency reasons explained in the previous section.
 Any information that can only be obtained or populated during the compilation step, when `GDScript` objects become available, must be handled before `GDScriptCompiler::_compile_class()` is called. This process is centralized in `GDScriptCompiler::_prepare_compilation()` which works as the compile-time equivalent of `GDScriptAnalyzer::resolve_class_interface()`: it populates a `GDScript`'s "interface" exclusively with information from the analysis step, and without processing other external classes. This information may then be referenced by other classes without introducing problematic cycles.
@@ -127,5 +127,5 @@ There are many other classes in the GDScript module. Here is a brief overview of
 - [`GDScriptFunction`](gdscript_function.h), which represents an executable GDScript function. The relevant file contains both static as well as runtime information.
 - The [virtual machine](gdscript_vm.cpp) is essentially defined as calling `GDScriptFunction::call()`.
 - Editor-related functions can be found in parts of `GDScriptLanguage`, originally declared in [`gdscript.h`](gdscript.h) but defined in [`gdscript_editor.cpp`](gdscript_editor.cpp). Code highlighting can be found in [`GDScriptSyntaxHighlighter`](editor/gdscript_highlighter.h).
-- GDScript decompilation is found in [`gdscript_disassembler.cpp`](gdscript_disassembler.h), defined as `GDScriptFunction::disassemble()`.
+- GDScript decompilation is found in [`gdscript_disassembler.cpp`](gdscript_disassembler.cpp), defined as `GDScriptFunction::disassemble()`.
 - Documentation generation from GDScript comments in [`GDScriptDocGen`](editor/gdscript_docgen.h)


### PR DESCRIPTION
`modules/gdscript/README.md` links `gdscript_vm.h` and `gdscript_disassembler.h`, neither of which exists — the VM and disassembler are implemented in `.cpp` files with no dedicated headers. Both links 404 on GitHub's rendered view.

- `[virtual machine](gdscript_vm.h)` → `gdscript_vm.cpp` (consistent with the README's later VM reference, which already uses `.cpp`)
- `[\`gdscript_disassembler.cpp\`](gdscript_disassembler.h)` → target now matches its own label

Docs only; found via a mechanical link audit, targets verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)