### PR TITLE
Fix `_update_transform_gizmo` throwing errors when calling `clear_points` on `Path3D`

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -894,6 +894,7 @@ void Path3DEditorPlugin::_clear_curve_points() {
 		return;
 	}
 	Ref<Curve3D> curve = path->get_curve();
+	Node3DEditor::get_singleton()->clear_subgizmo_selection(path);
 	curve->set_closed(false);
 	curve->clear_points();
 }


### PR DESCRIPTION

## What problem(s) does this PR solve?

 Fixes a bunch of errors being thrown when clearing all points in a Path3D while having a point selected.
 
 Essentially, if you have a subgizmo drawn, and call a clear_points on the curve, an update signal will be emited, triggering a call to _update_transform_gizmo() while holding an index to a point that has been deleted, this triggers:
  ERR_FAIL_INDEX_V(p_id, curve->get_point_count(), Transform3D());
  
  
  
  This one line fix clears subgizmo selection before clearing points. 