### PR TITLE
Fix Tab unexpected behavior in PopupMenu when searching

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1133,6 +1133,8 @@ void PopupMenu::_items_focus_entered() {
 void PopupMenu::_search_bar_text_changed(const String &p_new_text) {
 	_filter_items(p_new_text);
 
+	prev_mouse_over = mouse_over;
+	mouse_over = -1;
 	queue_accessibility_update();
 	control->queue_redraw();
 	child_controls_changed();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120790 

## Changes

Added a `mouse_over` reset in the `PopupMenu::_search_bar_text_changed` function, so that even when the pointer is hovering on an element, the moment the user searches `mouse_over` gets reset, so that pressing `Tab` selects the first element from the search results.
