### PR TITLE
Implement node stashing using placeholders

### DIFF
--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InstancePlaceholder" inherits="Node" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="InstancePlaceholder" inherits="PlaceholderNode" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Placeholder for the root [Node] of a [PackedScene].
 	</brief_description>
 	<description>
-		Turning on the option [b]Load As Placeholder[/b] for an instantiated scene in the editor causes it to be replaced by an [InstancePlaceholder] when running the game, this will not replace the node in the editor. This makes it possible to delay actually loading the scene until calling [method create_instance]. This is useful to avoid loading large scenes all at once by loading parts of it selectively.
+		InstancePlaceholder is a special case of [PlaceholderNode]. Turning on the option [b]Load As Placeholder[/b] for an instantiated scene in the editor causes it to be replaced by an [InstancePlaceholder] when running the game, this will not replace the node in the editor. This makes it possible to delay actually loading the scene. This is useful to avoid loading large scenes all at once by loading parts of it selectively. The scene is instantiated when calling [method prepare_instance], or when the stashed node is requested (either via [method PlaceholderNode.get_stashed_node] or [method PlaceholderNode.unstash_node]).
 		[b]Note:[/b] Like [Node], [InstancePlaceholder] does not have a transform. This causes any child nodes to be positioned relatively to the [Viewport] origin, rather than their parent as displayed in the editor. Replacing the placeholder with a scene with a transform will transform children relatively to their parent again.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="create_instance">
+		<method name="create_instance" deprecated="Use [method PlaceholderNode.unstash_node] instead.">
 			<return type="Node" />
 			<param index="0" name="replace" type="bool" default="false" />
 			<param index="1" name="custom_scene" type="PackedScene" default="null" />
@@ -31,6 +31,12 @@
 			<description>
 				Returns the list of properties that will be applied to the node when [method create_instance] is called.
 				If [param with_order] is [code]true[/code], a key named [code].order[/code] (note the leading period) is added to the dictionary. This [code].order[/code] key is an [Array] of [String] property names specifying the order in which properties will be applied (with index 0 being the first).
+			</description>
+		</method>
+		<method name="prepare_instance">
+			<return type="void" />
+			<description>
+				Instantiates the scene into memory. The instance is not added to tree until [method PlaceholderNode.unstash_node] is called.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -553,6 +553,12 @@
 				Returns [code]true[/code] if this node is an instance load placeholder. See [InstancePlaceholder] and [method set_scene_instance_load_placeholder].
 			</description>
 		</method>
+		<method name="get_stash_owner" qualifiers="const">
+			<return type="PlaceholderNode" />
+			<description>
+				If this node is stashed, returns the placeholder that replaced this node.
+			</description>
+		</method>
 		<method name="get_tree" qualifiers="const">
 			<return type="SceneTree" />
 			<description>
@@ -735,6 +741,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the node is processing unhandled key input (see [method set_process_unhandled_key_input]).
+			</description>
+		</method>
+		<method name="is_stashed" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this node is stashed (see [method stash]).
 			</description>
 		</method>
 		<method name="move_child">
@@ -1028,6 +1040,18 @@
 			<description>
 				Makes this node inherit the translation domain from its parent node. If this node has no parent, the main translation domain will be used.
 				This is the default behavior for all nodes. Calling [method Object.set_translation_domain] disables this behavior.
+			</description>
+		</method>
+		<method name="stash">
+			<return type="void" />
+			<description>
+				Removes this node from the scene tree and replaces it with a [PlaceholderNode]. This makes the current node effectively disabled for all interactions, like collision detection etc. The placeholder uses the same name and can be used to restore this node to the scene tree.
+			</description>
+		</method>
+		<method name="unstash">
+			<return type="void" />
+			<description>
+				Restores a node that was stashed with [method stash]. The placeholder node is freed.
 			</description>
 		</method>
 		<method name="update_configuration_warnings">

--- a/doc/classes/PlaceholderNode.xml
+++ b/doc/classes/PlaceholderNode.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PlaceholderNode" inherits="Node" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Placeholder for accessing a stashed node.
+	</brief_description>
+	<description>
+		PlaceholderNode is created when a node is stashed using [method Node.stash]. It has the same name and index in the scene tree as the node it replaced and can be used to restore that node. Restoring the stashed node frees the placeholder. Freeing the placeholder automatically frees the stashed node.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_stashed_node">
+			<return type="Node" />
+			<description>
+				Returns the node replaced by this placeholder.
+			</description>
+		</method>
+		<method name="unstash_node">
+			<return type="void" />
+			<description>
+				Restores the stashed node into the scene tree and frees this placeholder. Same as using [method Node.unstash].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1369,35 +1369,40 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			const List<Node *>::Element *e = selection.front();
-			if (e) {
-				Node *node = e->get();
-				if (node) {
-					bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
-					bool placeholder = node->get_scene_instance_load_placeholder();
+			if (selection.is_empty()) {
+				break;
+			}
 
-					// Fire confirmation dialog when children are editable.
-					if (editable && !placeholder) {
-						placeholder_editable_instance_remove_dialog->set_text(TTRC("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
-						placeholder_editable_instance_remove_dialog->popup_centered();
-						break;
-					}
+			Node *node = selection.front()->get();
+			PlaceholderNode *placeholder_node = Object::cast_to<PlaceholderNode>(node);
 
-					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			if (placeholder_node) {
+				undo_redo->create_action_for_history(TTR("Unstash PlaceholderNode"), editor_data->get_current_edited_scene_history_id());
+				undo_redo->add_do_method(placeholder_node->get_stashed_node(), "unstash");
+				undo_redo->add_undo_method(placeholder_node->get_stashed_node(), "stash");
+			} else {
+				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(node);
+				bool placeholder = node->get_scene_instance_load_placeholder();
 
-					placeholder = !placeholder;
+				// Fire confirmation dialog when children are editable.
+				if (editable && !placeholder) {
+					placeholder_editable_instance_remove_dialog->set_text(TTRC("Enabling \"Load as Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
+					placeholder_editable_instance_remove_dialog->popup_centered();
+					break;
+				}
 
-					undo_redo->create_action(TTR("Toggle Load as Placeholder"));
-					undo_redo->add_undo_method(node, "set_scene_instance_load_placeholder", !placeholder);
-					undo_redo->add_do_method(node, "set_scene_instance_load_placeholder", placeholder);
+				placeholder = !placeholder;
 
-					if (placeholder) {
-						EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
-					}
+				undo_redo->create_action_for_history(TTR("Stash Node"), editor_data->get_current_edited_scene_history_id());
+				undo_redo->add_do_method(node, "stash");
+				undo_redo->add_undo_method(node, "unstash");
 
-					undo_redo->commit_action();
+				if (placeholder) {
+					EditorNode::get_singleton()->get_edited_scene()->set_editable_instance(node, false);
 				}
 			}
+			undo_redo->commit_action();
 		} break;
 		case TOOL_SCENE_MAKE_LOCAL: {
 			if (!profile_allow_editing) {
@@ -4060,11 +4065,12 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), ED_GET_SHORTCUT("scene_tree/save_branch_as_scene"), TOOL_NEW_SCENE_FROM);
 		}
 
-		// Group "make_local" etc. with "save_branch_as_scene", if it is available.
-		bool is_external = selection.front()->get()->is_instance();
+		Node *selected_node = selection.front()->get();
+
+		bool is_external = selected_node->is_instance();
 		if (is_external) {
-			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
-			bool is_top_level = selection.front()->get()->get_owner() == nullptr;
+			bool is_inherited = selected_node->get_scene_inherited_state().is_valid();
+			bool is_top_level = selected_node->get_owner() == nullptr;
 			if (is_inherited && is_top_level) {
 				if (profile_allow_editing) {
 					BEGIN_SECTION()
@@ -4072,23 +4078,23 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				}
 				is_tool_scene_open_inherited_available = true;
 			} else if (!is_top_level) {
-				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
-				bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
 				if (profile_allow_editing) {
 					BEGIN_SECTION()
 					menu->add_item(TTRC("Make Local"), TOOL_SCENE_MAKE_LOCAL);
 
 					menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 					menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
-
-					menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Editable Children")), editable);
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Load as Placeholder")), placeholder);
+					menu->set_item_checked(-1, EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selected_node));
 				}
 				is_tool_scene_open_available = true;
 			}
 		}
+
+		if (profile_allow_editing) {
+			menu->add_check_item(TTRC("Stash Node"), TOOL_SCENE_USE_PLACEHOLDER);
+			menu->set_item_checked(-1, Object::cast_to<PlaceholderNode>(selected_node));
+		}
+
 		END_SECTION()
 	}
 

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -63,6 +63,33 @@ void InstancePlaceholder::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+Node *InstancePlaceholder::get_stashed_node() {
+	if (!stashed_node) {
+		prepare_instance();
+	}
+	return stashed_node;
+}
+
+void InstancePlaceholder::prepare_instance() {
+	const Ref<PackedScene> ps = ResourceLoader::load(path, "PackedScene");
+	if (ps.is_null()) {
+		ERR_FAIL_MSG("InstancePlaceholder couldn't load scene.");
+	}
+
+	Node *instance = ps->instantiate();
+	if (!instance) {
+		ERR_FAIL_MSG("Failed to instantiate placeholder scene.");
+	}
+	instance->set_name(get_name());
+	instance->set_multiplayer_authority(get_multiplayer_authority());
+	instance->set_stash_owner(this);
+	stashed_node = instance;
+
+	for (const PropSet &E : stored_values) {
+		set_value_on_instance(this, instance, E);
+	}
+}
+
 void InstancePlaceholder::set_instance_path(const String &p_name) {
 	path = p_name;
 }
@@ -71,6 +98,7 @@ String InstancePlaceholder::get_instance_path() const {
 	return path;
 }
 
+#ifndef DISABLE_DEPRECATED
 Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene> &p_custom_scene) {
 	ERR_FAIL_COND_V(!is_inside_tree(), nullptr);
 
@@ -111,6 +139,7 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 
 	return instance;
 }
+#endif
 
 // This method will attempt to set the correct values on the placeholder instance
 // for regular types this is trivial and unnecessary.
@@ -250,9 +279,9 @@ Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
 
 void InstancePlaceholder::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stored_values", "with_order"), &InstancePlaceholder::get_stored_values, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("create_instance", "replace", "custom_scene"), &InstancePlaceholder::create_instance, DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_instance_path"), &InstancePlaceholder::get_instance_path);
-}
-
-InstancePlaceholder::InstancePlaceholder() {
+	ClassDB::bind_method(D_METHOD("prepare_instance"), &InstancePlaceholder::prepare_instance);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("create_instance", "replace", "custom_scene"), &InstancePlaceholder::create_instance, DEFVAL(false), DEFVAL(Variant()));
+#endif
 }

--- a/scene/main/instance_placeholder.h
+++ b/scene/main/instance_placeholder.h
@@ -34,8 +34,8 @@
 
 class PackedScene;
 
-class InstancePlaceholder : public Node {
-	GDCLASS(InstancePlaceholder, Node);
+class InstancePlaceholder : public PlaceholderNode {
+	GDCLASS(InstancePlaceholder, PlaceholderNode);
 
 	String path;
 	struct PropSet {
@@ -57,12 +57,15 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Node *get_stashed_node() override;
+	void prepare_instance();
+
 	void set_instance_path(const String &p_name);
 	String get_instance_path() const;
 
 	Dictionary get_stored_values(bool p_with_order = false);
 
+#ifndef DISABLE_DEPRECATED
 	Node *create_instance(bool p_replace = false, const Ref<PackedScene> &p_custom_scene = Ref<PackedScene>());
-
-	InstancePlaceholder();
+#endif
 };

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1714,7 +1714,8 @@ void Node::add_child(RequiredParam<Node> rp_child, bool p_force_readable_name, I
 	ERR_THREAD_GUARD
 	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
 	ERR_FAIL_COND_MSG(p_child == this, vformat("Can't add child '%s' to itself.", p_child->get_name())); // adding to itself!
-	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); //Fail if node has a parent
+	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); // Fail if node has a parent.
+	ERR_FAIL_COND_MSG(p_child->data.stash_owner, vformat("Can't add child '%s' to '%s', the node is stashed.", p_child->get_name(), get_name())); // Fail if node was stashed.
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(p_child->is_ancestor_of(this), vformat("Can't add child '%s' to '%s' as it would result in a cyclic dependency since '%s' is already a parent of '%s'.", p_child->get_name(), get_name(), p_child->get_name(), get_name()));
 #endif
@@ -1799,6 +1800,46 @@ void Node::remove_child(RequiredParam<Node> rp_child) {
 	if (data.tree) {
 		p_child->_propagate_after_exit_tree();
 	}
+}
+
+void Node::stash() {
+	ERR_FAIL_NULL_MSG(data.parent, "Can't stash: Node has no parent.");
+	ERR_FAIL_COND_MSG(is_internal(), "Can't stash: Node is internal.");
+
+	PlaceholderNode *placeholder = PlaceholderNode::create_for_node(this);
+
+	int index = data.index;
+	Node *parent = data.parent;
+	Node *owner = get_owner();
+
+	parent->remove_child(this);
+	parent->add_child(placeholder);
+	parent->move_child(placeholder, index);
+
+	placeholder->set_owner(owner);
+}
+
+void Node::unstash() {
+	ERR_FAIL_NULL_MSG(data.stash_owner, "Node is not stashed.");
+
+	PlaceholderNode *stasher = data.stash_owner;
+	data.stash_owner = nullptr;
+	int index = stasher->data.index;
+	Node *parent = stasher->data.parent;
+	Node *owner = stasher->get_owner();
+
+	parent->remove_child(stasher);
+	parent->add_child(this);
+	parent->move_child(this, index);
+	set_owner(owner);
+
+	stasher->stashed_node = nullptr;
+	stasher->queue_free();
+}
+
+PlaceholderNode *Node::get_stash_owner() const {
+	ERR_FAIL_NULL_V_MSG(data.stash_owner, nullptr, "Node is not stashed.");
+	return data.stash_owner;
 }
 
 void Node::_update_children_cache_impl() const {
@@ -3808,6 +3849,11 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 
+	ClassDB::bind_method(D_METHOD("stash"), &Node::stash);
+	ClassDB::bind_method(D_METHOD("unstash"), &Node::unstash);
+	ClassDB::bind_method(D_METHOD("is_stashed"), &Node::is_stashed);
+	ClassDB::bind_method(D_METHOD("get_stash_owner"), &Node::get_stash_owner);
+
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
 	ClassDB::bind_method(D_METHOD("is_part_of_edited_scene"), &Node::is_part_of_edited_scene);
 	ClassDB::bind_method(D_METHOD("is_ancestor_of", "node"), &Node::is_ancestor_of);
@@ -4167,6 +4213,11 @@ Node::~Node() {
 	data.children.clear();
 	data.children_cache.clear();
 
+	if (data.stash_owner) {
+		data.stash_owner->stashed_node = nullptr;
+		memdelete(data.stash_owner);
+	}
+
 	ERR_FAIL_COND(data.parent);
 	ERR_FAIL_COND(data.children_cache.size());
 
@@ -4298,3 +4349,29 @@ bool Node::has_connections(const StringName &p_signal) const {
 }
 
 #endif
+
+void PlaceholderNode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_stashed_node"), &PlaceholderNode::get_stashed_node);
+	ClassDB::bind_method(D_METHOD("unstash_node"), &PlaceholderNode::unstash_node);
+}
+
+PlaceholderNode *PlaceholderNode::create_for_node(Node *p_node) {
+	PlaceholderNode *placeholder = memnew(PlaceholderNode);
+	placeholder->stashed_node = p_node;
+	placeholder->set_name(p_node->get_name());
+	p_node->set_stash_owner(placeholder);
+	return placeholder;
+}
+
+void PlaceholderNode::unstash_node() {
+	Node *node_to_unstash = get_stashed_node();
+	ERR_FAIL_NULL(node_to_unstash);
+	node_to_unstash->unstash();
+}
+
+PlaceholderNode::~PlaceholderNode() {
+	if (stashed_node) {
+		stashed_node->set_stash_owner(nullptr);
+	}
+	memdelete(stashed_node);
+}

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -40,6 +40,7 @@
 
 class MultiplayerAPI;
 class NodePath;
+class PlaceholderNode;
 class Resource;
 class SceneState;
 class SceneTree;
@@ -202,6 +203,7 @@ private:
 		Ref<SceneState> inherited_state;
 
 		Node *parent = nullptr;
+		PlaceholderNode *stash_owner = nullptr;
 		Node *owner = nullptr;
 		HashMap<StringName, Node *> children;
 		mutable bool children_cache_dirty = false;
@@ -525,6 +527,13 @@ public:
 	void add_child(RequiredParam<Node> rp_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name = false);
 	void remove_child(RequiredParam<Node> rp_child);
+
+	void stash();
+	void unstash();
+	bool is_stashed() const { return data.stash_owner; }
+	PlaceholderNode *get_stash_owner() const;
+
+	void set_stash_owner(PlaceholderNode *p_owner) { data.stash_owner = p_owner; }
 
 	/// Optimal way to iterate the children of this node.
 	/// The caller is responsible to ensure:
@@ -901,6 +910,25 @@ public:
 #endif
 	Node();
 	~Node();
+};
+
+class PlaceholderNode : public Node {
+	GDCLASS(PlaceholderNode, Node);
+
+	friend class Node;
+
+protected:
+	Node *stashed_node = nullptr;
+
+	static void _bind_methods();
+
+public:
+	static PlaceholderNode *create_for_node(Node *p_node);
+
+	virtual Node *get_stashed_node() { return stashed_node; }
+	void unstash_node();
+
+	~PlaceholderNode();
 };
 
 VARIANT_ENUM_CAST(Node::DuplicateFlags);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -438,6 +438,7 @@ void register_scene_types() {
 
 	GDREGISTER_CLASS(Node);
 	GDREGISTER_CLASS(MissingNode);
+	GDREGISTER_ABSTRACT_CLASS(PlaceholderNode);
 	GDREGISTER_ABSTRACT_CLASS(InstancePlaceholder);
 
 	GDREGISTER_ABSTRACT_CLASS(CanvasItem);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -584,6 +584,11 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				node->add_to_group(snames[n.groups[j]], true);
 			}
 
+			Node *added_node = node;
+			if (n.placeholder) {
+				added_node = PlaceholderNode::create_for_node(node);
+			}
+
 			if (n.instance >= 0 || n.type != TYPE_INSTANTIATED || i == 0) {
 				//if node was not part of instance, must set its name, parenthood and ownership
 				if (i > 0) {
@@ -612,11 +617,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 							}
 						}
 #endif
+
 						if (pending_add) {
-							parent->_add_child_nocheck(node, snames[n.name]);
+							parent->_add_child_nocheck(added_node, snames[n.name]);
 						}
 						if (n.index >= 0 && n.index < parent->get_child_count() - 1) {
-							parent->move_child(node, n.index);
+							parent->move_child(added_node, n.index);
 						}
 					} else {
 						//it may be possible that an instantiated scene has changed
@@ -640,7 +646,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			if (n.owner >= 0) {
 				NODE_FROM_ID(owner, n.owner);
 				if (owner) {
-					node->_set_owner_nocheck(owner);
+					added_node->_set_owner_nocheck(owner);
 					if (node->data.unique_name_in_owner) {
 						node->_acquire_unique_name_in_owner();
 					}
@@ -873,6 +879,12 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		return OK;
 	}
 
+	Node *real_node = p_node;
+	PlaceholderNode *placeholder = Object::cast_to<PlaceholderNode>(p_node);
+	if (placeholder) {
+		real_node = placeholder->get_stashed_node();
+	}
+
 	bool is_editable_instance = false;
 
 	// save the child instantiated scenes that are chosen as editable, so they can be restored
@@ -890,6 +902,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	nd.name = _nm_get_string(p_node->get_name(), name_map);
 	nd.instance = -1; //not instantiated by default
+	nd.placeholder = placeholder != nullptr;
 
 	//really convoluted condition, but it basically checks that index is only saved when part of an inherited scene OR the node parent is from the edited scene
 	if (p_owner->get_scene_inherited_state().is_null() && (p_node == p_owner || (p_node->get_owner() == p_owner && (p_node->get_parent() == p_owner || p_node->get_parent()->get_owner() == p_owner)))) {
@@ -911,8 +924,8 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	bool instantiated_by_owner = false;
 	Vector<SceneState::PackState> states_stack = PropertyUtils::get_node_states_stack(p_node, p_owner, &instantiated_by_owner);
 
-	if (p_node->is_instance() && p_node->get_owner() == p_owner && instantiated_by_owner) {
-		if (p_node->get_scene_instance_load_placeholder()) {
+	if (real_node->is_instance() && p_node->get_owner() == p_owner && instantiated_by_owner) {
+		if (placeholder) {
 			//it's a placeholder, use the placeholder path
 			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
 			nd.instance |= FLAG_INSTANCE_IS_PLACEHOLDER;
@@ -931,10 +944,10 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	// and save the ones that are worth saving
 
 	List<PropertyInfo> plist;
-	p_node->get_property_list(&plist);
+	real_node->get_property_list(&plist);
 
-	Array pinned_props = _sanitize_node_pinned_properties(p_node);
-	Dictionary missing_resource_properties = p_node->get_meta(META_MISSING_RESOURCES, Dictionary());
+	Array pinned_props = _sanitize_node_pinned_properties(real_node);
+	Dictionary missing_resource_properties = real_node->get_meta(META_MISSING_RESOURCES, Dictionary());
 
 	for (const PropertyInfo &E : plist) {
 		if (!(E.usage & PROPERTY_USAGE_STORAGE) && !missing_resource_properties.has(E.name)) {
@@ -953,7 +966,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		}
 
 		StringName name = E.name;
-		Variant value = p_node->get(name);
+		Variant value = real_node->get(name);
 		bool use_deferred_node_path_bit = false;
 
 		if (E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_NODE_TYPE) {
@@ -1052,9 +1065,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 		if (!pinned_props.has(name)) {
 			bool is_valid_default = false;
-			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, &is_valid_default, &states_stack, true);
+			Variant default_value = PropertyUtils::get_property_default_value(real_node, name, &is_valid_default, &states_stack, true);
 
-			if (is_valid_default && !PropertyUtils::is_property_value_different(p_node, value, default_value)) {
+			if (is_valid_default && !PropertyUtils::is_property_value_different(real_node, value, default_value)) {
 				if (value.get_type() == Variant::ARRAY && has_local_resource(value)) {
 					// Save anyway
 				} else if (value.get_type() == Variant::DICTIONARY) {
@@ -1081,7 +1094,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	// discard groups that come from the original scene
 
 	List<Node::GroupInfo> groups;
-	p_node->get_groups(&groups);
+	real_node->get_groups(&groups);
 	for (const Node::GroupInfo &gi : groups) {
 		if (!gi.persistent) {
 			continue;
@@ -1118,7 +1131,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		nd.owner = -1;
 	}
 
-	MissingNode *missing_node = Object::cast_to<MissingNode>(p_node);
+	MissingNode *missing_node = Object::cast_to<MissingNode>(real_node);
 
 	// Save the right type. If this node was created by an instance
 	// then flag that the node should not be created but reused
@@ -1128,7 +1141,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			// It's a missing node (type non existent on load).
 			nd.type = _nm_get_string(missing_node->get_original_class(), name_map);
 		} else {
-			nd.type = _nm_get_string(p_node->get_class(), name_map);
+			nd.type = _nm_get_string(real_node->get_class(), name_map);
 		}
 	} else {
 		// this node is part of an instantiated process, so do not save the type.
@@ -1152,7 +1165,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	if (save_node || save_data) {
 		//don't save the node if nothing and subscene
 
-		node_map[p_node] = idx;
+		node_map[real_node] = idx;
 
 		//ok validate parent node
 		if (p_parent_idx == NO_PARENT_SAVED) {
@@ -1169,7 +1182,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			nd.parent = p_parent_idx;
 		}
 
-		int32_t unique_scene_id = p_node->get_unique_scene_id();
+		int32_t unique_scene_id = real_node->get_unique_scene_id();
 		if (save_node && (unique_scene_id == Node::UNIQUE_SCENE_ID_UNASSIGNED || ids_saved.has(unique_scene_id))) {
 			// Unassigned or clash somehow.
 			// Clashes will always happen with instantiated scenes, so it is normal
@@ -1189,7 +1202,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				break;
 			}
 
-			p_node->set_unique_scene_id(unique_scene_id);
+			real_node->set_unique_scene_id(unique_scene_id);
 		}
 
 		ids_saved.insert(unique_scene_id);
@@ -1199,8 +1212,8 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		nodes.push_back(nd);
 	}
 
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		Node *c = p_node->get_child(i);
+	for (int i = 0; i < real_node->get_child_count(); i++) {
+		Node *c = real_node->get_child(i);
 		Error err = _parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map, ids_saved);
 		if (err) {
 			return err;
@@ -1492,7 +1505,11 @@ Error SceneState::pack(Node *p_scene) {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Build node path cache
 		for (const KeyValue<Node *, int> &E : node_map) {
-			node_path_cache[scene->get_path_to(E.key)] = E.value;
+			Node *node = E.key;
+			if (node->is_stashed()) {
+				node = node->get_stash_owner();
+			}
+			node_path_cache[scene->get_path_to(node)] = E.value;
 		}
 	}
 
@@ -1982,6 +1999,11 @@ bool SceneState::is_node_instance_placeholder(int p_idx) const {
 	return nodes[p_idx].instance >= 0 && (nodes[p_idx].instance & FLAG_INSTANCE_IS_PLACEHOLDER);
 }
 
+bool SceneState::is_node_placeholder(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, nodes.size(), false);
+	return nodes[p_idx].placeholder;
+}
+
 Ref<PackedScene> SceneState::get_node_instance(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, nodes.size(), Ref<PackedScene>());
 
@@ -2385,7 +2407,7 @@ int SceneState::add_node_path(const NodePath &p_path, const PackedInt32Array &p_
 	return (node_paths.size() - 1) | FLAG_ID_IS_PATH;
 }
 
-int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int32_t p_unique_id) {
+int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, bool p_placeholder, int p_index, int32_t p_unique_id) {
 	NodeData nd;
 	nd.parent = p_parent;
 	nd.owner = p_owner;
@@ -2393,6 +2415,7 @@ int SceneState::add_node(int p_parent, int p_owner, int p_type, int p_name, int 
 	nd.name = p_name;
 	nd.instance = p_instance;
 	nd.index = p_index;
+	nd.placeholder = p_placeholder;
 
 	nodes.push_back(nd);
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -62,6 +62,7 @@ class SceneState : public RefCounted {
 		int name = 0;
 		int instance = 0;
 		int index = 0;
+		bool placeholder = false;
 
 		struct Property {
 			int name = 0;
@@ -187,6 +188,7 @@ public:
 	Ref<PackedScene> get_node_instance(int p_idx) const;
 	String get_node_instance_placeholder(int p_idx) const;
 	bool is_node_instance_placeholder(int p_idx) const;
+	bool is_node_placeholder(int p_idx) const;
 	Vector<StringName> get_node_groups(int p_idx) const;
 	int get_node_index(int p_idx) const;
 
@@ -219,7 +221,7 @@ public:
 	int add_name(const StringName &p_name);
 	int add_value(const Variant &p_value);
 	int add_node_path(const NodePath &p_path, const PackedInt32Array &p_uid_path);
-	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int32_t p_unique_id);
+	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, bool p_placeholder, int p_index, int32_t p_unique_id);
 	void add_node_property(int p_node, int p_name, int p_value, bool p_deferred_node_path = false);
 	void add_node_group(int p_node, int p_group);
 	void set_base_scene(int p_idx);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -196,6 +196,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 			int instance = -1;
 			int index = -1;
 			int unique_id = Node::UNIQUE_SCENE_ID_UNASSIGNED;
+			bool placeholder = false;
 
 			//int base_scene=-1;
 
@@ -255,6 +256,10 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				instance = path_v | SceneState::FLAG_INSTANCE_IS_PLACEHOLDER;
 			}
 
+			if (next_tag.fields.has("placeholder")) {
+				placeholder = true;
+			}
+
 			if (next_tag.fields.has("owner")) {
 				PackedInt32Array np_id;
 				if (next_tag.fields.has("owner_uid_path")) {
@@ -271,7 +276,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				index = next_tag.fields["index"];
 			}
 
-			int node_id = packed_scene->get_state()->add_node(parent, owner, type, name, instance, index, unique_id);
+			int node_id = packed_scene->get_state()->add_node(parent, owner, type, name, instance, placeholder, index, unique_id);
 
 			if (next_tag.fields.has("groups")) {
 				Array groups = next_tag.fields["groups"];
@@ -2018,6 +2023,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			NodePath owner = state->get_node_owner_path(i);
 			Ref<PackedScene> instance = state->get_node_instance(i);
 			String instance_placeholder = state->get_node_instance_placeholder(i);
+			bool is_placeholder = state->is_node_placeholder(i);
 			Vector<StringName> groups = state->get_node_groups(i);
 			Vector<String> deferred_node_paths = state->get_node_deferred_nodepath_properties(i);
 
@@ -2074,6 +2080,10 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 				f->store_string(" instance_placeholder=");
 				VariantWriter::write_to_string(instance_placeholder, vars, true, _write_resources, this, use_compat);
 				f->store_string(vars);
+			}
+
+			if (is_placeholder) {
+				f->store_string(" placeholder=true");
 			}
 
 			if (instance.is_valid()) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Alternative to #115212

## Additional information

This PR adds node stashing, but instead of keeping nodes in stash, they are replaced with placeholders. When you call `Node.stash()`, the node is removed from tree and a PlaceholderNode is added in that place. The original node is effectively disabled, while the placeholder can be used to access or restore it.

Putting as draft, because this is just the base implementation. This approach should make it easier to implement stashing on the editor side and in PackedScene. Also, as suggested in https://github.com/godotengine/godot-proposals/issues/15234, I plan to merge/integrate InstancePlaceholder with PlaceholderNode, since they are very similar.

btw since the implementation no longer involves "stash", the feature might use a better name.