### PR TITLE
Fix inconsistent visibility of animation bar in the canvas editor

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -4196,9 +4196,8 @@ Node *AnimationTrackEditor::get_root() const {
 void AnimationTrackEditor::update_keying() {
 	bool keying_enabled = false;
 
-	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
-	if (is_visible_in_tree() && animation.is_valid() && editor_history->get_path_size() > 0) {
-		Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
+	if (is_visible_in_tree() && animation.is_valid()) {
+		Object *obj = InspectorDock::get_inspector_singleton()->get_edited_object();
 		keying_enabled = Object::cast_to<Node>(obj) != nullptr || Object::cast_to<MultiNodeEdit>(obj) != nullptr;
 	}
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -569,11 +569,7 @@ Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
 
 void CanvasItemEditor::_keying_changed() {
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (te && te->is_visible_in_tree() && te->get_current_animation().is_valid()) {
-		animation_hb->show();
-	} else {
-		animation_hb->hide();
-	}
+	animation_hb->set_visible(te && te->has_keying());
 }
 
 Rect2 CanvasItemEditor::_get_encompassing_rect_from_list(const List<CanvasItem *> &p_list) {
@@ -4501,7 +4497,6 @@ void CanvasItemEditor::_notification(int p_what) {
 
 			AnimationPlayerEditor::get_singleton()->get_track_editor()->connect("keying_changed", callable_mp(this, &CanvasItemEditor::_keying_changed));
 			AnimationPlayerEditor::get_singleton()->connect("animation_selected", callable_mp(this, &CanvasItemEditor::_keying_changed).unbind(1));
-			_keying_changed();
 			_update_editor_settings();
 
 			connect("item_lock_status_changed", callable_mp(this, &CanvasItemEditor::_update_lock_and_group_button));


### PR DESCRIPTION
## What problem(s) does this PR solve?

The current behavior of the animation bar (the one that appears in the canvas editor top bar when opening the animation editor) is quite inconsistent, and buggy:
- It will not show if the selection history is empty, then it can show even if nothing is selected.
- If the animation editor is left open when reopening the project, the bar will stay present despite the history being empty, or even if the animation editor is hidden.
- Internally, the code to change the visibility of the bar tries to check by itself if keying is being used or not, instead of just asking the `AnimationTrackEditor` directly.

This PR makes so that the bar will only show if something valid is selected, and uses `AnimationTrackEditor` to check for keying.