### PR TITLE
ORMMaterial3D: Enable AO when an ORM texture is added.

### DIFF
--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -474,8 +474,9 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 	EditorUndoRedoManager *undo_redo = Object::cast_to<EditorUndoRedoManager>(p_undo_redo);
 	ERR_FAIL_NULL(undo_redo);
 
-	// For BaseMaterial3D, if a roughness or metallic textures is being assigned to an empty slot,
-	// set the respective metallic or roughness factor to 1.0 as a convenience feature
+	// For StandardMaterial3D, if a roughness or metallic textures is being assigned to an empty slot,
+	// set the respective metallic or roughness factor to 1.0 as a convenience feature.
+	// For ORMMaterial3D, if an ORM texture is being assigned, set ao_enabled to true.
 	BaseMaterial3D *base_material = Object::cast_to<BaseMaterial3D>(p_edited);
 	if (base_material) {
 		Texture2D *texture = Object::cast_to<Texture2D>(p_new_value);

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -476,7 +476,7 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 
 	// For BaseMaterial3D, if a roughness or metallic textures is being assigned to an empty slot,
 	// set the respective metallic or roughness factor to 1.0 as a convenience feature
-	BaseMaterial3D *base_material = Object::cast_to<StandardMaterial3D>(p_edited);
+	BaseMaterial3D *base_material = Object::cast_to<BaseMaterial3D>(p_edited);
 	if (base_material) {
 		Texture2D *texture = Object::cast_to<Texture2D>(p_new_value);
 		if (texture) {
@@ -498,6 +498,16 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 					Variant value = p_edited->get("metallic", &valid);
 					if (valid) {
 						undo_redo->add_undo_property(p_edited, "metallic", value);
+					}
+				}
+			} else if (p_property == "orm_texture") {
+				if (base_material->get_texture(ORMMaterial3D::TEXTURE_ORM).is_null()) {
+					undo_redo->add_do_property(p_edited, "ao_enabled", true);
+
+					bool valid = false;
+					Variant value = p_edited->get("ao_enabled", &valid);
+					if (valid) {
+						undo_redo->add_undo_property(p_edited, "ao_enabled", value);
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
This PR enables AO by default when an ORM texture is detected. It's a purely QOL change. See [godot-proposals#15224](https://github.com/godotengine/godot-proposals/issues/15224) for more details.

- Closes [godot-proposals#15224](https://github.com/godotengine/godot-proposals/issues/15224)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
I modified editor/scene/material_editor_plugin.cpp `EditorInspectorPluginMaterial::_undo_redo_inspector_callback` to have an if statement checking whether the change is an orm texture being added and enabling ao if it is.

This is my first time writing CPP code. I basically just copy pasted the code above it to add this feature. I also had to change an Object cast to StandardMaterial3D to instead be cast to BaseMaterial3D.