### PR TITLE
Fix Duplicate Keyboard Entries inside Input Event Configuration Dialog

### DIFF
--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -316,8 +316,15 @@ void InputEventConfigurationDialog::_update_input_list() {
 		kb_root->set_collapsed(collapse);
 		kb_root->set_meta("__type", INPUT_KEY);
 
+		HashSet<int> keycodes_found;
 		for (int i = 0; i < keycode_get_count(); i++) {
 			String name = keycode_get_name_by_index(i);
+			int keycode = keycode_get_value_by_index(i);
+
+			// To avoid duplicate entries
+			if (keycodes_found.has(keycode)) {
+				continue;
+			}
 
 			if (!search_term.is_empty() && !name.containsn(search_term)) {
 				continue;
@@ -325,7 +332,8 @@ void InputEventConfigurationDialog::_update_input_list() {
 
 			TreeItem *item = input_list_tree->create_item(kb_root);
 			item->set_text(0, name);
-			item->set_meta("__keycode", keycode_get_value_by_index(i));
+			item->set_meta("__keycode", keycode);
+			keycodes_found.insert(keycode);
 		}
 	}
 


### PR DESCRIPTION
## Brief Description
Currently there's duplicate entries for specific modifier keys (like Ctrl & Command) that are handled at preprocessor level, this causes the problem described in #121578 issue, more detail over on that issue.

## What problem(s) does this PR solve?

- Closes #121578 

## Testing

Tested these changes on Windows 11, which fixes the duplicate Ctrl modifier, but I can't confirm the same on MacOS with Command modifier as I don't have the necessary hardware to do so.

Also I haven't had the time to test on Linux, if prompted to test by the maintainers, then I've no problems testing on Linux as well (maybe this weekend).

<details><summary><b>Screenshots</b></summary>
<p>

<img width="799" height="429" alt="image" src="https://github.com/user-attachments/assets/5315252e-d85b-4f85-a9ce-9b50c3731291" />

</p>
</details> 

## Additional information
As I'm not knowledgeable enough in CS, idk if this's the most optimal solution in time/space complexity (even though it isn't called often, but still), if anyone have insight on this matter, then suggestions are welcomed 😄

## Use of AI
No AI was used in the process of finding, debugging, and implementing a solution for the issue this PR tries to solve.