### PR TITLE
Prevent using struct with name of an existed function in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9483,7 +9483,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				tk = _get_token();
 				if (tk.type == TK_IDENTIFIER) {
 					st.name = tk.text;
-					if (shader->constants.has(st.name) || shader->structs.has(st.name)) {
+					if (shader->functions.has(st.name) || shader->constants.has(st.name) || shader->structs.has(st.name)) {
 						_set_redefinition_error(String(st.name));
 						return ERR_PARSE_ERROR;
 					}


### PR DESCRIPTION
Just an one-liner fix to prevent writing things like:

```gdshader
void foo() {
	
}

struct foo {
	int a;
};
```

This is similar to behavior of GLSL.