### PR TITLE
[Android] Fix issue causing the engine to crash when starting while the screen is off

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -108,6 +108,7 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 			// Pause the renderer
 			godotRenderer.onActivityPaused();
 		});
+		pauseGLThread();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -93,6 +93,7 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 			// Pause the renderer
 			mRenderer.onVkPause();
 		});
+		pauseRenderThread();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkRenderer.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkRenderer.kt
@@ -93,6 +93,7 @@ internal class VkRenderer {
 	 * Called when the rendering thread is resumed.
 	 */
 	fun onVkResume() {
+		Log.v(TAG, "Renderer resumed")
 		GodotLib.onRendererResumed()
 	}
 
@@ -100,6 +101,7 @@ internal class VkRenderer {
 	 * Called when the rendering thread is paused.
 	 */
 	fun onVkPause() {
+		Log.v(TAG, "Renderer paused")
 		GodotLib.onRendererPaused()
 	}
 
@@ -107,7 +109,7 @@ internal class VkRenderer {
 	 * Invoked when the render thread is in the process of shutting down.
 	 */
 	fun onRenderThreadExiting() {
-		Log.d(TAG, "Destroying Godot Engine")
+		Log.v(TAG, "Destroying Godot Engine")
 		GodotLib.ondestroy()
 	}
 }

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkSurfaceView.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkSurfaceView.kt
@@ -32,6 +32,7 @@
 package org.godotengine.godot.vulkan
 
 import android.content.Context
+import android.util.Log
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 
@@ -51,6 +52,8 @@ import android.view.SurfaceView
  */
 open internal class VkSurfaceView(context: Context) : SurfaceView(context), SurfaceHolder.Callback {
 	companion object {
+		private val TAG = VkSurfaceView::class.java.simpleName
+
 		fun checkState(expression: Boolean, errorMessage: Any) {
 			check(expression) { errorMessage.toString() }
 		}
@@ -129,14 +132,17 @@ open internal class VkSurfaceView(context: Context) : SurfaceView(context), Surf
 	}
 
 	override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+		Log.v(TAG, "On surface changed [$format]: $width x $height")
 		vkThread.onSurfaceChanged(width, height)
 	}
 
 	override fun surfaceDestroyed(holder: SurfaceHolder) {
+		Log.v(TAG, "On surface destroyed")
 		vkThread.onSurfaceDestroyed()
 	}
 
 	override fun surfaceCreated(holder: SurfaceHolder) {
+		Log.v(TAG, "On surface created")
 		vkThread.onSurfaceCreated()
 	}
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -246,8 +246,11 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, j
 				ANativeWindow *native_window = ANativeWindow_fromSurface(env, p_surface);
 				os_android->set_native_window(native_window);
 			}
-			DisplayServerAndroid::get_singleton()->reset_window();
-			DisplayServerAndroid::get_singleton()->notify_surface_changed(p_width, p_height);
+
+			DisplayServerAndroid *dsa = DisplayServerAndroid::get_singleton();
+			ERR_FAIL_NULL(dsa);
+			dsa->reset_window();
+			dsa->notify_surface_changed(p_width, p_height);
 		}
 	}
 }
@@ -288,8 +291,14 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 
 	if (step.get() == STEP_SETUP) {
 		// Since Godot is initialized on the UI thread, main_thread_id was set to that thread's id,
-		// but for Godot purposes, the main thread is the one running the game loop
-		Main::setup2(false); // The logo is shown in the next frame otherwise we run into rendering issues
+		// but for Godot purposes, the main thread is the one running the game loop.
+		// The logo is shown in the next frame otherwise we run into rendering issues.
+		if (Main::setup2(false) != OK) {
+			ERR_PRINT("Unable to complete engine setup!");
+			OS::get_singleton()->alert("Unable to complete engine setup!");
+			_terminate(env, false);
+			return false;
+		}
 		input_handler = new AndroidInputHandler();
 		step.increment();
 		return true;
@@ -316,7 +325,10 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 
 	if (step.get() == STEP_STARTED) {
 		if (Main::start() != EXIT_SUCCESS) {
-			return true; // should exit instead and print the error
+			ERR_PRINT("Unable to start engine!");
+			OS::get_singleton()->alert("Unable to start engine!");
+			_terminate(env, false);
+			return false;
 		}
 
 		godot_java->on_godot_setup_completed(env);
@@ -325,10 +337,13 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 		step.increment();
 	}
 
-	DisplayServerAndroid::get_singleton()->process_accelerometer(accelerometer);
-	DisplayServerAndroid::get_singleton()->process_gravity(gravity);
-	DisplayServerAndroid::get_singleton()->process_magnetometer(magnetometer);
-	DisplayServerAndroid::get_singleton()->process_gyroscope(gyroscope);
+	DisplayServerAndroid *dsa = DisplayServerAndroid::get_singleton();
+	if (dsa) {
+		dsa->process_accelerometer(accelerometer);
+		dsa->process_gravity(gravity);
+		dsa->process_magnetometer(magnetometer);
+		dsa->process_gyroscope(gyroscope);
+	}
 
 	bool should_swap_buffers = false;
 	if (os_android->main_loop_iterate(&should_swap_buffers)) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -383,14 +383,17 @@ bool OS_Android::main_loop_iterate(bool *r_should_swap_buffers) {
 	if (!main_loop) {
 		return false;
 	}
-	DisplayServerAndroid::get_singleton()->reset_swap_buffers_flag();
-	DisplayServerAndroid::get_singleton()->process_events();
+	DisplayServerAndroid *dsa = DisplayServerAndroid::get_singleton();
+	ERR_FAIL_NULL_V(dsa, true);
+	dsa->reset_swap_buffers_flag();
+	dsa->process_events();
+
 	uint64_t current_frames_drawn = Engine::get_singleton()->get_frames_drawn();
 	bool exit = Main::iteration();
 
 	if (r_should_swap_buffers) {
 		*r_should_swap_buffers = !is_in_low_processor_usage_mode() ||
-				DisplayServerAndroid::get_singleton()->should_swap_buffers() ||
+				dsa->should_swap_buffers() ||
 				RenderingServer::get_singleton()->has_changed() ||
 				current_frames_drawn != Engine::get_singleton()->get_frames_drawn();
 	}
@@ -436,17 +439,25 @@ void OS_Android::_on_distraction_free_mode_changed(bool p_enable) {
 #endif
 
 void OS_Android::main_loop_focusout() {
-	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
+	DisplayServerAndroid *dsa = DisplayServerAndroid::get_singleton();
+	if (dsa) {
+		dsa->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
+	}
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 	}
 
-	// Only pause when we are not in PiP mode.
-	audio_driver_android.set_pause(!DisplayServerAndroid::get_singleton()->is_in_pip_mode());
+	if (dsa) {
+		// Only pause when we are not in PiP mode.
+		audio_driver_android.set_pause(!dsa->is_in_pip_mode());
+	}
 }
 
 void OS_Android::main_loop_focusin() {
-	DisplayServerAndroid::get_singleton()->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_IN);
+	DisplayServerAndroid *dsa = DisplayServerAndroid::get_singleton();
+	if (dsa) {
+		dsa->send_window_event(DisplayServerEnums::WINDOW_EVENT_FOCUS_IN);
+	}
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 	}

--- a/platform/android/rendering_context_driver_vulkan_android.cpp
+++ b/platform/android/rendering_context_driver_vulkan_android.cpp
@@ -32,6 +32,8 @@
 
 #ifdef VULKAN_ENABLED
 
+#include "core/variant/variant.h"
+
 #include <drivers/vulkan/godot_vulkan.h>
 
 const char *RenderingContextDriverVulkanAndroid::_get_platform_surface_extension() const {
@@ -47,7 +49,7 @@ RenderingContextDriver::SurfaceID RenderingContextDriverVulkanAndroid::surface_c
 
 	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
 	VkResult err = vkCreateAndroidSurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
+	ERR_FAIL_COND_V_MSG(err != VK_SUCCESS, SurfaceID(), vformat("Couldn't create Android Surface (VkResult error %d).", err));
 
 	Surface *surface = memnew(Surface);
 	surface->vk_surface = vk_surface;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/114800
- Closes https://github.com/godotengine/godot/issues/107446

## Additional information

This issue only occurred with the vulkan (Forward mobile) renderer, and was caused because we attempted to create a vulkan swapchain while the screen was off, and the underlying surface was being destroyed. This occurs because the app goes through the following activity lifecycle when the screen is off: ON_CREATE -> ON_START -> ON_RESUME -> ON_PAUSE -> ON_STOP

Between the ON_PAUSE and ON_STOP lifecycle, the surface is being created, resized, then destroyed because the screen is off. The current vk thread logic however will kickstart the creation of the vulkan swapchain after the ON_PAUSE lifecycle, right after the surface is created and resized, and only stops when the ON_STOP lifecycle fires, by which point it's too late because the surface is already destroyed. The fix involves stopping the creation of the vulkan swapchain when ON_PAUSE fires and before the surface is destroyed. This allows to properly resume when the activity is resumed.

Failing to create the vulkan swapchain would cause the creation of the `DisplayServerAndroid` to fail, causing its singleton to be destroyed. Part of the Android code however would access and use the `null` singleton without checking, causing the engine to crash. So additional logic was added to check that `DisplayServerAndroid::get_singleton() != nullptr` before using it.

The crashes manifested in the play store as a SIGSEV on `Callable::is_valid()`.

Many thanks for @chanwoo0125 for providing repro steps in https://github.com/godotengine/godot/issues/107446#issuecomment-4995145133 which allowed to trace down the root cause of the issue!

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
