### PR TITLE
Document that `Packed*Array`s' `remove_at` method cannot take negative indices

### DIFF
--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -455,7 +455,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -142,7 +142,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -143,7 +143,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -144,7 +144,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -138,7 +138,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -139,7 +139,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -145,7 +145,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -148,7 +148,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -147,7 +147,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">

--- a/doc/classes/PackedVector4Array.xml
+++ b/doc/classes/PackedVector4Array.xml
@@ -147,7 +147,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes an element from the array by index.
+				Removes an element from the array by index. If [param index] is out-of-bounds or negative, this method fails.
 			</description>
 		</method>
 		<method name="resize">


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Documents #121554's limitation, not sure if it counts as fixing it

## Additional information

Not sure if this is best wording or formatting etc., so please suggest changes.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

* *Bugsquad edit, closes #121554 (as any change in the behavior would require a formal proposal)*
