### PR TITLE
Fix sky shader `SCREEN_UV` builtin in Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -200,7 +200,7 @@ void main() {
 	cube_normal = mat3(orientation) * cube_normal;
 	cube_normal = normalize(cube_normal);
 
-	vec2 uv = gl_FragCoord.xy; // uv_interp * 0.5 + 0.5;
+	vec2 uv = uv_interp * 0.5 + 0.5;
 
 	vec2 panorama_coords = vec2(atan2_approx(cube_normal.x, -cube_normal.z), acos_approx(cube_normal.y));
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121522

## Additional information

Git blame for this line points to #60643. I couldn't find a reason for this change, so I'm assuming it was done by mistake. The code in this PR matches the Forward+ and Mobile renderers.

This technically breaks compatibility, though the behavior was incorrect before.