### PR TITLE
GDScript: Allow implicit conversion for `preload()` argument

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4801,7 +4801,7 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 		return;
 	}
 
-	if (p_preload->path->reduced_value.get_type() != Variant::STRING) {
+	if (!Variant::can_convert_strict(p_preload->path->reduced_value.get_type(), Variant::STRING)) {
 		push_error("Preloaded path must be a constant string.", p_preload->path);
 	} else {
 		p_preload->resolved_path = p_preload->path->reduced_value;

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
@@ -10,3 +10,8 @@ func test():
 	var string_name := &"A"
 	print(ord(string))
 	print(ord(string_name))
+
+	const PATH_STRING = "../../utils.notest.gd"
+	const PATH_STRING_NAME = &"../../utils.notest.gd"
+	print((preload(PATH_STRING) as GDScript).get_class())
+	print((preload(PATH_STRING_NAME) as GDScript).get_class())

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
@@ -3,3 +3,5 @@ Color(1, 0, 0, 1)
 Color(1, 0, 0, 1)
 65
 65
+GDScript
+GDScript


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121648.

## Additional information

`preload` is a keyword, so it has special handling compared to regular methods and utility functions. This change is consistent with the behavior fix for utility functions added in #84368.