### PR TITLE
Fix BoxContainer not notifying about minimum_size change when resorting

### DIFF
--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -97,6 +97,8 @@ void Container::_sort_children() {
 		return;
 	}
 
+	update_minimum_size();
+
 	notification(NOTIFICATION_PRE_SORT_CHILDREN);
 	emit_signal(SceneStringName(pre_sort_children));
 


### PR DESCRIPTION
The main problem fixed by this PR:
`Control::get_bounds_minimum_size()` updates minimum_size used by containers, but callers are responsible for calling `update_minimum_size()` to invalidate and send `minimum_size_changed` signal. Many callers do not call `update_minimum_size()`. This causes container sorting to end prematurely, which happens in this bug. This is fixed by calling `update_minimum_size()` on `NOTIFICATION_SORT_CHILDREN`. It is more granular than updating on any minimum_size change (e.g. `NOTIFICATION_RESIZE`), and perhaps covers less edge cases I am not aware of, but it should have better performance. This problem likely spans more than BoxContainer but currently it only fixes BoxContainer bug case.

## What problem(s) does this PR solve?

- Closes #121372

## Additional information

There are other problems related to the bug which complicate things (unintended or intended):
1. TextureRect gives incorrect minimum_size to BoxContainer multiple times. Then, TextureRect resizes on its own, which causes BoxContainer reordering multiple times. Originally, these independent TextureRect resizes were not visible to BoxContainer, and BoxContainer did not call `update_minimum_size()`.
2. Changing size and resorting are deferred calls. This causes temporary state to be rendered sometimes. In the editor, it can be noticed how resizing node flickers to temporary state for a frame, but it happens rarely and barely noticeable.

2 examples in MVP were tested, and manipulating MVP in real-time in various ways in the editor.

<img width="677" height="256" alt="image" src="https://github.com/user-attachments/assets/ba80d417-4b39-4b63-ac57-f6bb08b115d9" />

[MVP-bug-121372.zip](https://github.com/user-attachments/files/30305450/MVP-bug-121372.zip)