### PR TITLE
3D: Add origin anchor when placing scenes

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -5459,6 +5459,10 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 		const Vector3 bb_basis_z = bb_basis_x.cross(bb_basis_y);
 		const Basis bb_basis = Basis(bb_basis_x, bb_basis_y, bb_basis_z);
 
+		if (preview_use_origin_anchor && Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+			return result.position;
+		}
+
 		// This normal-aligned Basis allows us to create an AABB that can fit on the surface plane as snugly as possible.
 		const Transform3D bb_transform = Transform3D(bb_basis, p_node->get_global_transform().origin);
 		const AABB p_node_bb = _calculate_spatial_bounds(p_node, true, &bb_transform);
@@ -5972,6 +5976,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 	// continue to check if the rest of the scenes are valid (don't have cyclic dependencies).
 	bool is_other_valid = false;
 	// Check if at least one of the dragged files is a mesh, material, texture, or scene.
+	preview_use_origin_anchor = false;
 	for (int i = 0; i < files.size(); i++) {
 		const String &res_type = ResourceLoader::get_resource_type(files[i]);
 		bool is_scene = ClassDB::is_parent_class(res_type, "PackedScene");
@@ -5991,6 +5996,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 			Ref<Texture2D> tex = res;
 			Ref<AudioStream> audio = res;
 			if (scn.is_valid()) {
+				preview_use_origin_anchor = true;
 				Node *instantiated_scene = scn->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
 				if (!instantiated_scene) {
 					continue;
@@ -6065,7 +6071,10 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 			"\n" +
 			TTRN("[b]Hold Alt:[/b] Add as child of root node.",
 					"[b]Hold Alt:[/b] Add as children of root node.",
-					files.size());
+					files.size()) +
+			"\n" +
+			vformat(TTR("[b]Hold %s:[/b] Place scenes using their origin instead of their AABB."),
+					keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL));
 
 	if (files.size() > 1) {
 		title = TTR("Dropping multiple files...");

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -249,6 +249,7 @@ private:
 	void _menu_option(int p_option);
 	Node3D *preview_node = nullptr;
 	bool update_preview_node = false;
+	bool preview_use_origin_anchor = false;
 	Point2 preview_node_viewport_pos;
 	Vector3 preview_node_pos;
 	AABB *preview_bounds = nullptr;


### PR DESCRIPTION

This implements the improvement proposed in:
https://github.com/godotengine/godot-proposals/issues/13299

## Changes

- Preserve the existing AABB-based placement behavior by default.
- Allow holding Ctrl on Windows/Linux, or Cmd on macOS, to place a dragged PackedScene using its origin.
- Allow the origin-placement modifier to be combined with the existing Shift and Alt hierarchy modifiers.
- Document the new modifier in the 3D viewport drop tooltip.
- Keep meshes, materials, textures, and audio on their existing drop behavior.

## Usage

When dragging a scene into the 3D viewport:

- No modifier: place using the existing AABB-based anchor.
- Hold Ctrl/Cmd: place the scene origin at the surface hit position.
- Hold Shift: add the scene as a child of the selected node.
- Hold Alt: add the scene as a child of the scene root.


https://github.com/user-attachments/assets/94018e72-9bc1-4f03-8a33-a9d02aa69399

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13299*