### PR TITLE
Improve support for Properties in NodePath exports

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -282,6 +282,10 @@ NodePath NodePath::slice(int p_begin, int p_end) const {
 	return NodePath(names, sub_names, absolute);
 }
 
+NodePath NodePath::with_subnames(const Vector<StringName> &p_subname) const {
+	return NodePath(get_names(), { p_subname }, is_absolute());
+}
+
 NodePath NodePath::rel_path_to(const NodePath &p_np) const {
 	ERR_FAIL_COND_V(!is_absolute(), NodePath());
 	ERR_FAIL_COND_V(!p_np.is_absolute(), NodePath());

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -72,6 +72,7 @@ public:
 	StringName get_concatenated_names() const;
 	StringName get_concatenated_subnames() const;
 	NodePath slice(int p_begin, int p_end = INT_MAX) const;
+	NodePath with_subnames(const Vector<StringName> &p_subname) const;
 
 	NodePath rel_path_to(const NodePath &p_np) const;
 	NodePath get_as_property_path() const;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3060,7 +3060,11 @@ void EditorPropertyNodePath::_node_assign() {
 		scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 		scene_tree->set_valid_types(valid_types);
 		add_child(scene_tree);
-		scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_node_selected).bind(true));
+		if (is_property_selector) {
+			scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_property_assign).bind(true));
+		} else {
+			scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_node_selected).bind(true));
+		}
 	}
 
 	Variant val = get_edited_property_value();
@@ -3072,6 +3076,44 @@ void EditorPropertyNodePath::_node_assign() {
 		n = Object::cast_to<Node>(val);
 	}
 	scene_tree->popup_scenetree_dialog(n, get_base_node());
+}
+
+void EditorPropertyNodePath::_property_selected(const String &p_name) {
+	emit_changed(get_edited_property(), adding_property_path.with_subnames({ p_name }));
+	update_property();
+}
+
+void EditorPropertyNodePath::_property_assign(const NodePath &p_path, bool p_absolute) {
+	Node *base_node = get_base_node();
+
+	if (!property_selector) {
+		property_selector = memnew(PropertySelector);
+		add_child(property_selector);
+		property_selector->connect("selected", callable_mp(this, &EditorPropertyNodePath::_property_selected));
+		if (!valid_property_types.is_empty()) {
+			Vector<Variant::Type> valid_variants;
+			for (const StringName &property_type : valid_property_types) {
+				valid_variants.append(Variant::get_type_by_name(property_type));
+			}
+			property_selector->set_type_filter(valid_variants);
+		}
+	}
+
+	if (!base_node && Object::cast_to<RefCounted>(get_edited_object())) {
+		Node *to_node = get_node(p_path);
+		ERR_FAIL_NULL(to_node);
+		adding_property_path = get_tree()->get_edited_scene_root()->get_path_to(to_node);
+	}
+
+	if (p_absolute && base_node) {
+		adding_property_path = base_node->get_path().rel_path_to(p_path);
+	}
+
+	if (!base_node) {
+		property_selector->select_property_from_instance(get_tree()->get_edited_scene_root()->get_node(adding_property_path));
+	} else {
+		property_selector->select_property_from_instance(base_node->get_node(adding_property_path));
+	}
 }
 
 void EditorPropertyNodePath::_assign_draw() {
@@ -3167,16 +3209,46 @@ bool EditorPropertyNodePath::can_drop_data_fw(const Point2 &p_point, const Varia
 void EditorPropertyNodePath::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	ERR_FAIL_COND(!is_drop_valid(p_data));
 	Dictionary data_dict = p_data;
-	Array nodes = data_dict["nodes"];
-	Node *node = get_tree()->get_edited_scene_root()->get_node(nodes[0]);
-
-	if (node) {
-		_node_selected(node->get_path());
+	Node *node;
+	if (data_dict["type"] == "obj_property") {
+		node = Object::cast_to<Node>(data_dict["object"]);
+		if (node) {
+			String property_name = data_dict["property"];
+			_node_selected(node->get_path().with_subnames({ property_name }));
+		}
+	}
+	if (data_dict["type"] == "nodes") {
+		Array nodes = data_dict["nodes"];
+		node = get_tree()->get_edited_scene_root()->get_node(nodes[0]);
+		if (node) {
+			_node_selected(node->get_path());
+		}
 	}
 }
 
 bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const {
-	if (!p_drag_data.has("type") || p_drag_data["type"] != "nodes") {
+	if (!p_drag_data.has("type")) {
+		return false;
+	}
+	const String type_value = p_drag_data["type"];
+	if (type_value == "obj_property" && !is_node_only) {
+		if (valid_property_types.is_empty()) {
+			return true;
+		}
+
+		Node *node = Object::cast_to<Node>(p_drag_data["object"]);
+		if (node) {
+			String property_name = p_drag_data["property"];
+			Variant value = node->get(property_name);
+			for (const StringName &type_name : valid_property_types) {
+				if (value.get_type() == Variant::get_type_by_name(type_name)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+	if (type_value != "nodes" || is_property_selector) {
 		return false;
 	}
 	Array nodes = p_drag_data["nodes"];
@@ -3245,16 +3317,36 @@ void EditorPropertyNodePath::update_property() {
 	}
 
 	if (p.get_subname_count() > 0) {
-		new_text += ":" + p.get_concatenated_subnames();
+		String property_name = String(p.get_concatenated_subnames());
+		Variant value = target_node->get(property_name);
+
+		new_text += ":" + property_name;
+		assign->set_text(new_text);
+		assign->set_button_icon(EditorNode::get_singleton()->get_class_icon(Variant::get_type_name(value.get_type())));
+		return;
 	}
 	assign->set_text(new_text);
 	assign->set_button_icon(EditorNode::get_singleton()->get_object_icon(target_node));
 }
 
-void EditorPropertyNodePath::setup(const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root, bool p_editing_node) {
+void EditorPropertyNodePath::setup_node_path(const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root, bool p_editing_node) {
 	valid_types = p_valid_types;
 	editing_node = p_editing_node;
 	use_path_from_scene_root = p_use_path_from_scene_root;
+	is_node_only = true;
+}
+
+void EditorPropertyNodePath::setup_node_path() {
+	is_node_only = true;
+}
+
+void EditorPropertyNodePath::setup_property_path(const Vector<StringName> &p_valid_property_types) {
+	valid_property_types = p_valid_property_types;
+	is_property_selector = true;
+}
+
+void EditorPropertyNodePath::setup_property_path() {
+	is_property_selector = true;
 }
 
 void EditorPropertyNodePath::_notification(int p_what) {
@@ -4244,10 +4336,13 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::NODE_PATH: {
 			EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
-			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && !p_hint_text.is_empty()) {
-				Vector<String> types = p_hint_text.split(",", false);
-				Vector<StringName> sn = Variant(types); //convert via variant
-				editor->setup(sn, (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));
+			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES) {
+				if (!p_hint_text.is_empty()) {
+					Vector<String> types = p_hint_text.split(",", false);
+					Vector<StringName> sn = Variant(types); //convert via variant
+					editor->setup_node_path(sn, (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));
+				}
+				editor->setup_node_path();
 			}
 			return editor;
 
@@ -4261,7 +4356,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
 				Vector<String> types = p_hint_text.split(",", false);
 				Vector<StringName> sn = Variant(types); //convert via variant
-				editor->setup(sn, false, true);
+				editor->setup_node_path(sn, false, true);
 				return editor;
 			} else {
 				EditorPropertyResource *editor = memnew(EditorPropertyResource);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "editor/inspector/editor_inspector.h"
+#include "editor/inspector/property_selector.h"
 
 class CheckBox;
 class ColorPickerButton;
@@ -698,13 +699,20 @@ class EditorPropertyNodePath : public EditorProperty {
 	LineEdit *edit = nullptr;
 
 	SceneTreeDialog *scene_tree = nullptr;
+	PropertySelector *property_selector = nullptr;
 	bool use_path_from_scene_root = false;
 	bool editing_node = false;
 	bool dropping = false;
+	bool is_node_only = false;
+	bool is_property_selector = false;
+	NodePath adding_property_path;
 
 	Vector<StringName> valid_types;
+	Vector<StringName> valid_property_types;
 	void _node_selected(const NodePath &p_path, bool p_absolute = true);
 	void _node_assign();
+	void _property_selected(const String &p_name);
+	void _property_assign(const NodePath &p_path, bool p_absolute = true);
 	void _assign_draw();
 	Node *get_base_node();
 	void _update_menu();
@@ -725,7 +733,10 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
+	void setup_node_path(const Vector<StringName> &p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
+	void setup_node_path();
+	void setup_property_path(const Vector<StringName> &p_valid_property_types);
+	void setup_property_path();
 	EditorPropertyNodePath();
 };
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Partially works towards https://github.com/godotengine/godot-proposals/issues/231

This PR touches up the EditorPropertyNodePath class a bit to better support properties, while the main improvement in this PR is the support of drag and drop, there is some logic bundled for implementing a new `@export_property_path` attribute which is the goal of the proposal. I'm not familiar with GDScript or its processes (aside from basic bindings).

https://github.com/user-attachments/assets/b1ac4ccb-b47c-47e8-a14d-646c7ff166aa

This PR also includes a new internal helper method for NodePath called "with_subpaths", this shrinks an otherwise cumbersome NodePath construction to a much more readable state.
Before example:
```cpp
const NodePath path = NodePath(adding_property_path.get_names(), {p_name}, adding_property_path.is_absolute());
```
After example:
```cpp
const NodePath path = adding_property_path.with_subnames({p_name});
```
While I would like to expose this to GDScript, for similar reasons as above I'm not sure what the correct way of binding it is, as the helper takes a Vector of StringNames, which as far as I know isn't supported by the binding layer. 

## Additional information

From a quick test, this has no compatibility issues, I was able to update a 4.7 project with a manually typed property and it updated to include the new type icon just fine.

While this PR does not add the ability to access the Property Selector or the filtering included in this PR, it will mean that the PR that follows this up is completely self-contained in GDScript, and there (hopefully) shouldn't be any changes required in this area to support a `@export_property_path` attribute. Regardless, I've tested the currently unused code and the filtering and selector works as expected, they just need to be wired up. 

Here is a demonstration of property selector enabled with a filter of `bool` and `float`:
(reminder that this functionality is not accessible yet)

https://github.com/user-attachments/assets/c60d90f2-30ca-4474-9414-f16de828c93e

I believe this qualifies as a feature PR, and I don't believe I'm at the requirement quite yet (one merged PR away I believe?), but seeing how old the proposal had me interested enough in doing it for fun, I can mark this as a draft until the requirement is met if desired.

Should also be noted that I am still rather unfamiliar with C++ so if any of my decisions look strange it's most certainly that. Any code feedback is always highly appreciated.
____

No AI was used in the creation or process of this PR