### PR TITLE
Allow `StringName`s to be used in `@export_enum`

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -407,7 +407,7 @@
 			<return type="void" />
 			<param index="0" name="names" type="String" />
 			<description>
-				Export an [int], [String], [Array][lb][int][rb], [Array][lb][String][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
+				Export an [int], [String], [StringName], [Array][lb][int][rb], [Array][lb][String][rb], [Array][lb][StringName][rb], [PackedByteArray], [PackedInt32Array], [PackedInt64Array], or [PackedStringArray] property as an enumerated list of options (or an array of options). If the property is an [int], then the index of the value is stored, in the same order the values are provided. You can add explicit values using a colon. If the property is a [String], then the value is stored.
 				See also [constant PROPERTY_HINT_ENUM].
 				[codeblock]
 				@export_enum("Warrior", "Magician", "Thief") var character_class: int

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4954,14 +4954,18 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 
 		Variant::Type enum_type = Variant::INT;
 
-		if (export_type.kind == DataType::BUILTIN && export_type.builtin_type == Variant::STRING) {
-			enum_type = Variant::STRING;
+		if (export_type.kind == DataType::BUILTIN) {
+			if (export_type.builtin_type == Variant::STRING) {
+				enum_type = Variant::STRING;
+			} else if (export_type.builtin_type == Variant::STRING_NAME) {
+				enum_type = Variant::STRING_NAME;
+			}
 		}
 
 		variable->export_info.type = enum_type;
 
 		if (!export_type.is_variant() && (export_type.kind != DataType::BUILTIN || export_type.builtin_type != enum_type)) {
-			Vector<Variant::Type> expected_types = { Variant::INT, Variant::STRING };
+			Vector<Variant::Type> expected_types = { Variant::INT, Variant::STRING, Variant::STRING_NAME };
 			push_error(_get_annotation_error_string(p_annotation->name, expected_types, variable->type_constraint), p_annotation);
 			return false;
 		}

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_array_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 1: "@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", or "PackedStringArray", but type "Array[Color]" was given instead.
+>> ERROR at line 1: "@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", "PackedStringArray", "StringName", or "Array[StringName]", but type "Array[Color]" was given instead.

--- a/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.out
+++ b/modules/gdscript/tests/scripts/parser/errors/export_enum_wrong_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 1: "@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", or "PackedStringArray", but type "Color" was given instead.
+>> ERROR at line 1: "@export_enum" annotation requires a variable of type "int", "Array[int]", "PackedByteArray", "PackedInt32Array", "PackedInt64Array", "String", "Array[String]", "PackedStringArray", "StringName", or "Array[StringName]", but type "Color" was given instead.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes godotengine/godot-proposals#13390

## Additional information

Should work 100%, but please double-check that it does. It was a minimal fix since `PROPERTY_HINT_ENUM` already supports it, as per the docs and `@export_custom`. No AI was used.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
