### PR TITLE
Pressing Tab in exported Array and Dictionary fix

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -567,6 +567,10 @@ void EditorPropertyArray::update_property() {
 					new_prop->add_inline_control(slot.remove_button, INLINE_CONTROL_RIGHT);
 				}
 
+				// Move the right container to be the last child, so that focusing on the next Control behaves in the expected order.
+				Control *right_cont = new_prop->get_inline_container(INLINE_CONTROL_RIGHT);
+				right_cont->get_parent()->move_child(right_cont, new_prop->get_child_count() - 1);
+
 				slot.prop->add_sibling(new_prop, false);
 				slot.prop->queue_free();
 				slot.prop = new_prop;
@@ -1487,6 +1491,10 @@ void EditorPropertyDictionary::update_property() {
 				if (slot.prop_key) {
 					new_prop->add_inline_control(slot.prop_key, INLINE_CONTROL_LEFT);
 				}
+
+				// Move the right container to be the last child, so that focusing on the next Control behaves in the expected order.
+				Control *right_cont = new_prop->get_inline_container(INLINE_CONTROL_RIGHT);
+				right_cont->get_parent()->move_child(right_cont, new_prop->get_child_count() - 1);
 
 				slot.set_prop(new_prop);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121643 

## Changes

Added a simple `move_child` when iterating `slots` in the `update_property` function of `EditorPropertyArray` and `EditorPropertyDictionary`. This moves the second child of the `EditorProperty` to be the last child, which makes pressing `Tab` focus elements in the expected order. `EditorProperty`'s child is it's `right_container` as per the constructor:
https://github.com/godotengine/godot/blob/30a0296cc25d7d62fd16e6f9ed5977c6c0ec0e3c/editor/inspector/editor_inspector.cpp#L1691-L1711

Here's a video showing before and after (starts at 30s):

https://github.com/user-attachments/assets/a3be8455-dc19-42fc-800b-7dbf9b8908fd
