### PR TITLE
Editor: Add 2D and 3D viewport bookmarks

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -54,6 +54,7 @@
 #include "editor/scene/3d/node_3d_editor_constants.h"
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "editor/scene/viewport_bookmarks.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/translations/editor_translation_preview_button.h"
 #include "scene/3d/audio_stream_player_3d.h"
@@ -1388,6 +1389,66 @@ void Node3DEditorViewport::_view_state_changed() {
 		_menu_option(VIEW_PERSPECTIVE);
 	}
 	_update_name();
+}
+
+void Node3DEditorViewport::_prepare_bookmarks_menu() {
+	bookmarks_menu->clear();
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	const bool camera_owned = previewing_camera || pilot_preview_enabled;
+	bookmarks_menu->add_item(TTR("Add Current View..."), 0);
+	bookmarks_menu->set_item_disabled(-1, !root || camera_owned);
+
+	Array bookmarks = ViewportBookmarks::get_bookmarks(root, ViewportBookmarks::TYPE_3D);
+	if (!bookmarks.is_empty()) {
+		bookmarks_menu->add_separator();
+		const int visible_bookmark_count = MIN(bookmarks.size(), 10);
+		for (int i = 0; i < visible_bookmark_count; i++) {
+			bookmarks_menu->add_item(Dictionary(bookmarks[i]).get("name", ""), i + 100);
+			bookmarks_menu->set_item_disabled(-1, camera_owned);
+			if (camera_owned) {
+				bookmarks_menu->set_item_tooltip(-1, TTR("Viewport bookmarks are unavailable while previewing or piloting a camera."));
+			}
+		}
+		if (bookmarks.size() > visible_bookmark_count) {
+			bookmarks_menu->add_item(vformat(TTR("More Bookmarks (%d)..."), bookmarks.size() - visible_bookmark_count), 1);
+			bookmarks_menu->set_item_disabled(-1, camera_owned);
+		}
+	}
+	bookmarks_menu->add_separator();
+	bookmarks_menu->add_item(TTR("Manage Bookmarks..."), 1);
+	bookmarks_menu->set_item_disabled(-1, !root || bookmarks.is_empty() || camera_owned);
+}
+
+void Node3DEditorViewport::_bookmark_menu_pressed(int p_id) {
+	if (p_id == 0) {
+		bookmark_manager->popup_add();
+	} else if (p_id == 1) {
+		bookmark_manager->popup_manage();
+	} else if (p_id >= 100 && !previewing_camera && !pilot_preview_enabled) {
+		bookmark_manager->activate(p_id - 100);
+	}
+}
+
+Dictionary Node3DEditorViewport::_capture_bookmark() const {
+	Dictionary bookmark;
+	bookmark["position"] = Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z);
+	bookmark["x_rotation"] = view_3d_controller->cursor.x_rot;
+	bookmark["y_rotation"] = view_3d_controller->cursor.y_rot;
+	bookmark["distance"] = view_3d_controller->cursor.distance;
+	bookmark["orthogonal"] = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
+	bookmark["view_type"] = view_3d_controller->get_view_type();
+	return bookmark;
+}
+
+void Node3DEditorViewport::_activate_bookmark(const Dictionary &p_bookmark) {
+	if (previewing_camera || pilot_preview_enabled) {
+		return;
+	}
+	set_state(p_bookmark);
+	_disable_follow_mode();
+	view_3d_controller->update_camera(0);
+	update_transform_gizmo_view();
+	surface->queue_redraw();
 }
 
 void Node3DEditorViewport::_update_name() {
@@ -2882,6 +2943,15 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			view_3d_controller->cursor.y_rot += Math::PI;
 			view_3d_controller->cursor.unsnapped_y_rot = view_3d_controller->cursor.y_rot;
 			view_3d_controller->set_view_type(View3DController::VIEW_TYPE_USER);
+		}
+		if (ED_IS_SHORTCUT("viewport_bookmarks/add", event_mod)) {
+			bookmark_manager->popup_add();
+		}
+		if (ED_IS_SHORTCUT("viewport_bookmarks/next", event_mod)) {
+			bookmark_manager->activate_next();
+		}
+		if (ED_IS_SHORTCUT("viewport_bookmarks/previous", event_mod)) {
+			bookmark_manager->activate_previous();
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/focus_origin", event_mod)) {
 			_menu_option(VIEW_CENTER_TO_ORIGIN);
@@ -6872,6 +6942,14 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_cinematic_preview", TTRC("Cinematic Preview")), VIEW_CINEMATIC_PREVIEW);
 
 	view_display_menu->get_popup()->add_separator();
+	bookmarks_menu = memnew(PopupMenu);
+	bookmarks_menu->connect("about_to_popup", callable_mp(this, &Node3DEditorViewport::_prepare_bookmarks_menu));
+	bookmarks_menu->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_bookmark_menu_pressed));
+	view_display_menu->get_popup()->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
+	bookmark_manager = memnew(ViewportBookmarkManager(ViewportBookmarks::TYPE_3D, callable_mp(this, &Node3DEditorViewport::_capture_bookmark), callable_mp(this, &Node3DEditorViewport::_activate_bookmark)));
+	add_child(bookmark_manager);
+
+	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
 	view_display_menu->get_popup()->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
@@ -6884,6 +6962,9 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	_load_viewport_inputs();
 	InputMap::get_singleton()->connect("project_settings_loaded", callable_mp(this, &Node3DEditorViewport::_load_viewport_inputs));
 
+	ED_SHORTCUT("viewport_bookmarks/add", TTRC("Add Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::B);
+	ED_SHORTCUT("viewport_bookmarks/next", TTRC("Next Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | Key::BRACKETRIGHT);
+	ED_SHORTCUT("viewport_bookmarks/previous", TTRC("Previous Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | Key::BRACKETLEFT);
 	ED_SHORTCUT("spatial_editor/lock_transform_x", TTRC("Lock Transformation to X axis"), Key::X);
 	ED_SHORTCUT("spatial_editor/lock_transform_y", TTRC("Lock Transformation to Y axis"), Key::Y);
 	ED_SHORTCUT("spatial_editor/lock_transform_z", TTRC("Lock Transformation to Z axis"), Key::Z);

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -143,6 +143,8 @@ public:
 	void set_viewport(Node3DEditorViewport *p_viewport);
 };
 
+class ViewportBookmarkManager;
+
 class Node3DEditorViewport : public Control {
 	GDCLASS(Node3DEditorViewport, Control);
 	friend class Node3DEditor;
@@ -270,6 +272,8 @@ private:
 
 	MenuButton *view_display_menu = nullptr;
 	PopupMenu *display_submenu = nullptr;
+	PopupMenu *bookmarks_menu = nullptr;
+	ViewportBookmarkManager *bookmark_manager = nullptr;
 
 	Control *surface = nullptr;
 	SubViewport *viewport = nullptr;
@@ -316,6 +320,10 @@ private:
 	};
 
 	void _view_state_changed();
+	void _prepare_bookmarks_menu();
+	void _bookmark_menu_pressed(int p_id);
+	Dictionary _capture_bookmark() const;
+	void _activate_bookmark(const Dictionary &p_bookmark);
 
 	void _update_name();
 	void _compute_edit(const Point2 &p_point);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -53,6 +53,7 @@
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/gui/control_editor_plugin.h"
+#include "editor/scene/viewport_bookmarks.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -547,6 +548,21 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (k->is_pressed() && !k->is_echo()) {
+			if (ED_IS_SHORTCUT("viewport_bookmarks/add", p_ev)) {
+				bookmark_manager->popup_add();
+				accept_event();
+				return;
+			}
+			if (ED_IS_SHORTCUT("viewport_bookmarks/next", p_ev)) {
+				bookmark_manager->activate_next();
+				accept_event();
+				return;
+			}
+			if (ED_IS_SHORTCUT("viewport_bookmarks/previous", p_ev)) {
+				bookmark_manager->activate_previous();
+				accept_event();
+				return;
+			}
 			if (reset_transform_position_shortcut.is_valid() && reset_transform_position_shortcut->matches_event(p_ev)) {
 				_reset_transform(TransformType::POSITION);
 			}
@@ -4908,6 +4924,52 @@ void CanvasItemEditor::_prepare_view_menu() {
 	popup->set_item_disabled(popup->get_item_index(CLEAR_GUIDES), !has_guides);
 }
 
+void CanvasItemEditor::_prepare_bookmarks_menu() {
+	bookmarks_menu->clear();
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	bookmarks_menu->add_item(TTR("Add Current View..."), 0);
+	bookmarks_menu->set_item_disabled(-1, !root);
+
+	Array bookmarks = ViewportBookmarks::get_bookmarks(root, ViewportBookmarks::TYPE_2D);
+	if (!bookmarks.is_empty()) {
+		bookmarks_menu->add_separator();
+		const int visible_bookmark_count = MIN(bookmarks.size(), 10);
+		for (int i = 0; i < visible_bookmark_count; i++) {
+			bookmarks_menu->add_item(Dictionary(bookmarks[i]).get("name", ""), i + 100);
+		}
+		if (bookmarks.size() > visible_bookmark_count) {
+			bookmarks_menu->add_item(vformat(TTR("More Bookmarks (%d)..."), bookmarks.size() - visible_bookmark_count), 1);
+		}
+	}
+	bookmarks_menu->add_separator();
+	bookmarks_menu->add_item(TTR("Manage Bookmarks..."), 1);
+	bookmarks_menu->set_item_disabled(-1, !root || bookmarks.is_empty());
+}
+
+void CanvasItemEditor::_bookmark_menu_pressed(int p_id) {
+	if (p_id == 0) {
+		bookmark_manager->popup_add();
+	} else if (p_id == 1) {
+		bookmark_manager->popup_manage();
+	} else if (p_id >= 100) {
+		bookmark_manager->activate(p_id - 100);
+	}
+}
+
+Dictionary CanvasItemEditor::_capture_bookmark() const {
+	Dictionary bookmark;
+	bookmark["offset"] = view_offset;
+	bookmark["zoom"] = zoom / MAX(1, EDSCALE);
+	return bookmark;
+}
+
+void CanvasItemEditor::_activate_bookmark(const Dictionary &p_bookmark) {
+	Dictionary state;
+	state["ofs"] = p_bookmark["offset"];
+	state["zoom"] = p_bookmark["zoom"];
+	set_state(state);
+}
+
 void CanvasItemEditor::_popup_callback(int p_op) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	last_option = MenuOption(p_op);
@@ -5759,6 +5821,9 @@ CanvasItemEditor::CanvasItemEditor() {
 	controls_vb->set_begin(Point2(5, 5));
 
 	ED_SHORTCUT("canvas_item_editor/cancel_transform", TTRC("Cancel Transformation"), Key::ESCAPE);
+	ED_SHORTCUT("viewport_bookmarks/add", TTRC("Add Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::B);
+	ED_SHORTCUT("viewport_bookmarks/next", TTRC("Next Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | Key::BRACKETRIGHT);
+	ED_SHORTCUT("viewport_bookmarks/previous", TTRC("Previous Viewport Bookmark"), KeyModifierMask::CMD_OR_CTRL | Key::BRACKETLEFT);
 
 	// To ensure that scripts can parse the list of shortcuts correctly, we have to define
 	// those shortcuts one by one. Define shortcut before using it (by EditorZoomWidget).
@@ -6063,6 +6128,13 @@ CanvasItemEditor::CanvasItemEditor() {
 	grid_menu->add_separator();
 	grid_menu->add_shortcut(ED_SHORTCUT("canvas_item_editor/toggle_grid", TTRC("Toggle Grid"), KeyModifierMask::CMD_OR_CTRL | Key::APOSTROPHE));
 	p->add_submenu_node_item(TTRC("Grid"), grid_menu);
+
+	bookmarks_menu = memnew(PopupMenu);
+	bookmarks_menu->connect("about_to_popup", callable_mp(this, &CanvasItemEditor::_prepare_bookmarks_menu));
+	bookmarks_menu->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_bookmark_menu_pressed));
+	p->add_submenu_node_item(TTRC("Bookmarks"), bookmarks_menu);
+	bookmark_manager = memnew(ViewportBookmarkManager(ViewportBookmarks::TYPE_2D, callable_mp(this, &CanvasItemEditor::_capture_bookmark), callable_mp(this, &CanvasItemEditor::_activate_bookmark)));
+	add_child(bookmark_manager);
 
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_helpers", TTRC("Show Helpers"), KeyModifierMask::SHIFT | Key::H), SHOW_HELPERS);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_rulers", TTRC("Show Rulers")), SHOW_RULERS);

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -50,6 +50,7 @@ class RichTextLabel;
 class StyleBoxTexture;
 class Timer;
 class ViewPanner;
+class ViewportBookmarkManager;
 class VScrollBar;
 class VSeparator;
 class VSplitContainer;
@@ -363,6 +364,8 @@ private:
 	Button *ungroup_button = nullptr;
 
 	MenuButton *view_menu = nullptr;
+	PopupMenu *bookmarks_menu = nullptr;
+	ViewportBookmarkManager *bookmark_manager = nullptr;
 	PopupMenu *grid_menu = nullptr;
 	PopupMenu *theme_menu = nullptr;
 	PopupMenu *gizmos_menu = nullptr;
@@ -434,6 +437,10 @@ private:
 	Vector2 _position_to_anchor(const Control *p_control, Vector2 position);
 
 	void _prepare_view_menu();
+	void _prepare_bookmarks_menu();
+	void _bookmark_menu_pressed(int p_id);
+	Dictionary _capture_bookmark() const;
+	void _activate_bookmark(const Dictionary &p_bookmark);
 	void _popup_callback(int p_op);
 	bool updating_scroll = false;
 	void _update_scroll(real_t);

--- a/editor/scene/viewport_bookmarks.cpp
+++ b/editor/scene/viewport_bookmarks.cpp
@@ -1,0 +1,411 @@
+/**************************************************************************/
+/*  viewport_bookmarks.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "viewport_bookmarks.h"
+
+#include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
+#include "core/templates/hash_set.h"
+#include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+
+static bool _is_finite_number(const Variant &p_value) {
+	return (p_value.get_type() == Variant::FLOAT || p_value.get_type() == Variant::INT) && Math::is_finite(double(p_value));
+}
+
+Array ViewportBookmarks::get_bookmarks(const Node *p_scene_root, Type p_type) {
+	Array valid;
+	if (!p_scene_root) {
+		return valid;
+	}
+
+	Variant metadata_variant = p_scene_root->get_meta(META_KEY, Dictionary());
+	if (metadata_variant.get_type() != Variant::DICTIONARY) {
+		return valid;
+	}
+	Dictionary metadata = metadata_variant;
+	if (int(metadata.get("version", 0)) != 1) {
+		return valid;
+	}
+
+	const StringName collection_key = p_type == TYPE_2D ? SNAME("2d") : SNAME("3d");
+	Variant bookmarks_variant = metadata.get(collection_key, Array());
+	if (bookmarks_variant.get_type() != Variant::ARRAY) {
+		return valid;
+	}
+
+	Array bookmarks = bookmarks_variant;
+	HashSet<String> names;
+	for (const Variant &bookmark_variant : bookmarks) {
+		if (bookmark_variant.get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+		Dictionary bookmark = bookmark_variant;
+		Variant name_variant = bookmark.get("name", Variant());
+		if (name_variant.get_type() != Variant::STRING) {
+			continue;
+		}
+		String name = String(name_variant).strip_edges();
+		if (name.is_empty() || names.has(name)) {
+			continue;
+		}
+
+		bool is_valid = false;
+		if (p_type == TYPE_2D) {
+			Variant offset = bookmark.get("offset", Variant());
+			Variant zoom = bookmark.get("zoom", Variant());
+			is_valid = offset.get_type() == Variant::VECTOR2 && Vector2(offset).is_finite() && _is_finite_number(zoom) && double(zoom) > 0.0;
+		} else {
+			Variant position = bookmark.get("position", Variant());
+			Variant x_rotation = bookmark.get("x_rotation", Variant());
+			Variant y_rotation = bookmark.get("y_rotation", Variant());
+			Variant distance = bookmark.get("distance", Variant());
+			Variant orthogonal = bookmark.get("orthogonal", Variant());
+			Variant view_type = bookmark.get("view_type", Variant());
+			is_valid = position.get_type() == Variant::VECTOR3 && Vector3(position).is_finite() && _is_finite_number(x_rotation) && _is_finite_number(y_rotation) && _is_finite_number(distance) && double(distance) > 0.0 && orthogonal.get_type() == Variant::BOOL && view_type.get_type() == Variant::INT;
+		}
+		if (!is_valid) {
+			continue;
+		}
+
+		bookmark["name"] = name;
+		valid.push_back(bookmark);
+		names.insert(name);
+	}
+	return valid;
+}
+
+Dictionary ViewportBookmarks::make_metadata(const Node *p_scene_root, Type p_type, const Array &p_bookmarks) {
+	Dictionary metadata;
+	if (p_scene_root) {
+		Variant existing = p_scene_root->get_meta(META_KEY, Dictionary());
+		if (existing.get_type() == Variant::DICTIONARY) {
+			metadata = Dictionary(existing).duplicate(true);
+		}
+	}
+	metadata["version"] = 1;
+	metadata[p_type == TYPE_2D ? "2d" : "3d"] = p_bookmarks;
+	return metadata;
+}
+
+bool ViewportBookmarks::is_valid_name(const Array &p_bookmarks, const String &p_name, int p_except) {
+	String name = p_name.strip_edges();
+	if (name.is_empty()) {
+		return false;
+	}
+	for (int i = 0; i < p_bookmarks.size(); i++) {
+		if (i != p_except && Dictionary(p_bookmarks[i]).get("name", "") == name) {
+			return false;
+		}
+	}
+	return true;
+}
+
+String ViewportBookmarks::make_unique_name(const Array &p_bookmarks) {
+	for (int i = 1;; i++) {
+		String candidate = vformat(TTR("Bookmark %d"), i);
+		if (is_valid_name(p_bookmarks, candidate)) {
+			return candidate;
+		}
+	}
+}
+
+Node *ViewportBookmarkManager::_get_scene_root() const {
+	return EditorNode::get_singleton()->get_edited_scene();
+}
+
+Array ViewportBookmarkManager::_get_bookmarks() const {
+	return ViewportBookmarks::get_bookmarks(_get_scene_root(), type);
+}
+
+void ViewportBookmarkManager::_commit_bookmarks(const Array &p_bookmarks, const String &p_action) {
+	Node *root = _get_scene_root();
+	ERR_FAIL_NULL(root);
+
+	Dictionary new_metadata = ViewportBookmarks::make_metadata(root, type, p_bookmarks);
+	Array other_bookmarks = ViewportBookmarks::get_bookmarks(root, type == ViewportBookmarks::TYPE_2D ? ViewportBookmarks::TYPE_3D : ViewportBookmarks::TYPE_2D);
+	const bool remove_new_metadata = p_bookmarks.is_empty() && other_bookmarks.is_empty();
+	const bool had_old_metadata = root->has_meta(ViewportBookmarks::META_KEY);
+	Variant old_metadata;
+	if (had_old_metadata) {
+		old_metadata = root->get_meta(ViewportBookmarks::META_KEY);
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(p_action);
+	if (remove_new_metadata) {
+		undo_redo->add_do_method(root, "remove_meta", ViewportBookmarks::META_KEY);
+	} else {
+		undo_redo->add_do_method(root, "set_meta", ViewportBookmarks::META_KEY, new_metadata);
+	}
+	if (had_old_metadata) {
+		undo_redo->add_undo_method(root, "set_meta", ViewportBookmarks::META_KEY, old_metadata);
+	} else {
+		undo_redo->add_undo_method(root, "remove_meta", ViewportBookmarks::META_KEY);
+	}
+	undo_redo->add_do_method(this, "refresh");
+	undo_redo->add_undo_method(this, "refresh");
+	undo_redo->commit_action();
+}
+
+void ViewportBookmarkManager::_selection_changed(int p_index) {
+	const bool selected = p_index >= 0;
+	go_to_button->set_disabled(!selected);
+	overwrite_button->set_disabled(!selected);
+	rename_button->set_disabled(!selected);
+	delete_button->set_disabled(!selected);
+}
+
+void ViewportBookmarkManager::_item_activated(int p_index) {
+	activate(p_index);
+}
+
+void ViewportBookmarkManager::_go_to_selected() {
+	PackedInt32Array selected = bookmark_list->get_selected_items();
+	if (!selected.is_empty()) {
+		activate(selected[0]);
+	}
+}
+
+void ViewportBookmarkManager::_overwrite_selected() {
+	PackedInt32Array selected = bookmark_list->get_selected_items();
+	if (selected.is_empty()) {
+		return;
+	}
+	Array bookmarks = _get_bookmarks();
+	const int index = selected[0];
+	ERR_FAIL_INDEX(index, bookmarks.size());
+	Dictionary bookmark = capture_view.call();
+	bookmark["name"] = Dictionary(bookmarks[index])["name"];
+	bookmarks[index] = bookmark;
+	_commit_bookmarks(bookmarks, TTR("Overwrite Viewport Bookmark"));
+	refresh();
+	bookmark_list->select(index);
+	_selection_changed(index);
+}
+
+void ViewportBookmarkManager::_rename_selected() {
+	PackedInt32Array selected = bookmark_list->get_selected_items();
+	if (!selected.is_empty()) {
+		_show_name_dialog(selected[0]);
+	}
+}
+
+void ViewportBookmarkManager::_show_name_dialog(int p_index) {
+	if (is_visible()) {
+		hide();
+	}
+	Array bookmarks = _get_bookmarks();
+	rename_index = p_index;
+	if (p_index >= 0) {
+		ERR_FAIL_INDEX(p_index, bookmarks.size());
+		name_dialog->set_title(TTR("Rename Viewport Bookmark"));
+		name_edit->set_text(Dictionary(bookmarks[p_index]).get("name", ""));
+	} else {
+		name_dialog->set_title(TTR("Add Viewport Bookmark"));
+		name_edit->set_text(ViewportBookmarks::make_unique_name(bookmarks));
+	}
+	_name_changed(name_edit->get_text());
+	name_edit->select_all();
+	name_dialog->popup_centered(Size2(360, 0) * EDSCALE);
+	name_edit->grab_focus();
+}
+
+void ViewportBookmarkManager::_name_changed(const String &p_name) {
+	const bool valid = ViewportBookmarks::is_valid_name(_get_bookmarks(), p_name, rename_index);
+	name_dialog->get_ok_button()->set_disabled(!valid);
+	name_error->set_text(valid ? String() : TTR("The name must be non-empty and unique."));
+}
+
+void ViewportBookmarkManager::_name_confirmed() {
+	Array bookmarks = _get_bookmarks();
+	String name = name_edit->get_text().strip_edges();
+	if (!ViewportBookmarks::is_valid_name(bookmarks, name, rename_index)) {
+		return;
+	}
+
+	if (rename_index >= 0) {
+		ERR_FAIL_INDEX(rename_index, bookmarks.size());
+		Dictionary bookmark = bookmarks[rename_index];
+		bookmark["name"] = name;
+		bookmarks[rename_index] = bookmark;
+		_commit_bookmarks(bookmarks, TTR("Rename Viewport Bookmark"));
+	} else {
+		Dictionary bookmark = capture_view.call();
+		bookmark["name"] = name;
+		bookmarks.push_back(bookmark);
+		_commit_bookmarks(bookmarks, TTR("Add Viewport Bookmark"));
+	}
+	refresh();
+}
+
+void ViewportBookmarkManager::_show_delete_dialog() {
+	if (is_visible()) {
+		hide();
+	}
+	PackedInt32Array selected = bookmark_list->get_selected_items();
+	if (selected.is_empty()) {
+		return;
+	}
+	Array bookmarks = _get_bookmarks();
+	const int index = selected[0];
+	ERR_FAIL_INDEX(index, bookmarks.size());
+	delete_dialog->set_text(vformat(TTR("Delete viewport bookmark \"%s\"?"), Dictionary(bookmarks[index]).get("name", "")));
+	delete_dialog->popup_centered();
+}
+
+void ViewportBookmarkManager::_delete_confirmed() {
+	PackedInt32Array selected = bookmark_list->get_selected_items();
+	if (selected.is_empty()) {
+		return;
+	}
+	Array bookmarks = _get_bookmarks();
+	const int index = selected[0];
+	ERR_FAIL_INDEX(index, bookmarks.size());
+	bookmarks.remove_at(index);
+	_commit_bookmarks(bookmarks, TTR("Delete Viewport Bookmark"));
+	refresh();
+}
+
+void ViewportBookmarkManager::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("refresh"), &ViewportBookmarkManager::refresh);
+}
+
+void ViewportBookmarkManager::refresh() {
+	bookmark_list->clear();
+	Array bookmarks = _get_bookmarks();
+	for (const Variant &bookmark_variant : bookmarks) {
+		bookmark_list->add_item(Dictionary(bookmark_variant).get("name", ""));
+	}
+	_selection_changed(-1);
+}
+
+void ViewportBookmarkManager::popup_add() {
+	if (!_get_scene_root()) {
+		return;
+	}
+	_show_name_dialog(-1);
+}
+
+void ViewportBookmarkManager::popup_manage() {
+	refresh();
+	popup_centered(Size2(520, 360) * EDSCALE);
+}
+
+void ViewportBookmarkManager::activate(int p_index) {
+	Array bookmarks = _get_bookmarks();
+	ERR_FAIL_INDEX(p_index, bookmarks.size());
+	active_index = p_index;
+	activate_view.call(Dictionary(bookmarks[p_index]));
+}
+
+void ViewportBookmarkManager::activate_next() {
+	Array bookmarks = _get_bookmarks();
+	if (bookmarks.is_empty()) {
+		return;
+	}
+	activate((active_index + 1) % bookmarks.size());
+}
+
+void ViewportBookmarkManager::activate_previous() {
+	Array bookmarks = _get_bookmarks();
+	if (bookmarks.is_empty()) {
+		return;
+	}
+	activate(active_index <= 0 ? bookmarks.size() - 1 : active_index - 1);
+}
+
+ViewportBookmarkManager::ViewportBookmarkManager(ViewportBookmarks::Type p_type, const Callable &p_capture_view, const Callable &p_activate_view) {
+	type = p_type;
+	capture_view = p_capture_view;
+	activate_view = p_activate_view;
+
+	set_title(TTRC("Viewport Bookmarks"));
+	set_ok_button_text(TTRC("Close"));
+	set_min_size(Size2(520, 360) * EDSCALE);
+
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	add_child(vbox);
+
+	bookmark_list = memnew(ItemList);
+	bookmark_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	bookmark_list->set_allow_reselect(true);
+	bookmark_list->connect(SceneStringName(item_selected), callable_mp(this, &ViewportBookmarkManager::_selection_changed));
+	bookmark_list->connect("item_activated", callable_mp(this, &ViewportBookmarkManager::_item_activated));
+	vbox->add_child(bookmark_list);
+
+	HBoxContainer *buttons = memnew(HBoxContainer);
+	vbox->add_child(buttons);
+	go_to_button = memnew(Button(TTRC("Go To")));
+	go_to_button->connect(SceneStringName(pressed), callable_mp(this, &ViewportBookmarkManager::_go_to_selected));
+	buttons->add_child(go_to_button);
+	overwrite_button = memnew(Button(TTRC("Overwrite")));
+	overwrite_button->connect(SceneStringName(pressed), callable_mp(this, &ViewportBookmarkManager::_overwrite_selected));
+	buttons->add_child(overwrite_button);
+	rename_button = memnew(Button(TTRC("Rename")));
+	rename_button->connect(SceneStringName(pressed), callable_mp(this, &ViewportBookmarkManager::_rename_selected));
+	buttons->add_child(rename_button);
+	delete_button = memnew(Button(TTRC("Delete")));
+	delete_button->connect(SceneStringName(pressed), callable_mp(this, &ViewportBookmarkManager::_show_delete_dialog));
+	buttons->add_child(delete_button);
+
+	name_dialog = memnew(ConfirmationDialog);
+	name_dialog->set_ok_button_text(TTRC("Save"));
+	name_dialog->set_exclusive(false);
+	// Nested windows may not render correctly, so use the editor root.
+	EditorNode::get_singleton()->get_gui_base()->add_child(name_dialog);
+	VBoxContainer *name_vbox = memnew(VBoxContainer);
+	name_dialog->add_child(name_vbox);
+	name_edit = memnew(LineEdit);
+	name_edit->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	name_edit->set_placeholder(TTRC("Bookmark name"));
+	name_edit->connect(SceneStringName(text_changed), callable_mp(this, &ViewportBookmarkManager::_name_changed));
+	name_vbox->add_margin_child(TTRC("Name:"), name_edit);
+	name_error = memnew(Label);
+	name_error->add_theme_color_override(SceneStringName(font_color), Color(1, 0.4, 0.4));
+	name_vbox->add_child(name_error);
+	name_dialog->register_text_enter(name_edit);
+	name_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ViewportBookmarkManager::_name_confirmed));
+
+	delete_dialog = memnew(ConfirmationDialog);
+	delete_dialog->set_title(TTRC("Delete Viewport Bookmark"));
+	delete_dialog->set_exclusive(false);
+	delete_dialog->set_ok_button_text(TTRC("Delete"));
+	delete_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ViewportBookmarkManager::_delete_confirmed));
+	EditorNode::get_singleton()->get_gui_base()->add_child(delete_dialog);
+
+	_selection_changed(-1);
+}

--- a/editor/scene/viewport_bookmarks.h
+++ b/editor/scene/viewport_bookmarks.h
@@ -1,0 +1,104 @@
+/**************************************************************************/
+/*  viewport_bookmarks.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/dialogs.h"
+
+class Button;
+class ConfirmationDialog;
+class ItemList;
+class Label;
+class LineEdit;
+class Node;
+
+class ViewportBookmarks {
+public:
+	enum Type {
+		TYPE_2D,
+		TYPE_3D,
+	};
+
+	static constexpr const char *META_KEY = "_edit_viewport_bookmarks_";
+
+	static Array get_bookmarks(const Node *p_scene_root, Type p_type);
+	static Dictionary make_metadata(const Node *p_scene_root, Type p_type, const Array &p_bookmarks);
+	static bool is_valid_name(const Array &p_bookmarks, const String &p_name, int p_except = -1);
+	static String make_unique_name(const Array &p_bookmarks);
+};
+
+class ViewportBookmarkManager : public AcceptDialog {
+	GDCLASS(ViewportBookmarkManager, AcceptDialog);
+
+	ViewportBookmarks::Type type = ViewportBookmarks::TYPE_2D;
+	Callable capture_view;
+	Callable activate_view;
+
+	ItemList *bookmark_list = nullptr;
+	Button *go_to_button = nullptr;
+	Button *overwrite_button = nullptr;
+	Button *rename_button = nullptr;
+	Button *delete_button = nullptr;
+
+	ConfirmationDialog *name_dialog = nullptr;
+	LineEdit *name_edit = nullptr;
+	Label *name_error = nullptr;
+	ConfirmationDialog *delete_dialog = nullptr;
+
+	int rename_index = -1;
+	int active_index = -1;
+
+	Node *_get_scene_root() const;
+	Array _get_bookmarks() const;
+	void _commit_bookmarks(const Array &p_bookmarks, const String &p_action);
+	void _selection_changed(int p_index);
+	void _item_activated(int p_index);
+	void _go_to_selected();
+	void _overwrite_selected();
+	void _rename_selected();
+	void _show_name_dialog(int p_index);
+	void _name_changed(const String &p_name);
+	void _name_confirmed();
+	void _show_delete_dialog();
+	void _delete_confirmed();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void refresh();
+	void popup_add();
+	void popup_manage();
+	void activate(int p_index);
+	void activate_next();
+	void activate_previous();
+
+	ViewportBookmarkManager(ViewportBookmarks::Type p_type, const Callable &p_capture_view, const Callable &p_activate_view);
+};

--- a/tests/scene/test_viewport_bookmarks.cpp
+++ b/tests/scene/test_viewport_bookmarks.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  test_viewport_bookmarks.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_viewport_bookmarks)
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/scene/viewport_bookmarks.h"
+#include "scene/main/node.h"
+
+namespace TestViewportBookmarks {
+
+TEST_CASE("[Editor][ViewportBookmarks] Validate and separate bookmark collections") {
+	Node root;
+
+	Dictionary valid_2d;
+	valid_2d["name"] = "Overview";
+	valid_2d["offset"] = Vector2(10, 20);
+	valid_2d["zoom"] = 2.0;
+
+	Dictionary invalid_2d = valid_2d.duplicate();
+	invalid_2d["name"] = "Invalid";
+	invalid_2d["zoom"] = -1.0;
+
+	Dictionary duplicate_2d = valid_2d.duplicate();
+
+	Dictionary valid_3d;
+	valid_3d["name"] = "Entrance";
+	valid_3d["position"] = Vector3(1, 2, 3);
+	valid_3d["x_rotation"] = 0.25;
+	valid_3d["y_rotation"] = 0.5;
+	valid_3d["distance"] = 12.0;
+	valid_3d["orthogonal"] = false;
+	valid_3d["view_type"] = 0;
+
+	Array bookmarks_2d_source;
+	bookmarks_2d_source.push_back(valid_2d);
+	bookmarks_2d_source.push_back(invalid_2d);
+	bookmarks_2d_source.push_back(duplicate_2d);
+	Array bookmarks_3d_source;
+	bookmarks_3d_source.push_back(valid_3d);
+
+	Dictionary metadata;
+	metadata["version"] = 1;
+	metadata["2d"] = bookmarks_2d_source;
+	metadata["3d"] = bookmarks_3d_source;
+	root.set_meta(ViewportBookmarks::META_KEY, metadata);
+
+	Array bookmarks_2d = ViewportBookmarks::get_bookmarks(&root, ViewportBookmarks::TYPE_2D);
+	REQUIRE(bookmarks_2d.size() == 1);
+	CHECK(Dictionary(bookmarks_2d[0])["name"] == "Overview");
+
+	Array bookmarks_3d = ViewportBookmarks::get_bookmarks(&root, ViewportBookmarks::TYPE_3D);
+	REQUIRE(bookmarks_3d.size() == 1);
+	CHECK(Dictionary(bookmarks_3d[0])["name"] == "Entrance");
+}
+
+TEST_CASE("[Editor][ViewportBookmarks] Preserve the other collection when updating metadata") {
+	Node root;
+
+	Dictionary bookmark_3d;
+	bookmark_3d["name"] = "Shared 3D";
+	bookmark_3d["position"] = Vector3();
+	bookmark_3d["x_rotation"] = 0.0;
+	bookmark_3d["y_rotation"] = 0.0;
+	bookmark_3d["distance"] = 4.0;
+	bookmark_3d["orthogonal"] = true;
+	bookmark_3d["view_type"] = 1;
+
+	Array bookmarks_3d;
+	bookmarks_3d.push_back(bookmark_3d);
+	Dictionary metadata;
+	metadata["version"] = 1;
+	metadata["3d"] = bookmarks_3d;
+	root.set_meta(ViewportBookmarks::META_KEY, metadata);
+
+	Dictionary bookmark_2d;
+	bookmark_2d["name"] = "Shared 2D";
+	bookmark_2d["offset"] = Vector2();
+	bookmark_2d["zoom"] = 1.0;
+
+	Array bookmarks_2d;
+	bookmarks_2d.push_back(bookmark_2d);
+	Dictionary updated = ViewportBookmarks::make_metadata(&root, ViewportBookmarks::TYPE_2D, bookmarks_2d);
+	CHECK(Array(updated["2d"]).size() == 1);
+	CHECK(Array(updated["3d"]).size() == 1);
+}
+
+TEST_CASE("[Editor][ViewportBookmarks] Validate names") {
+	Dictionary bookmark;
+	bookmark["name"] = "Existing";
+	Array bookmarks;
+	bookmarks.push_back(bookmark);
+
+	CHECK_FALSE(ViewportBookmarks::is_valid_name(bookmarks, ""));
+	CHECK_FALSE(ViewportBookmarks::is_valid_name(bookmarks, " Existing "));
+	CHECK(ViewportBookmarks::is_valid_name(bookmarks, "Existing", 0));
+	CHECK(ViewportBookmarks::is_valid_name(bookmarks, "Other"));
+}
+
+} // namespace TestViewportBookmarks
+
+#endif // TOOLS_ENABLED


### PR DESCRIPTION
### Problem
As suggested in [proposal discussion #12815](https://github.com/godotengine/godot-proposals/discussions/12815), for large scenes it takes a long time to navigate between different areas. A solution I and probably other developers where using was adding a Marker 3D/2D and using a shortcutt to move camera to it, however this is inconvenient and clutters the runtime scene tree.

### Features
- Adds a "Bookmarks" submenu to the view menu in both 2D and 3D editors.
- Add Current view... saves and names the current viewport
- Clicking a bookmark returns to that view
- A management dialog that supports Go To, overwrite, rename and delete
- Bookmark changes support Undo/Redo
- The direct submenu is limited to 10 entries, more opens a scrollable manager (the management dialog)
- Shortcuts : Ctrl/Cmd + Alt + B: add current view. Ctrl/Cmd + ]: next bookmark. Ctrl/Cmd + [: previous bookmark.
- Shortcuts are configurable in Editor Setttings
- 2D bookmarks store pan offset and DPI independent zoom
- 3d Bookmarks store pivot position, rotation, camera distance, perspective/orthographic mode, and view type.
- 3D bookmark actions are unavailable while previewing or piloting a Camera3D.

### Version Control behavior
The bookmarks are stored as versioned metadata on the scene root under `_edit_viewport_bookmakrs_`, when the scene is saved, the data is written into the scene file, so bookmarks can be tracked by Git and shared across devices or team members, separate 2D and 3D lists are kept in the same metadata structure.

### Technical mentions
shared validation and management UI are implemented in `viewport_bookmarks.cpp` and ` viewport_bookmarks.h`, and invalid metadata entries duplicate names non finite position and invalid zoom and distance values are ignored safely.
Existing metadata for the other viewport type is preserved when one collection changes, and the stored format is versioned for future compatibility

### Caveats
Bookmarks intentionally live in scene files so teams can share them, as requested in the proposal discussion, however this may create scene file diffs for editor only navigation changes, this is intentional but I dont know if this is the preffered persistance location.
I also tought about implementing Folders/Tags but maybe in a future implementation, I wanted not to overcomplicate this first version.
### AI disclosure
AI assistance was used for menial things like code completion, I made sure not to use it again for the PR after I found out its not allowed and I agree with it.

edit: Forgot to add some videos

https://github.com/user-attachments/assets/451a0a47-f282-47e4-8209-95b826e9744e



https://github.com/user-attachments/assets/2766e54e-0681-4d7c-a4e0-b0390480b470

