### PR TITLE
Expose undo_enabled as a property on TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1424,6 +1424,9 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
+		<member name="undo_enabled" type="bool" setter="set_undo_enabled" getter="is_undo_enabled" default="true" keywords="undo, redo, history, disabled, enabled">
+			If set to [code]false[/code], the undo history is cleared. Text changes are applied normally, but no undo history is recorded. [method undo] and [method redo] have no effect while [method has_undo] and [method has_redo] return [code]false[/code] until this property is enabled again. Re-enabling does not restore previously cleared undo history.
+		</member>
 		<member name="use_custom_word_separators" type="bool" setter="set_use_custom_word_separators" getter="is_custom_word_separators_enabled" default="false">
 			If [code]false[/code], using [kbd]Ctrl + Left[/kbd] or [kbd]Ctrl + Right[/kbd] ([kbd]Cmd + Left[/kbd] or [kbd]Cmd + Right[/kbd] on macOS) bindings will use the behavior of [member use_default_word_separators]. If [code]true[/code], it will also stop the caret if a character within [member custom_word_separators] is detected. Useful for subword moving. This behavior also will be applied to the behavior of text selection.
 		</member>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4154,6 +4154,21 @@ bool TextEdit::is_editable() const {
 	return editable;
 }
 
+void TextEdit::set_undo_enabled(bool p_enabled) {
+	if (undo_enabled == p_enabled) {
+		return;
+	}
+
+	undo_enabled = p_enabled;
+	if (!undo_enabled) {
+		clear_undo_history();
+	}
+}
+
+bool TextEdit::is_undo_enabled() const {
+	return undo_enabled;
+}
+
 void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 	ERR_FAIL_COND((int)p_text_direction < -1 || (int)p_text_direction > 3);
 	if (text_direction != p_text_direction) {
@@ -5146,6 +5161,9 @@ void TextEdit::end_complex_operation() {
 }
 
 bool TextEdit::has_undo() const {
+	if (!undo_enabled) {
+		return false;
+	}
 	if (undo_stack_pos == nullptr) {
 		int pending = current_op.type == TextOperation::TYPE_NONE ? 0 : 1;
 		return undo_stack.size() + pending > 0;
@@ -5154,11 +5172,11 @@ bool TextEdit::has_undo() const {
 }
 
 bool TextEdit::has_redo() const {
-	return undo_stack_pos != nullptr;
+	return undo_enabled && undo_stack_pos != nullptr;
 }
 
 void TextEdit::undo() {
-	if (!editable) {
+	if (!editable || !undo_enabled) {
 		return;
 	}
 
@@ -5224,7 +5242,7 @@ void TextEdit::undo() {
 }
 
 void TextEdit::redo() {
-	if (!editable) {
+	if (!editable || !undo_enabled) {
 		return;
 	}
 
@@ -7585,6 +7603,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &TextEdit::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &TextEdit::is_editable);
 
+	ClassDB::bind_method(D_METHOD("set_undo_enabled", "enabled"), &TextEdit::set_undo_enabled);
+	ClassDB::bind_method(D_METHOD("is_undo_enabled"), &TextEdit::is_undo_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_text_direction", "direction"), &TextEdit::set_text_direction);
 	ClassDB::bind_method(D_METHOD("get_text_direction"), &TextEdit::get_text_direction);
 
@@ -8027,6 +8048,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "placeholder_text", PROPERTY_HINT_MULTILINE_TEXT), "set_placeholder", "get_placeholder");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "undo_enabled"), "set_undo_enabled", "is_undo_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "context_menu_enabled"), "set_context_menu_enabled", "is_context_menu_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emoji_menu_enabled"), "set_emoji_menu_enabled", "is_emoji_menu_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "backspace_deletes_composite_character_enabled"), "set_backspace_deletes_composite_character_enabled", "is_backspace_deletes_composite_character_enabled");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -832,6 +832,9 @@ public:
 	void set_editable(bool p_editable);
 	bool is_editable() const;
 
+	void set_undo_enabled(bool p_enabled);
+	bool is_undo_enabled() const;
+
 	void set_text_direction(TextDirection p_text_direction);
 	TextDirection get_text_direction() const;
 

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -8138,6 +8138,65 @@ TEST_CASE("[SceneTree][TextEdit] setter getters") {
 		CHECK_FALSE(text_edit->is_drawing_minimap());
 	}
 
+	SUBCASE("[TextEdit] undo_enabled") {
+		text_edit->set_undo_enabled(true);
+		CHECK(text_edit->is_undo_enabled());
+
+		text_edit->insert_text_at_caret("x");
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "x");
+		CHECK(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+		text_edit->undo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "");
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK(text_edit->has_redo());
+		text_edit->redo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "x");
+		CHECK(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+
+		text_edit->set_undo_enabled(false);
+		CHECK_FALSE(text_edit->is_undo_enabled());
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+
+		text_edit->insert_text_at_caret("y");
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xy");
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+		text_edit->undo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xy");
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+		text_edit->redo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xy");
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+
+		text_edit->set_undo_enabled(true);
+		CHECK(text_edit->is_undo_enabled());
+		text_edit->insert_text_at_caret("z");
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xyz");
+		CHECK(text_edit->has_undo());
+		text_edit->undo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xy");
+		CHECK_FALSE(text_edit->has_undo());
+		CHECK(text_edit->has_redo());
+		text_edit->redo();
+		MessageQueue::get_singleton()->flush();
+		CHECK(text_edit->get_text() == "xyz");
+		CHECK(text_edit->has_undo());
+		CHECK_FALSE(text_edit->has_redo());
+	}
+
 	SUBCASE("[TextEdit] minimap width") {
 		text_edit->set_minimap_width(-1);
 		CHECK(text_edit->get_minimap_width() == -1);


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/15241

This implements Option A.

Implementing Option B, like explained in https://github.com/godotengine/godot-proposals/issues/15241, would include deleting `if (!undo_enabled) {
		clear_undo_history();
	}` and changing the documentation text from:

> If set to [code]false[/code], the undo history is cleared. Text changes are applied normally, but no undo history is recorded. [method undo] and [method redo] have no effect while [method has_undo] and [method has_redo] return [code]false[/code] until this property is enabled again. Re-enabling does not restore previously cleared undo history.

 to:

> If [code]false[/code], text changes are applied normally, but no undo history is recorded. [method undo] and [method redo] have no effect while [method has_undo] and [method has_redo] return [code]false[/code] until this property is enabled again. The existing undo history is kept internally and becomes available again once this property is enabled again.


Validated by building the Windows editor with SCons and testing it.