### PR TITLE
Gray out drag handle icon to make it stand out less

### DIFF
--- a/editor/icons/DragHandle.svg
+++ b/editor/icons/DragHandle.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="#def"><circle cx="4" cy="3" r="2"/><circle cx="4" cy="8" r="2"/><circle cx="4" cy="13" r="2"/><circle cx="12" cy="3" r="2"/><circle cx="12" cy="8" r="2"/><circle cx="12" cy="13" r="2"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="#fff" fill-opacity=".4"><circle cx="4" cy="3" r="2"/><circle cx="4" cy="8" r="2"/><circle cx="4" cy="13" r="2"/><circle cx="12" cy="3" r="2"/><circle cx="12" cy="8" r="2"/><circle cx="12" cy="13" r="2"/></g></svg>


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Helps with #121675.

Currently the drag handle icon stands out a little too much, due to it having the same brightness as common icons. This PR halfs its opacity, making it match the gray look of other handle-like icons in the editor:

|PR|`master`|
|-|-|
|<img width="263" height="274" alt="image" src="https://github.com/user-attachments/assets/fb49f617-4410-4a26-a64d-339b4227bd3f" />|<img width="263" height="274" alt="Screenshot_20260723_131208" src="https://github.com/user-attachments/assets/80e0730b-848c-4efb-b4ef-cf639df8ac97" />|

Note: The icon type used here are how the UI will look with #121675.