### PR TITLE
Remove `script_editor/window_move_up` and `down` default keybinds and rename them

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3145,11 +3145,11 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		}
 		accept_event();
 	}
-	if (ED_IS_SHORTCUT("script_editor/window_move_up", p_event)) {
+	if (ED_IS_SHORTCUT("script_editor/move_document_up", p_event)) {
 		_menu_option(FILE_MENU_MOVE_UP);
 		accept_event();
 	}
-	if (ED_IS_SHORTCUT("script_editor/window_move_down", p_event)) {
+	if (ED_IS_SHORTCUT("script_editor/move_document_down", p_event)) {
 		_menu_option(FILE_MENU_MOVE_DOWN);
 		accept_event();
 	}
@@ -3248,9 +3248,9 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 	}
 
 	if (p_is_context_menu) {
-		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_up"), FILE_MENU_MOVE_UP);
-		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_down"), FILE_MENU_MOVE_DOWN);
-		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_sort"), FILE_MENU_SORT);
+		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/move_document_up"), FILE_MENU_MOVE_UP);
+		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/move_document_down"), FILE_MENU_MOVE_DOWN);
+		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/sort_documents"), FILE_MENU_SORT);
 	}
 
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"), FILE_MENU_TOGGLE_FILES_PANEL);
@@ -4094,9 +4094,9 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	code_editor_container->add_child(find_replace_bar);
 	find_replace_bar->hide();
 
-	ED_SHORTCUT("script_editor/window_sort", TTRC("Sort"));
-	ED_SHORTCUT("script_editor/window_move_up", TTRC("Move Up"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::UP);
-	ED_SHORTCUT("script_editor/window_move_down", TTRC("Move Down"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::DOWN);
+	ED_SHORTCUT("script_editor/sort_documents", TTRC("Sort Documents"));
+	ED_SHORTCUT("script_editor/move_document_up", TTRC("Move Document Up"));
+	ED_SHORTCUT("script_editor/move_document_down", TTRC("Move Document Down"));
 	// FIXME: These should be `Key::GREATER` and `Key::LESS` but those don't work.
 	ED_SHORTCUT("script_editor/next_script", TTRC("Next Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::PERIOD);
 	ED_SHORTCUT("script_editor/prev_script", TTRC("Previous Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::COMMA);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1353,6 +1353,9 @@ void EditorSettings::_handle_setting_compatibility() {
 
 	// Handle renamed shortcuts.
 	_rename_shortcut("editor/editor_assetlib", "editor/editor_asset_store");
+	_rename_shortcut("script_editor/window_move_up", "script_editor/move_document_up");
+	_rename_shortcut("script_editor/window_move_down", "script_editor/move_document_down");
+	_rename_shortcut("script_editor/window_sort", "script_editor/sort_documents");
 }
 
 void EditorSettings::_rename_setting(const String &p_old_name, const String &p_new_name) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15233

## Additional information
This PR renames the shortcut path `script_editor/window_move_up` and `down` to `script_editor/move_document_up` and `down`. Also updates the shortcut display names from `Move Up` and `Down` to `Move Document Up` and `Down`.

It also removes the default keybind (`Shift+Alt+Up/Down`) for these shortcuts, leaving them unbind by default.

Before:
<img width="1492" height="488" alt="Screenshot_20260723-221129_Godot Engine 4" src="https://github.com/user-attachments/assets/5f14c53a-3bee-4a02-ad40-d65cca3a41af" />
After:
<img width="1303" height="454" alt="markup_1000252638" src="https://github.com/user-attachments/assets/f9f566de-04c3-4683-a953-894c84abe25f" />