### PR TITLE
Code editor improvements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+scons platform=x11 tools=yes target=release_debug -j4

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1295,80 +1295,113 @@ void CodeTextEditor::duplicate_selection() {
 }
 
 void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
-	text_editor->begin_complex_operation();
-	if (text_editor->is_selection_active()) {
-		int begin = text_editor->get_selection_from_line();
-		int end = text_editor->get_selection_to_line();
+    text_editor->begin_complex_operation();
 
-		// End of selection ends on the first column of the last line, ignore it.
-		if (text_editor->get_selection_to_column() == 0) {
-			end -= 1;
-		}
+    int delimiter_length = delimiter.length();
 
-		int col_to = text_editor->get_selection_to_column();
-		int cursor_pos = text_editor->cursor_get_column();
+    if (text_editor->is_selection_active()) {
+        int begin = text_editor->get_selection_from_line();
+        int end = text_editor->get_selection_to_line();
 
-		// Check if all lines in the selected block are commented.
-		bool is_commented = true;
-		for (int i = begin; i <= end; i++) {
-			if (!text_editor->get_line(i).begins_with(delimiter)) {
-				is_commented = false;
-				break;
-			}
-		}
-		for (int i = begin; i <= end; i++) {
-			String line_text = text_editor->get_line(i);
+        // End of selection ends on the first column of the last line, ignore it.
+        if (text_editor->get_selection_to_column() == 0) {
+            end -= 1;
+        }
 
-			if (line_text.strip_edges().empty()) {
-				line_text = delimiter;
-			} else {
-				if (is_commented) {
-					line_text = line_text.substr(delimiter.length(), line_text.length());
-				} else {
-					line_text = delimiter + line_text;
-				}
-			}
-			text_editor->set_line(i, line_text);
-		}
+        int col_from = text_editor->get_selection_from_column();
+        int col_to = text_editor->get_selection_to_column();
+        int cursor_pos = text_editor->cursor_get_column();
+        int cursor_line = text_editor->cursor_get_line();
 
-		// Adjust selection & cursor position.
-		int offset = (is_commented ? -1 : 1) * delimiter.length();
-		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
+        int begin_offset = 0;
+        int end_offset = 0;
+        int cursor_offset = 0;
 
-		if (is_commented && text_editor->cursor_get_column() == text_editor->get_line(text_editor->cursor_get_line()).length() + 1) {
-			cursor_pos += 1;
-		}
+        for (int i = begin; i <= end; i++) {
+            String line_text = text_editor->get_line(i);
 
-		if (text_editor->get_selection_to_column() != 0 && col_to != text_editor->get_line(text_editor->get_selection_to_line()).length() + 1) {
-			col_to += offset;
-		}
+            // Skip empty or whitespace-only lines completely
+            if (line_text.strip_edges().empty()) {
+                continue;
+            }
 
-		if (text_editor->cursor_get_column() != 0) {
-			cursor_pos += offset;
-		}
+            // Find the first non-whitespace character
+            int first_non_ws = 0;
+            while (first_non_ws < line_text.length() && (line_text[first_non_ws] == ' ' || line_text[first_non_ws] == '\t')) {
+                first_non_ws++;
+            }
 
-		text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
-		text_editor->cursor_set_column(cursor_pos);
+            int line_offset = 0;
+            // Check if this specific line is commented right after its indentation
+            if (line_text.substr(first_non_ws).begins_with(delimiter)) {
+                // Uncomment: Strip the delimiter
+                line_text = line_text.left(first_non_ws) + line_text.substr(first_non_ws + delimiter_length);
+                line_offset = -delimiter_length;
+            } else {
+                // Comment: Inject the delimiter after the leading whitespace
+                line_text = line_text.left(first_non_ws) + delimiter + line_text.substr(first_non_ws);
+                line_offset = delimiter_length;
+            }
 
-	} else {
-		int begin = text_editor->cursor_get_line();
-		String line_text = text_editor->get_line(begin);
-		int delimiter_length = delimiter.length();
+            text_editor->set_line(i, line_text);
 
-		int col = text_editor->cursor_get_column();
-		if (line_text.begins_with(delimiter)) {
-			line_text = line_text.substr(delimiter_length, line_text.length());
-			col -= delimiter_length;
-		} else {
-			line_text = delimiter + line_text;
-			col += delimiter_length;
-		}
+            // Track individual offsets for selection and cursor adjustments
+            if (i == begin) {
+                begin_offset = line_offset;
+            }
+            if (i == end) {
+                end_offset = line_offset;
+            }
+            if (i == cursor_line) {
+                cursor_offset = line_offset;
+            }
+        }
 
-		text_editor->set_line(begin, line_text);
-		text_editor->cursor_set_column(col);
-	}
-	text_editor->end_complex_operation();
-	text_editor->update();
+        // Adjust selection columns
+        if (col_from > 0) {
+            col_from = MAX(0, col_from + begin_offset);
+        }
+        if (text_editor->get_selection_to_column() != 0) {
+            col_to = MAX(0, col_to + end_offset);
+        }
+        if (text_editor->cursor_get_column() != 0) {
+            cursor_pos = MAX(0, cursor_pos + cursor_offset);
+        }
+
+        text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
+        text_editor->cursor_set_column(cursor_pos);
+
+    } else {
+        // No selection active - single line behavior
+        int begin = text_editor->cursor_get_line();
+        String line_text = text_editor->get_line(begin);
+
+        // Do nothing if the single line is empty or whitespace-only
+        if (!line_text.strip_edges().empty()) {
+            int col = text_editor->cursor_get_column();
+
+            int first_non_ws = 0;
+            while (first_non_ws < line_text.length() && (line_text[first_non_ws] == ' ' || line_text[first_non_ws] == '\t')) {
+                first_non_ws++;
+            }
+
+            if (line_text.substr(first_non_ws).begins_with(delimiter)) {
+                // Uncomment
+                line_text = line_text.left(first_non_ws) + line_text.substr(first_non_ws + delimiter_length);
+                col -= delimiter_length;
+            } else {
+                // Comment
+                line_text = line_text.left(first_non_ws) + delimiter + line_text.substr(first_non_ws);
+                col += delimiter_length;
+            }
+
+            text_editor->set_line(begin, line_text);
+            text_editor->cursor_set_column(MAX(0, col));
+        }
+    }
+
+    text_editor->end_complex_operation();
+    text_editor->update();
 }
 
 void CodeTextEditor::goto_line(int p_line) {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1745,6 +1745,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_brace_matching(true);
 	text_editor->set_auto_indent(true);
 	text_editor->set_deselect_on_focus_loss_enabled(false);
+	text_editor->set_paste_selected(true);
 
 	status_bar = memnew(HBoxContainer);
 	add_child(status_bar);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2137,55 +2137,68 @@ void TextEdit::backspace_at_cursor() {
 }
 
 void TextEdit::indent_right() {
-	int start_line;
-	int end_line;
+    int start_line;
+    int end_line;
 
-	// This value informs us by how much we changed selection position by indenting right.
-	// Default is 1 for tab indentation.
-	int selection_offset = 1;
-	begin_complex_operation();
+    int selection_offset = 1;
+    int begin_line_offset = 1;
+    int end_line_offset = 1;
 
-	if (is_selection_active()) {
-		start_line = get_selection_from_line();
-		end_line = get_selection_to_line();
-	} else {
-		start_line = cursor.line;
-		end_line = start_line;
-	}
+    begin_complex_operation();
 
-	// Ignore if the cursor is not past the first column.
-	if (is_selection_active() && get_selection_to_column() == 0) {
-		selection_offset = 0;
-		end_line--;
-	}
+    if (is_selection_active()) {
+        start_line = get_selection_from_line();
+        end_line = get_selection_to_line();
+    } else {
+        start_line = cursor.line;
+        end_line = start_line;
+    }
 
-	for (int i = start_line; i <= end_line; i++) {
-		String line_text = get_line(i);
-		if (line_text.size() == 0 && is_selection_active()) {
-			continue;
-		}
-		if (indent_using_spaces) {
-			// We don't really care where selection is - we just need to know indentation level at the beginning of the line.
-			int left = _find_first_non_whitespace_column_of_line(line_text);
-			int spaces_to_add = _calculate_spaces_till_next_right_indent(left);
-			// Since we will add this much spaces we want move whole selection and cursor by this much.
-			selection_offset = spaces_to_add;
-			for (int j = 0; j < spaces_to_add; j++) {
-				line_text = ' ' + line_text;
-			}
-		} else {
-			line_text = '\t' + line_text;
-		}
-		set_line(i, line_text);
-	}
+    // FIXED CHECK: Only decrement end_line if column is 0 AND the line isn't empty.
+    if (is_selection_active() && get_selection_to_column() == 0 && get_line(end_line).length() > 0) {
+        selection_offset = 0;
+        begin_line_offset = 0;
+        end_line_offset = 0;
+        end_line--;
+    }
 
-	// Fix selection and cursor being off after shifting selection right.
-	if (is_selection_active()) {
-		select(selection.from_line, selection.from_column + selection_offset, selection.to_line, selection.to_column + selection_offset);
-	}
-	cursor_set_column(cursor.column + selection_offset, false);
-	end_complex_operation();
-	update();
+    for (int i = start_line; i <= end_line; i++) {
+        String line_text = get_line(i);
+
+        int current_line_offset = 1;
+
+        if (indent_using_spaces) {
+            int left = _find_first_non_whitespace_column_of_line(line_text);
+            int spaces_to_add = _calculate_spaces_till_next_right_indent(left);
+            current_line_offset = spaces_to_add;
+            
+            for (int j = 0; j < spaces_to_add; j++) {
+                line_text = ' ' + line_text;
+            }
+        } else {
+            line_text = '\t' + line_text;
+        }
+        
+        set_line(i, line_text);
+
+        if (i == selection.from_line) {
+            begin_line_offset = current_line_offset;
+        }
+        if (i == selection.to_line) {
+            end_line_offset = current_line_offset;
+        }
+        if (i == cursor.line) {
+            selection_offset = current_line_offset;
+        }
+    }
+
+    if (is_selection_active()) {
+        select(selection.from_line, selection.from_column + begin_line_offset, selection.to_line, selection.to_column + end_line_offset);
+    }
+    cursor_set_column(cursor.column + selection_offset, false);
+    
+    end_complex_operation();
+    update();
 }
 
 void TextEdit::indent_left() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5670,9 +5670,21 @@ void TextEdit::paste() {
 		clipboard += ins;
 	}
 
-	_insert_text_at_cursor(clipboard);
-	end_complex_operation();
+	// Capture the start coordinates before the text is inserted
+	int start_line = cursor_get_line();
+	int start_column = cursor_get_column();
 
+	_insert_text_at_cursor(clipboard);
+
+	// If the option is enabled and we actually pasted something, select it
+	if (paste_selected && !clipboard.empty()) {
+		int end_line = cursor_get_line();
+		int end_column = cursor_get_column();
+		
+		select(start_line, start_column, end_line, end_column);
+	}
+
+	end_complex_operation();
 	update();
 }
 
@@ -7353,6 +7365,10 @@ void TextEdit::set_middle_mouse_paste_enabled(bool p_enabled) {
 	middle_mouse_paste_enabled = p_enabled;
 }
 
+void TextEdit::set_paste_selected(bool p_enabled) {
+	paste_selected = p_enabled;
+}
+
 void TextEdit::set_selecting_enabled(bool p_enabled) {
 	selecting_enabled = p_enabled;
 
@@ -7396,6 +7412,10 @@ bool TextEdit::is_virtual_keyboard_enabled() const {
 
 bool TextEdit::is_middle_mouse_paste_enabled() const {
 	return middle_mouse_paste_enabled;
+}
+
+bool TextEdit::is_paste_selected() const {
+	return paste_selected;
 }
 
 PopupMenu *TextEdit::get_menu() const {
@@ -7498,6 +7518,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_virtual_keyboard_enabled"), &TextEdit::is_virtual_keyboard_enabled);
 	ClassDB::bind_method(D_METHOD("set_middle_mouse_paste_enabled", "enable"), &TextEdit::set_middle_mouse_paste_enabled);
 	ClassDB::bind_method(D_METHOD("is_middle_mouse_paste_enabled"), &TextEdit::is_middle_mouse_paste_enabled);
+	ClassDB::bind_method(D_METHOD("set_paste_selected", "enabled"), &TextEdit::set_paste_selected);
+	ClassDB::bind_method(D_METHOD("is_paste_selected"), &TextEdit::is_paste_selected);
 	ClassDB::bind_method(D_METHOD("set_selecting_enabled", "enable"), &TextEdit::set_selecting_enabled);
 	ClassDB::bind_method(D_METHOD("is_selecting_enabled"), &TextEdit::is_selecting_enabled);
 	ClassDB::bind_method(D_METHOD("set_deselect_on_focus_loss_enabled", "enable"), &TextEdit::set_deselect_on_focus_loss_enabled);
@@ -7616,6 +7638,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_keys_enabled"), "set_shortcut_keys_enabled", "is_shortcut_keys_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "virtual_keyboard_enabled"), "set_virtual_keyboard_enabled", "is_virtual_keyboard_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "middle_mouse_paste_enabled"), "set_middle_mouse_paste_enabled", "is_middle_mouse_paste_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paste_selected"), "set_paste_selected", "is_paste_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selecting_enabled"), "set_selecting_enabled", "is_selecting_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_on_focus_loss_enabled"), "set_deselect_on_focus_loss_enabled", "is_deselect_on_focus_loss_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_and_drop_selection_enabled"), "set_drag_and_drop_selection_enabled", "is_drag_and_drop_selection_enabled");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6303,26 +6303,21 @@ bool TextEdit::can_fold(int p_line) const {
 	if (is_line_hidden(p_line)) {
 		return false;
 	}
-	if (is_line_comment(p_line)) {
-		return false;
-	}
-
+	
 	int start_indent = get_indent_level(p_line);
-
+	
 	for (int i = p_line + 1; i < text.size(); i++) {
 		if (text[i].strip_edges().size() == 0) {
 			continue;
 		}
 		int next_indent = get_indent_level(i);
-		if (is_line_comment(i)) {
-			continue;
-		} else if (next_indent > start_indent) {
+		if (next_indent > start_indent) {
 			return true;
 		} else {
 			return false;
 		}
 	}
-
+	
 	return false;
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6144,6 +6144,14 @@ void TextEdit::clear_info_icons() {
 	update();
 }
 
+void TextEdit::set_line_as_folded(int p_line, bool p_folded) {
+	ERR_FAIL_INDEX(p_line, text.size());
+	if (is_hiding_enabled() || !p_folded) {
+		text.set_folded(p_line, p_folded);
+	}
+	update();
+}
+
 void TextEdit::set_line_as_hidden(int p_line, bool p_hidden) {
 	ERR_FAIL_INDEX(p_line, text.size());
 	if (is_hiding_enabled() || !p_hidden) {
@@ -6158,8 +6166,11 @@ bool TextEdit::is_line_hidden(int p_line) const {
 }
 
 void TextEdit::fold_all_lines() {
-	for (int i = 0; i < text.size(); i++) {
-		fold_line(i);
+	// Fold bottom-up so child blocks fold before parent blocks
+	for (int i = text.size() - 1; i >= 0; i--) {
+		if (can_fold(i)) {
+			fold_line(i);
+		}
 	}
 	_update_scrollbars();
 	update();
@@ -6168,6 +6179,7 @@ void TextEdit::fold_all_lines() {
 void TextEdit::unhide_all_lines() {
 	for (int i = 0; i < text.size(); i++) {
 		text.set_hidden(i, false);
+		text.set_folded(i, false); // Clear explicit fold state on every line
 	}
 	_update_scrollbars();
 	update();
@@ -6319,39 +6331,33 @@ bool TextEdit::can_fold(int p_line) const {
 	if (p_line + 1 >= text.size()) {
 		return false;
 	}
-	if (text[p_line].strip_edges().size() == 0) {
+	if (text[p_line].strip_edges().empty()) {
 		return false;
 	}
 	if (is_folded(p_line)) {
 		return false;
 	}
-	if (is_line_hidden(p_line)) {
-		return false;
-	}
-	
+
 	int start_indent = get_indent_level(p_line);
-	
+
 	for (int i = p_line + 1; i < text.size(); i++) {
-		if (text[i].strip_edges().size() == 0) {
+		if (text[i].strip_edges().empty()) {
 			continue;
 		}
 		int next_indent = get_indent_level(i);
 		if (next_indent > start_indent) {
-			return true;
+			return true; // Found at least one deeper line
 		} else {
-			return false;
+			return false; // Scope ended without deeper lines
 		}
 	}
-	
+
 	return false;
 }
 
 bool TextEdit::is_folded(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), false);
-	if (p_line + 1 >= text.size()) {
-		return false;
-	}
-	return !is_line_hidden(p_line) && is_line_hidden(p_line + 1);
+	return text.is_folded(p_line);
 }
 
 Vector<int> TextEdit::get_folded_lines() const {
@@ -6374,9 +6380,12 @@ void TextEdit::fold_line(int p_line) {
 		return;
 	}
 
-	// Hide lines below this one.
+	// 1. Mark this line as explicitly folded
+	set_line_as_folded(p_line, true);
+
+	// 2. Find the scope end line
 	int start_indent = get_indent_level(p_line);
-	int last_line = start_indent;
+	int last_line = p_line;
 	for (int i = p_line + 1; i < text.size(); i++) {
 		if (text[i].strip_edges().size() != 0) {
 			if (is_line_comment(i) && get_indent_level(i) <= start_indent) {
@@ -6389,11 +6398,13 @@ void TextEdit::fold_line(int p_line) {
 			}
 		}
 	}
+
+	// 3. Hide all child lines within the block scope
 	for (int i = p_line + 1; i <= last_line; i++) {
 		set_line_as_hidden(i, true);
 	}
 
-	// Fix selection.
+	// Fix selection
 	if (is_selection_active()) {
 		if (is_line_hidden(selection.from_line) && is_line_hidden(selection.to_line)) {
 			deselect();
@@ -6404,11 +6415,12 @@ void TextEdit::fold_line(int p_line) {
 		}
 	}
 
-	// Reset cursor.
+	// Reset cursor
 	if (is_line_hidden(cursor.line)) {
 		cursor_set_line(p_line, false, false);
 		cursor_set_column(get_line(p_line).length(), false);
 	}
+
 	_update_scrollbars();
 	update();
 }
@@ -6416,24 +6428,67 @@ void TextEdit::fold_line(int p_line) {
 void TextEdit::unfold_line(int p_line) {
 	ERR_FAIL_INDEX(p_line, text.size());
 
-	if (!is_folded(p_line) && !is_line_hidden(p_line)) {
+	if (!is_folded(p_line)) {
 		return;
 	}
-	int fold_start;
-	for (fold_start = p_line; fold_start > 0; fold_start--) {
-		if (is_folded(fold_start)) {
-			break;
-		}
-	}
-	fold_start = is_folded(fold_start) ? fold_start : p_line;
 
-	for (int i = fold_start + 1; i < text.size(); i++) {
-		if (is_line_hidden(i)) {
-			set_line_as_hidden(i, false);
-		} else {
-			break;
+	// 1. Unmark this line as folded
+	set_line_as_folded(p_line, false);
+
+	// 2. Retrieve remaining active folds across the document
+	Vector<int> folded_lines = get_folded_lines();
+
+	// 3. Determine the end of p_line's block scope
+	int start_indent = get_indent_level(p_line);
+	int last_line = p_line;
+	for (int i = p_line + 1; i < text.size(); i++) {
+		if (text[i].strip_edges().size() != 0) {
+			if (is_line_comment(i) && get_indent_level(i) <= start_indent) {
+				continue;
+			} else if (get_indent_level(i) > start_indent) {
+				last_line = i;
+			} else {
+				break;
+			}
 		}
 	}
+
+	// 4. Update visibility for lines inside this block scope
+	for (int i = p_line + 1; i <= last_line; i++) {
+		bool should_stay_hidden = false;
+
+		// Check if line 'i' belongs to ANY active nested fold scope
+		for (int f = 0; f < folded_lines.size(); f++) {
+			int fold_idx = folded_lines[f];
+			if (fold_idx == p_line) {
+				continue;
+			}
+
+			// Find boundary for this active fold
+			int f_indent = get_indent_level(fold_idx);
+			int f_last_line = fold_idx;
+			for (int j = fold_idx + 1; j < text.size(); j++) {
+				if (text[j].strip_edges().size() != 0) {
+					if (is_line_comment(j) && get_indent_level(j) <= f_indent) {
+						continue;
+					} else if (get_indent_level(j) > f_indent) {
+						f_last_line = j;
+					} else {
+						break;
+					}
+				}
+			}
+
+			// If line 'i' is inside an active folded range, keep it hidden
+			if (i > fold_idx && i <= f_last_line) {
+				should_stay_hidden = true;
+				break;
+			}
+		}
+
+		set_line_as_hidden(i, should_stay_hidden);
+	}
+
 	_update_scrollbars();
 	update();
 }
@@ -6441,10 +6496,10 @@ void TextEdit::unfold_line(int p_line) {
 void TextEdit::toggle_fold_line(int p_line) {
 	ERR_FAIL_INDEX(p_line, text.size());
 
-	if (!is_folded(p_line)) {
-		fold_line(p_line);
-	} else {
+	if (is_folded(p_line)) {
 		unfold_line(p_line);
+	} else {
+		fold_line(p_line);
 	}
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -77,6 +77,7 @@ public:
 			bool marked : 1;
 			bool breakpoint : 1;
 			bool bookmark : 1;
+			bool folded : 1;
 			bool hidden : 1;
 			bool safe : 1;
 			bool has_info : 1;
@@ -90,6 +91,7 @@ public:
 				marked = false;
 				breakpoint = false;
 				bookmark = false;
+				folded = false;
 				hidden = false;
 				safe = false;
 				has_info = false;
@@ -126,6 +128,8 @@ public:
 		bool is_breakpoint(int p_line) const { return text[p_line].breakpoint; }
 		void set_hidden(int p_line, bool p_hidden) { text.write[p_line].hidden = p_hidden; }
 		bool is_hidden(int p_line) const { return text[p_line].hidden; }
+		void set_folded(int p_line, bool p_folded) { text.write[p_line].folded = p_folded; }
+		bool is_folded(int p_line) const { return text[p_line].folded; }
 		void set_safe(int p_line, bool p_safe) { text.write[p_line].safe = p_safe; }
 		bool is_safe(int p_line) const { return text[p_line].safe; }
 		void set_info_icon(int p_line, Ref<Texture> p_icon, String p_info) {
@@ -646,6 +650,7 @@ public:
 	void set_line_info_icon(int p_line, Ref<Texture> p_icon, String p_info = "");
 	void clear_info_icons();
 
+	void set_line_as_folded(int p_line, bool p_folded);
 	void set_line_as_hidden(int p_line, bool p_hidden);
 	bool is_line_hidden(int p_line) const;
 	void fold_all_lines();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -449,6 +449,8 @@ private:
 
 	bool middle_mouse_paste_enabled;
 
+	bool paste_selected = false;
+
 	int executing_line;
 
 	void _generate_context_menu();
@@ -875,6 +877,9 @@ public:
 
 	void set_middle_mouse_paste_enabled(bool p_enabled);
 	bool is_middle_mouse_paste_enabled() const;
+
+	void set_paste_selected(bool p_enabled);
+	bool is_paste_selected() const;
 
 	PopupMenu *get_menu() const;
 


### PR DESCRIPTION
Improved inline comment toggling

    "#" now appears after any whitespace, not at column zero.
    Any empty lines are ignored.
    Any commented lines become uncommented.
    Any uncommented lines become commented.

Inline comment Toggle now acts as a true toggle.

Added comment folding support

    Indented comments can now be folded.

Added paste_selected to TextEdit, made it default to true in the editor.

    TextEdit now has the possibility to paste selected, whatever contents are pasted will become selected automatically.
    CodeEditor has that enabled by default.

Fixed indentation on empty lines

    Empty lines are now indented right with the rest of the code instead of being ignored.

Fixed nested line folding in TextEdit

    When unfolding lines, child folded lines do not get unfolded with it anymore.
