### PR TITLE
Make @export_flags a dropdown inspector menu

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1012,32 +1012,46 @@ EditorPropertyEnum::EditorPropertyEnum() {
 ///////////////////// FLAGS /////////////////////////
 
 void EditorPropertyFlags::_set_read_only(bool p_read_only) {
-	for (CheckBox *check : flags) {
-		check->set_disabled(p_read_only);
-	}
+	menu->set_disabled(p_read_only);
 }
 
-void EditorPropertyFlags::_flag_toggled(int p_index) {
+void EditorPropertyFlags::_flag_selected(int p_index) {
 	uint32_t value = get_edited_property_value();
-	if (flags[p_index]->is_pressed()) {
+	PopupMenu *popup = menu->get_popup();
+	popup->toggle_item_checked(p_index);
+	if (popup->is_item_checked(p_index)) {
 		value |= flag_values[p_index];
 	} else {
 		value &= ~flag_values[p_index];
 	}
 
+	_update_button_text(value);
 	emit_changed(get_edited_property(), value);
+}
+
+void EditorPropertyFlags::_update_button_text(uint32_t p_value) {
+	Vector<String> selected_options;
+	for (int i = 0; i < flag_names.size(); i++) {
+		if ((p_value & flag_values[i]) == flag_values[i]) {
+			selected_options.push_back(flag_names[i]);
+		}
+	}
+
+	menu->set_text(selected_options.is_empty() ? TTR("None") : String(", ").join(selected_options));
 }
 
 void EditorPropertyFlags::update_property() {
 	uint32_t value = get_edited_property_value();
+	PopupMenu *popup = menu->get_popup();
 
-	for (int i = 0; i < flags.size(); i++) {
-		flags[i]->set_pressed((value & flag_values[i]) == flag_values[i]);
+	for (int i = 0; i < flag_values.size(); i++) {
+		popup->set_item_checked(i, (value & flag_values[i]) == flag_values[i]);
 	}
+	_update_button_text(value);
 }
 
 void EditorPropertyFlags::setup(const Vector<String> &p_options) {
-	ERR_FAIL_COND(flags.size());
+	ERR_FAIL_COND(!flag_values.is_empty());
 
 	bool first = true;
 	uint32_t current_val;
@@ -1047,7 +1061,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 		if (option.is_empty()) {
 			continue;
 		}
-		const int flag_index = flags.size(); // Index of the next element (added by the code below).
+		const int flag_index = flag_values.size(); // Index of the next element (added by the code below).
 
 		// Value for a flag can be explicitly overridden.
 		Vector<String> text_split = option.split(":");
@@ -1061,28 +1075,31 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 			current_val = 1u << i;
 		}
 		flag_values.push_back(current_val);
-
-		// Create a CheckBox for the current flag.
-		CheckBox *cb = memnew(CheckBox);
-		cb->set_text(text_split[0]);
-		cb->set_clip_text(true);
-		cb->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyFlags::_flag_toggled).bind(flag_index));
-		add_focusable(cb);
-		vbox->add_child(cb);
-		flags.push_back(cb);
+		flag_names.push_back(text_split[0]);
+		
+		// Add a CheckBox item for the current flag to the dropdown menu.
+		menu->get_popup()->add_check_item(text_split[0], flag_index);
 
 		// Can't use `i == 0` because we want to find the first none-empty option.
 		if (first) {
-			set_label_reference(cb);
+			set_label_reference(menu);
 			first = false;
 		}
 	}
 }
 
 EditorPropertyFlags::EditorPropertyFlags() {
-	vbox = memnew(VBoxContainer);
-	vbox->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	add_child(vbox);
+	menu = memnew(MenuButton);
+	menu->set_clip_text(true);
+	menu->set_flat(true);
+	menu->set_theme_type_variation(SNAME("EditorInspectorButton"));
+	menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	menu->get_popup()->set_hide_on_checkable_item_selection(false);
+	menu->get_popup()->set_search_bar_enabled(true);
+	menu->get_popup()->set_search_bar_min_item_count(10);
+	menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorPropertyFlags::_flag_selected));
+	add_child(menu);
+	add_focusable(menu);
 }
 
 ///////////////////// LAYERS /////////////////////////

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -296,11 +296,12 @@ public:
 
 class EditorPropertyFlags : public EditorProperty {
 	GDCLASS(EditorPropertyFlags, EditorProperty);
-	VBoxContainer *vbox = nullptr;
-	Vector<CheckBox *> flags;
+	MenuButton *menu = nullptr;
+	Vector<String> flag_names;
 	Vector<uint32_t> flag_values;
 
-	void _flag_toggled(int p_index);
+	void _flag_selected(int p_index);
+	void _update_button_text(uint32_t p_value);
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

This PR (my first on Godot) makes @export_flags act as a dropdown menu in the inspector.

## What problem(s) does this PR solve?

A simple, yet annoying problem: Exported flags (using @export_flags) takes up too much space on the inspector. Here's a comparison from before and after the change:

<img width="264" height="658" alt="image" src="https://github.com/user-attachments/assets/58f8ec92-893a-4169-ad9b-3f2d029f6cac" />
<img width="275" height="567" alt="image" src="https://github.com/user-attachments/assets/9ff765ed-8ba9-4af4-aaf7-093d29071639" />

It works exactly the same as before, I just wrapped up on a dropdown menu. My motivation is entirely based on the pet peeve I have with the current way and how I hate how Unity does this better (<3), but the benefit is real! I did a bit of research on other PRs/Issues/Proposals and although I found some that mean to change how we use bitmasks on Godot (#117381 and #117601) I didn't find any changing the inspector behavior itself, so I hope that this PR presents/suggest a cleaner way of dealing with bitmasks on Godot even if it isn't merged!

If one wants to test it, just compile the engine and create an @export_flags variable on any script. Here's what I used for testing it on my end:
```
## Pokémon Types + Steam type just to test "non-power-of-two" flags.
@export_flags(
	"Fire:1", 
	"Water:2", 
	"Steam:3", 
	"Grass:4", 
	"Normal:8", 
	"Ghost:16",
	"Ice:32",
	"Psychic:64",
	"Electric:128",
	"Bug:256",
	"Fighting:512",
	"Flying:1024",
	"Rock:2048",
	"Ground:4096",
	"Dragon:8192",
	"Poison:16384",
	"Steel:32768",
	"Dark:65536",
	"Fairy:131072"
) var elemental_types: int = 0

## Shoutout to Fire Emblem fans.
@export_enum("Sword", "Axe", "Lance") var weapon_types
```

Also, there's a layout factor that I feel it needs discussing. If we compare the "BitField" export with the Enum one, we see that the Enum's OptionButton's text is left oriented while the BitField's text is centered:
<img width="279" height="101" alt="image" src="https://github.com/user-attachments/assets/97124580-77c5-49b7-a64b-46958209f1ab" />

_I feel it makes more sense for the BitField's text to be centered because it displays much more information than just a single Enum value, but also feel that the two have similarities enough for me to be annoyed that they don't align._

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Gonna start by saying I used AI (more specifically OpenAI's 5.6 Terra for this task) to help me save time, find where in the code to change this and to point out my options. I tried to base myself on the EditorPropertyEnum, but OptionMenu is a single-choice option. The AI then suggested to use a MenuButton instead and it worked well enough. The rest of it was based on the needs of the new popup and making its theme the same as the Enum's.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/15245*