### PR TITLE
Move `ScriptEditor` gui to `DocumentEditorContainer`

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -294,14 +294,14 @@ CodeTextEditor *get_code_edit(const String &p_fpath) {
 	ShaderEditorPlugin *shader_editor_plugin = ShaderEditorPlugin::get_singleton();
 	ScriptEditorPlugin *script_editor_plugin = ScriptEditorPlugin::get_singleton();
 
-	ScriptEditor *script_editor = nullptr;
+	DocumentEditorContainer *document_editor_container = nullptr;
 	if (shader_editor_plugin && shader_editor_plugin->handles(res.ptr())) {
-		script_editor = ScriptEditor::get_bottom_script_editor();
+		document_editor_container = shader_editor_plugin->get_shader_container();
 	} else if (script_editor_plugin && script_editor_plugin->handles(res.ptr())) {
-		script_editor = ScriptEditor::get_singleton();
+		document_editor_container = ScriptEditor::get_singleton()->get_script_container();
 	}
-	if (script_editor) {
-		TextEditorBase *teb = Object::cast_to<TextEditorBase>(script_editor->get_resource_editor(res));
+	if (document_editor_container) {
+		TextEditorBase *teb = Object::cast_to<TextEditorBase>(document_editor_container->get_resource_editor(res));
 		if (teb) {
 			return teb->get_code_editor();
 		}

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -50,7 +50,6 @@ void ScriptEditorBase::_bind_methods() {
 
 	// First use in TextEditorBase.
 	ADD_SIGNAL(MethodInfo("_validation_updated"));
-	ADD_SIGNAL(MethodInfo("search_in_files_requested", PropertyInfo(Variant::STRING, "text")));
 	ClassDB::bind_method(D_METHOD("add_syntax_highlighter", "highlighter"), &ScriptEditorBase::add_syntax_highlighter);
 	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditorBase::get_base_editor);
 
@@ -60,13 +59,14 @@ void ScriptEditorBase::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("request_help", PropertyInfo(Variant::STRING, "topic")));
 	ADD_SIGNAL(MethodInfo("request_open_script_at_line", PropertyInfo(Variant::OBJECT, "script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("go_to_help", PropertyInfo(Variant::STRING, "what")));
-	ADD_SIGNAL(MethodInfo("replace_in_files_requested", PropertyInfo(Variant::STRING, "text")));
 	ADD_SIGNAL(MethodInfo("go_to_method", PropertyInfo(Variant::OBJECT, "script"), PropertyInfo(Variant::STRING, "method")));
 
 #ifndef DISABLE_DEPRECATED
 	ADD_SIGNAL(MethodInfo("request_save_history"));
 	ADD_SIGNAL(MethodInfo("request_save_previous_state", PropertyInfo(Variant::DICTIONARY, "state")));
 	ADD_SIGNAL(MethodInfo("edited_script_changed"));
+	ADD_SIGNAL(MethodInfo("search_in_files_requested", PropertyInfo(Variant::STRING, "text")));
+	ADD_SIGNAL(MethodInfo("replace_in_files_requested", PropertyInfo(Variant::STRING, "text")));
 #endif
 }
 
@@ -100,8 +100,8 @@ void ScriptEditorBase::tag_saved_version() {
 //// TextEditorBase
 
 TextEditorBase *TextEditorBase::EditMenus::_get_active_editor() {
-	if (se) {
-		return Object::cast_to<TextEditorBase>(se->get_current_editor());
+	if (document_editor_container) {
+		return Object::cast_to<TextEditorBase>(document_editor_container->get_current_editor());
 	}
 	return nullptr;
 }
@@ -188,8 +188,8 @@ void TextEditorBase::EditMenus::_bookmark_item_pressed(int p_idx) {
 	}
 }
 
-TextEditorBase::EditMenus::EditMenus(ScriptEditor *p_se) {
-	se = p_se;
+TextEditorBase::EditMenus::EditMenus(DocumentEditorContainer *p_document_editor_container) {
+	document_editor_container = p_document_editor_container;
 
 	edit_menu = memnew(MenuButton);
 	edit_menu->set_flat(false);
@@ -811,7 +811,7 @@ void CodeEditorBase::EditMenusCEB::_notification(int p_what) {
 	}
 }
 
-CodeEditorBase::EditMenusCEB::EditMenusCEB(ScriptEditor *p_se, String p_breakpoint_menu_name) : EditMenus(p_se) {
+CodeEditorBase::EditMenusCEB::EditMenusCEB(DocumentEditorContainer *p_document_editor_container, String p_breakpoint_menu_name) : EditMenus(p_document_editor_container) {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
 	_popup_move_item(EDIT_TRIM_TRAILING_WHITESAPCE, edit_menu->get_popup(), false);
 	edit_menu_line->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -36,7 +36,7 @@
 class EditorSyntaxHighlighter;
 class MenuButton;
 class VSplitContainer;
-class ScriptEditor;
+class DocumentEditorContainer;
 
 class ScriptEditorBase : public VBoxContainer {
 	GDCLASS(ScriptEditorBase, VBoxContainer);
@@ -51,7 +51,7 @@ public:
 		GDCLASS(EditMenusBase, HBoxContainer);
 
 	protected:
-		ScriptEditor *se = nullptr;
+		DocumentEditorContainer *document_editor_container = nullptr;
 
 	public:
 		virtual bool handles(ScriptEditorBase *p_seb) = 0;
@@ -160,7 +160,7 @@ protected:
 		void _bookmark_item_pressed(int p_idx);
 
 	public:
-		EditMenus(ScriptEditor *p_se);
+		EditMenus(DocumentEditorContainer *p_document_editor_container);
 	};
 
 	static void _popup_move_item(int p_target_id, PopupMenu *r_popup, bool p_move_after = true, int p_idx = -1) {
@@ -210,7 +210,7 @@ public:
 	virtual void reload_text();
 	virtual void enable_editor();
 
-	virtual EditMenusBase *create_edit_menu(ScriptEditor *p_se) = 0;
+	virtual EditMenusBase *create_edit_menu(DocumentEditorContainer *p_document_editor_container) = 0;
 
 	virtual Control *get_base_editor() const override { return code_editor->get_text_editor(); }
 	virtual CodeTextEditor *get_code_editor() const { return code_editor; }
@@ -280,7 +280,7 @@ protected:
 		void _notification(int p_what);
 
 	public:
-		EditMenusCEB(ScriptEditor *p_se, String p_breakpoint_menu_name);
+		EditMenusCEB(DocumentEditorContainer *p_document_editor_container, String p_breakpoint_menu_name);
 	};
 
 	VSplitContainer *editor_box = nullptr;

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -177,7 +177,7 @@ void DocumentList::_notification(int p_what) {
 
 			const Ref<Texture2D> &help_icon = get_editor_theme_icon(SNAME("Help"));
 			for (ItemData &item : items) {
-				Control *editor = script_editor->tab_container->get_tab_control(item.index);
+				Control *editor = document_editor_container->tab_container->get_tab_control(item.index);
 				ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(editor);
 				EditorHelp *eh = Object::cast_to<EditorHelp>(editor);
 				if (seb) {
@@ -192,7 +192,7 @@ void DocumentList::_notification(int p_what) {
 }
 
 Variant DocumentList::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	Node *cur_node = script_editor->tab_container->get_current_tab_control();
+	Node *cur_node = document_editor_container->tab_container->get_current_tab_control();
 	if (cur_node == nullptr) {
 		return Variant();
 	}
@@ -226,7 +226,7 @@ Variant DocumentList::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	Dictionary drag_data;
 	drag_data["type"] = "script_list_element";
 	drag_data["script_list_element"] = cur_node;
-	drag_data["editor"] = script_editor->config_section;
+	drag_data["editor"] = document_editor_container->config_section;
 
 	return drag_data;
 }
@@ -236,7 +236,7 @@ bool DocumentList::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 	const String type = d.get("type", "");
 
 	if (type == "script_list_element") {
-		if (d["editor"] != script_editor->config_section) {
+		if (d["editor"] != document_editor_container->config_section) {
 			return false;
 		}
 		Node *node = Object::cast_to<Node>(d["script_list_element"]);
@@ -254,7 +254,7 @@ bool DocumentList::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 		}
 
 		for (const String &file : files) {
-			if (script_editor->can_open_file(file)) {
+			if (document_editor_container->can_open_file(file)) {
 				return true;
 			}
 		}
@@ -290,7 +290,7 @@ void DocumentList::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 				}
 				new_index = item_list->get_item_metadata(pos);
 			}
-			TabContainer *tab_container = script_editor->tab_container;
+			TabContainer *tab_container = document_editor_container->tab_container;
 			tab_container->move_child(node, new_index);
 			tab_container->set_current_tab(new_index);
 			update_list();
@@ -312,14 +312,14 @@ void DocumentList::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 			}
 			new_index = item_list->get_item_metadata(pos);
 		}
-		TabContainer *tab_container = script_editor->tab_container;
+		TabContainer *tab_container = document_editor_container->tab_container;
 		int num_tabs_before = tab_container->get_tab_count();
 		for (const String &file : files) {
-			if (!script_editor->can_open_file(file)) {
+			if (!document_editor_container->can_open_file(file)) {
 				continue;
 			}
 
-			Ref<Resource> res = script_editor->open_file(file);
+			Ref<Resource> res = document_editor_container->open_file(file);
 			if (res.is_valid()) {
 				const int num_tabs = tab_container->get_tab_count();
 				if (num_tabs > num_tabs_before) {
@@ -338,13 +338,13 @@ void DocumentList::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 }
 
 void DocumentList::_document_selected(int p_index) {
-	script_editor->_go_to_tab(item_list->get_item_metadata(p_index), true);
+	document_editor_container->_go_to_tab(item_list->get_item_metadata(p_index), true);
 }
 
 void DocumentList::_document_clicked(int p_index, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index) {
 	if (p_mouse_button_index == MouseButton::MIDDLE) {
 		_document_selected(p_index);
-		script_editor->_menu_option(ScriptEditor::FILE_MENU_CLOSE);
+		document_editor_container->_menu_option(DocumentEditorContainer::FILE_MENU_CLOSE);
 	}
 
 	if (p_mouse_button_index == MouseButton::RIGHT) {
@@ -355,14 +355,14 @@ void DocumentList::_document_clicked(int p_index, Vector2 p_local_mouse_pos, Mou
 void DocumentList::_show_context_menu() {
 	context_menu->clear();
 
-	int selected = script_editor->tab_container->get_current_tab();
+	int selected = document_editor_container->tab_container->get_current_tab();
 	if (selected < 0) {
 		return;
 	}
 
-	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(script_editor->tab_container->get_tab_control(selected));
-	script_editor->_setup_popup_menu(context_menu, true);
-	script_editor->_prepare_popup_menu(context_menu, true);
+	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(document_editor_container->tab_container->get_tab_control(selected));
+	document_editor_container->_setup_popup_menu(context_menu, true);
+	document_editor_container->_prepare_popup_menu(context_menu, true);
 
 	// Context menu plugin.
 	PackedStringArray selected_paths;
@@ -398,12 +398,12 @@ static void _find_scripts(Node *p_base, Node *p_current, HashSet<Ref<Script>> &r
 }
 
 void DocumentList::update_list() {
-	TabContainer *tab_container = script_editor->tab_container;
+	TabContainer *tab_container = document_editor_container->tab_container;
 	const int num_open_editors = tab_container->get_tab_count();
 	const Ref<Texture2D> &help_icon = get_editor_theme_icon(SNAME("Help"));
 
 	HashSet<Ref<Script>> scripts_in_scene;
-	if (script_editor->highlight_scene_scripts && num_open_editors > 0) {
+	if (document_editor_container->highlight_scene_scripts && num_open_editors > 0) {
 		Node *edited = EditorNode::get_singleton()->get_edited_scene();
 		if (edited) {
 			_find_scripts(edited, edited, scripts_in_scene);
@@ -475,7 +475,7 @@ void DocumentList::_update_item_list() {
 		return;
 	}
 
-	TabContainer *tab_container = script_editor->tab_container;
+	TabContainer *tab_container = document_editor_container->tab_container;
 	const int current_index = tab_container->get_current_tab();
 
 	Color tool_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
@@ -515,7 +515,7 @@ void DocumentList::_update_item_list() {
 	hot_color.set_s(hot_color.get_s() * 0.9);
 	Color cold_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
 
-	int edit_pass = script_editor->edit_pass;
+	int edit_pass = document_editor_container->edit_pass;
 
 	for (int i = 0; i < item_list->get_item_count(); i++) {
 		int index = item_list->get_item_metadata(i);
@@ -550,7 +550,7 @@ void DocumentList::goto_next_document(bool p_previous) {
 	}
 	int next_tab = item_list->get_current() + (p_previous ? -1 : 1);
 	next_tab = Math::wrapi(next_tab, 0, item_list->get_item_count());
-	script_editor->_go_to_tab(item_list->get_item_metadata(next_tab), true);
+	document_editor_container->_go_to_tab(item_list->get_item_metadata(next_tab), true);
 }
 
 void DocumentList::update_editor_settings() {
@@ -560,8 +560,8 @@ void DocumentList::update_editor_settings() {
 	update_list();
 }
 
-DocumentList::DocumentList(ScriptEditor *p_script_editor) {
-	script_editor = p_script_editor;
+DocumentList::DocumentList(DocumentEditorContainer *p_document_editor_container) {
+	document_editor_container = p_document_editor_container;
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
 	filter = memnew(LineEdit);
@@ -584,7 +584,7 @@ DocumentList::DocumentList(ScriptEditor *p_script_editor) {
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect(SceneStringName(id_pressed), callable_mp(script_editor, &ScriptEditor::_menu_option));
+	context_menu->connect(SceneStringName(id_pressed), callable_mp(document_editor_container, &DocumentEditorContainer::_menu_option));
 }
 
 /////////////////////////////////
@@ -600,7 +600,7 @@ void DocumentOutline::_notification(int p_what) {
 }
 
 void DocumentOutline::_item_list_selected(int p_idx) {
-	Control *active_editor = script_editor->get_active_editor();
+	Control *active_editor = document_editor_container->get_active_editor();
 
 	int line = item_list->get_item_metadata(p_idx);
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(active_editor)) {
@@ -622,7 +622,7 @@ void DocumentOutline::update_editor_settings() {
 }
 
 void DocumentOutline::update_outline() {
-	Control *active_editor = script_editor->get_active_editor();
+	Control *active_editor = document_editor_container->get_active_editor();
 	item_list->clear();
 
 	if (CodeEditorBase *ceb = Object::cast_to<CodeEditorBase>(active_editor)) {
@@ -664,7 +664,7 @@ void DocumentOutline::update_outline() {
 }
 
 void DocumentOutline::update_visibility() {
-	Control *active_editor = script_editor->get_active_editor();
+	Control *active_editor = document_editor_container->get_active_editor();
 	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(active_editor);
 	EditorHelp *eh = Object::cast_to<EditorHelp>(active_editor);
 
@@ -685,8 +685,8 @@ void DocumentOutline::update_visibility() {
 	}
 }
 
-DocumentOutline::DocumentOutline(ScriptEditor *p_script_editor) {
-	script_editor = p_script_editor;
+DocumentOutline::DocumentOutline(DocumentEditorContainer *p_document_editor_container) {
+	document_editor_container = p_document_editor_container;
 	buttons_hbox = memnew(HBoxContainer);
 
 	filter = memnew(FilterLineEdit);
@@ -721,7 +721,7 @@ DocumentOutline::DocumentOutline(ScriptEditor *p_script_editor) {
 
 /*** SCRIPT EDITOR ******/
 
-String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *p_se) {
+String DocumentEditorContainer::_get_debug_tooltip(const String &p_text, Node *p_se) {
 	if (EDITOR_GET("text_editor/behavior/documentation/enable_tooltips")) {
 		return String();
 	}
@@ -739,19 +739,11 @@ String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *p_se) {
 	return debug_value;
 }
 
-void ScriptEditor::_resource_created(Ref<Resource> p_res) {
+void DocumentEditorContainer::_resource_created(Ref<Resource> p_res) {
 	EditorNode::get_singleton()->push_item(p_res.ptr());
 }
 
-void ScriptEditor::_goto_script_line2(int p_line) {
-	if (TextEditorBase *current = Object::cast_to<TextEditorBase>(_get_current_editor())) {
-		ScriptEditorNavigationMarker::get_singleton()->locate_begin();
-		current->goto_line(p_line);
-		ScriptEditorNavigationMarker::get_singleton()->locate_end();
-	}
-}
-
-void ScriptEditor::_goto_script_line(Ref<RefCounted> p_script, int p_line) {
+void DocumentEditorContainer::_goto_script_line(Ref<RefCounted> p_script, int p_line) {
 	Ref<Script> scr = Object::cast_to<Script>(*p_script);
 	if (scr.is_valid() && (scr->has_source_code() || scr->get_path().is_resource_file())) {
 		if (edit(p_script, p_line, 0)) {
@@ -760,7 +752,7 @@ void ScriptEditor::_goto_script_line(Ref<RefCounted> p_script, int p_line) {
 	}
 }
 
-void ScriptEditor::_change_execution(Ref<RefCounted> p_script, int p_line, bool p_set) {
+void DocumentEditorContainer::_change_execution(Ref<RefCounted> p_script, int p_line, bool p_set) {
 	Ref<Script> scr = Object::cast_to<Script>(*p_script);
 	if (scr.is_valid() && (scr->has_source_code() || scr->get_path().is_resource_file())) {
 		for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -777,7 +769,7 @@ void ScriptEditor::_change_execution(Ref<RefCounted> p_script, int p_line, bool 
 	}
 }
 
-void ScriptEditor::_set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_enabled) {
+void DocumentEditorContainer::_set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_enabled) {
 	Ref<Script> scr = Object::cast_to<Script>(*p_script);
 	if (scr.is_valid() && (scr->has_source_code() || scr->get_path().is_resource_file())) {
 		// Update if open.
@@ -809,7 +801,7 @@ void ScriptEditor::_set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_
 	}
 }
 
-void ScriptEditor::_clear_breakpoints() {
+void DocumentEditorContainer::_clear_breakpoints() {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (CodeEditorBase *ceb = Object::cast_to<CodeEditorBase>(tab_container->get_tab_control(i))) {
 			ceb->clear_breakpoints();
@@ -832,7 +824,7 @@ void ScriptEditor::_clear_breakpoints() {
 	}
 }
 
-Array ScriptEditor::_get_cached_breakpoints_for_script(const String &p_path) const {
+Array DocumentEditorContainer::_get_cached_breakpoints_for_script(const String &p_path) const {
 	if (!ResourceLoader::exists(p_path, "Script") || p_path.begins_with("local://") || !script_editor_cache->has_section_key(p_path, "state")) {
 		return Array();
 	}
@@ -844,16 +836,16 @@ Array ScriptEditor::_get_cached_breakpoints_for_script(const String &p_path) con
 	return state["breakpoints"];
 }
 
-ScriptEditorBase *ScriptEditor::_get_current_editor() const {
+ScriptEditorBase *DocumentEditorContainer::_get_current_editor() const {
 	return Object::cast_to<ScriptEditorBase>(tab_container->get_current_tab_control());
 }
 
-void ScriptEditor::_update_history_arrows() {
+void DocumentEditorContainer::_update_history_arrows() {
 	script_back->set_disabled(history_pos <= 0);
 	script_forward->set_disabled(history_pos >= history.size() - 1);
 }
 
-void ScriptEditor::_save_new_history(const Dictionary &p_state, Control *p_control) {
+void DocumentEditorContainer::_save_new_history(const Dictionary &p_state, Control *p_control) {
 	if (restoring_layout) {
 		return;
 	}
@@ -888,7 +880,7 @@ void ScriptEditor::_save_new_history(const Dictionary &p_state, Control *p_contr
 	_update_history_arrows();
 }
 
-void ScriptEditor::_save_previous_state(const Dictionary &p_state, Control *p_control) {
+void DocumentEditorContainer::_save_previous_state(const Dictionary &p_state, Control *p_control) {
 	if (history_pos < 0 || history_pos >= history.size()) {
 		return;
 	}
@@ -902,7 +894,7 @@ void ScriptEditor::_save_previous_state(const Dictionary &p_state, Control *p_co
 // Compress the history and remove duplicate patterns.
 // Example 1: If the history is ...ABAB..., it will be compressed to ...AB....
 // Example 2: If the history is ...ABCABC..., it will be compressed to ...ABC....
-void ScriptEditor::_compress_history_patterns(bool p_once) {
+void DocumentEditorContainer::_compress_history_patterns(bool p_once) {
 	bool stop = false;
 	bool changed = true;
 	int iterations = 0;
@@ -970,7 +962,7 @@ void ScriptEditor::_compress_history_patterns(bool p_once) {
 	}
 }
 
-void ScriptEditor::_go_to_tab(int p_idx, bool p_save_history) {
+void DocumentEditorContainer::_go_to_tab(int p_idx, bool p_save_history) {
 	if (restoring_layout) {
 		return;
 	}
@@ -1003,7 +995,7 @@ void ScriptEditor::_go_to_tab(int p_idx, bool p_save_history) {
 
 		Ref<Script> scr = seb->get_edited_resource();
 		if (scr.is_valid()) {
-			notify_script_changed(scr);
+			ScriptEditor::get_singleton()->notify_script_changed(scr);
 		}
 
 		seb->validate_script();
@@ -1025,7 +1017,7 @@ void ScriptEditor::_go_to_tab(int p_idx, bool p_save_history) {
 	_update_history_arrows();
 }
 
-void ScriptEditor::_add_recent_script(const String &p_path) {
+void DocumentEditorContainer::_add_recent_script(const String &p_path) {
 	if (p_path.is_empty()) {
 		return;
 	}
@@ -1043,7 +1035,7 @@ void ScriptEditor::_add_recent_script(const String &p_path) {
 	_update_recent_scripts();
 }
 
-void ScriptEditor::_update_recent_scripts() {
+void DocumentEditorContainer::_update_recent_scripts() {
 	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", config_section, Array());
 	recent_scripts->clear();
 
@@ -1061,11 +1053,11 @@ void ScriptEditor::_update_recent_scripts() {
 	recent_scripts->reset_size();
 }
 
-void ScriptEditor::_open_recent_script(int p_idx) {
+void DocumentEditorContainer::_open_recent_script(int p_idx) {
 	// clear button
 	if (p_idx == recent_scripts->get_item_count() - 1) {
 		EditorSettings::get_singleton()->set_project_metadata("recent_files", config_section, Array());
-		callable_mp(this, &ScriptEditor::_update_recent_scripts).call_deferred();
+		callable_mp(this, &DocumentEditorContainer::_update_recent_scripts).call_deferred();
 		return;
 	}
 
@@ -1111,12 +1103,12 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	_show_error_dialog(path);
 }
 
-void ScriptEditor::_show_error_dialog(const String &p_path) {
+void DocumentEditorContainer::_show_error_dialog(const String &p_path) {
 	error_dialog->set_text(vformat(TTR("Can't open '%s'. The file could have been moved or deleted."), p_path));
 	error_dialog->popup_centered();
 }
 
-void ScriptEditor::_close_tab(int p_idx, bool p_save) {
+void DocumentEditorContainer::_close_tab(int p_idx, bool p_save) {
 	int selected = p_idx;
 	if (selected < 0 || selected >= tab_container->get_tab_count()) {
 		return;
@@ -1141,7 +1133,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 
 			Ref<Script> scr = file;
 			if (scr.is_valid()) {
-				notify_script_close(scr);
+				ScriptEditor::get_singleton()->notify_script_close(scr);
 			}
 		}
 	}
@@ -1185,20 +1177,23 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save) {
 	}
 }
 
-void ScriptEditor::_close_current_tab(bool p_save) {
+void DocumentEditorContainer::_close_current_tab(bool p_save) {
 	_close_tab(tab_container->get_current_tab(), p_save);
 }
 
-void ScriptEditor::_close_discard_current_tab(const String &p_str) {
-	Ref<Script> scr = _get_current_script();
-	if (scr.is_valid()) {
-		scr->reload_from_file();
+void DocumentEditorContainer::_close_discard_current_tab(const String &p_str) {
+	ScriptEditorBase *seb = _get_current_editor();
+	if (seb) {
+		Ref<Script> scr = seb->get_edited_resource();
+		if (scr.is_valid()) {
+			scr->reload_from_file();
+		}
 	}
 	_close_tab(tab_container->get_current_tab(), false);
 	erase_tab_confirm->hide();
 }
 
-void ScriptEditor::_close_docs_tab() {
+void DocumentEditorContainer::_close_docs_tab() {
 	int child_count = tab_container->get_tab_count();
 	for (int i = child_count - 1; i >= 0; i--) {
 		if (Object::cast_to<EditorHelp>(tab_container->get_tab_control(i))) {
@@ -1207,14 +1202,14 @@ void ScriptEditor::_close_docs_tab() {
 	}
 }
 
-void ScriptEditor::_copy_script_path() {
+void DocumentEditorContainer::_copy_script_path() {
 	if (ScriptEditorBase *seb = _get_current_editor()) {
 		Ref<Resource> scr = seb->get_edited_resource();
 		DisplayServer::get_singleton()->clipboard_set(scr->get_path());
 	}
 }
 
-void ScriptEditor::_copy_script_uid() {
+void DocumentEditorContainer::_copy_script_uid() {
 	if (ScriptEditorBase *seb = _get_current_editor()) {
 		Ref<Resource> scr = seb->get_edited_resource();
 		ResourceUID::ID uid = ResourceLoader::get_resource_uid(scr->get_path());
@@ -1222,7 +1217,7 @@ void ScriptEditor::_copy_script_uid() {
 	}
 }
 
-void ScriptEditor::_close_other_tabs() {
+void DocumentEditorContainer::_close_other_tabs() {
 	int current_idx = tab_container->get_current_tab();
 	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
 		if (i != current_idx) {
@@ -1232,7 +1227,7 @@ void ScriptEditor::_close_other_tabs() {
 	_queue_close_tabs();
 }
 
-void ScriptEditor::_close_tabs_below() {
+void DocumentEditorContainer::_close_tabs_below() {
 	int current_idx = tab_container->get_current_tab();
 	for (int i = tab_container->get_tab_count() - 1; i > current_idx; i--) {
 		script_close_queue.push_back(i);
@@ -1241,14 +1236,14 @@ void ScriptEditor::_close_tabs_below() {
 	_queue_close_tabs();
 }
 
-void ScriptEditor::_close_all_tabs() {
+void DocumentEditorContainer::_close_all_tabs() {
 	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
 		script_close_queue.push_back(i);
 	}
 	_queue_close_tabs();
 }
 
-void ScriptEditor::_queue_close_tabs() {
+void DocumentEditorContainer::_queue_close_tabs() {
 	while (!script_close_queue.is_empty()) {
 		int idx = script_close_queue.front()->get();
 		script_close_queue.pop_front();
@@ -1259,7 +1254,7 @@ void ScriptEditor::_queue_close_tabs() {
 			// Maybe there are unsaved changes.
 			if (seb->is_unsaved()) {
 				_ask_close_current_unsaved_tab(seb);
-				erase_tab_confirm->connect(SceneStringName(visibility_changed), callable_mp(this, &ScriptEditor::_queue_close_tabs), CONNECT_ONE_SHOT);
+				erase_tab_confirm->connect(SceneStringName(visibility_changed), callable_mp(this, &DocumentEditorContainer::_queue_close_tabs), CONNECT_ONE_SHOT);
 				break;
 			}
 		}
@@ -1269,12 +1264,12 @@ void ScriptEditor::_queue_close_tabs() {
 	_update_find_replace_bar();
 }
 
-void ScriptEditor::_ask_close_current_unsaved_tab(ScriptEditorBase *p_seb) {
+void DocumentEditorContainer::_ask_close_current_unsaved_tab(ScriptEditorBase *p_seb) {
 	erase_tab_confirm->set_text(TTR("Close and save changes?") + "\n\"" + p_seb->get_document_name() + "\"");
 	erase_tab_confirm->popup_centered();
 }
 
-void ScriptEditor::_resave_scripts(const String &p_str) {
+void DocumentEditorContainer::_resave_scripts(const String &p_str) {
 	apply_scripts();
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -1305,7 +1300,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 	disk_changed->hide();
 }
 
-void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
+void DocumentEditorContainer::_res_saved_callback(const Ref<Resource> &p_res) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
 			if (seb->get_edited_resource() == p_res) {
@@ -1326,12 +1321,12 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 	}
 }
 
-void ScriptEditor::_scene_saved_callback(const String &p_path) {
+void DocumentEditorContainer::_scene_saved_callback(const String &p_path) {
 	// If scene was saved, mark all built-in scripts from that scene as saved.
 	_mark_built_in_scripts_as_saved(p_path);
 }
 
-void ScriptEditor::_mark_built_in_scripts_as_saved(const String &p_parent_path) {
+void DocumentEditorContainer::_mark_built_in_scripts_as_saved(const String &p_parent_path) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!seb) {
@@ -1358,7 +1353,7 @@ void ScriptEditor::_mark_built_in_scripts_as_saved(const String &p_parent_path) 
 	}
 }
 
-void ScriptEditor::trigger_live_script_reload(const String &p_script_path) {
+void DocumentEditorContainer::trigger_live_script_reload(const String &p_script_path) {
 	if (!script_paths_to_reload.has(p_script_path)) {
 		Ref<Script> reloaded_script = ResourceCache::get_ref(p_script_path);
 		if (reloaded_script.is_null()) {
@@ -1374,18 +1369,18 @@ void ScriptEditor::trigger_live_script_reload(const String &p_script_path) {
 		script_paths_to_reload.append(p_script_path);
 	}
 	if (!pending_auto_reload && auto_reload_running_scripts) {
-		callable_mp(this, &ScriptEditor::_live_auto_reload_running_scripts).call_deferred();
+		callable_mp(this, &DocumentEditorContainer::_live_auto_reload_running_scripts).call_deferred();
 		pending_auto_reload = true;
 	}
 }
 
-void ScriptEditor::_live_auto_reload_running_scripts() {
+void DocumentEditorContainer::_live_auto_reload_running_scripts() {
 	pending_auto_reload = false;
 	EditorDebuggerNode::get_singleton()->reload_scripts(script_paths_to_reload);
 	script_paths_to_reload.clear();
 }
 
-bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
+bool DocumentEditorContainer::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	disk_changed_list->clear();
 	TreeItem *r = disk_changed_list->create_item();
 
@@ -1432,6 +1427,63 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	}
 
 	return need_reload;
+}
+
+static void _find_changed_scripts_for_external_editor(Node *p_base, Node *p_current, HashSet<Ref<Script>> &r_scripts) {
+	if (p_current->get_owner() != p_base && p_base != p_current) {
+		return;
+	}
+	Ref<Script> c = p_current->get_script();
+
+	if (c.is_valid()) {
+		r_scripts.insert(c);
+	}
+
+	for (int i = 0; i < p_current->get_child_count(); i++) {
+		_find_changed_scripts_for_external_editor(p_base, p_current->get_child(i), r_scripts);
+	}
+}
+
+void DocumentEditorContainer::_update_modified_scripts_for_external_editor(Ref<Script> p_for_script) {
+	bool use_external_editor = bool(EDITOR_GET("text_editor/external/use_external_editor"));
+
+	ERR_FAIL_NULL(get_tree());
+
+	HashSet<Ref<Script>> scripts;
+
+	Node *base = get_tree()->get_edited_scene_root();
+	if (base) {
+		_find_changed_scripts_for_external_editor(base, base, scripts);
+	}
+
+	for (const Ref<Script> &E : scripts) {
+		Ref<Script> scr = E;
+
+		if (!use_external_editor && !scr->get_language()->overrides_external_editor()) {
+			continue; // We're not using an external editor for this script.
+		}
+
+		if (p_for_script.is_valid() && p_for_script != scr) {
+			continue;
+		}
+
+		if (scr->is_built_in()) {
+			continue; //internal script, who cares, though weird
+		}
+
+		uint64_t last_date = scr->get_last_modified_time();
+		uint64_t date = FileAccess::get_modified_time(scr->get_path());
+
+		if (last_date != date) {
+			Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+			ERR_CONTINUE(rel_scr.is_null());
+			scr->set_source_code(rel_scr->get_source_code());
+			scr->set_last_modified_time(rel_scr->get_last_modified_time());
+			scr->update_exports();
+
+			trigger_live_script_reload(scr->get_path());
+		}
+	}
 }
 
 void _import_text_editor_theme(const String &p_file) {
@@ -1501,7 +1553,7 @@ void _save_text_editor_theme_as(const String &p_file) {
 	}
 }
 
-bool ScriptEditor::_script_exists(const String &p_path) const {
+bool DocumentEditorContainer::_script_exists(const String &p_path) const {
 	if (p_path.is_empty()) {
 		return false;
 	} else if (p_path.is_resource_file()) {
@@ -1511,7 +1563,7 @@ bool ScriptEditor::_script_exists(const String &p_path) const {
 	}
 }
 
-void ScriptEditor::_file_dialog_action(const String &p_file) {
+void DocumentEditorContainer::_file_dialog_action(const String &p_file) {
 	switch (file_dialog_option) {
 		case FILE_MENU_NEW_TEXTFILE: {
 			Error err;
@@ -1562,36 +1614,17 @@ void ScriptEditor::_file_dialog_action(const String &p_file) {
 	file_dialog_option = -1;
 }
 
-Ref<Script> ScriptEditor::_get_current_script() {
-	if (ScriptEditorBase *current = _get_current_editor()) {
-		Ref<Script> scr = current->get_edited_resource();
-		return scr.is_valid() ? scr : nullptr;
-	} else {
-		return nullptr;
-	}
-}
-
-TypedArray<Script> ScriptEditor::_get_open_scripts() const {
-	TypedArray<Script> ret;
-	Vector<Ref<Script>> scripts = get_open_scripts();
-	int scripts_amount = scripts.size();
-	for (int idx_script = 0; idx_script < scripts_amount; idx_script++) {
-		ret.push_back(scripts[idx_script]);
-	}
-	return ret;
-}
-
-bool ScriptEditor::toggle_files_panel() {
+bool DocumentEditorContainer::toggle_files_panel() {
 	list_split->set_visible(!list_split->is_visible());
 	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", list_split->is_visible());
 	return list_split->is_visible();
 }
 
-bool ScriptEditor::is_files_panel_toggled() {
+bool DocumentEditorContainer::is_files_panel_toggled() {
 	return list_split->is_visible();
 }
 
-List<String> ScriptEditor::_get_recognized_extensions() {
+List<String> DocumentEditorContainer::_get_recognized_extensions() {
 	List<String> extensions;
 	for (const String &type : handled_resource_types) {
 		ResourceLoader::get_recognized_extensions_for_type(type, &extensions);
@@ -1599,7 +1632,7 @@ List<String> ScriptEditor::_get_recognized_extensions() {
 	return extensions;
 }
 
-void ScriptEditor::_menu_option(int p_option) {
+void DocumentEditorContainer::_menu_option(int p_option) {
 	Node *current_editor = tab_container->get_current_tab_control();
 	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(current_editor);
 	EditorHelp *eh = Object::cast_to<EditorHelp>(current_editor);
@@ -1715,13 +1748,13 @@ void ScriptEditor::_menu_option(int p_option) {
 			}
 		} break;
 		case SEARCH_IN_FILES: {
-			open_find_in_files_dialog("");
+			ScriptEditor::get_singleton()->open_find_in_files_dialog("");
 		} break;
 		case REPLACE_IN_FILES: {
-			open_find_in_files_dialog("", true);
+			ScriptEditor::get_singleton()->open_find_in_files_dialog("", true);
 		} break;
 		case SEARCH_HELP: {
-			script_editor->help_search_dialog->popup_dialog();
+			_help_search();
 		} break;
 		case SEARCH_WEBSITE: {
 			bool native_class_doc = false;
@@ -1896,7 +1929,7 @@ void ScriptEditor::_menu_option(int p_option) {
 	}
 }
 
-void ScriptEditor::_theme_option(int p_option) {
+void DocumentEditorContainer::_theme_option(int p_option) {
 	switch (p_option) {
 		case THEME_IMPORT: {
 			file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
@@ -1912,12 +1945,12 @@ void ScriptEditor::_theme_option(int p_option) {
 			EditorSettings::get_singleton()->notify_changes();
 		} break;
 		case THEME_SAVE_AS: {
-			ScriptEditor::_show_save_theme_as_dialog();
+			DocumentEditorContainer::_show_save_theme_as_dialog();
 		} break;
 	}
 }
 
-void ScriptEditor::_show_save_theme_as_dialog() {
+void DocumentEditorContainer::_show_save_theme_as_dialog() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_dialog_option = THEME_SAVE_AS;
@@ -1928,7 +1961,7 @@ void ScriptEditor::_show_save_theme_as_dialog() {
 	file_dialog->popup_file_dialog();
 }
 
-bool ScriptEditor::_has_docs_tab() const {
+bool DocumentEditorContainer::_has_docs_tab() const {
 	const int child_count = tab_container->get_tab_count();
 	for (int i = 0; i < child_count; i++) {
 		if (Object::cast_to<EditorHelp>(tab_container->get_tab_control(i))) {
@@ -1938,7 +1971,7 @@ bool ScriptEditor::_has_docs_tab() const {
 	return false;
 }
 
-bool ScriptEditor::_has_script_tab() const {
+bool DocumentEditorContainer::_has_script_tab() const {
 	const int child_count = tab_container->get_tab_count();
 	for (int i = 0; i < child_count; i++) {
 		if (Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
@@ -1948,7 +1981,7 @@ bool ScriptEditor::_has_script_tab() const {
 	return false;
 }
 
-void ScriptEditor::_notification(int p_what) {
+void DocumentEditorContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_apply_editor_settings();
@@ -1971,7 +2004,7 @@ void ScriptEditor::_notification(int p_what) {
 
 			_calculate_script_name_button_size();
 
-			if (this == script_editor) {
+			if (is_main_editor) {
 				help_search->set_button_icon(get_editor_theme_icon(SNAME("HelpSearch")));
 			}
 			site_search->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
@@ -1997,26 +2030,23 @@ void ScriptEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			// Can't set own styles in NOTIFICATION_THEME_CHANGED, so for now this will do.
-			add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ScriptEditorPanel"), EditorStringName(EditorStyles)));
-
-			if (this == script_editor) {
-				InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
-				EditorNode::get_singleton()->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
-				EditorNode::get_singleton()->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
+			if (is_main_editor) {
+				InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &DocumentEditorContainer::_help_class_open));
+				EditorNode::get_singleton()->connect("request_help_search", callable_mp(this, &DocumentEditorContainer::_help_search));
+				EditorNode::get_singleton()->connect("script_add_function_request", callable_mp(this, &DocumentEditorContainer::_add_callback));
 			}
-			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ScriptEditor::_close_builtin_scripts_from_scene));
-			EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
-			EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
+			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &DocumentEditorContainer::_close_builtin_scripts_from_scene));
+			EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &DocumentEditorContainer::_res_saved_callback));
+			EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &DocumentEditorContainer::_scene_saved_callback));
 			// Connect to scene_root child entered instead of scene_changed for new scenes.
-			EditorNode::get_singleton()->get_scene_root()->connect("child_entered_tree", callable_mp(this, &ScriptEditor::_connect_to_scene).unbind(1));
-			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
-			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
+			EditorNode::get_singleton()->get_scene_root()->connect("child_entered_tree", callable_mp(this, &DocumentEditorContainer::_connect_to_scene).unbind(1));
+			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &DocumentEditorContainer::_files_moved));
+			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &DocumentEditorContainer::_file_removed));
 
-			script_split->connect("dragged", callable_mp(this, &ScriptEditor::_split_dragged));
-			list_split->connect("dragged", callable_mp(this, &ScriptEditor::_split_dragged));
+			script_split->connect("dragged", callable_mp(this, &DocumentEditorContainer::_split_dragged));
+			list_split->connect("dragged", callable_mp(this, &DocumentEditorContainer::_split_dragged));
 
-			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &ScriptEditor::_update_filenames));
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &DocumentEditorContainer::_update_filenames));
 #ifdef ANDROID_ENABLED
 			set_process(true);
 #endif
@@ -2073,7 +2103,7 @@ void ScriptEditor::_notification(int p_what) {
 	}
 }
 
-void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
+void DocumentEditorContainer::_close_builtin_scripts_from_scene(const String &p_scene) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
 			Ref<Resource> res = seb->get_edited_resource();
@@ -2085,19 +2115,11 @@ void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 	}
 }
 
-void ScriptEditor::edited_scene_changed() {
+void DocumentEditorContainer::edited_scene_changed() {
 	_update_modified_scripts_for_external_editor();
 }
 
-void ScriptEditor::notify_script_close(const Ref<Script> &p_script) {
-	emit_signal(SNAME("script_close"), p_script);
-}
-
-void ScriptEditor::notify_script_changed(const Ref<Script> &p_script) {
-	emit_signal(SNAME("editor_script_changed"), p_script);
-}
-
-Vector<String> ScriptEditor::_get_breakpoints() {
+Vector<String> DocumentEditorContainer::_get_breakpoints() {
 	List<String> bpoints_list;
 	get_breakpoints(&bpoints_list);
 
@@ -2109,7 +2131,7 @@ Vector<String> ScriptEditor::_get_breakpoints() {
 	return ret;
 }
 
-void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
+void DocumentEditorContainer::get_breakpoints(List<String> *p_breakpoints) {
 	HashSet<String> loaded_scripts;
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		CodeEditorBase *ceb = Object::cast_to<CodeEditorBase>(tab_container->get_tab_control(i));
@@ -2148,7 +2170,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 	}
 }
 
-void ScriptEditor::ensure_select_current() {
+void DocumentEditorContainer::ensure_select_current() {
 	if (restoring_layout) {
 		return;
 	}
@@ -2174,11 +2196,11 @@ void ScriptEditor::ensure_select_current() {
 	_update_document_name_button();
 }
 
-bool ScriptEditor::is_editor_floating() {
+bool DocumentEditorContainer::is_editor_floating() {
 	return is_floating;
 }
 
-void ScriptEditor::_connect_to_scene() {
+void DocumentEditorContainer::_connect_to_scene() {
 	if (!highlight_scene_scripts) {
 		return;
 	}
@@ -2189,39 +2211,39 @@ void ScriptEditor::_connect_to_scene() {
 	_connect_to_scene_recursive(edited_scene, edited_scene);
 }
 
-void ScriptEditor::_connect_to_scene_recursive(Node *p_current, Node *p_base) {
+void DocumentEditorContainer::_connect_to_scene_recursive(Node *p_current, Node *p_base) {
 	if (p_current != p_base && p_current->get_owner() != p_base) {
 		return;
 	}
 
 	_queue_update_list();
-	const Callable update_callable = callable_mp(this, &ScriptEditor::_queue_update_list);
+	const Callable update_callable = callable_mp(this, &DocumentEditorContainer::_queue_update_list);
 	if (p_current->is_connected(CoreStringName(script_changed), update_callable)) {
 		return;
 	}
 	p_current->connect(CoreStringName(script_changed), update_callable);
 	p_current->connect(SceneStringName(tree_exited), update_callable);
-	p_current->connect(SNAME("child_entered_tree"), callable_mp(this, &ScriptEditor::_connect_to_scene_recursive).bind(p_base), CONNECT_DEFERRED);
+	p_current->connect(SNAME("child_entered_tree"), callable_mp(this, &DocumentEditorContainer::_connect_to_scene_recursive).bind(p_base), CONNECT_DEFERRED);
 
 	for (Node *child : p_current->iterate_children()) {
 		_connect_to_scene_recursive(child, p_base);
 	}
 }
 
-void ScriptEditor::_update_document_list() {
+void DocumentEditorContainer::_update_document_list() {
 	document_list->update_list();
 	list_update_queued = false;
 }
 
-void ScriptEditor::_queue_update_list() {
+void DocumentEditorContainer::_queue_update_list() {
 	if (list_update_queued || !highlight_scene_scripts) {
 		return;
 	}
 	list_update_queued = true;
-	callable_mp(this, &ScriptEditor::_update_document_list).call_deferred();
+	callable_mp(this, &DocumentEditorContainer::_update_document_list).call_deferred();
 }
 
-void ScriptEditor::_update_online_doc() {
+void DocumentEditorContainer::_update_online_doc() {
 	Node *current = tab_container->get_current_tab_control();
 
 	EditorHelp *eh = Object::cast_to<EditorHelp>(current);
@@ -2241,7 +2263,7 @@ void ScriptEditor::_update_online_doc() {
 	}
 }
 
-Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error) const {
+Ref<TextFile> DocumentEditorContainer::_load_text_file(const String &p_path, Error *r_error) const {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
@@ -2288,7 +2310,7 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	return text_file;
 }
 
-Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_path) {
+Error DocumentEditorContainer::_save_text_file(Ref<TextFile> p_text_file, const String &p_path) {
 	Ref<TextFile> sqscr = p_text_file;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -2316,7 +2338,7 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 	return OK;
 }
 
-bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus) {
+bool DocumentEditorContainer::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus) {
 	if (p_resource.is_null()) {
 		return false;
 	}
@@ -2401,7 +2423,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	seb->set_edited_resource(p_resource);
 
-	seb->set_toggle_list_control(get_left_list_split());
+	seb->set_toggle_list_control(list_split);
 	grab_focus_block = !p_grab_focus;
 	tab_container->add_child(seb);
 	grab_focus_block = false;
@@ -2447,8 +2469,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	seb->edited_file_data.path = p_resource->get_path();
 	seb->edited_file_data.last_modified_time = FileAccess::get_modified_time(p_resource->get_path());
 
-	seb->connect("name_changed", callable_mp(this, &ScriptEditor::_update_filenames));
-	seb->connect("_validation_updated", callable_mp(this, &ScriptEditor::_validation_updated));
+	seb->connect("name_changed", callable_mp(this, &DocumentEditorContainer::_update_filenames));
+	seb->connect("_validation_updated", callable_mp(this, &DocumentEditorContainer::_validation_updated));
 
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(seb)) {
 		// Syntax highlighting.
@@ -2488,16 +2510,19 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			}
 		}
 
-		teb->set_tooltip_request_func(callable_mp(this, &ScriptEditor::_get_debug_tooltip));
+		teb->set_tooltip_request_func(callable_mp(this, &DocumentEditorContainer::_get_debug_tooltip));
 
-		teb->connect("request_help", callable_mp(this, &ScriptEditor::_help_search));
-		teb->connect("request_open_script_at_line", callable_mp(this, &ScriptEditor::_goto_script_line));
-		teb->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-		teb->connect("_request_save_new_history", callable_mp(this, &ScriptEditor::_save_new_history).bind(teb));
-		teb->connect("_request_save_previous_state", callable_mp(this, &ScriptEditor::_save_previous_state).bind(teb));
-		teb->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(false));
-		teb->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog).bind(true));
-		teb->connect("go_to_method", callable_mp(this, &ScriptEditor::script_goto_method));
+		teb->connect("request_help", callable_mp(this, &DocumentEditorContainer::_help_search));
+		teb->connect("request_open_script_at_line", callable_mp(this, &DocumentEditorContainer::_goto_script_line));
+		teb->connect("go_to_help", callable_mp(this, &DocumentEditorContainer::_help_class_goto));
+		teb->connect("_request_save_new_history", callable_mp(this, &DocumentEditorContainer::_save_new_history).bind(teb));
+		teb->connect("_request_save_previous_state", callable_mp(this, &DocumentEditorContainer::_save_previous_state).bind(teb));
+		teb->connect("go_to_method", callable_mp(this, &DocumentEditorContainer::script_goto_method));
+
+#ifndef DISABLE_DEPRECATED
+		teb->connect("search_in_files_requested", callable_mp(ScriptEditor::get_singleton(), &ScriptEditor::open_find_in_files_dialog).bind(false));
+		teb->connect("replace_in_files_requested", callable_mp(ScriptEditor::get_singleton(), &ScriptEditor::open_find_in_files_dialog).bind(true));
+#endif
 
 		if (script_editor_cache->has_section(p_resource->get_path())) {
 			teb->set_edit_state(script_editor_cache->get_value(p_resource->get_path(), "state"), p_grab_focus);
@@ -2508,8 +2533,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 		if (CodeTextEditor *cte = teb->get_code_editor()) {
 			cte->set_zoom_factor(zoom_factor);
-			cte->connect("zoomed", callable_mp(this, &ScriptEditor::_set_script_zoom_factor));
-			cte->connect(SceneStringName(visibility_changed), callable_mp(this, &ScriptEditor::_update_code_editor_zoom_factor).bind(cte));
+			cte->connect("zoomed", callable_mp(this, &DocumentEditorContainer::_set_script_zoom_factor));
+			cte->connect(SceneStringName(visibility_changed), callable_mp(this, &DocumentEditorContainer::_update_code_editor_zoom_factor).bind(cte));
 		}
 	}
 
@@ -2531,20 +2556,29 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		ScriptEditorNavigationMarker::get_singleton()->locate_end();
 	}
 
-	notify_script_changed(p_resource);
+	ScriptEditor::get_singleton()->notify_script_changed(p_resource);
 	return true;
 }
 
-void ScriptEditor::reload_open_files() {
+void DocumentEditorContainer::reload_open_files() {
 	_test_script_times_on_disk();
 	_update_modified_scripts_for_external_editor();
 }
 
-Control *ScriptEditor::get_active_editor() const {
+Control *DocumentEditorContainer::get_active_editor() const {
 	return tab_container->get_current_tab_control();
 }
 
-PackedStringArray ScriptEditor::get_unsaved_scripts() const {
+Vector<Control *> DocumentEditorContainer::get_all_editors() const {
+	Vector<Control *> editors;
+	editors.reserve(tab_container->get_tab_count());
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		editors.push_back(tab_container->get_tab_control(i));
+	}
+	return editors;
+}
+
+PackedStringArray DocumentEditorContainer::get_unsaved_scripts() const {
 	PackedStringArray unsaved_list;
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -2556,7 +2590,7 @@ PackedStringArray ScriptEditor::get_unsaved_scripts() const {
 	return unsaved_list;
 }
 
-PackedStringArray ScriptEditor::get_unsaved_files() const {
+PackedStringArray DocumentEditorContainer::get_unsaved_files() const {
 	PackedStringArray unsaved_list;
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -2568,7 +2602,7 @@ PackedStringArray ScriptEditor::get_unsaved_files() const {
 	return unsaved_list;
 }
 
-void ScriptEditor::save_current_script() {
+void DocumentEditorContainer::save_current_script() {
 	ScriptEditorBase *current = _get_current_editor();
 	if (!current || _test_script_times_on_disk()) {
 		return;
@@ -2597,7 +2631,7 @@ void ScriptEditor::save_current_script() {
 	}
 }
 
-void ScriptEditor::save_all_scripts() {
+void DocumentEditorContainer::save_all_scripts() {
 	HashSet<String> scenes_to_save;
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -2652,7 +2686,7 @@ void ScriptEditor::save_all_scripts() {
 	_update_filenames();
 }
 
-void ScriptEditor::update_script_times() {
+void DocumentEditorContainer::update_script_times() {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
 			seb->edited_file_data.last_modified_time = FileAccess::get_modified_time(seb->edited_file_data.path);
@@ -2660,7 +2694,7 @@ void ScriptEditor::update_script_times() {
 	}
 }
 
-void ScriptEditor::apply_scripts() const {
+void DocumentEditorContainer::apply_scripts() const {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!seb) {
@@ -2674,16 +2708,16 @@ void ScriptEditor::apply_scripts() const {
 	}
 }
 
-void ScriptEditor::reload_scripts(bool p_refresh_only) {
+void DocumentEditorContainer::reload_scripts(bool p_refresh_only) {
 	// Call deferred to make sure it runs on the main thread.
 	if (!Thread::is_main_thread()) {
-		callable_mp(this, &ScriptEditor::_reload_scripts).call_deferred(p_refresh_only);
+		callable_mp(this, &DocumentEditorContainer::_reload_scripts).call_deferred(p_refresh_only);
 		return;
 	}
 	_reload_scripts(p_refresh_only);
 }
 
-void ScriptEditor::_reload_scripts(bool p_refresh_only) {
+void DocumentEditorContainer::_reload_scripts(bool p_refresh_only) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!seb) {
@@ -2758,7 +2792,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 	disk_changed->hide();
 }
 
-void ScriptEditor::_auto_format_text(ScriptEditorBase *p_seb) {
+void DocumentEditorContainer::_auto_format_text(ScriptEditorBase *p_seb) {
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(p_seb)) {
 		if (trim_trailing_whitespace_on_save) {
 			teb->trim_trailing_whitespace();
@@ -2772,22 +2806,18 @@ void ScriptEditor::_auto_format_text(ScriptEditorBase *p_seb) {
 	}
 }
 
-void ScriptEditor::open_find_in_files_dialog(const String &p_initial_text, bool p_replace) {
-	script_editor->find_in_files->open_dialog(p_initial_text, p_replace);
-}
-
-void ScriptEditor::open_script_create_dialog(const String &p_base_name, const String &p_base_path) {
+void DocumentEditorContainer::open_script_create_dialog(const String &p_base_name, const String &p_base_path) {
 	_menu_option(FILE_MENU_NEW_SCRIPT);
 	script_create_dialog->config(p_base_name, p_base_path);
 }
 
-void ScriptEditor::open_text_file_create_dialog(const String &p_base_path, const String &p_base_name) {
+void DocumentEditorContainer::open_text_file_create_dialog(const String &p_base_path, const String &p_base_name) {
 	_menu_option(FILE_MENU_NEW_TEXTFILE);
 	file_dialog->set_current_dir(p_base_path);
 	file_dialog->set_current_file(p_base_name);
 }
 
-Ref<Resource> ScriptEditor::open_file(const String &p_file) {
+Ref<Resource> DocumentEditorContainer::open_file(const String &p_file) {
 	if (_get_recognized_extensions().find(p_file.get_extension())) {
 		Ref<Resource> scr = ResourceLoader::load(p_file);
 		if (scr.is_null()) {
@@ -2813,7 +2843,7 @@ Ref<Resource> ScriptEditor::open_file(const String &p_file) {
 	return Ref<Resource>();
 }
 
-bool ScriptEditor::can_open_file(const String &p_file) const {
+bool DocumentEditorContainer::can_open_file(const String &p_file) const {
 	if (p_file.is_empty() || !FileAccess::exists(p_file)) {
 		return false;
 	}
@@ -2823,7 +2853,7 @@ bool ScriptEditor::can_open_file(const String &p_file) const {
 		return true;
 	}
 
-	if (this == script_editor && textfile_extensions.has(p_file.get_extension())) {
+	if (is_main_editor && textfile_extensions.has(p_file.get_extension())) {
 		Error err;
 		Ref<TextFile> text_file = _load_text_file(p_file, &err);
 		if (text_file.is_valid() && err == OK) {
@@ -2833,7 +2863,7 @@ bool ScriptEditor::can_open_file(const String &p_file) const {
 	return false;
 }
 
-Error ScriptEditor::close_file(const String &p_file) {
+Error DocumentEditorContainer::close_file(const String &p_file) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (seb && seb->get_edited_resource()->get_path() == p_file) {
@@ -2847,7 +2877,7 @@ Error ScriptEditor::close_file(const String &p_file) {
 	return ERR_FILE_NOT_FOUND;
 }
 
-void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {
+void DocumentEditorContainer::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {
 	ERR_FAIL_NULL(p_obj);
 	Ref<Script> scr = p_obj->get_script();
 	ERR_FAIL_COND(scr.is_null());
@@ -2884,7 +2914,7 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 	EditorNode::get_singleton()->edit_previous_item();
 }
 
-void ScriptEditor::_save_editor_state(ScriptEditorBase *p_editor) {
+void DocumentEditorContainer::_save_editor_state(ScriptEditorBase *p_editor) {
 	if (restoring_layout) {
 		return;
 	}
@@ -2900,7 +2930,7 @@ void ScriptEditor::_save_editor_state(ScriptEditorBase *p_editor) {
 	// This is saved later when we save the editor layout.
 }
 
-void ScriptEditor::_save_layout() {
+void DocumentEditorContainer::_save_layout() {
 	if (restoring_layout) {
 		return;
 	}
@@ -2908,7 +2938,7 @@ void ScriptEditor::_save_layout() {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
-void ScriptEditor::_apply_editor_settings() {
+void DocumentEditorContainer::_apply_editor_settings() {
 	textfile_extensions.clear();
 	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
 	for (const String &E : textfile_ext) {
@@ -2955,7 +2985,7 @@ void ScriptEditor::_apply_editor_settings() {
 	}
 }
 
-void ScriptEditor::_update_filenames() {
+void DocumentEditorContainer::_update_filenames() {
 	if (restoring_layout) {
 		return;
 	}
@@ -3024,7 +3054,7 @@ void ScriptEditor::_update_filenames() {
 	_update_document_name_button();
 }
 
-void ScriptEditor::_files_moved(const String &p_old_file, const String &p_new_file) {
+void DocumentEditorContainer::_files_moved(const String &p_old_file, const String &p_new_file) {
 	if (!script_editor_cache->has_section(p_old_file)) {
 		return;
 	}
@@ -3053,7 +3083,7 @@ void ScriptEditor::_files_moved(const String &p_old_file, const String &p_new_fi
 	// This is saved later when we save the editor layout.
 }
 
-void ScriptEditor::_file_removed(const String &p_removed_file) {
+void DocumentEditorContainer::_file_removed(const String &p_removed_file) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (seb && seb->edited_file_data.path == p_removed_file) {
@@ -3072,7 +3102,7 @@ void ScriptEditor::_file_removed(const String &p_removed_file) {
 	}
 }
 
-void ScriptEditor::_update_find_replace_bar() {
+void DocumentEditorContainer::_update_find_replace_bar() {
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(_get_current_editor())) {
 		teb->set_find_replace_bar(find_replace_bar);
 	} else {
@@ -3081,11 +3111,11 @@ void ScriptEditor::_update_find_replace_bar() {
 	}
 }
 
-void ScriptEditor::_autosave_scripts() {
+void DocumentEditorContainer::_autosave_scripts() {
 	save_all_scripts();
 }
 
-void ScriptEditor::_update_autosave_timer() {
+void DocumentEditorContainer::_update_autosave_timer() {
 	if (!autosave_timer->is_inside_tree()) {
 		return;
 	}
@@ -3099,11 +3129,11 @@ void ScriptEditor::_update_autosave_timer() {
 	}
 }
 
-void ScriptEditor::_split_dragged(float) {
+void DocumentEditorContainer::_split_dragged(float) {
 	_save_layout();
 }
 
-void ScriptEditor::input(const Ref<InputEvent> &p_event) {
+void DocumentEditorContainer::input(const Ref<InputEvent> &p_event) {
 	// This feature can be disabled to avoid interfering with other uses of the additional
 	// mouse buttons, such as push-to-talk in a VoIP program.
 	if (EDITOR_GET("interface/editor/input/mouse_extra_buttons_navigate_history")) {
@@ -3127,7 +3157,7 @@ void ScriptEditor::input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+void DocumentEditorContainer::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (!is_visible_in_tree() || !p_event->is_pressed()) {
@@ -3171,11 +3201,11 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) {
+void DocumentEditorContainer::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) {
 	ScriptEditorBase *seb = _get_current_editor();
 	const Ref<Resource> res = seb ? seb->get_edited_resource() : Ref<Resource>();
 	if (!p_is_context_menu) {
-		if (this == script_editor) {
+		if (is_main_editor) {
 			p_menu->add_shortcut(ED_SHORTCUT("script_editor/new_script", TTRC("New Script..."), KeyModifierMask::CMD_OR_CTRL | Key::N), FILE_MENU_NEW_SCRIPT);
 			p_menu->add_shortcut(ED_SHORTCUT("script_editor/new_textfile", TTRC("New Text File..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::N), FILE_MENU_NEW_TEXTFILE);
 			p_menu->add_shortcut(ED_SHORTCUT("script_editor/open", TTRC("Open...")), FILE_MENU_OPEN);
@@ -3207,13 +3237,13 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), FILE_MENU_CLOSE_OTHER_TABS);
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_tabs_below"), FILE_MENU_CLOSE_TABS_BELOW);
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), FILE_MENU_CLOSE_ALL);
-	if (this == script_editor) {
+	if (is_main_editor) {
 		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_docs"), FILE_MENU_CLOSE_DOCS);
 	}
 	p_menu->add_separator();
 
 	Ref<Script> script = res;
-	if (this == script_editor && (!p_is_context_menu || (script.is_valid() && script->is_tool()))) {
+	if (is_main_editor && (!p_is_context_menu || (script.is_valid() && script->is_tool()))) {
 		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_MENU_SOFT_RELOAD_TOOL);
 		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_MENU_RUN);
 		p_menu->add_separator();
@@ -3222,7 +3252,7 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_MENU_COPY_PATH);
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_uid"), FILE_MENU_COPY_UID);
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), FILE_MENU_SHOW_IN_FILE_SYSTEM);
-	if (this == bottom_script_editor) {
+	if (!is_main_editor) {
 		p_menu->add_shortcut(ED_SHORTCUT("script_editor/open_in_inspector", TTRC("Open File in Inspector")), FILE_MENU_INSPECT);
 		p_menu->add_shortcut(ED_SHORTCUT("script_editor/inspect_native_code", TTRC("Inspect Native Shader Code...")), FILE_MENU_INSPECT_NATIVE_SHADER_CODE);
 	}
@@ -3246,7 +3276,7 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"), FILE_MENU_TOGGLE_FILES_PANEL);
 }
 
-void ScriptEditor::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) {
+void DocumentEditorContainer::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) {
 	ScriptEditorBase *seb = _get_current_editor();
 	const Ref<Resource> res = seb ? seb->get_edited_resource() : Ref<Resource>();
 	if (!p_is_context_menu) {
@@ -3265,12 +3295,12 @@ void ScriptEditor::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_CLOSE_OTHER_TABS), tab_container->get_tab_count() <= 1);
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_CLOSE_TABS_BELOW), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_CLOSE_ALL), tab_container->get_tab_count() < 1);
-	if (this == script_editor) {
+	if (is_main_editor) {
 		p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_CLOSE_DOCS), !_has_docs_tab());
 	}
 
 	Ref<Script> script = res;
-	if (this == script_editor && (!p_is_context_menu || (script.is_valid() && script->is_tool()))) {
+	if (is_main_editor && (!p_is_context_menu || (script.is_valid() && script->is_tool()))) {
 		p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_SOFT_RELOAD_TOOL), script.is_null() || !script->is_tool());
 		p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_RUN), script.is_null());
 	}
@@ -3278,7 +3308,7 @@ void ScriptEditor::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_COPY_PATH), res.is_null() || res->get_path().is_empty());
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_COPY_UID), res.is_null() || ResourceLoader::get_resource_uid(res->get_path()) == ResourceUID::INVALID_ID);
 	p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_SHOW_IN_FILE_SYSTEM), res.is_null() || res->get_path().is_empty());
-	if (this == bottom_script_editor) {
+	if (!is_main_editor) {
 		p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_INSPECT), !seb);
 		p_menu->set_item_disabled(p_menu->get_item_index(FILE_MENU_INSPECT_NATIVE_SHADER_CODE), !seb);
 	}
@@ -3295,11 +3325,11 @@ void ScriptEditor::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu
 	}
 }
 
-void ScriptEditor::_prepare_file_menu() {
+void DocumentEditorContainer::_prepare_file_menu() {
 	_prepare_popup_menu(file_menu->get_popup(), false);
 }
 
-void ScriptEditor::_file_menu_closed() {
+void DocumentEditorContainer::_file_menu_closed() {
 	PopupMenu *menu = file_menu->get_popup();
 	for (int i = 0; i < menu->get_item_count(); i++) {
 		menu->set_item_disabled(i, false);
@@ -3325,7 +3355,7 @@ struct SortItemData {
 	}
 };
 
-void ScriptEditor::sort_document_editors() {
+void DocumentEditorContainer::sort_document_editors() {
 	if (restoring_layout) {
 		return;
 	}
@@ -3379,7 +3409,7 @@ void ScriptEditor::sort_document_editors() {
 	document_list->update_list();
 }
 
-void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
+void DocumentEditorContainer::set_window_layout(Ref<ConfigFile> p_layout) {
 	if (!p_layout->has_section_key(config_section, "open_scripts") && !p_layout->has_section_key(config_section, "open_help")) {
 		return;
 	}
@@ -3531,7 +3561,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
-void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
+void DocumentEditorContainer::get_window_layout(Ref<ConfigFile> p_layout) {
 	Array scripts;
 	Array helps;
 	String selected_script;
@@ -3566,7 +3596,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join(cache_path));
 }
 
-void ScriptEditor::_help_class_open(const String &p_class) {
+void DocumentEditorContainer::_help_class_open(const String &p_class) {
 	if (p_class.is_empty()) {
 		return;
 	}
@@ -3582,8 +3612,8 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 
 	EditorHelp *eh = memnew(EditorHelp);
 
-	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-	eh->connect("_request_save_new_history", callable_mp(this, &ScriptEditor::_save_new_history).bind(eh));
+	eh->connect("go_to_help", callable_mp(this, &DocumentEditorContainer::_help_class_goto));
+	eh->connect("_request_save_new_history", callable_mp(this, &DocumentEditorContainer::_save_new_history).bind(eh));
 
 	// Go to the class first, so it has a class name when switching to it.
 	ScriptEditorNavigationMarker::get_singleton()->locate_begin();
@@ -3598,7 +3628,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	_save_layout();
 }
 
-void ScriptEditor::_help_class_goto(const String &p_desc) {
+void DocumentEditorContainer::_help_class_goto(const String &p_desc) {
 	const String cname = p_desc.get_slicec(':', 1);
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -3615,8 +3645,8 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 
 	EditorHelp *eh = memnew(EditorHelp);
 
-	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-	eh->connect("_request_save_new_history", callable_mp(this, &ScriptEditor::_save_new_history).bind(eh));
+	eh->connect("go_to_help", callable_mp(this, &DocumentEditorContainer::_help_class_goto));
+	eh->connect("_request_save_new_history", callable_mp(this, &DocumentEditorContainer::_save_new_history).bind(eh));
 
 	ScriptEditorNavigationMarker::get_singleton()->locate_begin();
 	eh->go_to_help(p_desc);
@@ -3630,7 +3660,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_save_layout();
 }
 
-void ScriptEditor::update_doc(const String &p_name) {
+void DocumentEditorContainer::update_doc(const String &p_name) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 		if (eh && eh->get_class() == p_name) {
@@ -3640,7 +3670,7 @@ void ScriptEditor::update_doc(const String &p_name) {
 	}
 }
 
-void ScriptEditor::clear_docs_from_script(const Ref<Script> &p_script) {
+void DocumentEditorContainer::clear_docs_from_script(const Ref<Script> &p_script) {
 	ERR_FAIL_COND(p_script.is_null());
 
 	for (const DocData::ClassDoc &cd : p_script->get_documentation()) {
@@ -3650,7 +3680,7 @@ void ScriptEditor::clear_docs_from_script(const Ref<Script> &p_script) {
 	}
 }
 
-void ScriptEditor::update_docs_from_script(const Ref<Script> &p_script) {
+void DocumentEditorContainer::update_docs_from_script(const Ref<Script> &p_script) {
 	ERR_FAIL_COND(p_script.is_null());
 
 	for (const DocData::ClassDoc &cd : p_script->get_documentation()) {
@@ -3659,7 +3689,7 @@ void ScriptEditor::update_docs_from_script(const Ref<Script> &p_script) {
 	}
 }
 
-void ScriptEditor::_update_selected_editor_menu() {
+void DocumentEditorContainer::_update_selected_editor_menu() {
 	for (ScriptEditorBase::EditMenusBase *editor_menu : editor_menus) {
 		editor_menu->set_visible(editor_menu->handles(_get_current_editor()));
 	}
@@ -3685,7 +3715,7 @@ void ScriptEditor::_update_selected_editor_menu() {
 	}
 }
 
-void ScriptEditor::_update_history_pos(int p_new_pos) {
+void DocumentEditorContainer::_update_history_pos(int p_new_pos) {
 	Node *n = tab_container->get_current_tab_control();
 	history_pos = p_new_pos;
 	tab_container->set_current_tab(tab_container->get_tab_idx_from_control(history[history_pos].control));
@@ -3700,7 +3730,7 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 		Ref<Script> scr = seb->get_edited_resource();
 		if (scr.is_valid()) {
-			notify_script_changed(scr);
+			ScriptEditor::get_singleton()->notify_script_changed(scr);
 		}
 
 		seb->validate_script();
@@ -3715,7 +3745,7 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 	_update_history_arrows();
 }
 
-void ScriptEditor::_history_forward() {
+void DocumentEditorContainer::_history_forward() {
 	if (history_pos < history.size() - 1) {
 		ScriptEditorNavigationMarker::get_singleton()->traverse_begin();
 		_update_history_pos(history_pos + 1);
@@ -3723,7 +3753,7 @@ void ScriptEditor::_history_forward() {
 	}
 }
 
-void ScriptEditor::_history_back() {
+void DocumentEditorContainer::_history_back() {
 	if (history_pos > 0) {
 		ScriptEditorNavigationMarker::get_singleton()->traverse_begin();
 		_update_history_pos(history_pos - 1);
@@ -3731,7 +3761,7 @@ void ScriptEditor::_history_back() {
 	}
 }
 
-void ScriptEditor::_roll_back_to_pre_tab() {
+void DocumentEditorContainer::_roll_back_to_pre_tab() {
 	Control *tselected = tab_container->get_current_tab_control();
 	if (history_pos == -1 || history[history_pos].control != tselected) {
 		return;
@@ -3754,7 +3784,7 @@ void ScriptEditor::_roll_back_to_pre_tab() {
 	}
 }
 
-Vector<Ref<Script>> ScriptEditor::get_open_scripts() const {
+Vector<Ref<Script>> DocumentEditorContainer::get_open_scripts() const {
 	Vector<Ref<Script>> out_scripts = Vector<Ref<Script>>();
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -3772,7 +3802,7 @@ Vector<Ref<Script>> ScriptEditor::get_open_scripts() const {
 	return out_scripts;
 }
 
-ScriptEditorBase *ScriptEditor::get_resource_editor(const Ref<Resource> &p_res) const {
+ScriptEditorBase *DocumentEditorContainer::get_resource_editor(const Ref<Resource> &p_res) const {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (seb && seb->get_edited_resource() == p_res) {
@@ -3782,17 +3812,7 @@ ScriptEditorBase *ScriptEditor::get_resource_editor(const Ref<Resource> &p_res) 
 	return nullptr;
 }
 
-TypedArray<ScriptEditorBase> ScriptEditor::_get_open_script_editors() const {
-	TypedArray<ScriptEditorBase> script_editors;
-	for (int i = 0; i < tab_container->get_tab_count(); i++) {
-		if (ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i))) {
-			script_editors.push_back(seb);
-		}
-	}
-	return script_editors;
-}
-
-void ScriptEditor::set_scene_root_script(Ref<Script> p_script) {
+void DocumentEditorContainer::set_scene_root_script(Ref<Script> p_script) {
 	// Don't open dominant script if using an external editor.
 	bool use_external_editor =
 			external_editor_active ||
@@ -3805,7 +3825,7 @@ void ScriptEditor::set_scene_root_script(Ref<Script> p_script) {
 	}
 }
 
-bool ScriptEditor::script_goto_method(Ref<Script> p_script, const String &p_method) {
+bool DocumentEditorContainer::script_goto_method(Ref<Script> p_script, const String &p_method) {
 	int line = p_script->get_member_line(p_method);
 
 	if (line == -1) {
@@ -3815,11 +3835,11 @@ bool ScriptEditor::script_goto_method(Ref<Script> p_script, const String &p_meth
 	return edit(p_script, line, 0);
 }
 
-void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {
+void DocumentEditorContainer::set_live_auto_reload_running_scripts(bool p_enabled) {
 	auto_reload_running_scripts = p_enabled;
 }
 
-void ScriptEditor::_calculate_script_name_button_size() {
+void DocumentEditorContainer::_calculate_script_name_button_size() {
 	Ref<Font> font = script_name_button->get_theme_font(SceneStringName(font), SNAME("Button"));
 	HorizontalAlignment alignment = script_name_button->get_text_alignment();
 	int font_size = script_name_button->get_theme_font_size(SceneStringName(font_size), SNAME("Button"));
@@ -3832,7 +3852,7 @@ void ScriptEditor::_calculate_script_name_button_size() {
 	_calculate_script_name_button_ratio();
 }
 
-void ScriptEditor::_calculate_script_name_button_ratio() {
+void DocumentEditorContainer::_calculate_script_name_button_ratio() {
 	const float total_width = script_name_button_hbox->get_size().width;
 	if (total_width <= 0) {
 		return;
@@ -3849,7 +3869,7 @@ void ScriptEditor::_calculate_script_name_button_ratio() {
 	script_name_button_right_spacer->set_stretch_ratio(ratio_left / 2);
 }
 
-void ScriptEditor::_update_document_name_button() {
+void DocumentEditorContainer::_update_document_name_button() {
 	if (tab_container->get_current_tab() >= 0) {
 		const String &name = tab_container->get_tab_title(tab_container->get_current_tab());
 		script_name_button->set_text(name);
@@ -3861,11 +3881,11 @@ void ScriptEditor::_update_document_name_button() {
 	}
 }
 
-void ScriptEditor::_help_search(const String &p_text) {
-	script_editor->help_search_dialog->popup_dialog(p_text);
+void DocumentEditorContainer::_help_search(const String &p_text) {
+	ScriptEditor::get_singleton()->open_help_search_dialog(p_text);
 }
 
-void ScriptEditor::register_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
+void DocumentEditorContainer::register_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
 	ERR_FAIL_COND(p_syntax_highlighter.is_null());
 
 	if (!syntax_highlighters.has(p_syntax_highlighter)) {
@@ -3873,21 +3893,21 @@ void ScriptEditor::register_syntax_highlighter(const Ref<EditorSyntaxHighlighter
 	}
 }
 
-void ScriptEditor::unregister_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
+void DocumentEditorContainer::unregister_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
 	ERR_FAIL_COND(p_syntax_highlighter.is_null());
 
 	syntax_highlighters.erase(p_syntax_highlighter);
 }
 
-int ScriptEditor::script_editor_func_count = 0;
-CreateScriptEditorFunc ScriptEditor::script_editor_funcs[ScriptEditor::SCRIPT_EDITOR_FUNC_MAX];
+int DocumentEditorContainer::script_editor_func_count = 0;
+CreateScriptEditorFunc DocumentEditorContainer::script_editor_funcs[DocumentEditorContainer::SCRIPT_EDITOR_FUNC_MAX];
 
-void ScriptEditor::register_create_script_editor_function(CreateScriptEditorFunc p_func) {
+void DocumentEditorContainer::register_create_script_editor_function(CreateScriptEditorFunc p_func) {
 	ERR_FAIL_COND(script_editor_func_count == SCRIPT_EDITOR_FUNC_MAX);
 	script_editor_funcs[script_editor_func_count++] = p_func;
 }
 
-void ScriptEditor::_validation_updated() {
+void DocumentEditorContainer::_validation_updated() {
 	document_list->update_list();
 
 	document_outline->update_outline();
@@ -3903,7 +3923,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_editor_data().get_editor_by_name("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);
-			if (ShaderTextEditor *shader_te = Object::cast_to<ShaderTextEditor>(ScriptEditor::get_bottom_script_editor()->get_resource_editor(res))) {
+			if (ShaderTextEditor *shader_te = Object::cast_to<ShaderTextEditor>(shader_editor->get_shader_container()->get_resource_editor(res))) {
 				shader_te->goto_line_selection(line_number - 1, begin, end);
 			}
 			ScriptEditorNavigationMarker::get_singleton()->locate_end();
@@ -3938,7 +3958,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 				Ref<Script> scr = ResourceLoader::load(fpath + "::" + script_id, "Script");
 				if (scr.is_valid()) {
 					edit(scr);
-					ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+					ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(get_current_editor());
 
 					if (ste) {
 						callable_mp(EditorInterface::get_singleton(), &EditorInterface::set_main_screen_editor).call_deferred("Script");
@@ -3960,7 +3980,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 			if (scr.is_valid() || json.is_valid()) {
 				edit(scr);
 
-				ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+				ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(get_current_editor());
 				if (ste) {
 					EditorInterface::get_singleton()->set_main_screen_editor("Script");
 					ste->goto_line_selection(line_number - 1, begin, end);
@@ -3972,12 +3992,9 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 	}
 
 	// If the file is not a valid resource/script, load it as a text file.
-	Error err;
-	Ref<TextFile> text_file = _load_text_file(fpath, &err);
+	Ref<Resource> text_file = script_container->open_file(fpath);
 	if (text_file.is_valid()) {
-		edit(text_file);
-
-		TextEditor *te = Object::cast_to<TextEditor>(_get_current_editor());
+		TextEditor *te = Object::cast_to<TextEditor>(get_current_editor());
 		if (te) {
 			te->goto_line_selection(line_number - 1, begin, end);
 		}
@@ -3986,11 +4003,10 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 }
 
 void ScriptEditor::_on_find_in_files_modified_files() {
-	_test_script_times_on_disk();
-	_update_modified_scripts_for_external_editor();
+	script_container->reload_open_files();
 }
 
-void ScriptEditor::_set_script_zoom_factor(float p_zoom_factor) {
+void DocumentEditorContainer::_set_script_zoom_factor(float p_zoom_factor) {
 	if (zoom_factor == p_zoom_factor) {
 		return;
 	}
@@ -3998,62 +4014,29 @@ void ScriptEditor::_set_script_zoom_factor(float p_zoom_factor) {
 	zoom_factor = p_zoom_factor;
 }
 
-void ScriptEditor::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor) {
+void DocumentEditorContainer::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor) {
 	if (p_code_text_editor && p_code_text_editor->is_visible_in_tree() && zoom_factor != p_code_text_editor->get_zoom_factor()) {
 		p_code_text_editor->set_zoom_factor(zoom_factor);
 	}
 }
 
-void ScriptEditor::_floating_state_changed(bool p_floating) {
+void DocumentEditorContainer::_floating_state_changed(bool p_floating) {
 	make_floating->set_visible(!p_floating);
 	is_floating = p_floating;
 }
 
-void ScriptEditor::_bind_methods() {
-	ClassDB::bind_method("get_current_editor", &ScriptEditor::_get_current_editor);
-	ClassDB::bind_method("get_open_script_editors", &ScriptEditor::_get_open_script_editors);
-	ClassDB::bind_method("get_breakpoints", &ScriptEditor::_get_breakpoints);
-
-	ClassDB::bind_method(D_METHOD("register_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::register_syntax_highlighter);
-	ClassDB::bind_method(D_METHOD("unregister_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::unregister_syntax_highlighter);
-
-	ClassDB::bind_method(D_METHOD("goto_line", "line_number"), &ScriptEditor::_goto_script_line2);
-	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
-	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
-	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
-	ClassDB::bind_method(D_METHOD("reload_open_files"), &ScriptEditor::reload_open_files);
-
-	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
-	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
-	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
-
-	ClassDB::bind_method(D_METHOD("get_unsaved_files"), &ScriptEditor::get_unsaved_files);
-
-	ClassDB::bind_method(D_METHOD("save_all_scripts"), &ScriptEditor::save_all_scripts);
-	ClassDB::bind_method(D_METHOD("close_file", "path"), &ScriptEditor::close_file);
-
-	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));
-	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));
+void DocumentEditorContainer::_make_floating(int p_screen) {
+	emit_signal("make_floating", p_screen);
 }
 
-ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache_path, WindowWrapper *p_wrapper, EditorDock *p_dock) {
+void DocumentEditorContainer::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("make_floating", PropertyInfo(Variant::INT, "screen")));
+}
+
+DocumentEditorContainer::DocumentEditorContainer(bool p_is_main_editor, const String &p_config_section, const String &p_cache_path) {
+	is_main_editor = p_is_main_editor;
 	config_section = p_config_section;
 	cache_path = p_cache_path;
-	// The main editor uses WindowWrapper while the shader editor uses EditorDock.
-	if (p_wrapper) {
-		script_editor = this;
-	} else {
-		bottom_script_editor = this;
-	}
-
-	make_floating = memnew(ScreenSelect);
-	make_floating->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-
-	if (p_wrapper) {
-		make_floating->connect("request_open_in_screen", callable_mp(p_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
-	} else if (p_dock) {
-		make_floating->connect("request_open_in_screen", callable_mp(p_dock, &EditorDock::make_floating));
-	}
 
 	script_editor_cache.instantiate();
 	script_editor_cache->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join(cache_path));
@@ -4151,18 +4134,18 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	file_menu->set_text(TTRC("File"));
 	file_menu->set_switch_on_hover(true);
 	file_menu->set_shortcut_context(this);
-	file_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_menu_option));
-	file_menu->get_popup()->connect("about_to_popup", callable_mp(this, &ScriptEditor::_prepare_file_menu));
-	file_menu->get_popup()->connect("popup_hide", callable_mp(this, &ScriptEditor::_file_menu_closed));
+	file_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &DocumentEditorContainer::_menu_option));
+	file_menu->get_popup()->connect("about_to_popup", callable_mp(this, &DocumentEditorContainer::_prepare_file_menu));
+	file_menu->get_popup()->connect("popup_hide", callable_mp(this, &DocumentEditorContainer::_file_menu_closed));
 	menu_hb->add_child(file_menu);
 
 	recent_scripts = memnew(PopupMenu);
 	recent_scripts->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	recent_scripts->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_open_recent_script));
+	recent_scripts->connect(SceneStringName(id_pressed), callable_mp(this, &DocumentEditorContainer::_open_recent_script));
 	_update_recent_scripts();
 
 	theme_submenu = memnew(PopupMenu);
-	theme_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_theme_option));
+	theme_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &DocumentEditorContainer::_theme_option));
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/import_theme", TTRC("Import Theme...")), THEME_IMPORT);
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/reload_theme", TTRC("Reload Theme")), THEME_RELOAD);
 	theme_submenu->add_separator();
@@ -4174,12 +4157,12 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	script_search_menu->set_text(TTRC("Search"));
 	script_search_menu->set_switch_on_hover(true);
 	script_search_menu->set_shortcut_context(this);
-	script_search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ScriptEditor::_menu_option));
+	script_search_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &DocumentEditorContainer::_menu_option));
 	menu_hb->add_child(script_search_menu);
 
 	_setup_popup_menu(file_menu->get_popup(), false);
 
-	if (this == script_editor) {
+	if (is_main_editor) {
 		MenuButton *debug_menu_btn = memnew(MenuButton);
 		debug_menu_btn->set_flat(false);
 		debug_menu_btn->set_theme_type_variation("FlatMenuButton");
@@ -4188,17 +4171,17 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 
 		EditorDebuggerNode *debugger = EditorDebuggerNode::get_singleton();
 		debugger->set_script_debug_button(debug_menu_btn);
-		debugger->connect("goto_script_line", callable_mp(this, &ScriptEditor::_goto_script_line));
-		debugger->connect("set_execution", callable_mp(this, &ScriptEditor::_set_execution));
-		debugger->connect("clear_execution", callable_mp(this, &ScriptEditor::_clear_execution));
-		debugger->connect("breakpoint_set_in_tree", callable_mp(this, &ScriptEditor::_set_breakpoint));
-		debugger->connect("breakpoints_cleared_in_tree", callable_mp(this, &ScriptEditor::_clear_breakpoints));
+		debugger->connect("goto_script_line", callable_mp(this, &DocumentEditorContainer::_goto_script_line));
+		debugger->connect("set_execution", callable_mp(this, &DocumentEditorContainer::_set_execution));
+		debugger->connect("clear_execution", callable_mp(this, &DocumentEditorContainer::_clear_execution));
+		debugger->connect("breakpoint_set_in_tree", callable_mp(this, &DocumentEditorContainer::_set_breakpoint));
+		debugger->connect("breakpoints_cleared_in_tree", callable_mp(this, &DocumentEditorContainer::_clear_breakpoints));
 	}
 
 	script_name_button_hbox = memnew(HBoxContainer);
 	script_name_button_hbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	script_name_button_hbox->add_theme_constant_override("separation", 0);
-	script_name_button_hbox->connect(SceneStringName(item_rect_changed), callable_mp(this, &ScriptEditor::_calculate_script_name_button_ratio));
+	script_name_button_hbox->connect(SceneStringName(item_rect_changed), callable_mp(this, &DocumentEditorContainer::_calculate_script_name_button_ratio));
 	menu_hb->add_child(script_name_button_hbox);
 
 	script_name_button_left_spacer = memnew(Control);
@@ -4220,14 +4203,14 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	site_search = memnew(Button);
 	site_search->set_theme_type_variation(SceneStringName(FlatButton));
 	site_search->set_accessibility_name(TTRC("Site Search"));
-	site_search->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_menu_option).bind(SEARCH_WEBSITE));
+	site_search->connect(SceneStringName(pressed), callable_mp(this, &DocumentEditorContainer::_menu_option).bind(SEARCH_WEBSITE));
 	menu_hb->add_child(site_search);
 
-	if (this == script_editor) {
+	if (is_main_editor) {
 		help_search = memnew(Button);
 		help_search->set_theme_type_variation(SceneStringName(FlatButton));
 		help_search->set_text(TTRC("Search Help"));
-		help_search->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_menu_option).bind(SEARCH_HELP));
+		help_search->connect(SceneStringName(pressed), callable_mp(this, &DocumentEditorContainer::_menu_option).bind(SEARCH_HELP));
 		menu_hb->add_child(help_search);
 		help_search->set_tooltip_text(TTRC("Search the reference documentation."));
 	}
@@ -4240,7 +4223,7 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	script_back->set_shortcut(ED_GET_SHORTCUT("script_editor/history_previous"));
 	script_back->set_disabled(true);
 	menu_hb->add_child(script_back);
-	script_back->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_back));
+	script_back->connect(SceneStringName(pressed), callable_mp(this, &DocumentEditorContainer::_history_back));
 
 	script_forward = memnew(Button);
 	script_forward->set_theme_type_variation(SceneStringName(FlatButton));
@@ -4248,34 +4231,38 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	script_forward->set_shortcut(ED_GET_SHORTCUT("script_editor/history_next"));
 	script_forward->set_disabled(true);
 	menu_hb->add_child(script_forward);
-	script_forward->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_forward));
+	script_forward->connect(SceneStringName(pressed), callable_mp(this, &DocumentEditorContainer::_history_forward));
 
 	menu_hb->add_child(memnew(VSeparator));
+
+	make_floating = memnew(ScreenSelect);
+	make_floating->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	make_floating->connect("request_open_in_screen", callable_mp(this, &DocumentEditorContainer::_make_floating));
 	menu_hb->add_child(make_floating);
 
-	tab_container->connect("tab_changed", callable_mp(this, &ScriptEditor::ensure_select_current).unbind(1));
+	tab_container->connect("tab_changed", callable_mp(this, &DocumentEditorContainer::ensure_select_current).unbind(1));
 
 	erase_tab_confirm = memnew(ConfirmationDialog);
 	erase_tab_confirm->set_flag(Window::FLAG_RESIZE_DISABLED, true);
 	erase_tab_confirm->set_ok_button_text(TTRC("Save"));
 	erase_tab_confirm->add_button(TTRC("Discard"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "discard");
-	erase_tab_confirm->connect(SceneStringName(confirmed), callable_mp(this, &ScriptEditor::_close_current_tab).bind(true));
-	erase_tab_confirm->connect("custom_action", callable_mp(this, &ScriptEditor::_close_discard_current_tab));
+	erase_tab_confirm->connect(SceneStringName(confirmed), callable_mp(this, &DocumentEditorContainer::_close_current_tab).bind(true));
+	erase_tab_confirm->connect("custom_action", callable_mp(this, &DocumentEditorContainer::_close_discard_current_tab));
 	add_child(erase_tab_confirm);
 
 	script_create_dialog = memnew(ScriptCreateDialog);
 	script_create_dialog->set_title(TTRC("Create Script"));
 	add_child(script_create_dialog);
-	script_create_dialog->connect("script_created", callable_mp(this, &ScriptEditor::_resource_created));
+	script_create_dialog->connect("script_created", callable_mp(this, &DocumentEditorContainer::_resource_created));
 
 	file_dialog_option = -1;
 	file_dialog = memnew(EditorFileDialog);
 	add_child(file_dialog);
-	file_dialog->connect("file_selected", callable_mp(this, &ScriptEditor::_file_dialog_action));
+	file_dialog->connect("file_selected", callable_mp(this, &DocumentEditorContainer::_file_dialog_action));
 
 	shader_create_dialog = memnew(ShaderCreateDialog);
-	shader_create_dialog->connect("shader_created", callable_mp(this, &ScriptEditor::_resource_created));
-	shader_create_dialog->connect("shader_include_created", callable_mp(this, &ScriptEditor::_resource_created));
+	shader_create_dialog->connect("shader_created", callable_mp(this, &DocumentEditorContainer::_resource_created));
+	shader_create_dialog->connect("shader_include_created", callable_mp(this, &DocumentEditorContainer::_resource_created));
 	add_child(shader_create_dialog);
 
 	error_dialog = memnew(AcceptDialog);
@@ -4303,30 +4290,20 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 		what_action_label->set_text(TTRC("What action should be taken?"));
 		vbc->add_child(what_action_label);
 
-		disk_changed->connect(SceneStringName(confirmed), callable_mp(this, &ScriptEditor::reload_scripts).bind(false));
+		disk_changed->connect(SceneStringName(confirmed), callable_mp(this, &DocumentEditorContainer::reload_scripts).bind(false));
 		disk_changed->set_ok_button_text(TTRC("Reload from disk"));
 
 		disk_changed->add_button(TTRC("Ignore external changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
-		disk_changed->connect("custom_action", callable_mp(this, &ScriptEditor::_resave_scripts));
+		disk_changed->connect("custom_action", callable_mp(this, &DocumentEditorContainer::_resave_scripts));
 	}
 
 	add_child(disk_changed);
 
 	autosave_timer = memnew(Timer);
 	autosave_timer->set_one_shot(false);
-	autosave_timer->connect(SceneStringName(tree_entered), callable_mp(this, &ScriptEditor::_update_autosave_timer));
-	autosave_timer->connect("timeout", callable_mp(this, &ScriptEditor::_autosave_scripts));
+	autosave_timer->connect(SceneStringName(tree_entered), callable_mp(this, &DocumentEditorContainer::_update_autosave_timer));
+	autosave_timer->connect("timeout", callable_mp(this, &DocumentEditorContainer::_autosave_scripts));
 	add_child(autosave_timer);
-
-	if (this == script_editor) {
-		help_search_dialog = memnew(EditorHelpSearch);
-		add_child(help_search_dialog);
-		help_search_dialog->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
-
-		find_in_files = memnew(FindInFiles);
-		find_in_files->connect("result_selected", callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
-		find_in_files->connect("files_modified", callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
-	}
 
 	history_pos = -1;
 
@@ -4353,11 +4330,108 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	register_syntax_highlighter(gdshader_syntax_highlighter);
 }
 
+void ScriptEditor::_goto_line(int p_line) {
+	TextEditorBase *teb = Object::cast_to<TextEditorBase>(get_current_editor());
+	if (teb) {
+		ScriptEditorNavigationMarker::get_singleton()->locate_begin();
+		teb->goto_line(p_line);
+		ScriptEditorNavigationMarker::get_singleton()->locate_end();
+	}
+}
+
+TypedArray<ScriptEditorBase> ScriptEditor::_get_open_script_editors() const {
+	TypedArray<ScriptEditorBase> script_editors;
+	for (Control *editor : script_container->get_all_editors()) {
+		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(editor);
+		if (seb) {
+			script_editors.push_back(seb);
+		}
+	}
+	return script_editors;
+}
+
+Ref<Script> ScriptEditor::_get_current_script() {
+	ScriptEditorBase *seb = get_current_editor();
+	if (seb) {
+		Ref<Script> scr = seb->get_edited_resource();
+		return scr.is_valid() ? scr : nullptr;
+	} else {
+		return nullptr;
+	}
+}
+
+TypedArray<Script> ScriptEditor::_get_open_scripts() const {
+	TypedArray<Script> ret;
+	Vector<Ref<Script>> scripts = get_open_scripts();
+	for (const Ref<Script> &script : scripts) {
+		ret.push_back(script);
+	}
+	return ret;
+}
+
+void ScriptEditor::notify_script_close(const Ref<Script> &p_script) {
+	emit_signal(SNAME("script_close"), p_script);
+}
+
+void ScriptEditor::notify_script_changed(const Ref<Script> &p_script) {
+	emit_signal(SNAME("editor_script_changed"), p_script);
+}
+
+void ScriptEditor::open_find_in_files_dialog(const String &p_initial_text, bool p_replace) {
+	find_in_files->open_dialog(p_initial_text, p_replace);
+}
+
+void ScriptEditor::open_help_search_dialog(const String &p_search_text) {
+	help_search_dialog->popup_dialog(p_search_text);
+}
+
+void ScriptEditor::_bind_methods() {
+	ClassDB::bind_method("get_current_editor", &ScriptEditor::get_current_editor);
+	ClassDB::bind_method("get_open_script_editors", &ScriptEditor::_get_open_script_editors);
+	ClassDB::bind_method("get_breakpoints", &ScriptEditor::_get_breakpoints);
+
+	ClassDB::bind_method(D_METHOD("register_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::register_syntax_highlighter);
+	ClassDB::bind_method(D_METHOD("unregister_syntax_highlighter", "syntax_highlighter"), &ScriptEditor::unregister_syntax_highlighter);
+
+	ClassDB::bind_method(D_METHOD("goto_line", "line_number"), &ScriptEditor::_goto_line);
+	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
+	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
+	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
+	ClassDB::bind_method(D_METHOD("reload_open_files"), &ScriptEditor::reload_open_files);
+
+	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
+	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
+	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
+
+	ClassDB::bind_method(D_METHOD("get_unsaved_files"), &ScriptEditor::get_unsaved_files);
+
+	ClassDB::bind_method(D_METHOD("save_all_scripts"), &ScriptEditor::save_all_scripts);
+	ClassDB::bind_method(D_METHOD("close_file", "path"), &ScriptEditor::close_file);
+
+	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));
+	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static())));
+}
+
+ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
+	script_editor = this;
+
+	script_container = memnew(DocumentEditorContainer(true, "ScriptEditor", "script_editor_cache.cfg"));
+	script_container->set_handled_resource_types({ "GDScript", "Script", "JSON" });
+	script_container->connect("make_floating", callable_mp(p_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
+	add_child(script_container);
+
+	help_search_dialog = memnew(EditorHelpSearch);
+	add_child(help_search_dialog);
+	help_search_dialog->connect("go_to_help", callable_mp(script_container, &DocumentEditorContainer::goto_help));
+
+	find_in_files = memnew(FindInFiles);
+	find_in_files->connect("result_selected", callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
+	find_in_files->connect("files_modified", callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
+}
+
 ScriptEditor::~ScriptEditor() {
 	ScriptEditorNavigationMarker::release_singleton();
-	if (this == script_editor) {
-		memdelete(find_in_files);
-	}
+	memdelete(find_in_files);
 }
 
 void ScriptEditorPlugin::_focus_another_editor() {
@@ -4375,7 +4449,12 @@ void ScriptEditorPlugin::_save_last_editor(const String &p_editor) {
 
 void ScriptEditorPlugin::_window_visibility_changed(bool p_visible) {
 	_focus_another_editor();
-	if (p_visible) {
+	_update_theme();
+}
+
+void ScriptEditorPlugin::_update_theme() {
+	// ScriptEditor cannot assign style overrides to itself on its theme changed notification.
+	if (script_editor->is_editor_floating()) {
 		script_editor->add_theme_style_override(SceneStringName(panel), script_editor->get_theme_stylebox("ScriptEditorPanelFloating", EditorStringName(EditorStyles)));
 	} else {
 		script_editor->add_theme_style_override(SceneStringName(panel), script_editor->get_theme_stylebox("ScriptEditorPanel", EditorStringName(EditorStyles)));
@@ -4598,8 +4677,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	window_wrapper = memnew(WindowWrapper);
 	window_wrapper->set_margins_enabled(true);
 
-	script_editor = memnew(ScriptEditor("ScriptEditor", "script_editor_cache.cfg", window_wrapper));
-	script_editor->set_handled_resource_types({ "GDScript", "Script", "JSON" });
+	script_editor = memnew(ScriptEditor(window_wrapper));
 	Ref<Shortcut> make_floating_shortcut = ED_SHORTCUT_AND_COMMAND("script_editor/make_floating", TTRC("Make Floating"));
 	window_wrapper->set_wrapped_control(script_editor, make_floating_shortcut);
 
@@ -4607,6 +4685,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 	window_wrapper->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	window_wrapper->hide();
 	window_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditorPlugin::_window_visibility_changed));
+	EditorNode::get_singleton()->get_gui_base()->connect(SceneStringName(theme_changed), callable_mp(this, &ScriptEditorPlugin::_update_theme));
 
 	ScriptServer::set_reload_scripts_on_save(EDITOR_GET("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save"));
 }

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -34,6 +34,7 @@
 #include "core/object/script_language.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/script/script_editor_base.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/panel_container.h"
 #include "scene/resources/text_file.h"
 
@@ -90,7 +91,7 @@ class DocumentList : public VBoxContainer {
 	LineEdit *filter = nullptr;
 	PopupMenu *context_menu = nullptr;
 
-	ScriptEditor *script_editor;
+	DocumentEditorContainer *document_editor_container;
 
 	bool script_temperature_enabled = false;
 	int temperature_history_size = 0;
@@ -114,13 +115,13 @@ public:
 	void goto_next_document(bool p_previous = false);
 	void update_editor_settings();
 
-	DocumentList(ScriptEditor *p_script_editor);
+	DocumentList(DocumentEditorContainer *p_document_editor_container);
 };
 
 class DocumentOutline : public VBoxContainer {
 	GDCLASS(DocumentOutline, VBoxContainer);
 
-	ScriptEditor *script_editor = nullptr;
+	DocumentEditorContainer *document_editor_container = nullptr;
 	ItemList *item_list = nullptr;
 	HBoxContainer *buttons_hbox = nullptr;
 	FilterLineEdit *filter = nullptr;
@@ -140,7 +141,7 @@ public:
 	void update_outline();
 	void update_visibility();
 
-	DocumentOutline(ScriptEditor *p_script_editor);
+	DocumentOutline(DocumentEditorContainer *p_document_editor_container);
 };
 
 class EditorScriptCodeCompletionCache;
@@ -148,8 +149,8 @@ class FindInFiles;
 class TextFile;
 class ShaderCreateDialog;
 
-class ScriptEditor : public PanelContainer {
-	GDCLASS(ScriptEditor, PanelContainer);
+class DocumentEditorContainer : public MarginContainer {
+	GDCLASS(DocumentEditorContainer, MarginContainer);
 
 	enum MenuOptions {
 		// File.
@@ -238,7 +239,6 @@ class ScriptEditor : public PanelContainer {
 	Button *site_search = nullptr;
 	Button *make_floating = nullptr;
 	bool is_floating = false;
-	EditorHelpSearch *help_search_dialog = nullptr;
 
 	friend class DocumentList;
 
@@ -272,8 +272,6 @@ class ScriptEditor : public PanelContainer {
 	Button *script_back = nullptr;
 	Button *script_forward = nullptr;
 
-	FindInFiles *find_in_files = nullptr;
-
 	WindowWrapper *window_wrapper = nullptr;
 
 #ifdef ANDROID_ENABLED
@@ -305,6 +303,8 @@ class ScriptEditor : public PanelContainer {
 	bool grab_focus_block = false;
 
 	int edit_pass = 0;
+
+	bool is_main_editor = false;
 
 	void _menu_option(int p_option);
 	void _theme_option(int p_option);
@@ -359,7 +359,6 @@ class ScriptEditor : public PanelContainer {
 	bool convert_indent_on_save;
 	bool external_editor_active;
 
-	void _goto_script_line2(int p_line);
 	void _goto_script_line(Ref<RefCounted> p_script, int p_line);
 	void _change_execution(Ref<RefCounted> p_script, int p_line = -1, bool p_set = false);
 	void _set_execution(Ref<RefCounted> p_script, int p_line) { _change_execution(p_script, p_line, true); }
@@ -371,7 +370,6 @@ class ScriptEditor : public PanelContainer {
 	Array _get_cached_breakpoints_for_script(const String &p_path) const;
 
 	ScriptEditorBase *_get_current_editor() const;
-	TypedArray<ScriptEditorBase> _get_open_script_editors() const;
 
 	Ref<ConfigFile> script_editor_cache;
 	String cache_path;
@@ -408,7 +406,7 @@ class ScriptEditor : public PanelContainer {
 	void _calculate_script_name_button_ratio();
 	void _update_document_name_button();
 
-	void _help_search(const String &p_text);
+	void _help_search(const String &p_text = String());
 
 	void _history_forward();
 	void _history_back();
@@ -428,9 +426,6 @@ class ScriptEditor : public PanelContainer {
 	int file_dialog_option;
 	void _file_dialog_action(const String &p_file);
 
-	Ref<Script> _get_current_script();
-	TypedArray<Script> _get_open_scripts() const;
-
 	String config_section;
 
 	HashSet<String> handled_resource_types;
@@ -439,32 +434,23 @@ class ScriptEditor : public PanelContainer {
 	Ref<TextFile> _load_text_file(const String &p_path, Error *r_error) const;
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);
 
-	void _on_find_in_files_result_selected(const String &p_path, int p_line_number, int p_begin, int p_end);
-	void _on_find_in_files_modified_files();
-
 	void _set_script_zoom_factor(float p_zoom_factor);
 	void _update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor);
 
 	void _floating_state_changed(bool p_floating);
+	void _make_floating(int p_screen);
 
 	void _close_builtin_scripts_from_scene(const String &p_scene);
-
-	inline static ScriptEditor *script_editor = nullptr;
-	inline static ScriptEditor *bottom_script_editor = nullptr;
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	static ScriptEditor *get_singleton() { return script_editor; }
-	static ScriptEditor *get_bottom_script_editor() { return bottom_script_editor; }
-
 	bool toggle_files_panel();
 	bool is_files_panel_toggled();
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
-	void open_find_in_files_dialog(const String &p_initial_text = "", bool p_replace = false);
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);
@@ -475,12 +461,13 @@ public:
 
 	bool is_editor_floating();
 
-	void set_handled_resource_types(HashSet<String> p_file_types) { handled_resource_types = p_file_types; }
+	void set_handled_resource_types(const HashSet<String> &p_file_types) { handled_resource_types = p_file_types; }
 
 	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
 	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);
 
 	Control *get_active_editor() const;
+	Vector<Control *> get_all_editors() const;
 
 	Vector<String> _get_breakpoints();
 	void get_breakpoints(List<String> *p_breakpoints);
@@ -506,17 +493,12 @@ public:
 
 	virtual void edited_scene_changed();
 
-	void notify_script_close(const Ref<Script> &p_script);
-	void notify_script_changed(const Ref<Script> &p_script);
-
 	void goto_help(const String &p_desc) { _help_class_goto(p_desc); }
 	void update_doc(const String &p_name);
 	void clear_docs_from_script(const Ref<Script> &p_script);
 	void update_docs_from_script(const Ref<Script> &p_script);
 
 	void trigger_live_script_reload(const String &p_script_path);
-
-	VSplitContainer *get_left_list_split() { return list_split; }
 
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 
@@ -525,7 +507,98 @@ public:
 
 	static void register_create_script_editor_function(CreateScriptEditorFunc p_func);
 
-	ScriptEditor(const String &p_config_section, const String &p_cache_path, WindowWrapper *p_wrapper = nullptr, EditorDock *p_dock = nullptr);
+	DocumentEditorContainer(bool p_is_main_editor, const String &p_config_section, const String &p_cache_path);
+};
+
+class ScriptEditor : public PanelContainer {
+	GDCLASS(ScriptEditor, PanelContainer);
+
+	inline static ScriptEditor *script_editor = nullptr;
+
+	DocumentEditorContainer *script_container = nullptr;
+
+	EditorHelpSearch *help_search_dialog = nullptr;
+	FindInFiles *find_in_files = nullptr;
+
+	void _on_find_in_files_result_selected(const String &p_path, int p_line_number, int p_begin, int p_end);
+	void _on_find_in_files_modified_files();
+
+	TypedArray<ScriptEditorBase> _get_open_script_editors() const;
+	void _goto_line(int p_line);
+	Ref<Script> _get_current_script();
+	TypedArray<Script> _get_open_scripts() const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static ScriptEditor *get_singleton() { return script_editor; }
+
+	DocumentEditorContainer *get_script_container() { return script_container; }
+
+	bool toggle_files_panel() { return script_container->toggle_files_panel(); }
+	bool is_files_panel_toggled() { return script_container->is_files_panel_toggled(); }
+	void apply_scripts() const { script_container->apply_scripts(); }
+	void reload_scripts(bool p_refresh_only = false) { script_container->reload_scripts(p_refresh_only); }
+
+	void open_find_in_files_dialog(const String &p_initial_text = String(), bool p_replace = false);
+	void open_help_search_dialog(const String &p_search_text = String());
+
+	void open_script_create_dialog(const String &p_base_name, const String &p_base_path) { script_container->open_script_create_dialog(p_base_name, p_base_path); }
+	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "") { script_container->open_text_file_create_dialog(p_base_path, p_base_name); }
+	Ref<Resource> open_file(const String &p_file) { return script_container->open_file(p_file); }
+	Error close_file(const String &p_file) { return script_container->close_file(p_file); }
+
+	void ensure_select_current() { script_container->ensure_select_current(); }
+
+	bool is_editor_floating() { return script_container->is_editor_floating(); }
+
+	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
+	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true) { return script_container->edit(p_resource, p_line, p_col, p_grab_focus); }
+
+	Control *get_active_editor() const { return script_container->get_active_editor(); }
+
+	Vector<String> _get_breakpoints() { return script_container->_get_breakpoints(); }
+	void get_breakpoints(List<String> *p_breakpoints) { script_container->get_breakpoints(p_breakpoints); }
+
+	void reload_open_files() { script_container->reload_open_files(); }
+	PackedStringArray get_unsaved_files() const { return script_container->get_unsaved_files(); }
+	PackedStringArray get_unsaved_scripts() const { return script_container->get_unsaved_scripts(); }
+	void save_current_script() { script_container->save_current_script(); }
+	void save_all_scripts() { script_container->save_all_scripts(); }
+	void update_script_times() { script_container->update_script_times(); }
+
+	void set_window_layout(Ref<ConfigFile> p_layout) { script_container->set_window_layout(p_layout); }
+	void get_window_layout(Ref<ConfigFile> p_layout) { script_container->get_window_layout(p_layout); }
+
+	void set_scene_root_script(Ref<Script> p_script) { script_container->set_scene_root_script(p_script); }
+	Vector<Ref<Script>> get_open_scripts() const { return script_container->get_open_scripts(); }
+	ScriptEditorBase *get_resource_editor(const Ref<Resource> &p_res) const { return script_container->get_resource_editor(p_res); }
+
+	ScriptEditorBase *get_current_editor() const { return script_container->get_current_editor(); }
+
+	bool script_goto_method(Ref<Script> p_script, const String &p_method) { return script_container->script_goto_method(p_script, p_method); }
+
+	virtual void edited_scene_changed() { script_container->edited_scene_changed(); }
+
+	void notify_script_close(const Ref<Script> &p_script);
+	void notify_script_changed(const Ref<Script> &p_script);
+
+	void goto_help(const String &p_desc) { script_container->goto_help(p_desc); }
+	void update_doc(const String &p_name) { script_container->update_doc(p_name); }
+	void clear_docs_from_script(const Ref<Script> &p_script) { script_container->clear_docs_from_script(p_script); }
+	void update_docs_from_script(const Ref<Script> &p_script) { script_container->update_docs_from_script(p_script); }
+
+	void trigger_live_script_reload(const String &p_script_path) { script_container->trigger_live_script_reload(p_script_path); }
+
+	void set_live_auto_reload_running_scripts(bool p_enabled) { script_container->set_live_auto_reload_running_scripts(p_enabled); }
+
+	void register_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) { script_container->register_syntax_highlighter(p_syntax_highlighter); }
+	void unregister_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) { script_container->unregister_syntax_highlighter(p_syntax_highlighter); }
+
+	static void register_create_script_editor_function(CreateScriptEditorFunc p_func) { DocumentEditorContainer::register_create_script_editor_function(p_func); }
+
+	ScriptEditor(WindowWrapper *p_wrapper);
 	~ScriptEditor();
 };
 
@@ -541,6 +614,7 @@ class ScriptEditorPlugin : public EditorPlugin {
 
 	void _save_last_editor(const String &p_editor);
 	void _window_visibility_changed(bool p_visible);
+	void _update_theme();
 
 	static inline ScriptEditorPlugin *script_editor_plugin = nullptr;
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -149,7 +149,7 @@ void ScriptTextEditor::EditMenusScTE::EditMenusScTE::_update_breakpoint_list() {
 	breakpoints_menu->set_item_index(-1, 0);
 }
 
-ScriptTextEditor::EditMenusScTE::EditMenusScTE(ScriptEditor *p_se) : EditMenusCEB(p_se, "Breakpoints") {
+ScriptTextEditor::EditMenusScTE::EditMenusScTE(DocumentEditorContainer *p_document_editor_container) : EditMenusCEB(p_document_editor_container, "Breakpoints") {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/evaluate_selection"), EDIT_EVALUATE);
 	_popup_move_item(EDIT_DUPLICATE_LINES, edit_menu->get_popup());
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
@@ -1079,63 +1079,6 @@ static Node *_find_node_for_script(Node *p_base, Node *p_current, const Ref<Scri
 	}
 
 	return nullptr;
-}
-
-static void _find_changed_scripts_for_external_editor(Node *p_base, Node *p_current, HashSet<Ref<Script>> &r_scripts) {
-	if (p_current->get_owner() != p_base && p_base != p_current) {
-		return;
-	}
-	Ref<Script> c = p_current->get_script();
-
-	if (c.is_valid()) {
-		r_scripts.insert(c);
-	}
-
-	for (int i = 0; i < p_current->get_child_count(); i++) {
-		_find_changed_scripts_for_external_editor(p_base, p_current->get_child(i), r_scripts);
-	}
-}
-
-void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_for_script) {
-	bool use_external_editor = bool(EDITOR_GET("text_editor/external/use_external_editor"));
-
-	ERR_FAIL_NULL(get_tree());
-
-	HashSet<Ref<Script>> scripts;
-
-	Node *base = get_tree()->get_edited_scene_root();
-	if (base) {
-		_find_changed_scripts_for_external_editor(base, base, scripts);
-	}
-
-	for (const Ref<Script> &E : scripts) {
-		Ref<Script> scr = E;
-
-		if (!use_external_editor && !scr->get_language()->overrides_external_editor()) {
-			continue; // We're not using an external editor for this script.
-		}
-
-		if (p_for_script.is_valid() && p_for_script != scr) {
-			continue;
-		}
-
-		if (scr->is_built_in()) {
-			continue; //internal script, who cares, though weird
-		}
-
-		uint64_t last_date = scr->get_last_modified_time();
-		uint64_t date = FileAccess::get_modified_time(scr->get_path());
-
-		if (last_date != date) {
-			Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-			ERR_CONTINUE(rel_scr.is_null());
-			scr->set_source_code(rel_scr->get_source_code());
-			scr->set_last_modified_time(rel_scr->get_last_modified_time());
-			scr->update_exports();
-
-			trigger_live_script_reload(scr->get_path());
-		}
-	}
 }
 
 void ScriptTextEditor::_code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -135,7 +135,7 @@ class ScriptTextEditor : public CodeEditorBase {
 	public:
 		virtual bool handles(ScriptEditorBase *p_seb) override { return Object::cast_to<ScriptTextEditor>(p_seb); }
 
-		EditMenusScTE(ScriptEditor *p_se);
+		EditMenusScTE(DocumentEditorContainer *p_document_editor_container);
 	};
 
 	void _script_res_changed();
@@ -217,7 +217,7 @@ public:
 	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
 
-	virtual EditMenusBase *create_edit_menu(ScriptEditor *p_se) override { return memnew(EditMenusScTE(p_se)); }
+	virtual EditMenusBase *create_edit_menu(DocumentEditorContainer *p_document_editor_container) override { return memnew(EditMenusScTE(p_document_editor_container)); }
 
 	virtual Ref<Texture2D> get_theme_icon() override;
 

--- a/editor/script/text_editor.h
+++ b/editor/script/text_editor.h
@@ -46,7 +46,7 @@ protected:
 	public:
 		virtual bool handles(ScriptEditorBase *p_seb) override { return Object::cast_to<TextEditor>(p_seb); }
 
-		EditMenusTEB(ScriptEditor *p_se) : EditMenus(p_se) {}
+		EditMenusTEB(DocumentEditorContainer *p_document_editor_container) : EditMenus(p_document_editor_container) {}
 	};
 
 	virtual void _validate_script() override;
@@ -54,7 +54,7 @@ protected:
 public:
 	virtual void apply_code() override;
 
-	virtual EditMenusBase *create_edit_menu(ScriptEditor *p_se) override { return memnew(EditMenusTEB(p_se)); }
+	virtual EditMenusBase *create_edit_menu(DocumentEditorContainer *p_document_editor_container) override { return memnew(EditMenusTEB(p_document_editor_container)); }
 
 	static void register_editor();
 

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_editor_plugin.h"
 
+#include "core/object/callable_mp.h"
 #include "core/variant/variant.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/docks/editor_dock_manager.h"
@@ -60,7 +61,7 @@ void ShaderEditorPlugin::make_visible(bool p_visible) {
 
 void ShaderEditorPlugin::set_current() {
 	shader_dock->make_visible();
-	TextEditorBase *text_shader_editor = Object::cast_to<TextEditorBase>(script_editor->get_current_editor());
+	TextEditorBase *text_shader_editor = Object::cast_to<TextEditorBase>(shader_container->get_current_editor());
 	if (text_shader_editor) {
 		text_shader_editor->ensure_focus();
 	}
@@ -72,7 +73,7 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 	}
 
 	if (Object::cast_to<Shader>(p_object) || Object::cast_to<ShaderInclude>(p_object)) {
-		script_editor->edit(Object::cast_to<Resource>(p_object), false);
+		shader_container->edit(Object::cast_to<Resource>(p_object), false);
 	}
 }
 
@@ -90,7 +91,7 @@ void ShaderEditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 #endif
 
 	if (bool(EDITOR_GET("editors/shader_editor/behavior/files/restore_shaders_on_load"))) {
-		script_editor->set_window_layout(p_layout);
+		shader_container->set_window_layout(p_layout);
 	}
 }
 
@@ -103,11 +104,11 @@ void ShaderEditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 	}
 #endif
 
-	script_editor->get_window_layout(p_layout);
+	shader_container->get_window_layout(p_layout);
 }
 
 String ShaderEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
-	const PackedStringArray unsaved_scripts = script_editor->get_unsaved_scripts();
+	const PackedStringArray unsaved_scripts = shader_container->get_unsaved_scripts();
 	if (unsaved_scripts.is_empty()) {
 		return String();
 	}
@@ -139,7 +140,7 @@ String ShaderEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 
 void ShaderEditorPlugin::save_external_data() {
 	if (!EditorNode::get_singleton()->is_exiting()) {
-		script_editor->save_all_scripts();
+		shader_container->save_all_scripts();
 	}
 }
 
@@ -163,9 +164,11 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 
 	make_floating_shortcut = ED_SHORTCUT_AND_COMMAND("shader_editor/make_floating", TTRC("Make Floating"));
 
-	script_editor = memnew(ScriptEditor(config_section, "shader_editor_cache.cfg", nullptr, shader_dock));
-	script_editor->set_handled_resource_types({ "Shader", "VisualShader", "ShaderInclude" });
-	shader_dock->add_child(script_editor);
+	shader_container = memnew(DocumentEditorContainer(false, config_section, "shader_editor_cache.cfg"));
+	shader_container->connect("make_floating", callable_mp(shader_dock, &EditorDock::make_floating));
+	shader_container->set_handled_resource_types({ "Shader", "VisualShader", "ShaderInclude" });
+
+	shader_dock->add_child(shader_container);
 }
 
 ShaderEditorPlugin::~ShaderEditorPlugin() {

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -35,7 +35,7 @@
 class ShaderEditorPlugin : public EditorPlugin {
 	GDCLASS(ShaderEditorPlugin, EditorPlugin);
 
-	ScriptEditor *script_editor = nullptr;
+	DocumentEditorContainer *shader_container = nullptr;
 
 	EditorDock *shader_dock = nullptr;
 	Ref<Shortcut> make_floating_shortcut;
@@ -61,6 +61,8 @@ protected:
 public:
 	static ShaderEditorPlugin *get_singleton() { return shader_editor_plugin; }
 
+	DocumentEditorContainer *get_shader_container() const { return shader_container; }
+
 	virtual String get_plugin_name() const override { return "Shader"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
@@ -72,7 +74,7 @@ public:
 
 	virtual String get_unsaved_status(const String &p_for_scene) const override;
 	virtual void save_external_data() override;
-	virtual void apply_changes() override { script_editor->apply_scripts(); }
+	virtual void apply_changes() override { shader_container->apply_scripts(); }
 
 	ShaderEditorPlugin();
 	~ShaderEditorPlugin();

--- a/editor/shader/shader_text_editor.h
+++ b/editor/shader/shader_text_editor.h
@@ -183,7 +183,7 @@ protected:
 	public:
 		virtual bool handles(ScriptEditorBase *p_seb) override { return Object::cast_to<ShaderTextEditor>(p_seb); }
 
-		EditMenusShTE(ScriptEditor *p_se) : EditMenusCEB(p_se, "Shader Previews") {}
+		EditMenusShTE(DocumentEditorContainer *p_document_editor_container) : EditMenusCEB(p_document_editor_container, "Shader Previews") {}
 	};
 
 	void _notification(int p_what);
@@ -209,7 +209,7 @@ public:
 	void set_code_block_changed(const String &p_code);
 	virtual void apply_code() override;
 
-	virtual EditMenusBase *create_edit_menu(ScriptEditor *p_se) override { return memnew(EditMenusShTE(p_se)); }
+	virtual EditMenusBase *create_edit_menu(DocumentEditorContainer *p_document_editor_container) override { return memnew(EditMenusShTE(p_document_editor_container)); }
 
 	static void register_editor();
 

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -51,6 +51,7 @@
 #include "editor/scene/material_editor_plugin.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/shader/shader_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/animation/tween.h"
@@ -8322,7 +8323,7 @@ void EditorPropertyVisualShaderMode::_option_selected(int p_which) {
 		return;
 	}
 
-	VisualShaderEditor *editor = Object::cast_to<VisualShaderEditor>(ScriptEditor::get_bottom_script_editor()->get_resource_editor(visual_shader));
+	VisualShaderEditor *editor = Object::cast_to<VisualShaderEditor>(ShaderEditorPlugin::get_singleton()->get_shader_container()->get_resource_editor(visual_shader));
 	if (!editor) {
 		return;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Followup for #115998
- Related to https://github.com/godotengine/godot/issues/28607#issuecomment-1493395507 (Like `ScriptEditorWindow`, but its not a window)

This addresses my previous concern and makes the shader editor not a ScriptEditor https://github.com/godotengine/godot/pull/115998#pullrequestreview-4744870400.
Since the same code is being used for the shader editor, there should be a more reusable class to handle the gui. This is what the `DocumentEditorContainer` is for. This way ScriptEditor can remain a singleton.

~Since I had to adjust the theme logic, this also
Fixes `base_spacing` EditorSetting not applying immediately to the ScriptEditor, it only changed after a restart or toggling floating.
Fixes the ShaderEditor margins to match the look before #115998, it them a bit larger on accident.~
- Edit: theme logic fixed by https://github.com/godotengine/godot/pull/113051

## Additional information

Pretty much everything that was in `ScriptEditor` is now in `DocumentEditorContainer`, to minimize changes in this PR (refactoring it so only what is needed to move would make a lot more to review).
In another PR, more things can be moved out for better re-use with the shader editor or better separation, such as using a single `script_editor_cache.cfg`, most file dialogs can be shared, debugger-only things, callbacks that only need to be triggered once. I may make a separate manager class for these.

I put `search_in_files_requested` and `replace_in_files_requested` in deprecated blocks since they aren't emitted anymore since #115998.
`FindInFiles` and the `SearchDialog` are put in ScriptEditor, since they were being accessed as a single instance.
Floating is now handled with a signal instead of taking a window wrapper or a dock.
Also moved `ScriptEditor::_update_modified_scripts_for_external_editor` out of ScriptTextEditor, it doesn't belong there.