### PR TITLE
Fix TextEdit.get_rect_at_line_column()

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5506,7 +5506,7 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 	}
 	LineDrawingCache cache_entry = line_drawing_cache[p_line];
 
-	int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
+	int wrap_index = get_line_wrap_index_at_column(p_line, p_column > 0 ? p_column - 1 : 0);
 	if (wrap_index >= cache_entry.first_visible_chars.size()) {
 		// Line seems to be wrapped beyond the viewable area.
 		return Rect2i(-1, -1, 0, 0);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -1772,7 +1772,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Select to the first character of a wrapped line.
 			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 11).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "so");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);


### PR DESCRIPTION
Fix #121704

---
I modified the failing unit test, because I believed the unit test was incorrect.
The comment states, “Select to the first character of a wrapped line.” However, the unit test actually selected the last character of the previous line.
The test previously passed because it relied on an incorrect result returned by the `get_rect_at_line_column()`.

The screen corresponding to the unit test:
<img width="167" height="139" alt="image" src="https://github.com/user-attachments/assets/0e11996c-c2b6-40c3-8da7-f6f2c402240e" />
---
Note:
Caret columns start at 0; char columns start at 1. 
<img width="762" height="761" alt="image" src="https://github.com/user-attachments/assets/f71a053c-2c75-45b4-99c4-f042deb0e57d" />
The `wrap_index` of the char at col 1 equals the `wrap_index` of the caret at col 0. 
So, I need to pass `p_column - 1` to `get_line_wrap_index_at_column`.

The valid values for `get_rect_at_line_column`'s `p_column` is 1<=`p_column`<= line length. So, the range of values for `p_column - 1` is 0<=`p_column - 1`<= line length-1.
But in fact, the `get_rect_at_line_column` can accept 0, and the return result is the same as when 1 is passed.
If `p_column` is 0, `p_column - 1` will be `-1`. Should we perform parameter validation to convert -1 to 0? It’s optional.
If we pass -1 to `get_line_wrap_index_at_column`, it will not cause errors but return 0 directly.
Of course, we can also choose to add parameter checks to improve robustness.
