### PR TITLE
NVIDIA Wayland Editor Unresponsive Fix & Mailbox opt-in

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1842,15 +1842,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "rendering/rendering_device/pipeline_cache/enable"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/rendering_device/pipeline_cache/save_chunk_size_mb", PROPERTY_HINT_RANGE, "0.000001,64.0,0.001,or_greater"), 3.0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/max_descriptors_per_pool", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
-	// Bounded timeout for vkAcquireNextImageKHR so a wedged compositor/driver (notably
-	// NVIDIA proprietary on Wayland) cannot freeze the main loop indefinitely. On timeout,
-	// the frame is skipped and the loop continues, keeping the editor UI interactive.
-	// 0 means wait forever (legacy behavior).
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms", PROPERTY_HINT_RANGE, "0,10000,1"), 1000);
-	// Opt-in workaround for frame-callback stalls observed with FIFO present mode on some
-	// driver/compositor combinations (notably NVIDIA proprietary on Wayland): transparently
-	// substitute MAILBOX for FIFO. MAILBOX keeps the same vsync cadence but does not block
-	// the queue on a missing frame callback.
 	GLOBAL_DEF("rendering/rendering_device/vulkan/prefer_mailbox_present_mode", false);
 
 	GLOBAL_DEF_RST("rendering/rendering_device/d3d12/max_resource_descriptors", 65536);

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1842,6 +1842,16 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "rendering/rendering_device/pipeline_cache/enable"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/rendering_device/pipeline_cache/save_chunk_size_mb", PROPERTY_HINT_RANGE, "0.000001,64.0,0.001,or_greater"), 3.0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/max_descriptors_per_pool", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
+	// Bounded timeout for vkAcquireNextImageKHR so a wedged compositor/driver (notably
+	// NVIDIA proprietary on Wayland) cannot freeze the main loop indefinitely. On timeout,
+	// the frame is skipped and the loop continues, keeping the editor UI interactive.
+	// 0 means wait forever (legacy behavior).
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms", PROPERTY_HINT_RANGE, "0,10000,1"), 1000);
+	// Opt-in workaround for frame-callback stalls observed with FIFO present mode on some
+	// driver/compositor combinations (notably NVIDIA proprietary on Wayland): transparently
+	// substitute MAILBOX for FIFO. MAILBOX keeps the same vsync cadence but does not block
+	// the queue on a missing frame callback.
+	GLOBAL_DEF("rendering/rendering_device/vulkan/prefer_mailbox_present_mode", false);
 
 	GLOBAL_DEF_RST("rendering/rendering_device/d3d12/max_resource_descriptors", 65536);
 	custom_prop_info["rendering/rendering_device/d3d12/max_resource_descriptors"] = PropertyInfo(Variant::INT, "rendering/rendering_device/d3d12/max_resource_descriptors", PROPERTY_HINT_RANGE, "512,1000000");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1116,8 +1116,7 @@
 			[b]Note:[/b] This property is only read when the project starts. To change the V-Sync mode at runtime, call [method DisplayServer.window_set_vsync_mode] instead.
 		</member>
 		<member name="display/window/wayland/frame_callback_timeout_ms" type="int" setter="" getter="" default="100">
-			Maximum time (in milliseconds) the main loop will block waiting for a Wayland frame callback before letting input and UI processing continue. Compositors normally deliver frame callbacks within a few milliseconds, but a stalled compositor or GPU driver can withhold them (observed with NVIDIA proprietary drivers when the window has embedded subsurfaces), which previously made the window appear frozen for up to a second at a time.
-			If set to [code]0[/code], the previous [code]1000[/code] ms ceiling is used instead.
+			Time to wait for the compositor before processing input again, in milliseconds. Lower values keep the window responsive when the compositor or video driver stalls. If [code]0[/code], waits up to a second.
 			[b]Note:[/b] Only effective on Linux (Wayland).
 		</member>
 		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
@@ -3417,13 +3416,10 @@
 			[b]Note:[/b] Changing this property requires a restart to take effect.
 		</member>
 		<member name="rendering/rendering_device/vulkan/prefer_mailbox_present_mode" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], the swapchain transparently uses MAILBOX present mode instead of FIFO when V-Sync is enabled and MAILBOX is available. This is an opt-in workaround for presentation stalls seen with FIFO present mode on some driver and compositor combinations, notably NVIDIA proprietary drivers on Wayland: MAILBOX keeps the same V-Sync cadence but does not block the presentation queue on a missing frame callback, at the cost of slightly higher GPU usage.
-			The substitution only applies when the requested present mode is FIFO; explicitly chosen Mailbox, Adaptive, or Disabled V-Sync modes are unaffected.
-			[b]Note:[/b] Changes to this setting are applied when the swapchain is (re)created.
+			If [code]true[/code], uses Mailbox presentation instead of FIFO when V-Sync is enabled. This can prevent freezes with some video drivers (notably NVIDIA on Wayland), at the cost of slightly higher GPU usage.
 		</member>
 		<member name="rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms" type="int" setter="" getter="" default="1000">
-			Maximum time (in milliseconds) to wait for [code]vkAcquireNextImageKHR[/code] before skipping the frame. A bounded wait prevents an unresponsive compositor or driver (notably NVIDIA proprietary drivers on Wayland) from blocking the main loop indefinitely; when the timeout is hit, the frame is skipped and processing continues, keeping input and UI responsive.
-			If set to [code]0[/code], the wait is unbounded (legacy behavior).
+			Time to wait for the video driver to provide the next frame, in milliseconds. If the driver stalls for longer, the frame is skipped and the application keeps running instead of freezing. If [code]0[/code], waits indefinitely.
 		</member>
 		<member name="rendering/scaling_3d/fsr_sharpness" type="float" setter="" getter="" default="0.2">
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1115,6 +1115,11 @@
 			[b]Note:[/b] The [b]Adaptive[/b] and [b]Mailbox[/b] V-Sync modes are only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 			[b]Note:[/b] This property is only read when the project starts. To change the V-Sync mode at runtime, call [method DisplayServer.window_set_vsync_mode] instead.
 		</member>
+		<member name="display/window/wayland/frame_callback_timeout_ms" type="int" setter="" getter="" default="100">
+			Maximum time (in milliseconds) the main loop will block waiting for a Wayland frame callback before letting input and UI processing continue. Compositors normally deliver frame callbacks within a few milliseconds, but a stalled compositor or GPU driver can withhold them (observed with NVIDIA proprietary drivers when the window has embedded subsurfaces), which previously made the window appear frozen for up to a second at a time.
+			If set to [code]0[/code], the previous [code]1000[/code] ms ceiling is used instead.
+			[b]Note:[/b] Only effective on Linux (Wayland).
+		</member>
 		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] and [code].sln[/code] files. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
 		</member>
@@ -3410,6 +3415,15 @@
 			The number of descriptors per pool. Godot's Vulkan backend uses linear pools for descriptors that will be created and destroyed within a single frame. Instead of destroying every single descriptor every frame, they all can be destroyed at once by resetting the pool they belong to.
 			A larger number is more efficient up to a limit, after that it will only waste RAM (maximum efficiency is achieved when there is no more than 1 pool per frame). A small number could end up with one pool per descriptor, which negatively impacts performance.
 			[b]Note:[/b] Changing this property requires a restart to take effect.
+		</member>
+		<member name="rendering/rendering_device/vulkan/prefer_mailbox_present_mode" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the swapchain transparently uses MAILBOX present mode instead of FIFO when V-Sync is enabled and MAILBOX is available. This is an opt-in workaround for presentation stalls seen with FIFO present mode on some driver and compositor combinations, notably NVIDIA proprietary drivers on Wayland: MAILBOX keeps the same V-Sync cadence but does not block the presentation queue on a missing frame callback, at the cost of slightly higher GPU usage.
+			The substitution only applies when the requested present mode is FIFO; explicitly chosen Mailbox, Adaptive, or Disabled V-Sync modes are unaffected.
+			[b]Note:[/b] Changes to this setting are applied when the swapchain is (re)created.
+		</member>
+		<member name="rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms" type="int" setter="" getter="" default="1000">
+			Maximum time (in milliseconds) to wait for [code]vkAcquireNextImageKHR[/code] before skipping the frame. A bounded wait prevents an unresponsive compositor or driver (notably NVIDIA proprietary drivers on Wayland) from blocking the main loop indefinitely; when the timeout is hit, the frame is skipped and processing continues, keeping input and UI responsive.
+			If set to [code]0[/code], the wait is unbounded (legacy behavior).
 		</member>
 		<member name="rendering/scaling_3d/fsr_sharpness" type="float" setter="" getter="" default="0.2">
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -3769,16 +3769,12 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 		present_mode = VkPresentModeKHR::VK_PRESENT_MODE_FIFO_KHR;
 	}
 
-	// Opt-in workaround for FIFO present stalls seen on some driver/compositor
-	// combinations (e.g. NVIDIA proprietary under Wayland with embedded subsurfaces).
-	// MAILBOX uses the same vsync cadence but does not block the queue on a missing
-	// frame callback, at the cost of slightly higher GPU use. Only kicks in for the
-	// FIFO case so user-chosen Mailbox/Adaptive/Disabled paths are unchanged.
+	// Optional workaround for FIFO present stalls on some drivers (e.g. NVIDIA on Wayland).
 	if (present_mode == VK_PRESENT_MODE_FIFO_KHR && present_modes.has(VK_PRESENT_MODE_MAILBOX_KHR) &&
 			GLOBAL_GET("rendering/rendering_device/vulkan/prefer_mailbox_present_mode")) {
 		present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
-		present_mode_name = "Mailbox (FIFO stall workaround)";
-		print_verbose("Vulkan: Using MAILBOX present mode instead of FIFO (rendering/rendering_device/vulkan/prefer_mailbox_present_mode).");
+		present_mode_name = "Mailbox (FIFO workaround)";
+		print_verbose("Vulkan: Using Mailbox present mode instead of FIFO.");
 	}
 
 	// Clamp the desired image count to the surface's capabilities.
@@ -4035,9 +4031,7 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::swap_chain_acquire_framebuffer(C
 	swap_chain->command_queues_acquired.push_back(command_queue);
 	swap_chain->command_queues_acquired_semaphores.push_back(semaphore_index);
 
-	// A bounded timeout prevents an unresponsive compositor or driver (e.g. NVIDIA
-	// proprietary on Wayland with nested/embedded surfaces) from blocking the main
-	// loop forever. 0 preserves the legacy infinite-wait behavior.
+	// Bounded timeout so a stalled driver can't block the main loop forever.
 	uint64_t acquire_timeout_ns = UINT64_MAX;
 	const int acquire_timeout_ms = GLOBAL_GET("rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms");
 	if (acquire_timeout_ms > 0) {
@@ -4054,9 +4048,7 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::swap_chain_acquire_framebuffer(C
 		r_resize_required = true;
 		return FramebufferID();
 	} else if (err == VK_TIMEOUT || err == VK_NOT_READY) {
-		// The compositor/driver did not deliver an image in time. The semaphore was not
-		// signaled, but bookkeeping above already enqueued it; reset it so the next
-		// acquire can use it again, then skip this frame so the main loop stays live.
+		// The semaphore wasn't signaled but was already enqueued above, so recreate it and skip the frame.
 		bool semaphore_recreated = _recreate_image_semaphore(command_queue, semaphore_index, true);
 		ERR_FAIL_COND_V(!semaphore_recreated, FramebufferID());
 		return FramebufferID();

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -3769,6 +3769,18 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 		present_mode = VkPresentModeKHR::VK_PRESENT_MODE_FIFO_KHR;
 	}
 
+	// Opt-in workaround for FIFO present stalls seen on some driver/compositor
+	// combinations (e.g. NVIDIA proprietary under Wayland with embedded subsurfaces).
+	// MAILBOX uses the same vsync cadence but does not block the queue on a missing
+	// frame callback, at the cost of slightly higher GPU use. Only kicks in for the
+	// FIFO case so user-chosen Mailbox/Adaptive/Disabled paths are unchanged.
+	if (present_mode == VK_PRESENT_MODE_FIFO_KHR && present_modes.has(VK_PRESENT_MODE_MAILBOX_KHR) &&
+			GLOBAL_GET("rendering/rendering_device/vulkan/prefer_mailbox_present_mode")) {
+		present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+		present_mode_name = "Mailbox (FIFO stall workaround)";
+		print_verbose("Vulkan: Using MAILBOX present mode instead of FIFO (rendering/rendering_device/vulkan/prefer_mailbox_present_mode).");
+	}
+
 	// Clamp the desired image count to the surface's capabilities.
 	uint32_t desired_swapchain_images = MAX(p_desired_framebuffer_count, surface_capabilities.minImageCount);
 	if (surface_capabilities.maxImageCount > 0) {
@@ -4023,7 +4035,16 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::swap_chain_acquire_framebuffer(C
 	swap_chain->command_queues_acquired.push_back(command_queue);
 	swap_chain->command_queues_acquired_semaphores.push_back(semaphore_index);
 
-	err = device_functions.AcquireNextImageKHR(vk_device, swap_chain->vk_swapchain, UINT64_MAX, semaphore, VK_NULL_HANDLE, &swap_chain->image_index);
+	// A bounded timeout prevents an unresponsive compositor or driver (e.g. NVIDIA
+	// proprietary on Wayland with nested/embedded surfaces) from blocking the main
+	// loop forever. 0 preserves the legacy infinite-wait behavior.
+	uint64_t acquire_timeout_ns = UINT64_MAX;
+	const int acquire_timeout_ms = GLOBAL_GET("rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms");
+	if (acquire_timeout_ms > 0) {
+		acquire_timeout_ns = uint64_t(acquire_timeout_ms) * 1000000ULL;
+	}
+
+	err = device_functions.AcquireNextImageKHR(vk_device, swap_chain->vk_swapchain, acquire_timeout_ns, semaphore, VK_NULL_HANDLE, &swap_chain->image_index);
 	if (err == VK_ERROR_OUT_OF_DATE_KHR) {
 		// Out of date leaves the semaphore in a signaled state that will never finish, so it's necessary to recreate it.
 		bool semaphore_recreated = _recreate_image_semaphore(command_queue, semaphore_index, true);
@@ -4031,6 +4052,13 @@ RDD::FramebufferID RenderingDeviceDriverVulkan::swap_chain_acquire_framebuffer(C
 
 		// Swap chain is out of date and must be recreated.
 		r_resize_required = true;
+		return FramebufferID();
+	} else if (err == VK_TIMEOUT || err == VK_NOT_READY) {
+		// The compositor/driver did not deliver an image in time. The semaphore was not
+		// signaled, but bookkeeping above already enqueued it; reset it so the next
+		// acquire can use it again, then skip this frame so the main loop stays live.
+		bool semaphore_recreated = _recreate_image_semaphore(command_queue, semaphore_index, true);
+		ERR_FAIL_COND_V(!semaphore_recreated, FramebufferID());
 		return FramebufferID();
 	} else if (err != VK_SUCCESS && err != VK_SUBOPTIMAL_KHR) {
 		// Swap chain failed to present but the reason is unknown.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2685,9 +2685,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF_RST("display/window/per_pixel_transparency/allowed", false);
-	// Watchdog for the Wayland frame-callback wait. Keeps the editor's UI responsive
-	// when the compositor or GPU driver stalls (notably NVIDIA proprietary on Wayland
-	// with embedded game subsurfaces). 0 falls back to the legacy 1000 ms ceiling.
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/wayland/frame_callback_timeout_ms", PROPERTY_HINT_RANGE, "0,1000,1"), 100);
 
 	load_shell_env = GLOBAL_DEF("application/run/load_shell_environment", false);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2685,6 +2685,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF_RST("display/window/per_pixel_transparency/allowed", false);
+	// Watchdog for the Wayland frame-callback wait. Keeps the editor's UI responsive
+	// when the compositor or GPU driver stalls (notably NVIDIA proprietary on Wayland
+	// with embedded game subsurfaces). 0 falls back to the legacy 1000 ms ceiling.
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/wayland/frame_callback_timeout_ms", PROPERTY_HINT_RANGE, "0,1000,1"), 100);
 
 	load_shell_env = GLOBAL_DEF("application/run/load_shell_environment", false);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1928,8 +1928,6 @@ void DisplayServerWayland::try_suspend() {
 	// window's suspend status. When a window is suspended, we can avoid drawing
 	// altogether, either because the compositor told us that we don't need to or
 	// because the pace of the frame events became unreliable.
-	// A bounded wait keeps input and UI processing going when the compositor or GPU
-	// driver stalls and stops delivering frame callbacks. 0 keeps the legacy ceiling.
 	int frame_callback_timeout_ms = GLOBAL_GET("display/window/wayland/frame_callback_timeout_ms");
 	if (frame_callback_timeout_ms <= 0) {
 		frame_callback_timeout_ms = WAYLAND_MAX_FRAME_TIME_US / 1000;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1928,7 +1928,13 @@ void DisplayServerWayland::try_suspend() {
 	// window's suspend status. When a window is suspended, we can avoid drawing
 	// altogether, either because the compositor told us that we don't need to or
 	// because the pace of the frame events became unreliable.
-	bool frame = wayland_thread.wait_frame_suspend_ms(WAYLAND_MAX_FRAME_TIME_US / 1000);
+	// A bounded wait keeps input and UI processing going when the compositor or GPU
+	// driver stalls and stops delivering frame callbacks. 0 keeps the legacy ceiling.
+	int frame_callback_timeout_ms = GLOBAL_GET("display/window/wayland/frame_callback_timeout_ms");
+	if (frame_callback_timeout_ms <= 0) {
+		frame_callback_timeout_ms = WAYLAND_MAX_FRAME_TIME_US / 1000;
+	}
+	bool frame = wayland_thread.wait_frame_suspend_ms(frame_callback_timeout_ms);
 	if (!frame) {
 		suspend_state = SuspendState::TIMEOUT;
 	}


### PR DESCRIPTION
Helps: [godotengine/godot#114986](https://github.com/godotengine/godot/issues/114986)

The editor can permanently freeze on Linux/Wayland causing lost work, especially with NVIDIA's proprietary driver when additional windows are involved (tooltips, popup menus, floating docks, the embedded game view, etc.). As described in https://github.com/godotengine/godot/issues/114986#issuecomment-4503913566, there are two places where the main loop can wait indefinitely:

1. `swap_chain_acquire_framebuffer()` calls `vkAcquireNextImageKHR` with `UINT64_MAX`. Under NVIDIA + Wayland, nested `wl_subsurface` windows (such as the embedded game view) can cause this call to block forever.
2. `DisplayServerWayland::try_suspend()` waits for frame callbacks for up to 1000 ms at a time. If the compositor stops delivering callbacks, input isn't processed and the editor appears frozen.

This PR bounds both waits and adds an optional workaround:

- `rendering/rendering_device/vulkan/swapchain_acquire_timeout_ms` (default: `1000`): Limits how long `vkAcquireNextImageKHR` can block. On timeout, the image semaphore is recreated (matching the existing `VK_ERROR_OUT_OF_DATE_KHR` path) and the frame is skipped. Setting this to `0` restores the previous unlimited wait.
- `display/window/wayland/frame_callback_timeout_ms` (default: `100`): Limits how long `try_suspend()` waits for frame callbacks so input continues to be processed during compositor stalls. Setting this to `0` restores the previous `1000` ms behavior.
- `rendering/rendering_device/vulkan/prefer_mailbox_present_mode` (default: `false`): Uses `MAILBOX` instead of `FIFO` when available. This avoids the stall entirely, at the cost of slightly higher GPU usage.

I originally enabled the mailbox workaround by default on NVIDIA, but left it opt-in because it previously caused issues on NVIDIA + X11 (https://github.com/godotengine/godot/issues/114986#issuecomment-4512438646). Present mode behavior varies significantly between vendors and drivers. With the timeout changes alone, the editor recovers instead of hanging permanently. Enabling mailbox also eliminates the temporary stutter.

Tested on an RTX 3060 (610.43.03) running KDE Wayland. Before this change I could reliably reproduce the freeze using the embedded game view. Afterward, the editor remains responsive and recovers correctly.

All three settings are documented in `ProjectSettings.xml`.