### PR TITLE
Fix window wrapper disabling prematurely on close request

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1423,26 +1423,24 @@ void GameView::_update_arguments_for_instance(int p_idx, List<String> &r_argumen
 }
 
 void GameView::_window_close_request() {
-	if (window_wrapper->get_window_enabled()) {
-		// Stop the embedded process timer before closing the window wrapper,
-		// so the signal to focus EDITOR_GAME isn't sent when the window is not enabled.
-		embedded_process->reset_timers();
-		window_wrapper->set_window_enabled(false);
-	}
-
 	// Before the parent window closed, we close the embedded game. That prevents
 	// the embedded game to be seen without a parent window for a fraction of second.
 	if (EditorRunBar::get_singleton()->is_playing() && (embedded_process->is_embedding_completed() || embedded_process->is_embedding_in_progress())) {
 		// When the embedding is not complete, we need to kill the process.
 		// If the game is paused, the close request will not be processed by the game, so it's better to kill the process.
 		if (paused || embedded_process->is_embedding_in_progress()) {
-			// Call deferred to prevent the _stop_pressed callback to be executed before the wrapper window
-			// actually closes.
+			if (window_wrapper->get_window_enabled()) {
+				embedded_process->reset_timers();
+				window_wrapper->set_window_enabled(false);
+			}
+			// Call deferred to prevent the _stop_pressed callback to be executed before the wrapper window actually closes.
 			embedded_process->reset();
 			callable_mp(EditorRunBar::get_singleton(), &EditorRunBar::stop_playing).call_deferred();
 		} else {
 			// Try to gracefully close the window. That way, the NOTIFICATION_WM_CLOSE_REQUEST
 			// notification should be propagated in the game process.
+			// We shouldn't disable the window_wrapper here since if auto_accept_quit is false,
+			// the game will ignore this request and stay alive.
 			embedded_process->request_close();
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121713 

## Additional information
This PR fixes an issue where attempting to close a floating game view window in projects with `auto_accept_quit` set to `false` causes the window frame & decorations to be disabled/hidden while the game process & remote debugger remain running in a "ghost" state.

### The Problem
In `GameView::_window_close_request()`, `window_wrapper->set_window_enabled(false)` was being called unconditionally at the beginning of the function before delegating the close request to the running game process.

When a project has `auto_accept_quit = false`, the game engine intentionally ignores `NOTIFICATION_WM_CLOSE_REQUEST` & waits for script logic to explicitly call `get_tree().quit()`. Because GameView had already disabled the `window_wrapper`, the UI container hid its window frame/decorations immediately, leaving the game process running continuously in the background without a visible outer window or title bar.

### The Fix
- Moved `window_wrapper->set_window_enabled(false)` & `embedded_process->reset_timers()` into the branch reserved for forced resets (when the game is paused or embedding is still in progress).

- Allowed graceful close requests (`embedded_process->request_close()`) to leave the `window_wrapper` active.

   -  If `auto_accept_quit` is `true`, the game process exits naturally, triggering `_stop_pressed()`, which safely handles disabling the window wrapper.

   - If `auto_accept_quit` is `false`, the game process ignores the close request & the window wrapper remains open & interactive as expected.

