### PR TITLE
Fix AO Light Affect in Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2776,6 +2776,10 @@ void main() {
 #else
 
 	diffuse_light *= albedo;
+
+	diffuse_light *= ao;
+	specular_light *= ao;
+
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
@@ -3052,6 +3056,8 @@ void main() {
 #endif // ADDITIVE_SPOT
 
 	diffuse_light *= albedo;
+	diffuse_light *= ao;
+	specular_light *= ao;
 	diffuse_light *= 1.0 - metallic;
 	vec3 additive_light_color = diffuse_light + specular_light;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121611

## Additional information

| Before | After |
|--------|-------|
| <img width="1866" height="1209" alt="old" src="https://github.com/user-attachments/assets/262ada24-00b5-441b-986c-67052a7ce0d8" /> | <img width="1866" height="1209" alt="new" src="https://github.com/user-attachments/assets/5ce6df43-1fc6-466e-b213-f4820b5a1c71" /> |

Scales the diffuse and specular light by the ambient occlusion factor, similarly to how Forward+ and Mobile handle it