### PR TITLE
SCons: Only apply `-mcmodel=medium` to `x86_64`

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -162,7 +162,7 @@ def configure(env: "SConsEnvironment"):
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"
 
-        if not env["use_llvm"] and "64" in env["arch"]:
+        if not env["use_llvm"] and env["arch"] == "x86_64":
             env.Append(CCFLAGS=["-mcmodel=medium"])
             env.Append(LINKFLAGS=["-mcmodel=medium"])
 


### PR DESCRIPTION
- Followup to #121647

## What problem(s) does this PR solve?

Shortly after the above PR was merged, it was noticed that the `-mcmodel` flag only applied to Intel compilers[^1], which meant that the conditional to apply it was too broad. This PR changes the conditional to apply to `x86_64` exclusively.

[^1]: https://github.com/godotengine/godot/pull/121647#discussion_r3634006551