### PR TITLE
Improve the AudioStreamPlayer2D and AudioStreamPlayer3D editor gizmos with a range display and draggable Max Distance handles

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -79,6 +79,7 @@
 #include "editor/inspector/input_event_editor_plugin.h"
 #include "editor/inspector/sub_viewport_preview_editor_plugin.h"
 #include "editor/inspector/tool_button_editor_plugin.h"
+#include "editor/scene/2d/audio_stream_player_2d_editor_plugin.h"
 #include "editor/scene/2d/camera_2d_editor_plugin.h"
 #include "editor/scene/2d/light_occluder_2d_editor_plugin.h"
 #include "editor/scene/2d/line_2d_editor_plugin.h"
@@ -256,6 +257,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<VirtualJoystickEditorPlugin>();
 
 	// Node2D-based editor plugins.
+	EditorPlugins::add_by_type<AudioStreamPlayer2DEditorPlugin>();
 	EditorPlugins::add_by_type<Camera2DEditorPlugin>();
 	EditorPlugins::add_by_type<CPUParticles2DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles2DEditorPlugin>();

--- a/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
+++ b/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
@@ -35,11 +35,9 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/main/scene_tree.h"
-
-// Screen-space distance (in pixels) within which the radius handle can be grabbed.
-static constexpr real_t HANDLE_GRAB_DISTANCE = 8.0;
 
 void AudioStreamPlayer2DEditor::_notification(int p_what) {
 	switch (p_what) {
@@ -95,7 +93,8 @@ bool AudioStreamPlayer2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
-			if (_get_handle_screen_position().distance_to(mb->get_position()) < HANDLE_GRAB_DISTANCE) {
+			const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+			if (_get_handle_screen_position().distance_to(mb->get_position()) < grab_threshold) {
 				dragging = true;
 				drag_from_max_distance = selected_player->get_max_distance();
 				return true;

--- a/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
+++ b/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
@@ -115,7 +115,7 @@ bool AudioStreamPlayer2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && dragging) {
 		const Transform2D canvas_xform = CanvasItemEditor::get_singleton()->get_canvas_transform();
-		const Vector2 mouse_pos = canvas_xform.affine_inverse().xform(mm->get_position());
+		const Vector2 mouse_pos = CanvasItemEditor::get_singleton()->snap_point(canvas_xform.affine_inverse().xform(mm->get_position()));
 		// Max Distance is a world-space radius, so it maps to the node-to-cursor distance (kept above the minimum).
 		const real_t new_distance = MAX((real_t)1.0, selected_player->get_global_position().distance_to(mouse_pos));
 		selected_player->set_max_distance(new_distance);

--- a/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
+++ b/editor/scene/2d/audio_stream_player_2d_editor_plugin.cpp
@@ -1,0 +1,177 @@
+/**************************************************************************/
+/*  audio_stream_player_2d_editor_plugin.cpp                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "audio_stream_player_2d_editor_plugin.h"
+
+#include "core/input/input_event.h"
+#include "core/object/callable_mp.h"
+#include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/scene/canvas_item_editor_plugin.h"
+#include "scene/2d/audio_stream_player_2d.h"
+#include "scene/main/scene_tree.h"
+
+// Screen-space distance (in pixels) within which the radius handle can be grabbed.
+static constexpr real_t HANDLE_GRAB_DISTANCE = 8.0;
+
+void AudioStreamPlayer2DEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			get_tree()->connect("node_removed", callable_mp(this, &AudioStreamPlayer2DEditor::_node_removed));
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			get_tree()->disconnect("node_removed", callable_mp(this, &AudioStreamPlayer2DEditor::_node_removed));
+		} break;
+	}
+}
+
+void AudioStreamPlayer2DEditor::_node_removed(Node *p_node) {
+	if (p_node == selected_player) {
+		selected_player->disconnect(SceneStringName(draw), callable_mp(plugin, &EditorPlugin::update_overlays));
+		selected_player = nullptr;
+		dragging = false;
+	}
+}
+
+Vector2 AudioStreamPlayer2DEditor::_get_handle_screen_position() const {
+	const Transform2D canvas_xform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+	const Vector2 center = canvas_xform.xform(selected_player->get_global_position());
+	const real_t radius = selected_player->get_max_distance() * canvas_xform.get_scale().x;
+	// Place the handle on the right of the circle.
+	return center + Vector2(radius, 0);
+}
+
+void AudioStreamPlayer2DEditor::edit(AudioStreamPlayer2D *p_player) {
+	if (p_player == selected_player) {
+		return;
+	}
+	// Follow the player's draw signal, which fires when Max Distance changes in the editor.
+	const Callable update_overlays = callable_mp(plugin, &EditorPlugin::update_overlays);
+
+	if (selected_player) {
+		selected_player->disconnect(SceneStringName(draw), update_overlays);
+	}
+	selected_player = p_player;
+
+	if (selected_player) {
+		selected_player->connect(SceneStringName(draw), update_overlays);
+	}
+	plugin->update_overlays();
+}
+
+bool AudioStreamPlayer2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
+	if (!selected_player || !selected_player->is_inside_tree()) {
+		return false;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
+		if (mb->is_pressed()) {
+			if (_get_handle_screen_position().distance_to(mb->get_position()) < HANDLE_GRAB_DISTANCE) {
+				dragging = true;
+				drag_from_max_distance = selected_player->get_max_distance();
+				return true;
+			}
+		} else if (dragging) {
+			dragging = false;
+			if (selected_player->get_max_distance() != drag_from_max_distance) {
+				EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+				ur->create_action(TTR("Change AudioStreamPlayer2D Max Distance"));
+				ur->add_do_property(selected_player, "max_distance", selected_player->get_max_distance());
+				ur->add_undo_property(selected_player, "max_distance", drag_from_max_distance);
+				ur->commit_action(false);
+			}
+			return true;
+		}
+	}
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid() && dragging) {
+		const Transform2D canvas_xform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+		const Vector2 mouse_pos = canvas_xform.affine_inverse().xform(mm->get_position());
+		// Max Distance is a world-space radius, so it maps to the node-to-cursor distance (kept above the minimum).
+		const real_t new_distance = MAX((real_t)1.0, selected_player->get_global_position().distance_to(mouse_pos));
+		selected_player->set_max_distance(new_distance);
+		CanvasItemEditor::get_singleton()->update_viewport();
+		return true;
+	}
+
+	return false;
+}
+
+void AudioStreamPlayer2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
+	if (!selected_player || !selected_player->is_inside_tree()) {
+		return;
+	}
+
+	const real_t max_distance = selected_player->get_max_distance();
+	if (max_distance <= 0.0) {
+		return;
+	}
+
+	const Transform2D canvas_xform = CanvasItemEditor::get_singleton()->get_canvas_transform();
+	const Vector2 center = canvas_xform.xform(selected_player->get_global_position());
+	// Max Distance is a world-space radius, so only the (uniform) editor zoom scales it.
+	const real_t radius = max_distance * canvas_xform.get_scale().x;
+	if (radius < 1.0) {
+		return;
+	}
+
+	// Circle marking the Max Distance boundary.
+	p_overlay->draw_arc(center, radius, 0, Math::TAU, 64, Color(1, 0.5, 0.2), 2.0, true);
+
+	// Draggable handle for editing Max Distance directly in the viewport.
+	const Ref<Texture2D> handle = get_editor_theme_icon(SNAME("EditorHandle"));
+	p_overlay->draw_texture(handle, center + Vector2(radius, 0) - handle->get_size() / 2);
+}
+
+AudioStreamPlayer2DEditor::AudioStreamPlayer2DEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
+}
+
+void AudioStreamPlayer2DEditorPlugin::edit(Object *p_object) {
+	audio_stream_player_2d_editor->edit(Object::cast_to<AudioStreamPlayer2D>(p_object));
+}
+
+bool AudioStreamPlayer2DEditorPlugin::handles(Object *p_object) const {
+	return p_object->is_class("AudioStreamPlayer2D");
+}
+
+void AudioStreamPlayer2DEditorPlugin::make_visible(bool p_visible) {
+	if (!p_visible) {
+		audio_stream_player_2d_editor->edit(nullptr);
+	}
+}
+
+AudioStreamPlayer2DEditorPlugin::AudioStreamPlayer2DEditorPlugin() {
+	audio_stream_player_2d_editor = memnew(AudioStreamPlayer2DEditor(this));
+	EditorNode::get_singleton()->get_gui_base()->add_child(audio_stream_player_2d_editor);
+}

--- a/editor/scene/2d/audio_stream_player_2d_editor_plugin.h
+++ b/editor/scene/2d/audio_stream_player_2d_editor_plugin.h
@@ -1,0 +1,78 @@
+/**************************************************************************/
+/*  audio_stream_player_2d_editor_plugin.h                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+
+class AudioStreamPlayer2D;
+
+class AudioStreamPlayer2DEditor : public Control {
+	GDCLASS(AudioStreamPlayer2DEditor, Control);
+
+	EditorPlugin *plugin = nullptr;
+
+	AudioStreamPlayer2D *selected_player = nullptr;
+
+	bool dragging = false;
+	real_t drag_from_max_distance = 0;
+
+	Vector2 _get_handle_screen_position() const;
+	void _node_removed(Node *p_node);
+
+	friend class AudioStreamPlayer2DEditorPlugin;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void edit(AudioStreamPlayer2D *p_player);
+
+	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
+	void forward_canvas_draw_over_viewport(Control *p_overlay);
+
+	AudioStreamPlayer2DEditor(EditorPlugin *p_plugin);
+};
+
+class AudioStreamPlayer2DEditorPlugin : public EditorPlugin {
+	GDCLASS(AudioStreamPlayer2DEditorPlugin, EditorPlugin);
+
+	AudioStreamPlayer2DEditor *audio_stream_player_2d_editor = nullptr;
+
+public:
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return audio_stream_player_2d_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { audio_stream_player_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
+
+	AudioStreamPlayer2DEditorPlugin();
+};

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -38,6 +38,12 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/audio_stream_player_3d.h"
 
+// IDs for the gizmo's draggable handles.
+enum HandleID {
+	HANDLE_MAX_DISTANCE = 0,
+	HANDLE_EMISSION_ANGLE = 1,
+};
+
 AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/stream_player_3d");
 
@@ -65,7 +71,7 @@ int AudioStreamPlayer3DGizmoPlugin::get_priority() const {
 }
 
 String AudioStreamPlayer3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
-	if (p_id == 0) {
+	if (p_id == HANDLE_MAX_DISTANCE) {
 		return "Max Distance";
 	}
 	return "Emission Radius";
@@ -73,7 +79,7 @@ String AudioStreamPlayer3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *
 
 Variant AudioStreamPlayer3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
-	if (p_id == 0) {
+	if (p_id == HANDLE_MAX_DISTANCE) {
 		return player->get_max_distance();
 	}
 	return player->get_emission_angle();
@@ -87,7 +93,7 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo
 	Vector3 ray_from = p_camera->project_ray_origin(p_point);
 	Vector3 ray_dir = p_camera->project_ray_normal(p_point);
 
-	if (p_id == 0) {
+	if (p_id == HANDLE_MAX_DISTANCE) {
 		// Max Distance: use the distance from the node to the cursor on a camera-facing plane.
 		Plane cp = Plane(p_camera->get_transform().basis.get_column(2), gt.origin);
 		Vector3 inters;
@@ -135,7 +141,7 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo
 void AudioStreamPlayer3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) {
 	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
-	if (p_id == 0) {
+	if (p_id == HANDLE_MAX_DISTANCE) {
 		if (p_cancel) {
 			player->set_max_distance(p_restore);
 		} else {
@@ -260,9 +266,9 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				// A gizmo uses one billboard flag for all handles, so only billboard the Max Distance
 				// handle when the fixed emission-angle handle isn't also present (keeps picking consistent).
 				if (player->is_emission_angle_enabled()) {
-					p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
+					p_gizmo->add_handles(distance_handles, get_material("handles"), { HANDLE_MAX_DISTANCE });
 				} else {
-					p_gizmo->add_handles(distance_handles, get_material("handles_billboard"), { 0 }, true);
+					p_gizmo->add_handles(distance_handles, get_material("handles_billboard"), { HANDLE_MAX_DISTANCE }, true);
 				}
 			}
 		}
@@ -339,7 +345,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			Vector<Vector3> handles;
 			handles.push_back(Vector3(Math::sin(ha), 0, -Math::cos(ha)));
-			p_gizmo->add_handles(handles, get_material("handles"), { 1 });
+			p_gizmo->add_handles(handles, get_material("handles"), { HANDLE_EMISSION_ANGLE });
 		}
 	}
 

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -47,7 +47,9 @@ AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	// Enable vertex colors so the range circles can reflect the attenuation model
 	// and whether Max Distance is capping the range (see redraw()).
 	create_material("stream_player_3d_material_lines", Color(1, 1, 1), false, false, true);
+	create_material("stream_player_3d_material_billboard", Color(1, 1, 1), true, false, true);
 	create_handle_material("handles");
+	create_handle_material("handles_billboard", true);
 }
 
 bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -165,9 +167,10 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		const AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 		if (player->get_attenuation_model() != AudioStreamPlayer3D::ATTENUATION_DISABLED || player->get_max_distance() > CMP_EPSILON) {
-			// Draw the attenuation range as three axis-aligned circles, giving a sphere-like
-			// representation (matching OmniLight3D).
+			// Draw the attenuation range as three axis-aligned circles plus a billboard circle,
+			// giving a sphere-like representation (matching OmniLight3D).
 			const Ref<Material> lines_material = get_material("stream_player_3d_material_lines", p_gizmo);
+			const Ref<Material> lines_billboard_material = get_material("stream_player_3d_material_billboard", p_gizmo);
 
 			// Soft distance cap varies depending on attenuation model, as some will fade out more aggressively than others.
 			// Multipliers were empirically determined through testing.
@@ -199,6 +202,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			}
 
 			Vector<Vector3> points;
+			Vector<Vector3> points_billboard;
 			for (int i = 0; i < 120; i++) {
 				const float ra = Math::deg_to_rad((float)(i * 3));
 				const float rb = Math::deg_to_rad((float)((i + 1) * 3));
@@ -212,6 +216,10 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				points.push_back(Vector3(0, b.x, b.y));
 				points.push_back(Vector3(a.x, a.y, 0));
 				points.push_back(Vector3(b.x, b.y, 0));
+
+				// Billboard circle.
+				points_billboard.push_back(Vector3(a.x, a.y, 0));
+				points_billboard.push_back(Vector3(b.x, b.y, 0));
 			}
 
 			Color color;
@@ -243,12 +251,19 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			}
 
 			p_gizmo->add_lines(points, lines_material, false, color);
+			p_gizmo->add_lines(points_billboard, lines_billboard_material, true, color);
 
 			if (player->get_max_distance() > CMP_EPSILON) {
-				// Handle to edit Max Distance directly in the viewport, placed on the range circle.
+				// Handle to edit Max Distance directly in the viewport, placed on the billboard circle.
 				Vector<Vector3> distance_handles;
 				distance_handles.push_back(Vector3(player->get_max_distance(), 0, 0));
-				p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
+				// A gizmo uses one billboard flag for all handles, so only billboard the Max Distance
+				// handle when the fixed emission-angle handle isn't also present (keeps picking consistent).
+				if (player->is_emission_angle_enabled()) {
+					p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
+				} else {
+					p_gizmo->add_handles(distance_handles, get_material("handles_billboard"), { 0 }, true);
+				}
 			}
 		}
 

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/audio_stream_player_3d.h"
 
@@ -47,6 +48,7 @@ AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	// AudioStreamPlayer3D attenuation type and source (Unit Size or Max Distance).
 	create_material("stream_player_3d_material_billboard", Color(1, 1, 1), true, false, true);
 	create_handle_material("handles");
+	create_handle_material("handles_billboard", true);
 }
 
 bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -62,11 +64,17 @@ int AudioStreamPlayer3DGizmoPlugin::get_priority() const {
 }
 
 String AudioStreamPlayer3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
+	if (p_id == 0) {
+		return "Max Distance";
+	}
 	return "Emission Radius";
 }
 
 Variant AudioStreamPlayer3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
+	if (p_id == 0) {
+		return player->get_max_distance();
+	}
 	return player->get_emission_angle();
 }
 
@@ -74,10 +82,26 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo
 	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 	Transform3D gt = player->get_global_transform();
-	Transform3D gi = gt.affine_inverse();
 
 	Vector3 ray_from = p_camera->project_ray_origin(p_point);
 	Vector3 ray_dir = p_camera->project_ray_normal(p_point);
+
+	if (p_id == 0) {
+		// Max Distance: use the distance from the node to the cursor on a camera-facing plane.
+		Plane cp = Plane(p_camera->get_transform().basis.get_column(2), gt.origin);
+		Vector3 inters;
+		if (cp.intersects_ray(ray_from, ray_dir, &inters)) {
+			float r = inters.distance_to(gt.origin);
+			if (Node3DEditor::get_singleton()->is_snap_enabled()) {
+				r = Math::snapped(r, Node3DEditor::get_singleton()->get_translate_snap());
+			}
+			player->set_max_distance(r);
+		}
+		return;
+	}
+
+	// Emission Radius (angle).
+	Transform3D gi = gt.affine_inverse();
 	Vector3 ray_to = ray_from + ray_dir * 4096;
 
 	ray_from = gi.xform(ray_from);
@@ -109,6 +133,19 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo
 
 void AudioStreamPlayer3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) {
 	AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
+
+	if (p_id == 0) {
+		if (p_cancel) {
+			player->set_max_distance(p_restore);
+		} else {
+			EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+			ur->create_action(TTR("Change AudioStreamPlayer3D Max Distance"));
+			ur->add_do_method(player, "set_max_distance", player->get_max_distance());
+			ur->add_undo_method(player, "set_max_distance", p_restore);
+			ur->commit_action();
+		}
+		return;
+	}
 
 	if (p_cancel) {
 		player->set_emission_angle(p_restore);
@@ -154,14 +191,13 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 					break;
 			}
 
-			// Draw the distance at which the sound can be reasonably heard.
-			// This can be either a hard distance cap with the Max Distance property (if set above 0.0),
-			// or a soft distance cap with the Unit Size property (sound never reaches true zero).
-			// When Max Distance is 0.0, `r` represents the distance above which the
-			// sound can't be heard in *most* (but not all) scenarios.
-			float radius = player->get_unit_size() * soft_multiplier;
+			// With a hard cap, draw the circle at Max Distance so it lines up with the draggable handle;
+			// otherwise fall back to the Unit Size-derived soft radius (where the sound fades to near silence).
+			float radius;
 			if (player->get_max_distance() > CMP_EPSILON) {
-				radius = MIN(radius, player->get_max_distance());
+				radius = player->get_max_distance();
+			} else {
+				radius = player->get_unit_size() * soft_multiplier;
 			}
 
 #define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y, m_y) \
@@ -232,6 +268,19 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			}
 
 			p_gizmo->add_lines(points_billboard, lines_billboard_material, true, color);
+
+			if (player->get_max_distance() > CMP_EPSILON) {
+				// Handle to edit Max Distance directly in the viewport, placed on the billboard circle.
+				Vector<Vector3> distance_handles;
+				distance_handles.push_back(Vector3(player->get_max_distance(), 0, 0));
+				// A gizmo uses one billboard flag for all handles, so only billboard the Max Distance
+				// handle when the fixed emission-angle handle isn't also present (keeps picking consistent).
+				if (player->is_emission_angle_enabled()) {
+					p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
+				} else {
+					p_gizmo->add_handles(distance_handles, get_material("handles_billboard"), { 0 }, true);
+				}
+			}
 		}
 
 		if (player->is_emission_angle_enabled()) {
@@ -306,7 +355,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			Vector<Vector3> handles;
 			handles.push_back(Vector3(Math::sin(ha), 0, -Math::cos(ha)));
-			p_gizmo->add_handles(handles, get_material("handles"));
+			p_gizmo->add_handles(handles, get_material("handles"), { 1 });
 		}
 	}
 

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -44,11 +44,10 @@ AudioStreamPlayer3DGizmoPlugin::AudioStreamPlayer3DGizmoPlugin() {
 	create_icon_material("stream_player_3d_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Gizmo3DSamplePlayer"), EditorStringName(EditorIcons)));
 	create_material("stream_player_3d_material_primary", gizmo_color);
 	create_material("stream_player_3d_material_secondary", gizmo_color * Color(1, 1, 1, 0.35));
-	// Enable vertex colors for the billboard material as the gizmo color depends on the
-	// AudioStreamPlayer3D attenuation type and source (Unit Size or Max Distance).
-	create_material("stream_player_3d_material_billboard", Color(1, 1, 1), true, false, true);
+	// Enable vertex colors so the range circles can reflect the attenuation model
+	// and whether Max Distance is capping the range (see redraw()).
+	create_material("stream_player_3d_material_lines", Color(1, 1, 1), false, false, true);
 	create_handle_material("handles");
-	create_handle_material("handles_billboard", true);
 }
 
 bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -166,10 +165,9 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		const AudioStreamPlayer3D *player = Object::cast_to<AudioStreamPlayer3D>(p_gizmo->get_node_3d());
 
 		if (player->get_attenuation_model() != AudioStreamPlayer3D::ATTENUATION_DISABLED || player->get_max_distance() > CMP_EPSILON) {
-			// Draw a circle to represent sound volume attenuation.
-			// Use only a billboard circle to represent radius.
-			// This helps distinguish AudioStreamPlayer3D gizmos from OmniLight3D gizmos.
-			const Ref<Material> lines_billboard_material = get_material("stream_player_3d_material_billboard", p_gizmo);
+			// Draw the attenuation range as three axis-aligned circles, giving a sphere-like
+			// representation (matching OmniLight3D).
+			const Ref<Material> lines_material = get_material("stream_player_3d_material_lines", p_gizmo);
 
 			// Soft distance cap varies depending on attenuation model, as some will fade out more aggressively than others.
 			// Multipliers were empirically determined through testing.
@@ -200,44 +198,21 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				radius = player->get_unit_size() * soft_multiplier;
 			}
 
-#define PUSH_QUARTER_XY(m_from_x, m_from_y, m_to_x, m_to_y, m_y) \
-	points_ptrw[index++] = Vector3(m_from_x, -m_from_y - m_y, 0); \
-	points_ptrw[index++] = Vector3(m_to_x, -m_to_y - m_y, 0); \
-	points_ptrw[index++] = Vector3(m_from_x, m_from_y + m_y, 0); \
-	points_ptrw[index++] = Vector3(m_to_x, m_to_y + m_y, 0); \
-	points_ptrw[index++] = Vector3(-m_from_x, -m_from_y - m_y, 0); \
-	points_ptrw[index++] = Vector3(-m_to_x, -m_to_y - m_y, 0); \
-	points_ptrw[index++] = Vector3(-m_from_x, m_from_y + m_y, 0); \
-	points_ptrw[index++] = Vector3(-m_to_x, m_to_y + m_y, 0);
+			Vector<Vector3> points;
+			for (int i = 0; i < 120; i++) {
+				const float ra = Math::deg_to_rad((float)(i * 3));
+				const float rb = Math::deg_to_rad((float)((i + 1) * 3));
+				const Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
+				const Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 
-			// Number of points in an octant. So there will be 8 * points_in_octant points in total.
-			// This corresponds to the smoothness of the circle.
-			const uint32_t points_in_octant = 15;
-			const real_t octant_angle = Math::PI / 4;
-			const real_t inc = (Math::PI / (4 * points_in_octant));
-			const real_t radius_squared = radius * radius;
-			real_t r = 0;
-
-			Vector<Vector3> points_billboard;
-			points_billboard.resize(8 * points_in_octant * 2);
-			Vector3 *points_ptrw = points_billboard.ptrw();
-
-			uint32_t index = 0;
-			float previous_x = radius;
-			float previous_y = 0.f;
-
-			for (uint32_t i = 0; i < points_in_octant; i++) {
-				r += inc;
-				real_t x = Math::cos((i == points_in_octant - 1) ? octant_angle : r) * radius;
-				real_t y = Math::sqrt(radius_squared - (x * x));
-
-				PUSH_QUARTER_XY(previous_x, previous_y, x, y, 0);
-				PUSH_QUARTER_XY(previous_y, previous_x, y, x, 0);
-				previous_x = x;
-				previous_y = y;
+				// One segment on each of the three axis-aligned circles.
+				points.push_back(Vector3(a.x, 0, a.y));
+				points.push_back(Vector3(b.x, 0, b.y));
+				points.push_back(Vector3(0, a.x, a.y));
+				points.push_back(Vector3(0, b.x, b.y));
+				points.push_back(Vector3(a.x, a.y, 0));
+				points.push_back(Vector3(b.x, b.y, 0));
 			}
-
-#undef PUSH_QUARTER_XY
 
 			Color color;
 			switch (player->get_attenuation_model()) {
@@ -267,19 +242,13 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				color.set_h(color.get_h() + 0.5);
 			}
 
-			p_gizmo->add_lines(points_billboard, lines_billboard_material, true, color);
+			p_gizmo->add_lines(points, lines_material, false, color);
 
 			if (player->get_max_distance() > CMP_EPSILON) {
-				// Handle to edit Max Distance directly in the viewport, placed on the billboard circle.
+				// Handle to edit Max Distance directly in the viewport, placed on the range circle.
 				Vector<Vector3> distance_handles;
 				distance_handles.push_back(Vector3(player->get_max_distance(), 0, 0));
-				// A gizmo uses one billboard flag for all handles, so only billboard the Max Distance
-				// handle when the fixed emission-angle handle isn't also present (keeps picking consistent).
-				if (player->is_emission_angle_enabled()) {
-					p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
-				} else {
-					p_gizmo->add_handles(distance_handles, get_material("handles_billboard"), { 0 }, true);
-				}
+				p_gizmo->add_handles(distance_handles, get_material("handles"), { 0 });
 			}
 		}
 

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -307,6 +307,9 @@ void AudioStreamPlayer2D::_validate_property(PropertyInfo &p_property) const {
 void AudioStreamPlayer2D::set_max_distance(float p_pixels) {
 	ERR_FAIL_COND(p_pixels <= 0.0);
 	max_distance = p_pixels;
+	if (is_part_of_edited_scene()) {
+		queue_redraw();
+	}
 }
 
 float AudioStreamPlayer2D::get_max_distance() const {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes [#15250](https://github.com/godotengine/godot-proposals/issues/15250)

## Additional information

**AudioStreamPlayer2D**:
Add a gizmo circle that displays `max_distance ` and a handle to easily modify it.

https://github.com/user-attachments/assets/a83b01bf-7509-4c5a-8022-846531d0a59e

**AudioStreamPlayer3D**:
Replace the current billboard circle with a 3d sphere gizmo (identical to OmniLight3D) while keeping all current functionality, and also adding a handle for `max_distance`

https://github.com/user-attachments/assets/d6a1bcd8-8320-4f23-928a-c8d837e9b968

---

An effort to implement accurate attenuation visualization and debug visualization is being worked on this PR: https://github.com/godotengine/godot/pull/121471
There may be some minor overlap but I believe both features complement each other nicely.