### PR TITLE
Cache result of keycode_get_count() for a small Speedup

### DIFF
--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -317,7 +317,8 @@ void InputEventConfigurationDialog::_update_input_list() {
 		kb_root->set_meta("__type", INPUT_KEY);
 
 		HashSet<int> keycodes_found;
-		for (int i = 0; i < keycode_get_count(); i++) {
+		int keycode_count = keycode_get_count();
+		for (int i = 0; i < keycode_count; i++) {
 			String name = keycode_get_name_by_index(i);
 			int keycode = keycode_get_value_by_index(i);
 


### PR DESCRIPTION
## Brief Description
`keycode_get_count` is being called every iteration of the for loop, even though it never changes, this PR caches the result to avoid unnecessary calls to `keycode_get_count` function.

## Testing
Compiled & tested Godot on Windows 11 with an Intel i7-6700K CPU, running at a constant 4.00GHz speed.

build options used: `target=editor dev_mode=yes optimaze=speed d3d12=no accesskit=no`

Testing methodology is the following:
- Used OS's `get_ticks_usec()` to capture the `start` & `end` times, and calculated the difference to know how long the for loop have taken.
- Inside the Editor, I've opened the Event Configuration Dialog and simply Typed `A` in the filter input field, then delete it, then re-add it, then deleted it, and so on... (to capture multiple data points, and calculate the average)
- the final average is the sum of these data points, regardless of whether it was an empty filter (takes longer, as there's more things to add to the Tree), or with `A` as a filter (takes less, because there's less things to do).

## Benchmark Results


Tried keeping background processes at a minimum, but I'm on Windows, so take these results with a grain of salt 🧂

```
                    Min     |   Median  |    Max    |     Average
Before changes:    205 us   |   442 us  |   523 us  |  346.5135135 us
After changes:     185 us   |   417 us  |   529 us  |  332.7027027 us

Net improvement: 4.15% speedup
```


## Additional information
This change was suggested by @KoBeWi in [this discussion](https://github.com/godotengine/godot/pull/121658#discussion_r3645569295), I've tried @bruvzg's idea of making `keycode_get_count` a `constexpr` function.. but it somehow made the code slower? likely my fault as I'm new to C++

Also out of topic question.. why is this code called 4 times when opening a project (when the editor starts up)? the dialog window isn't visible to user, maybe I'm missing something?

## Use of AI
No AI was used in the process of making these changes.