### PR TITLE
Add proper empty Resource handling in Polygon3D editor

### DIFF
--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -55,7 +55,6 @@ void Polygon3DEditor::_notification(int p_what) {
 			button_create->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			button_edit->set_button_icon(get_editor_theme_icon(SNAME("MovePoint")));
 			button_edit->set_pressed(true);
-			get_tree()->connect("node_removed", callable_mp(this, &Polygon3DEditor::_node_removed));
 
 		} break;
 
@@ -73,17 +72,6 @@ void Polygon3DEditor::_notification(int p_what) {
 	}
 }
 
-void Polygon3DEditor::_node_removed(Node *p_node) {
-	if (p_node == node) {
-		node = nullptr;
-		if (imgeom->get_parent() == p_node) {
-			p_node->remove_child(imgeom);
-		}
-		hide();
-		set_process(false);
-	}
-}
-
 void Polygon3DEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MODE_CREATE: {
@@ -97,6 +85,24 @@ void Polygon3DEditor::_menu_option(int p_option) {
 			button_edit->set_pressed(true);
 		} break;
 	}
+}
+
+void Polygon3DEditor::_update_resource() {
+	Ref<Resource> new_resource;
+	if (node && using_resource) {
+		new_resource = node->call("_get_editable_3d_polygon_resource");
+	}
+	if (new_resource != node_resource) {
+		if (node_resource.is_valid()) {
+			node_resource->disconnect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
+		}
+		node_resource = new_resource;
+		if (node_resource.is_valid()) {
+			node_resource->connect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
+		}
+	}
+	_polygon_draw();
+	set_process(_get_edited_object());
 }
 
 void Polygon3DEditor::_wip_close() {
@@ -118,7 +124,7 @@ void Polygon3DEditor::_wip_close() {
 }
 
 EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
-	if (!node) {
+	if (_get_edited_object() == nullptr) {
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
 	}
 
@@ -349,10 +355,18 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 	return EditorPlugin::AFTER_GUI_INPUT_PASS;
 }
 
-float Polygon3DEditor::_get_depth() {
-	Object *obj = node_resource.is_valid() ? (Object *)node_resource.ptr() : node;
-	ERR_FAIL_NULL_V_MSG(obj, 0.0f, "Edited object is not valid.");
+Object *Polygon3DEditor::_get_edited_object() const {
+	if (using_resource) {
+		return node_resource.ptr();
+	}
+	return node;
+}
 
+float Polygon3DEditor::_get_depth() {
+	Object *obj = _get_edited_object();
+	if (!obj) {
+		return 0.0f;
+	}
 	if (bool(obj->call("_has_editable_3d_polygon_no_depth"))) {
 		return 0.0f;
 	}
@@ -361,19 +375,24 @@ float Polygon3DEditor::_get_depth() {
 }
 
 PackedVector2Array Polygon3DEditor::_get_polygon() {
-	Object *obj = node_resource.is_valid() ? (Object *)node_resource.ptr() : node;
-	ERR_FAIL_NULL_V_MSG(obj, PackedVector2Array(), "Edited object is not valid.");
-	return PackedVector2Array(obj->call("get_polygon"));
+	Object *obj = _get_edited_object();
+	if (obj) {
+		return PackedVector2Array(obj->call("get_polygon"));
+	}
+	return PackedVector2Array();
 }
 
 void Polygon3DEditor::_set_polygon(const PackedVector2Array &p_poly) {
-	Object *obj = node_resource.is_valid() ? (Object *)node_resource.ptr() : node;
-	ERR_FAIL_NULL_MSG(obj, "Edited object is not valid.");
-	obj->call("set_polygon", p_poly);
+	Object *obj = _get_edited_object();
+	if (obj) {
+		obj->call("set_polygon", p_poly);
+	}
 }
 
 void Polygon3DEditor::_polygon_draw() {
-	if (!node) {
+	if (!_get_edited_object()) {
+		m->clear_surfaces();
+		imesh->clear_surfaces();
 		return;
 	}
 
@@ -494,13 +513,23 @@ void Polygon3DEditor::_polygon_draw() {
 }
 
 void Polygon3DEditor::edit(Node *p_node) {
+	if (node == p_node) {
+		return;
+	}
+
+	if (node && node->has_signal("_editable_3d_polygon_changed")) {
+		node->disconnect("_editable_3d_polygon_changed", callable_mp(this, &Polygon3DEditor::_update_resource));
+	}
+
 	if (p_node) {
 		node = Object::cast_to<Node3D>(p_node);
-		node_resource = node->call("_get_editable_3d_polygon_resource");
+		using_resource = node->has_method("_get_editable_3d_polygon_resource");
 
-		if (node_resource.is_valid()) {
-			node_resource->connect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
+		if (p_node->has_signal("_editable_3d_polygon_changed")) {
+			node->connect("_editable_3d_polygon_changed", callable_mp(this, &Polygon3DEditor::_update_resource));
 		}
+		_update_resource();
+
 		//Enable the pencil tool if the polygon is empty
 		if (_get_polygon().is_empty()) {
 			_menu_option(MODE_CREATE);
@@ -513,22 +542,15 @@ void Polygon3DEditor::edit(Node *p_node) {
 		} else {
 			p_node->add_child(imgeom);
 		}
-		_polygon_draw();
-		set_process(true);
 		prev_depth = -1;
 
 	} else {
 		node = nullptr;
-		if (node_resource.is_valid()) {
-			node_resource->disconnect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
-		}
-		node_resource.unref();
+		_update_resource();
 
 		if (imgeom->get_parent()) {
 			imgeom->get_parent()->remove_child(imgeom);
 		}
-
-		set_process(false);
 	}
 }
 

--- a/editor/scene/3d/polygon_3d_editor_plugin.h
+++ b/editor/scene/3d/polygon_3d_editor_plugin.h
@@ -57,9 +57,11 @@ class Polygon3DEditor : public HBoxContainer {
 	Ref<StandardMaterial3D> line_material;
 	Ref<StandardMaterial3D> handle_material;
 
-	Panel *panel = nullptr;
 	Node3D *node = nullptr;
 	Ref<Resource> node_resource;
+	bool using_resource = false;
+
+	Panel *panel = nullptr;
 	Ref<ImmediateMesh> imesh;
 	MeshInstance3D *imgeom = nullptr;
 	MeshInstance3D *pointsm = nullptr;
@@ -74,17 +76,18 @@ class Polygon3DEditor : public HBoxContainer {
 
 	float prev_depth = 0.0f;
 
+	void _update_resource();
 	void _wip_close();
 	void _polygon_draw();
 	void _menu_option(int p_option);
 
+	Object *_get_edited_object() const;
 	float _get_depth();
 	PackedVector2Array _get_polygon();
 	void _set_polygon(const PackedVector2Array &p_poly);
 
 protected:
 	void _notification(int p_what);
-	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -44,10 +44,6 @@
 #include "scene/resources/surface_tool.h"
 #include "servers/rendering/rendering_server.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/editor_node.h"
-#endif
-
 RID Occluder3D::get_rid() const {
 	return occluder;
 }
@@ -458,10 +454,7 @@ void OccluderInstance3D::set_occluder(const Ref<Occluder3D> &p_occluder) {
 	update_configuration_warnings();
 
 #ifdef TOOLS_ENABLED
-	// PolygonOccluder3D is edited via an editor plugin, this ensures the plugin is shown/hidden when necessary
-	if (Engine::get_singleton()->is_editor_hint()) {
-		callable_mp(EditorNode::get_singleton(), &EditorNode::edit_current).call_deferred();
-	}
+	emit_signal("_editable_3d_polygon_changed");
 #endif
 }
 
@@ -725,11 +718,11 @@ PackedStringArray OccluderInstance3D::get_configuration_warnings() const {
 }
 
 bool OccluderInstance3D::_is_editable_3d_polygon() const {
-	return Ref<PolygonOccluder3D>(occluder).is_valid();
+	return true;
 }
 
 Ref<Resource> OccluderInstance3D::_get_editable_3d_polygon_resource() const {
-	return occluder;
+	return Ref<PolygonOccluder3D>(occluder);
 }
 
 void OccluderInstance3D::_bind_methods() {
@@ -745,6 +738,7 @@ void OccluderInstance3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_is_editable_3d_polygon"), &OccluderInstance3D::_is_editable_3d_polygon);
 	ClassDB::bind_method(D_METHOD("_get_editable_3d_polygon_resource"), &OccluderInstance3D::_get_editable_3d_polygon_resource);
+	ADD_SIGNAL(MethodInfo("_editable_3d_polygon_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "occluder", PROPERTY_HINT_RESOURCE_TYPE, Occluder3D::get_class_static()), "set_occluder", "get_occluder");
 	ADD_GROUP("Bake", "bake_");


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

See https://github.com/godotengine/godot/pull/118486#issuecomment-5073836523

This replaces the editor hack in OccluderInstance3D with an internal signal that notifies the editor that editing status may have changed. The editor's code was changed to handle it.

## Additional information

With this PR, Polygon3DEditor has a concept of "empty" state, i.e. a state where it doesn't have edited node, or the node doesn't have valid polygon resource. Note that the polygon editor can edit both nodes and their resources, so I added a kind of "resource mode", which is determined by the existence of `_get_editable_3d_polygon_resource()` method. The method can now return null and it makes the editor inactive until a valid resource is assigned to node. The newly added `_editable_3d_polygon_changed` signal is intended for notifying the editor about polygon object changes.

The OccluderInstance3D is no longer conditionally editable. The editor will always edit it, but stay inactive if the occluder does not have polygon assigned.

I think similar logic may need to be applied in other nodes, if their polygon object can change. We might have some undiscovered bugs here.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
