### PR TITLE
CI: treat JSON files as build inputs

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -10,6 +10,7 @@ sources:
   - .github/{actions/*,workflows}/*.yml
   - "**/{SConstruct,SCsub,*.py}"
   - "**/*.{h,hpp,hh,hxx,c,cpp,cc,cxx,m,mm,inc,glsl}"
+  - core/extension/gdextension_interface.json
   - misc/extension_api_validation/**
   - modules/*/tests/**
   - modules/mono/**/*.{cs,csproj,sln,props,targets}


### PR DESCRIPTION
Motivated by https://github.com/godotengine/godot/pull/121199, which changed only JSON and skipped most CI checks.

---

In practice, `gdextension_interface.json` is used as a build input -- changing it regenerates `gdextension_interface.gen.h` and rebuilds the engine.

However, the _"Determines if build actions should occur after static checks are ran."_ list does not currently include it, which means follow-up CI steps are skipped if only the JSON is changed.