### PR TITLE
Document `translate()` does not function in editor `@tool`

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1001,7 +1001,7 @@
 				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns the [param message] without changes. See [method set_message_translation].
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url].
 				[b]Note:[/b] This method can't be used without an [Object] instance, as it requires the [method can_translate_messages] method. To translate strings in a static context, use [method TranslationServer.translate].
-				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.get_message_list] and retrieve the translated string with [method Translation.get_message].
+				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.find_translations] and retrieve the translated string with [method Translation.get_message].
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1001,6 +1001,7 @@
 				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns the [param message] without changes. See [method set_message_translation].
 				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url].
 				[b]Note:[/b] This method can't be used without an [Object] instance, as it requires the [method can_translate_messages] method. To translate strings in a static context, use [method TranslationServer.translate].
+				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.get_message_list] and retrieve the translated string with [method Translation.get_message].
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -231,6 +231,7 @@
 			<description>
 				Returns the current locale's translation for the given message and context.
 				[b]Note:[/b] This method always uses the main translation domain.
+				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.get_message_list] and retrieve the translated string with [method Translation.get_message].
 			</description>
 		</method>
 		<method name="translate_plural" qualifiers="const">

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -231,7 +231,7 @@
 			<description>
 				Returns the current locale's translation for the given message and context.
 				[b]Note:[/b] This method always uses the main translation domain.
-				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.get_message_list] and retrieve the translated string with [method Translation.get_message].
+				[b]Note:[/b] This method cannot be used in the editor via a `@tool` script. If you need to translate strings in an editor tool, you can manually look up the [Translation] using [method TranslationServer.find_translations] and retrieve the translated string with [method Translation.get_message].
 			</description>
 		</method>
 		<method name="translate_plural" qualifiers="const">


### PR DESCRIPTION
- Added a note to `Object.tr()` and `TranslationServer.translate()` to document that they do not function when called in-editor through a `@tool` script.
- Added links to functions that can be called in a tool script, allowing you to work around this limitation.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
## Additional information
My first attempt at a change to the `class` reference. I hope this went well!

I wanted to create a link to `@tool`, but it seems it has no class_reference or similar page to link to. It seems other pages do not reference any page or method when referring to `@tool`, so I did not either.

There is an argument to be made to merge the new note with
> If [can_translate_messages()](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-can-translate-messages) is false, or no translation is available, this method returns the message without changes. See [set_message_translation()](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-set-message-translation).

since being in-editor is likely just one of the reasons `can_translate_messages()` will return false, and the workaround likely works for other instances where `can_translate_messages()` is false as well. But in the interest of not messing anything up, I chose the conservative route and simply added a note.

Similarly, I added the notes at the bottom, because I wasn't sure what the priority order of these notes should be.

<img width="897" height="550" alt="image" src="https://github.com/user-attachments/assets/4987ba3f-2c85-4b78-8cca-1cc4eb417883" />

_Calling TranslationServer.translate() and tr() do not work when used in a `@tool` script_

I ran into this when generating images for use in shaders, based on translated strings. When `tr()` didn't work, I was a bit surprised but switched to using `TranslationServer.translate()`, expecting that one to work regardless. I was quite surprised to find that function to not work either, which lead to making a simple workaround. I don't think it's the biggest issue, but `tr()` is so commonly used, I think it can be assumed that users will expect it to work in-editor too, meaning a note to align their expectation with reality was required.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
