### PR TITLE
Document link to `context` tutorial in `Translation` description

### DIFF
--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[Translation] maps a collection of strings to their individual translations, and also provides convenience methods for pluralization.
-		A [Translation] consists of messages. A message is identified by its context and untranslated string. Unlike [url=https://www.gnu.org/software/gettext/]gettext[/url], using an empty context string in Godot means not using any context.
+		A [Translation] consists of messages. Each message is identified by its untranslated string and [url=https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#translation-contexts]context[/url]. Unlike [url=https://www.gnu.org/software/gettext/]gettext[/url], using an empty context string in Godot means not using any context.
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[Translation] maps a collection of strings to their individual translations, and also provides convenience methods for pluralization.
-		A [Translation] consists of messages. Each message is identified by its untranslated string and [url=https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#translation-contexts]context[/url]. Unlike [url=https://www.gnu.org/software/gettext/]gettext[/url], using an empty context string in Godot means not using any context.
+		A [Translation] consists of messages. Each message is identified by its untranslated string and [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html#translation-contexts]context[/url]. Unlike [url=https://www.gnu.org/software/gettext/]gettext[/url], using an empty context string in Godot means not using any context.
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>


### PR DESCRIPTION
- Added a link to the [tutorial ](https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#translation-contexts)that explains the meaning and usecase for `context` in `Translation`
- Rephrased the description sentence to feel less repetitive with the previous sentence.
- Switched the order of
> identified by its context and untranslated string

to
> identified by its untranslated string and context

to better match argument order in functions such as `Translation.get_message()`

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## Additional information
I was not entirely sure how to best link to the tutorial page, but since the `gnu` link was a simple URL, I saw no harm in doing the same.

I switched the order of `context and untranslated string` around, since that better matches the argument order in the methods. I presume this doesn't matter, but in case the order hints at the order in which they are saved inside the `message`, I can change it back.

Multiple methods have a message to somewhat explain the `context`

> An additional context could be used to specify the translation context or differentiate polysemic words.

There is an argument to be made to add this one to **all** methods that use `context` (a few are missing), or to better document `context` at the description level, and remove the repetitive note from all the method descriptions instead. Perhaps an additional explanation of what polysemic means wouldn't go amiss either.

I also considered adding an additional sentence at the end of the description, to indicate what would happen if a duplicate translation key is detected, and no context is provided. As far as I know, the first entry found is returned, which might not be consistent. However, I was unsure about how accurate that is (especially in 4.x), and whether that would be a useful addition to the description. Perhaps it's better mentioned in `get_message()` and similar methods.

### Reason for change
Ran into `context` referenced in `TranslationServer.translate()`, but it had no further information on what it meant or was used for. Similarly, `Translation` documentation only described that it was part of the `message`, and essentially described the `context` as 'the context' with no further explanation of how that is relevant or used.

Only after seeing the note

> An additional context could be used to specify the translation context or differentiate polysemic words.

in some of the methods, I was reminded of the tutorial that explains about translating strings with ambiguous meanings, which is where contexts come in. The entire journey took a bit too long, so I wanted to update the main description of `Translation`, so it can directly reference to the in-depth tutorial explanation.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
