### PR TITLE
GDScript: fix unhandled division / modulo quotient overflow causes crash.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -265,6 +265,32 @@ constexpr int64_t division_round_up(int64_t p_num, int64_t p_den) {
 constexpr uint64_t division_round_up(uint64_t p_num, uint64_t p_den) {
 	return (p_num + p_den - 1) / p_den;
 }
+GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4146) // Unary minus operator applied to unsigned type, result still unsigned
+constexpr int32_t division_no_overflow(int32_t p_num, int32_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return int32_t(-uint32_t(p_num));
+	}
+	return p_num / p_den;
+}
+constexpr int64_t division_no_overflow(int64_t p_num, int64_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return int64_t(-uint64_t(p_num));
+	}
+	return p_num / p_den;
+}
+GODOT_MSVC_WARNING_POP
+constexpr int32_t modulo_no_overflow(int32_t p_num, int32_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return 0;
+	}
+	return p_num % p_den;
+}
+constexpr int64_t modulo_no_overflow(int64_t p_num, int64_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return 0;
+	}
+	return p_num % p_den;
+}
 
 constexpr bool is_finite(double p_val) {
 	return !is_nan(p_val) && !is_inf(p_val);

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -265,6 +265,30 @@ constexpr int64_t division_round_up(int64_t p_num, int64_t p_den) {
 constexpr uint64_t division_round_up(uint64_t p_num, uint64_t p_den) {
 	return (p_num + p_den - 1) / p_den;
 }
+constexpr int32_t division_no_overflow(int32_t p_num, int32_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return int32_t(0u - uint32_t(p_num));
+	}
+	return p_num / p_den;
+}
+constexpr int64_t division_no_overflow(int64_t p_num, int64_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return int64_t(0ull - uint64_t(p_num));
+	}
+	return p_num / p_den;
+}
+constexpr int32_t modulo_no_overflow(int32_t p_num, int32_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return 0;
+	}
+	return p_num % p_den;
+}
+constexpr int64_t modulo_no_overflow(int64_t p_num, int64_t p_den) {
+	if (unlikely(p_den == -1)) {
+		return 0;
+	}
+	return p_num % p_den;
+}
 
 constexpr bool is_finite(double p_val) {
 	return !is_nan(p_val) && !is_inf(p_val);

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -197,29 +197,29 @@ constexpr void Vector2i::operator*=(int32_t p_rvalue) {
 }
 
 constexpr Vector2i Vector2i::operator/(const Vector2i &p_v1) const {
-	return Vector2i(x / p_v1.x, y / p_v1.y);
+	return Vector2i(Math::division_no_overflow(x, p_v1.x), Math::division_no_overflow(y, p_v1.y));
 }
 
 constexpr Vector2i Vector2i::operator/(int32_t p_rvalue) const {
-	return Vector2i(x / p_rvalue, y / p_rvalue);
+	return Vector2i(Math::division_no_overflow(x, p_rvalue), Math::division_no_overflow(y, p_rvalue));
 }
 
 constexpr void Vector2i::operator/=(int32_t p_rvalue) {
-	x /= p_rvalue;
-	y /= p_rvalue;
+	x = Math::division_no_overflow(x, p_rvalue);
+	y = Math::division_no_overflow(y, p_rvalue);
 }
 
 constexpr Vector2i Vector2i::operator%(const Vector2i &p_v1) const {
-	return Vector2i(x % p_v1.x, y % p_v1.y);
+	return Vector2i(Math::modulo_no_overflow(x, p_v1.x), Math::modulo_no_overflow(y, p_v1.y));
 }
 
 constexpr Vector2i Vector2i::operator%(int32_t p_rvalue) const {
-	return Vector2i(x % p_rvalue, y % p_rvalue);
+	return Vector2i(Math::modulo_no_overflow(x, p_rvalue), Math::modulo_no_overflow(y, p_rvalue));
 }
 
 constexpr void Vector2i::operator%=(int32_t p_rvalue) {
-	x %= p_rvalue;
-	y %= p_rvalue;
+	x = Math::modulo_no_overflow(x, p_rvalue);
+	y = Math::modulo_no_overflow(y, p_rvalue);
 }
 
 constexpr Vector2i Vector2i::operator-() const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -218,25 +218,25 @@ constexpr Vector3i Vector3i::operator*(const Vector3i &p_v) const {
 }
 
 constexpr Vector3i &Vector3i::operator/=(const Vector3i &p_v) {
-	x /= p_v.x;
-	y /= p_v.y;
-	z /= p_v.z;
+	x = Math::division_no_overflow(x, p_v.x);
+	y = Math::division_no_overflow(y, p_v.y);
+	z = Math::division_no_overflow(z, p_v.z);
 	return *this;
 }
 
 constexpr Vector3i Vector3i::operator/(const Vector3i &p_v) const {
-	return Vector3i(x / p_v.x, y / p_v.y, z / p_v.z);
+	return Vector3i(Math::division_no_overflow(x, p_v.x), Math::division_no_overflow(y, p_v.y), Math::division_no_overflow(z, p_v.z));
 }
 
 constexpr Vector3i &Vector3i::operator%=(const Vector3i &p_v) {
-	x %= p_v.x;
-	y %= p_v.y;
-	z %= p_v.z;
+	x = Math::modulo_no_overflow(x, p_v.x);
+	y = Math::modulo_no_overflow(y, p_v.y);
+	z = Math::modulo_no_overflow(z, p_v.z);
 	return *this;
 }
 
 constexpr Vector3i Vector3i::operator%(const Vector3i &p_v) const {
-	return Vector3i(x % p_v.x, y % p_v.y, z % p_v.z);
+	return Vector3i(Math::modulo_no_overflow(x, p_v.x), Math::modulo_no_overflow(y, p_v.y), Math::modulo_no_overflow(z, p_v.z));
 }
 
 constexpr Vector3i &Vector3i::operator*=(int32_t p_scalar) {
@@ -269,25 +269,25 @@ constexpr Vector3i operator*(double p_scalar, const Vector3i &p_vector) {
 }
 
 constexpr Vector3i &Vector3i::operator/=(int32_t p_scalar) {
-	x /= p_scalar;
-	y /= p_scalar;
-	z /= p_scalar;
+	x = Math::division_no_overflow(x, p_scalar);
+	y = Math::division_no_overflow(y, p_scalar);
+	z = Math::division_no_overflow(z, p_scalar);
 	return *this;
 }
 
 constexpr Vector3i Vector3i::operator/(int32_t p_scalar) const {
-	return Vector3i(x / p_scalar, y / p_scalar, z / p_scalar);
+	return Vector3i(Math::division_no_overflow(x, p_scalar), Math::division_no_overflow(y, p_scalar), Math::division_no_overflow(z, p_scalar));
 }
 
 constexpr Vector3i &Vector3i::operator%=(int32_t p_scalar) {
-	x %= p_scalar;
-	y %= p_scalar;
-	z %= p_scalar;
+	x = Math::modulo_no_overflow(x, p_scalar);
+	y = Math::modulo_no_overflow(y, p_scalar);
+	z = Math::modulo_no_overflow(z, p_scalar);
 	return *this;
 }
 
 constexpr Vector3i Vector3i::operator%(int32_t p_scalar) const {
-	return Vector3i(x % p_scalar, y % p_scalar, z % p_scalar);
+	return Vector3i(Math::modulo_no_overflow(x, p_scalar), Math::modulo_no_overflow(y, p_scalar), Math::modulo_no_overflow(z, p_scalar));
 }
 
 constexpr Vector3i Vector3i::operator-() const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -211,27 +211,27 @@ constexpr Vector4i Vector4i::operator*(const Vector4i &p_v) const {
 }
 
 constexpr Vector4i &Vector4i::operator/=(const Vector4i &p_v) {
-	x /= p_v.x;
-	y /= p_v.y;
-	z /= p_v.z;
-	w /= p_v.w;
+	x = Math::division_no_overflow(x, p_v.x);
+	y = Math::division_no_overflow(y, p_v.y);
+	z = Math::division_no_overflow(z, p_v.z);
+	w = Math::division_no_overflow(w, p_v.w);
 	return *this;
 }
 
 constexpr Vector4i Vector4i::operator/(const Vector4i &p_v) const {
-	return Vector4i(x / p_v.x, y / p_v.y, z / p_v.z, w / p_v.w);
+	return Vector4i(Math::division_no_overflow(x, p_v.x), Math::division_no_overflow(y, p_v.y), Math::division_no_overflow(z, p_v.z), Math::division_no_overflow(w, p_v.w));
 }
 
 constexpr Vector4i &Vector4i::operator%=(const Vector4i &p_v) {
-	x %= p_v.x;
-	y %= p_v.y;
-	z %= p_v.z;
-	w %= p_v.w;
+	x = Math::modulo_no_overflow(x, p_v.x);
+	y = Math::modulo_no_overflow(y, p_v.y);
+	z = Math::modulo_no_overflow(z, p_v.z);
+	w = Math::modulo_no_overflow(w, p_v.w);
 	return *this;
 }
 
 constexpr Vector4i Vector4i::operator%(const Vector4i &p_v) const {
-	return Vector4i(x % p_v.x, y % p_v.y, z % p_v.z, w % p_v.w);
+	return Vector4i(Math::modulo_no_overflow(x, p_v.x), Math::modulo_no_overflow(y, p_v.y), Math::modulo_no_overflow(z, p_v.z), Math::modulo_no_overflow(w, p_v.w));
 }
 
 constexpr Vector4i &Vector4i::operator*=(int32_t p_scalar) {
@@ -265,27 +265,27 @@ constexpr Vector4i operator*(double p_scalar, const Vector4i &p_vector) {
 }
 
 constexpr Vector4i &Vector4i::operator/=(int32_t p_scalar) {
-	x /= p_scalar;
-	y /= p_scalar;
-	z /= p_scalar;
-	w /= p_scalar;
+	x = Math::division_no_overflow(x, p_scalar);
+	y = Math::division_no_overflow(y, p_scalar);
+	z = Math::division_no_overflow(z, p_scalar);
+	w = Math::division_no_overflow(w, p_scalar);
 	return *this;
 }
 
 constexpr Vector4i Vector4i::operator/(int32_t p_scalar) const {
-	return Vector4i(x / p_scalar, y / p_scalar, z / p_scalar, w / p_scalar);
+	return Vector4i(Math::division_no_overflow(x, p_scalar), Math::division_no_overflow(y, p_scalar), Math::division_no_overflow(z, p_scalar), Math::division_no_overflow(w, p_scalar));
 }
 
 constexpr Vector4i &Vector4i::operator%=(int32_t p_scalar) {
-	x %= p_scalar;
-	y %= p_scalar;
-	z %= p_scalar;
-	w %= p_scalar;
+	x = Math::modulo_no_overflow(x, p_scalar);
+	y = Math::modulo_no_overflow(y, p_scalar);
+	z = Math::modulo_no_overflow(z, p_scalar);
+	w = Math::modulo_no_overflow(w, p_scalar);
 	return *this;
 }
 
 constexpr Vector4i Vector4i::operator%(int32_t p_scalar) const {
-	return Vector4i(x % p_scalar, y % p_scalar, z % p_scalar, w % p_scalar);
+	return Vector4i(Math::modulo_no_overflow(x, p_scalar), Math::modulo_no_overflow(y, p_scalar), Math::modulo_no_overflow(z, p_scalar), Math::modulo_no_overflow(w, p_scalar));
 }
 
 constexpr Vector4i Vector4i::operator-() const {

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/math_funcs.h"
 #include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant.h"
@@ -225,6 +226,29 @@ public:
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
 };
 
+template <>
+class OperatorEvaluatorDivNZ<int64_t, int64_t, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const int64_t &a = VariantInternalAccessor<int64_t>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+		if (unlikely(b == 0)) {
+			r_valid = false;
+			*r_ret = "Division by zero error";
+			return;
+		}
+		*r_ret = Math::division_no_overflow(a, b);
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *p_left, const Variant *p_right, Variant *r_ret) {
+		VariantInternalAccessor<int64_t>::get(r_ret) = Math::division_no_overflow(VariantInternalAccessor<int64_t>::get(p_left), VariantInternalAccessor<int64_t>::get(p_right));
+	}
+	static void ptr_evaluate(const void *p_left, const void *p_right, void *r_ret) {
+		PtrToArg<int64_t>::encode(Math::division_no_overflow(PtrToArg<int64_t>::convert(p_left), PtrToArg<int64_t>::convert(p_right)), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<int64_t>::VARIANT_TYPE; }
+};
+
 template <typename R, typename A, typename B>
 class OperatorEvaluatorMod : public CommonEvaluate<OperatorEvaluatorMod<R, A, B>> {
 public:
@@ -330,6 +354,29 @@ public:
 		PtrToArg<Vector4i>::encode(PtrToArg<Vector4i>::convert(p_left) % PtrToArg<Vector4i>::convert(p_right), r_ret);
 	}
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector4i>::VARIANT_TYPE; }
+};
+
+template <>
+class OperatorEvaluatorModNZ<int64_t, int64_t, int64_t> {
+public:
+	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
+		const int64_t &a = VariantInternalAccessor<int64_t>::get(&p_left);
+		const int64_t &b = VariantInternalAccessor<int64_t>::get(&p_right);
+		if (unlikely(b == 0)) {
+			r_valid = false;
+			*r_ret = "Modulo by zero error";
+			return;
+		}
+		*r_ret = Math::modulo_no_overflow(a, b);
+		r_valid = true;
+	}
+	static inline void validated_evaluate(const Variant *p_left, const Variant *p_right, Variant *r_ret) {
+		VariantInternalAccessor<int64_t>::get(r_ret) = Math::modulo_no_overflow(VariantInternalAccessor<int64_t>::get(p_left), VariantInternalAccessor<int64_t>::get(p_right));
+	}
+	static void ptr_evaluate(const void *p_left, const void *p_right, void *r_ret) {
+		PtrToArg<int64_t>::encode(Math::modulo_no_overflow(PtrToArg<int64_t>::convert(p_left), PtrToArg<int64_t>::convert(p_right)), r_ret);
+	}
+	static Variant::Type get_return_type() { return GetTypeInfo<int64_t>::VARIANT_TYPE; }
 };
 
 template <typename R, typename A>

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/math_funcs.h"
 #include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant.h"
@@ -130,6 +131,26 @@ public:
 	using ReturnType = R;
 };
 
+namespace VariantOpInternal {
+
+template <typename A, typename B>
+constexpr auto div_nz(const A &p_a, const B &p_b) -> decltype(p_a / p_b) {
+	return p_a / p_b;
+}
+constexpr int64_t div_nz(int64_t p_a, int64_t p_b) {
+	return Math::division_no_overflow(p_a, p_b);
+}
+
+template <typename A, typename B>
+constexpr auto mod_nz(const A &p_a, const B &p_b) -> decltype(p_a % p_b) {
+	return p_a % p_b;
+}
+constexpr int64_t mod_nz(int64_t p_a, int64_t p_b) {
+	return Math::modulo_no_overflow(p_a, p_b);
+}
+
+} // namespace VariantOpInternal
+
 template <typename R, typename A, typename B>
 class OperatorEvaluatorDivNZ {
 public:
@@ -141,14 +162,14 @@ public:
 			*r_ret = "Division by zero error";
 			return;
 		}
-		*r_ret = a / b;
+		*r_ret = VariantOpInternal::div_nz(a, b);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *p_left, const Variant *p_right, Variant *r_ret) {
-		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(p_left) / VariantInternalAccessor<B>::get(p_right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantOpInternal::div_nz(VariantInternalAccessor<A>::get(p_left), VariantInternalAccessor<B>::get(p_right));
 	}
 	static void ptr_evaluate(const void *p_left, const void *p_right, void *r_ret) {
-		PtrToArg<R>::encode(PtrToArg<A>::convert(p_left) / PtrToArg<B>::convert(p_right), r_ret);
+		PtrToArg<R>::encode(VariantOpInternal::div_nz(PtrToArg<A>::convert(p_left), PtrToArg<B>::convert(p_right)), r_ret);
 	}
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
@@ -248,14 +269,14 @@ public:
 			*r_ret = "Modulo by zero error";
 			return;
 		}
-		*r_ret = a % b;
+		*r_ret = VariantOpInternal::mod_nz(a, b);
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *p_left, const Variant *p_right, Variant *r_ret) {
-		VariantInternalAccessor<R>::get(r_ret) = VariantInternalAccessor<A>::get(p_left) % VariantInternalAccessor<B>::get(p_right);
+		VariantInternalAccessor<R>::get(r_ret) = VariantOpInternal::mod_nz(VariantInternalAccessor<A>::get(p_left), VariantInternalAccessor<B>::get(p_right));
 	}
 	static void ptr_evaluate(const void *p_left, const void *p_right, void *r_ret) {
-		PtrToArg<R>::encode(PtrToArg<A>::convert(p_left) % PtrToArg<B>::convert(p_right), r_ret);
+		PtrToArg<R>::encode(VariantOpInternal::mod_nz(PtrToArg<A>::convert(p_left), PtrToArg<B>::convert(p_right)), r_ret);
 	}
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };

--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -672,4 +672,28 @@ TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {
 	static_assert(Math::is_equal_approx(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0), (T)1.0));
 }
 
+TEST_CASE("[Math] division_no_overflow/modulo_no_overflow") {
+	// `INT_MIN / -1` overflows the quotient. That is undefined behavior, and on x86
+	// it traps at the hardware level rather than wrapping.
+	static_assert(Math::division_no_overflow(INT32_MIN, -1) == INT32_MIN);
+	static_assert(Math::division_no_overflow(INT64_MIN, (int64_t)-1) == INT64_MIN);
+	static_assert(Math::modulo_no_overflow(INT32_MIN, -1) == 0);
+	static_assert(Math::modulo_no_overflow(INT64_MIN, (int64_t)-1) == 0);
+
+	// Everything else must behave exactly like the built-in operators.
+	static_assert(Math::division_no_overflow(10, -1) == -10);
+	static_assert(Math::division_no_overflow(-10, -1) == 10);
+	static_assert(Math::division_no_overflow(7, 2) == 3);
+	static_assert(Math::division_no_overflow(-7, 2) == -3);
+	static_assert(Math::modulo_no_overflow(10, -1) == 0);
+	static_assert(Math::modulo_no_overflow(7, 2) == 1);
+	static_assert(Math::modulo_no_overflow(-7, 2) == -1);
+
+	// Non-constant operands take the runtime path rather than being folded.
+	int64_t num = INT64_MIN;
+	int64_t den = -1;
+	CHECK(Math::division_no_overflow(num, den) == INT64_MIN);
+	CHECK(Math::modulo_no_overflow(num, den) == 0);
+}
+
 } // namespace TestMathFuncs

--- a/tests/core/math/test_vector2i.cpp
+++ b/tests/core/math/test_vector2i.cpp
@@ -167,4 +167,44 @@ TEST_CASE("[Vector2i] Abs and sign methods") {
 			"Vector2i sign should work as expected.");
 }
 
+TEST_CASE("[Vector2i] Division and modulo by -1") {
+	// `INT32_MIN / -1` overflows the quotient. That is undefined behavior, and on x86
+	// it traps at the hardware level rather than wrapping.
+	const Vector2i overflowing = Vector2i(INT32_MIN, 0);
+	const Vector2i minus_one_v = Vector2i(-1, 1);
+
+	CHECK_MESSAGE(
+			overflowing / minus_one_v == Vector2i(INT32_MIN, 0),
+			"Vector2i division of INT32_MIN by -1 should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing / -1 == Vector2i(INT32_MIN, 0),
+			"Vector2i division of INT32_MIN by the -1 scalar should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % minus_one_v == Vector2i(0, 0),
+			"Vector2i modulo of INT32_MIN by -1 should be zero instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % -1 == Vector2i(0, 0),
+			"Vector2i modulo of INT32_MIN by the -1 scalar should be zero instead of overflowing.");
+
+	Vector2i assigned = overflowing;
+	assigned /= -1;
+	CHECK_MESSAGE(
+			assigned == Vector2i(INT32_MIN, 0),
+			"Vector2i division assignment by -1 should wrap instead of overflowing.");
+	assigned = overflowing;
+	assigned %= -1;
+	CHECK_MESSAGE(
+			assigned == Vector2i(0, 0),
+			"Vector2i modulo assignment by -1 should be zero instead of overflowing.");
+
+	// Values that do not overflow must keep their ordinary results.
+	const Vector2i ordinary = Vector2i(10, -20);
+	CHECK_MESSAGE(
+			ordinary / -1 == Vector2i(-10, 20),
+			"Vector2i division by -1 should still negate when the quotient fits.");
+	CHECK_MESSAGE(
+			ordinary % -1 == Vector2i(0, 0),
+			"Vector2i modulo by -1 should still be zero when the quotient fits.");
+}
+
 } // namespace TestVector2i

--- a/tests/core/math/test_vector3i.cpp
+++ b/tests/core/math/test_vector3i.cpp
@@ -166,4 +166,44 @@ TEST_CASE("[Vector3i] Abs and sign methods") {
 			"Vector3i sign should work as expected.");
 }
 
+TEST_CASE("[Vector3i] Division and modulo by -1") {
+	// `INT32_MIN / -1` overflows the quotient. That is undefined behavior, and on x86
+	// it traps at the hardware level rather than wrapping.
+	const Vector3i overflowing = Vector3i(INT32_MIN, 0, 0);
+	const Vector3i minus_one_v = Vector3i(-1, 1, 1);
+
+	CHECK_MESSAGE(
+			overflowing / minus_one_v == Vector3i(INT32_MIN, 0, 0),
+			"Vector3i division of INT32_MIN by -1 should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing / -1 == Vector3i(INT32_MIN, 0, 0),
+			"Vector3i division of INT32_MIN by the -1 scalar should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % minus_one_v == Vector3i(0, 0, 0),
+			"Vector3i modulo of INT32_MIN by -1 should be zero instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % -1 == Vector3i(0, 0, 0),
+			"Vector3i modulo of INT32_MIN by the -1 scalar should be zero instead of overflowing.");
+
+	Vector3i assigned = overflowing;
+	assigned /= -1;
+	CHECK_MESSAGE(
+			assigned == Vector3i(INT32_MIN, 0, 0),
+			"Vector3i division assignment by -1 should wrap instead of overflowing.");
+	assigned = overflowing;
+	assigned %= -1;
+	CHECK_MESSAGE(
+			assigned == Vector3i(0, 0, 0),
+			"Vector3i modulo assignment by -1 should be zero instead of overflowing.");
+
+	// Values that do not overflow must keep their ordinary results.
+	const Vector3i ordinary = Vector3i(10, -20, 30);
+	CHECK_MESSAGE(
+			ordinary / -1 == Vector3i(-10, 20, -30),
+			"Vector3i division by -1 should still negate when the quotient fits.");
+	CHECK_MESSAGE(
+			ordinary % -1 == Vector3i(0, 0, 0),
+			"Vector3i modulo by -1 should still be zero when the quotient fits.");
+}
+
 } // namespace TestVector3i

--- a/tests/core/math/test_vector4i.cpp
+++ b/tests/core/math/test_vector4i.cpp
@@ -170,4 +170,44 @@ TEST_CASE("[Vector4i] Abs and sign methods") {
 			"Vector4i sign should work as expected.");
 }
 
+TEST_CASE("[Vector4i] Division and modulo by -1") {
+	// `INT32_MIN / -1` overflows the quotient. That is undefined behavior, and on x86
+	// it traps at the hardware level rather than wrapping.
+	const Vector4i overflowing = Vector4i(INT32_MIN, 0, 0, 0);
+	const Vector4i minus_one_v = Vector4i(-1, 1, 1, 1);
+
+	CHECK_MESSAGE(
+			overflowing / minus_one_v == Vector4i(INT32_MIN, 0, 0, 0),
+			"Vector4i division of INT32_MIN by -1 should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing / -1 == Vector4i(INT32_MIN, 0, 0, 0),
+			"Vector4i division of INT32_MIN by the -1 scalar should wrap instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % minus_one_v == Vector4i(0, 0, 0, 0),
+			"Vector4i modulo of INT32_MIN by -1 should be zero instead of overflowing.");
+	CHECK_MESSAGE(
+			overflowing % -1 == Vector4i(0, 0, 0, 0),
+			"Vector4i modulo of INT32_MIN by the -1 scalar should be zero instead of overflowing.");
+
+	Vector4i assigned = overflowing;
+	assigned /= -1;
+	CHECK_MESSAGE(
+			assigned == Vector4i(INT32_MIN, 0, 0, 0),
+			"Vector4i division assignment by -1 should wrap instead of overflowing.");
+	assigned = overflowing;
+	assigned %= -1;
+	CHECK_MESSAGE(
+			assigned == Vector4i(0, 0, 0, 0),
+			"Vector4i modulo assignment by -1 should be zero instead of overflowing.");
+
+	// Values that do not overflow must keep their ordinary results.
+	const Vector4i ordinary = Vector4i(10, -20, 30, -40);
+	CHECK_MESSAGE(
+			ordinary / -1 == Vector4i(-10, 20, -30, 40),
+			"Vector4i division by -1 should still negate when the quotient fits.");
+	CHECK_MESSAGE(
+			ordinary % -1 == Vector4i(0, 0, 0, 0),
+			"Vector4i modulo by -1 should still be zero when the quotient fits.");
+}
+
 } // namespace TestVector4i


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #26131

## Additional information
print(-9223372036854775808 / -1) gives -9223372036854775808
print(-9223372036854775808 % -1) gives 0

