### PR TITLE
Use implicit MSAA resolve framebuffer for postprocess ( draft )

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -779,13 +779,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			// If we do a nearest or bilinear upscale, we just render into our render target and our shader will upscale automatically.
 			// Target size in this case is lying as we never get our real target size communicated.
 			// Bit nasty but...
-
-			if (dest_is_msaa_2d) {
-				dest_fb = FramebufferCacheRD::get_singleton()->get_cache(texture_storage->render_target_get_rd_texture_msaa(render_target));
-				texture_storage->render_target_set_msaa_needs_resolve(render_target, true); // Make sure this gets resolved.
-			} else {
-				dest_fb = texture_storage->render_target_get_rd_framebuffer(render_target);
-			}
+			
+			dest_fb = texture_storage->render_target_get_rd_framebuffer(render_target);
 
 			tonemap.dest_texture_size = texture_storage->render_target_get_size(render_target);
 			tonemap.bilinear_filtering = scale_mode != RSE::VIEWPORT_SCALING_3D_MODE_NEAREST;
@@ -847,12 +842,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				RID dest_texture = rb->create_texture(SNAME("SMAA"), SNAME("destination"), rb->get_base_data_format(), RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT, RD::TEXTURE_SAMPLES_1, Size2i(), 0, 1, true, true);
 				dest_fb = FramebufferCacheRD::get_singleton()->get_cache(dest_texture);
 			} else {
-				if (dest_is_msaa_2d) {
-					dest_fb = FramebufferCacheRD::get_singleton()->get_cache(texture_storage->render_target_get_rd_texture_msaa(render_target));
-					texture_storage->render_target_set_msaa_needs_resolve(render_target, true); // Make sure this gets resolved.
-				} else {
 					dest_fb = texture_storage->render_target_get_rd_framebuffer(render_target);
-				}
 			}
 
 			smaa->process(rb, source_texture, dest_fb, rb->get_use_debanding() && !using_hdr);
@@ -890,10 +880,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		if (dest_is_msaa_2d) {
 			// We can't upscale directly into our MSAA buffer so we need to do a copy
 			RID source_texture = texture_storage->render_target_get_rd_texture(render_target);
-			RID dest_fb = FramebufferCacheRD::get_singleton()->get_cache(texture_storage->render_target_get_rd_texture_msaa(render_target));
+			RID dest_fb = texture_storage->render_target_get_rd_framebuffer(render_target);
 			copy_effects->copy_to_fb_rect(source_texture, dest_fb, Rect2i(Point2i(), rb->get_target_size()));
-
-			texture_storage->render_target_set_msaa_needs_resolve(render_target, true); // Make sure this gets resolved.
 		}
 
 		RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -754,6 +754,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 	if (RSG::texture_storage->render_target_get_msaa_needs_resolve(p_viewport->render_target)) {
 		WARN_PRINT_ONCE("2D MSAA is enabled while there is no 2D content. Disable 2D MSAA for better performance.");
+		// And there is no need for this pass now
 		RSG::texture_storage->render_target_do_msaa_resolve(p_viewport->render_target);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120637

## Additional information

Hello :v:

Any "final" postprocess step would render into frame buffer with msaa/resolve attachment instead of color_multisample. Thus there is no need for the explicit resolve pass at `renderer_scene_render_rd.cpp,  line/ ~757`. By "final" I mean branches like the one at  `renderer_scene_render_rd.cpp,  line/ 771`   `if (using_scaling_pass || use_smaa) {`. So it is reasonable to do an implicit msaa resolve at every such place.

On the downside, code becomes kinda fragile, but that may be fixes by some clever refactoring.

Since the #120637 issue is cause by explicit msaa resolve via empty render pass, we can use approach #121595 or this one. 
In theory this PR will save some memory bandwidth without any regression, or at least I couldn't find any potential one.

Note that's draft PR for discussion. If it works as I think it does then I'll do an update after a couple of improvements :kissing_cat:

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
