### PR TITLE
Fix area monitoring logic bugs

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -83,30 +83,28 @@ void GodotArea2D::set_space(GodotSpace2D *p_space) {
 }
 
 void GodotArea2D::set_monitor_callback(const Callable &p_callback) {
-	_unregister_shapes();
-
+	if (monitor_callback.is_valid() == p_callback.is_valid()) {
+		monitor_callback = p_callback;
+		return;
+	}
 	monitor_callback = p_callback;
-
 	monitored_bodies.clear();
-	monitored_areas.clear();
 
-	_shape_changed();
-
+	_set_static(!(area_monitor_callback.is_valid() || monitor_callback.is_valid()));
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
 	}
 }
 
 void GodotArea2D::set_area_monitor_callback(const Callable &p_callback) {
-	_unregister_shapes();
-
+	if (area_monitor_callback.is_valid() == p_callback.is_valid()) {
+		area_monitor_callback = p_callback;
+		return;
+	}
 	area_monitor_callback = p_callback;
-
-	monitored_bodies.clear();
 	monitored_areas.clear();
 
-	_shape_changed();
-
+	_set_static(!(area_monitor_callback.is_valid() || monitor_callback.is_valid()));
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
 	}
@@ -117,9 +115,10 @@ void GodotArea2D::_set_space_override_mode(PS2DE::AreaSpaceOverrideMode &r_mode,
 	if (do_override == (r_mode != PS2DE::AREA_SPACE_OVERRIDE_DISABLED)) {
 		return;
 	}
-	_unregister_shapes();
 	r_mode = p_new_mode;
-	_shape_changed();
+	if (!moved_list.in_list() && get_space()) {
+		get_space()->area_add_to_moved_list(&moved_list);
+	}
 }
 
 void GodotArea2D::set_param(PS2DE::AreaParameter p_param, const Variant &p_value) {
@@ -198,8 +197,9 @@ void GodotArea2D::set_monitorable(bool p_monitorable) {
 	}
 
 	monitorable = p_monitorable;
-	_set_static(!monitorable);
-	_shapes_changed();
+	if (!moved_list.in_list() && get_space()) {
+		get_space()->area_add_to_moved_list(&moved_list);
+	}
 }
 
 void GodotArea2D::call_queries() {

--- a/modules/godot_physics_2d/godot_area_2d.h
+++ b/modules/godot_physics_2d/godot_area_2d.h
@@ -115,6 +115,10 @@ public:
 	void set_param(PS2DE::AreaParameter p_param, const Variant &p_value);
 	Variant get_param(PS2DE::AreaParameter p_param) const;
 
+	_FORCE_INLINE_ bool has_space_override() const {
+		return gravity_override_mode != PS2DE::AREA_SPACE_OVERRIDE_DISABLED || linear_damping_override_mode != PS2DE::AREA_SPACE_OVERRIDE_DISABLED || angular_damping_override_mode != PS2DE::AREA_SPACE_OVERRIDE_DISABLED;
+	}
+
 	_FORCE_INLINE_ void set_gravity(real_t p_gravity) { gravity = p_gravity; }
 	_FORCE_INLINE_ real_t get_gravity() const { return gravity; }
 
@@ -143,6 +147,12 @@ public:
 
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }
+
+	void refresh_pair(GodotCollisionObject2D *p_source) override {
+		if (this != p_source) {
+			_shapes_changed();
+		}
+	}
 
 	void set_transform(const Transform2D &p_transform);
 

--- a/modules/godot_physics_2d/godot_area_pair_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_pair_2d.cpp
@@ -33,58 +33,44 @@
 #include "godot_collision_solver_2d.h"
 
 bool GodotAreaPair2D::setup(real_t p_step) {
-	bool result = false;
-	if (area->collides_with(body) && GodotCollisionSolver2D::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), nullptr, this)) {
-		result = true;
-	}
-
-	process_collision = false;
-	has_space_override = false;
-	if (result != colliding) {
-		if ((int)area->get_param(PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE) != PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		} else if ((int)area->get_param(PS2DE::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE) != PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		} else if ((int)area->get_param(PS2DE::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE) != PS2DE::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		}
-		process_collision = has_space_override;
-
-		if (area->has_monitor_callback()) {
-			process_collision = true;
-		}
-
-		colliding = result;
-	}
-
-	return process_collision;
-}
-
-bool GodotAreaPair2D::pre_solve(real_t p_step) {
-	if (!process_collision) {
+	bool latest_has_space_override = area->has_space_override();
+	bool latest_monitoring = area->has_monitor_callback();
+	if (!latest_has_space_override && !has_space_override && !latest_monitoring) {
 		return false;
 	}
 
-	if (colliding) {
-		if (has_space_override) {
-			body_has_attached_area = true;
+	bool latest_colliding = area->collides_with(body);
+	if (latest_colliding && !GodotCollisionSolver2D::solve(body->get_shape(body_shape), body->get_transform() * body->get_shape_transform(body_shape), Vector2(), area->get_shape(area_shape), area->get_transform() * area->get_shape_transform(area_shape), Vector2(), nullptr, this)) {
+		latest_colliding = false;
+	}
+
+	process_collision = (colliding && has_space_override) != (latest_colliding && latest_has_space_override);
+	process_monitored_collision = latest_monitoring && ((monitoring && (latest_colliding != colliding)) || (latest_colliding && !monitoring));
+
+	has_space_override = latest_has_space_override;
+	monitoring = latest_monitoring;
+	colliding = latest_colliding;
+
+	return process_collision || process_monitored_collision;
+}
+
+bool GodotAreaPair2D::pre_solve(real_t p_step) {
+	if (process_collision) {
+		// TODO: Confirm this `body` access is the reason pre-solve is not threaded, then fix, or enable threading again.
+		if (colliding && has_space_override) {
 			body->add_area(area);
-		}
-
-		if (area->has_monitor_callback()) {
-			area->add_body_to_query(body, body_shape, area_shape);
-		}
-	} else {
-		if (has_space_override) {
-			body_has_attached_area = false;
+		} else {
 			body->remove_area(area);
-		}
-
-		if (area->has_monitor_callback()) {
-			area->remove_body_from_query(body, body_shape, area_shape);
 		}
 	}
 
+	if (process_monitored_collision) {
+		if (colliding) {
+			area->add_body_to_query(body, body_shape, area_shape);
+		} else {
+			area->remove_body_from_query(body, body_shape, area_shape);
+		}
+	}
 	return false; // Never do any post solving.
 }
 
@@ -97,6 +83,8 @@ GodotAreaPair2D::GodotAreaPair2D(GodotBody2D *p_body, int p_body_shape, GodotAre
 	area = p_area;
 	body_shape = p_body_shape;
 	area_shape = p_area_shape;
+	monitoring = area->has_monitor_callback();
+	has_space_override = area->has_space_override();
 	body->add_constraint(this, 0);
 	area->add_constraint(this);
 	if (p_body->get_mode() == PS2DE::BODY_MODE_KINEMATIC) { //need to be active to process pair
@@ -106,8 +94,7 @@ GodotAreaPair2D::GodotAreaPair2D(GodotBody2D *p_body, int p_body_shape, GodotAre
 
 GodotAreaPair2D::~GodotAreaPair2D() {
 	if (colliding) {
-		if (body_has_attached_area) {
-			body_has_attached_area = false;
+		if (has_space_override) {
 			body->remove_area(area);
 		}
 		if (area->has_monitor_callback()) {
@@ -121,34 +108,36 @@ GodotAreaPair2D::~GodotAreaPair2D() {
 //////////////////////////////////
 
 bool GodotArea2Pair2D::setup(real_t p_step) {
-	bool result_a = area_a->collides_with(area_b);
-	bool result_b = area_b->collides_with(area_a);
+	bool result_a = area_a->collides_with(area_b) && area_b->is_monitorable();
+	bool result_b = area_b->collides_with(area_a) && area_a->is_monitorable();
+
 	if ((result_a || result_b) && !GodotCollisionSolver2D::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), nullptr, this)) {
 		result_a = false;
 		result_b = false;
 	}
 
-	bool process_collision = false;
-
 	process_collision_a = false;
 	if (result_a != colliding_a) {
-		if (area_a->has_area_monitor_callback() && area_b_monitorable) {
-			process_collision_a = true;
-			process_collision = true;
-		}
+		process_collision_a = area_a_monitoring;
 		colliding_a = result_a;
 	}
 
 	process_collision_b = false;
 	if (result_b != colliding_b) {
-		if (area_b->has_area_monitor_callback() && area_a_monitorable) {
-			process_collision_b = true;
-			process_collision = true;
-		}
+		process_collision_b = area_b_monitoring;
 		colliding_b = result_b;
 	}
 
-	return process_collision;
+	if (area_a->has_area_monitor_callback() != area_a_monitoring) {
+		area_a_monitoring = area_a->has_area_monitor_callback();
+		process_collision_a = area_a_monitoring && colliding_a;
+	}
+	if (area_b->has_area_monitor_callback() != area_b_monitoring) {
+		area_b_monitoring = area_b->has_area_monitor_callback();
+		process_collision_b = area_b_monitoring && colliding_b;
+	}
+
+	return process_collision_a || process_collision_b;
 }
 
 bool GodotArea2Pair2D::pre_solve(real_t p_step) {
@@ -182,6 +171,8 @@ GodotArea2Pair2D::GodotArea2Pair2D(GodotArea2D *p_area_a, int p_shape_a, GodotAr
 	shape_b = p_shape_b;
 	area_a_monitorable = area_a->is_monitorable();
 	area_b_monitorable = area_b->is_monitorable();
+	area_a_monitoring = area_a->has_area_monitor_callback();
+	area_b_monitoring = area_b->has_area_monitor_callback();
 	area_a->add_constraint(this);
 	area_b->add_constraint(this);
 }

--- a/modules/godot_physics_2d/godot_area_pair_2d.h
+++ b/modules/godot_physics_2d/godot_area_pair_2d.h
@@ -40,14 +40,20 @@ class GodotAreaPair2D : public GodotConstraint2D {
 	int body_shape = 0;
 	int area_shape = 0;
 	bool colliding = false;
-	bool has_space_override = false;
+	bool process_monitored_collision = false;
 	bool process_collision = false;
-	bool body_has_attached_area = false;
+	bool has_space_override;
+	bool monitoring;
 
 public:
 	virtual bool setup(real_t p_step) override;
 	virtual bool pre_solve(real_t p_step) override;
 	virtual void solve(real_t p_step) override;
+
+	virtual void refresh_pair(GodotCollisionObject2D *p_source) override {
+		body->refresh_pair(p_source);
+		area->refresh_pair(p_source);
+	}
 
 	GodotAreaPair2D(GodotBody2D *p_body, int p_body_shape, GodotArea2D *p_area, int p_area_shape);
 	~GodotAreaPair2D();
@@ -64,11 +70,18 @@ class GodotArea2Pair2D : public GodotConstraint2D {
 	bool process_collision_b = false;
 	bool area_a_monitorable;
 	bool area_b_monitorable;
+	bool area_a_monitoring;
+	bool area_b_monitoring;
 
 public:
 	virtual bool setup(real_t p_step) override;
 	virtual bool pre_solve(real_t p_step) override;
 	virtual void solve(real_t p_step) override;
+
+	virtual void refresh_pair(GodotCollisionObject2D *p_source) override {
+		area_a->refresh_pair(p_source);
+		area_b->refresh_pair(p_source);
+	}
 
 	GodotArea2Pair2D(GodotArea2D *p_area_a, int p_shape_a, GodotArea2D *p_area_b, int p_shape_b);
 	~GodotArea2Pair2D();

--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -656,23 +656,8 @@ void GodotBody2D::integrate_velocities(real_t p_step) {
 
 void GodotBody2D::wakeup_neighbours() {
 	for (const Pair<GodotConstraint2D *, int> &E : constraint_list) {
-		const GodotConstraint2D *c = E.first;
-		GodotBody2D **n = c->get_body_ptr();
-		int bc = c->get_body_count();
-
-		for (int i = 0; i < bc; i++) {
-			if (i == E.second) {
-				continue;
-			}
-			GodotBody2D *b = n[i];
-			if (b->mode < PS2DE::BODY_MODE_RIGID) {
-				continue;
-			}
-
-			if (!b->is_active()) {
-				b->set_active(true);
-			}
-		}
+		GodotConstraint2D *c = E.first;
+		c->refresh_pair(this);
 	}
 }
 

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -293,6 +293,12 @@ public:
 		set_active(true);
 	}
 
+	void refresh_pair(GodotCollisionObject2D *p_source) override {
+		if (this != p_source) {
+			wakeup();
+		}
+	}
+
 	void set_param(PS2DE::BodyParameter p_param, const Variant &p_value);
 	Variant get_param(PS2DE::BodyParameter p_param) const;
 

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -183,6 +183,7 @@ public:
 	void remove_shape(GodotShape2D *p_shape) override;
 	void remove_shape(int p_index);
 
+	virtual void refresh_pair(GodotCollisionObject2D *p_source) = 0;
 	virtual void set_space(GodotSpace2D *p_space) = 0;
 
 	_FORCE_INLINE_ bool is_static() const { return _static; }

--- a/modules/godot_physics_2d/godot_constraint_2d.h
+++ b/modules/godot_physics_2d/godot_constraint_2d.h
@@ -32,6 +32,8 @@
 
 #include "godot_body_2d.h"
 
+#include "modules/godot_physics_2d/godot_collision_object_2d.h"
+
 class GodotConstraint2D {
 	GodotBody2D **_body_ptr;
 	int _body_count;
@@ -58,6 +60,13 @@ public:
 
 	_FORCE_INLINE_ void disable_collisions_between_bodies(const bool p_disabled) { disabled_collisions_between_bodies = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled_collisions_between_bodies() const { return disabled_collisions_between_bodies; }
+
+	virtual void refresh_pair(GodotCollisionObject2D *p_source) {
+		for (int i = 0; i < _body_count; i++) {
+			GodotCollisionObject2D *body = _body_ptr[i];
+			body->refresh_pair(p_source);
+		}
+	}
 
 	virtual bool setup(real_t p_step) = 0;
 	virtual bool pre_solve(real_t p_step) = 0;

--- a/modules/godot_physics_2d/godot_joints_2d.h
+++ b/modules/godot_physics_2d/godot_joints_2d.h
@@ -52,6 +52,8 @@ public:
 	_FORCE_INLINE_ void set_max_bias(real_t p_bias) { max_bias = p_bias; }
 	_FORCE_INLINE_ real_t get_max_bias() const { return max_bias; }
 
+	virtual void refresh_pair(GodotCollisionObject2D *p_source) override {}
+
 	virtual bool setup(real_t p_step) override { return false; }
 	virtual bool pre_solve(real_t p_step) override { return false; }
 	virtual void solve(real_t p_step) override {}


### PR DESCRIPTION
- Remove unnecessary BVH shape change triggers from godot_area_2d.cpp
- Consolidate area parameter change logic within godot_area_pair_2d.cpp
- Add fast and simple `has_space_override()` access function to area
- Move `_set_static()` to respond to Monitoring, not Monitorable
- Add virtual functions `refresh_pair(p_source)` to propagate changes via constraint graph

## What problem(s) does this PR solve?

Closes: #121094
Closes: #100346
Closes: #25331
Closes: #111823
Closes: #81883
Closes: #71489

Closes for 2D (no MRP to test):
#17238

May close or positively impact other issues I haven't fully read or tested, inc:
#14578, #19271, #25769

Supersedes: #111880

## What was wrong

Besides bugs and missing edge cases: 

### Areas were being assigned to the wrong BVH tree
This PR assigns areas to the static or dynamic BVH tree based on `monitoring` settings, rather than `monitorable`. 

I suspect that `monitorable` was being used because it improved performance in the past, before areas were able to be used dynamically.

This fix could have peformance impacts I am happy to discuss, but they seem immaterial in testing of my own games. The peformance impact will be where areas are actually detecting static bodies, in scenarios where they were not before (which was a bug of omission). 

### Parameter changes were propagating via BVH side effects
Basically the code was calling broadphase->move() and sometimes destroying and recreating BVH shapes in the hope that the BVH will then destroy and re-create a constraint pair, which will then check all the collision and monitoring flags anew.

This cannot work properly for monitoring/monitorable for complicated reasons. In other cases, the BVH optimizes away the codes attempts to force a constraint re-creation, because it sees that their AABB hasn't changed.

This PR consolidates logic for relevant parameter changes within the constraint processing itself. As a result, it should make future fixes and maintenance easier.

## Testing

I have tested on MRPs from these issues:
#121094, #100346, #25331, #111823, #81883, #71489, 

I have tested on my own games/prototypes:
*  A side view, physics heavy game with hordes and platform like geometry (inc tilemaps, SmartShapes and polygons). 
* A top down shooter with character bodies and areas for collisions.

I have tested on about 5 other related MRPs and haven't found any regressions. 

My primary working test was an expanded version of the MRP from #121094. This MRP tests a large number of detection and movement scenarios at once. See below:

[area-2d.zip](https://github.com/user-attachments/files/30367786/area-2d.zip)



