### PR TITLE
Wake bodies on constraint addition and removal

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -143,6 +143,9 @@ void GodotBody2D::set_active(bool p_active) {
 			active = false;
 		} else if (get_space()) {
 			get_space()->body_add_to_active_list(&active_list);
+
+			// Give the body at least one physics frame to start moving, before allowing it to sleep again.
+			still_time = get_space()->get_body_time_to_sleep() - 0.0001;
 		}
 	} else if (get_space()) {
 		get_space()->body_remove_from_active_list(&active_list);
@@ -711,9 +714,9 @@ bool GodotBody2D::sleep_test(real_t p_step) {
 	ERR_FAIL_NULL_V(get_space(), true);
 
 	if (Math::abs(angular_velocity) < get_space()->get_body_angular_velocity_sleep_threshold() && Math::abs(linear_velocity.length_squared()) < get_space()->get_body_linear_velocity_sleep_threshold() * get_space()->get_body_linear_velocity_sleep_threshold()) {
+		bool result = still_time > get_space()->get_body_time_to_sleep();
 		still_time += p_step;
-
-		return still_time > get_space()->get_body_time_to_sleep();
+		return result;
 	} else {
 		still_time = 0; //maybe this should be set to 0 on set_active?
 		return false;

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -204,8 +204,14 @@ public:
 	_FORCE_INLINE_ uint64_t get_island_step() const { return island_step; }
 	_FORCE_INLINE_ void set_island_step(uint64_t p_step) { island_step = p_step; }
 
-	_FORCE_INLINE_ void add_constraint(GodotConstraint2D *p_constraint, int p_pos) { constraint_list.push_back({ p_constraint, p_pos }); }
-	_FORCE_INLINE_ void remove_constraint(GodotConstraint2D *p_constraint, int p_pos) { constraint_list.erase({ p_constraint, p_pos }); }
+	_FORCE_INLINE_ void add_constraint(GodotConstraint2D *p_constraint, int p_pos) {
+		constraint_list.push_back({ p_constraint, p_pos });
+		wakeup();
+	}
+	_FORCE_INLINE_ void remove_constraint(GodotConstraint2D *p_constraint, int p_pos) {
+		constraint_list.erase({ p_constraint, p_pos });
+		wakeup();
+	}
 	const List<Pair<GodotConstraint2D *, int>> &get_constraint_list() const { return constraint_list; }
 	_FORCE_INLINE_ void clear_constraint_list() { constraint_list.clear(); }
 


### PR DESCRIPTION
Also allow at least one frame before sleeping, to allow bodies to integrate forces before the movement test.

## What problem(s) does this PR solve?

- Closes #64890

## Additional information

Bodies were not waking when constraints were removed. So a rigid body sitting on a character body would not fall when the character body was moved or removed. 

Additionally, depending on when bodies were awoken, they may not have been given a full force integration cycle before being put back to sleep again. 

This PR calls wake when constraints are added or removed and also tries to ensure that one frame is offered before sleeping again (which is necessary to make this PR work).

There are more robust ways to ensure at least one frame gap between sleep activations, but they require more changes and access to objects that godot_body_2d.cpp doesn't currently have access to. 

## Testing
Tested on my own game and prototype as well as the MRP from #64890 

Additionally, edit the #64890 MRP so that the CharacterBody2D moves rather than being removed.