### PR TITLE
[4.2] CI: Fix GitHub Action workflows 

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Restore SCons cache directory
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Save SCons cache directory
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: x64
   scons-version:
     description: The SCons version to use.
-    default: 4.8.1
+    default: 4.10.1
 
 runs:
   using: composite

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         # Semantic version range syntax or exact version of a Python version.
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Upload Godot Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   ios-template:
+    # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
     runs-on: macos-latest
     name: Template (target=template_release)
     timeout-minutes: 60
@@ -19,6 +20,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+
+      # From https://github.com/actions/runner-images/blob/main/images/macos
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   build-macos:
+    # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
     runs-on: macos-latest
     name: ${{ matrix.name }}
     timeout-minutes: 120
@@ -36,8 +37,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      # From https://github.com/actions/runner-images/blob/main/images/macos
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -79,7 +79,8 @@ void StringName::cleanup() {
 		data.sort_custom<DebugSortReferences>();
 		int unreferenced_stringnames = 0;
 		int rarely_referenced_stringnames = 0;
-		for (int i = 0; i < data.size(); i++) {
+		const int data_size = data.size();
+		for (int i = 0; i < data_size; i++) {
 			print_line(itos(i + 1) + ": " + data[i]->get_name() + " - " + itos(data[i]->debug_references));
 			if (data[i]->debug_references == 0) {
 				unreferenced_stringnames += 1;
@@ -88,8 +89,8 @@ void StringName::cleanup() {
 			}
 		}
 
-		print_line(vformat("\nOut of %d StringNames, %d StringNames were never referenced during this run (0 times) (%.2f%%).", data.size(), unreferenced_stringnames, unreferenced_stringnames / float(data.size()) * 100));
-		print_line(vformat("Out of %d StringNames, %d StringNames were rarely referenced during this run (1-4 times) (%.2f%%).", data.size(), rarely_referenced_stringnames, rarely_referenced_stringnames / float(data.size()) * 100));
+		print_line(vformat("\nOut of %d StringNames, %d StringNames were never referenced during this run (0 times) (%.2f%%).", data_size, unreferenced_stringnames, unreferenced_stringnames / float(data_size) * 100));
+		print_line(vformat("Out of %d StringNames, %d StringNames were rarely referenced during this run (1-4 times) (%.2f%%).", data_size, rarely_referenced_stringnames, rarely_referenced_stringnames / float(data_size) * 100));
 	}
 #endif
 	int lost_strings = 0;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -193,8 +193,9 @@ void GenericTilePolygonEditor::_base_control_draw() {
 		base_control->draw_polygon(polygon, v_color);
 
 		color.a = 0.7;
-		for (int j = 0; j < polygon.size(); j++) {
-			base_control->draw_line(polygon[j], polygon[(j + 1) % polygon.size()], color);
+		const int polygon_size = polygon.size();
+		for (int j = 0; j < polygon_size; j++) {
+			base_control->draw_line(polygon[j], polygon[(j + 1) % polygon_size], color);
 		}
 	}
 
@@ -404,8 +405,9 @@ void GenericTilePolygonEditor::_grab_polygon_segment_point(Vector2 p_pos, const 
 	float closest_distance = grab_threshold * 2.0;
 	for (unsigned int i = 0; i < polygons.size(); i++) {
 		const Vector<Vector2> &polygon = polygons[i];
-		for (int j = 0; j < polygon.size(); j++) {
-			Vector2 segment[2] = { polygon[j], polygon[(j + 1) % polygon.size()] };
+		const int polygon_size = polygon.size();
+		for (int j = 0; j < polygon_size; j++) {
+			Vector2 segment[2] = { polygon[j], polygon[(j + 1) % polygon_size] };
 			Vector2 closest_point = Geometry2D::get_closest_point_to_segment(point, segment);
 			float distance = closest_point.distance_to(point);
 			if (distance < grab_threshold / editor_zoom_widget->get_zoom() && distance < closest_distance) {
@@ -429,7 +431,8 @@ void GenericTilePolygonEditor::_snap_to_tile_shape(Point2 &r_point, float &r_cur
 
 	// Snap to polygon vertices.
 	bool snapped = false;
-	for (int i = 0; i < polygon.size(); i++) {
+	const int polygon_size = polygon.size();
+	for (int i = 0; i < polygon_size; i++) {
 		float distance = r_point.distance_to(polygon[i]);
 		if (distance < p_snap_dist && distance < r_current_snapped_dist) {
 			snapped_point = polygon[i];
@@ -440,8 +443,8 @@ void GenericTilePolygonEditor::_snap_to_tile_shape(Point2 &r_point, float &r_cur
 
 	// Snap to edges if we did not snap to vertices.
 	if (!snapped) {
-		for (int i = 0; i < polygon.size(); i++) {
-			Point2 segment[2] = { polygon[i], polygon[(i + 1) % polygon.size()] };
+		for (int i = 0; i < polygon_size; i++) {
+			Point2 segment[2] = { polygon[i], polygon[(i + 1) % polygon_size] };
 			Point2 point = Geometry2D::get_closest_point_to_segment(r_point, segment);
 			float distance = r_point.distance_to(point);
 			if (distance < p_snap_dist && distance < r_current_snapped_dist) {

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -42,9 +42,10 @@ void CollisionPolygon2D::_build_polygon() {
 	collision_object->shape_owner_clear_shapes(owner_id);
 
 	bool solids = build_mode == BUILD_SOLIDS;
+	const int polygon_size = polygon.size();
 
 	if (solids) {
-		if (polygon.size() < 3) {
+		if (polygon_size < 3) {
 			return;
 		}
 
@@ -58,19 +59,19 @@ void CollisionPolygon2D::_build_polygon() {
 		}
 
 	} else {
-		if (polygon.size() < 2) {
+		if (polygon_size < 2) {
 			return;
 		}
 
 		Ref<ConcavePolygonShape2D> concave = memnew(ConcavePolygonShape2D);
 
 		Vector<Vector2> segments;
-		segments.resize(polygon.size() * 2);
+		segments.resize(polygon_size * 2);
 		Vector2 *w = segments.ptrw();
 
-		for (int i = 0; i < polygon.size(); i++) {
+		for (int i = 0; i < polygon_size; i++) {
 			w[(i << 1) + 0] = polygon[i];
-			w[(i << 1) + 1] = polygon[(i + 1) % polygon.size()];
+			w[(i << 1) + 1] = polygon[(i + 1) % polygon_size];
 		}
 
 		concave->set_segments(segments);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -911,10 +911,11 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		GenProbesOctree octree;
 		octree.size = subdiv;
 
-		for (int i = 0; i < mesh_data.size(); i++) {
+		const int mesh_data_size = mesh_data.size();
+		for (int i = 0; i < mesh_data_size; i++) {
 			if (p_bake_step) {
-				float p = (float)(i) / mesh_data.size();
-				p_bake_step(0.3 + p * 0.1, vformat(RTR("Creating probes from mesh %d/%d"), i, mesh_data.size()), p_bake_userdata, false);
+				float p = (float)(i) / mesh_data_size;
+				p_bake_step(0.3 + p * 0.1, vformat(RTR("Creating probes from mesh %d/%d"), i, mesh_data_size), p_bake_userdata, false);
 			}
 
 			for (int j = 0; j < mesh_data[i].points.size(); j += 3) {

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -382,6 +382,8 @@ Files generated from upstream source:
 4. Delete `data/out` folder and rebuild data: `cd data && rm -rf ./out && make`
 5. Copy `source/data/out/icudt73l.dat` to the `{GODOT_SOURCE}/thirdparty/icu4c/icudt73l.dat`
 
+Apply `patches` to fix the `-Wunnecessary-virtual-specifier` warning in Clang. Newer versions of ICU4C do not have this warning, this only applies to older versions.
+
 
 ## jpeg-compressor
 

--- a/thirdparty/icu4c/common/unicode/uniset.h
+++ b/thirdparty/icu4c/common/unicode/uniset.h
@@ -282,7 +282,7 @@ class RuleCharacterIterator;
  * @author Alan Liu
  * @stable ICU 2.0
  */
-class U_COMMON_API UnicodeSet final : public UnicodeFilter {
+class U_COMMON_API UnicodeSet : public UnicodeFilter {
 private:
     /**
      * Enough for sets with few ranges.

--- a/thirdparty/icu4c/patches/icu4c_remove_final_unicode_set.patch
+++ b/thirdparty/icu4c/patches/icu4c_remove_final_unicode_set.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/icu4c/common/unicode/uniset.h b/thirdparty/icu4c/common/unicode/uniset.h
+index 127e4ce..f68e714 100644
+--- a/thirdparty/icu4c/common/unicode/uniset.h
++++ b/thirdparty/icu4c/common/unicode/uniset.h
+@@ -282,7 +282,7 @@ class RuleCharacterIterator;
+  * @author Alan Liu
+  * @stable ICU 2.0
+  */
+-class U_COMMON_API UnicodeSet final : public UnicodeFilter {
++class U_COMMON_API UnicodeSet : public UnicodeFilter {
+ private:
+     /**
+      * Enough for sets with few ranges.


### PR DESCRIPTION
This PR fixes several problems that occur on the GitHub Actions CI checks when compiling the 4.2 branch.

Note: I am aware that the Godot maintainers have told me to stop touching old Godot branches. However, I believe "making it compile" should still be in the scope of support (so, basically zero support, but not quite zero).

Namely, it cherry-picks the following commits and PRs:

- PR https://github.com/godotengine/godot/pull/115132 commit 30cfb06941ec86d7b7da164ca67cb5094c82441a
  - Note: I included a further manual tweak to bump to v7 instead of just bumping to v6.
  - Avoids warnings from GitHub Actions itself.
- PR https://github.com/godotengine/godot/pull/111799 commit fe6763c7232cbe85ffb85b3726c6a083685e0bb6.
  - Required to fix compatibility with `macos-latest`.
- PR https://github.com/godotengine/godot/pull/117428 commit 423ba3da00f9601be3acb813ef84b903524e36dd
  - Avoids warnings from GitHub Actions itself.
- PR https://github.com/godotengine/godot/pull/113403 commit a998842e3e7b7517c2f5a173635ed7883b43d7eb
  - This is actually a combination of several "bump SCons version" PRs by @Repiteo, but I'm only crediting the last one.
  - Required to fix compatibility with `windows-latest` and MSVC for Visual Studio 2026.
- New commit: "[4.2] Remove final from ICU4C UnicodeSet class"
  - Required to fix a warning in Clang: `-Wunnecessary-virtual-specifier`
  - This isn't cherry-picked from anything, since it only affects old versions of ICU4C. Newer Godot versions have a different fix: updating ICU4C to a newer release that fixes this warning.
- PR https://github.com/godotengine/godot/pull/121746
  - Required to fix compiling with MSVC with `werror=yes`.
