### PR TITLE
Document `Image.blend_rect()` blends sequentially per-pixel

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -30,7 +30,7 @@
 			<param index="2" name="dst" type="Vector2i" />
 			<description>
 				Alpha-blends [param src_rect] from [param src] image to this image at coordinates [param dst], clipped accordingly to both image bounds. This image and [param src] image [b]must[/b] have the same format. [param src_rect] with non-positive size is treated as empty.
-				Simultaneously reading and writing to the same image reference may lead to unexpected results.
+				[b]Note:[/b] Simultaneously reading and writing to the same image reference may lead to unexpected results.
 			</description>
 		</method>
 		<method name="blend_rect_mask">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -30,7 +30,7 @@
 			<param index="2" name="dst" type="Vector2i" />
 			<description>
 				Alpha-blends [param src_rect] from [param src] image to this image at coordinates [param dst], clipped accordingly to both image bounds. This image and [param src] image [b]must[/b] have the same format. [param src_rect] with non-positive size is treated as empty.
-				This method blends each pixel within the rect in sequence and does [b]not[/b] handle the entire image in one go. As a result of this, reading from and writing to the same image reference (i.e. `image.blend_rect(image, ...)` may lead to unexpected results.
+				Simultaneously reading and writing to the same image reference may lead to unexpected results.
 			</description>
 		</method>
 		<method name="blend_rect_mask">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -30,6 +30,7 @@
 			<param index="2" name="dst" type="Vector2i" />
 			<description>
 				Alpha-blends [param src_rect] from [param src] image to this image at coordinates [param dst], clipped accordingly to both image bounds. This image and [param src] image [b]must[/b] have the same format. [param src_rect] with non-positive size is treated as empty.
+				This method blends each pixel within the rect in sequence and does [b]not[/b] handle the entire image in one go. As a result of this, reading from and writing to the same image reference (i.e. `image.blend_rect(image, ...)` may lead to unexpected results.
 			</description>
 		</method>
 		<method name="blend_rect_mask">


### PR DESCRIPTION
- Added a note to `Image.blend_rect()` to explain it does not blend the two images in one go, but reads and writes each pixel in sequence.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## Additional information
I decide to add a linebreak to avoid the block of text becoming too large and unwieldy. 

### Open Questions
I presume `blit_rect()` and the `.._mask()` functions work the exact same way. Adding this note to all of them felt a bit overkill, but would be correct. I'm unsure what the best solution is here, so I kept it at just `blend_rect()` for now.

I considered adding a *starting from the topleft* as a way to explain *how* the sequential per-pixel blending is ordered, but I decided that might be overkill and unlikely to be incorrectly assumed.

Originally I was planning to note that using Resource.duplicate() on the `read` image is a way to work around this issue, but I decided not to. This could be added again if that's preferable.

When working on this, I noticed that the input argument names are unusually *unreadable* for Godot. Is there a reason it is referenced as `src` rather than `source(_image)`? And what does `dst` even stand for? Distance? Isn't it simply a pixel coordinate that the rect should be pasted at? I'm unsure what the conventions for this are, and whether making changes is compatibility breaking, but I feel like this is a potential area for improvement.

### Reason for change
My expectation for `blend_rect` was that it blended the entire rect of the image onto the target image in one go. This is, for example, how Aseprite's `Image:drawImage(image, rect, ...)` works (at least in how it is presented to the user, internally I'm sure it works sequentially per-pixel too).  But since in Godot it reads and writes each pixel one by one, the write from a previous pixel can impact the read from another, causing odd artifacts. This makes sense in hindsight, but caused more confusion than necessary at the time. The fact that my mental model of how the function worked and how it works in reality were so far apart, warranted a note to better align the two for any future readers.

I understand that the real issue stems from the fact that I didn't immediately remember that image references in Godot are immediately updated and not generally automatically duplicated when used in functions, and that with that information, the `blend_rect()` function behaves exactly as expected. But since users that already have that innate understanding likely won't run into this issue, I instead chose to explain this in a 'per pixel' versus 'in one go' approach. After all, if you think about this not as a singular action, but as each pixel being updated one-by-one, it makes sense that the next pixel can be influenced by pixels earlier in the loop. And with that, this addition should hopefully catch only the users that have the wrong expectation, while not getting in the way of those that do not.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
