### PR TITLE
OS: Enable getentropy on all Apple platforms

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -95,7 +95,7 @@
 #define GODOT_DLOPEN_MODE RTLD_NOW
 #endif
 
-#if defined(MACOS_ENABLED) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
+#if defined(__APPLE__) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
 // Random location for getentropy. Fitting.
 #include <sys/random.h>
 #define UNIX_GET_ENTROPY


### PR DESCRIPTION
This seems supported as part of the [Apple Platform Security](https://support.apple.com/en-il/guide/security/seca0c73a75b/web#sece0fd0ca73).