### PR TITLE
Move `toggle_files_button` to `ScriptEditor` / menu bar

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3308,11 +3308,6 @@ void EditorHelp::generate_doc(bool p_use_cache, bool p_use_script_cache) {
 	}
 }
 
-void EditorHelp::_toggle_files_pressed() {
-	ScriptEditor::get_singleton()->toggle_files_panel();
-	update_toggle_files_button();
-}
-
 void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -3350,14 +3345,12 @@ void EditorHelp::_notification(int p_what) {
 
 				_class_desc_resized(true);
 			}
-			update_toggle_files_button();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (update_pending && is_visible_in_tree()) {
 				_update_doc();
 			}
-			update_toggle_files_button();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -3370,11 +3363,7 @@ void EditorHelp::_notification(int p_what) {
 			} else {
 				update_pending = true;
 			}
-			[[fallthrough]];
 		}
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update_toggle_files_button();
-		} break;
 	}
 }
 
@@ -3460,15 +3449,6 @@ void EditorHelp::set_scroll(int p_scroll) {
 	class_desc->get_v_scroll_bar()->set_value(p_scroll);
 }
 
-void EditorHelp::update_toggle_files_button() {
-	if (is_layout_rtl()) {
-		toggle_files_button->set_button_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_files_panel_toggled() ? SNAME("Forward") : SNAME("Back")));
-	} else {
-		toggle_files_button->set_button_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_files_panel_toggled() ? SNAME("Back") : SNAME("Forward")));
-	}
-	toggle_files_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Files Panel"), ED_GET_SHORTCUT("script_editor/toggle_files_panel")->get_as_text()));
-}
-
 void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
@@ -3505,18 +3485,6 @@ EditorHelp::EditorHelp() {
 	add_child(find_bar);
 	find_bar->hide();
 	find_bar->set_rich_text_label(class_desc);
-
-	status_bar = memnew(HBoxContainer);
-	add_child(status_bar);
-	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
-	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
-
-	toggle_files_button = memnew(Button);
-	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
-	toggle_files_button->set_accessibility_name(TTRC("Scripts"));
-	toggle_files_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	toggle_files_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelp::_toggle_files_pressed));
-	status_bar->add_child(toggle_files_button);
 
 	class_desc->set_selection_enabled(true);
 	class_desc->set_context_menu_enabled(true);

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3346,11 +3346,6 @@ void EditorHelp::generate_doc(bool p_use_cache, bool p_use_script_cache) {
 	}
 }
 
-void EditorHelp::_toggle_files_pressed() {
-	ScriptEditor::get_singleton()->toggle_files_panel();
-	update_toggle_files_button();
-}
-
 void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -3388,14 +3383,12 @@ void EditorHelp::_notification(int p_what) {
 
 				_class_desc_resized(true);
 			}
-			update_toggle_files_button();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (update_pending && is_visible_in_tree()) {
 				_update_doc();
 			}
-			update_toggle_files_button();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -3408,11 +3401,7 @@ void EditorHelp::_notification(int p_what) {
 			} else {
 				update_pending = true;
 			}
-			[[fallthrough]];
 		}
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update_toggle_files_button();
-		} break;
 	}
 }
 
@@ -3498,15 +3487,6 @@ void EditorHelp::set_scroll(int p_scroll) {
 	class_desc->get_v_scroll_bar()->set_value(p_scroll);
 }
 
-void EditorHelp::update_toggle_files_button() {
-	if (is_layout_rtl()) {
-		toggle_files_button->set_button_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_files_panel_toggled() ? SNAME("Forward") : SNAME("Back")));
-	} else {
-		toggle_files_button->set_button_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_files_panel_toggled() ? SNAME("Back") : SNAME("Forward")));
-	}
-	toggle_files_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Files Panel"), ED_GET_SHORTCUT("script_editor/toggle_files_panel")->get_as_text()));
-}
-
 void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_class_list_select", &EditorHelp::_class_list_select);
 	ClassDB::bind_method("_request_help", &EditorHelp::_request_help);
@@ -3543,18 +3523,6 @@ EditorHelp::EditorHelp() {
 	add_child(find_bar);
 	find_bar->hide();
 	find_bar->set_rich_text_label(class_desc);
-
-	status_bar = memnew(HBoxContainer);
-	add_child(status_bar);
-	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
-	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
-
-	toggle_files_button = memnew(Button);
-	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
-	toggle_files_button->set_accessibility_name(TTRC("Scripts"));
-	toggle_files_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	toggle_files_button->connect(SceneStringName(pressed), callable_mp(this, &EditorHelp::_toggle_files_pressed));
-	status_bar->add_child(toggle_files_button);
 
 	class_desc->set_selection_enabled(true);
 	class_desc->set_context_menu_enabled(true);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -116,8 +116,6 @@ class EditorHelp : public VBoxContainer {
 
 	LineEdit *search = nullptr;
 	FindBar *find_bar = nullptr;
-	HBoxContainer *status_bar = nullptr;
-	Button *toggle_files_button = nullptr;
 
 	struct ThemeCache {
 		Ref<StyleBox> background_style;
@@ -186,8 +184,6 @@ class EditorHelp : public VBoxContainer {
 
 	void _request_help(const String &p_string);
 	void _search(bool p_search_previous = false);
-
-	void _toggle_files_pressed();
 
 	inline static int doc_generation_count = 0;
 	inline static String doc_version_hash;
@@ -267,8 +263,6 @@ public:
 
 	int get_scroll() const;
 	void set_scroll(int p_scroll);
-
-	void update_toggle_files_button();
 
 	static void init_gdext_pointers();
 

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1741,13 +1741,6 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 	emit_signal(SNAME("show_warnings_panel"), p_show);
 }
 
-void CodeTextEditor::_toggle_files_pressed() {
-	ERR_FAIL_NULL(toggle_files_list);
-	toggle_files_list->set_visible(!toggle_files_list->is_visible());
-	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", toggle_files_list->is_visible());
-	update_toggle_files_button();
-}
-
 void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -1765,15 +1758,11 @@ void CodeTextEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			if (toggle_files_button->is_visible()) {
-				update_toggle_files_button();
-			}
 			_update_text_editor_theme();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			set_indent_using_spaces(text_editor->is_indent_using_spaces());
-			update_toggle_files_button();
 
 			zoom_button->set_tooltip_text(
 					TTR("Zoom Factor") + "\n" +
@@ -1783,15 +1772,9 @@ void CodeTextEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			if (toggle_files_button->is_visible()) {
-				update_toggle_files_button();
-			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (toggle_files_button->is_visible()) {
-				update_toggle_files_button();
-			}
 			set_process_input(is_visible_in_tree());
 		} break;
 
@@ -1953,21 +1936,6 @@ void CodeTextEditor::set_code_complete_func(CodeTextEditorCodeCompleteFunc p_cod
 	code_complete_ud = p_ud;
 }
 
-void CodeTextEditor::set_toggle_list_control(Control *p_toggle_list_control) {
-	toggle_files_list = p_toggle_list_control;
-}
-
-void CodeTextEditor::show_toggle_files_button() {
-	toggle_files_button->show();
-}
-
-void CodeTextEditor::update_toggle_files_button() {
-	ERR_FAIL_NULL(toggle_files_list);
-	bool forward = toggle_files_list->is_visible() == is_layout_rtl();
-	toggle_files_button->set_button_icon(get_editor_theme_icon(forward ? SNAME("Forward") : SNAME("Back")));
-	toggle_files_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Files Panel"), ED_GET_SHORTCUT("script_editor/toggle_files_panel")->get_as_text()));
-}
-
 CodeTextEditor::CodeTextEditor() {
 	code_complete_func = nullptr;
 	ED_SHORTCUT("script_editor/zoom_in", TTRC("Zoom In"), KeyModifierMask::CMD_OR_CTRL | Key::EQUAL);
@@ -2002,15 +1970,6 @@ CodeTextEditor::CodeTextEditor() {
 
 	error_line = 0;
 	error_column = 0;
-
-	toggle_files_button = memnew(Button);
-	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
-	toggle_files_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
-	toggle_files_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	toggle_files_button->connect(SceneStringName(pressed), callable_mp(this, &CodeTextEditor::_toggle_files_pressed));
-	toggle_files_button->set_accessibility_name(TTRC("Scripts"));
-	status_bar->add_child(toggle_files_button);
-	toggle_files_button->hide();
 
 	// Error
 	error = memnew(RichTextLabel);

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -164,8 +164,6 @@ class CodeTextEditor : public VBoxContainer {
 	FindReplaceBar *find_replace_bar = nullptr;
 	HBoxContainer *status_bar = nullptr;
 
-	Button *toggle_files_button = nullptr;
-	Control *toggle_files_list = nullptr;
 	Button *error_button = nullptr;
 	Button *warning_button = nullptr;
 
@@ -222,8 +220,6 @@ class CodeTextEditor : public VBoxContainer {
 	void _error_pressed(const Ref<InputEvent> &p_event);
 
 	void _zoom_popup_id_pressed(int p_idx);
-
-	void _toggle_files_pressed();
 
 protected:
 	void _text_changed_idle_timeout();
@@ -302,10 +298,6 @@ public:
 	void set_code_complete_func(CodeTextEditorCodeCompleteFunc p_code_complete_func, void *p_ud);
 
 	void validate_script();
-
-	void set_toggle_list_control(Control *p_toggle_list_control);
-	void show_toggle_files_button();
-	void update_toggle_files_button();
 
 	CodeTextEditor();
 };

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -726,7 +726,6 @@ TextEditorBase::TextEditorBase() {
 	code_editor = memnew(CodeTextEditor);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	code_editor->show_toggle_files_button();
 	code_editor->get_text_editor()->set_context_menu_enabled(false);
 	code_editor->get_text_editor()->connect(SceneStringName(gui_input), callable_mp(this, &TextEditorBase::_text_edit_gui_input));
 	code_editor->get_text_editor()->connect(SceneStringName(text_changed), callable_mp(this, &TextEditorBase::_saved_update));

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -725,7 +725,6 @@ TextEditorBase::TextEditorBase() {
 	code_editor = memnew(CodeTextEditor);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	code_editor->show_toggle_files_button();
 	code_editor->get_text_editor()->set_context_menu_enabled(false);
 	code_editor->get_text_editor()->connect(SceneStringName(gui_input), callable_mp(this, &TextEditorBase::_text_edit_gui_input));
 	code_editor->get_text_editor()->connect(SceneStringName(text_changed), callable_mp(this, &TextEditorBase::_saved_update));

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -66,9 +66,6 @@ public:
 	virtual String get_doc_url_path() { return "/"; }
 	virtual Ref<Texture2D> get_theme_icon();
 
-	virtual void set_toggle_list_control(Control *p_toggle_list_control) = 0;
-	virtual void update_toggle_files_button() = 0;
-
 	virtual bool show_members_overview() { return false; }
 
 	virtual void ensure_focus() = 0;
@@ -242,11 +239,6 @@ public:
 
 	virtual void validate_script() override { code_editor->validate_script(); }
 	bool get_validation_success() { return validation_success; }
-
-	virtual void set_toggle_list_control(Control *p_toggle_list_control) override {
-		code_editor->set_toggle_list_control(p_toggle_list_control);
-	}
-	virtual void update_toggle_files_button() override { code_editor->update_toggle_files_button(); }
 
 	TextEditorBase();
 	~TextEditorBase();

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1582,16 +1582,6 @@ TypedArray<Script> ScriptEditor::_get_open_scripts() const {
 	return ret;
 }
 
-bool ScriptEditor::toggle_files_panel() {
-	list_split->set_visible(!list_split->is_visible());
-	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", list_split->is_visible());
-	return list_split->is_visible();
-}
-
-bool ScriptEditor::is_files_panel_toggled() {
-	return list_split->is_visible();
-}
-
 List<String> ScriptEditor::_get_recognized_extensions() {
 	List<String> extensions;
 	for (const String &type : handled_resource_types) {
@@ -1749,14 +1739,6 @@ void ScriptEditor::_menu_option(int p_option) {
 		} break;
 		case FILE_MENU_SORT: {
 			sort_document_editors();
-		} break;
-		case FILE_MENU_TOGGLE_FILES_PANEL: {
-			toggle_files_panel();
-			if (seb) {
-				seb->update_toggle_files_button();
-			} else if (eh) {
-				eh->update_toggle_files_button();
-			}
 		} break;
 		case FILE_MENU_CLOSE: {
 			if (seb && seb->is_unsaved()) {
@@ -1986,6 +1968,8 @@ void ScriptEditor::_notification(int p_what) {
 			}
 
 			recent_scripts->reset_size();
+
+			toggle_files_button->set_button_icon(get_editor_theme_icon(SNAME("FileList")));
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -2084,6 +2068,12 @@ void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 			}
 		}
 	}
+}
+
+void ScriptEditor::_toggle_files_pressed(bool p_pressed) {
+	ERR_FAIL_NULL(list_split);
+	list_split->set_visible(p_pressed);
+	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", list_split->is_visible());
 }
 
 void ScriptEditor::edited_scene_changed() {
@@ -2402,7 +2392,6 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	seb->set_edited_resource(p_resource);
 
-	seb->set_toggle_list_control(get_left_list_split());
 	grab_focus_block = !p_grab_focus;
 	tab_container->add_child(seb);
 	grab_focus_block = false;
@@ -2426,7 +2415,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			editor_edit_menu->hide();
 			editor_menus.push_back(editor_edit_menu);
 			menu_hb->add_child(editor_edit_menu);
-			menu_hb->move_child(editor_edit_menu, 1);
+			menu_hb->move_child(editor_edit_menu, 3);
 			for (int i = 0; i < editor_edit_menu->get_child_count(); ++i) {
 				Control *c = Object::cast_to<Control>(editor_edit_menu->get_child(i));
 				if (c) {
@@ -3237,7 +3226,6 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 		p_menu->add_separator();
 
 		p_menu->add_submenu_node_item(TTRC("Theme"), theme_submenu, FILE_MENU_THEME_SUBMENU);
-		p_menu->add_separator();
 	}
 
 	if (p_is_context_menu) {
@@ -3245,8 +3233,6 @@ void ScriptEditor::_setup_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) 
 		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_down"), FILE_MENU_MOVE_DOWN);
 		p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_sort"), FILE_MENU_SORT);
 	}
-
-	p_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"), FILE_MENU_TOGGLE_FILES_PANEL);
 }
 
 void ScriptEditor::_prepare_popup_menu(PopupMenu *p_menu, bool p_is_context_menu) {
@@ -4097,9 +4083,7 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	document_outline = memnew(DocumentOutline(this));
 	document_outline->set_custom_minimum_size(Size2(0, 90));
 	document_outline->set_v_size_flags(SIZE_EXPAND_FILL);
-
 	list_split->add_child(document_outline);
-	list_split->set_visible(EditorSettings::get_singleton()->get_project_metadata("files_panel", "show_files_panel", true));
 
 	VBoxContainer *code_editor_container = memnew(VBoxContainer);
 	script_split->add_child(code_editor_container);
@@ -4149,6 +4133,23 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 
 	set_process_input(true);
 	set_process_shortcut_input(true);
+
+	toggle_files_button = memnew(Button);
+	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
+	toggle_files_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	toggle_files_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	toggle_files_button->connect(SceneStringName(toggled), callable_mp(this, &ScriptEditor::_toggle_files_pressed));
+	toggle_files_button->set_accessibility_name(TTRC("Toggle Document List"));
+	toggle_files_button->set_toggle_mode(true);
+	toggle_files_button->set_shortcut_context(this);
+	toggle_files_button->set_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"));
+	menu_hb->add_child(toggle_files_button);
+	bool initial_state = EditorSettings::get_singleton()->get_project_metadata("files_panel", "show_files_panel", true);
+	toggle_files_button->set_pressed_no_signal(initial_state);
+	_toggle_files_pressed(initial_state);
+
+	VSeparator *sep = memnew(VSeparator);
+	menu_hb->add_child(sep);
 
 	file_menu = memnew(MenuButton);
 	file_menu->set_flat(false);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1771,16 +1771,6 @@ Dictionary ScriptEditor::get_context_data(Control *p_tab_control) {
 	return context_data;
 }
 
-bool ScriptEditor::toggle_files_panel() {
-	list_split->set_visible(!list_split->is_visible());
-	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", list_split->is_visible());
-	return list_split->is_visible();
-}
-
-bool ScriptEditor::is_files_panel_toggled() {
-	return list_split->is_visible();
-}
-
 List<String> ScriptEditor::_get_recognized_extensions() {
 	List<String> extensions;
 	for (const String &type : handled_resource_types) {
@@ -1936,14 +1926,6 @@ void ScriptEditor::_menu_option(int p_option) {
 		} break;
 		case FILE_MENU_SORT: {
 			sort_document_editors();
-		} break;
-		case FILE_MENU_TOGGLE_FILES_PANEL: {
-			toggle_files_panel();
-			if (seb) {
-				seb->update_toggle_files_button();
-			} else if (eh) {
-				eh->update_toggle_files_button();
-			}
 		} break;
 		case FILE_MENU_CLOSE: {
 			if (seb && seb->is_unsaved()) {
@@ -2164,6 +2146,8 @@ void ScriptEditor::_notification(int p_what) {
 			}
 
 			recent_scripts->reset_size();
+
+			toggle_files_button->set_button_icon(get_editor_theme_icon(SNAME("FileList")));
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -2258,6 +2242,12 @@ void ScriptEditor::_close_builtin_scripts_from_scene(const String &p_scene) {
 			}
 		}
 	}
+}
+
+void ScriptEditor::_toggle_files_pressed(bool p_pressed) {
+	ERR_FAIL_NULL(list_split);
+	list_split->set_visible(p_pressed);
+	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", list_split->is_visible());
 }
 
 void ScriptEditor::edited_scene_changed() {
@@ -2586,7 +2576,6 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	seb->set_edited_resource(p_resource);
 
-	seb->set_toggle_list_control(get_left_list_split());
 	grab_focus_block = !p_grab_focus;
 	tab_container->add_child(seb);
 	grab_focus_block = false;
@@ -2610,7 +2599,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			editor_edit_menu->hide();
 			editor_menus.push_back(editor_edit_menu);
 			menu_hb->add_child(editor_edit_menu);
-			menu_hb->move_child(editor_edit_menu, 1);
+			menu_hb->move_child(editor_edit_menu, 3);
 			for (int i = 0; i < editor_edit_menu->get_child_count(); ++i) {
 				Control *c = Object::cast_to<Control>(editor_edit_menu->get_child(i));
 				if (c) {
@@ -4169,9 +4158,7 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	document_outline = memnew(DocumentOutline(this));
 	document_outline->set_custom_minimum_size(Size2(0, 90));
 	document_outline->set_v_size_flags(SIZE_EXPAND_FILL);
-
 	list_split->add_child(document_outline);
-	list_split->set_visible(EditorSettings::get_singleton()->get_project_metadata("files_panel", "show_files_panel", true));
 
 	VBoxContainer *code_editor_container = memnew(VBoxContainer);
 	script_split->add_child(code_editor_container);
@@ -4222,6 +4209,23 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	set_process_input(true);
 	set_process_shortcut_input(true);
 
+	toggle_files_button = memnew(Button);
+	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
+	toggle_files_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	toggle_files_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	toggle_files_button->connect(SceneStringName(toggled), callable_mp(this, &ScriptEditor::_toggle_files_pressed));
+	toggle_files_button->set_accessibility_name(TTRC("Toggle Document List"));
+	toggle_files_button->set_toggle_mode(true);
+	toggle_files_button->set_shortcut_context(this);
+	toggle_files_button->set_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"));
+	menu_hb->add_child(toggle_files_button);
+	bool initial_state = EditorSettings::get_singleton()->get_project_metadata("files_panel", "show_files_panel", true);
+	toggle_files_button->set_pressed_no_signal(initial_state);
+	_toggle_files_pressed(initial_state);
+
+	VSeparator *sep = memnew(VSeparator);
+	menu_hb->add_child(sep);
+
 	file_menu = memnew(MenuButton);
 	file_menu->set_flat(false);
 	file_menu->set_theme_type_variation("FlatMenuButton");
@@ -4270,8 +4274,6 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 		file_menu->get_popup()->add_separator();
 	}
 	file_menu->get_popup()->add_submenu_node_item(TTRC("Theme"), theme_submenu, FILE_MENU_THEME_SUBMENU);
-	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"), FILE_MENU_TOGGLE_FILES_PANEL);
 
 	script_search_menu = memnew(MenuButton);
 	script_search_menu->set_flat(false);

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -189,8 +189,6 @@ class ScriptEditor : public PanelContainer {
 
 		FILE_MENU_RUN,
 
-		FILE_MENU_TOGGLE_FILES_PANEL,
-
 		FILE_MENU_MOVE_UP,
 		FILE_MENU_MOVE_DOWN,
 		FILE_MENU_SORT,
@@ -225,6 +223,7 @@ class ScriptEditor : public PanelContainer {
 	};
 
 	HBoxContainer *menu_hb = nullptr;
+	Button *toggle_files_button = nullptr;
 	MenuButton *file_menu = nullptr;
 	MenuButton *script_search_menu = nullptr;
 	MenuButton *debug_menu = nullptr;
@@ -449,6 +448,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
+	void _toggle_files_pressed(bool p_pressed);
+
 	inline static ScriptEditor *script_editor = nullptr;
 	inline static ScriptEditor *bottom_script_editor = nullptr;
 
@@ -460,8 +461,6 @@ public:
 	static ScriptEditor *get_singleton() { return script_editor; }
 	static ScriptEditor *get_bottom_script_editor() { return bottom_script_editor; }
 
-	bool toggle_files_panel();
-	bool is_files_panel_toggled();
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
 	void open_find_in_files_dialog(const String &p_initial_text = "", bool p_replace = false);
@@ -515,8 +514,6 @@ public:
 	void update_docs_from_script(const Ref<Script> &p_script);
 
 	void trigger_live_script_reload(const String &p_script_path);
-
-	VSplitContainer *get_left_list_split() { return list_split; }
 
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -192,8 +192,6 @@ class ScriptEditor : public EditorDock {
 
 		FILE_MENU_RUN,
 
-		FILE_MENU_TOGGLE_FILES_PANEL,
-
 		FILE_MENU_MOVE_UP,
 		FILE_MENU_MOVE_DOWN,
 		FILE_MENU_SORT,
@@ -228,6 +226,7 @@ class ScriptEditor : public EditorDock {
 	};
 
 	HBoxContainer *menu_hb = nullptr;
+	Button *toggle_files_button = nullptr;
 	MenuButton *file_menu = nullptr;
 	MenuButton *script_search_menu = nullptr;
 	MenuButton *debug_menu = nullptr;
@@ -445,6 +444,8 @@ class ScriptEditor : public EditorDock {
 
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
+	void _toggle_files_pressed(bool p_pressed);
+
 	inline static ScriptEditor *script_editor = nullptr;
 	inline static ScriptEditor *bottom_script_editor = nullptr;
 
@@ -460,8 +461,6 @@ public:
 
 	static Dictionary get_context_data(Control *p_tab_control);
 
-	bool toggle_files_panel();
-	bool is_files_panel_toggled();
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
@@ -514,8 +513,6 @@ public:
 	void update_docs_from_script(const Ref<Script> &p_script);
 
 	void trigger_live_script_reload(const String &p_script_path);
-
-	VSplitContainer *get_left_list_split() { return list_split; }
 
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -2559,13 +2559,6 @@ void VisualShaderEditor::_set_mode(int p_which) {
 	set_current_shader_type((VisualShader::Type)saved_type);
 }
 
-void VisualShaderEditor::update_toggle_files_button() {
-	ERR_FAIL_NULL(toggle_files_list);
-	bool forward = toggle_files_list->is_visible() == is_layout_rtl();
-	toggle_files_button->set_button_icon(get_editor_theme_icon(forward ? SNAME("Forward") : SNAME("Back")));
-	toggle_files_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Files Panel"), ED_GET_SHORTCUT("script_editor/toggle_files_panel")->get_as_text()));
-}
-
 void VisualShaderEditor::_draw_color_over_button(Object *p_obj, Color p_color) {
 	Button *button = Object::cast_to<Button>(p_obj);
 	if (!button) {
@@ -5412,12 +5405,10 @@ void VisualShaderEditor::_notification(int p_what) {
 			} else {
 				theme_dirty = true;
 			}
-			update_toggle_files_button();
 			_update_options_menu();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			update_toggle_files_button();
 			if (theme_dirty && is_visible_in_tree()) {
 				theme_dirty = false;
 				_update_graph();
@@ -6554,16 +6545,6 @@ void VisualShaderEditor::_show_shader_preview() {
 	}
 }
 
-void VisualShaderEditor::set_toggle_list_control(Control *p_toggle_list_control) {
-	toggle_files_list = p_toggle_list_control;
-}
-
-void VisualShaderEditor::_toggle_files_pressed() {
-	ERR_FAIL_NULL(toggle_files_list);
-	toggle_files_list->set_visible(!toggle_files_list->is_visible());
-	update_toggle_files_button();
-}
-
 void VisualShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_update_nodes", &VisualShaderEditor::_update_nodes);
 	ClassDB::bind_method("_update_graph", &VisualShaderEditor::_update_graph);
@@ -6824,16 +6805,6 @@ VisualShaderEditor::VisualShaderEditor() {
 	shader_preview_button->set_pressed(true);
 	toolbar_hflow->add_child(shader_preview_button);
 	shader_preview_button->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_show_shader_preview));
-
-	VSeparator *separator = memnew(VSeparator);
-	toolbar_hflow->add_child(separator);
-	toolbar_hflow->move_child(separator, 0);
-
-	toggle_files_button = memnew(Button);
-	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
-	toggle_files_button->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_toggle_files_pressed));
-	toolbar_hflow->add_child(toggle_files_button);
-	toolbar_hflow->move_child(toggle_files_button, 0);
 
 	///////////////////////////////////////
 	// CODE PREVIEW

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -3302,13 +3302,6 @@ void VisualShaderEditor::_edit_group_ports_pressed(int p_group_input_node_id, Bu
 	group_ports_dialog->popup();
 }
 
-void VisualShaderEditor::update_toggle_files_button() {
-	ERR_FAIL_NULL(toggle_files_list);
-	bool forward = toggle_files_list->is_visible() == is_layout_rtl();
-	toggle_files_button->set_button_icon(get_editor_theme_icon(forward ? SNAME("Forward") : SNAME("Back")));
-	toggle_files_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Files Panel"), ED_GET_SHORTCUT("script_editor/toggle_files_panel")->get_as_text()));
-}
-
 void VisualShaderEditor::_draw_color_over_button(Object *p_obj, Color p_color) {
 	Button *button = Object::cast_to<Button>(p_obj);
 	if (!button) {
@@ -6168,12 +6161,10 @@ void VisualShaderEditor::_notification(int p_what) {
 			} else {
 				theme_dirty = true;
 			}
-			update_toggle_files_button();
 			_update_options_menu();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			update_toggle_files_button();
 			if (theme_dirty && is_visible_in_tree()) {
 				theme_dirty = false;
 				_update_graph();
@@ -7403,16 +7394,6 @@ void VisualShaderEditor::_show_shader_preview() {
 	}
 }
 
-void VisualShaderEditor::set_toggle_list_control(Control *p_toggle_list_control) {
-	toggle_files_list = p_toggle_list_control;
-}
-
-void VisualShaderEditor::_toggle_files_pressed() {
-	ERR_FAIL_NULL(toggle_files_list);
-	toggle_files_list->set_visible(!toggle_files_list->is_visible());
-	update_toggle_files_button();
-}
-
 void VisualShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_update_available_nodes", &VisualShaderEditor::_update_available_nodes);
 	ClassDB::bind_method("_update_graph", &VisualShaderEditor::_update_graph);
@@ -7681,16 +7662,6 @@ VisualShaderEditor::VisualShaderEditor() {
 	exit_group_button->set_visible(false);
 	toolbar_hflow->add_child(exit_group_button);
 	exit_group_button->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_exit_group));
-
-	VSeparator *separator = memnew(VSeparator);
-	toolbar_hflow->add_child(separator);
-	toolbar_hflow->move_child(separator, 0);
-
-	toggle_files_button = memnew(Button);
-	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));
-	toggle_files_button->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_toggle_files_pressed));
-	toolbar_hflow->add_child(toggle_files_button);
-	toolbar_hflow->move_child(toggle_files_button, 0);
 
 	///////////////////////////////////////
 	// CODE PREVIEW

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.h
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.h
@@ -217,8 +217,6 @@ class VisualShaderEditor : public ScriptEditorBase {
 	EditorProperty *current_prop = nullptr;
 	VBoxContainer *shader_preview_vbox = nullptr;
 	Button *site_search = nullptr;
-	Button *toggle_files_button = nullptr;
-	Control *toggle_files_list = nullptr;
 	GraphEdit *graph = nullptr;
 	Button *add_node = nullptr;
 	MenuButton *varying_button = nullptr;
@@ -466,8 +464,6 @@ class VisualShaderEditor : public ScriptEditorBase {
 
 	void _show_shader_preview();
 
-	void _toggle_files_pressed();
-
 	Vector<int> nodes_link_to_frame_buffer; // Contains the nodes that are requested to be linked to a frame. This is used to perform one Undo/Redo operation for dragging nodes.
 	int frame_node_id_to_link_to = -1;
 
@@ -670,9 +666,6 @@ public:
 
 	virtual void ensure_focus() override { graph->grab_focus(true); }
 
-	virtual void set_toggle_list_control(Control *p_toggle_list_control) override;
-
-	virtual void update_toggle_files_button() override;
 	void save_editor_layout();
 
 	void set_current_shader_type(VisualShader::Type p_type);

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.h
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.h
@@ -281,8 +281,6 @@ class VisualShaderEditor : public ScriptEditorBase {
 	EditorProperty *current_prop = nullptr;
 	VBoxContainer *shader_preview_vbox = nullptr;
 	Button *site_search = nullptr;
-	Button *toggle_files_button = nullptr;
-	Control *toggle_files_list = nullptr;
 	GraphEdit *graph = nullptr;
 	Button *add_node = nullptr;
 	MenuButton *varying_button = nullptr;
@@ -547,8 +545,6 @@ class VisualShaderEditor : public ScriptEditorBase {
 
 	void _show_shader_preview();
 
-	void _toggle_files_pressed();
-
 	Vector<int> nodes_link_to_frame_buffer; // Contains the nodes that are requested to be linked to a frame. This is used to perform one Undo/Redo operation for dragging nodes.
 	int frame_node_id_to_link_to = -1;
 
@@ -763,9 +759,6 @@ public:
 
 	virtual void ensure_focus() override { graph->grab_focus(true); }
 
-	virtual void set_toggle_list_control(Control *p_toggle_list_control) override;
-
-	virtual void update_toggle_files_button() override;
 	void save_editor_layout();
 
 	void set_current_shader_type(VisualShader::Type p_type);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121757
- Followup #115998

## Additional information

https://github.com/godotengine/godot/pull/115998 unified the menu bar of all editors, most notably the `VisualShaderEditor` now has one too. This PR utilizes the unified menu bar by putting the `toggle_files_button` as the first element of the menu bar (see images). This allows removing the otherwise unused `status_bar` of `EditorHelp` and moving the individual implementations to a single implementation in the `ScriptEditor`. I also removed the `File` menu option 

## Images
### ScriptTextEditor
<img width="298" height="230" alt="image" src="https://github.com/user-attachments/assets/c64aa248-479d-4c65-b74a-83c18ace2a52" />

### VisualShaderEditor
<img width="315" height="243" alt="image" src="https://github.com/user-attachments/assets/1fe07b3f-1966-46e4-9f75-efce1fc32334" />

### Closed
<img width="304" height="241" alt="image" src="https://github.com/user-attachments/assets/4ad1c234-63dd-440b-bf7f-e3f165781851" />


