### PR TITLE
Fix TLS 1.3 session ticket handling in StreamPeerMbedTLS

### DIFF
--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -175,6 +175,8 @@ Error StreamPeerMbedTLS::put_partial_data(const uint8_t *p_data, int p_bytes, in
 			// Clean close
 			disconnect_from_stream();
 			return ERR_FILE_EOF;
+		} else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+			continue; // Re-connection cookies are not currently supported, ignore them.
 		} else if (ret <= 0) {
 			TLSContextMbedTLS::print_mbedtls_error(ret);
 			disconnect_from_stream();
@@ -256,6 +258,8 @@ void StreamPeerMbedTLS::poll() {
 		// Clean close (disconnect)
 		disconnect_from_stream();
 		return;
+	} else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+		// Session ticket received, ignore it (reconnection cookies not supported)
 	} else if (ret < 0) {
 		TLSContextMbedTLS::print_mbedtls_error(ret);
 		disconnect_from_stream();


### PR DESCRIPTION
## Summary

Fixes WebSocket (`wss://`) connections failing when connecting to TLS 1.3 servers that send session tickets.

## Problem

TLS 1.3 servers send session tickets after the handshake completes. When mbedTLS receives one during a read or write operation, it returns `MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET` (-0x7B00), which is **not an error** but signals that the operation should be retried.

`StreamPeerMbedTLS::put_partial_data()` and `poll()` incorrectly treated this as a fatal error and called `disconnect_from_stream()`, causing WebSocket upgrade handshakes to fail silently.

## Reproduction

1. Connect a WebSocket client to a TLS 1.3 server (e.g., nginx with Let's Encrypt certificates)
2. Connection fails during handshake with `mbedtls error: returned -0x7b00`
3. WebSocket never reaches `STATE_OPEN`

## Solution

Added `MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET` handling to `put_partial_data()` and `poll()`, matching the existing correct handling in `get_partial_data()` (line 224):

```cpp
} else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
    continue; // Re-connection cookies are not currently supported, ignore them.
```

Session tickets are ignored since Godot doesn't implement session resumption.

Testing

- ✅ WebSocket client successfully connects to TLS 1.3 servers
- ✅ No regression on TLS 1.2 servers
- ✅ Tested on macOS and Android

Related

This bug affects any WebSocket connection to modern TLS 1.3 servers. The issue became visible as Let's Encrypt migrated to ECDSA certificates and more servers enabled TLS 1.3 by default.

### 4. 等待 review

Godot 的 CI 会自动运行测试。maintainers 会 review 代码。

---

"Reported-by: @laoleshisui"。