### PR TITLE
GDScript: Fix shutdown crash when `ScriptInstance` references its owner

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2272,7 +2272,13 @@ void GDScriptLanguage::finish() {
 			while (script->instances.first() != nullptr) {
 				// Turns instances into core objects that can outlive `GDScriptLanguage`.
 				const SelfList<GDScriptInstance> *elem = script->instances.first();
+
+				// In case the last reference to the owner comes from the script instance itself, we need to ensure that `set_script` can finish cleanly, before destructing the owner.
+				Variant owner = elem->self()->get_owner();
+				std::ignore = owner; // Suppress unused warnings, holding the reference is the point.
+
 				elem->self()->get_owner()->set_script(Variant());
+
 				ERR_BREAK_MSG(script->instances.first() == elem, "GDScript bug (please report): Detaching a script does not destruct instance.");
 			}
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/121729

## Additional information

In this case, the script instance was the last thing holding a reference to its owner. So during `set_script(Variant())` the script instance destructor would try to free the owner. However since `set_script` was not done yet we tried to destruct the instance a second time through that. We now hold a reference while calling `set_script` to prevent that.

Our test suite can't test this, since it happens during shutdown. I added it to my personal collection of lifecycle related tests instead: https://github.com/HolonProduction/godot-extended-tests/commit/9977f26f75f6bfb7ea9e417742419e28d1b65e33
