### PR TITLE
OS: Move get_entropy implementation out of OS_Unix

### DIFF
--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -99,6 +99,7 @@ public:
 
 	void start();
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
 	virtual Vector<String> get_system_fonts() const override;

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -159,6 +159,11 @@ OS_AppleEmbedded::OS_AppleEmbedded() {
 
 OS_AppleEmbedded::~OS_AppleEmbedded() {}
 
+Error OS_AppleEmbedded::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int status = SecRandomCopyBytes(kSecRandomDefault, p_bytes, r_buffer);
+	return status == errSecSuccess ? OK : FAILED;
+}
+
 void OS_AppleEmbedded::alert(const String &p_alert, const String &p_title) {
 	const CharString utf8_alert = p_alert.utf8();
 	const CharString utf8_title = p_title.utf8();

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -95,21 +95,6 @@
 #define GODOT_DLOPEN_MODE RTLD_NOW
 #endif
 
-#if defined(MACOS_ENABLED) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 28)
-// Random location for getentropy. Fitting.
-#include <sys/random.h>
-#define UNIX_GET_ENTROPY
-#elif defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__GLIBC_MINOR__) && (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26))
-// In <unistd.h>.
-// One day... (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)
-// https://publications.opengroup.org/standards/unix/c211
-#define UNIX_GET_ENTROPY
-#endif
-
-#if !defined(UNIX_GET_ENTROPY) && !defined(NO_URANDOM)
-#include <fcntl.h>
-#endif
-
 /// Clock Setup function (used by get_ticks_usec)
 static uint64_t _clock_start = 0;
 #if defined(__APPLE__)
@@ -277,32 +262,6 @@ OS_Unix::StdHandleType OS_Unix::get_stderr_type() const {
 		return STD_HANDLE_FILE;
 	}
 	return STD_HANDLE_UNKNOWN;
-}
-
-Error OS_Unix::get_entropy(uint8_t *r_buffer, int p_bytes) {
-#if defined(UNIX_GET_ENTROPY)
-	int left = p_bytes;
-	int ofs = 0;
-	do {
-		int chunk = MIN(left, 256);
-		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
-		left -= chunk;
-		ofs += chunk;
-	} while (left > 0);
-// Define this yourself if you don't want to fall back to /dev/urandom.
-#elif !defined(NO_URANDOM)
-	int r = open("/dev/urandom", O_RDONLY);
-	ERR_FAIL_COND_V(r < 0, FAILED);
-	int left = p_bytes;
-	do {
-		ssize_t ret = read(r, r_buffer, p_bytes);
-		ERR_FAIL_COND_V(ret <= 0, FAILED);
-		left -= ret;
-	} while (left > 0);
-#else
-	return ERR_UNAVAILABLE;
-#endif
-	return OK;
 }
 
 String OS_Unix::get_name() const {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -93,8 +93,6 @@ public:
 	virtual StdHandleType get_stdout_type() const override;
 	virtual StdHandleType get_stderr_type() const override;
 
-	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
-
 	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data = nullptr) override;
 	virtual Error close_dynamic_library(void *p_library_handle) override;
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) override;

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -61,6 +61,7 @@
 #endif
 
 #include <dlfcn.h>
+#include <stdlib.h>
 #include <sys/system_properties.h>
 
 const char *OS_Android::ANDROID_EXEC_PATH = "apk";
@@ -989,6 +990,11 @@ Error OS_Android::kill(const ProcessID &p_pid) {
 
 String OS_Android::get_system_ca_certificates() {
 	return godot_java->get_ca_certificates();
+}
+
+Error OS_Android::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	arc4random_buf(r_buffer, p_bytes);
+	return OK;
 }
 
 Error OS_Android::setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -168,6 +168,7 @@ public:
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
 	virtual Error kill(const ProcessID &p_pid) override;
 	virtual String get_system_ca_certificates() override;
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
 	virtual Error setup_remote_filesystem(const String &p_server_host, int p_port, const String &p_password, String &r_project_path) override;
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -100,6 +100,15 @@
 #endif
 #endif
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__GLIBC_MINOR__) && (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26))
+// In <unistd.h>.
+// One day... (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)
+// https://publications.opengroup.org/standards/unix/c211
+#define UNIX_GET_ENTROPY
+#elif !defined(NO_URANDOM)
+#include <fcntl.h>
+#endif
+
 void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	const char *message_programs[] = { "zenity", "kdialog", "Xdialog", "xmessage" };
 
@@ -1215,6 +1224,32 @@ String OS_LinuxBSD::get_system_ca_certificates() {
 	ERR_FAIL_COND_V_MSG(f.is_null(), "", vformat("Failed to open system CA certificates file: '%s'", certfile));
 
 	return f->get_as_text();
+}
+
+Error OS_LinuxBSD::get_entropy(uint8_t *r_buffer, int p_bytes) {
+#if defined(UNIX_GET_ENTROPY)
+	int left = p_bytes;
+	int ofs = 0;
+	do {
+		int chunk = MIN(left, 256);
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+		left -= chunk;
+		ofs += chunk;
+	} while (left > 0);
+// Define this yourself if you don't want to fall back to /dev/urandom.
+#elif !defined(NO_URANDOM)
+	int r = open("/dev/urandom", O_RDONLY);
+	ERR_FAIL_COND_V(r < 0, FAILED);
+	int left = p_bytes;
+	do {
+		ssize_t ret = read(r, r_buffer, p_bytes);
+		ERR_FAIL_COND_V(ret <= 0, FAILED);
+		left -= ret;
+	} while (left > 0);
+#else
+	return ERR_UNAVAILABLE;
+#endif
+	return OK;
 }
 
 #ifdef TOOLS_ENABLED

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -133,6 +133,7 @@ public:
 	virtual Error move_to_trash(const String &p_path) override;
 
 	virtual String get_system_ca_certificates() override;
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
 #ifdef TOOLS_ENABLED
 	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const override;

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -125,6 +125,7 @@ public:
 	virtual String get_godot_dir_name() const override;
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
 
 	virtual Error shell_open(const String &p_uri) override;
 	virtual Error shell_show_in_file_manager(String p_path, bool p_open_folder) override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1018,6 +1018,11 @@ String OS_MacOS::get_system_ca_certificates() {
 	return certs;
 }
 
+Error OS_MacOS::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int status = SecRandomCopyBytes(kSecRandomDefault, p_bytes, r_buffer);
+	return status == errSecSuccess ? OK : FAILED;
+}
+
 OS::PreferredTextureFormat OS_MacOS::get_preferred_texture_format() const {
 	// macOS supports both formats on ARM. Prefer S3TC/BPTC
 	// for better compatibility with x86 platforms.

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -272,6 +272,18 @@ bool OS_Web::is_userfs_persistent() const {
 	return idb_available;
 }
 
+Error OS_Web::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int left = p_bytes;
+	int ofs = 0;
+	do {
+		int chunk = MIN(left, 256);
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+		left -= chunk;
+		ofs += chunk;
+	} while (left > 0);
+	return OK;
+}
+
 Error OS_Web::open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data) {
 	String path = p_path.get_file();
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -108,6 +108,8 @@ public:
 
 	bool is_userfs_persistent() const override;
 
+	Error get_entropy(uint8_t *r_buffer, int p_bytes) override;
+
 	void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
 	Error open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data = nullptr) override;


### PR DESCRIPTION
Use SecRandomCopyBytes on macOS / Apple Embedded
Use get_entropy on Web
Use arc4random_buf on Android (part of bionic)
Use get_entropy or /dev/urandom on LinuxBSD

Closes #121760 (follow-up on https://github.com/godotengine/godot/pull/121760#issuecomment-5078321426)

I've tested on Linux, Android and Web, the macOS and Apple embedded bits where tested by @bruvzg in #121760