### PR TITLE
Update Add Action button Disabled Status when Removing any action

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -189,6 +189,10 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 			// Send removed action name
 			String name = item->get_meta("__name");
 			emit_signal(SNAME("action_removed"), name);
+
+			// Update the "Add" button in case the deleted action shares
+			// the same name as the new one.
+			_add_edit_text_changed(add_edit->get_text());
 		} break;
 		case ActionMapEditor::BUTTON_REMOVE_EVENT: {
 			// Remove event and send updated action


### PR DESCRIPTION
## Commit Description

Makes sure the add action button is enabled when the action name the user wants to add is equal to recently removed action inside the tree. without this change, the add button will remain disabled (even though it's a valid action name), making the user feel the GUI is unresponsive.

## Testing

### Before Changes

https://github.com/user-attachments/assets/405ac525-e392-4a13-9320-ae43eee38289

### After Changes

https://github.com/user-attachments/assets/1e20aaeb-ff3a-4b04-905a-0e8715173159

## Additional information
- You can still add the action by clicking EditLine field, and pressing `Enter`, but I think if it's valid to do this using shortcuts, it's should be the same using UI components (through the add button in this case).
- Reason behind calling the `_add_edit_text_changed` callback is because it does all the validation needed when deciding to Enable or Disable the `Add Action` button, and setting tooltip text, so calling it makes more sense then code duplication.

## Use of AI
No AI was used in the process of making these changes.