### PR TITLE
CI: Update all GitHub Actions to latest versions

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Restore default cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       id: cache-ping
       with:
         path: ${{ inputs.scons-cache }}
@@ -27,7 +27,7 @@ runs:
     # This is done after pulling the default cache so that PRs can integrate any potential changes
     # from the default branch without conflicting with whatever local changes were already made.
     - name: Restore local cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       if: github.ref_name != github.event.repository.default_branch
       with:
         path: ${{ inputs.scons-cache }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -16,7 +16,7 @@ runs:
       run: misc/scripts/purge_cache.py ${{ env.CACHE_TIMESTAMP }} "${{ inputs.scons-cache }}"
 
     - name: Save SCons cache directory
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}

--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
         repository: godotengine/godot-cpp

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python 3.x
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         # Semantic version range syntax or exact version of a Python version.
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -20,7 +20,7 @@ jobs:
       sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
           filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Takes our handful of GitHub Action calls that are a few versions behind and bumps them to their latest equivalents.

## Additional information

Not *as* pertinent now that everything is already bumped to Node 24. However, `actions/checkout@v7` in particular would enable us to safely utilize `pull_request_target`[^1], if we ever desire a more comprehensive GHA workflow (which I do 🙂).

[^1]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target