### PR TITLE
gdscript 'Standalone expression (the line has no effect)' warning

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2059,6 +2059,61 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 	return suite;
 }
 
+#ifdef DEBUG_ENABLED
+static bool _is_standalone_expression_effective(const GDScriptParser::ExpressionNode *p_expression) {
+	if (p_expression == nullptr) {
+		return false;
+	}
+	switch (p_expression->type) {
+		case GDScriptParser::Node::CALL:
+		case GDScriptParser::Node::AWAIT:
+			return true;
+		case GDScriptParser::Node::ARRAY: {
+			const GDScriptParser::ArrayNode *array = static_cast<const GDScriptParser::ArrayNode *>(p_expression);
+			for (int i = 0; i < array->elements.size(); i++) {
+				if (_is_standalone_expression_effective(array->elements[i])) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDScriptParser::Node::BINARY_OPERATOR: {
+			const GDScriptParser::BinaryOpNode *binary_op = static_cast<const GDScriptParser::BinaryOpNode *>(p_expression);
+			return _is_standalone_expression_effective(binary_op->left_operand) || _is_standalone_expression_effective(binary_op->right_operand);
+		}
+		case GDScriptParser::Node::CAST:
+			return _is_standalone_expression_effective(static_cast<const GDScriptParser::CastNode *>(p_expression)->operand);
+		case GDScriptParser::Node::DICTIONARY: {
+			const GDScriptParser::DictionaryNode *dictionary = static_cast<const GDScriptParser::DictionaryNode *>(p_expression);
+			for (int i = 0; i < dictionary->elements.size(); i++) {
+				if (_is_standalone_expression_effective(dictionary->elements[i].key) || _is_standalone_expression_effective(dictionary->elements[i].value)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDScriptParser::Node::SUBSCRIPT: {
+			const GDScriptParser::SubscriptNode *subscript = static_cast<const GDScriptParser::SubscriptNode *>(p_expression);
+			if (_is_standalone_expression_effective(subscript->base)) {
+				return true;
+			}
+			return !subscript->is_attribute && _is_standalone_expression_effective(subscript->index);
+		}
+		case GDScriptParser::Node::TERNARY_OPERATOR: {
+			const GDScriptParser::TernaryOpNode *ternary_op = static_cast<const GDScriptParser::TernaryOpNode *>(p_expression);
+			return _is_standalone_expression_effective(ternary_op->condition) || _is_standalone_expression_effective(ternary_op->true_expr) || _is_standalone_expression_effective(ternary_op->false_expr);
+		}
+		case GDScriptParser::Node::TYPE_TEST:
+			return _is_standalone_expression_effective(static_cast<const GDScriptParser::TypeTestNode *>(p_expression)->operand);
+		case GDScriptParser::Node::UNARY_OPERATOR:
+			return _is_standalone_expression_effective(static_cast<const GDScriptParser::UnaryOpNode *>(p_expression)->operand);
+		default:
+			// Note: A `LAMBDA` body is not evaluated by the expression that contains it.
+			return false;
+	}
+}
+#endif // DEBUG_ENABLED
+
 GDScriptParser::Node *GDScriptParser::parse_statement() {
 	Node *result = nullptr;
 #ifdef DEBUG_ENABLED
@@ -2214,7 +2269,11 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 						push_warning(expression, GDScriptWarning::STANDALONE_TERNARY);
 						break;
 					default:
-						push_warning(expression, GDScriptWarning::STANDALONE_EXPRESSION);
+						// A sub-expression may still have an effect, e.g. a call in the
+						// short-circuit operand of `and`/`or`.
+						if (!_is_standalone_expression_effective(expression)) {
+							push_warning(expression, GDScriptWarning::STANDALONE_EXPRESSION);
+						}
 				}
 			}
 #endif

--- a/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.gd
@@ -19,3 +19,24 @@ func test():
 	"""
 	@warning_ignore("standalone_ternary")
 	1 if 2 else 3 # Produces `STANDALONE_TERNARY` instead.
+	# Logical `and`/`or` short-circuit can conditionally execute a call, which is a
+	# valid effect, so these should not produce `STANDALONE_EXPRESSION`:
+	_a and absi(5)
+	_a or absi(6)
+	absi(7) and _a
+	_a and (_a or absi(8))
+	# A logical operator with no side effect is still reported:
+	_a and _a
+	# The effect can be nested in any sub-expression, so these should not produce
+	# `STANDALONE_EXPRESSION` either:
+	_a and (absi(9) + 2)
+	_a and not absi(10)
+	_a and (absi(11) if _a else 0)
+	@warning_ignore("redundant_await")
+	_a and await 12
+	[absi(13)]
+	{ "key": absi(14) }
+	# Without a call, the same expressions are still reported:
+	not _a
+	[_a]
+	{ "key": _a }

--- a/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/standalone_expression.out
@@ -3,3 +3,7 @@ GDTEST_OK
 ~~ WARNING at line 4: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
 ~~ WARNING at line 6: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
 ~~ WARNING at line 7: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
+~~ WARNING at line 29: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
+~~ WARNING at line 40: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
+~~ WARNING at line 41: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).
+~~ WARNING at line 42: (STANDALONE_EXPRESSION) Standalone expression (the line may have no effect).


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #47088

## Additional information

```gdscript
#Warn olds are no longer giving warnings while #Warn remains warned
var t := true
var f := false

func _ready():
	t and foo(1) # Warn old
	f and foo(2) # Warn old
	foo(3) and t # Warn old
	t and (f or foo(4)) # Warn old
	t and f #warn
	t and not foo(5) # Warn old
	t and (foo(6) != f) # Warn old
	t and (foo(7) if t else f)   #Warn old
	[foo(8)] #Warn old
	{ "key": foo(9) } #Warn old
	[foo(10), false][0] #Warn old
	not t # Warn
	[t, f] #Warn
	{ "key": t } # Warn
	
func foo(val: int) -> bool:
	print("foo(%d)" % val)
	return false
```
