### PR TITLE
mbedTLS: Ignore TLSv1.3 session ticket during poll/hanshake

### DIFF
--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -84,6 +84,8 @@ Error StreamPeerMbedTLS::_do_handshake() {
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		// Handshake is still in progress, will retry via poll later.
 		return OK;
+	} else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+		return OK; // Re-connection cookies are not currently supported, ignore them.
 	} else if (ret != 0) {
 		// An error occurred.
 		ERR_PRINT("TLS handshake error: " + itos(ret));
@@ -252,6 +254,8 @@ void StreamPeerMbedTLS::poll() {
 
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		// Nothing to read/write (non blocking IO)
+	} else if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+		// Re-connection cookies are not currently supported, ignore them.
 	} else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
 		// Clean close (disconnect)
 		disconnect_from_stream();


### PR DESCRIPTION
We were already handling it in `get_partial_data`, but this might happen during poll as we call `mbedtls_ssl_read` to update the state.

Non slop bit of #121761 (+ handshake check)