### PR TITLE
Fix directional shadow culling for orthogonal cameras

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2145,7 +2145,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 
 void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect) {
 	// For later tight culling, the light culler needs to know the details of the directional light.
-	light_culler->prepare_directional_light(p_instance, p_shadow_index);
+	light_culler->prepare_directional_light_begin(p_instance, p_shadow_index);
 
 	InstanceLightData *light = static_cast<InstanceLightData *>(p_instance->base_data);
 
@@ -2212,11 +2212,14 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 			camera_matrix.set_perspective(fov, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], true);
 		}
 
-		//obtain the frustum endpoints
+		Vector<Plane> receiver_frustum_planes = camera_matrix.get_projection_planes(p_cam_transform);
 
+		//obtain the frustum endpoints
 		Vector3 endpoints[8]; // frustum plane endpoints
 		bool res = camera_matrix.get_endpoints(p_cam_transform, endpoints);
 		ERR_CONTINUE(!res);
+
+		light_culler->prepare_directional_light_cascade(p_shadow_index, i, receiver_frustum_planes, endpoints);
 
 		// obtain the light frustum ranges (given endpoints)
 

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -72,8 +72,7 @@ String RenderingLightCuller::Data::plane_bitfield_to_string(unsigned int BF) {
 }
 #endif
 
-void RenderingLightCuller::prepare_directional_light(const RendererSceneCull::Instance *p_instance, int32_t p_directional_light_id) {
-	//data.directional_light = p_instance;
+void RenderingLightCuller::prepare_directional_light_begin(const RendererSceneCull::Instance *p_instance, int32_t p_directional_light_id) {
 	// Something is probably going wrong, we shouldn't have this many directional lights...
 	ERR_FAIL_COND(p_directional_light_id > 512);
 	DEV_ASSERT(p_directional_light_id >= 0);
@@ -83,10 +82,30 @@ void RenderingLightCuller::prepare_directional_light(const RendererSceneCull::In
 		data.directional_cull_planes.resize(p_directional_light_id + 1);
 	}
 
-	_prepare_light(*p_instance, p_directional_light_id);
+	DirectionalLightCullData &directional_cull_planes = data.directional_cull_planes[p_directional_light_id];
+	directional_cull_planes.light_source = LightSource();
+	directional_cull_planes.light_source.type = LightSource::ST_DIRECTIONAL;
+	directional_cull_planes.light_source.pos = p_instance->transform.origin;
+	directional_cull_planes.light_source.dir = -p_instance->transform.basis.get_column(2);
+	directional_cull_planes.light_source.dir.normalize();
+	for (LightCullPlanes &planes : directional_cull_planes.planes) {
+		planes.num_cull_planes = 0;
+	}
 }
 
-bool RenderingLightCuller::_prepare_light(const RendererSceneCull::Instance &p_instance, int32_t p_directional_light_id) {
+void RenderingLightCuller::prepare_directional_light_cascade(int32_t p_directional_light_id, int32_t p_cascade, const Vector<Plane> &p_receiver_frustum_planes, const Vector3 *p_receiver_frustum_points) {
+	ERR_FAIL_INDEX(p_directional_light_id, (int32_t)data.directional_cull_planes.size());
+	ERR_FAIL_INDEX(p_cascade, 4);
+	ERR_FAIL_COND(p_receiver_frustum_planes.size() != NUM_CAM_PLANES);
+	ERR_FAIL_NULL(p_receiver_frustum_points);
+
+	DirectionalLightCullData &directional_cull_planes = data.directional_cull_planes[p_directional_light_id];
+	LightCullPlanes &destination = directional_cull_planes.planes[p_cascade];
+	destination.num_cull_planes = 0;
+	_add_light_camera_planes(destination, directional_cull_planes.light_source, { p_receiver_frustum_planes.ptr(), p_receiver_frustum_points });
+}
+
+bool RenderingLightCuller::_prepare_light(const RendererSceneCull::Instance &p_instance) {
 	if (!data.is_active()) {
 		return true;
 	}
@@ -108,28 +127,7 @@ bool RenderingLightCuller::_prepare_light(const RendererSceneCull::Instance &p_i
 			float half_diagonal = lsource.area_size.length() / 2.0;
 			lsource.range = RSG::light_storage->light_get_param(p_instance.base, RSE::LIGHT_PARAM_RANGE) + half_diagonal;
 		} break;
-		case RSE::LIGHT_DIRECTIONAL:
-			lsource.type = LightSource::ST_DIRECTIONAL;
-
-			lsource.range = RSG::light_storage->light_get_param(p_instance.base, RSE::LIGHT_PARAM_SHADOW_MAX_DISTANCE);
-			switch (RSG::light_storage->light_directional_get_shadow_mode(p_instance.base)) {
-				case RSE::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL:
-					lsource.cascade_count = 1;
-					break;
-				case RSE::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS:
-					lsource.cascade_count = 2;
-					break;
-				case RSE::LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS:
-					lsource.cascade_count = 4;
-					break;
-				default:
-					ERR_FAIL_V_MSG(false, "Only directional lights with 1, 2, or 4 shadow cascades are supported.");
-					break;
-			}
-			lsource.cascade_splits[0] = RSG::light_storage->light_get_param(p_instance.base, RSE::LIGHT_PARAM_SHADOW_SPLIT_1_OFFSET);
-			lsource.cascade_splits[1] = RSG::light_storage->light_get_param(p_instance.base, RSE::LIGHT_PARAM_SHADOW_SPLIT_2_OFFSET);
-			lsource.cascade_splits[2] = RSG::light_storage->light_get_param(p_instance.base, RSE::LIGHT_PARAM_SHADOW_SPLIT_3_OFFSET);
-			lsource.blend_splits = RSG::light_storage->light_directional_get_blend_splits(p_instance.base);
+		default:
 			break;
 	}
 
@@ -137,90 +135,7 @@ bool RenderingLightCuller::_prepare_light(const RendererSceneCull::Instance &p_i
 	lsource.dir = -p_instance.transform.basis.get_column(2);
 	lsource.dir.normalize();
 
-	// In reality there's always going to be at least one cascade, but the compiler can't know that.
-	// If SOMEHOW there's actually 0 cascades though, I suppose there isn't going to be anything visible after all.
-	bool visible = false;
-	if (p_directional_light_id == -1) {
-		visible = _add_light_camera_planes(data.regular_cull_planes, lsource, { &data.frustum_planes[0], data.frustum_points });
-	} else {
-		int used_planes = 1 + lsource.cascade_count; // 2 for ortho (near+far), 3 for pssm2 (near+mid+far), 5 for pssm4 (near+3mids+far).
-		Plane boundary_planes[5];
-		{
-			constexpr const int MAX_PLANES = 5;
-			// Orthogonal cameras have fixed max shadow distance, determined by the camera far plane.
-			// That must be accounted for, or else GH-120457 happens.
-			// For perspective cameras, shadow far must also never be further than the camera far plane (otherwise things break).
-			float camera_far = data.camera_projection.get_z_far();
-			float shadow_far = data.camera_projection.is_orthogonal() ? camera_far : MIN(lsource.range, camera_far);
-			real_t plane_distances[MAX_PLANES] = {
-				data.camera_projection.get_z_near(),
-				lsource.cascade_splits[0] * shadow_far,
-				lsource.cascade_splits[1] * shadow_far,
-				lsource.cascade_splits[2] * shadow_far,
-				shadow_far,
-			};
-			// If not 4 cascades, replace last used cascade plane distance with max shadow range (shadow far plane distance).
-			plane_distances[used_planes - 1] = shadow_far;
-#ifdef LIGHT_CULLER_DEBUG_LOGGING
-			if (is_logging()) {
-				print_line("cascade split planes (first " + itos(used_planes) + " used): " +
-						String(Variant(plane_distances[0])) + "m, " +
-						String(Variant(plane_distances[1])) + "m, " +
-						String(Variant(plane_distances[2])) + "m, " +
-						String(Variant(plane_distances[3])) + "m, " +
-						String(Variant(plane_distances[4])) + "m");
-			}
-#endif
-			Vector3 camera_normal = data.camera_transform.basis.xform(Vector3(0, 0, 1)).normalized();
-			for (int i = 0; i < used_planes; i++) {
-				real_t plane_distance = plane_distances[i];
-
-				//Plane compute
-				boundary_planes[i] = Plane(
-						camera_normal,
-						data.camera_transform.origin + camera_normal * -plane_distance);
-			}
-		}
-
-		for (int i = 0; i < lsource.cascade_count; i++) {
-			/*
-			enum PlaneOrder {
-				PLANE_NEAR,
-				PLANE_FAR,
-				PLANE_LEFT,
-				PLANE_TOP,
-				PLANE_RIGHT,
-				PLANE_BOTTOM,
-				PLANE_TOTAL,
-			};
-			*/
-			Plane cull_planes[6] = {
-				boundary_planes[MAX(i - (lsource.blend_splits ? 1 : 0), 0)],
-				Plane(-boundary_planes[i + 1].normal, -boundary_planes[i + 1].d), // Normal flip to ensure far is outward-facing.
-				data.frustum_planes[2],
-				data.frustum_planes[3],
-				data.frustum_planes[4],
-				data.frustum_planes[5],
-			};
-
-#ifdef LIGHT_CULLER_DEBUG_LOGGING
-			if (is_logging()) {
-				for (int p = 0; p < 6; p++) {
-					print_line("cascade " + itos(i) + " plane " + itos(p) + " : " + String(cull_planes[p]));
-				}
-			}
-#endif
-
-			// Frustum point calculation
-			Vector3 frustum_points[8];
-			bool success = create_frustum_points(cull_planes, frustum_points);
-			ERR_FAIL_COND_V(!success, false);
-
-			// Replace frustum arguments with cascade's.
-			LightCullPlanes &destination = data.directional_cull_planes[p_directional_light_id].planes[i];
-			visible = _add_light_camera_planes(destination, lsource, { cull_planes, frustum_points });
-		}
-	}
+	bool visible = _add_light_camera_planes(data.regular_cull_planes, lsource, { &data.frustum_planes[0], data.frustum_points });
 
 	if (data.light_culling_active) {
 		return visible;

--- a/servers/rendering/rendering_light_culler.h
+++ b/servers/rendering/rendering_light_culler.h
@@ -85,9 +85,6 @@ private:
 			type = ST_UNKNOWN;
 			angle = 0.0f;
 			range = FLT_MAX;
-			cascade_count = 0;
-			cascade_splits[0] = cascade_splits[1] = cascade_splits[2] = 0;
-			blend_splits = false;
 		}
 
 		// All in world space, culling done in world space.
@@ -100,10 +97,6 @@ private:
 		float width; // For area light.
 		float height;
 		Vector2 area_size; // For area light.
-
-		int cascade_count;
-		float cascade_splits[3]; // Max 4 cascades, which only has 3 splits.
-		bool blend_splits;
 	};
 
 	// Directional lights have separate cull frustums for each cascade, so this struct is needed to specify which one to use for each cull step.
@@ -153,14 +146,15 @@ public:
 	// REGULAR LIGHTS (SPOT, OMNI).
 	// These are prepared then used for culling one by one, single threaded.
 	// prepare_regular_light() returns false if the entire light is culled (i.e. there is no intersection between the light and the view frustum).
-	bool prepare_regular_light(const RendererSceneCull::Instance &p_instance) { return _prepare_light(p_instance, -1); }
+	bool prepare_regular_light(const RendererSceneCull::Instance &p_instance) { return _prepare_light(p_instance); }
 
 	// Cull according to the regular light planes that were setup in the previous call to prepare_regular_light.
 	void cull_regular_light(PagedArray<RendererSceneCull::Instance *> &r_instance_shadow_cull_result);
 
 	// Directional lights are prepared in advance, and can be culled multithreaded chopping and changing between
 	// different directional_light_id.
-	void prepare_directional_light(const RendererSceneCull::Instance *p_instance, int32_t p_directional_light_id);
+	void prepare_directional_light_begin(const RendererSceneCull::Instance *p_instance, int32_t p_directional_light_id);
+	void prepare_directional_light_cascade(int32_t p_directional_light_id, int32_t p_cascade, const Vector<Plane> &p_receiver_frustum_planes, const Vector3 *p_receiver_frustum_points);
 
 	// Return false if the instance is to be culled.
 	bool cull_directional_light(const RendererSceneCull::InstanceBounds &p_bound, int32_t p_directional_light_id, int32_t p_cascade);
@@ -179,11 +173,12 @@ private:
 #endif
 	};
 
-	struct DirectionalCullPlanes {
-		LightCullPlanes planes[4]; // One set of cull planes per cascade
+	struct DirectionalLightCullData {
+		LightSource light_source;
+		LightCullPlanes planes[4]; // One set of cull planes per cascade.
 	};
 
-	bool _prepare_light(const RendererSceneCull::Instance &p_instance, int32_t p_directional_light_id = -1);
+	bool _prepare_light(const RendererSceneCull::Instance &p_instance);
 
 	// Avoid adding extra culling planes derived from near colinear triangles.
 	// The normals derived from these will be inaccurate, and can lead to false
@@ -259,7 +254,7 @@ private:
 		// chops and changes between culling different lights
 		// instead of doing one by one, and we don't want to prepare
 		// lights multiple times per frame.
-		LocalVector<DirectionalCullPlanes> directional_cull_planes;
+		LocalVector<DirectionalLightCullData> directional_cull_planes;
 
 		Transform3D camera_transform;
 		Projection camera_projection;


### PR DESCRIPTION


### What does this fix?

This fixes incorrect directional shadow caster culling with orthogonal cameras.

Before
<img width="1906" height="1080" alt="Screenshot 2026-07-26 001954" src="https://github.com/user-attachments/assets/565fa00c-157c-47ff-83b6-e60f05d8083f" />

After
<img width="1917" height="1080" alt="Screenshot 2026-07-26 001851" src="https://github.com/user-attachments/assets/dd419f2b-6f67-4581-b672-49d87de4b044" />


This is a regression from the tighter per-cascade shadow caster culling introduced in #114678, it fixes incorrect directional shadow caster culling with orthogonal cameras, the issue being caused by the renderer and the light culler reconstruicting cascade bounds independently. The culler could then use different split distances and side planes from the cascade actually rendered, causing valid shadow casters to be removed.



### What changed?

The light culler now uses the actual cascade geometry directly, before it would internally recalculate these bounds, each cascade now passes its precise projected planes (and endpoints) to the light culler.

The existing directional silhouette and extrusion algorithm then constructs the tight caster volume from the cascade geometry data provided by each cascade. The directional culling behavior remains the same, and each cascade still defines its own set of culling planes.

The existing per-cascade tight culling optimization (#114678) is still active. I removed the redundant cascade volume reconstruction in the culler and its obsolete split state variable, shouldnt cause any issues , I mean everyone says that and then an issue appears lol, but no, im confident.




Closes https://github.com/godotengine/godot/issues/121644