### PR TITLE
gdscript fix highlighting after single line for loop

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -478,6 +478,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				col = reserved_keywords[word];
 				// Don't highlight `list` as a type in `for elem: Type in list`.
 				expect_type = false;
+				if (word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::TK_IN)) {
+					is_after_var_const_declaration = false;
+				}
 			} else if (member_keywords.has(word)) {
 				col = member_keywords[word];
 				in_member_variable = true;


### PR DESCRIPTION


## What problem(s) does this PR solve?

- Partially fixes #111692

## Additional information
old  
<img width="711" height="141" alt="image" src="https://github.com/user-attachments/assets/ee32c1cd-48bd-4815-bb3a-73e2410df11c" />


new
<img width="694" height="132" alt="image" src="https://github.com/user-attachments/assets/e70bd2b1-be42-4d25-ac30-e87fda7da040" />

this does not address the multi-line problem
