### PR TITLE
fix: sanitize shell/subprocess call in editor_builders.py

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -85,9 +85,9 @@ def make_translations(target, source, env):
             # msgfmt erases non-translated messages, so avoid using it if exporting the POT.
             if msgfmt and name != category:
                 mo_path = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex + ".mo")
-                cmd = f'{msgfmt} "{path}" --no-hash -o "{mo_path}"'
+                cmd = [msgfmt, path, "--no-hash", "-o", mo_path]
                 try:
-                    subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+                    subprocess.Popen(cmd, stderr=subprocess.PIPE).communicate()
                     buffer = methods.get_buffer(mo_path)
                 except OSError as e:
                     methods.print_warning(


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `editor/editor_builders.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `editor/editor_builders.py:88` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The make_translations function constructs a shell command using f-string interpolation with user-controlled file paths, then executes it with shell=True. This allows command injection if an attacker can control the filename.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a CLI tool - exploitation requires the attacker to control arguments or input files passed to the tool.

## Changes
- `editor/editor_builders.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
