### PR TITLE
Install Mold with an explicit flag instead of "proj-test"

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -59,6 +59,7 @@ jobs:
               use_ubsan=yes
               linker=mold
             bin: ./bin/godot.linuxbsd.editor.dev.double.x86_64.san
+            install-mold: true
             proj-test: true
             free-space: true
 
@@ -180,8 +181,10 @@ jobs:
           fi
 
       - name: Install mold linker
-        if: matrix.proj-test
+        if: matrix.install-mold
         uses: rui314/setup-mold@v1
+        with:
+          make-default: false
 
       - name: Compilation
         uses: ./.github/actions/godot-build


### PR DESCRIPTION
In my fork, I tried replacing `linker=mold` with `linker=bfd` and it did not work, it kept using Mold. Why? Because the default behavior of Mold is to override `bfd` if you don't specify `make-default: false`: https://github.com/rui314/setup-mold#usage

Also, the installation of Mold was gated on `if: matrix.proj-test`. What... why? That makes no sense. I changed it to an explicit flag for installing mold: `if: matrix.install-mold`.