### PR TITLE
Fix incorrect memory allocation in ShaderLanguage::_parse_shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10740,7 +10740,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 								array_size = constant.array_size;
 
-								ConstantNode *expr = memnew(ConstantNode);
+								ConstantNode *expr = alloc_node<ConstantNode>();
 
 								expr->datatype = constant.type;
 


### PR DESCRIPTION
Disclaimer: I don't know anything about the specifics of this class. What I do know:

- This fixes a memory leak when using clang sanitizers, a CI failure is what motivated this change.
- This was the only case of `memnew` in this file, everything else in this file is `alloc_node` (57 instances).
- The blame for this line traces back 6 years ago: https://github.com/godotengine/godot/pull/32751/changes#diff-fd807e7ef53c99f78fdbbe48a2844b79e63326fc1c3704b8738d1b71526396f0R6661
- The problematic line and suggested fix was identified by AI.