### PR TITLE
Fix XMLParser state leaks and memory deletion mismatch

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -68,8 +68,6 @@ bool XMLParser::_set_text(const char *p_start, const char *p_end) {
 
 void XMLParser::_parse_closing_xml_element() {
 	node_type = NODE_ELEMENT_END;
-	node_empty = false;
-	attributes.clear();
 
 	next_char();
 	const char *pBeginClose = P;
@@ -198,8 +196,6 @@ void XMLParser::_parse_comment() {
 
 void XMLParser::_parse_opening_xml_element() {
 	node_type = NODE_ELEMENT;
-	node_empty = false;
-	attributes.clear();
 
 	// find name
 	const char *startName = P;
@@ -293,6 +289,9 @@ void XMLParser::_parse_opening_xml_element() {
 }
 
 void XMLParser::_parse_current_node() {
+	node_empty = false;
+	attributes.clear();
+
 	const char *start = P;
 	node_offset = P - data;
 
@@ -536,15 +535,18 @@ void XMLParser::skip_section() {
 
 void XMLParser::close() {
 	if (data_copy) {
-		memdelete_arr(data);
+		memdelete_arr(data_copy);
 		data_copy = nullptr;
 	}
 	data = nullptr;
 	length = 0;
 	P = nullptr;
+	current_line = 0;
+	node_name = "";
 	node_empty = false;
 	node_type = NODE_NONE;
 	node_offset = 0;
+	attributes.clear();
 }
 
 int XMLParser::get_current_line() const {

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -231,4 +231,33 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_name(), "a");
 }
 
+TEST_CASE("[XMLParser] State reset and attribute leakage") {
+	const String input = "<elem attr=\"val\"/><!-- comment -->";
+	XMLParser parser;
+	REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser.get_node_name(), "elem");
+	CHECK_EQ(parser.get_attribute_count(), 1);
+	CHECK_EQ(parser.get_attribute_name(0), "attr");
+	CHECK_EQ(parser.get_attribute_value(0), "val");
+
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_COMMENT);
+	CHECK_EQ(parser.get_node_name(), " comment ");
+	// Verify that attributes do not leak to the next non-element node
+	CHECK_EQ(parser.get_attribute_count(), 0);
+
+	parser.close();
+
+	// Verify full state reset after close
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_NONE);
+	CHECK_EQ(parser.get_node_name(), "");
+	CHECK_EQ(parser.get_attribute_count(), 0);
+	CHECK_EQ(parser.get_current_line(), 0);
+	CHECK_EQ(parser.get_node_offset(), 0);
+	CHECK_EQ(parser.is_empty(), false);
+}
+
 } // namespace TestXMLParser


### PR DESCRIPTION
While going through xml_parser.cpp, I noticed close() was deleting the wrong pointer (data instead of data_copy) and leaving parser state dirty, which caused attribute leaks into non‑element nodes. This patch fixes the memory deletion, fully resets state in close(), and centralises attribute clearing to prevent any leakage. A unit test confirms both fixes.
