### PR TITLE
Fix possible reads from a null DockTabContainer in EditorDockManager

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -374,7 +374,7 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	p_dock->hide();
 
 	DockTabContainer *dock_tab_container = Object::cast_to<DockTabContainer>(p_target);
-	if (p_target != closed_dock_parent && (dock_tab_container->layout != p_dock->current_layout || dock_tab_container->dock_slot != p_dock->dock_slot_index)) {
+	if (dock_tab_container && p_target != closed_dock_parent && (dock_tab_container->layout != p_dock->current_layout || dock_tab_container->dock_slot != p_dock->dock_slot_index)) {
 		p_dock->update_layout(dock_tab_container->layout, dock_tab_container->dock_slot);
 		p_dock->current_layout = dock_tab_container->layout;
 		p_dock->dock_slot_index = dock_tab_container->dock_slot;


### PR DESCRIPTION
This code runs `Object::cast_to<DockTabContainer>(p_target);` but then uses the casted object without checking if the cast succeeds. There is already a similar check below, but it was missing here.

This problem was found with GCC sanitizers: `editor/docks/editor_dock_manager.cpp:377:79: runtime error: load of value 3200171710, which is not a valid value for type 'DockLayout'`
