### PR TITLE
Fix uninitialized memory in ShaderLanguage::FunctionNode::Argument

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -749,14 +749,14 @@ public:
 			StringName struct_name;
 			DataPrecision precision;
 			//for passing textures as arguments
-			bool tex_argument_check;
+			bool tex_argument_check = false;
 			TextureFilter tex_argument_filter;
 			TextureRepeat tex_argument_repeat;
-			bool tex_builtin_check;
+			bool tex_builtin_check = false;
 			StringName tex_builtin;
-			ShaderNode::Uniform::Hint tex_hint;
-			bool is_const;
-			int array_size;
+			ShaderNode::Uniform::Hint tex_hint = ShaderNode::Uniform::HINT_NONE;
+			bool is_const = false;
+			int array_size = 0;
 
 			HashMap<StringName, HashSet<int>> tex_argument_connect;
 		};


### PR DESCRIPTION
The primitive members of this struct are not explicitly initialized, which means they can contain garbage data. This PR fixes it.

This problem was found with GCC sanitizers: `servers/rendering/shader_language.h:745:10: runtime error: load of value 4116606352, which is not a valid value for type 'Hint'`