### PR TITLE
Fix `String.append_utf32_unchecked` undefined behavior with zero span size

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -221,6 +221,10 @@ Error String::append_utf32(const Span<char32_t> &p_cstr) {
 }
 
 void String::append_utf32_unchecked(const Span<char32_t> &p_span) {
+	if (unlikely(p_span.size() == 0)) {
+		// Nothing to do when empty. Otherwise, calling `memcpy` with a nullptr would be UB.
+		return;
+	}
 	const int prev_length = length();
 	resize_uninitialized(prev_length + p_span.size() + 1); // + 1 for \0
 	char32_t *dst = ptrw() + prev_length;


### PR DESCRIPTION
The existing function was causing undefined behavior, passing `nullptr` into `memcpy` when the input Span is a size of zero and its pointer points to null. This PR adds a check for this to avoid undefined behavior. It also avoids multiple calls to `size()` and avoids unnecessary resize work in this case, but it is guarded with `unlikely` to try and avoid performance reduction.

Note that the "unchecked" part of this function's name is referring to checking the string, so it's fine to check the input.

This problem was found with GCC sanitizers: `core/string/ustring.cpp:227:8: runtime error: null pointer passed as argument 2, which is declared to never be null`