### PR TITLE
Add quick exit to StyleBoxFlat.adapt_values()

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -436,12 +436,22 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 	}
 }
 
-inline void adapt_values(int p_index_a, int p_index_b, real_t *adapted_values, const real_t *p_values, const real_t p_width, const real_t p_max_a, const real_t p_max_b) {
+// Scales values proportionally to a width or a height, for example, scaling down big corner radii for a small stylebox.
+// Values and side length should be non-negative, and max_a and max_b should be less than or equal to the side length.
+inline void adapt_values(int p_index_a, int p_index_b, real_t *adapted_values, const real_t *p_values, const real_t p_side_length, const real_t p_max_a, const real_t p_max_b) {
 	real_t value_a = p_values[p_index_a];
 	real_t value_b = p_values[p_index_b];
-	real_t factor = MIN(1.0, p_width / (value_a + value_b));
-	adapted_values[p_index_a] = MIN(MIN(value_a * factor, p_max_a), adapted_values[p_index_a]);
-	adapted_values[p_index_b] = MIN(MIN(value_b * factor, p_max_b), adapted_values[p_index_b]);
+	if (value_a <= 0.0) {
+		adapted_values[p_index_a] = 0;
+		adapted_values[p_index_b] = MIN(MIN(value_b, p_max_b), adapted_values[p_index_b]);
+	} else if (value_b <= 0.0) {
+		adapted_values[p_index_a] = MIN(MIN(value_a, p_max_a), adapted_values[p_index_a]);
+		adapted_values[p_index_b] = 0;
+	} else {
+		real_t factor = MIN(1.0, p_side_length / (value_a + value_b));
+		adapted_values[p_index_a] = MIN(MIN(value_a * factor, p_max_a), adapted_values[p_index_a]);
+		adapted_values[p_index_b] = MIN(MIN(value_b * factor, p_max_b), adapted_values[p_index_b]);
+	}
 }
 
 Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {


### PR DESCRIPTION
I don't know if this speeds anything up, but it should clear some runtime warnings about dividing by 0 when both values are 0 (previously, this case would result in +inf and get clamped down to 1, so this shouldn't affect the behavior).

Note: Wasn't able to test it, my laptop's RAM is way too compromised, it would fail to build Godot and freeze on the Github CI builds