### PR TITLE
Core: Remove hash_map.h include from dictionary.h

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/hash_map.h"
 #include "core/variant/variant.h"
 
 class DocData {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -34,27 +34,99 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 
+#include "memory.h"
+
 #include "core/templates/hash_map.h"
 #include "core/templates/safe_refcount.h"
 #include "core/variant/container_type_validate.h"
 #include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
+typedef HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator> VHashMap;
+
 struct DictionaryPrivate {
 	SafeRefCount refcount;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator> variant_map;
+	VHashMap variant_map;
 	ContainerTypeValidate typed_key;
 	ContainerTypeValidate typed_value;
 	Variant *typed_fallback = nullptr; // Allows a typed dictionary to return dummy values when attempting an invalid access.
 };
 
+// ConstIterator mirrors the HashMap version
+struct Dictionary::ConstIteratorPrivate {
+	friend Dictionary;
+	friend ConstIterator;
+
+	ConstIteratorPrivate(const VHashMap::ConstIterator p_it) : it{ p_it } {}
+
+private:
+	VHashMap::ConstIterator it;
+};
+
+const KeyValue<Variant, Variant> &Dictionary::ConstIterator::operator*() const {
+	return _p->it.operator*();
+}
+const KeyValue<Variant, Variant> *Dictionary::ConstIterator::operator->() const {
+	return _p->it.operator->();
+}
+Dictionary::ConstIterator &Dictionary::ConstIterator::operator++() {
+	_p->it.operator++();
+	return *this;
+}
+Dictionary::ConstIterator &Dictionary::ConstIterator::operator--() {
+	_p->it.operator--();
+	return *this;
+}
+
+bool Dictionary::ConstIterator::operator==(const ConstIterator &p_other) const {
+	return _p->it.operator==(p_other._p->it);
+}
+bool Dictionary::ConstIterator::operator!=(const ConstIterator &p_other) const {
+	return _p->it.operator!=(p_other._p->it);
+}
+
+Dictionary::ConstIterator::operator bool() const {
+	return _p->it.operator bool();
+}
+
+Dictionary::ConstIterator::ConstIterator(const ConstIterator &p_other) : _p{ memnew(Dictionary::ConstIteratorPrivate(p_other._p->it)) } {}
+
+Dictionary::ConstIterator::ConstIterator(ConstIterator &&p_other) : _p{ p_other._p } {
+	p_other._p = nullptr;
+}
+
+Dictionary::ConstIterator &Dictionary::ConstIterator::operator=(const ConstIterator &p_other) {
+	if (_p != nullptr) {
+		memdelete(_p);
+	}
+	_p = memnew(Dictionary::ConstIteratorPrivate{ p_other._p->it });
+	return *this;
+}
+
+Dictionary::ConstIterator &Dictionary::ConstIterator::operator=(ConstIterator &&p_other) {
+	if (_p != nullptr) {
+		memdelete(_p);
+	}
+	_p = p_other._p;
+	p_other._p = nullptr;
+	return *this;
+}
+
+Dictionary::ConstIterator::~ConstIterator() {
+	if (_p != nullptr) {
+		memdelete(_p);
+	}
+}
+
+Dictionary::ConstIterator::ConstIterator(ConstIteratorPrivate *p_p) : _p{ p_p } {}
+
 Dictionary::ConstIterator Dictionary::begin() const {
-	return _p->variant_map.begin();
+	return Dictionary::ConstIterator(memnew(Dictionary::ConstIteratorPrivate(_p->variant_map.begin())));
 }
 
 Dictionary::ConstIterator Dictionary::end() const {
-	return _p->variant_map.end();
+	return Dictionary::ConstIterator(memnew(Dictionary::ConstIteratorPrivate(_p->variant_map.end())));
 }
 
 LocalVector<Variant> Dictionary::get_key_list() const {
@@ -139,7 +211,7 @@ const Variant *Dictionary::getptr(const Variant &p_key) const {
 	if (unlikely(!_p->typed_key.validate(key, "getptr"))) {
 		return nullptr;
 	}
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(key));
+	VHashMap::ConstIterator E(_p->variant_map.find(key));
 	if (!E) {
 		return nullptr;
 	}
@@ -152,7 +224,7 @@ Variant *Dictionary::getptr(const Variant &p_key) {
 	if (unlikely(!_p->typed_key.validate(key, "getptr"))) {
 		return nullptr;
 	}
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::Iterator E(_p->variant_map.find(key));
+	VHashMap::Iterator E(_p->variant_map.find(key));
 	if (!E) {
 		return nullptr;
 	}
@@ -167,7 +239,7 @@ Variant *Dictionary::getptr(const Variant &p_key) {
 Variant Dictionary::get_valid(const Variant &p_key) const {
 	Variant key = p_key;
 	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "get_valid"), Variant());
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(key));
+	VHashMap::ConstIterator E(_p->variant_map.find(key));
 
 	if (!E) {
 		return Variant();
@@ -276,7 +348,7 @@ bool Dictionary::recursive_equal(const Dictionary &p_dictionary, int p_recursion
 	}
 	p_recursion_count++;
 	for (const KeyValue<Variant, Variant> &this_E : _p->variant_map) {
-		HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator other_E(p_dictionary._p->variant_map.find(this_E.key));
+		VHashMap::ConstIterator other_E(p_dictionary._p->variant_map.find(this_E.key));
 		if (!other_E || !this_E.value.hash_compare(other_E->value, p_recursion_count, false)) {
 			return false;
 		}
@@ -436,7 +508,7 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 	}
 
 	int size = p_dictionary._p->variant_map.size();
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator> variant_map = HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>(size);
+	VHashMap variant_map(size);
 
 	Vector<Variant> key_array;
 	key_array.resize(size);
@@ -569,7 +641,7 @@ const Variant *Dictionary::next(const Variant *p_key) const {
 	}
 	Variant key = *p_key;
 	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "next"), nullptr);
-	HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::Iterator E = _p->variant_map.find(key);
+	VHashMap::Iterator E = _p->variant_map.find(key);
 
 	if (!E) {
 		return nullptr;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
 #include "core/variant/variant_deep_duplicate.h"
@@ -58,7 +57,30 @@ class _WARN_UNUSED_ Dictionary {
 	void _unref() const;
 
 public:
-	using ConstIterator = HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator;
+	struct ConstIteratorPrivate;
+	struct ConstIterator {
+		friend Dictionary;
+
+		const KeyValue<Variant, Variant> &operator*() const;
+		const KeyValue<Variant, Variant> *operator->() const;
+		ConstIterator &operator++();
+		ConstIterator &operator--();
+
+		bool operator==(const ConstIterator &p_other) const;
+		bool operator!=(const ConstIterator &p_other) const;
+
+		explicit operator bool() const;
+
+		ConstIterator(const ConstIterator &p_other);
+		ConstIterator(ConstIterator &&p_other);
+		ConstIterator &operator=(const ConstIterator &p_other);
+		ConstIterator &operator=(ConstIterator &&p_other);
+		~ConstIterator();
+
+	private:
+		ConstIterator(ConstIteratorPrivate *p_p);
+		ConstIteratorPrivate *_p = nullptr;
+	};
 
 	ConstIterator begin() const;
 	ConstIterator end() const;

--- a/servers/audio/audio_driver.h
+++ b/servers/audio/audio_driver.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/hash_map.h"
 #include "core/templates/vector.h"
 #include "core/variant/variant.h"
 #include "servers/audio/audio_server_enums.h"

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/core_globals.h" // IWYU pragma: keep. Used in macro.
+#include "core/templates/hash_map.h"
 #include "core/variant/variant.h"
 
 #if defined(_MSC_VER) && !defined(DOCTEST_THREAD_LOCAL)


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- `dictionary.h` and by extension `variant.h` no longer include `hash_map.h`

## Additional information

`HashMap` was included so that the `ConstIterator` could be referenced to support ranged for-loops. The fix adds a wrapper over it.

I had to use the same trick as `DictionaryPrivate`: create a struct and store a pointer to it. I would be happy to hear prettier solutions.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
