### PR TITLE
[`GDScriptAnalyzer`] Don't error on subscript access for `Dictionary` with `Variant`-typed key

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5089,32 +5089,34 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 							case Variant::DICTIONARY:
 								if (base_type.has_container_element_type(0)) {
 									GDScriptParser::DataType key_type = base_type.get_container_element_type(0);
-									switch (index_type.builtin_type) {
-										// Null value will be treated as an empty object, allow.
-										case Variant::NIL:
-											error = key_type.builtin_type != Variant::OBJECT;
-											break;
-										// Objects are parsed for validity in a similar manner to container types.
-										case Variant::OBJECT:
-											if (key_type.builtin_type == Variant::OBJECT) {
-												error = !key_type.can_reference(index_type);
-											} else {
-												error = key_type.builtin_type != Variant::NIL;
-											}
-											break;
-										// String and StringName interchangeable in this context.
-										case Variant::STRING:
-										case Variant::STRING_NAME:
-											error = key_type.builtin_type != Variant::STRING_NAME && key_type.builtin_type != Variant::STRING;
-											break;
-										// Ints are valid indices for floats, but not the other way around.
-										case Variant::INT:
-											error = key_type.builtin_type != Variant::INT && key_type.builtin_type != Variant::FLOAT;
-											break;
-										// All other cases require the types to match exactly.
-										default:
-											error = key_type.builtin_type != index_type.builtin_type;
-											break;
+									if (!key_type.is_variant() && key_type.is_hard_type()) {
+										switch (index_type.builtin_type) {
+											// Null value will be treated as an empty object, allow.
+											case Variant::NIL:
+												error = key_type.builtin_type != Variant::OBJECT;
+												break;
+											// Objects are parsed for validity in a similar manner to container types.
+											case Variant::OBJECT:
+												if (key_type.builtin_type == Variant::OBJECT) {
+													error = !key_type.can_reference(index_type);
+												} else {
+													error = key_type.builtin_type != Variant::NIL;
+												}
+												break;
+											// String and StringName interchangeable in this context.
+											case Variant::STRING:
+											case Variant::STRING_NAME:
+												error = key_type.builtin_type != Variant::STRING_NAME && key_type.builtin_type != Variant::STRING;
+												break;
+											// Ints are valid indices for floats, but not the other way around.
+											case Variant::INT:
+												error = key_type.builtin_type != Variant::INT && key_type.builtin_type != Variant::FLOAT;
+												break;
+											// All other cases require the types to match exactly.
+											default:
+												error = key_type.builtin_type != index_type.builtin_type;
+												break;
+										}
 									}
 								}
 								break;

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_dictionary.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_dictionary.gd
@@ -9,3 +9,13 @@ func test():
 	var dict_2: Dictionary[int, int] = float_dict
 	var dict_3: Dictionary[Object, Object] = { integer: integer }
 	expect_typed(float_dict)
+
+	# Subscript access for Variant-typed key should not error (GH-121780).
+	var variant_key_dict: Dictionary[Variant, int] = { "key": 1 }
+	var key_untyped = "key"
+	var key_string_typed: String = "key"
+	var key_variant_typed: Variant = "key"
+	variant_key_dict["key"]
+	variant_key_dict[key_untyped]
+	variant_key_dict[key_string_typed]
+	variant_key_dict[key_variant_typed]


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #121780

## Additional information

No AI.