### PR TITLE
Fix miscellaneous oddities around the class reference (part 8)

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -133,10 +133,10 @@
 			<param index="1" name="x" type="float" />
 			<description>
 				Returns the arc tangent of [code]y/x[/code] in radians. Use to get the angle of tangent [code]y/x[/code]. To compute the value, the method takes into account the sign of both arguments in order to determine the quadrant.
-				Important note: The Y coordinate comes first, by convention.
 				[codeblock]
 				var a = atan2(0, -1) # a is 3.141593
 				[/codeblock]
+				[b]Important:[/b] The Y coordinate comes first, by convention.
 			</description>
 		</method>
 		<method name="atanh">

--- a/doc/classes/AccessibilityServer.xml
+++ b/doc/classes/AccessibilityServer.xml
@@ -77,7 +77,7 @@
 		<method name="is_supported" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if screen reader is support by this implementation.
+				Returns [code]true[/code] if screen readers are supported.
 			</description>
 		</method>
 		<method name="set_window_focused">
@@ -772,8 +772,8 @@
 			Region/landmark element. Screen readers can navigate between regions using landmark navigation.
 		</constant>
 		<constant name="ROLE_TEXT_RUN" value="47" enum="AccessibilityRole">
-			Unifor text run.
-			Note: This role is used for internal text elements, and should not be assigned to nodes.
+			Uniform text run.
+			[b]Note:[/b] This role is used for internal text elements, and should not be assigned to nodes.
 		</constant>
 		<constant name="POPUP_MENU" value="0" enum="AccessibilityPopupType">
 			Popup menu.

--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -97,7 +97,7 @@
 			The progress value between [code]0.0[/code] and [code]1.0[/code] until the current frame transitions to the next frame. If the animation is playing backwards, the value transitions from [code]1.0[/code] to [code]0.0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
+			The texture's drawing offset, relative to this node (+Y is down).
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -117,7 +117,7 @@
 			If [code]true[/code], sync mode is enabled (equivalent to [constant SYNC_MODE_INDEPENDENT]). This property is kept for backward compatibility.
 		</member>
 		<member name="sync_mode" type="int" setter="set_sync_mode" getter="get_sync_mode" enum="AnimationNodeBlendSpace1D.SyncMode" default="0">
-			Controls how animations are synced when blended. See [enum SyncMode] for available options.
+			Controls how animations are synced when blended.
 		</member>
 		<member name="value_label" type="String" setter="set_value_label" getter="get_value_label" default="&quot;value&quot;">
 			Label of the virtual axis of the blend space.

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -152,7 +152,7 @@
 			If [code]true[/code], sync mode is enabled (equivalent to [constant SYNC_MODE_INDEPENDENT]). This property is kept for backward compatibility.
 		</member>
 		<member name="sync_mode" type="int" setter="set_sync_mode" getter="get_sync_mode" enum="AnimationNodeBlendSpace2D.SyncMode" default="0">
-			Controls how animations are synced when blended. See [enum SyncMode] for available options.
+			Controls how animations are synced when blended.
 		</member>
 		<member name="x_label" type="String" setter="set_x_label" getter="get_x_label" default="&quot;x&quot;">
 			Name of the blend space's X axis.

--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -30,7 +30,7 @@
 			Amount of compression applied to the audio once it passes the volume threshold level. The higher the ratio, the stronger the compression applied to audio signals that pass the volume threshold level. Value can range from 1 to 48.
 		</member>
 		<member name="release_ms" type="float" setter="set_release_ms" getter="get_release_ms" default="250.0">
-			Compressor's delay time to stop decreasing the volume after the it falls below the volume threshold level, in milliseconds. Value can range from 20 to 2000.
+			Compressor's delay time to stop decreasing the volume after it falls below the volume threshold level, in milliseconds. Value can range from 20 to 2000.
 		</member>
 		<member name="sidechain" type="StringName" setter="set_sidechain" getter="get_sidechain" default="&amp;&quot;&quot;">
 			Audio bus to use for the volume threshold detection.

--- a/doc/classes/AudioEffectDistortion.xml
+++ b/doc/classes/AudioEffectDistortion.xml
@@ -24,7 +24,7 @@
 			High-pass filter, in Hz. Frequencies higher than this value will not be affected by the distortion. Value can range from 1 to 20000.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="AudioEffectDistortion.Mode" default="0">
-			Distortion type. Changes the nonlinear function used to distort the waveform. See [enum Mode].
+			Distortion type. Changes the nonlinear function used to distort the waveform.
 		</member>
 		<member name="post_gain" type="float" setter="set_post_gain" getter="get_post_gain" default="0.0">
 			Gain after the effect, in dB. Value can range from -80 to 24.

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2606,7 +2606,7 @@
 			<param index="0" name="state" type="int" enum="DisplayServer.ProgressState" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the type and state of the progress bar on the taskbar/dock icon of the window specified by [param window_id]. See [enum ProgressState] for possible values and how each mode behaves.
+				Sets the type and state of the progress bar on the taskbar/dock icon of the window specified by [param window_id].
 				[b]Note:[/b] This method is implemented only on Windows and macOS.
 				[b]Note:[/b] On macOS, the progress bar is displayed only for the main window.
 			</description>
@@ -2797,7 +2797,7 @@
 			Display server supports native color picker. [b]Linux (X11/Wayland)[/b]
 		</constant>
 		<constant name="FEATURE_SELF_FITTING_WINDOWS" value="33" enum="Feature">
-			Display server automatically fits popups according to the screen boundaries. Window nodes should not attempt to do that themselves.
+			Display server automatically fits popups according to the screen boundaries. [Window] nodes should not attempt to do that themselves.
 		</constant>
 		<constant name="FEATURE_ACCESSIBILITY_SCREEN_READER" value="34" enum="Feature">
 			Display server supports interaction with screen reader or Braille display. [b]Linux (X11/Wayland), macOS, Windows[/b]
@@ -2950,8 +2950,8 @@
 			Region/landmark element. Screen readers can navigate between regions using landmark navigation.
 		</constant>
 		<constant name="ROLE_TEXT_RUN" value="47" enum="AccessibilityRole" deprecated="Use [AccessibilityServer] instead.">
-			Unifor text run.
-			Note: This role is used for internal text elements, and should not be assigned to nodes.
+			Uniform text run.
+			[b]Note:[/b] This role is used for internal text elements, and should not be assigned to nodes.
 		</constant>
 		<constant name="POPUP_MENU" value="0" enum="AccessibilityPopupType" deprecated="Use [AccessibilityServer] instead.">
 			Popup menu.

--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="menu_node" type="Object" />
 			<description>
-				This virtual method is called when updating the context menu of an [member editable] [EditorResourcePicker]. Implement this method to override the "New" items section with your own options. [param menu_node] is a reference to the [PopupMenu] node.
+				This virtual method is called if [member editable] is [code]true[/code] and the context menu needs to be updated. Implement this method to override the "New" items section with your own options. [param menu_node] is a reference to the [PopupMenu] node.
 				[b]Note:[/b] Implement [method _handle_menu_selected] to handle these custom items.
 				[b]Note:[/b] Relevant built-in options ("Load", "Copy", "Paste", etc.) are automatically added to the [param menu_node] afterwards, using their hard-coded IDs starting from [code]0[/code]. Custom options need to use non-colliding IDs to be handled properly. Using [code]id = 100 + custom_option_index[/code] is safe (this is what the default items in the "New" section use).
 			</description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1025,7 +1025,7 @@
 			If [code]true[/code], scenes and scripts are saved when the editor loses focus. Depending on the work flow, this behavior can be less intrusive than [member text_editor/behavior/files/autosave_interval_secs] or remembering to save manually.
 		</member>
 		<member name="interface/editor/behavior/separate_distraction_mode" type="bool" setter="" getter="">
-			If [code]true[/code], the editor's Script tab will have a separate distraction mode setting from the 2D/3D/Game/AssetLib tabs. If [code]false[/code], the distraction-free mode toggle is shared between all tabs.
+			If [code]true[/code], the Script editor's distraction-free mode will be separate from the 2D/3D/Game/Asset Store main screens. If [code]false[/code], the distraction-free mode toggle is shared between all main screens.
 		</member>
 		<member name="interface/editor/behavior/show_internal_errors_in_toast_notifications" type="int" setter="" getter="">
 			If enabled, displays internal engine errors in toast notifications (toggleable by clicking the "bell" icon at the bottom of the editor). No matter the value of this setting, non-internal engine errors will always be visible in toast notifications.

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -36,20 +36,20 @@
 	</methods>
 	<members>
 		<member name="adjustment_brightness" type="float" setter="set_adjustment_brightness" getter="get_adjustment_brightness" default="1.0">
-			Applies a simple brightness adjustment to the rendered image after tonemaping. To adjust scene brightness use [member tonemap_exposure] instead, which is applied before tonemapping and thus less prone to issues with bright colors. Effective only if [member adjustment_enabled] is [code]true[/code].
+			Applies a simple brightness adjustment to the rendered image after tonemapping. To adjust scene brightness use [member tonemap_exposure] instead, which is applied before tonemapping and thus less prone to issues with bright colors. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="adjustment_color_correction" type="Texture" setter="set_adjustment_color_correction" getter="get_adjustment_color_correction">
 			The [Texture2D] or [Texture3D] lookup table (LUT) to use for the built-in post-process color grading. Can use a [GradientTexture1D] for a 1-dimensional LUT, or a [Texture3D] for a more complex LUT. Effective only if [member adjustment_enabled] is [code]true[/code].
 			[b]Note:[/b] Color correction does not currently support HDR output due to only supporting values in the SDR (0.0 to 1.0) range.
 		</member>
 		<member name="adjustment_contrast" type="float" setter="set_adjustment_contrast" getter="get_adjustment_contrast" default="1.0">
-			Increasing [member adjustment_contrast] will make dark values darker and bright values brighter. This simple adjustment is applied to the rendered image after tonemaping. When set to a value greater than [code]1.0[/code], [member adjustment_contrast] is prone to clipping colors that become too bright or too dark. Effective only if [member adjustment_enabled] is [code]true[/code].
+			Increasing [member adjustment_contrast] will make dark values darker and bright values brighter. This simple adjustment is applied to the rendered image after tonemapping. When set to a value greater than [code]1.0[/code], [member adjustment_contrast] is prone to clipping colors that become too bright or too dark. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enabled" getter="is_adjustment_enabled" default="false">
 			If [code]true[/code], enables the [code]adjustment_*[/code] properties provided by this resource. If [code]false[/code], modifications to the [code]adjustment_*[/code] properties will have no effect on the rendered scene.
 		</member>
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation" default="1.0">
-			Applies a simple saturation adjustment to the rendered image after tonemaping. When [member adjustment_saturation] is set to [code]0.0[/code], the rendered image will be fully converted to a grayscale image. Effective only if [member adjustment_enabled] is [code]true[/code].
+			Applies a simple saturation adjustment to the rendered image after tonemapping. When [member adjustment_saturation] is set to [code]0.0[/code], the rendered image will be fully converted to a grayscale image. Effective only if [member adjustment_enabled] is [code]true[/code].
 		</member>
 		<member name="ambient_light_color" type="Color" setter="set_ambient_light_color" getter="get_ambient_light_color" default="Color(0, 0, 0, 1)">
 			The ambient light's [Color]. Only effective if [member ambient_light_sky_contribution] is lower than [code]1.0[/code] (exclusive).

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -196,7 +196,7 @@
 			<return type="void" />
 			<param index="0" name="recents" type="PackedStringArray" />
 			<description>
-				Sets the list of recent directories, which is shared by all [FileDialog] nodes. Useful to restore the list of recents saved with [method set_recent_list]. This method can be called only from the main thread.
+				Sets the list of recent directories, which is shared by all [FileDialog] nodes. Useful to restore the list of recents saved via [method get_recent_list]. This method can be called only from the main thread.
 				[b]Note:[/b] [FileDialog] will update its internal [ItemList] of recent directories when its visibility changes. Be sure to call this method earlier if you want your changes to have effect.
 			</description>
 		</method>

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -445,7 +445,7 @@
 			<param index="1" name="height" type="int" />
 			<param index="2" name="interpolation" type="int" enum="Image.Interpolation" default="1" />
 			<description>
-				Resizes the image to the given [param width] and [param height]. New pixels are calculated using the [param interpolation] mode defined via [enum Interpolation] constants.
+				Resizes the image to the given [param width] and [param height]. New pixels are calculated using the [param interpolation] mode.
 				[b]Note:[/b] If the image's format is [constant FORMAT_RGBA4444], [constant FORMAT_RGB565], or [constant FORMAT_RGBE9995], it will be temporarily converted to either [constant FORMAT_RGBA8] or [constant FORMAT_RGBAH]. This can affect the quality of the resized image.
 			</description>
 		</method>
@@ -454,7 +454,7 @@
 			<param index="0" name="square" type="bool" default="false" />
 			<param index="1" name="interpolation" type="int" enum="Image.Interpolation" default="1" />
 			<description>
-				Resizes the image to the nearest power of 2 for the width and height. If [param square] is [code]true[/code], sets width and height to be the same. New pixels are calculated using the [param interpolation] mode defined via [enum Interpolation] constants.
+				Resizes the image to the nearest power of 2 for the width and height. If [param square] is [code]true[/code], sets width and height to be the same. New pixels are calculated using the [param interpolation] mode.
 			</description>
 		</method>
 		<method name="rgbe_to_srgb">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -532,7 +532,7 @@
 			<return type="bool" />
 			<param index="0" name="button" type="int" enum="MouseButton" />
 			<description>
-				Returns [code]true[/code] if you are pressing the mouse button specified with [enum MouseButton].
+				Returns [code]true[/code] if you are pressing the given mouse button.
 				[b]Note:[/b] If you want to check if a mouse button was just pressed, use Godot's input action system with [method is_action_just_pressed] or use the [method Node._input] method like this instead:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -450,7 +450,7 @@
 			The way which scroll hints (indicators that show that the content can still be scrolled in a certain direction) will be shown.
 		</member>
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="ItemList.SelectMode" default="0">
-			Allows single or multiple item selection. See the [enum SelectMode] constants.
+			Allows single or multiple item selection.
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="3">
 			The clipping behavior when the text exceeds an item's bounding rectangle.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1238,9 +1238,9 @@
 		</member>
 		<member name="gui/common/show_focus_state_on_pointer_event" type="int" setter="" getter="" default="1">
 			Determines whether a [Control] should visually indicate focus when that focus is gained using a mouse or touch input.
-			- [b]Never[/b] ([code]0[/code]) show the focused state for mouse/touch input.
-			- [b]Text Input Controls[/b] ([code]1[/code]) show the focused state even if that focus was gained via mouse/touch input (similar to browser behavior).
-			- [b]Always[/b] ([code]2[/code]) show the focused state, even if that focus was gained via mouse/touch input.
+			- [b]Never[/b] ([code]0[/code]): Do not show the focused state for mouse/touch input.
+			- [b]Text Input Controls[/b] ([code]1[/code]): Show the focused state even if that focus was gained via mouse/touch input (similar to browser behavior).
+			- [b]Always[/b] ([code]2[/code]): Show the focused state, even if that focus was gained via mouse/touch input.
 		</member>
 		<member name="gui/common/snap_controls_to_pixels" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], snaps [Control] node vertices to the nearest pixel to ensure they remain crisp even when the camera moves or zooms.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -2439,14 +2439,12 @@
 			Input attachment uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_UNIFORM_BUFFER_DYNAMIC" value="10" enum="UniformType">
-			Same as UNIFORM_TYPE_UNIFORM_BUFFER but for buffers created with BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT.
-			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e. wrong usage can result in visual glitches).
-			It's exposed in case GD users receive a buffer created with such flag from Godot.
+			Same as [constant UNIFORM_TYPE_UNIFORM_BUFFER] but for buffers created with [code]BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT[/code].
+			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e., wrong usage can result in visual glitches). It's exposed in case GD users receive a buffer created with this flag from Godot.
 		</constant>
 		<constant name="UNIFORM_TYPE_STORAGE_BUFFER_DYNAMIC" value="11" enum="UniformType">
-			Same as UNIFORM_TYPE_STORAGE_BUFFER but for buffers created with BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT.
-			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e. wrong usage can result in visual glitches).
-			It's exposed in case GD users receive a buffer created with such flag from Godot.
+			Same as [constant UNIFORM_TYPE_STORAGE_BUFFER] but for buffers created with [code]BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT[/code].
+			[b]Note:[/b] This flag is not available to GD users due to being too dangerous (i.e., wrong usage can result in visual glitches). It's exposed in case GD users receive a buffer created with this flag from Godot.
 		</constant>
 		<constant name="UNIFORM_TYPE_ACCELERATION_STRUCTURE" value="12" enum="UniformType">
 			Acceleration structure uniform.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3542,7 +3542,7 @@
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="resolution" type="int" />
 			<description>
-				Deprecated. This method does nothing.
+				This method does nothing.
 			</description>
 		</method>
 		<method name="reflection_probe_set_size">
@@ -3634,7 +3634,7 @@
 			<param index="2" name="stretch_mode" type="int" enum="RenderingServer.SplashStretchMode" />
 			<param index="3" name="use_filter" type="bool" default="true" />
 			<description>
-				Sets a boot image. The [param color] defines the background color. The value of [param stretch_mode] indicates how the image will be stretched (see [enum SplashStretchMode] for possible values). If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
+				Sets a boot image. [param color] defines the background color. [param stretch_mode] indicates how the image will be stretched. If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
 			</description>
 		</method>
 		<method name="set_debug_generate_wireframes">

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -69,8 +69,7 @@
 			The number of columns in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
-			[b]Note:[/b] When you increase [member offset].y in Sprite2D, the sprite moves downward on screen (i.e., +Y is down).
+			The texture's drawing offset, relative to this node (+Y is down).
 		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], texture is cut from a larger atlas texture. See [member region_rect].

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -84,8 +84,7 @@
 			If [code]true[/code], depth testing is disabled and the object will be drawn in render order.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The texture's drawing offset.
-			[b]Note:[/b] When you increase [member offset].y in Sprite3D, the sprite moves upward in world space (i.e., +Y is up).
+			The texture's drawing offset, relative to this node (+Y is up).
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the sprite to scale it in 3D.

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -92,7 +92,7 @@
 		<method name="capitalize" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns a copy of the string with changed appearance. Replaces underscores ([code]_[/code]) and hyphens ([code]-[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
+				Returns a copy of the string with the following changes: replaces underscores ([code]_[/code]) and hyphens ([code]-[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
 				[codeblocks]
 				[gdscript]
 				"move_local_x".capitalize()   # Returns "Move Local X"
@@ -345,11 +345,11 @@
 			<param index="0" name="delimiter" type="String" />
 			<description>
 				Returns the total number of slices when the string is split with the given [param delimiter] (see [method split]).
-				Use [method get_slice] to extract a specific slice.
 				[codeblock]
-				print("i/am/example/string".get_slice_count("/")) # Prints '4'.
-				print("i am example string".get_slice_count("/")) # Prints '1'.
+				print("i/am/example/hi".get_slice_count("/")) # Prints 4
+				print("i am example hi".get_slice_count("/")) # Prints 1
 				[/codeblock]
+				Use [method get_slice] to extract a specific slice.
 			</description>
 		</method>
 		<method name="get_slicec" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -86,17 +86,19 @@
 		<method name="capitalize" qualifiers="const">
 			<return type="String" />
 			<description>
-				Changes the appearance of the string: replaces underscores ([code]_[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
+				Returns a copy of the string with the following changes: replaces underscores ([code]_[/code]) and hyphens ([code]-[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
 				[codeblocks]
 				[gdscript]
 				"move_local_x".capitalize()   # Returns "Move Local X"
 				"sceneFile_path".capitalize() # Returns "Scene File Path"
 				"2D, FPS, PNG".capitalize()   # Returns "2d, Fps, Png"
+				"example-name".capitalize()   # Returns "Example Name"
 				[/gdscript]
 				[csharp]
 				"move_local_x".Capitalize();   // Returns "Move Local X"
 				"sceneFile_path".Capitalize(); // Returns "Scene File Path"
 				"2D, FPS, PNG".Capitalize();   // Returns "2d, Fps, Png"
+				"example-name".Capitalize();   // Returns "Example Name"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -314,7 +316,7 @@
 			<param index="1" name="slice" type="int" />
 			<description>
 				Splits the string using a [param delimiter] and returns the substring at index [param slice]. Returns the original string if [param delimiter] does not occur in the string. Returns an empty string if the [param slice] does not exist.
-				This is faster than [method split], if you only need one substring.
+				This is faster than [method split], if you only need one or two substrings.
 				[codeblock]
 				print("i/am/example/hi".get_slice("/", 2)) # Prints "example"
 				[/codeblock]
@@ -325,6 +327,11 @@
 			<param index="0" name="delimiter" type="String" />
 			<description>
 				Returns the total number of slices when the string is split with the given [param delimiter] (see [method split]).
+				[codeblock]
+				print("i/am/example/hi".get_slice_count("/")) # Prints 4
+				print("i am example hi".get_slice_count("/")) # Prints 1
+				[/codeblock]
+				Use [method get_slice] to extract a specific slice.
 			</description>
 		</method>
 		<method name="get_slicec" qualifiers="const">
@@ -333,7 +340,8 @@
 			<param index="1" name="slice" type="int" />
 			<description>
 				Splits the string using a Unicode character with code [param delimiter] and returns the substring at index [param slice]. Returns an empty string if the [param slice] does not exist.
-				This is faster than [method split], if you only need one substring.
+				This is faster than [method split], if you only need one or two substrings.
+				This is a Unicode version of [method get_slice].
 			</description>
 		</method>
 		<method name="hash" qualifiers="const">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -407,7 +407,7 @@
 			If [code]true[/code], enables vertical scrolling.
 		</member>
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="Tree.SelectMode" default="0">
-			Allows single or multiple selection. See the [enum SelectMode] constants.
+			Allows single or multiple selection.
 		</member>
 		<member name="tile_scroll_hint" type="bool" setter="set_tile_scroll_hint" getter="is_scroll_hint_tiled" default="false">
 			If [code]true[/code], the scroll hint texture will be tiled instead of stretched. See [member scroll_hint_mode].

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -383,10 +383,13 @@
 			See also [member ProjectSettings.rendering/anti_aliasing/quality/msaa_3d] and [method RenderingServer.viewport_set_msaa_3d].
 		</member>
 		<member name="oversampling" type="bool" setter="set_use_oversampling" getter="is_using_oversampling" default="true">
-			If [code]true[/code] and one of the following conditions are true: [member SubViewport.size_2d_override_stretch] and [member SubViewport.size_2d_override] are set, [member Window.content_scale_factor] is set and scaling is enabled, [member oversampling_override] is set, font and [DPITexture] oversampling are enabled.
+			If [code]true[/code], tries to enable font and [DPITexture] oversampling. This is only effective when any of the following is true:
+			- [member oversampling_override] is greater than [code]0.0[/code];
+			- For [SubViewport], [member SubViewport.size_2d_override_stretch] and [member SubViewport.size_2d_override] are set;
+			- For [Window], [member Window.content_scale_factor] is set and [member Window.content_scale_mode] is set to either [constant Window.CONTENT_SCALE_MODE_CANVAS_ITEMS] or [constant Window.CONTENT_SCALE_MODE_VIEWPORT].
 		</member>
 		<member name="oversampling_override" type="float" setter="set_oversampling_override" getter="get_oversampling_override" default="0.0">
-			If greater than zero, this value is used as the font oversampling factor, otherwise oversampling is equal to viewport scale.
+			If greater than [code]0.0[/code], this value is used as the font oversampling factor, otherwise the factor is based on the viewport's scale (see also [method get_stretch_transform]).
 		</member>
 		<member name="own_world_3d" type="bool" setter="set_use_own_world_3d" getter="is_using_own_world_3d" default="false">
 			If [code]true[/code], the viewport will use a unique copy of the [World3D] defined in [member world_3d].

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -96,8 +96,8 @@
 			The operation that is performed on this shape. This is ignored for the first CSG child node as the operation is between this node and the previous child of this nodes parent.
 		</member>
 		<member name="smoothing_angle" type="float" setter="set_smoothing_angle" getter="get_smoothing_angle" default="50.0">
-			When autosmooth is enabled, faces with an angle between them greater than this will be smoothed, while faces with a smaller angle will remain sharp.
-			Note: An angle lower than 0.1 will cause all smoothing to be disabled, this can be used to increase performance.
+			When autosmooth is enabled, faces with an angle between them greater than this value will be smoothed, while faces with a smaller angle will remain sharp.
+			[b]Note:[/b] An angle smaller than [code]0.1[/code] will cause all smoothing to be disabled, which can increase performance.
 		</member>
 		<member name="snap" type="float" setter="set_snap" getter="get_snap" deprecated="The CSG library no longer uses snapping.">
 			This property does nothing.

--- a/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
+++ b/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_text_document" deprecated="[GDScriptTextDocument] is deprecated.">
+		<method name="get_text_document" deprecated="">
 			<return type="GDScriptTextDocument" />
 			<description>
 				Returns the language server's [GDScriptTextDocument] instance.

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -53,7 +53,7 @@
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)" keywords="colour">
-			The [Color] of the light in linear space. Defaults to white. A black color causes the light to have no effect.
+			The color of the light, in linear space. Defaults to white. A black color causes the light to have no effect.
 			This value is linear to match glTF, but will be converted to nonlinear sRGB when creating a Godot [Light3D] node upon import, or converted to linear when exporting a Godot [Light3D] to glTF.
 		</member>
 		<member name="inner_cone_angle" type="float" setter="set_inner_cone_angle" getter="get_inner_cone_angle" default="0.0">

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -308,7 +308,7 @@
 			The binary buffer attached to a .glb file.
 		</member>
 		<member name="handle_binary_image_mode" type="int" setter="set_handle_binary_image_mode" getter="get_handle_binary_image_mode" enum="GLTFState.HandleBinaryImageMode" default="1">
-			When importing a glTF file with unimported raw binary images embedded inside of binary blob buffers, in data URIs, or separate files not imported by Godot, this controls how the images are handled. Images can be discarded, saved as separate files, or embedded in the scene lossily or losslessly. See [enum HandleBinaryImageMode] for options.
+			When importing a glTF file with unimported raw binary images embedded inside of binary blob buffers, in data URIs, or separate files not imported by Godot, this controls how the images are handled. Images can be discarded, saved as separate files, or embedded in the scene lossily or losslessly.
 			This property does nothing for image files in the [code]res://[/code] folder imported by Godot, as those are handled by Godot's image importer directly, and then the Godot scene generated from the glTF file will use the images as Godot imported them.
 		</member>
 		<member name="import_as_skeleton_bones" type="bool" setter="set_import_as_skeleton_bones" getter="get_import_as_skeleton_bones" default="false">

--- a/modules/openxr/doc_classes/OpenXRAndroidThreadSettingsExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRAndroidThreadSettingsExtension.xml
@@ -15,8 +15,8 @@
 			<param index="1" name="thread_id" type="int" default="0" />
 			<description>
 				Sets the thread type of the given thread, so that the XR runtime can adjust its scheduling priority accordingly.
-				[param thread_id] refers to the OS thread id (ie from [code]gettid()[/code]). When [param thread_id] is [code]0[/code], it will set the thread type of the current thread.
-				[b]NOTE:[/b] The id returned by [method Thread.get_id] is incompatible with [param thread_id].
+				[param thread_id] refers to the OS thread ID (i.e., from [code]gettid()[/code]). If [param thread_id] is [code]0[/code], it will set the thread type of the current thread.
+				[b]Note:[/b] The ID returned by [method Thread.get_id] is incompatible with [param thread_id].
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/doc_classes/OpenXRSpatialAnchorCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialAnchorCapability.xml
@@ -133,7 +133,7 @@
 			Provides the application with read-only access (i.e. application cannot modify this scope) to spatial entities persisted and managed by the system. The application can use the UUID in the persistence component for this scope to correlate entities across spatial contexts and device reboots.
 		</constant>
 		<constant name="PERSISTENCE_SCOPE_LOCAL_ANCHORS" value="1000781000" enum="PersistenceScope">
-			Persistence operations and data access is limited to spatial anchors, on the same device, for the same user and same app (using [method persist_anchor] and [method unpersist_anchor] functions)
+			Persistence operations and data access is limited to spatial anchors, on the same device, for the same user and same app (using [method persist_anchor] and [method unpersist_anchor] functions).
 		</constant>
 	</constants>
 </class>

--- a/modules/visual_shader/doc_classes/VisualShaderNodeCustom.xml
+++ b/modules/visual_shader/doc_classes/VisualShaderNodeCustom.xml
@@ -177,7 +177,7 @@
 			<param index="0" name="mode" type="int" enum="Shader.Mode" />
 			<param index="1" name="type" type="int" enum="VisualShader.Type" />
 			<description>
-				Override this method to prevent the node to be visible in the member dialog for the certain [param mode] and/or [param type].
+				Override this method to return [code]true[/code] if the node should be visible in the member dialog for the given [param mode] and/or [param type].
 				Defining this method is [b]optional[/b]. If not overridden, it's [code]true[/code].
 			</description>
 		</method>

--- a/modules/visual_shader/doc_classes/VisualShaderNodeParameter.xml
+++ b/modules/visual_shader/doc_classes/VisualShaderNodeParameter.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="instance_index" type="int" setter="set_instance_index" getter="get_instance_index" default="0">
-			The index within 0-15 range, which is used to avoid clashes when shader used on multiple materials.
+			The index used to avoid clashes when the shader is used on multiple materials, ranging from [code]0[/code] to [code]15[/code].
 		</member>
 		<member name="parameter_name" type="String" setter="set_parameter_name" getter="get_parameter_name" default="&quot;&quot;">
 			Name of the parameter, by which it can be accessed through the [ShaderMaterial] properties.

--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -76,7 +76,7 @@
 	</methods>
 	<members>
 		<member name="compression_level" type="int" setter="set_compression_level" getter="get_compression_level" default="-1">
-			The compression level used when [method start_file] is called. Use [enum ZIPPacker.CompressionLevel] as a reference.
+			The compression level used when [method start_file] is called. You can use [enum ZIPPacker.CompressionLevel] as a point of reference.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/113261

The sequel no one wanted.
This PR addressed yet yet another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

Of particular note:
- Remove more redundant references to enums where the type is known
	- Guys, please! https://github.com/godotengine/godot/pull/106159 
- Make more String and StringName's descriptions match exactly
	- This has to be done _manually_ every time you forget https://github.com/godotengine/godot/pull/95758
- Remove more redundant mentions of "Deprecated"
	- The "deprecated" tag is self-explanatory, you don't need to say it again!
- Fix improperly-formatted admonitions
- Fix missed mention of the old "AssetLib"
- Remove very nasty usage of a property name as part of a sentence:
	- "updating the context menu of an [member editable] [EditorResourcePicker]" 


For some of the descriptions affected, additional tweaks have been made, as well.