### PR TITLE
Rewrite the descriptions for AimModifier3D

### DIFF
--- a/doc/classes/AimModifier3D.xml
+++ b/doc/classes/AimModifier3D.xml
@@ -4,8 +4,8 @@
 		The [AimModifier3D] rotates a bone to look at a reference bone.
 	</brief_description>
 	<description>
-		This is a simple version of [LookAtModifier3D] that only allows bone to the reference without advanced options such as angle limitation or time-based interpolation.
-		The feature is simplified, but instead it is implemented with smooth tracking without euler, see [method set_use_euler].
+		This is a simple version of [LookAtModifier3D] that only allows a bone to rotate towards the reference bone, without advanced options such as angle limitation or time-based interpolation.
+		The feature is simplified, but instead it is implemented with smooth tracking without Euler angles (see [method set_use_euler]).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -14,14 +14,14 @@
 			<return type="int" enum="SkeletonModifier3D.BoneAxis" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the forward axis of the bone.
+				Returns the forward axis of the bone at [param index].
 			</description>
 		</method>
 		<method name="get_primary_rotation_axis" qualifiers="const">
 			<return type="int" enum="Vector3.Axis" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the axis of the first rotation. It is enabled only if [method is_using_euler] is [code]true[/code].
+				Returns the axis of the first rotation of the bone at [param index]. It is enabled only when [method is_using_euler] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="is_relative" qualifiers="const">
@@ -35,14 +35,14 @@
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if it provides rotation with using euler.
+				Returns [code]true[/code] if the rotation of the bone at [param index] is provided using Euler angles.
 			</description>
 		</method>
 		<method name="is_using_secondary_rotation" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if it provides rotation by two axes. It is enabled only if [method is_using_euler] is [code]true[/code].
+				Returns [code]true[/code] if the rotation of the bone at [param index] is provided using two axes. It is enabled only when [method is_using_euler] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="set_forward_axis">
@@ -50,7 +50,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="axis" type="int" enum="SkeletonModifier3D.BoneAxis" />
 			<description>
-				Sets the forward axis of the bone.
+				Sets the forward axis of the bone at [param index] to [param axis].
 			</description>
 		</method>
 		<method name="set_primary_rotation_axis">
@@ -58,7 +58,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<description>
-				Sets the axis of the first rotation. It is enabled only if [method is_using_euler] is [code]true[/code].
+				Sets the axis of the first rotation. It is enabled only if [method is_using_euler] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="set_relative">
@@ -67,8 +67,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets relative option in the setting at [param index] to [param enabled].
-				If sets [param enabled] to [code]true[/code], the rotation is applied relative to the pose.
-				If sets [param enabled] to [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [AimModifier3D]'s result.
+				If [param enabled] is [code]true[/code], the rotation is applied relative to the pose.
+				If [param enabled] is [code]false[/code], the rotation is applied relative to the rest. It means to replace the current pose with the [AimModifier3D]'s result.
 			</description>
 		</method>
 		<method name="set_use_euler">
@@ -76,8 +76,8 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], it provides rotation with using euler.
-				If sets [param enabled] to [code]false[/code], it provides rotation with using rotation by arc generated from the forward axis vector and the vector toward the reference.
+				If [param enabled] is [code]true[/code], the rotation of the bone at [param index] is provided using Euler angles.
+				If [param enabled] is [code]false[/code], the rotation is provided using an arc generated from the forward axis vector and the vector toward the reference bone.
 			</description>
 		</method>
 		<method name="set_use_secondary_rotation">
@@ -85,7 +85,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If sets [param enabled] to [code]true[/code], it provides rotation by two axes. It is enabled only if [method is_using_euler] is [code]true[/code].
+				If [param enabled] is [code]true[/code], the rotation of the bone at [param index] is provided using two axes. It is enabled only if [method is_using_euler] returns [code]true[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The class reference documentation of **AimModifier3D** features some rather crude usage of the English language. This PR attempts to mitigate it, to my uttermost confusion.

This has been separated https://github.com/godotengine/godot/pull/121791 because it requires a specific look from the animation team, for accuracy and further details.