### PR TITLE
Fix moving/duplicating file stored in the root `res://` folder

### DIFF
--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -135,13 +135,16 @@ void EditorDirDialog::_notification(int p_what) {
 				}
 
 				tree->deselect_all();
+
+				TreeItem *item = tree->get_root();
 				const PackedStringArray parts = base_directory_path.trim_prefix("res://").split("/", false);
 				if (parts.is_empty()) {
+					item->select(0);
+					tree->ensure_cursor_is_visible();
 					break;
 				}
 
 				int i = 0;
-				TreeItem *item = tree->get_root();
 				while (i < parts.size()) {
 					const String &folder = parts[i];
 					for (TreeItem *child = item->get_first_child(); child; child = child->get_next()) {


### PR DESCRIPTION
Improved changes from 08e3358 by processing separately the case when moved/duplicated item is being stored in the root folder (res://), which was completely ignored previosly.

## What problem(s) does this PR solve?

- Closes #121755 
- Select res:// as target folder to move/duplicate file, stored in it. Equally to behavior with items, stored in nested folders, when their parent folders are being selected.

## Additional information

Previosly, the case where file's base directory contains only res:// folder is skipped. The res:// is being trimmed and the root item is never being selected back. That's why the assert is raised later.
I propose to process this case separately and explicitly. It is also may be usefull to add an assert for `parts.is_empty()` case on next lines, instead of just break , since the situation may never arise.

@KoBeWi , could you please take a look? Am I not missing anything with this dialog processing?