### PR TITLE
Improve error message for wrongly indented `_:` on match statements

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2169,6 +2169,15 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 			}
 			break;
 		}
+		case GDScriptTokenizer::Token::UNDERSCORE: {
+			advance();
+			if (check(GDScriptTokenizer::Token::COLON)) {
+				push_error(R"(Incorrect indentation for "_:")");
+			} else {
+				push_error(vformat(R"(Expected statement, found "%s" instead.)", previous.get_name()));
+			}
+			break;
+		}
 		default: {
 			// Expression statement.
 			ExpressionNode *expression = parse_expression(true); // Allow assignment here.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #98384

## Additional information
old:
<img width="481" height="340" alt="Screenshot 2026-07-26 085728" src="https://github.com/user-attachments/assets/fcb71faf-5ed9-4cb8-9628-884bfe4e1c15" />
 
new:

<img width="404" height="340" alt="image" src="https://github.com/user-attachments/assets/5e7113d7-f696-4644-b556-0727e5fee6db" />

