### PR TITLE
🤖 GDScript: Don't suggest completion options for Lua-style dictionary keys

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -378,7 +378,7 @@ void GDScriptParser::override_completion_context(const Node *p_for_node, Complet
 }
 
 void GDScriptParser::make_completion_context(CompletionType p_type, Node *p_node, int p_argument, bool p_force) {
-	if (!for_completion || (!p_force && completion_context.type != COMPLETION_NONE)) {
+	if (!for_completion || suppress_completion || (!p_force && completion_context.type != COMPLETION_NONE)) {
 		return;
 	}
 	if (previous.cursor_place != GDScriptTokenizerText::CURSOR_MIDDLE && previous.cursor_place != GDScriptTokenizerText::CURSOR_END && current.cursor_place == GDScriptTokenizerText::CURSOR_NONE) {
@@ -400,7 +400,7 @@ void GDScriptParser::make_completion_context(CompletionType p_type, Node *p_node
 }
 
 void GDScriptParser::make_completion_context(CompletionType p_type, Variant::Type p_builtin_type, bool p_force) {
-	if (!for_completion || (!p_force && completion_context.type != COMPLETION_NONE)) {
+	if (!for_completion || suppress_completion || (!p_force && completion_context.type != COMPLETION_NONE)) {
 		return;
 	}
 	if (previous.cursor_place != GDScriptTokenizerText::CURSOR_MIDDLE && previous.cursor_place != GDScriptTokenizerText::CURSOR_END && current.cursor_place == GDScriptTokenizerText::CURSOR_NONE) {
@@ -3285,12 +3285,15 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 	DictionaryNode *dictionary = alloc_node<DictionaryNode>();
 
 	bool decided_style = false;
+	const bool was_suppressing_completion = suppress_completion;
 	if (!check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 		do {
 			if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 				// Allow for trailing comma.
 				break;
 			}
+
+			suppress_completion = was_suppressing_completion;
 
 			// Key.
 			ExpressionNode *key = parse_expression(false, true); // Stop on "=" so we can check for Lua table style.
@@ -3312,6 +3315,16 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 						break;
 				}
 				decided_style = true;
+			}
+
+			if (key != nullptr && dictionary->style == DictionaryNode::LUA_TABLE && completion_context.node == key) {
+				// A Lua-style key is a plain identifier and not an expression, so it must not
+				// produce completion options. The style is only known once the key has been
+				// parsed, so the context the key created is discarded here. Completion stays
+				// suppressed for the rest of the entry because, when the "=" is missing, the
+				// error recovery below re-parses from the cursor and would recreate it.
+				override_completion_context(key, COMPLETION_NONE, nullptr);
+				suppress_completion = true;
 			}
 
 			switch (dictionary->style) {
@@ -3377,6 +3390,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 
 		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
 	}
+	suppress_completion = was_suppressing_completion;
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACE_CLOSE, R"(Expected closing "}" after dictionary elements.)");
 	complete_extents(dictionary);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1374,6 +1374,9 @@ private:
 	bool _is_tool = false;
 	String script_path;
 	bool for_completion = false;
+	// Set while parsing a region that can never produce completion options,
+	// e.g. a Lua-style dictionary key, which is a plain identifier and not an expression.
+	bool suppress_completion = false;
 	bool parse_body = true;
 	bool panic_mode = false;
 	bool can_break = false;

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_1.gd
@@ -1,4 +1,3 @@
-# Disabled due to GH-105421
 extends Node
 
 var test = {

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_3.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_3.cfg
@@ -1,0 +1,4 @@
+[output]
+exclude=[
+	{"display": "PI"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_3.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_3.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var test = {
+	t = 1,
+	pri➡
+}

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_4.cfg
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_4.cfg
@@ -1,0 +1,4 @@
+[output]
+exclude=[
+	{"display": "PI"},
+]

--- a/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_4.gd
+++ b/modules/gdscript/tests/scripts/completion/enum_values_in_dictionary/lua_key_4.gd
@@ -1,0 +1,5 @@
+extends Node
+
+var test = {
+	pri➡ = 1
+}


### PR DESCRIPTION
> [!INFO] *AI disclosure*: This contribution was authored by an autonomous AI agent, on behalf of a user, to fix the issue linked below.
>
> How AI was used: the agent selected the issue, diagnosed the root cause by reading the parser and the completion front-end, wrote the patch and the regression tests, and ran the repository's static checks locally (`clang-format` 22.1.5, `file_format.py`, `header_guards.py`, `validate_includes.py`, `copyright_headers.py`, `codespell` — all clean). It could **not** compile the engine on the machine it ran on, so the completion test suite has not been executed locally; this PR is opened as a draft so that CI verifies it. The behavioural claims below were derived by reading the code and hand-tracing every existing test in `completion/enum_values_in_dictionary/`, not by running them.

## What problem(s) does this PR solve?

Autocompletion offers options while the cursor sits on a **Lua-style dictionary key**:

```gdscript
var a = {
	pri = "",
	pri  # <-- completion popup appears here
}
```

A Lua-style key is a plain identifier, not an expression, so there is nothing meaningful to complete there.

`parse_dictionary()` reads keys with `parse_expression()`, because the dictionary style is only known once a `:` or `=` has been seen. Every identifier parsed as part of an expression registers a completion context in `parse_precedence()`, so Lua-style keys register one too.

This also unblocks the `enum_values_in_dictionary/lua_key_1` completion test, which was disabled as `lua_key_1.notest.gd` with the comment `# Disabled due to GH-105421` when #94996 was merged. This PR re-enables it.

## Additional information

**The fix.** Once the key has been parsed and the style turns out to be `LUA_TABLE`, the completion context that the key created is discarded via `override_completion_context()`.

That alone is not enough. `COMPLETION_NONE` doubles as the "no context yet" sentinel, so a later non-forced `make_completion_context()` can re-set it — and when the `=` is missing, the parser recovers by parsing a *value* starting from the exact position the cursor is on, which re-registers `COMPLETION_IDENTIFIER` for the key token. So a `suppress_completion` flag keeps completion off for the rest of that entry. It is only ever set when the completion context actually belongs to the key we just parsed, which means:

- it is never set when parsing outside the editor (`for_completion == false`), so non-tools builds are unaffected;
- entries where the cursor is *not* on the key keep completing normally, including the malformed-entry recovery paths covered by `lua_value_3` (`e AutoTranslateMode.|,`) and `lua_value_5` (`1 AutoTranslateMode.|,`).

The flag is saved and restored around the element loop, so a nested dictionary in a value position does not inherit an outer suppression.

**Behavioural change worth a look.** The style of the *first* element is only decided once its `=` is reached, so `{ pri| = 1 }` previously offered completion and now does not. That seemed like the consistent reading of "Lua keys never complete" rather than a separate case, and it is covered by the new `lua_key_4` test — but it is a user-visible change, so please say if you would rather keep the first element as it was.

Python-style dictionaries are untouched: `{ AutoTranslateMode.| }` and `{ AutoTranslateMode.|: 1 }` still offer enum values (`py_key_1`..`py_key_4`), since the style is either `PYTHON_DICT` or not yet decided.

**Tests.**

- `lua_key_1` — re-enabled (attribute key on a later element, the case this issue disabled).
- `lua_key_3` — new; bare identifier key on a later element. This is the exact shape from the issue and it goes through `COMPLETION_IDENTIFIER`, a different path from `lua_key_1`'s `COMPLETION_ATTRIBUTE`.
- `lua_key_4` — new; key of the first element, covering the "style discovered at `=`" path.

`lua_key_3` and `lua_key_4` exclude `PI`, which `_find_identifiers()` always emits, so they fail if *any* identifier completion happens at the key.