### PR TITLE
Account for trailing spaces when converting to tabs

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1304,7 +1304,7 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 			}
 			space_count++;
 
-			if (!indent_using_spaces && space_count != indent_size) {
+			if (!indent_using_spaces && space_count != indent_size && line[j + 1] == ' ') {
 				j++;
 				continue;
 			}
@@ -1316,11 +1316,14 @@ void CodeEdit::convert_indent(int p_from_line, int p_to_line) {
 				changed_indentation = true;
 			}
 
-			// Calculate new line.
-			line = line.left(j + ((size_diff < 0) ? size_diff : 0)) + indent_text + line.substr(j + 1);
+			int replace_count = space_count == indent_size
+					? ((size_diff < 0) ? size_diff : 0)
+					: 1 - space_count;
 
+			line = line.left(j + replace_count) + indent_text + line.substr(j + 1);
+
+			j += space_count == indent_size ? size_diff : space_count;
 			space_count = 0;
-			j += size_diff;
 		}
 
 		if (line_changed) {

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -2813,6 +2813,16 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->get_selection_origin_column() == 2);
 		CHECK(code_edit->get_caret_column() == 3);
 
+		// Converts leftover spaces to tabs
+		code_edit->set_text("line_1\n    line_2\n     line_3\n    line_4\n          line_5");
+		code_edit->convert_indent();
+		CHECK(code_edit->get_text() == "line_1\n\tline_2\n\t\tline_3\n\tline_4\n\t\t\tline_5");
+
+		// Doesn't go out of bounds on whitespace lines
+		code_edit->set_text("  ");
+		code_edit->convert_indent();
+		CHECK(code_edit->get_text() == "\t");
+
 		// Within provided range.
 		code_edit->set_text("    test\n        test\n");
 		code_edit->select(1, 8, 1, 9);


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR aims to close https://github.com/godotengine/godot/issues/35007.

When converting a file with space indentation to tab indentation it would be left in a broken state if not all space indentation was a multiple of `indent_size`.

In order to at least solve this `CodeEdit::convert_indent` now accounts for a possibility that there are 'trailing_spaces' and instead of ignoring them it will now convert those to a single `\t` as well.

```gdscript
# before this PR
func test():
    if true:        # 4 spaces (would convert to '\t')
     print("oops")  # 5 spaces (would convert to '\t ' <- extra space)

# after this PR
func test():
    if true:           # 4 spaces (converts to '\t')
        print("oops")  # 5 spaces (converts to '\t\t')
```

## Additional information

- I've kept the combined logic of tabs and spaces to keep the change minimal. Although I feel it would be best to have a separate function for to_spaces and to_tabs.
- The `String` class already protects against out of bounds reads, but I've kept the unit test to highlight that whitespace only lines are included in this conversion. I think it makes more sense to collapse whitespace only lines to `\n` instead.
- There is no guard blocking this conversion logic on invalid files, if the file isn't valid `CodeEdit::validate_script` suggests that we can check the script before converting, but I don't quite know how to follow the signal path here.

## AI DISCLOSURE

No AI was used.