### PR TITLE
Add a dynamic Minimum Width to Vector3 & Vector4 Variants Extensible to Other Variant Types

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -156,6 +156,25 @@ void EditorPropertyVariant::update_property() {
 		// Doesn't affect foldable property types, since they don't start with a bottom editor.
 		set_bottom_editor(sub_property->get_bottom_editor() ? content : nullptr);
 
+		// Set Minimum width based on Chosen Type
+		uint32_t n_component = 0;
+		switch (current_type) {
+			case Variant::VECTOR4I:
+			case Variant::VECTOR4: {
+				n_component = 4;
+			} break;
+			case Variant::VECTOR3I:
+			case Variant::VECTOR3: {
+				n_component = 3;
+			} break;
+			default:
+				n_component = 0;
+		}
+
+		const real_t edit_size_x = edit_button->get_size().x;
+		const real_t min_width = EDSCALE * (n_component ? n_component + 1 : 0) * 2 * edit_size_x; // + 1 for edit_button
+		content->set_custom_minimum_size(Size2(min_width, 0));
+
 		sub_property->set_object_and_property(get_edited_object(), get_edited_property());
 		sub_property->set_name_split_ratio(0);
 		sub_property->set_selectable(false);


### PR DESCRIPTION
## Commit Description

Allows the changing of Variant Types in the Inspector, through the Edit Button, without the need to manual resize of Inspector Dock.

## What problem(s) does this PR solve?

- Closes (Partially) #120365

## Testing

### Before Changes

https://github.com/user-attachments/assets/4a541b9c-37be-40d3-a377-ea2d2708fbb1

### After Changes

https://github.com/user-attachments/assets/642b4f8a-1d27-4149-9fd7-0c3f4327df77

## Additional information
- This _should_ be flexible enough to add other Types like `Basis`, `Transform2D` & `Transform3D`, as well as `PackedVector3` & `PackedVector4`, The `Packed` types need a bit of work by showing it horizontally (similar to @YeldhamDev 's PR #120590), but other then that, should be as simple as adding how many items horizontally (the `n_component`) inside the switch statement.

- Also right at the end of Before changes video, you'll notice that regular `Vector4I` (even `Vector4`) have similar issue with min width not being set properly, haven't fixed it in this PR as it's out-of-scope, should be addressed in a separate PR.

## Use of AI
No AI was used in the process of making these changes.