### PR TITLE
Fix Follow Selection mode not behaving as expected.

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -6409,6 +6409,9 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 			}
 
 			Vector3 motion = intersection - click;
+			if (focused_node_id.is_valid() && get_selected_count() > 0 && times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0) {
+				motion /= 2;
+			}
 			if (_edit.plane != TRANSFORM_VIEW) {
 				if (!plane_mv) {
 					motion = motion_mask.dot(motion) * motion_mask;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120064 

## Changes

When in Follow Selection mode, divide motion by 2. This eliminates the problem shown in the bug report.
The weird thing for me was that the selection continued moving if you just wiggled your mouse after dragging it a bit in a direction (19s in the first video, 13s in the second one).

Before:

https://github.com/user-attachments/assets/7b8b8457-5063-4e64-b007-c08b9999f975

After:

https://github.com/user-attachments/assets/94e7ccb9-135f-436d-962a-463e27c10f37

I think that Follow Selection should also be added to 2D view for consistency.

Additionally, I think it is a good idea to have camera warping for all 3d (2d) operations (pan, scale, translate, rotate, etc.) like Blender, because, at least, the translating with Follow Selection mode feels limited, when you reach the edge and have to release, move mouse back, and then drag again.

## Something not quite related

This is a bit unrelated to the bug, but in my opinion it feels much nicer to use if the camera wouldn't lerp. With lerping it feels like the camera is lagging behind, while without it the camera feels snappy. Maybe a setting would be a solution if some people like the lag.

Fixed bug + removed camera lerp:

https://github.com/user-attachments/assets/97ab6226-7f21-46a1-aa1e-7ee01850c554

