### PR TITLE
LinuxBSD: Fix missing FontConfig FcConfigSetCurrent call

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1343,9 +1343,12 @@ OS_LinuxBSD::~OS_LinuxBSD() {
 #ifdef FONTCONFIG_ENABLED
 	if (object_set) {
 		FcObjectSetDestroy(object_set);
+		object_set = nullptr;
 	}
 	if (config) {
+		FcConfigSetCurrent(nullptr);
 		FcConfigDestroy(config);
+		config = nullptr;
 	}
 #endif // FONTCONFIG_ENABLED
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR addresses a direct memory leak in the Linux FontConfig code, caught by GCC sanitizers:

```
=================================================================
[1m[31m==398957==ERROR: LeakSanitizer: detected memory leaks
[1m[0m
[1m[34mDirect leak of 256 byte(s) in 1 object(s) allocated from:
[1m[0m    #0 0x7df043efd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7df036d357fc  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x227fc) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #2 0x7df036d39ed8  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x26ed8) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #3 0x7df036d48331  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x35331) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #4 0x7df036c2593f  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa93f) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #5 0x7df036c26772  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb772) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #6 0x7df036c27747  (/lib/x86_64-linux-gnu/libexpat.so.1+0xc747) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #7 0x7df036c29f70  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef70) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #8 0x7df036c1f46e  (/lib/x86_64-linux-gnu/libexpat.so.1+0x446e) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #9 0x7df036c2c43d in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x1143d) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #10 0x7df036d4283d  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x2f83d) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #11 0x7df036d4322c  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x3022c) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #12 0x7df036d43478  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x30478) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #13 0x7df036d46436  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x33436) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #14 0x7df036c2593f  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa93f) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #15 0x7df036c26772  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb772) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #16 0x7df036c27747  (/lib/x86_64-linux-gnu/libexpat.so.1+0xc747) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #17 0x7df036c29f70  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef70) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #18 0x7df036c1f46e  (/lib/x86_64-linux-gnu/libexpat.so.1+0x446e) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #19 0x7df036c2c43d in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x1143d) (BuildId: 6634bb422dbd36f2476c855381ab1020a2455eb4)
    #20 0x7df036d4283d  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x2f83d) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #21 0x7df036d4322c  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x3022c) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #22 0x7df036d2a3b5  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x173b5) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #23 0x7df036d23751  (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x10751) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #24 0x7df036d24f84 in FcConfigSubstituteWithPat (/lib/x86_64-linux-gnu/libfontconfig.so.1+0x11f84) (BuildId: 9ea8985291d6ca9e904a796a5767d191039d813d)
    #25 0x5afd1368a489 in OS_LinuxBSD::get_system_font_path(String const&, int, int, bool) const platform/linuxbsd/os_linuxbsd.cpp:852
    #26 0x5afd2db2aa2f in editor_register_fonts(Ref<Theme> const&) editor/themes/editor_fonts.cpp:191
    #27 0x5afd2db57dfb in EditorThemeManager::_create_base_theme(Ref<EditorTheme> const&) editor/themes/editor_theme_manager.cpp:216
    #28 0x5afd2db82acd in EditorThemeManager::generate_theme(Ref<EditorTheme> const&) editor/themes/editor_theme_manager.cpp:690
    #29 0x5afd2710a20e in EditorNode::EditorNode() editor/editor_node.cpp:8677
```

This PR adds a FontConfig lifecycle function call in an attempt to fix this:

- `FcConfigSetCurrent`: Sets the current FontConfig configuration to null.

Additionally, the PR adds `= nullptr;` lines. These are effectively no-ops, because these variables will be destroyed at the end of this destructor anyway. However, the addition of these lines makes the intent clear, and also makes the correctness more portable, such as if we ever want to move this code into a separate `OS_LinuxBSD::destroy_fontconfig_memory` function or something.

A previous version of this PR had `FcFini` at the end, which is supposed to be a final lifecycle call for FontConfig to destroy its allocated memory. This seems like it would be a more direct fix to the memory leak, and it works locally on my Linux computer, but for some reason it causes CI to crash? So I removed it for now.

## Additional information

AI Disclaimer: I used AI to find and generate this fix. Due to how annoying it is to dissect stack traces, I started with throwing an AI at all of the direct memory leaks that occurred on the Linux CI checks. One of the fixes it came up with is this one. Ultimately, the fix I ended up going with is similar to what it generated. I reviewed it carefully line-by-line, and now that I know this information I would end up writing the same exact code if I had to fix it again.

No AI was used for writing the PR description. Also, my other PRs fixing GCC sanitizer discovered issues did not have AI used in them, as it was easy to look at the code and fix it.

