### PR TITLE
Replace `TextEdit.get_rect_at_column`

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -242,7 +242,8 @@
 			<return type="Vector2" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns the caret pixel draw position.
+				Returns the latest caret draw position in pixels. The position is at the bottom of the caret. If the caret was scrolled out of view, the draw position will not update. See also [method get_column_position].
+				[b]Note:[/b] This method is dependent on draw updates, so changes to the caret, text, or scroll position may not be accounted for immediately.
 			</description>
 		</method>
 		<method name="get_caret_index_edit_order" deprecated="Carets no longer need to be edited in any specific order. If the carets need to be sorted, use [method get_sorted_carets] instead.">
@@ -265,6 +266,16 @@
 				Returns the wrap index the editing caret is on.
 			</description>
 		</method>
+		<method name="get_column_position" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="column" type="int" />
+			<param index="2" name="only_in_bounds" type="bool" default="true" />
+			<description>
+				Returns the local position of the given line and column in pixels, as if a caret was placed there. The line and column parameters will be clamped to the text. The returned [code]y[/code] position is the top of the line.
+				If [param only_in_bounds] is [code]true[/code], positions outside of the viewable text area will return [code]Point2(-1, -1)[/code].
+			</description>
+		</method>
 		<method name="get_first_non_whitespace_column" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="line" type="int" />
@@ -276,6 +287,16 @@
 			<return type="int" />
 			<description>
 				Returns the first visible line.
+			</description>
+		</method>
+		<method name="get_grapheme_rect" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="column" type="int" />
+			<param index="2" name="only_in_bounds" type="bool" default="true" />
+			<description>
+				Returns the local rect of the grapheme on the given line and column in pixels. The line and column parameters will be clamped to the text. The used grapheme will be the one after the column, so column [code]0[/code] is the first grapheme. The returned height is always the line height, and the [code]y[/code] position is the top of the line.
+				If [param only_in_bounds] is [code]true[/code], graphemes outside of the viewable text area will return [code]Rect2(-1, -1, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_gutter_count" qualifiers="const">
@@ -543,13 +564,14 @@
 				Returns the count to the next visible line from [param line] to [code]line + visible_amount[/code]. Can also count backwards. For example if a [TextEdit] has 5 lines with lines 2 and 3 hidden, calling this with [code]line = 1, visible_amount = 1[/code] would return 3.
 			</description>
 		</method>
-		<method name="get_pos_at_line_column" qualifiers="const">
+		<method name="get_pos_at_line_column" qualifiers="const" deprecated="Use [method get_grapheme_rect] or [method get_column_position] instead.">
 			<return type="Vector2i" />
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				Returns the local position for the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] of the returned vector equal [code]-1[/code], the position is outside of the viewable area of the control.
+				Returns the local position for the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] of the returned vector equal [code]-1[/code], the position is outside of the viewable area of the control. The returned position will be the one before the column, so column [code]1[/code] is the start of the line.
 				[b]Note:[/b] The Y position corresponds to the bottom side of the line. Use [method get_rect_at_line_column] to get the top side position.
+				[b]Note:[/b] This method is dependent on draw updates, so changes to the text or scroll position may not be accounted for immediately.
 			</description>
 		</method>
 		<method name="get_previous_composite_character_column" qualifiers="const">
@@ -561,13 +583,14 @@
 				[b]Note:[/b] To check at caret location use [code]get_previous_composite_character_column(get_caret_line(), get_caret_column())[/code]
 			</description>
 		</method>
-		<method name="get_rect_at_line_column" qualifiers="const">
+		<method name="get_rect_at_line_column" qualifiers="const" deprecated="Use [method get_grapheme_rect] instead.">
 			<return type="Rect2i" />
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				Returns the local position and size for the grapheme at the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] position of the returned rect equal [code]-1[/code], the position is outside of the viewable area of the control.
+				Returns the local position and size for the grapheme at the given [param line] and [param column]. If the [code]x[/code] or [code]y[/code] position of the returned rectangle equal [code]-1[/code], the position is outside of the viewable area of the control. The used grapheme will be the one before the column, so column [code]1[/code] is the first grapheme.
 				[b]Note:[/b] The Y position of the returned rect corresponds to the top side of the line, unlike [method get_pos_at_line_column] which returns the bottom side.
+				[b]Note:[/b] This method is dependent on draw updates, so changes to the text or scroll position may not be accounted for immediately.
 			</description>
 		</method>
 		<method name="get_saved_version" qualifiers="const">

--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -89,7 +89,7 @@ void TextShaderPreviewLineLayer::_notification(int p_what) {
 				const Color polygon_color = Color(line_color, alpha);
 				E.value->update_panel_color(polygon_color);
 
-				Point2i end_pos = code_editor->get_pos_at_line_column(E.key, 0);
+				Point2 end_pos = code_editor->get_column_position(E.key, 0);
 				if (end_pos.x == -1) {
 					continue;
 				}
@@ -97,8 +97,8 @@ void TextShaderPreviewLineLayer::_notification(int p_what) {
 				Point2 preview_size = panel_container->get_size();
 				const Point2 preview_bottom = panel_container->get_global_position() + preview_size;
 				const Point2 preview_top = preview_bottom - Point2(0, preview_size.y);
-				const Point2 line_bottom = code_editor->get_global_position() + Point2(0, end_pos.y);
-				const Point2 line_top = line_bottom - Point2(0, code_editor->get_line_height());
+				const Point2 line_top = code_editor->get_global_position() + Point2(0, end_pos.y);
+				const Point2 line_bottom = line_top + Point2(0, code_editor->get_line_height());
 				const Point2 line_bottom_gutter = line_bottom + Point2(total_gutter_width, 0);
 				const Point2 line_top_gutter = line_top + Point2(total_gutter_width, 0);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1399,7 +1399,9 @@ void TextEdit::_notification(int p_what) {
 			_draw_guidelines();
 
 			// Draw main text.
+#ifndef DISABLE_DEPRECATED
 			line_drawing_cache.clear();
+#endif // DISABLE_DEPRECATED
 			int row_height = draw_placeholder ? placeholder_line_height + theme_cache.line_spacing : get_line_height();
 			int line = first_vis_line;
 			for (int i = 0; i < draw_amount; i++) {
@@ -1420,7 +1422,9 @@ void TextEdit::_notification(int p_what) {
 					continue;
 				}
 
+#ifndef DISABLE_DEPRECATED
 				LineDrawingCache cache_entry;
+#endif
 
 				const Vector<Pair<int64_t, Color>> color_map = _get_line_syntax_highlighting(line);
 
@@ -1491,7 +1495,9 @@ void TextEdit::_notification(int p_what) {
 					if (line_wrap_index == 0) {
 						// Only do these if we are on the first wrapped part of a line.
 
+#ifndef DISABLE_DEPRECATED
 						cache_entry.y_offset = ofs_y;
+#endif
 
 						int gutter_offset = left_margin;
 						for (int g = 0; g < gutters.size(); g++) {
@@ -1712,9 +1718,10 @@ void TextEdit::_notification(int p_what) {
 					int gl_size = TS->shaped_text_get_glyph_count(rid);
 
 					ofs_y += ldata->get_line_ascent(line_wrap_index);
-
+#ifndef DISABLE_DEPRECATED
 					int first_visible_char = TS->shaped_text_get_range(rid).y;
 					int last_visible_char = TS->shaped_text_get_range(rid).x;
+#endif
 
 					float char_ofs = 0;
 					if (theme_cache.outline_size > 0 && theme_cache.outline_color.a > 0) {
@@ -1802,20 +1809,27 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
+#ifndef DISABLE_DEPRECATED
 						bool had_glyphs_drawn = false;
+#endif
 						for (int k = 0; k < glyphs[j].repeat; k++) {
 							if (!clipped && (char_ofs + char_margin) >= xmargin_beg && (char_ofs + glyphs[j].advance + char_margin) <= xmargin_end) {
 								if (glyphs[j].font_rid != RID()) {
 									TS->font_draw_glyph(glyphs[j].font_rid, text_ci, glyphs[j].font_size, Vector2(char_margin + char_ofs + glyphs[j].x_off, ofs_y + glyphs[j].y_off), glyphs[j].index, gl_color);
+#ifndef DISABLE_DEPRECATED
 									had_glyphs_drawn = true;
+#endif
 								} else if (((glyphs[j].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) && ((glyphs[j].flags & TextServer::GRAPHEME_IS_EMBEDDED_OBJECT) != TextServer::GRAPHEME_IS_EMBEDDED_OBJECT)) {
 									TS->draw_hex_code_box(text_ci, glyphs[j].font_size, Vector2(char_margin + char_ofs + glyphs[j].x_off, ofs_y + glyphs[j].y_off), glyphs[j].index, gl_color);
+#ifndef DISABLE_DEPRECATED
 									had_glyphs_drawn = true;
+#endif
 								}
 							}
 							char_ofs += glyphs[j].advance;
 						}
 
+#ifndef DISABLE_DEPRECATED
 						if (had_glyphs_drawn) {
 							if (first_visible_char > glyphs[j].start) {
 								first_visible_char = glyphs[j].start;
@@ -1824,6 +1838,7 @@ void TextEdit::_notification(int p_what) {
 								last_visible_char = glyphs[j].end;
 							}
 						}
+#endif
 
 						if ((char_ofs + char_margin) >= xmargin_end) {
 							break;
@@ -1839,10 +1854,10 @@ void TextEdit::_notification(int p_what) {
 						int end_column = u.end_column;
 
 						if (line != u.start_line) {
-							start_column = 0;
+							start_column = TS->shaped_text_get_range(rid).x;
 						}
 						if (line != u.end_line) {
-							end_column = last_visible_char;
+							end_column = TS->shaped_text_get_range(rid).y;
 						}
 
 						const Vector<Vector2> underline = TS->shaped_text_get_selection(rid, start_column, end_column);
@@ -1908,8 +1923,10 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
+#ifndef DISABLE_DEPRECATED
 					cache_entry.first_visible_chars.push_back(first_visible_char);
 					cache_entry.last_visible_chars.push_back(last_visible_char);
+#endif
 
 					// is_line_folded
 					if (line_wrap_index == line_wrap_amount && line < text.size() - 1 && _is_line_hidden(line + 1)) {
@@ -2090,10 +2107,11 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 				}
-
+#ifndef DISABLE_DEPRECATED
 				if (!draw_placeholder) {
 					line_drawing_cache[line] = cache_entry;
 				}
+#endif
 			}
 
 			// Selection handles.
@@ -2103,9 +2121,9 @@ void TextEdit::_notification(int p_what) {
 						continue;
 					}
 
-					Vector<Point2i> handles_pos = _get_selection_handles_pos(c);
-					Point2i start_pos = handles_pos[0];
-					Point2i end_pos = handles_pos[1];
+					Vector<Point2> handles_pos = _get_selection_handles_pos(c);
+					Point2 start_pos = handles_pos[0];
+					Point2 end_pos = handles_pos[1];
 					if (start_pos.x != -1) {
 						_draw_selection_handle(start_pos);
 					}
@@ -2229,40 +2247,14 @@ void TextEdit::_draw_selection_handle(Vector2 p_pos) const {
 	RS::get_singleton()->canvas_item_add_circle(text_ci, circle_center, selection_handle_radius, handle_color);
 }
 
-/*
- * Returns true if p_column is at index 0 or if it is the first character of a wrapped line segment.
- */
-bool TextEdit::_is_first_column(int p_line, int p_column) const {
-	bool is_first_column = p_column == 0;
-	if (!is_first_column && is_line_wrapped(p_line)) {
-		int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
-		int wrap_index_last_column = get_line_wrap_index_at_column(p_line, p_column - 1);
-		is_first_column = wrap_index != wrap_index_last_column;
-	}
-	return is_first_column;
-}
-
-Vector<Point2i> TextEdit::_get_selection_handles_pos(int p_caret) const {
+Vector<Point2> TextEdit::_get_selection_handles_pos(int p_caret) const {
 	int selection_from_line = get_selection_from_line(p_caret);
 	int selection_from_column = get_selection_from_column(p_caret);
 	int selection_to_line = get_selection_to_line(p_caret);
 	int selection_to_column = get_selection_to_column(p_caret);
-	Rect2i start_rect = get_rect_at_line_column(selection_from_line, selection_from_column);
-	Rect2i end_rect = get_rect_at_line_column(selection_to_line, selection_to_column);
-
-	Point2i start_pos = start_rect.position;
-	if (start_pos.x != -1 && !_is_first_column(selection_from_line, selection_from_column)) {
-		start_pos.x += start_rect.size.x;
-	}
-
-	Point2i end_pos = end_rect.position;
-	if (end_pos.x != -1 && !_is_first_column(selection_to_line, selection_to_column)) {
-		end_pos.x += end_rect.size.x;
-	}
-
-	Vector<Point2i> result;
-	result.push_back(start_pos);
-	result.push_back(end_pos);
+	Vector<Point2> result;
+	result.push_back(get_column_position(selection_from_line, selection_from_column));
+	result.push_back(get_column_position(selection_to_line, selection_to_column));
 	return result;
 }
 
@@ -2645,8 +2637,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 
 						if (mpos.x > obj_rect.position.x && mpos.x < obj_rect.get_end().x) {
-							Rect2 col_rect = get_rect_at_line_column(line, col);
-							col_rect.position += get_screen_position() + Vector2(col_rect.size.x, 0);
+							Rect2 col_rect;
+							col_rect.position = get_column_position(line, col) + get_screen_position();
 							col_rect.size = obj_rect.size;
 							set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_NONE);
 							inline_object_click_handler.call(info, col_rect);
@@ -2737,9 +2729,9 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					continue;
 				}
 
-				Vector<Point2i> handles_pos = _get_selection_handles_pos(c);
-				Point2i start_pos = handles_pos[0];
-				Point2i end_pos = handles_pos[1];
+				Vector<Point2> handles_pos = _get_selection_handles_pos(c);
+				Point2 start_pos = handles_pos[0];
+				Point2 end_pos = handles_pos[1];
 
 				int line_height = get_line_height();
 
@@ -2882,8 +2874,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 
 					if (touch_pos.x > obj_rect.position.x && touch_pos.x < obj_rect.get_end().x) {
-						Rect2 col_rect = get_rect_at_line_column(line, col);
-						col_rect.position += get_screen_position() + Vector2(col_rect.size.x, 0);
+						Rect2 col_rect;
+						col_rect.position = get_column_position(line, col) + get_screen_position();
 						col_rect.size = obj_rect.size;
 						set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_NONE);
 						inline_object_click_handler.call(info, col_rect);
@@ -5743,6 +5735,7 @@ Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line
 	return Point2i(col, row);
 }
 
+#ifndef DISABLE_DEPRECATED
 Point2i TextEdit::get_pos_at_line_column(int p_line, int p_column) const {
 	Rect2i rect = get_rect_at_line_column(p_line, p_column);
 	return rect.position.x == -1 ? rect.position : rect.position + Vector2i(0, get_line_height());
@@ -5791,6 +5784,84 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 	size.y = get_line_height();
 
 	return Rect2i(pos, size);
+}
+#endif // DISABLE_DEPRECATED
+
+Rect2 TextEdit::get_grapheme_rect(int p_line, int p_column, bool p_only_in_bounds) const {
+	p_line = CLAMP(p_line, 0, text.size() - 1);
+	const int line_length = text.get_text_with_ime(p_line).length();
+	p_column = CLAMP(p_column, 0, MAX(0, line_length - 1));
+
+	const int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
+	const float wrap_indent = _get_wrap_indent_offset(p_line, wrap_index, is_layout_rtl());
+	Ref<StyleBox> style = _get_current_stylebox();
+
+	Rect2 rect;
+	rect.position.y = _get_line_start_y(p_line, wrap_index);
+	rect.size.y = get_line_height();
+
+	if (p_only_in_bounds) {
+		const int top_draw_limit = style->get_margin(SIDE_TOP) - get_line_height();
+		const int bottom_draw_limit = get_size().height - style->get_margin(SIDE_BOTTOM) + get_line_height();
+		if (rect.position.y + rect.size.y < top_draw_limit || rect.position.y > bottom_draw_limit) {
+			return Rect2(-1, -1, 0, 0);
+		}
+	}
+
+	const RID text_rid = text.get_line_data(p_line)->get_line_rid(wrap_index);
+	const int start_column = get_previous_composite_character_column(p_line, MIN(p_column + 1, line_length));
+	const int end_column = get_next_composite_character_column(p_line, p_column);
+	const Vector<Vector2> selection = TS->shaped_text_get_selection(text_rid, start_column, end_column);
+	Vector2 col_bounds;
+	if (!selection.is_empty()) {
+		col_bounds = selection[0];
+	}
+	rect.size.x = col_bounds.y - col_bounds.x;
+	float start_pos_x = get_line_start_margin() + get_total_gutter_width() + wrap_indent - h_scroll->get_value();
+	if (is_layout_rtl()) {
+		rect.position.x = get_size().width - start_pos_x - TS->shaped_text_get_size(text_rid).x + col_bounds.x;
+	} else {
+		rect.position.x = start_pos_x + col_bounds.x;
+	}
+
+	if (p_only_in_bounds) {
+		const int left_draw_limit = get_line_start_margin() + get_total_gutter_width();
+		const int right_draw_limit = get_size().width - Math::floor(style->get_margin(SIDE_RIGHT)) - (draw_minimap ? minimap_width : 0);
+		if (rect.position.x + rect.size.x < left_draw_limit || rect.position.x > right_draw_limit) {
+			return Rect2(-1, -1, 0, 0);
+		}
+	}
+
+	return rect;
+}
+
+Point2 TextEdit::get_column_position(int p_line, int p_column, bool p_only_in_bounds) const {
+	p_line = CLAMP(p_line, 0, text.size() - 1);
+	const int line_length = text.get_text_with_ime(p_line).length();
+	p_column = CLAMP(p_column, 0, line_length);
+
+	const int wrap_index = get_line_wrap_index_at_column(p_line, p_column);
+
+	float start_pos_x = get_line_start_margin() + get_total_gutter_width() - h_scroll->get_value();
+	if (is_layout_rtl()) {
+		RID text_rid = text.get_line_data(p_line)->get_line_rid(wrap_index);
+		start_pos_x = get_size().width - start_pos_x - TS->shaped_text_get_size(text_rid).x;
+	}
+	Point2 pos;
+	pos.x = start_pos_x + _get_column_x_offset_for_line(p_column, p_line, p_column);
+	pos.y = _get_line_start_y(p_line, wrap_index);
+
+	if (p_only_in_bounds) {
+		Ref<StyleBox> style = _get_current_stylebox();
+		const int top_draw_limit = style->get_margin(SIDE_TOP) - get_line_height();
+		const int bottom_draw_limit = get_size().height - style->get_margin(SIDE_BOTTOM) + get_line_height();
+		const int left_draw_limit = get_line_start_margin() + get_total_gutter_width();
+		const int right_draw_limit = get_size().width - Math::floor(style->get_margin(SIDE_RIGHT)) - (draw_minimap ? minimap_width : 0);
+		if (pos.x < left_draw_limit || pos.x > right_draw_limit || pos.y < top_draw_limit || pos.y > bottom_draw_limit) {
+			return Point2(-1, -1);
+		}
+	}
+	return pos;
 }
 
 int TextEdit::get_line_start_margin() const {
@@ -6916,17 +6987,17 @@ int TextEdit::get_selection_origin_column(int p_caret) const {
 
 int TextEdit::get_next_composite_character_column(int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), -1);
-	ERR_FAIL_INDEX_V(p_column, text[p_line].length() + 1, -1);
-	if (p_column == text[p_line].length()) {
+	ERR_FAIL_INDEX_V(p_column, text.get_text_with_ime(p_line).length() + 1, -1);
+	if (p_column == text.get_text_with_ime(p_line).length()) {
 		return p_column;
 	} else {
-		return TS->shaped_text_next_character_pos(text.get_line_data(p_line)->get_rid(), (p_column));
+		return TS->shaped_text_next_character_pos(text.get_line_data(p_line)->get_rid(), p_column);
 	}
 }
 
 int TextEdit::get_previous_composite_character_column(int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), -1);
-	ERR_FAIL_INDEX_V(p_column, text[p_line].length() + 1, -1);
+	ERR_FAIL_INDEX_V(p_column, text.get_text_with_ime(p_line).length() + 1, -1);
 	if (p_column == 0) {
 		return 0;
 	} else {
@@ -8017,8 +8088,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_word_at_pos", "position"), &TextEdit::get_word_at_pos);
 
 	ClassDB::bind_method(D_METHOD("get_line_column_at_pos", "position", "clamp_line", "clamp_column"), &TextEdit::get_line_column_at_pos, DEFVAL(true), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("get_pos_at_line_column", "line", "column"), &TextEdit::get_pos_at_line_column);
-	ClassDB::bind_method(D_METHOD("get_rect_at_line_column", "line", "column"), &TextEdit::get_rect_at_line_column);
+	ClassDB::bind_method(D_METHOD("get_grapheme_rect", "line", "column", "only_in_bounds"), &TextEdit::get_grapheme_rect, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_column_position", "line", "column", "only_in_bounds"), &TextEdit::get_column_position, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("get_minimap_line_at_pos", "position"), &TextEdit::get_minimap_line_at_pos);
 
@@ -8279,6 +8350,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_caret_index_edit_order"), &TextEdit::get_caret_index_edit_order);
 	ClassDB::bind_method(D_METHOD("get_selection_line", "caret_index"), &TextEdit::get_selection_line, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_selection_column", "caret_index"), &TextEdit::get_selection_column, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_pos_at_line_column", "line", "column"), &TextEdit::get_pos_at_line_column);
+	ClassDB::bind_method(D_METHOD("get_rect_at_line_column", "line", "column"), &TextEdit::get_rect_at_line_column);
 #endif
 
 	/* Inspector */
@@ -9020,7 +9093,7 @@ void TextEdit::_toggle_draw_caret() {
 	}
 }
 
-int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column) const {
+float TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 
 	int wrap_index = 0;
@@ -9042,6 +9115,13 @@ int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column
 	} else {
 		return ts_caret.t_caret.position.x + (rtl ? -wrap_indent : wrap_indent);
 	}
+}
+
+float TextEdit::_get_line_start_y(int p_line, int p_wrap_index) const {
+	const int num_lines_before = p_line == 0 ? 0 : get_visible_line_count_in_range(0, p_line - 1);
+	Ref<StyleBox> style = _get_current_stylebox();
+	const int top_start = style->get_margin(SIDE_TOP);
+	return top_start + get_line_height() * (num_lines_before + p_wrap_index - get_v_scroll());
 }
 
 bool TextEdit::_is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_include_edges) const {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -435,6 +435,7 @@ private:
 	Callable tooltip_callback;
 
 	/* Mouse */
+#ifndef DISABLE_DEPRECATED
 	struct LineDrawingCache {
 		int y_offset = 0;
 		Vector<int> first_visible_chars;
@@ -442,6 +443,7 @@ private:
 	};
 
 	HashMap<int, LineDrawingCache> line_drawing_cache;
+#endif // DISABLE_DEPRECATED
 
 	int _get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 
@@ -501,7 +503,8 @@ private:
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
-	int _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
+	float _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
+	float _get_line_start_y(int p_line, int p_wrap_index = 0) const;
 	bool _is_line_col_in_range(int p_line, int p_column, int p_from_line, int p_from_column, int p_to_line, int p_to_column, bool p_include_edges = true) const;
 
 	void _offset_carets_after(int p_old_line, int p_old_column, int p_new_line, int p_new_column, bool p_include_selection_begin = true, bool p_include_selection_end = true);
@@ -549,8 +552,7 @@ private:
 	Vector2 selection_handle_drag_offset;
 	bool show_selection_handle = false;
 	bool selection_handle_enabled = true;
-	Vector<Point2i> _get_selection_handles_pos(int p_cursor) const;
-	bool _is_first_column(int p_line, int p_column) const;
+	Vector<Point2> _get_selection_handles_pos(int p_cursor) const;
 	void _draw_selection_handle(Vector2 p_pos) const;
 
 	void _cancel_inertial_scroll();
@@ -1002,8 +1004,12 @@ public:
 	String get_word(int p_line, int p_column) const;
 
 	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line = true, bool p_clamp_column = true) const;
+#ifndef DISABLE_DEPRECATED
 	Point2i get_pos_at_line_column(int p_line, int p_column) const;
 	Rect2i get_rect_at_line_column(int p_line, int p_column) const;
+#endif
+	Rect2 get_grapheme_rect(int p_line, int p_column, bool p_only_in_bounds = true) const;
+	Point2 get_column_position(int p_line, int p_column, bool p_only_in_bounds = true) const;
 	int get_line_start_margin() const;
 
 	int get_minimap_line_at_pos(const Point2i &p_pos) const;

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -1665,9 +1665,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 
 			// Click and drag to make a selection.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			// Add (2,0) to bring it past the center point of the grapheme and account for integer division flooring.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			// Add (1, 0) to bring it past the center point of the grapheme.
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -1679,10 +1679,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_dragging_cursor());
 
 			// Releasing finishes.
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 8).get_center() + Point2(1, 0), MouseButtonMask::NONE, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
 			CHECK(text_edit->get_selection_origin_line() == 1);
@@ -1692,17 +1692,17 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin());
 
 			// Clicking clears selection.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 7);
 
 			// Cannot select when disabled, but caret still moves.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -1715,8 +1715,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(0, 11, 0, 15, 1);
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_caret_count() == 3);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
 			CHECK_FALSE(text_edit->has_selection(0));
@@ -1738,7 +1738,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK_FALSE(text_edit->is_caret_after_selection_origin(2));
 
 			// Overlapping carets and selections merges them.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 2).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "s is some text\nfor s");
@@ -1755,7 +1755,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "thiaelection");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 4);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 9).get_center() + Point2(1, 0), MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 4);
@@ -1771,8 +1771,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_line_wrapped(0));
 
 			// Select to the first character of a wrapped line.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 11).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "so");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -1792,7 +1792,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			// Double click to select word.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 2).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(1, 1).get_center() + Point2(1, 0), Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1806,7 +1806,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			// Moving mouse selects entire words at a time.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 5).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1821,7 +1821,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			// Moving to a word before the initial selected word reverses selection direction and keeps the initial word selected.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some text\nfor");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1835,22 +1835,22 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
 			// Releasing finishes.
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 9).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some text\nfor");
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 1).get_center(), MouseButtonMask::NONE, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some text\nfor");
 			text_edit->deselect();
 
 			// Can start word select mode on an empty line.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(2, 0).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(2, 0).get_center() + Point2(1, 0), Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->get_caret_line() == 2);
 			CHECK(text_edit->get_caret_column() == 0);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "selection\n");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1860,13 +1860,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 0);
 
 			// Clicking clears selection.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
 
 			// Can select word from left endpoint.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 8).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 7).get_center() + Point2(1, 0), Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1876,7 +1876,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
 			// Can select word from right endpoint.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 12).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 11).get_center() + Point2(1, 0), Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -1885,7 +1885,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some text\nfor selection");
@@ -1894,7 +1894,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some");
@@ -1903,11 +1903,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 15).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 14).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 
 			// Add a new selection without affecting the old one.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 7).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
@@ -1925,9 +1925,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column(1) == 5);
 
 			// Shift + double click to extend selection and start word select mode.
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 7).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			text_edit->remove_secondary_carets();
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "some text\nfor selection");
@@ -1938,7 +1938,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Cannot select when disabled, but caret still moves to end of word.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 1).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(1, 0).get_center() + Point2(1, 0), Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 3);
@@ -1947,13 +1947,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can start word select mode when not on a word.
 			text_edit->set_text("this is  some text\nwith an extra space\n");
 			MessageQueue::get_singleton()->flush();
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 8).get_center() + Point2i(2, 0), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 7).get_center() + Point2(1, 0), Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 8);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 13).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 12).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == " some text\nwith an extra");
@@ -1963,7 +1963,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
 			// Can reverse selection direction without retaining previous selection.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "this is ");
@@ -1973,7 +1973,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 8);
 
 			// Can deselect by moving to initial selection point.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 8).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 7).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1988,8 +1988,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 
 			// Triple click to select line.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 2).get_center(), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(1, 1).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 1).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection\n");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -2002,7 +2002,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin());
 
 			// Moving mouse selects entire lines at a time. Selecting above reverses the selection direction.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "this is some text\nfor selection");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -2016,7 +2016,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_dragging_cursor());
 
 			// Selecting to the last line puts the caret at end of the line.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(2, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -2029,25 +2029,25 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_caret_after_selection_origin());
 
 			// Releasing finishes.
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(2, 9).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 2).get_center(), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 1).get_center(), MouseButtonMask::NONE, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection\nwith 3 lines");
 
 			// Clicking clears selection.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 
 			// Can start line select mode on an empty line.
 			text_edit->set_text("this is some text\n\nfor selection\nwith 4 lines");
 			MessageQueue::get_singleton()->flush();
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(1, 0).get_center() + Point2i(2, 0), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(1, 0).get_center() + Point2(1, 0), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "\n");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -2056,7 +2056,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 1);
 			CHECK(text_edit->get_selection_origin_column() == 0);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(2, 8).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "\nfor selection\n");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -2066,8 +2066,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 0);
 
 			// Add a new selection without affecting the old one.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 3).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::ALT);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->has_selection(0));
@@ -2087,8 +2087,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->deselect();
 
 			// Selecting the last line puts caret at the end.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(3, 3).get_center(), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 3).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(3, 2).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(3, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "with 4 lines");
@@ -2098,7 +2098,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_column() == 0);
 
 			// Selecting above reverses direction.
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(2, 9).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection\nwith 4 lines");
@@ -2107,11 +2107,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 3);
 			CHECK(text_edit->get_selection_origin_column() == 12);
 
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(2, 10).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(2, 9).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 
 			// Shift + triple click to extend selection and restart line select mode.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 9).get_center() + Point2i(2, 0), Key::NONE | KeyModifierMask::SHIFT);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 9).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 8).get_center() + Point2(1, 0), Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 8).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "this is some text\n\nfor selection\nwith 4 lines");
@@ -2122,8 +2122,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Cannot select when disabled, but caret still moves to the start of the next line.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 2).get_center(), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 1).get_center(), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2138,9 +2138,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 
 			// Shift click to make a selection from the previous caret position.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 1).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 1).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 0).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 0).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "or s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -2149,10 +2149,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
 			CHECK(text_edit->is_caret_after_selection_origin());
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 
 			// Shift click above to switch selection direction. Uses original selection position.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "s some text\nf");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -2161,33 +2161,33 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 6);
 			CHECK_FALSE(text_edit->is_caret_after_selection_origin());
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 
 			// Clicking clears selection.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 7);
 
 			// Cannot select when disabled, but caret still moves.
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			text_edit->set_selecting_enabled(true);
 
 			// Shift click to make a selection from caret.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			text_edit->set_caret_column(5, false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 13).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 12).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "is some ");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -2196,12 +2196,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 13);
 			CHECK(text_edit->is_caret_after_selection_origin());
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 13).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 12).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			text_edit->deselect();
 
 			// Shift click with an existing selection.
 			text_edit->select(1, 2, 1, 5);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 7).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "r sele");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -2210,12 +2210,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 8);
 			CHECK(text_edit->is_caret_after_selection_origin());
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 8).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 7).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			text_edit->deselect();
 
 			// Shift selecting after word selection mode keeps the selection on the word.
-			SEND_GUI_DOUBLE_CLICK(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "is");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2223,7 +2223,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 5);
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 10).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 9).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "is so");
@@ -2232,7 +2232,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 5);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 2).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "is is");
@@ -2240,7 +2240,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 2);
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 7);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 		}
 
 		SUBCASE("[TextEdit] select and deselect") {
@@ -2462,9 +2462,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Drag and drop selected text to mouse position.
 			text_edit->select(0, 0, 0, 4);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
 			CHECK(text_edit->has_selection());
@@ -2472,8 +2472,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 4);
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 0);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 10).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 10).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == " test\ndrop here 'drag'");
 			CHECK(text_edit->has_selection());
@@ -2502,15 +2502,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Hold control when dropping to not delete selected text.
 			text_edit->select(1, 10, 1, 16);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 11).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "'drag'");
 			CHECK(text_edit->has_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			SEND_GUI_KEY_UP_EVENT(Key::CMD_OR_CTRL);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' test\ndrop here 'drag'");
@@ -2525,9 +2525,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_caret(1, 2);
 			text_edit->select(1, 2, 1, 4, 1);
 			text_edit->add_caret(1, 12);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection(true, 1));
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 11).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test\nop");
 			// Carets aren't removed from dragging, only dropping.
@@ -2545,8 +2545,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK_FALSE(text_edit->has_selection(2));
 			CHECK(text_edit->get_caret_line(2) == 1);
 			CHECK(text_edit->get_caret_column(2) == 12);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 9).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 8).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 8).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
 			CHECK(text_edit->get_caret_count() == 1);
@@ -2558,12 +2558,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Drop onto same selection should do effectively nothing.
 			text_edit->select(1, 3, 1, 7);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(1, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "here");
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
 			CHECK(text_edit->get_caret_count() == 1);
@@ -2576,11 +2576,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Cannot drag when drag and drop selection is disabled. It becomes regular drag to select.
 			text_edit->set_drag_and_drop_selection_enabled(false);
 			text_edit->select(0, 1, 0, 5);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
 			CHECK(text_edit->has_selection());
@@ -2592,9 +2592,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Cancel drag and drop from Escape key.
 			text_edit->select(0, 1, 0, 5);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
 			SEND_GUI_KEY_EVENT(Key::ESCAPE);
@@ -2608,9 +2608,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Cancel drag and drop from caret move key input.
 			text_edit->select(0, 1, 0, 5);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
 			SEND_GUI_KEY_EVENT(Key::RIGHT);
@@ -2622,9 +2622,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Cancel drag and drop from text key input.
 			text_edit->select(0, 1, 0, 5);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
 			SEND_GUI_KEY_EVENT(Key::A);
@@ -2656,9 +2656,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 
 			// Drag text between text edits.
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
 			CHECK(text_edit->has_selection());
@@ -2743,15 +2743,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(0, 5, 0, 7, 0);
 			text_edit->add_caret(0, 1);
 			text_edit->select(0, 1, 0, 0, 1);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 5).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 4).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 5).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "d\nte");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			SEND_GUI_KEY_UP_EVENT(Key::CMD_OR_CTRL);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "drag test\ndrop test");
@@ -2775,14 +2775,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->remove_secondary_carets();
 			text_edit->select(0, 5, 0, 9);
 			target_text_edit->select(0, 6, 0, 8);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 5).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test");
 			CHECK(text_edit->has_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "drag \ndrop test");
 			CHECK(target_text_edit->get_caret_count() == 1);
@@ -2802,14 +2802,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			target_text_edit->set_drag_and_drop_selection_enabled(false);
 			text_edit->select(0, 4, 0, 5);
 			target_text_edit->deselect();
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 3).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == " ");
 			CHECK(text_edit->has_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 6).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "drag\ndrop test");
 			CHECK(target_text_edit->get_text() == "drag md test\ntee");
@@ -2827,14 +2827,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			target_text_edit->set_editable(false);
 			text_edit->select(0, 1, 0, 4);
 			target_text_edit->deselect();
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "rag");
 			CHECK(text_edit->has_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "drag\ndrop test");
 			CHECK(target_text_edit->get_text() == "drag md test\ntee");
@@ -2845,14 +2845,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can drag when not editable, but text will not be removed.
 			text_edit->set_editable(false);
 			text_edit->select(0, 0, 0, 4);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 6).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
 			CHECK(text_edit->has_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 3).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_grapheme_rect(0, 3).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "drag\ndrop test");
 			CHECK(target_text_edit->get_text() == "dragdrag md test\ntee");
@@ -3586,9 +3586,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(0, 1).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 2).get_center() + Point2(1, 0), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_grapheme_rect(1, 2).get_center() + Point2(1, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(DS->clipboard_get() == "");
 			CHECK(DS->clipboard_get_primary() == "is is\nsom");
 			CHECK(text_edit->get_text() == "this is\nsome\n\ntext");
@@ -3609,7 +3609,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 			lines_edited_args = { { 3, 4 } };
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(3, 2).get_center() + Point2i(2, 0), MouseButton::MIDDLE, MouseButtonMask::MIDDLE, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_grapheme_rect(3, 1).get_center() + Point2(1, 0), MouseButton::MIDDLE, MouseButtonMask::MIDDLE, Key::NONE);
 			CHECK(DS->clipboard_get_primary() == "is is\nsom");
 			CHECK(text_edit->get_text() == "this is\nsome\n\nteis is\nsomxt");
 			CHECK_FALSE(text_edit->has_selection());
@@ -3621,7 +3621,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Paste at mouse position if there is only one caret.
 			text_edit->set_text("this is\nsome\n\ntext");
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::NONE, Key::NONE);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -3646,7 +3646,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(0);
 			text_edit->add_caret(2, 0);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(0, 0).get_center() + Point2(1, 0), MouseButtonMask::NONE, Key::NONE);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -3673,7 +3673,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("this is\nsome\n\ntext");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(4);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 3).get_center() + Point2i(2, 0), MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_grapheme_rect(1, 2).get_center() + Point2(1, 0), MouseButtonMask::NONE, Key::NONE);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -6657,37 +6657,33 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 
 	text_edit->set_size(Size2(800, 200));
+	const Ref<StyleBox> &stylebox = text_edit->get_theme_stylebox(CoreStringName(normal));
 
-	CHECK(text_edit->get_rect_at_line_column(0, 0).get_position() == Point2i(0, 0));
+	CHECK(text_edit->get_grapheme_rect(0, 0).get_position() == Point2(stylebox->get_margin(SIDE_LEFT), stylebox->get_margin(SIDE_TOP)));
 
 	text_edit->set_line(0, "A");
 	MessageQueue::get_singleton()->flush();
-	CHECK(text_edit->get_rect_at_line_column(0, 1).get_position().x > 0);
+	CHECK(text_edit->get_grapheme_rect(0, 0).get_position().x > 0);
 
 	text_edit->clear(); // Necessary, otherwise the following test cases fail.
 
 	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	MessageQueue::get_singleton()->flush();
 
-	CHECK(text_edit->get_word_at_pos(text_edit->get_pos_at_line_column(0, 1)) == "Lorem");
-	CHECK(text_edit->get_word_at_pos(text_edit->get_pos_at_line_column(0, 9)) == "ipsum");
+	CHECK(text_edit->get_word_at_pos(text_edit->get_column_position(0, 0)) == "Lorem");
+	CHECK(text_edit->get_word_at_pos(text_edit->get_column_position(0, 8)) == "ipsum");
 
 	ERR_PRINT_OFF;
-	CHECK(text_edit->get_pos_at_line_column(0, -1) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(-1, 0) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(-1, -1) == Point2i(-1, -1));
-
-	CHECK(text_edit->get_pos_at_line_column(0, 500) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(2, 0) == Point2i(-1, -1));
-	CHECK(text_edit->get_pos_at_line_column(2, 500) == Point2i(-1, -1));
 
 	// Out of view.
-	CHECK(text_edit->get_pos_at_line_column(0, text_edit->get_line(0).length() - 1) == Point2i(-1, -1));
+	CHECK(text_edit->get_column_position(0, 499) == Point2(-1, -1));
+	CHECK(text_edit->get_column_position(2, 499) == Point2(-1, -1));
+	CHECK(text_edit->get_column_position(0, text_edit->get_line(0).length() - 1) == Point2(-1, -1));
 	ERR_PRINT_ON;
 
 	// Add method to get drawn column count?
-	Point2i start_pos = text_edit->get_pos_at_line_column(0, 0);
-	Point2i end_pos = text_edit->get_pos_at_line_column(0, 104);
+	Point2i start_pos = text_edit->get_column_position(0, 0);
+	Point2i end_pos = text_edit->get_column_position(0, 103);
 
 	CHECK(text_edit->get_line_column_at_pos(Point2i(start_pos.x, start_pos.y)) == Point2i(0, 0));
 	CHECK(text_edit->get_line_column_at_pos(Point2i(end_pos.x, end_pos.y)) == Point2i(103, 0));


### PR DESCRIPTION

## What problem(s) does this PR solve?

`get_rect_at_line_column` and `get_pos_at_line_column` had many issues:
- Incorrect position when there is no text, the margins aren't accounted for.
- Dependent on drawing, so you have to wait a frame if you make certain changes. Related https://github.com/godotengine/godot/issues/88722
- Did not account for RTL layout.
- Could not get some rects of bidirectional text.
- Bidirectional text bounds checking wasn't correct in some cases.
- Errored when column was after length of text without IME when there was IME text.
- Columns were 1-indexed (just LTR) and 0 got the same value as 1, fixes https://github.com/godotengine/godot/issues/82280
	- `get_pos_at_line_column` couldn't give you the position of the last column.
- Could not get the rect at the end of a line wrap, fixes https://github.com/godotengine/godot/issues/121704
	- Supersedes https://github.com/godotengine/godot/pull/121705
- Precision loss due to using ints, fixes https://github.com/godotengine/godot/issues/83311
	- Supersedes https://github.com/godotengine/godot/pull/83312

Users already have to account for things like the 1-indexed column, so changing it would be too compat breaking IMO. Instead I deprecated them and made 2 new methods.

`get_grapheme_rect`to get the rects of graphemes (with line height),  and `get_column_position` to get the position at a column. I have both because some use cases want the position for the column in between 2 characters as if the caret was placed there, and the logic to properly handle it is a bit different.
`get_column_position` gets the position at the top, since drawing is top to bottom, I think its more useful and makes more sense than getting the position at the bottom of the line.
Passing line or column out of range now clamps it for you like some other TextEdit APIs do, this allows you to pass the last column to get the last character without error.
It is possible to get the position/rect even when they aren't visible with `only_in_bounds`, this is useful if you haven't set the TextEdit's size to account for it, or if you want effects from out of view.

## Additional information

I switched to use `TS->shaped_text_get_selection` instead of `TS->shaped_text_get_grapheme_bounds` because it had issues with bidirectional text.

`get_column_position` uses different logic because it needs to account for columns at the end of the line and things like inline objects, and RTL text is handled a bit differently. Now it should return the position where the caret would be if it were there.
The selection handles now use `get_column_position`, so they should handle the case where an inline object was at the start of a wrapped line correctly now.

I made underlines use the line range instead of `last_visible_char`, like regular selections do. It may not have been accurate in certain edge cases (https://github.com/godotengine/godot/pull/55102#discussion_r752618293), though I don't think it caused issues for underlines. Apparently `last_visible_char` was an optimization to avoid needing to calculate positions outside of the visible range, but its not really needed, doesn't work in all cases, and its cleaner to deprecate its code together with `first_visible_char`.

I updated the tests to use the new method and subtracted 1 from the passed columns, so they should be the functionally pretty much the same.
The only exceptions were the last case of `[TextEdit] mouse drag select` needs the first column of the wrapped line, and `[SceneTree][TextEdit] mouse` had no text and didn't account for the Stylebox margins.

Shader preview lines should probably be changed to use the position even when it is out of bounds, since when the preview is scrolled out of view it still draws lines from it. I'll leave it for another PR though.
