### PR TITLE
Fix exponential ratio of `Range` when `min_value` is zero

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -150,23 +150,9 @@ void ProgressBar::_notification(int p_what) {
 			}
 
 			if (show_percentage) {
-				double ratio = 0;
+				double percentage = _get_as_ratio_unclamped();
 
-				// Avoid division by zero.
-				if (Math::is_equal_approx(get_max(), get_min())) {
-					ratio = 1;
-				} else if (is_ratio_exp() && get_min() >= 0 && get_value() >= 0) {
-					double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
-					double exp_max = Math::log(get_max()) / Math::log((double)2);
-					double exp_value = get_value() == 0 ? 0.0 : Math::log(get_value()) / Math::log((double)2);
-					double percentage = (exp_value - exp_min) / (exp_max - exp_min);
-
-					ratio = CLAMP(percentage, is_lesser_allowed() ? percentage : 0, is_greater_allowed() ? percentage : 1);
-				} else {
-					double percentage = (get_value() - get_min()) / (get_max() - get_min());
-
-					ratio = CLAMP(percentage, is_lesser_allowed() ? percentage : 0, is_greater_allowed() ? percentage : 1);
-				}
+				double ratio = CLAMP(percentage, is_lesser_allowed() ? percentage : 0, is_greater_allowed() ? percentage : 1);
 
 				String txt = itos(int(Math::round(ratio * 100)));
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -301,13 +301,16 @@ double Range::get_page() const {
 void Range::set_as_ratio(double p_value) {
 	double v;
 
-	if (shared->exp_ratio && get_min() >= 0) {
-		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
-		double exp_max = Math::log(get_max()) / Math::log((double)2);
-		v = Math::pow(2, exp_min + (exp_max - exp_min) * p_value);
+	if (shared->exp_ratio && get_min() >= 0.0) {
+		const double shift = get_min() == 0.0 ? EXP_RATIO_ZERO_SHIFT : 0.0;
+
+		double exp_min = Math::log2(get_min() + shift);
+		double exp_max = Math::log2(get_max() + shift);
+
+		v = Math::pow(2.0, exp_min + (exp_max - exp_min) * p_value) - shift;
 	} else {
 		double percent = (get_max() - get_min()) * p_value;
-		if (get_step() > 0) {
+		if (get_step() > 0.0) {
 			double steps = std::round(percent / get_step());
 			v = steps * get_step() + get_min();
 		} else {
@@ -319,21 +322,24 @@ void Range::set_as_ratio(double p_value) {
 }
 
 double Range::get_as_ratio() const {
+	return CLAMP(_get_as_ratio_unclamped(), 0, 1);
+}
+
+double Range::_get_as_ratio_unclamped() const {
 	if (Math::is_equal_approx(get_max(), get_min())) {
 		// Avoid division by zero.
 		return 1.0;
 	}
 
-	if (shared->exp_ratio && get_min() >= 0) {
-		double exp_min = get_min() == 0 ? 0.0 : Math::log(get_min()) / Math::log((double)2);
-		double exp_max = Math::log(get_max()) / Math::log((double)2);
-		double value = CLAMP(get_value(), shared->min, shared->max);
-		double v = Math::log(value) / Math::log((double)2);
+	if (shared->exp_ratio && get_min() >= 0.0 && get_value() >= 0.0) {
+		const double shift = get_min() == 0.0 ? EXP_RATIO_ZERO_SHIFT : 0.0;
 
-		return CLAMP((v - exp_min) / (exp_max - exp_min), 0, 1);
+		double exp_min = Math::log2(get_min() + shift);
+		double exp_max = Math::log2(get_max() + shift);
+		double exp_value = Math::log2(get_value() + shift);
+		return (exp_value - exp_min) / (exp_max - exp_min);
 	} else {
-		double value = CLAMP(get_value(), shared->min, shared->max);
-		return CLAMP((value - get_min()) / (get_max() - get_min()), 0, 1);
+		return (get_value() - get_min()) / (get_max() - get_min());
 	}
 }
 

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -33,6 +33,8 @@
 #include "scene/gui/control.h"
 
 class Range : public Control {
+	static constexpr double EXP_RATIO_ZERO_SHIFT = 1e-3;
+
 	GDCLASS(Range, Control);
 
 	struct Shared {
@@ -64,6 +66,8 @@ class Range : public Control {
 protected:
 	static double _snapped_r128(double p_value, double p_step);
 	double _calc_value(double p_val, double p_step) const;
+	double _get_as_ratio_unclamped() const;
+
 	virtual void _value_changed(double p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); }
 	void _notification(int p_what);


### PR DESCRIPTION
## What problem(s) does this PR solve?

When `exp_edit` is enabled on a `Range` node and `min_value` is set to `0`, setting `ratio` to `0` currently yields a `value` of `1`. Moreover, if `min_value` is `0` and `max_value` is less than `1`, the slider becomes completely unusable.

This happens because the internal mapping treats `0` as `1` to avoid undefined behaviour of `log(0)`, which brings the inconsistency. The solution is to shift the range with a small positive epsilon before taking the logarithm when `min_value` is zero, and then shift the value back. The chosen epsilon (`1e-3`) is the same as the default step of `EditorSpinSlider`, which avoids a steep curve and unintended non‑zero values displayed as zero.

- Closes #121804
- Closes #109248

## Additional information

This PR also removes a redundant calculation in `ProgressBar`, and the fix only affects `Range` and its child classes, specifically when `min_value` is exactly `0`.

This PR implements one of the approaches discussed in #121804.

Tests were done on MRPs from #121804 and #109248, and worked as expected.