### PR TITLE
OpenXR use proper spatial entity NULL constant

### DIFF
--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -1039,7 +1039,7 @@ void OpenXRSpatialAnchorCapability::remove_anchor(Ref<OpenXRAnchorTracker> p_anc
 
 	// Get our entity id.
 	XrSpatialEntityIdEXT entity_id = se_extension->get_spatial_entity_id(entity);
-	ERR_FAIL_COND(entity_id == XR_NULL_ENTITY);
+	ERR_FAIL_COND(entity_id == XR_NULL_SPATIAL_ENTITY_ID_EXT);
 
 	// Remove it from our entity list.
 	for (KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>>> &anchors : anchor_trackers) {
@@ -1076,7 +1076,7 @@ Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::persist_anchor(Ref<OpenXR
 	ERR_FAIL_COND_V(entity.is_null(), nullptr);
 
 	XrSpatialEntityIdEXT entity_id = se_extension->get_spatial_entity_id(entity);
-	ERR_FAIL_COND_V(entity_id == XR_NULL_ENTITY, nullptr);
+	ERR_FAIL_COND_V(entity_id == XR_NULL_SPATIAL_ENTITY_ID_EXT, nullptr);
 
 	RID spatial_context_rid = se_extension->get_spatial_entity_context(entity);
 	const XrSpatialContextEXT spatial_context_handle = se_extension->get_spatial_context_handle(spatial_context_rid);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
@@ -147,7 +147,7 @@ void OpenXRSpatialEntityTracker::set_entity(const RID &p_entity) {
 
 		XrSpatialEntityIdEXT entity_id = se_extension->get_spatial_entity_id(p_entity);
 
-		String tracker_name = String("openxr/spatial_entity/") + String::num_int64(entity_id);
+		String tracker_name = String("openxr/spatial_entity/") + String::num_uint64(entity_id);
 		set_tracker_name(tracker_name);
 	} else {
 		set_tracker_name("openxr/spatial_entity/null");
@@ -562,7 +562,7 @@ void *OpenXRSpatialQueryResultData::get_structure_data(void *p_next) {
 }
 
 XrSpatialEntityIdEXT OpenXRSpatialQueryResultData::get_entity_id(int64_t p_index) const {
-	ERR_FAIL_INDEX_V(p_index, entity_ids.size(), XR_NULL_ENTITY);
+	ERR_FAIL_INDEX_V(p_index, entity_ids.size(), XR_NULL_SPATIAL_ENTITY_ID_EXT);
 
 	return entity_ids[p_index];
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
@@ -37,8 +37,6 @@
 
 #include <openxr/openxr.h>
 
-#define XR_NULL_ENTITY 0x7FFFFFFF
-
 // Wrapper class for XrSpatialCapabilityConfigurationBaseHeaderEXT
 class OpenXRSpatialCapabilityConfigurationBaseHeader : public RefCounted {
 	GDCLASS(OpenXRSpatialCapabilityConfigurationBaseHeader, RefCounted);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -1203,7 +1203,7 @@ RID OpenXRSpatialEntityExtension::_make_entity(RID p_spatial_context, uint64_t p
 
 XrSpatialEntityIdEXT OpenXRSpatialEntityExtension::get_spatial_entity_id(RID p_entity) const {
 	SpatialEntityData *entity_data = spatial_entity_owner.get_or_null(p_entity);
-	ERR_FAIL_NULL_V(entity_data, XR_NULL_ENTITY);
+	ERR_FAIL_NULL_V(entity_data, XR_NULL_SPATIAL_ENTITY_ID_EXT);
 
 	return entity_data->entity_id;
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
@@ -181,7 +181,7 @@ private:
 	// Entities
 	struct SpatialEntityData {
 		RID spatial_context;
-		XrSpatialEntityIdEXT entity_id = XR_NULL_ENTITY;
+		XrSpatialEntityIdEXT entity_id = XR_NULL_SPATIAL_ENTITY_ID_EXT;
 		XrSpatialEntityEXT entity = XR_NULL_HANDLE;
 	};
 	mutable RID_Owner<SpatialEntityData> spatial_entity_owner;


### PR DESCRIPTION
## What problem(s) does this PR solve?

I improperly introduced a NULL define (`XR_NULL_ENTITY`), probably because the official one wasn't yet known at the time.

This PR changes its usage to the official `XR_NULL_SPATIAL_ENTITY_ID_EXT`.

## Additional information

This was discovered when implementing the first piece of logic that makes  use of this in GDExtensions. As we never exposed the constant, using the correct OpenXR constant failed.
Technically this is a minor breaking change but seeing the circumstances we can likely do this with no real impact.