### PR TITLE
Fix prek checks sometimes checking zero files or failing with too many

### DIFF
--- a/.github/actions/clangd-tidy/action.yml
+++ b/.github/actions/clangd-tidy/action.yml
@@ -26,5 +26,14 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Running clangd-tidy"
-        clangd-tidy ${{ inputs.changed-files }}
+        CHANGED_FILES='${{ inputs.changed-files }}'
+        CHANGED_FILES_LENGTH=${#CHANGED_FILES}
+        if [ "$CHANGED_FILES_LENGTH" -lt 5 ]; then
+          echo "No changed files to check."
+        elif [ "$CHANGED_FILES_LENGTH" -gt 100000 ]; then
+          # Avoid argument length limitations by using xargs to pass the file list.
+          printf '%s\n' $CHANGED_FILES | tr -d '"' | xargs clangd-tidy
+        else
+          clangd-tidy $CHANGED_FILES
+        fi
         echo "::endgroup::"

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -39,7 +39,27 @@ jobs:
           skip_initial_fetch: true
           files_yaml_from_source_file: .github/changed_files.yml
 
-      - name: Style checks via prek
+      - name: Decide prek file scope (all files or only changed files)
+        id: prek-scope
+        shell: bash
+        env:
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+        run: |
+          CHANGED_FILES_LENGTH=${#CHANGED_FILES}
+          if [ "$CHANGED_FILES_LENGTH" -lt 5 ] || [ "$CHANGED_FILES_LENGTH" -gt 100000 ]; then
+            echo "use_all_files=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_all_files=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Style checks via prek (all files)
+        if: steps.prek-scope.outputs.use_all_files == 'true'
+        uses: j178/prek-action@v2
+        with:
+          extra-args: --all-files
+
+      - name: Style checks via prek (changed files)
+        if: steps.prek-scope.outputs.use_all_files == 'false'
         uses: j178/prek-action@v2
         env:
           CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.


### PR DESCRIPTION
## What problem(s) does this PR solve?

The new CI for static checks gathers the list of changed files, and then passes this to `prek`. There are 2 problems with this:

1. If the list of changed files is too long, the checks will fail with "Argument list too long". This can actually happen when updating a fork after a long time, a push to `master` results in insane diffs.
2. If the list of changed files is somehow empty, the checks do nothing.  This can actually happen with new branches when the base can't be determined.

### Proof of the problems

Problem 1: A failure occurs whenever there is a large diff between the branch's previous state and the new state, resulting in an "Argument list too long" error. Linux has a 128 KiB limit for command line arguments, and this example tries to run a command that is 143,832 characters long, so it fails. If anyone has a Godot fork, and they just... don't sync their `master` branch for awhile, then they sync their `master` branch, `prek` explodes. Here is a screenshot of that happening:

<img width="1698" height="1428" alt="Screenshot 2026-07-27 010225" src="https://github.com/user-attachments/assets/5b0af949-f585-4493-afc9-05fb784e9f70" />

For reference, see this CI run: https://github.com/godot-dimensions/godot/actions/runs/30243286140/job/89904801550

Problem 2: When a brand new branch is created, if a base branch cannot be determined, the list of changed files is reported as nothing... so the checks completely skip everything, and a style problem would go unchecked until after the user submits that branch as a PR. Here is a screenshot of that happening:

<img width="1384" height="1218" alt="Screenshot 2026-07-27 012653" src="https://github.com/user-attachments/assets/3e12f410-a19f-4bde-acb7-802c049bed09" />

For reference, see this CI run: https://github.com/godot-dimensions/godot/actions/runs/30236212822/job/89884403855

### The solution

I split the "Style checks via prek" step into "Style checks via prek (all files)" and "Style checks via prek (changed files)". Then I added a new step to check the length of `CHANGED_FILES`: if it's less than 5 characters or longer than 100,000 characters, then it will use only the "(all files)" step, otherwise it will use only the "(changed files)" step.

### Proof of the solution

This PR passing the CI checks and using the "Style checks via prek (changed files)" is proof that this code path works.

For the other code path, I ran a torture test, which you can view here: https://github.com/aaronfranke/godot/actions/runs/30252618805/job/89934030583 or look at this screenshot:

<img width="1754" height="1380" alt="Screenshot 2026-07-27 022601" src="https://github.com/user-attachments/assets/a9abc476-c087-45ab-8f80-1d98f86fef20" />

## Additional information

AI usage disclosure: As GitHub Actions specific stuff is outside of my area of expertise, I used AI to generate a solution after coming up with the general design in my own brain (and talking it out on RocketChat), then I significantly modified the AI's code. The AI's effective contribution is menial, filling in the syntactic gaps that I'd otherwise need to search online for.

I also asked AI to generate the files for the torture test.

I understand every line of this PR, and if I had to write it again from scratch, I'd probably have to look up a few things like the behavior of `"$GITHUB_OUTPUT"`, but I'd come up with generally the same code, as I designed the fix manually in my head.
