### PR TITLE
Prevent viewport size getting out of sync in X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2726,15 +2726,13 @@ void DisplayServerX11::window_set_size(const Size2i p_size, DisplayServerEnums::
 	// Resize the window
 	XResizeWindow(x11_display, wd.x11_window, size.x, size.y);
 
-	for (int timeout = 0; timeout < 50; ++timeout) {
-		XSync(x11_display, False);
-		XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
+	XSync(x11_display, False);
+	XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
 
-		if (old_w != xwa.width || old_h != xwa.height) {
-			break;
-		}
-
-		OS::get_singleton()->delay_usec(10'000);
+	wd.size = Vector2i(xwa.width, xwa.height);
+	if (old_w == xwa.width && old_h == xwa.height) {
+		WARN_PRINT("Resizing window to requested size has failed.");
+		return;
 	}
 
 	// Keep rendering context window size in sync

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -35,6 +35,7 @@
 #include "x11/key_mapping_x11.h"
 
 #include "core/config/project_settings.h"
+#include "core/error/error_macros.h"
 #include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/math/math_funcs.h"
@@ -2726,15 +2727,13 @@ void DisplayServerX11::window_set_size(const Size2i p_size, DisplayServerEnums::
 	// Resize the window
 	XResizeWindow(x11_display, wd.x11_window, size.x, size.y);
 
-	for (int timeout = 0; timeout < 50; ++timeout) {
-		XSync(x11_display, False);
-		XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
+	XSync(x11_display, False);
+	XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
 
-		if (old_w != xwa.width || old_h != xwa.height) {
-			break;
-		}
-
-		OS::get_singleton()->delay_usec(10'000);
+	wd.size = Vector2i(xwa.width, xwa.height);
+	if (old_w == xwa.width && old_h == xwa.height) {
+		WARN_VERBOSE("Resizing window to requested size has failed.");
+		return;
 	}
 
 	// Keep rendering context window size in sync

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1298,9 +1298,9 @@ void Window::_update_window_size() {
 			DisplayServer::get_singleton()->window_set_max_size(max_size_used, window_id);
 			DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 			DisplayServer::get_singleton()->window_set_size(size, window_id);
-		} else if (Engine::get_singleton()->is_embedded_in_editor()) {
-			size = DisplayServer::get_singleton()->window_get_size(window_id); // Reset size.
 		}
+		// Always check size because WM or embedded window can mess with window set_size
+		size = DisplayServer::get_singleton()->window_get_size(window_id);
 	}
 
 	//update the viewport

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -40,6 +40,7 @@ class DisplayServerMock : public DisplayServerHeadless {
 private:
 	friend class DisplayServer;
 
+	Vector2i size = Size2i(1920, 1080);
 	Point2i mouse_position = Point2i(-1, -1); // Outside of Window.
 	DisplayServerEnums::CursorShape cursor_shape = DisplayServerEnums::CursorShape::CURSOR_ARROW;
 	bool window_over = false;
@@ -78,8 +79,12 @@ public:
 	virtual void clipboard_set_primary(const String &p_text) override { primary_clipboard_text = p_text; }
 	virtual String clipboard_get_primary() const override { return primary_clipboard_text; }
 
+	void window_set_size(const Size2i p_size, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override {
+		size = p_size;
+	}
+
 	virtual Size2i window_get_size(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const override {
-		return Size2i(1920, 1080);
+		return size;
 	}
 
 	virtual void cursor_set_shape(DisplayServerEnums::CursorShape p_shape) override {


### PR DESCRIPTION
During `set_size` in X11, if window manager doesn't update the size or sets different size than expected, viewport size and window stored size will get out of sync. This causes flickering or black boxes depending on the scenario. Every `set_size` call which doesn't change window size due to window manager (e.g. tiling WMs or fullscreen apps in floating window WMs) causes 500 ms delay.

The fix is to check window size from window manager after sending size update request, and not expect that requested size is applied.

## What problem(s) does this PR solve?

- Partially fixes #114034 (a bug discovered as part of the issue)
- Closes #122077

## Additional information

Tested on X11 by setting initial window size, updating window size at _ready, and updating window size on request. Tested floating and embedded game window.

Before:

https://github.com/user-attachments/assets/d54de42f-9913-4b2e-8178-1ca2cd3f7b32

After:

https://github.com/user-attachments/assets/2ad760f6-60e3-45dd-a04a-ba87e7029009

[MRP-bug-114034.zip](https://github.com/user-attachments/files/30407516/MRP-bug-114034.zip)

One question I have is if the warning should be printed or not, because in tiling WMs the warning would be printed quite frequently.

Edit: Updated PR to support #122077.