### PR TITLE
Fix documentation of `Script.get_property_default_value`

### DIFF
--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -56,6 +56,7 @@
 			<param index="0" name="property" type="StringName" />
 			<description>
 				Returns the default value of the specified property.
+				[b]Note:[/b] In GDScript and C#, this method returns [code]null[/code] outside of editor builds.
 			</description>
 		</method>
 		<method name="get_rpc_config" qualifiers="const">


### PR DESCRIPTION
This method always returns `null` outside of editor builds.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121824 
